### PR TITLE
Revert "feat: add optional OIDN denoiser pass with beauty/albedo/normal inputs"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,6 @@ option(BUILD_DOCS "Build documentation" OFF)
 option(USE_NATIVE_ARCH "Build with -march=native" ON)
 option(USE_FAST_MATH "Enable fast math optimizations" ON)
 option(ASTRORAY_ENABLE_CUDA "Enable CUDA GPU acceleration" ON)
-option(ASTRORAY_ENABLE_OIDN "Enable Intel Open Image Denoise integration" ON)
 # Disable OpenMP entirely. Needed when building the Python module (.pyd) for
 # distribution as a Blender addon: MinGW's libgomp deadlocks during module
 # init when loaded into Blender's MSVC-built Python host. Standalone pytest
@@ -46,28 +45,6 @@ if(ASTRORAY_ENABLE_CUDA)
 else()
     set(ASTRORAY_CUDA_FOUND FALSE)
     message(STATUS "CUDA disabled via ASTRORAY_ENABLE_CUDA=OFF")
-endif()
-
-# ---------------------------------------------------------------------------
-# OIDN detection (graceful fallback when library not installed)
-# ---------------------------------------------------------------------------
-if(ASTRORAY_ENABLE_OIDN)
-    find_package(OpenImageDenoise CONFIG QUIET)
-    if(OpenImageDenoise_FOUND)
-        set(ASTRORAY_OIDN_FOUND TRUE)
-        if(TARGET OpenImageDenoise::OpenImageDenoise)
-            set(ASTRORAY_OIDN_TARGET OpenImageDenoise::OpenImageDenoise)
-        elseif(TARGET OpenImageDenoise)
-            set(ASTRORAY_OIDN_TARGET OpenImageDenoise)
-        endif()
-        message(STATUS "OIDN found — denoiser support enabled")
-    else()
-        set(ASTRORAY_OIDN_FOUND FALSE)
-        message(STATUS "OIDN not found — denoiser support disabled")
-    endif()
-else()
-    set(ASTRORAY_OIDN_FOUND FALSE)
-    message(STATUS "OIDN disabled via ASTRORAY_ENABLE_OIDN=OFF")
 endif()
 
 # Compiler flags for optimization
@@ -215,11 +192,6 @@ if(ASTRORAY_CUDA_FOUND)
     target_compile_definitions(raytracer_standalone PRIVATE ASTRORAY_CUDA_ENABLED)
 endif()
 
-if(ASTRORAY_OIDN_FOUND AND ASTRORAY_OIDN_TARGET)
-    target_link_libraries(raytracer_standalone PRIVATE ${ASTRORAY_OIDN_TARGET})
-    target_compile_definitions(raytracer_standalone PRIVATE ASTRORAY_OIDN_ENABLED)
-endif()
-
 # Set output name and configuration-specific properties
 set_target_properties(raytracer_standalone PROPERTIES
     OUTPUT_NAME raytracer
@@ -300,11 +272,6 @@ if(BUILD_PYTHON_MODULE)
         target_compile_definitions(astroray PRIVATE ASTRORAY_CUDA_ENABLED)
     endif()
 
-    if(ASTRORAY_OIDN_FOUND AND ASTRORAY_OIDN_TARGET)
-        target_link_libraries(astroray PRIVATE ${ASTRORAY_OIDN_TARGET})
-        target_compile_definitions(astroray PRIVATE ASTRORAY_OIDN_ENABLED)
-    endif()
-
     # Set output directory to CMAKE_BINARY_DIR for both Windows and Linux
     # pybind11_add_module automatically handles .pyd on Windows and .so on Linux
     set_target_properties(astroray PROPERTIES
@@ -355,11 +322,6 @@ if(BUILD_BLENDER_MODULE)
     
     if(OpenMP_CXX_FOUND)
         target_link_libraries(raytracer_blender PRIVATE OpenMP::OpenMP_CXX)
-    endif()
-
-    if(ASTRORAY_OIDN_FOUND AND ASTRORAY_OIDN_TARGET)
-        target_link_libraries(raytracer_blender PRIVATE ${ASTRORAY_OIDN_TARGET})
-        target_compile_definitions(raytracer_blender PRIVATE ASTRORAY_OIDN_ENABLED)
     endif()
     
     # Set properties for Python module
@@ -437,7 +399,6 @@ message(STATUS "OpenMP: ${OpenMP_CXX_FOUND}")
 message(STATUS "Native arch: ${USE_NATIVE_ARCH}")
 message(STATUS "Fast math: ${USE_FAST_MATH}")
 message(STATUS "CUDA GPU backend: ${ASTRORAY_CUDA_FOUND}")
-message(STATUS "OIDN denoiser: ${ASTRORAY_OIDN_FOUND}")
 message(STATUS "Python module: ${BUILD_PYTHON_MODULE}")
 if(BUILD_PYTHON_MODULE)
     message(STATUS "  Python: ${Python3_VERSION}")

--- a/include/raytracer.h
+++ b/include/raytracer.h
@@ -11,7 +11,6 @@
 #include <array>
 #include <cstdint>
 #include <cstddef>
-#include <cctype>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
@@ -19,9 +18,6 @@
 #include <string>
 #include <unordered_map>
 #include "stb_image.h"
-#ifdef ASTRORAY_OIDN_ENABLED
-#include <OpenImageDenoise/oidn.hpp>
-#endif
 
 // Forward declaration needed by HitRecord
 class Hittable;
@@ -1715,8 +1711,6 @@ class Renderer {
     float filterGlossy = 0.0f;
     bool useReflectiveCaustics = true;
     bool useRefractiveCaustics = true;
-    bool useDenoiser = false;
-    std::string denoiserType = "none";
     int renderSeed = 0;  // 0 = random (non-deterministic), non-zero = deterministic seed
     // Pixel reconstruction filter (0=Box, 1=Gaussian, 2=Blackman-Harris)
     int pixelFilterType = 0;
@@ -1746,55 +1740,7 @@ class Renderer {
             std::exp(-std::max(0.0f, sigmaT.z) * d)
         );
     }
-
-    void runDenoiser(Camera& cam) const {
-        if (!useDenoiser) return;
-        if (denoiserType != "oidn") return;
-#ifdef ASTRORAY_OIDN_ENABLED
-        const size_t pixelCount = static_cast<size_t>(cam.width) * static_cast<size_t>(cam.height);
-        if (cam.pixels.size() != pixelCount || cam.albedoBuffer.size() != pixelCount || cam.normalBuffer.size() != pixelCount) {
-            return;
-        }
-
-        std::vector<float> beauty(pixelCount * 3);
-        std::vector<float> albedo(pixelCount * 3);
-        std::vector<float> normal(pixelCount * 3);
-        std::vector<float> denoised(pixelCount * 3, 0.0f);
-        for (size_t i = 0; i < pixelCount; ++i) {
-            beauty[i*3] = cam.pixels[i].x;
-            beauty[i*3 + 1] = cam.pixels[i].y;
-            beauty[i*3 + 2] = cam.pixels[i].z;
-            albedo[i*3] = cam.albedoBuffer[i].x;
-            albedo[i*3 + 1] = cam.albedoBuffer[i].y;
-            albedo[i*3 + 2] = cam.albedoBuffer[i].z;
-            normal[i*3] = cam.normalBuffer[i].x;
-            normal[i*3 + 1] = cam.normalBuffer[i].y;
-            normal[i*3 + 2] = cam.normalBuffer[i].z;
-        }
-
-        oidn::DeviceRef device = oidn::newDevice();
-        device.commit();
-
-        oidn::FilterRef filter = device.newFilter("RT");
-        filter.setImage("color", beauty.data(), oidn::Format::Float3, cam.width, cam.height);
-        filter.setImage("albedo", albedo.data(), oidn::Format::Float3, cam.width, cam.height);
-        filter.setImage("normal", normal.data(), oidn::Format::Float3, cam.width, cam.height);
-        filter.setImage("output", denoised.data(), oidn::Format::Float3, cam.width, cam.height);
-        filter.set("hdr", true);
-        filter.commit();
-        filter.execute();
-
-        const char* errorMessage = nullptr;
-        if (device.getError(errorMessage) != oidn::Error::None) {
-            return;
-        }
-
-        for (size_t i = 0; i < pixelCount; ++i) {
-            cam.pixels[i] = Vec3(denoised[i*3], denoised[i*3 + 1], denoised[i*3 + 2]);
-        }
-#endif
-    }
-     
+    
 public:
     void setEnvironmentMap(std::shared_ptr<EnvironmentMap> map) { envMap = map; }
     void setBackgroundColor(const Vec3& color) { backgroundColor = color; }
@@ -1806,12 +1752,6 @@ public:
     void setFilterGlossy(float value) { filterGlossy = std::max(0.0f, value); }
     void setUseReflectiveCaustics(bool use) { useReflectiveCaustics = use; }
     void setUseRefractiveCaustics(bool use) { useRefractiveCaustics = use; }
-    void setUseDenoiser(bool use) { useDenoiser = use; }
-    void setDenoiserType(const std::string& type) {
-        std::string key = type;
-        for (char& c : key) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
-        denoiserType = (key == "oidn") ? "oidn" : "none";
-    }
     void setSeed(int s) { renderSeed = s; }
     void setPixelFilter(int type, float width) {
         pixelFilterType = std::clamp(type, 0, 2);
@@ -2462,7 +2402,6 @@ void render(Camera& cam, int maxSamples, int maxDepth, std::function<void(float)
                 if (progress) progress(float(++tilesCompleted) / totalTiles);
             }
         }
-        runDenoiser(cam);
     }
 };
 

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -456,14 +456,6 @@ public:
         renderer.setUseRefractiveCaustics(use);
     }
 
-    void setUseDenoiser(bool use) {
-        renderer.setUseDenoiser(use);
-    }
-
-    void setDenoiserType(const std::string& type) {
-        renderer.setDenoiserType(type);
-    }
-
     void setUseTransparentFilm(bool use) {
         renderer.setUseTransparentFilm(use);
     }
@@ -839,8 +831,6 @@ PYBIND11_MODULE(astroray, m) {
              "density"_a, "color"_a, "anisotropy"_a = 0.0f)
         .def("set_use_reflective_caustics", &PyRenderer::setUseReflectiveCaustics, "use"_a)
         .def("set_use_refractive_caustics", &PyRenderer::setUseRefractiveCaustics, "use"_a)
-        .def("set_use_denoiser", &PyRenderer::setUseDenoiser, "use"_a)
-        .def("set_denoiser_type", &PyRenderer::setDenoiserType, "type"_a)
         .def("load_environment_map", &PyRenderer::loadEnvironmentMap,
               "path"_a, "strength"_a = 1.0f, "rotation"_a = 0.0f)
         .def("set_background_color", &PyRenderer::setBackgroundColor, "color"_a)
@@ -874,14 +864,9 @@ PYBIND11_MODULE(astroray, m) {
         "adaptive_sampling"_a=true, "volumes"_a=true, "textures"_a=true, "subsurface"_a=true,
         "gr_black_holes"_a=true,
 #ifdef ASTRORAY_CUDA_ENABLED
-        "cuda"_a=true,
+        "cuda"_a=true
 #else
-        "cuda"_a=false,
-#endif
-#ifdef ASTRORAY_OIDN_ENABLED
-        "oidn"_a=true
-#else
-        "oidn"_a=false
+        "cuda"_a=false
 #endif
     );
 }

--- a/tests/test_python_bindings.py
+++ b/tests/test_python_bindings.py
@@ -74,7 +74,6 @@ def test_module_version():
     features = astroray.__features__
     for key in ('nee', 'mis', 'disney_brdf', 'sah_bvh', 'adaptive_sampling'):
         assert key in features, f"Missing feature key: {key}"
-    assert 'oidn' in features, "Missing 'oidn' key in __features__"
 
 
 def test_renderer_creation():
@@ -1444,34 +1443,6 @@ def test_render_apply_gamma_toggle():
     expected_gamma_image = np.power(np.clip(linear, 0.0, 1.0), 1.0 / 2.2)
     assert np.allclose(gamma, expected_gamma_image, atol=0.03), \
         "Gamma output should match pow(linear, 1/2.2) per pixel"
-
-
-def _render_for_denoiser_test(use_denoiser: bool, denoiser_type: str = "none") -> np.ndarray:
-    r = create_renderer()
-    r.set_seed(1337)
-    create_cornell_box(r)
-    mat = r.create_material('lambertian', [0.8, 0.3, 0.3], {})
-    r.add_sphere([0, -0.5, 0], 1.0, mat)
-    r.set_use_denoiser(use_denoiser)
-    r.set_denoiser_type(denoiser_type)
-    setup_camera(r, look_from=[0, 0, 5.5], look_at=[0, 0, 0], vfov=38, width=100, height=75)
-    return render_image(r, samples=SAMPLES_FAST, max_depth=8, apply_gamma=False)
-
-
-def test_denoiser_none_matches_disabled():
-    off = _render_for_denoiser_test(use_denoiser=False, denoiser_type="none")
-    none_enabled = _render_for_denoiser_test(use_denoiser=True, denoiser_type="none")
-    assert np.allclose(off, none_enabled, atol=1e-6), "Denoiser type 'none' should be a no-op"
-
-
-def test_oidn_denoiser_graceful_fallback_or_finite_output():
-    oidn_output = _render_for_denoiser_test(use_denoiser=True, denoiser_type="oidn")
-    assert oidn_output.shape == (75, 100, 3)
-    assert np.isfinite(oidn_output).all(), "OIDN output must remain finite"
-    if not astroray.__features__.get("oidn", False):
-        off = _render_for_denoiser_test(use_denoiser=False, denoiser_type="none")
-        assert np.allclose(off, oidn_output, atol=1e-6), \
-            "When OIDN is unavailable, enabling OIDN should gracefully fall back to no-op"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Reverts HendrikGC02/Astroray#79

=========================== short test summary info ============================
FAILED tests/test_material_properties.py::test_disney_roughness_changes_glossiness - AssertionError: disney_r0.3: contains NaN values
FAILED tests/test_material_properties.py::test_disney_clearcoat_adds_gloss - AssertionError: no_clearcoat: contains NaN values
FAILED tests/test_material_properties.py::test_no_material_is_overexposed - AssertionError: disney_metallic: mean nan ≥ 0.90 — BRDF likely broken (energy not conserved)
assert nan < 0.9
FAILED tests/test_python_bindings.py::test_glossy_matches_principled_metallic_roughness - AssertionError: disney_parity: contains NaN values
FAILED tests/test_python_bindings.py::test_glossy_bounces_zero_reduces_specular_reflections - AssertionError: glossy_disabled: contains NaN values
FAILED tests/test_python_bindings.py::test_disney_brdf_render - AssertionError: disney_brdf: contains NaN values
FAILED tests/test_python_bindings.py::test_disney_brdf_parameter_grid - AssertionError: Dielectric Rough: contains NaN values
FAILED tests/test_python_bindings.py::test_material_comparison_grid - AssertionError: Disney Metal: contains NaN values
FAILED tests/test_python_bindings.py::test_sampling_convergence - AssertionError: 4spp: contains NaN values
FAILED tests/test_python_bindings.py::test_adaptive_sampling_flag - AssertionError: adaptive: contains NaN values
FAILED tests/test_python_bindings.py::test_metallic_vs_diffuse_differ - AssertionError: diffuse: contains NaN values
FAILED tests/test_python_bindings.py::test_performance_benchmark - AssertionError: 10 objects: contains NaN values
FAILED tests/test_python_bindings.py::test_quality_analysis - AssertionError: Low (16 spp): PSNR nan dB regressed below previous 0.0 dB
assert nan >= (0.0 - 3.0)
FAILED tests/test_python_bindings.py::test_black_hole_showcase_scene - AssertionError: bh_showcase: contains NaN values
FAILED tests/test_python_bindings.py::test_normal_map_adds_visible_surface_detail - AssertionError: normal_mapped: contains NaN values
FAILED tests/test_python_bindings.py::test_normal_map_shifts_specular_highlights - assert (241 > 0 and 0 > 0)
 +  where 241 = array([117, 118, 112, 115, 116, 117, 119, 120, 112, 113, 114, 115, 116,\n       117, 118, 119, 120, 121, 122, 111, 112, 113, 114, 115, 116, 117,\n       118, 119, 120, 121, 122, 123, 124, 125, 110, 111, 112, 113, 114,\n       115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 110, 111,\n       112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124,\n       126, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121,\n       122, 123, 124, 125, 126, 108, 110, 111, 112, 113, 114, 115, 116,\n       117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 110, 111,\n       112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124,\n       125, 126, 127, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118,\n       119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 109, 110, 111,\n       112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124,\n       125, 126, 127, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119,\n       120, 121, 122, 123, 124, 125, 126, 110, 111, 112, 113, 114, 115,\n       116, 117, 118, 119, 120, 121, 122, 123, 124, 126, 111, 112, 113,\n       114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 112,\n       113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125,\n       113, 115, 116, 117, 118, 119, 120, 121, 122, 123, 114, 116, 117,\n       118, 119, 120, 121, 122, 118, 119]).size
 +  and   0 = array([], dtype=int64).size
