### PR TITLE
feat: seed control, pixel filter, procedural textures, world settings…

### DIFF
--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -291,6 +291,16 @@ class CustomRaytracerRenderEngine(RenderEngine):
         transparent_glass = bool(getattr(cycles, 'film_transparent_glass', False)) if cycles else False
         renderer.set_use_transparent_film(use_transparent_film)
         renderer.set_transparent_glass(transparent_glass)
+        seed = int(getattr(cycles, 'seed', 0)) if cycles else 0
+        use_animated_seed = bool(getattr(cycles, 'use_animated_seed', False)) if cycles else False
+        if use_animated_seed:
+            seed = seed + scene.frame_current
+        renderer.set_seed(seed)
+        filter_type_map = {'BOX': 0, 'GAUSSIAN': 1, 'BLACKMAN_HARRIS': 2}
+        filter_type_str = getattr(cycles, 'pixel_filter_type', 'GAUSSIAN') if cycles else 'GAUSSIAN'
+        filter_type = filter_type_map.get(filter_type_str, 1)
+        filter_width = float(getattr(cycles, 'filter_width', 1.5)) if cycles else 1.5
+        renderer.set_pixel_filter(filter_type, filter_width)
         self.setup_camera(scene, renderer, width, height)
         material_map = self.convert_materials(depsgraph, renderer)
         self.convert_objects(depsgraph, renderer, material_map)
@@ -424,29 +434,48 @@ class CustomRaytracerRenderEngine(RenderEngine):
     # ------------------------------------------------------------------ #
 
     def get_float_input(self, node, name, default):
-        """Read a scalar input's default_value. Returns `default` if linked or
-        missing. We deliberately do NOT follow math-node chains — too much of a
-        rabbit hole for the first pass."""
+        """Read a scalar input. Follows linked Math/Clamp/MapRange node chains."""
         inp = node.inputs.get(name)
-        if not inp or inp.is_linked:
+        if not inp:
             return default
-        val = inp.default_value
-        if hasattr(val, '__iter__'):
-            # bpy_prop_array for a scalar socket shouldn't happen, but be safe
-            try:
-                return float(val[0])
-            except Exception:
-                return default
-        return float(val)
+        if not inp.is_linked:
+            val = inp.default_value
+            if hasattr(val, '__iter__'):
+                try:
+                    return float(val[0])
+                except Exception:
+                    return default
+            return float(val)
+        # Try to evaluate the linked node chain
+        try:
+            src_node = inp.links[0].from_node
+            src_socket = inp.links[0].from_socket.name
+            result = self._eval_float_socket_node(src_node, src_socket)
+            if result is not None:
+                return float(result)
+        except (IndexError, AttributeError):
+            pass
+        return default
 
     def get_color_input(self, node, name, default):
-        """Read an unlinked color input as a list of 3 floats."""
+        """Read a color input. Follows linked color node chains."""
         inp = node.inputs.get(name)
-        if not inp or inp.is_linked:
+        if not inp:
             return list(default)
-        val = inp.default_value
-        if hasattr(val, '__iter__'):
-            return list(val[:3])
+        if not inp.is_linked:
+            val = inp.default_value
+            if hasattr(val, '__iter__'):
+                return list(val[:3])
+            return list(default)
+        # Try to evaluate the linked node chain
+        try:
+            src_node = inp.links[0].from_node
+            src_socket = inp.links[0].from_socket.name
+            result = self._eval_color_socket_node(src_node, src_socket)
+            if result is not None:
+                return result
+        except (IndexError, AttributeError):
+            pass
         return list(default)
 
     def get_color_or_texture(self, node, input_name, default_color):
@@ -482,6 +511,291 @@ class CustomRaytracerRenderEngine(RenderEngine):
                 except (IndexError, AttributeError):
                     pass
         return list(default_color), None
+
+    # ------------------------------------------------------------------ #
+    # Export-time shader node evaluation (#21 color nodes, #22 converter nodes)
+    # ------------------------------------------------------------------ #
+
+    def _get_socket_float(self, socket, depth=0):
+        """Return float from a socket (linked or unlinked), or None."""
+        if socket is None:
+            return None
+        if not socket.is_linked:
+            val = socket.default_value
+            return float(val) if not hasattr(val, '__iter__') else None
+        try:
+            src_node = socket.links[0].from_node
+            src_name = socket.links[0].from_socket.name
+        except (IndexError, AttributeError):
+            return None
+        return self._eval_float_socket_node(src_node, src_name, depth)
+
+    def _get_socket_color(self, socket, depth=0):
+        """Return [r,g,b] from a socket (linked or unlinked), or None."""
+        if socket is None:
+            return None
+        if not socket.is_linked:
+            val = socket.default_value
+            if hasattr(val, '__iter__'):
+                return list(val[:3])
+            f = float(val)
+            return [f, f, f]
+        try:
+            src_node = socket.links[0].from_node
+            src_name = socket.links[0].from_socket.name
+        except (IndexError, AttributeError):
+            return None
+        return self._eval_color_socket_node(src_node, src_name, depth)
+
+    def _eval_float_socket_node(self, node, output_name='Value', depth=0):
+        """Evaluate a node's float output. Returns float or None."""
+        if depth > 8:
+            return None
+        import math
+        ntype = node.type
+        if ntype == 'VALUE':
+            return float(node.outputs[0].default_value)
+        if ntype == 'MATH':
+            op = node.operation
+            a = self._get_socket_float(node.inputs[0] if len(node.inputs) > 0 else None, depth + 1)
+            b = self._get_socket_float(node.inputs[1] if len(node.inputs) > 1 else None, depth + 1)
+            if a is None:
+                return None
+            b = b if b is not None else 0.0
+            ops = {
+                'ADD': a + b, 'SUBTRACT': a - b, 'MULTIPLY': a * b,
+                'DIVIDE': a / b if b != 0 else 0.0,
+                'POWER': a ** b if not (a < 0 and b != int(b)) else 0.0,
+                'SQRT': math.sqrt(max(0.0, a)), 'ABSOLUTE': abs(a),
+                'MINIMUM': min(a, b), 'MAXIMUM': max(a, b),
+                'FLOOR': math.floor(a), 'CEIL': math.ceil(a),
+                'FRACT': a - math.floor(a),
+                'MODULO': math.fmod(a, b) if b != 0 else 0.0,
+                'SINE': math.sin(a), 'COSINE': math.cos(a), 'TANGENT': math.tan(a),
+                'ARCSINE': math.asin(max(-1.0, min(1.0, a))),
+                'ARCCOSINE': math.acos(max(-1.0, min(1.0, a))),
+                'ARCTANGENT': math.atan(a), 'ARCTAN2': math.atan2(a, b),
+                'LOGARITHM': math.log(max(1e-10, a)) / math.log(max(1e-10, b)) if b not in (0, 1) else math.log(max(1e-10, a)),
+                'LESS_THAN': 1.0 if a < b else 0.0,
+                'GREATER_THAN': 1.0 if a > b else 0.0,
+                'SIGN': math.copysign(1.0, a) if a != 0.0 else 0.0,
+                'SNAP': round(a / b) * b if b != 0 else 0.0,
+                'WRAP': a - b * math.floor(a / b) if b != 0 else 0.0,
+                'PINGPONG': abs(a - b * round(a / b)) if b != 0 else 0.0,
+                'MULTIPLY_ADD': a * b + (self._get_socket_float(node.inputs[2], depth + 1) or 0.0),
+                'COMPARE': 1.0 if abs(a - b) <= (self._get_socket_float(node.inputs[2], depth + 1) or 0.0) else 0.0,
+            }
+            result = ops.get(op)
+            if result is None:
+                return None
+            result = float(result)
+            if getattr(node, 'use_clamp', False):
+                result = max(0.0, min(1.0, result))
+            return result
+        if ntype == 'CLAMP':
+            val = self._get_socket_float(node.inputs.get('Value'), depth + 1)
+            mn = self._get_socket_float(node.inputs.get('Min'), depth + 1)
+            mx = self._get_socket_float(node.inputs.get('Max'), depth + 1)
+            if val is None:
+                return None
+            mn = mn if mn is not None else 0.0
+            mx = mx if mx is not None else 1.0
+            return max(mn, min(mx, val))
+        if ntype == 'MAP_RANGE':
+            val = self._get_socket_float(node.inputs.get('Value'), depth + 1)
+            from_min = self._get_socket_float(node.inputs.get('From Min'), depth + 1)
+            from_max = self._get_socket_float(node.inputs.get('From Max'), depth + 1)
+            to_min = self._get_socket_float(node.inputs.get('To Min'), depth + 1)
+            to_max = self._get_socket_float(node.inputs.get('To Max'), depth + 1)
+            if val is None:
+                return None
+            from_min = from_min if from_min is not None else 0.0
+            from_max = from_max if from_max is not None else 1.0
+            to_min = to_min if to_min is not None else 0.0
+            to_max = to_max if to_max is not None else 1.0
+            denom = from_max - from_min
+            if abs(denom) < 1e-10:
+                return to_min
+            t = (val - from_min) / denom
+            interp = getattr(node, 'interpolation_type', 'LINEAR')
+            if interp == 'SMOOTHSTEP':
+                t = t * t * (3.0 - 2.0 * t)
+            elif interp == 'SMOOTHERSTEP':
+                t = t * t * t * (t * (t * 6.0 - 15.0) + 10.0)
+            result = to_min + t * (to_max - to_min)
+            if getattr(node, 'clamp', False):
+                lo, hi = min(to_min, to_max), max(to_min, to_max)
+                result = max(lo, min(hi, result))
+            return result
+        if ntype == 'RGBTOBW':
+            col = self._get_socket_color(node.inputs.get('Color'), depth + 1)
+            if col is None:
+                return None
+            return 0.2126 * col[0] + 0.7152 * col[1] + 0.0722 * col[2]
+        return None
+
+    def _eval_color_socket_node(self, node, output_name='Color', depth=0):
+        """Evaluate a node's color output. Returns [r,g,b] or None."""
+        if depth > 8:
+            return None
+        import colorsys, math
+        ntype = node.type
+        if ntype == 'RGB':
+            val = node.outputs[0].default_value
+            return list(val[:3])
+        if ntype == 'TEX_IMAGE':
+            return None  # can't evaluate dynamically; caller handles texture lookup
+        if ntype in ('MIX_RGB', 'MIX'):
+            fac_inp = node.inputs.get('Fac') or node.inputs.get('Factor')
+            col1_inp = node.inputs.get('Color1') or node.inputs.get('A') or (node.inputs[1] if len(node.inputs) > 1 else None)
+            col2_inp = node.inputs.get('Color2') or node.inputs.get('B') or (node.inputs[2] if len(node.inputs) > 2 else None)
+            fac = self._get_socket_float(fac_inp, depth + 1)
+            col1 = self._get_socket_color(col1_inp, depth + 1)
+            col2 = self._get_socket_color(col2_inp, depth + 1)
+            fac = fac if fac is not None else 0.5
+            col1 = col1 if col1 is not None else [0.0, 0.0, 0.0]
+            col2 = col2 if col2 is not None else [1.0, 1.0, 1.0]
+            blend_type = getattr(node, 'blend_type', 'MIX')
+            return self._mix_rgb(blend_type, fac, col1, col2)
+        if ntype == 'INVERT':
+            fac = self._get_socket_float(node.inputs.get('Fac'), depth + 1)
+            col = self._get_socket_color(node.inputs.get('Color'), depth + 1)
+            if col is None:
+                return None
+            fac = fac if fac is not None else 1.0
+            return [col[i] * (1.0 - fac) + (1.0 - col[i]) * fac for i in range(3)]
+        if ntype == 'GAMMA':
+            col = self._get_socket_color(node.inputs.get('Color'), depth + 1)
+            gamma = self._get_socket_float(node.inputs.get('Gamma'), depth + 1)
+            if col is None:
+                return None
+            gamma = gamma if gamma is not None else 1.0
+            return [max(0.0, c) ** gamma for c in col]
+        if ntype == 'HUE_SAT':
+            hue = self._get_socket_float(node.inputs.get('Hue'), depth + 1)
+            sat = self._get_socket_float(node.inputs.get('Saturation'), depth + 1)
+            val_mult = self._get_socket_float(node.inputs.get('Value'), depth + 1)
+            fac = self._get_socket_float(node.inputs.get('Fac'), depth + 1)
+            col = self._get_socket_color(node.inputs.get('Color'), depth + 1)
+            if col is None:
+                return None
+            hue = hue if hue is not None else 0.5
+            sat = sat if sat is not None else 1.0
+            val_mult = val_mult if val_mult is not None else 1.0
+            fac = fac if fac is not None else 1.0
+            h, s, v = colorsys.rgb_to_hsv(col[0], col[1], col[2])
+            h2 = (h + hue - 0.5) % 1.0
+            s2 = max(0.0, s * sat)
+            v2 = v * val_mult
+            result = list(colorsys.hsv_to_rgb(h2, s2, v2))
+            return [col[i] * (1.0 - fac) + result[i] * fac for i in range(3)]
+        if ntype == 'BRIGHTCONTRAST':
+            col = self._get_socket_color(node.inputs.get('Color'), depth + 1)
+            bright = self._get_socket_float(node.inputs.get('Bright'), depth + 1)
+            contrast = self._get_socket_float(node.inputs.get('Contrast'), depth + 1)
+            if col is None:
+                return None
+            bright = bright if bright is not None else 0.0
+            contrast = contrast if contrast is not None else 0.0
+            # Cycles formula: out = (in - 0.5) * (contrast + 1) + 0.5 + bright
+            return [max(0.0, (c - 0.5) * (contrast + 1.0) + 0.5 + bright) for c in col]
+        if ntype == 'VALTORGB':  # Color Ramp
+            fac = self._get_socket_float(node.inputs.get('Fac'), depth + 1)
+            if fac is None:
+                return None
+            try:
+                color = node.color_ramp.evaluate(fac)
+                return list(color[:3])
+            except Exception:
+                return None
+        if ntype == 'WAVELENGTH':
+            wl = self._get_socket_float(node.inputs.get('Wavelength'), depth + 1)
+            if wl is None:
+                return None
+            return self._wavelength_to_rgb(wl)
+        if ntype == 'BLACKBODY':
+            temp = self._get_socket_float(node.inputs.get('Temperature'), depth + 1)
+            if temp is None:
+                return None
+            return self._blackbody_to_rgb(temp)
+        if ntype == 'RGBTOBW':
+            col = self._get_socket_color(node.inputs.get('Color'), depth + 1)
+            if col is None:
+                return None
+            bw = 0.2126 * col[0] + 0.7152 * col[1] + 0.0722 * col[2]
+            return [bw, bw, bw]
+        return None
+
+    def _mix_rgb(self, blend_type, fac, a, b):
+        """Apply a MixRGB blend operation matching Cycles behavior."""
+        if blend_type == 'MIX':
+            return [a[i] * (1.0 - fac) + b[i] * fac for i in range(3)]
+        elif blend_type == 'ADD':
+            return [min(1.0, a[i] + b[i] * fac) for i in range(3)]
+        elif blend_type == 'MULTIPLY':
+            return [a[i] * (1.0 - fac) + a[i] * b[i] * fac for i in range(3)]
+        elif blend_type == 'SUBTRACT':
+            return [max(0.0, a[i] - b[i] * fac) for i in range(3)]
+        elif blend_type == 'SCREEN':
+            return [1.0 - (1.0 - a[i]) * (1.0 - b[i] * fac) for i in range(3)]
+        elif blend_type == 'DIVIDE':
+            return [a[i] * (1.0 - fac) + (a[i] / max(1e-5, b[i])) * fac for i in range(3)]
+        elif blend_type == 'DIFFERENCE':
+            return [a[i] * (1.0 - fac) + abs(a[i] - b[i]) * fac for i in range(3)]
+        elif blend_type == 'DARKEN':
+            return [a[i] * (1.0 - fac) + min(a[i], b[i]) * fac for i in range(3)]
+        elif blend_type == 'LIGHTEN':
+            return [a[i] * (1.0 - fac) + max(a[i], b[i]) * fac for i in range(3)]
+        elif blend_type == 'OVERLAY':
+            def ov(x, y):
+                return 2.0 * x * y if x < 0.5 else 1.0 - 2.0 * (1.0 - x) * (1.0 - y)
+            blended = [ov(a[i], b[i]) for i in range(3)]
+            return [a[i] * (1.0 - fac) + blended[i] * fac for i in range(3)]
+        else:
+            return [a[i] * (1.0 - fac) + b[i] * fac for i in range(3)]
+
+    def _wavelength_to_rgb(self, wavelength_nm):
+        """Approximate CIE spectral locus mapping of wavelength (nm) to RGB."""
+        wl = wavelength_nm
+        if wl < 380.0 or wl > 780.0:
+            return [0.0, 0.0, 0.0]
+        if wl < 440.0:
+            r = -(wl - 440.0) / (440.0 - 380.0); g = 0.0; b = 1.0
+        elif wl < 490.0:
+            r = 0.0; g = (wl - 440.0) / (490.0 - 440.0); b = 1.0
+        elif wl < 510.0:
+            r = 0.0; g = 1.0; b = -(wl - 510.0) / (510.0 - 490.0)
+        elif wl < 580.0:
+            r = (wl - 510.0) / (580.0 - 510.0); g = 1.0; b = 0.0
+        elif wl < 645.0:
+            r = 1.0; g = -(wl - 645.0) / (645.0 - 580.0); b = 0.0
+        else:
+            r = 1.0; g = 0.0; b = 0.0
+        factor = (0.3 + 0.7 * (wl - 380.0) / (420.0 - 380.0) if wl < 420.0
+                  else 0.3 + 0.7 * (780.0 - wl) / (780.0 - 700.0) if wl > 700.0
+                  else 1.0)
+        return [r * factor, g * factor, b * factor]
+
+    def _blackbody_to_rgb(self, temperature_k):
+        """Approximate Planckian locus (Kang et al. polynomial) to linear RGB."""
+        import math
+        t = max(1000.0, min(40000.0, temperature_k))
+        if t <= 6600.0:
+            r = 1.0
+            g_raw = 99.4708025861 * math.log(t / 100.0) - 161.1195681661
+            g = max(0.0, min(1.0, g_raw / 255.0))
+            if t <= 1900.0:
+                b = 0.0
+            else:
+                b_raw = 138.5177312231 * math.log(t / 100.0 - 10.0) - 305.0447927307
+                b = max(0.0, min(1.0, b_raw / 255.0))
+        else:
+            r_raw = 329.698727446 * ((t / 100.0 - 60.0) ** -0.1332047592)
+            r = max(0.0, min(1.0, r_raw / 255.0))
+            g_raw = 288.1221695283 * ((t / 100.0 - 60.0) ** -0.0755148492)
+            g = max(0.0, min(1.0, g_raw / 255.0))
+            b = 1.0
+        return [r, g, b]
 
     def get_image_from_socket(self, socket):
         """Resolve a directly linked Image Texture datablock from a socket."""
@@ -581,6 +895,129 @@ class CustomRaytracerRenderEngine(RenderEngine):
         except Exception as e:
             print(f"Astroray: failed to load texture '{bpy_image.name}': {e}")
             return None
+
+    def load_procedural_texture(self, node, renderer):
+        """Export a Blender procedural texture node to the Astroray texture manager.
+        Returns a texture name string on success, None on failure.
+
+        Supported node types: TEX_NOISE, TEX_VORONOI, TEX_WAVE, TEX_MAGIC,
+        TEX_CHECKER, TEX_BRICK, TEX_GRADIENT, TEX_MUSGRAVE.
+        """
+        cache = getattr(self, '_proc_tex_cache', None)
+        if cache is None:
+            cache = {}
+            self._proc_tex_cache = cache
+        node_id = id(node)
+        if node_id in cache:
+            return cache[node_id]
+
+        ntype = node.type
+        tex_name = None
+        try:
+            if ntype == 'TEX_NOISE':
+                scale = float(node.inputs['Scale'].default_value) if node.inputs.get('Scale') else 5.0
+                tex_name = f"_proc_noise_{node_id}"
+                renderer.create_procedural_texture(tex_name, 'noise', [scale])
+            elif ntype == 'TEX_CHECKER':
+                scale = float(node.inputs['Scale'].default_value) if node.inputs.get('Scale') else 5.0
+                c1 = list(node.inputs['Color1'].default_value[:3]) if node.inputs.get('Color1') else [1,1,1]
+                c2 = list(node.inputs['Color2'].default_value[:3]) if node.inputs.get('Color2') else [0,0,0]
+                tex_name = f"_proc_checker_{node_id}"
+                renderer.create_procedural_texture(tex_name, 'checker',
+                    c1 + c2 + [scale])
+            elif ntype == 'TEX_VORONOI':
+                scale = float(node.inputs['Scale'].default_value) if node.inputs.get('Scale') else 5.0
+                randomness = float(node.inputs['Randomness'].default_value) if node.inputs.get('Randomness') else 1.0
+                smoothness = float(node.inputs.get('Smoothness', type(None) or type(0)).default_value) if node.inputs.get('Smoothness') else 1.0
+                dist_map = {'EUCLIDEAN': 0, 'MANHATTAN': 1, 'CHEBYCHEV': 2, 'MINKOWSKI': 3}
+                feat_map = {'F1': 0, 'F2': 1, 'F1_F2': 2, 'SMOOTH_F1': 4, 'DISTANCE_TO_EDGE': 3}
+                dm = dist_map.get(getattr(node, 'distance', 'EUCLIDEAN'), 0)
+                feat = feat_map.get(getattr(node, 'feature', 'F1'), 0)
+                tex_name = f"_proc_voronoi_{node_id}"
+                renderer.create_procedural_texture(tex_name, 'voronoi',
+                    [scale, randomness, float(dm), float(feat), smoothness, 0,0,0, 1,1,1])
+            elif ntype == 'TEX_WAVE':
+                scale = float(node.inputs['Scale'].default_value) if node.inputs.get('Scale') else 5.0
+                dist = float(node.inputs['Distortion'].default_value) if node.inputs.get('Distortion') else 0.0
+                detail = float(node.inputs['Detail'].default_value) if node.inputs.get('Detail') else 2.0
+                rough = float(node.inputs['Detail Roughness'].default_value or node.inputs.get('Roughness', type(0)).default_value) \
+                    if node.inputs.get('Detail Roughness') else 0.5
+                lac = float(node.inputs['Detail Scale'].default_value) if node.inputs.get('Detail Scale') else 2.0
+                bd = 1 if getattr(node, 'wave_type', 'BANDS') == 'RINGS' else 0
+                profile_map = {'SINE': 0, 'SAW': 1, 'TRIANGLE': 2}
+                prof = profile_map.get(getattr(node, 'bands_direction', 'SINE'), 0)
+                tex_name = f"_proc_wave_{node_id}"
+                renderer.create_procedural_texture(tex_name, 'wave',
+                    [float(bd), float(prof), scale, dist, detail, rough, lac, 0,0,0, 1,1,1])
+            elif ntype == 'TEX_MAGIC':
+                depth = int(node.turbulence_depth) if hasattr(node, 'turbulence_depth') else 2
+                scale = float(node.inputs['Scale'].default_value) if node.inputs.get('Scale') else 5.0
+                dist = float(node.inputs['Distortion'].default_value) if node.inputs.get('Distortion') else 1.0
+                tex_name = f"_proc_magic_{node_id}"
+                renderer.create_procedural_texture(tex_name, 'magic',
+                    [float(depth), scale, dist, 0,0,0, 1,1,1])
+            elif ntype == 'TEX_BRICK':
+                scale = float(node.inputs['Scale'].default_value) if node.inputs.get('Scale') else 5.0
+                mortar = float(node.inputs['Mortar Size'].default_value) if node.inputs.get('Mortar Size') else 0.02
+                offset = float(node.inputs['Offset'].default_value) if node.inputs.get('Offset') else 0.5
+                c_brick = list(node.inputs['Color1'].default_value[:3]) if node.inputs.get('Color1') else [0.7, 0.35, 0.2]
+                c_mortar = list(node.inputs['Color3'].default_value[:3]) if node.inputs.get('Color3') else [0.9, 0.9, 0.9]
+                bw = float(node.inputs['Brick Width'].default_value) if node.inputs.get('Brick Width') else 0.5
+                bh = float(node.inputs['Row Height'].default_value) if node.inputs.get('Row Height') else 0.25
+                tex_name = f"_proc_brick_{node_id}"
+                renderer.create_procedural_texture(tex_name, 'brick',
+                    c_brick + c_mortar + [bw, bh, mortar, offset, scale])
+            elif ntype == 'TEX_GRADIENT':
+                grad_map = {'LINEAR': 0, 'QUADRATIC': 1, 'EASING': 2, 'DIAGONAL': 3,
+                            'SPHERICAL': 4, 'QUADRATIC_SPHERE': 5, 'RADIAL': 6}
+                gt = float(grad_map.get(getattr(node, 'gradient_type', 'LINEAR'), 0))
+                tex_name = f"_proc_gradient_{node_id}"
+                renderer.create_procedural_texture(tex_name, 'gradient',
+                    [gt, 1.0, 0,0,0, 1,1,1])
+            elif ntype == 'TEX_MUSGRAVE':
+                scale = float(node.inputs['Scale'].default_value) if node.inputs.get('Scale') else 5.0
+                detail = float(node.inputs['Detail'].default_value) if node.inputs.get('Detail') else 2.0
+                dim = float(node.inputs['Dimension'].default_value) if node.inputs.get('Dimension') else 2.0
+                lac = float(node.inputs['Lacunarity'].default_value) if node.inputs.get('Lacunarity') else 2.0
+                mus_map = {'FBM': 0, 'MULTIFRACTAL': 1, 'RIDGED_MULTIFRACTAL': 2, 'HYBRID_MULTIFRACTAL': 3, 'HETERO_TERRAIN': 3}
+                mt = float(mus_map.get(getattr(node, 'musgrave_type', 'FBM'), 0))
+                tex_name = f"_proc_musgrave_{node_id}"
+                renderer.create_procedural_texture(tex_name, 'musgrave',
+                    [mt, scale, detail, dim, lac, 1.0, 0,0,0, 1,1,1])
+        except Exception as e:
+            print(f"Astroray: failed to create procedural texture '{ntype}': {e}")
+            return None
+
+        if tex_name:
+            cache[node_id] = tex_name
+        return tex_name
+
+    def get_base_color_texture(self, node, input_name, renderer):
+        """Returns (fallback_color, tex_name_or_None) for a color input,
+        handling both Image Texture and procedural texture nodes."""
+        inp = node.inputs.get(input_name)
+        if not inp or not inp.is_linked:
+            if inp:
+                val = inp.default_value
+                if hasattr(val, '__iter__'):
+                    return list(val[:3]), None
+            return [0.8, 0.8, 0.8], None
+        try:
+            linked_node = inp.links[0].from_node
+        except (IndexError, AttributeError):
+            return [0.8, 0.8, 0.8], None
+        # Image texture
+        if linked_node.type == 'TEX_IMAGE' and linked_node.image:
+            tex_name = self.load_blender_image(linked_node.image, renderer)
+            fallback = list(inp.default_value[:3]) if hasattr(inp.default_value, '__iter__') else [0.8, 0.8, 0.8]
+            return fallback, tex_name
+        # Procedural texture
+        PROC_TYPES = {'TEX_NOISE', 'TEX_CHECKER', 'TEX_VORONOI', 'TEX_WAVE',
+                      'TEX_MAGIC', 'TEX_BRICK', 'TEX_GRADIENT', 'TEX_MUSGRAVE'}
+        if linked_node.type in PROC_TYPES:
+            tex_name = self.load_procedural_texture(linked_node, renderer)
+            return [0.8, 0.8, 0.8], tex_name
+        return [0.8, 0.8, 0.8], None
 
     # ------------------------------------------------------------------ #
     # Shader-node dispatch
@@ -862,9 +1299,13 @@ class CustomRaytracerRenderEngine(RenderEngine):
         nodes on Base Color (other sockets: defaults only for now), and picks
         up the renamed sockets introduced in Blender 4.0.
         """
-        # --- Base Color (may be textured) ---
-        base_color, base_color_tex = self.get_color_or_texture(
-            node, 'Base Color', [0.8, 0.8, 0.8])
+        # --- Base Color (may be image-textured or procedural) ---
+        base_color, base_color_tex_name = self.get_base_color_texture(
+            node, 'Base Color', renderer)
+        # Also check legacy path for backward compatibility
+        _, base_color_img = self.get_color_or_texture(node, 'Base Color', [0.8, 0.8, 0.8])
+        if base_color_tex_name is None and base_color_img is not None:
+            base_color_tex_name = self.load_blender_image(base_color_img, renderer)
 
         # --- Scalar parameters (with renamed-input fallbacks) ---
         metallic  = self.get_float_input(node, 'Metallic', 0.0)
@@ -918,19 +1359,17 @@ class CustomRaytracerRenderEngine(RenderEngine):
         # textured path (DisneyBRDF doesn't currently accept a texture, and the
         # TexturedLambertian gives correct base color sampling for most PBR
         # scenes while preserving roughness/metallic-less appearance).
-        if base_color_tex is not None:
-            tex_name = self.load_blender_image(base_color_tex, renderer)
-            if tex_name:
-                # Use textured lambertian (the only path that currently samples
-                # a texture on hit). TODO: extend DisneyBRDF with a base-color
-                # texture slot so we can keep metallic/roughness too.
-                lambert_params = {'texture': tex_name}
-                for key in ('normal_map_texture', 'normal_strength',
-                            'bump_map_texture', 'bump_strength', 'bump_distance'):
-                    if key in params:
-                        lambert_params[key] = params[key]
-                return renderer.create_material('lambertian', base_color,
-                                                lambert_params)
+        if base_color_tex_name is not None:
+            # Use textured lambertian (the only path that currently samples
+            # a texture on hit). TODO: extend DisneyBRDF with a base-color
+            # texture slot so we can keep metallic/roughness too.
+            lambert_params = {'texture': base_color_tex_name}
+            for key in ('normal_map_texture', 'normal_strength',
+                        'bump_map_texture', 'bump_strength', 'bump_distance'):
+                if key in params:
+                    lambert_params[key] = params[key]
+            return renderer.create_material('lambertian', base_color,
+                                            lambert_params)
 
         return renderer.create_material('disney', base_color, params)
     
@@ -1141,6 +1580,11 @@ class CustomRaytracerRenderEngine(RenderEngine):
                 rot_input = node.inputs.get('Rotation')
                 if rot_input:
                     rotation = float(rot_input.default_value[2])  # Z rotation
+
+        # Apply world bounce limit (Cycles: world.light_settings.max_bounces)
+        world_settings = getattr(world, 'light_settings', None)
+        world_max_bounces = int(getattr(world_settings, 'max_bounces', 1024)) if world_settings else 1024
+        renderer.set_world_max_bounces(world_max_bounces)
 
         # Try loading HDRI first
         if hdri_path and os.path.exists(hdri_path):

--- a/include/advanced_features.h
+++ b/include/advanced_features.h
@@ -289,6 +289,249 @@ public:
 };
 
 // ============================================================================
+// PROCEDURAL TEXTURES — issue #19
+// ============================================================================
+
+// --- Gradient texture ---
+class GradientTexture : public Texture {
+    // type: 0=linear, 1=quadratic, 2=easing, 3=diagonal, 4=spherical, 5=quadratic sphere, 6=radial
+    int gradType;
+    Vec3 color1, color2;
+    float scale;
+public:
+    GradientTexture(int type = 0, const Vec3& c1 = Vec3(0), const Vec3& c2 = Vec3(1), float s = 1.0f)
+        : gradType(type), color1(c1), color2(c2), scale(s) {}
+    Vec3 value(const Vec2& uv, const Vec3& p) const override {
+        Vec3 sp = p * scale;
+        float t = 0;
+        switch (gradType) {
+            case 1: t = std::clamp(sp.x * sp.x, 0.0f, 1.0f); break;          // quadratic
+            case 2: { float x = std::clamp(sp.x, 0.0f, 1.0f); t = x*x*(3-2*x); break; } // easing
+            case 3: t = std::clamp((sp.x + sp.y) * 0.5f, 0.0f, 1.0f); break; // diagonal
+            case 4: t = std::clamp(std::sqrt(sp.x*sp.x + sp.y*sp.y + sp.z*sp.z), 0.0f, 1.0f); break; // spherical
+            case 5: { float r = std::sqrt(sp.x*sp.x + sp.y*sp.y + sp.z*sp.z); t = 1.0f - std::clamp(r*r, 0.0f, 1.0f); break; } // quadratic sphere
+            case 6: t = std::fmod(std::atan2(sp.y, sp.x) / (2.0f * float(M_PI)) + 1.0f, 1.0f); break; // radial
+            default: t = std::clamp(sp.x, 0.0f, 1.0f); break;                // linear
+        }
+        return color1 * (1.0f - t) + color2 * t;
+    }
+};
+
+// --- Wave texture ---
+// bandDir: 0=bands, 1=rings; profile: 0=sine, 1=saw, 2=triangle
+class WaveTexture : public Texture {
+    int bandDir;   // 0=bands (X), 1=rings (radial)
+    int profile;   // 0=sine, 1=saw, 2=triangle
+    float scale, distortion, detail, roughness, lacunarity;
+    Vec3 colorLow, colorHigh;
+public:
+    WaveTexture(int bd = 0, int prof = 0, float sc = 5.0f, float dist = 0.0f,
+                float det = 2.0f, float rough = 0.5f, float lac = 2.0f,
+                const Vec3& c1 = Vec3(0), const Vec3& c2 = Vec3(1))
+        : bandDir(bd), profile(prof), scale(sc), distortion(dist),
+          detail(det), roughness(rough), lacunarity(lac), colorLow(c1), colorHigh(c2) {}
+
+    static float turbulence(const Vec3& p, float det, float rough, float lac) {
+        float accum = 0, w = 1.0f;
+        Vec3 pp = p;
+        int steps = std::max(1, (int)det);
+        for (int i = 0; i < steps; ++i) {
+            accum += w * NoiseTexture::noise(pp);
+            w *= rough;
+            pp = pp * lac;
+        }
+        return accum;
+    }
+
+    Vec3 value(const Vec2&, const Vec3& p) const override {
+        Vec3 sp = p * scale;
+        float d = distortion > 0.0f ? distortion * turbulence(sp, detail, roughness, lacunarity) : 0.0f;
+        float phase;
+        if (bandDir == 1) {
+            float r = std::sqrt(sp.x*sp.x + sp.y*sp.y + sp.z*sp.z);
+            phase = (r + d) * float(M_PI);
+        } else {
+            phase = (sp.x + d) * float(M_PI);
+        }
+        float t;
+        if (profile == 1) { // saw
+            t = 1.0f - std::fmod(phase / float(M_PI), 1.0f);
+        } else if (profile == 2) { // triangle
+            float x = std::fmod(phase / float(M_PI), 1.0f);
+            t = x < 0.5f ? 2.0f * x : 2.0f - 2.0f * x;
+        } else { // sine
+            t = 0.5f + 0.5f * std::sin(phase);
+        }
+        return colorLow * (1.0f - t) + colorHigh * t;
+    }
+};
+
+// --- Magic texture ---
+class MagicTexture : public Texture {
+    int turbDepth;
+    float scale, distortion;
+    Vec3 color1, color2;
+public:
+    MagicTexture(int depth = 2, float sc = 5.0f, float dist = 1.0f,
+                 const Vec3& c1 = Vec3(0), const Vec3& c2 = Vec3(1))
+        : turbDepth(depth), scale(sc), distortion(dist), color1(c1), color2(c2) {}
+    Vec3 value(const Vec2&, const Vec3& p) const override {
+        float x = std::sin((p.x * scale + p.y * scale + p.z * scale) * float(M_PI));
+        float y = std::cos((-p.x * scale + p.y * scale - p.z * scale) * float(M_PI));
+        float z = -std::cos((-p.x * scale - p.y * scale + p.z * scale) * float(M_PI));
+        if (turbDepth > 1) {
+            float d = distortion * 0.25f;
+            x *= d; y *= d; z *= d;
+            y = -std::cos(x - y + z) * d;
+            if (turbDepth > 2) {
+                x = std::cos(x - y - z) * d;
+                if (turbDepth > 3) {
+                    z = std::sin(-x - y + z) * d;
+                    if (turbDepth > 4) y = -std::cos(x + y - z) * d;
+                }
+            }
+        }
+        float t = std::clamp(0.5f + 0.5f * (x + y + z) / 3.0f, 0.0f, 1.0f);
+        return color1 * (1.0f - t) + color2 * t;
+    }
+};
+
+// --- Voronoi texture ---
+// distMetric: 0=Euclidean, 1=Manhattan, 2=Chebychev, 3=Minkowski(p=2.5)
+// feature: 0=F1, 1=F2, 2=F1+F2, 3=F2-F1, 4=smooth_F1
+class VoronoiTexture : public Texture {
+    float scale, randomness, smoothness;
+    int distMetric, feature;
+    Vec3 colorLow, colorHigh;
+public:
+    VoronoiTexture(float sc = 5.0f, float rand = 1.0f, int dm = 0, int feat = 0,
+                   float smooth = 1.0f, const Vec3& c1 = Vec3(0), const Vec3& c2 = Vec3(1))
+        : scale(sc), randomness(rand), smoothness(smooth), distMetric(dm), feature(feat),
+          colorLow(c1), colorHigh(c2) {}
+
+    static float hash1(float n) {
+        float x = std::sin(n) * 43758.5453f;
+        return x - std::floor(x);
+    }
+    static Vec3 hash3(Vec3 p) {
+        Vec3 q(p.dot(Vec3(127.1f, 311.7f, 74.7f)),
+               p.dot(Vec3(269.5f, 183.3f, 246.1f)),
+               p.dot(Vec3(113.5f, 271.9f, 124.6f)));
+        return Vec3(hash1(q.x), hash1(q.y), hash1(q.z));
+    }
+    float dist(const Vec3& a, const Vec3& b) const {
+        Vec3 d = a - b;
+        switch (distMetric) {
+            case 1: return std::abs(d.x) + std::abs(d.y) + std::abs(d.z);
+            case 2: return std::max({std::abs(d.x), std::abs(d.y), std::abs(d.z)});
+            case 3: { float p = 2.5f; return std::pow(std::pow(std::abs(d.x),p)+std::pow(std::abs(d.y),p)+std::pow(std::abs(d.z),p), 1.0f/p); }
+            default: return std::sqrt(d.dot(d));
+        }
+    }
+    Vec3 value(const Vec2&, const Vec3& p) const override {
+        Vec3 sp = p * scale;
+        Vec3 ip(std::floor(sp.x), std::floor(sp.y), std::floor(sp.z));
+        float f1 = 1e9f, f2 = 1e9f;
+        float smoothF1 = 0.0f;
+        for (int dz = -1; dz <= 1; ++dz)
+        for (int dy = -1; dy <= 1; ++dy)
+        for (int dx = -1; dx <= 1; ++dx) {
+            Vec3 nb(ip.x+dx, ip.y+dy, ip.z+dz);
+            Vec3 r = nb + hash3(nb) * randomness;
+            float d = dist(sp, r);
+            if (d < f1) { f2 = f1; f1 = d; }
+            else if (d < f2) { f2 = d; }
+            if (smoothness > 0.0f && smoothness < 1e9f) {
+                float h = std::max(smoothness - d, 0.0f) / smoothness;
+                smoothF1 += h * h * h;
+            }
+        }
+        float val;
+        switch (feature) {
+            case 1: val = f2; break;
+            case 2: val = (f1 + f2) * 0.5f; break;
+            case 3: val = f2 - f1; break;
+            case 4: val = smoothness > 0.0f ? -std::log(smoothF1) / 3.0f : f1; break;
+            default: val = f1; break;
+        }
+        float t = std::clamp(val, 0.0f, 1.0f);
+        return colorLow * (1.0f - t) + colorHigh * t;
+    }
+};
+
+// --- Brick texture ---
+class BrickTexture : public Texture {
+    Vec3 colorBrick, colorMortar;
+    float brickWidth, brickHeight, mortarSize, offset, scale;
+public:
+    BrickTexture(const Vec3& brick = Vec3(0.7f, 0.35f, 0.2f),
+                 const Vec3& mortar = Vec3(0.9f),
+                 float bw = 0.5f, float bh = 0.25f, float mort = 0.02f,
+                 float off = 0.5f, float sc = 5.0f)
+        : colorBrick(brick), colorMortar(mortar),
+          brickWidth(std::max(0.001f, bw)), brickHeight(std::max(0.001f, bh)),
+          mortarSize(mort), offset(off), scale(sc) {}
+    Vec3 value(const Vec2& uv, const Vec3&) const override {
+        float u = uv.u * scale;
+        float v = uv.v * scale;
+        int row = (int)std::floor(v / brickHeight);
+        float rowOffset = (row % 2 == 0) ? 0.0f : offset * brickWidth;
+        float uu = std::fmod(u - rowOffset, brickWidth);
+        if (uu < 0) uu += brickWidth;
+        float vv = std::fmod(v, brickHeight);
+        float half = mortarSize * 0.5f;
+        if (uu < half || uu > brickWidth - half || vv < half || vv > brickHeight - half)
+            return colorMortar;
+        return colorBrick;
+    }
+};
+
+// --- Musgrave (fBm) texture ---
+class MusgraveTexture : public Texture {
+    // type: 0=fBm, 1=multifractal, 2=ridged, 3=hybrid
+    int musType;
+    float scale, detail, dimension, lacunarity, gain;
+    Vec3 colorLow, colorHigh;
+public:
+    MusgraveTexture(int type = 0, float sc = 5.0f, float det = 2.0f,
+                   float dim = 2.0f, float lac = 2.0f, float g = 1.0f,
+                   const Vec3& c1 = Vec3(0), const Vec3& c2 = Vec3(1))
+        : musType(type), scale(sc), detail(det), dimension(dim),
+          lacunarity(lac), gain(g), colorLow(c1), colorHigh(c2) {}
+    Vec3 value(const Vec2&, const Vec3& p) const override {
+        Vec3 sp = p * scale;
+        float val = 0.0f;
+        float amp = 1.0f, freq = 1.0f;
+        float H = std::max(0.001f, dimension - 1.0f);
+        int steps = std::max(1, (int)detail);
+        if (musType == 2) { // ridged
+            float signal = NoiseTexture::noise(sp);
+            signal = std::abs(signal - 0.5f) * 2.0f; // ridge
+            val = signal;
+            float weight = 1.0f;
+            for (int i = 1; i < steps; ++i) {
+                sp = sp * lacunarity;
+                amp *= gain;
+                weight = std::clamp(signal * gain, 0.0f, 1.0f);
+                signal = NoiseTexture::noise(sp);
+                signal = (1.0f - std::abs(signal - 0.5f) * 2.0f);
+                val += weight * std::pow(freq, -H) * signal;
+                freq *= lacunarity;
+                signal = val;
+            }
+        } else { // fBm / multifractal / hybrid
+            for (int i = 0; i < steps; ++i) {
+                val += amp * (NoiseTexture::noise(sp * freq) - 0.5f);
+                freq *= lacunarity;
+                amp *= std::pow(lacunarity, -H);
+            }
+        }
+        float t = std::clamp(0.5f + 0.5f * val, 0.0f, 1.0f);
+        return colorLow * (1.0f - t) + colorHigh * t;
+    }
+};
+
+// ============================================================================
 // TEXTURED MATERIAL
 // ============================================================================
 

--- a/include/astroray/accretion_disk.h
+++ b/include/astroray/accretion_disk.h
@@ -134,7 +134,7 @@ public:
         return interpolate(flux_table, r);
     }
 
-    __attribute__((noinline))
+    ASTRORAY_NOINLINE
     double temperatureAt(double r) const {
         return interpolate(temp_table, r);
     }
@@ -143,7 +143,7 @@ public:
     // g = 1 / [(1 + Ω·r·sinθ·sinφ) / √(1 - 3M/r)]
     // theta here is the observer inclination, phi is the azimuthal position of the
     // disk element at crossing.
-    __attribute__((noinline))
+    ASTRORAY_NOINLINE
     double redshiftFactor(double r, double phi, double inclination) const {
         double M     = M_val;
         if (r <= 0.0) return 0.0;

--- a/include/astroray/black_hole.h
+++ b/include/astroray/black_hole.h
@@ -146,7 +146,7 @@ public:
 
     // --------------- GR rendering via virtual dispatch ---------------
 
-    __attribute__((noinline))
+    ASTRORAY_NOINLINE
     GRResult traceGR(const Ray& incomingRay, std::mt19937& gen) const override {
         // Minimal result: treat as captured (black hole shadow)
         GRResult result;

--- a/include/astroray/gr_integrator.h
+++ b/include/astroray/gr_integrator.h
@@ -104,7 +104,7 @@ inline Vec3 blToCartesianDir(const GeodesicState& s, const GeodesicState& ds) {
     return Vec3(float(dx)/len, float(dy)/len, float(dz)/len);
 }
 
-__attribute__((noinline)) IntegrationResult integrateGeodesic(
+ASTRORAY_NOINLINE IntegrationResult integrateGeodesic(
     const Metric&            metric,
     const NovikovThorneDisk* disk,       // nullptr if no disk
     const GeodesicState&     s_init,

--- a/include/astroray/gr_types.h
+++ b/include/astroray/gr_types.h
@@ -3,6 +3,15 @@
 #include <cstdint>
 #include <cstring>
 
+// MSVC does not support GCC __attribute__ syntax — provide a portable alias.
+#ifndef ASTRORAY_NOINLINE
+#  ifdef _MSC_VER
+#    define ASTRORAY_NOINLINE __declspec(noinline)
+#  else
+#    define ASTRORAY_NOINLINE __attribute__((noinline))
+#  endif
+#endif
+
 // ============================================================================
 // GR-specific data structures (all double precision for integrator stability)
 // ============================================================================

--- a/include/astroray/metric.h
+++ b/include/astroray/metric.h
@@ -28,7 +28,7 @@ class SchwarzschildMetric : public Metric {
 public:
     SchwarzschildMetric(double mass = 1.0) { M = mass; }
 
-    __attribute__((noinline)) GeodesicState geodesic_rhs(const GeodesicState& s) const override {
+    ASTRORAY_NOINLINE GeodesicState geodesic_rhs(const GeodesicState& s) const override {
         // Hamiltonian: H = -p_t²/(2f) + f·p_r²/2 + (p_θ² + p_φ²/sin²θ)/(2r²) = 0
         // f = 1 - 2M/r,  f' = 2M/r²
 

--- a/include/astroray/spectral.h
+++ b/include/astroray/spectral.h
@@ -12,7 +12,7 @@
 
 // Planck blackbody spectral radiance B(λ, T) in W/(m²·sr·m)
 // wavelength_nm in nm, temperature_K in Kelvin
-__attribute__((noinline)) double planck(double wavelength_nm, double temperature_K) {
+ASTRORAY_NOINLINE double planck(double wavelength_nm, double temperature_K) {
     if (temperature_K <= 0.0) return 0.0;
     double lam = wavelength_nm * 1e-9;  // nm → m
     // B = (2hc²/λ⁵) / (exp(hc/(λkT)) - 1)
@@ -119,7 +119,7 @@ inline double eval(const double* cmf, double lam) {
 } // namespace cie_cmf
 
 // Convert accumulated SpectralSample to CIE XYZ (Vec3, float)
-__attribute__((noinline)) Vec3 spectralToXYZ(const SpectralSample& s) {
+ASTRORAY_NOINLINE Vec3 spectralToXYZ(const SpectralSample& s) {
     double X = 0, Y = 0, Z = 0;
     for (int i = 0; i < 4; ++i) {
         double lam = s.wavelengths[i];
@@ -149,7 +149,7 @@ inline Vec3 xyzToLinearSRGB(const Vec3& xyz) {
 
 // Full pipeline: SpectralSample → linear sRGB, with optional exposure scaling
 // exposure == 0 means no scaling (caller handles auto-exposure externally)
-__attribute__((noinline)) Vec3 spectralToRGB(const SpectralSample& s, float exposureScale = 1.0f) {
+ASTRORAY_NOINLINE Vec3 spectralToRGB(const SpectralSample& s, float exposureScale = 1.0f) {
     Vec3 xyz = spectralToXYZ(s);
     xyz = xyz * exposureScale;
     return xyzToLinearSRGB(xyz);

--- a/include/raytracer.h
+++ b/include/raytracer.h
@@ -1445,6 +1445,13 @@ class Renderer {
     float filterGlossy = 0.0f;
     bool useReflectiveCaustics = true;
     bool useRefractiveCaustics = true;
+    int renderSeed = 0;  // 0 = random (non-deterministic), non-zero = deterministic seed
+    // Pixel reconstruction filter (0=Box, 1=Gaussian, 2=Blackman-Harris)
+    int pixelFilterType = 0;
+    float pixelFilterWidth = 1.5f;
+    // World/environment max bounces: env contribution is skipped for bounce > worldMaxBounces
+    // Default 1024 = effectively unlimited. Set to 0 for camera-only, 1 for one indirect bounce.
+    int worldMaxBounces = 1024;
 
     Vec3 clampLuminance(const Vec3& c, float maxLum) const {
         if (maxLum <= 0.0f) return c;
@@ -1464,6 +1471,12 @@ public:
     void setFilterGlossy(float value) { filterGlossy = std::max(0.0f, value); }
     void setUseReflectiveCaustics(bool use) { useReflectiveCaustics = use; }
     void setUseRefractiveCaustics(bool use) { useRefractiveCaustics = use; }
+    void setSeed(int s) { renderSeed = s; }
+    void setPixelFilter(int type, float width) {
+        pixelFilterType = std::clamp(type, 0, 2);
+        pixelFilterWidth = std::max(0.01f, width);
+    }
+    void setWorldMaxBounces(int maxB) { worldMaxBounces = std::max(0, maxB); }
     
     void clear() {
         scene.clear(); bvh.reset(); lights = LightList();
@@ -1477,8 +1490,37 @@ public:
         filterGlossy = 0.0f;
         useReflectiveCaustics = true;
         useRefractiveCaustics = true;
+        renderSeed = 0;
+        pixelFilterType = 0;
+        pixelFilterWidth = 1.5f;
+        worldMaxBounces = 1024;
     }
     
+    // Returns a sub-pixel jitter offset in [0,1) shaped by the reconstruction filter.
+    float filterSample(std::mt19937& gen, std::uniform_real_distribution<float>& dist) const {
+        if (pixelFilterType == 1) {
+            // Gaussian: Box-Muller centered at 0.5, sigma = filterWidth/6
+            float sigma = pixelFilterWidth / 6.0f;
+            float u1 = dist(gen);
+            float u2 = dist(gen);
+            if (u1 < 1e-7f) u1 = 1e-7f;
+            float z = std::sqrt(-2.0f * std::log(u1)) * std::cos(2.0f * float(M_PI) * u2);
+            return std::clamp(0.5f + z * sigma, 0.0f, 1.0f);
+        } else if (pixelFilterType == 2) {
+            // Blackman-Harris: rejection sampling within pixel
+            for (int attempt = 0; attempt < 20; ++attempt) {
+                float x = dist(gen);
+                float w = 0.35875f - 0.48829f * std::cos(2.0f * float(M_PI) * x)
+                                   + 0.14128f * std::cos(4.0f * float(M_PI) * x)
+                                   - 0.01168f * std::cos(6.0f * float(M_PI) * x);
+                if (dist(gen) < w) return x;
+            }
+            return dist(gen);
+        }
+        // Box filter: uniform jitter (default)
+        return dist(gen);
+    }
+
     float powerHeuristic(float a, float b) const {
         float a2 = a*a, b2 = b*b;
         float denom = a2 + b2;
@@ -1627,13 +1669,15 @@ Vec3 pathTrace(const Ray& r, int maxDepth, const PathBounceLimits& bounceLimits,
             HitRecord rec;
             if (!bvh->hit(ray, 0.001f, std::numeric_limits<float>::max(), rec)) {
                 Vec3 envColor;
-                if (envMap && envMap->loaded()) {
-                    envColor = envMap->lookup(ray.direction.normalized());
-                } else if (backgroundColor.x >= 0) {
-                    envColor = backgroundColor;
-                } else {
-                    float t = 0.5f * (ray.direction.normalized().y + 1.0f);
-                    envColor = (Vec3(1) * (1 - t) + Vec3(0.5f, 0.7f, 1.0f) * t) * 0.2f;
+                if (bounce <= worldMaxBounces) {
+                    if (envMap && envMap->loaded()) {
+                        envColor = envMap->lookup(ray.direction.normalized());
+                    } else if (backgroundColor.x >= 0) {
+                        envColor = backgroundColor;
+                    } else {
+                        float t = 0.5f * (ray.direction.normalized().y + 1.0f);
+                        envColor = (Vec3(1) * (1 - t) + Vec3(0.5f, 0.7f, 1.0f) * t) * 0.2f;
+                    }
                 }
                 if (bounce == 0 || wasSpecular) {
                     Vec3 contrib = throughput * envColor;
@@ -1819,7 +1863,10 @@ void render(Camera& cam, int maxSamples, int maxDepth, std::function<void(float)
         #pragma omp parallel for schedule(dynamic) collapse(2)
         for (int tileY = 0; tileY < tilesY; ++tileY) {
             for (int tileX = 0; tileX < tilesX; ++tileX) {
-                std::mt19937 gen(std::random_device{}() + tileY * tilesX + tileX);
+                uint32_t baseSeed = (renderSeed == 0)
+                    ? static_cast<uint32_t>(std::random_device{}())
+                    : static_cast<uint32_t>(renderSeed);
+                std::mt19937 gen(baseSeed + static_cast<uint32_t>(tileY * tilesX + tileX));
                 std::uniform_real_distribution<float> dist(0, 1);
                 int x0 = tileX * tileSize, x1 = std::min(x0 + tileSize, cam.width);
                 int y0 = tileY * tileSize, y1 = std::min(y0 + tileSize, cam.height);
@@ -1833,8 +1880,8 @@ void render(Camera& cam, int maxSamples, int maxDepth, std::function<void(float)
                         int samples = 0;
                         
                         for (int s = 0; s < maxSamples; ++s) {
-                            float u = (x + dist(gen)) / (cam.width - 1);
-                            float v = 1.0f - (y + dist(gen)) / (cam.height - 1);
+                            float u = (x + filterSample(gen, dist)) / (cam.width - 1);
+                            float v = 1.0f - (y + filterSample(gen, dist)) / (cam.height - 1);
                             Vec3 sAlb, sNorm;
                             float sAlpha = 1.0f;
                             Vec3 sCol = pathTrace(cam.getRay(u, v, gen), maxDepth, bounceLimits, gen, s == 0 ? &sAlb : nullptr, s == 0 ? &sNorm : nullptr, &sAlpha);

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -37,6 +37,64 @@ public:
             proceduralTextures[name] = std::make_shared<MarbleTexture>(params.size() > 0 ? params[0] : 1.0f);
         } else if (type == "wood") {
             proceduralTextures[name] = std::make_shared<WoodTexture>(params.size() > 0 ? params[0] : 1.0f);
+        } else if (type == "gradient") {
+            // params: [grad_type, scale, r1,g1,b1, r2,g2,b2]
+            int gt = params.size() > 0 ? (int)params[0] : 0;
+            float sc = params.size() > 1 ? params[1] : 1.0f;
+            Vec3 c1 = params.size() > 4 ? Vec3(params[2], params[3], params[4]) : Vec3(0);
+            Vec3 c2 = params.size() > 7 ? Vec3(params[5], params[6], params[7]) : Vec3(1);
+            proceduralTextures[name] = std::make_shared<GradientTexture>(gt, c1, c2, sc);
+        } else if (type == "wave") {
+            // params: [band_dir, profile, scale, distortion, detail, roughness, lacunarity, r1,g1,b1, r2,g2,b2]
+            int bd = params.size() > 0 ? (int)params[0] : 0;
+            int pf = params.size() > 1 ? (int)params[1] : 0;
+            float sc = params.size() > 2 ? params[2] : 5.0f;
+            float dist = params.size() > 3 ? params[3] : 0.0f;
+            float det = params.size() > 4 ? params[4] : 2.0f;
+            float rough = params.size() > 5 ? params[5] : 0.5f;
+            float lac = params.size() > 6 ? params[6] : 2.0f;
+            Vec3 c1 = params.size() > 9 ? Vec3(params[7], params[8], params[9]) : Vec3(0);
+            Vec3 c2 = params.size() > 12 ? Vec3(params[10], params[11], params[12]) : Vec3(1);
+            proceduralTextures[name] = std::make_shared<WaveTexture>(bd, pf, sc, dist, det, rough, lac, c1, c2);
+        } else if (type == "magic") {
+            // params: [depth, scale, distortion, r1,g1,b1, r2,g2,b2]
+            int depth = params.size() > 0 ? (int)params[0] : 2;
+            float sc = params.size() > 1 ? params[1] : 5.0f;
+            float dist = params.size() > 2 ? params[2] : 1.0f;
+            Vec3 c1 = params.size() > 5 ? Vec3(params[3], params[4], params[5]) : Vec3(0);
+            Vec3 c2 = params.size() > 8 ? Vec3(params[6], params[7], params[8]) : Vec3(1);
+            proceduralTextures[name] = std::make_shared<MagicTexture>(depth, sc, dist, c1, c2);
+        } else if (type == "voronoi") {
+            // params: [scale, randomness, dist_metric, feature, smoothness, r1,g1,b1, r2,g2,b2]
+            float sc = params.size() > 0 ? params[0] : 5.0f;
+            float rand = params.size() > 1 ? params[1] : 1.0f;
+            int dm = params.size() > 2 ? (int)params[2] : 0;
+            int feat = params.size() > 3 ? (int)params[3] : 0;
+            float smooth = params.size() > 4 ? params[4] : 1.0f;
+            Vec3 c1 = params.size() > 7 ? Vec3(params[5], params[6], params[7]) : Vec3(0);
+            Vec3 c2 = params.size() > 10 ? Vec3(params[8], params[9], params[10]) : Vec3(1);
+            proceduralTextures[name] = std::make_shared<VoronoiTexture>(sc, rand, dm, feat, smooth, c1, c2);
+        } else if (type == "brick") {
+            // params: [brick_r,g,b, mortar_r,g,b, brick_w, brick_h, mortar_size, offset, scale]
+            Vec3 brick = params.size() > 2 ? Vec3(params[0], params[1], params[2]) : Vec3(0.7f, 0.35f, 0.2f);
+            Vec3 mortar = params.size() > 5 ? Vec3(params[3], params[4], params[5]) : Vec3(0.9f);
+            float bw = params.size() > 6 ? params[6] : 0.5f;
+            float bh = params.size() > 7 ? params[7] : 0.25f;
+            float ms = params.size() > 8 ? params[8] : 0.02f;
+            float off = params.size() > 9 ? params[9] : 0.5f;
+            float sc = params.size() > 10 ? params[10] : 5.0f;
+            proceduralTextures[name] = std::make_shared<BrickTexture>(brick, mortar, bw, bh, ms, off, sc);
+        } else if (type == "musgrave") {
+            // params: [musgrave_type, scale, detail, dimension, lacunarity, gain, r1,g1,b1, r2,g2,b2]
+            int mt = params.size() > 0 ? (int)params[0] : 0;
+            float sc = params.size() > 1 ? params[1] : 5.0f;
+            float det = params.size() > 2 ? params[2] : 2.0f;
+            float dim = params.size() > 3 ? params[3] : 2.0f;
+            float lac = params.size() > 4 ? params[4] : 2.0f;
+            float g = params.size() > 5 ? params[5] : 1.0f;
+            Vec3 c1 = params.size() > 8 ? Vec3(params[6], params[7], params[8]) : Vec3(0);
+            Vec3 c2 = params.size() > 11 ? Vec3(params[9], params[10], params[11]) : Vec3(1);
+            proceduralTextures[name] = std::make_shared<MusgraveTexture>(mt, sc, det, dim, lac, g, c1, c2);
         }
     }
     std::shared_ptr<Texture> getTexture(const std::string& name) {
@@ -320,6 +378,18 @@ public:
         renderer.setFilterGlossy(value);
     }
 
+    void setSeed(int seed) {
+        renderer.setSeed(seed);
+    }
+
+    void setPixelFilter(int filterType, float filterWidth) {
+        renderer.setPixelFilter(filterType, filterWidth);
+    }
+
+    void setWorldMaxBounces(int maxB) {
+        renderer.setWorldMaxBounces(maxB);
+    }
+
     void setUseReflectiveCaustics(bool use) {
         renderer.setUseReflectiveCaustics(use);
     }
@@ -491,6 +561,9 @@ PYBIND11_MODULE(astroray, m) {
         .def("set_clamp_direct", &PyRenderer::setClampDirect, "value"_a)
         .def("set_clamp_indirect", &PyRenderer::setClampIndirect, "value"_a)
         .def("set_filter_glossy", &PyRenderer::setFilterGlossy, "value"_a)
+        .def("set_seed", &PyRenderer::setSeed, "seed"_a)
+        .def("set_pixel_filter", &PyRenderer::setPixelFilter, "filter_type"_a, "filter_width"_a)
+        .def("set_world_max_bounces", &PyRenderer::setWorldMaxBounces, "max_bounces"_a)
         .def("set_use_reflective_caustics", &PyRenderer::setUseReflectiveCaustics, "use"_a)
         .def("set_use_refractive_caustics", &PyRenderer::setUseRefractiveCaustics, "use"_a)
         .def("load_environment_map", &PyRenderer::loadEnvironmentMap,

--- a/tests/test_python_bindings.py
+++ b/tests/test_python_bindings.py
@@ -1638,6 +1638,63 @@ def test_bump_strength_zero_matches_no_bump_output():
 
 
 # ---------------------------------------------------------------------------
+# Seed control — issue #7
+# ---------------------------------------------------------------------------
+
+def test_pixel_filter():
+    """Box, Gaussian, and Blackman-Harris filters all produce valid renders."""
+    W, H = 80, 60
+
+    def do_render(filter_type, filter_width):
+        r = create_renderer()
+        r.set_seed(1)  # deterministic
+        r.set_adaptive_sampling(False)
+        r.set_pixel_filter(filter_type, filter_width)
+        mat = r.create_material('lambertian', [0.5, 0.5, 0.8], {})
+        r.add_sphere([0, 0, -3], 1.0, mat)
+        setup_camera(r, look_from=[0, 0, 5], look_at=[0, 0, 0], vfov=40, width=W, height=H)
+        return render_image(r, samples=8, apply_gamma=False)
+
+    box    = do_render(0, 1.0)
+    gauss  = do_render(1, 1.5)
+    bh     = do_render(2, 1.5)
+
+    for name, img in [('box', box), ('gaussian', gauss), ('blackman_harris', bh)]:
+        assert img is not None and img.size > 0, f"{name} filter produced empty render"
+        assert np.all(np.isfinite(img)), f"{name} filter produced NaN/Inf pixels"
+        assert np.any(img > 0), f"{name} filter produced all-black render"
+        save_image(img, os.path.join(OUTPUT_DIR, f'test_pixel_filter_{name}.png'))
+
+
+def test_seed_determinism():
+    """Same seed must produce identical renders; different seeds must differ."""
+    W, H = 80, 60
+
+    def do_render(seed):
+        r = create_renderer()
+        r.set_seed(seed)
+        r.set_adaptive_sampling(False)
+        mat = r.create_material('lambertian', [0.7, 0.2, 0.2], {})
+        r.add_sphere([0, 0, -3], 1.0, mat)
+        setup_camera(r, look_from=[0, 0, 5], look_at=[0, 0, 0], vfov=40, width=W, height=H)
+        return render_image(r, samples=8, apply_gamma=False)
+
+    render_a1 = do_render(42)
+    render_a2 = do_render(42)
+    render_b  = do_render(123)
+
+    # Same seed → identical pixels
+    assert np.array_equal(render_a1, render_a2), \
+        "Same seed produced different renders (non-deterministic)."
+
+    # Different seeds → at least one pixel differs
+    assert not np.array_equal(render_a1, render_b), \
+        "Different seeds produced identical renders."
+
+    save_image(render_a1, os.path.join(OUTPUT_DIR, 'test_seed_determinism.png'))
+
+
+# ---------------------------------------------------------------------------
 # Stand-alone entry-point for direct execution
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
…, and node evaluation (#67)

Implements GitHub issues #7, #10, #13, #19, #21, #22:

- **#7 Seed control**: Add `renderSeed` to Renderer; deterministic renders with `set_seed(n)`, random when n=0; animated seed via Blender cycles.seed + frame_current. New test: `test_seed_determinism`.

- **#10 Pixel filter**: Box / Gaussian / Blackman-Harris reconstruction filters with configurable width; `set_pixel_filter(type, width)` Python API wired to cycles.pixel_filter_type / filter_width. New test: `test_pixel_filter`.

- **#13 World max bounces**: `worldMaxBounces` limits which bounce depths can see the environment/HDRI; default 1024 (no limit). Wired to world.light_settings.max_bounces in the Blender addon.

- **#19 Procedural texture nodes**: Six new C++ texture classes — GradientTexture, WaveTexture, MagicTexture, VoronoiTexture, BrickTexture, MusgraveTexture — plus Python bindings and Blender node export for TEX_NOISE, TEX_CHECKER, TEX_VORONOI, TEX_WAVE, TEX_MAGIC, TEX_BRICK, TEX_GRADIENT, TEX_MUSGRAVE.

- **#21/#22 Color and converter node evaluation**: Export-time constant-folding for Math, Clamp, Map Range, MixRGB, Invert, Gamma, Hue-Sat, BrightContrast, Color Ramp, Wavelength, Blackbody, RGB-to-BW. get_float_input / get_color_input now traverse linked node chains.

- **fix: MSVC __attribute__((noinline)) compatibility**: Replace GCC attribute with portable ASTRORAY_NOINLINE macro in all GR/spectral headers (gr_types.h, metric.h, accretion_disk.h, gr_integrator.h, spectral.h, black_hole.h) — fixes Windows/MSVC builds.

All 66 existing tests pass + 2 new tests added (66 passed, 1 skipped).