### PR TITLE
docs(pillar2): plan pkg11-14 — remaining spectral-core migration

### DIFF
--- a/.astroray_plan/packages/pkg11-spectral-path-tracer.md
+++ b/.astroray_plan/packages/pkg11-spectral-path-tracer.md
@@ -1,0 +1,184 @@
+# pkg11 — Spectral path tracer
+
+**Pillar:** 2
+**Track:** A
+**Status:** open
+**Estimated effort:** 1 week (~3 sessions)
+**Depends on:** pkg10
+
+---
+
+## Goal
+
+**Before:** the pkg10 spectral types compile and are tested in isolation,
+but no integrator consumes them. The default integrator is the legacy
+RGB `path_tracer` plugin; `Integrator::sampleSpectral` returns a
+flat-luminance fallback over the legacy `SpectralSample`.
+
+**After:** a new `spectral_path_tracer` plugin (registered alongside
+the existing `path_tracer` and `ambient_occlusion`) traces with
+`SampledSpectrum` throughout — radiance, throughput, BSDF eval, light
+contribution. `Material` gains a virtual `evalSpectral(...)` with a
+default that calls the existing RGB `eval(...)` and upsamples via
+Jakob-Hanika; concrete materials override it in pkg12–13. The renderer
+accumulates XYZ per pixel when this integrator is active and converts
+to sRGB once at framebuffer write time. The legacy `path_tracer` stays
+the registry default — flipping the default is pkg14.
+
+---
+
+## Context
+
+This is Phase 2B of the Pillar 2 roadmap (spectral-core.md). It is the
+"shadow path tracer" step: spectral and RGB code paths run side by side,
+selectable from Python via `set_integrator("spectral_path_tracer")`,
+so we can A/B compare on a single scene before committing the renderer
+to spectral-only. The default `evalSpectral` fallback is the load-bearing
+piece — without it, every existing material would have to migrate before
+the spectral integrator is even runnable. With it, pkg11 ships a working
+end-to-end spectral path on day one and pkg12+ migrate materials one at
+a time, each step keeping the test suite green.
+
+---
+
+## Reference
+
+- Design doc: `.astroray_plan/docs/spectral-core.md §Migration strategy → Phase 2B`
+- Per-path lifecycle pseudocode: same doc, §Per-path lifecycle
+- Existing integrator pattern: `plugins/integrators/path_tracer.cpp`,
+  `plugins/integrators/ambient_occlusion.cpp`
+- Integrator base + `SampleResult`: `include/astroray/integrator.h`
+- Spectral types: `include/astroray/spectrum.h` (pkg10)
+- Material interface: `include/astroray/material.h`,
+  `include/raytracer.h` (Material::eval)
+
+---
+
+## Prerequisites
+
+- [ ] pkg10 is merged on `main`; `tests/test_spectrum.py` is green.
+- [ ] Build is green on `main`: `cmake -B build && cmake --build build -j && pytest tests/ -v`.
+- [ ] A reference Cornell box render exists from `main` for the A/B
+      comparison check below.
+
+---
+
+## Specification
+
+### Files to create
+
+| File | Purpose |
+|---|---|
+| `plugins/integrators/spectral_path_tracer.cpp` | Registers `spectral_path_tracer`. Implements `sampleSpectral(ray, gen) -> SampleResult` using `SampledWavelengths::sampleUniform`, recursive bounce loop, MIS-equivalent NEE, firefly clamp at luminance > 20.0f, emission only when `wasSpecular` or `bounce==0`. Returns `SampleResult` with `radiance` populated as the XYZ projection (`rad.toXYZ(lambdas) / kSpectrumSamples`) so the existing RGB framebuffer path keeps working. |
+| `tests/test_spectral_path_tracer.py` | pytest: spectral integrator registers; A/B Cornell box renders within 1% mean brightness of legacy `path_tracer`; prism scene shows dispersion in spectral mode (qualitative — distinct R/G/B exit angles assert non-zero spread); existing 189 tests still pass. |
+| `tests/data/cornell_spectral_baseline.exr` *(optional)* | Reference baseline for pixel-mean comparison if EXR support exists; otherwise a JSON of mean RGB. |
+
+### Files to modify
+
+| File | What changes |
+|---|---|
+| `include/astroray/material.h` | Add `virtual SampledSpectrum evalSpectral(const Vec3& wo, const Vec3& wi, const Vec3& normal, const Vec2& uv, const SampledWavelengths& lambdas) const`. Default implementation: call `eval(wo, wi, normal, uv)` to get RGB, build `RGBAlbedoSpectrum(rgb)` and return `.sample(lambdas)`. Same for any other return-radiance entry point currently on the interface (e.g. `emitted`/`emission` if present — add `emittedSpectral` mirror with `RGBIlluminantSpectrum` fallback). Keep all existing `Vec3` methods unchanged. |
+| `include/astroray/integrator.h` | Replace the placeholder `sampleSpectral` default with one that delegates to `sample(ray, gen)` and upsamples the resulting RGB radiance via `RGBIlluminantSpectrum`. New plugins override either `sample` or `sampleSpectral`; `Renderer` picks based on integrator capability flag (see below). |
+| `include/raytracer.h` (`Renderer`) | Add `bool spectralMode_` set when the active integrator advertises `kind() == IntegratorKind::Spectral`. When true, the per-pixel accumulator stores XYZ; final sRGB conversion uses the `xyzToLinearSRGB` matrix already in `spectral.h`. RGB integrators continue to write into the RGB accumulator unchanged. The firefly clamp moves to operate on luminance computed from XYZ when in spectral mode. |
+| `module/blender_module.cpp` | Expose `set_integrator("spectral_path_tracer")` (already works via the registry binding from pkg05 — verify and add a Blender UI option). Add `is_spectral_mode()` debug binding. |
+| `.astroray_plan/docs/STATUS.md` | Mark pkg11 in-progress → done; bump Pillar 2 % to ~40; surface pkg12 as next. |
+| `CHANGELOG.md` | Add pkg11 entry under "Pillar 2 — Spectral core (in progress)". |
+
+### Files explicitly NOT touched
+
+- `plugins/integrators/path_tracer.cpp` — legacy RGB integrator stays
+  the registry default.
+- `plugins/materials/*.cpp` — every material keeps its `Vec3 eval`;
+  spectral overrides land in pkg12 (Lambertian) and pkg13 (rest).
+- `plugins/passes/*.cpp` — passes still operate on the RGB framebuffer.
+- `include/astroray/spectral.h` — GR renderer still depends on it.
+- Env map / HDRI handling — that is pkg14.
+
+### Key design decisions
+
+1. **Two integrator paths, one Renderer.** Legacy `Integrator::sample`
+   returns RGB `SampleResult`; new `sampleSpectral` returns the same
+   shape with the radiance pre-projected to XYZ. The Renderer chooses
+   which to call from a `kind()` enum. This avoids a whole-codebase
+   API churn and keeps RGB plugins (AO, future toy integrators) working.
+2. **Default `evalSpectral` is a Jakob-Hanika upsample of `eval`.** This
+   is the entire reason pkg11 can ship before pkg12. Materials missing
+   a spectral override produce identical results to RGB mode — the only
+   visible difference is dispersive ones (handled by overrides in
+   pkg13's dielectric).
+3. **Hero-wavelength sampling per pixel sample.** `SampledWavelengths::sampleUniform(rng())`
+   per primary ray, propagated through every bounce. At a dispersive
+   interface the override calls `lambdas.terminateSecondary()`.
+4. **XYZ accumulation, single conversion at output.** The per-pixel
+   accumulator is XYZ in spectral mode; sRGB conversion happens in
+   `Renderer::render` exactly once, alongside gamma correction (the
+   project's "gamma once" invariant is preserved).
+5. **No new Material plugins.** Every existing material keeps its
+   single-file plugin; the `evalSpectral` override lives in the same
+   file when added in pkg12+.
+6. **Firefly clamp in spectral mode.** Luminance is computed from the
+   XYZ Y component (well-defined, photometric); the threshold stays
+   20.0f exactly to preserve current image character.
+7. **No MIS rewrite.** Existing NEE / multiple importance sampling code
+   is rewired to operate on `SampledSpectrum`; the math is identical
+   componentwise. Variance reduction over hero wavelengths is a future
+   tuning package, not pkg11.
+
+---
+
+## Acceptance criteria
+
+- [ ] `astroray.integrator_registry_names()` contains `"spectral_path_tracer"`.
+- [ ] Cornell box at 32 spp rendered with `spectral_path_tracer` matches
+      the legacy `path_tracer` baseline mean RGB within 1% per channel.
+- [ ] A glass-prism scene under D65 illumination renders visible
+      rainbow dispersion in spectral mode (R/G/B exit-ray spread > 0)
+      and a single refracted spot in RGB mode.
+- [ ] Spectral render time on Cornell box at 32 spp is no more than
+      1.5× the RGB render time.
+- [ ] All previously-passing tests still pass (189 + new).
+- [ ] No signature change to any existing `Material::eval` — only new
+      virtual methods added with safe defaults.
+- [ ] `plugins/passes/*.cpp` and `plugins/materials/*.cpp` are unchanged.
+
+---
+
+## Non-goals
+
+- No migration of any concrete material (Lambertian, Metal, Dielectric,
+  Disney, etc.) to a spectral-native `evalSpectral` body. That is
+  pkg12–13.
+- No spectral env map sampling. The env map still returns RGB; the
+  default upsampling kicks in transparently. pkg14 makes it native.
+- No deletion of `pathTrace` or `path_tracer` plugin. pkg14 flips the
+  default.
+- No new spectral AOV pass.
+- No measured-BRDF or Hošek-Wilkie work.
+- No tuning of `kSpectrumSamples`.
+- No GR-renderer changes — `spectral.h` and the GR path stay frozen.
+
+---
+
+## Progress
+
+- [ ] Branch `pkg11-spectral-path-tracer` from `main`.
+- [ ] Add `evalSpectral` (and `emittedSpectral` if applicable) defaults
+      to `Material` interface with Jakob-Hanika upsample.
+- [ ] Wire `IntegratorKind` enum + `Renderer::spectralMode_` switch
+      and XYZ accumulator path.
+- [ ] Implement `plugins/integrators/spectral_path_tracer.cpp`.
+- [ ] Add Blender UI option for the spectral integrator.
+- [ ] Build a glass-prism reference scene under `tests/scenes/` (or
+      reuse an existing Cornell box variant) and capture pre-pkg11
+      baseline.
+- [ ] Write `tests/test_spectral_path_tracer.py`.
+- [ ] Run full pytest; render Cornell + prism A/B comparison.
+- [ ] Profile spectral vs RGB on Cornell — confirm ≤1.5× ratio.
+- [ ] Update STATUS.md, CHANGELOG.md.
+- [ ] Commit per granularity plan; push branch; open PR.
+
+---
+
+## Lessons
+
+*(Fill in after the package is done.)*

--- a/.astroray_plan/packages/pkg12-spectral-lambertian.md
+++ b/.astroray_plan/packages/pkg12-spectral-lambertian.md
@@ -1,0 +1,147 @@
+# pkg12 — Spectral Lambertian
+
+**Pillar:** 2
+**Track:** A
+**Status:** open
+**Estimated effort:** 1 session (~2–3 h)
+**Depends on:** pkg11
+
+---
+
+## Goal
+
+**Before:** all materials, including Lambertian, rely on the default
+`evalSpectral` from pkg11 — Jakob-Hanika upsamples the RGB albedo at
+every shading event. Correct, but redundant: the upsample is recomputed
+per-call from the same `Vec3 albedo`. No material has yet demonstrated
+the spectral-native pattern.
+
+**After:** `plugins/materials/lambertian.cpp` overrides `evalSpectral`
+(and emission/`emittedSpectral` if Lambertian carries an emissive
+variant). The override caches a `RGBAlbedoSpectrum` once per material
+instance and samples it on demand: `albedo_spec_.sample(lambdas) / pi`.
+Identical numerical behaviour to the default fallback (verified by
+test) but ~3–5× faster in spectral mode and pattern-establishing for
+pkg13. Lambertian becomes the reference example of "what a spectral
+material looks like in this codebase."
+
+---
+
+## Context
+
+Phase 2C of Pillar 2 begins here. Lambertian is the right first
+material for the same reason it was first to migrate to plugins in
+pkg02: minimal BSDF (constant ÷ π), no Fresnel, no anisotropy, no
+microfacet machinery. Whatever pattern lands here gets copy-pasted
+across nine other materials in pkg13. Picking the wrong cache shape
+or naming convention costs nine refactors downstream. Keep it boring,
+keep it ugly-direct, keep it copy-pastable.
+
+---
+
+## Reference
+
+- Design doc: `.astroray_plan/docs/spectral-core.md §Phase 2C`
+- Default fallback we're replacing: `Material::evalSpectral` (added in pkg11)
+- Existing Lambertian: `plugins/materials/lambertian.cpp`
+- pkg10 spectral types: `include/astroray/spectrum.h`
+
+---
+
+## Prerequisites
+
+- [ ] pkg11 is merged on `main`; `spectral_path_tracer` integrator is
+      present in the registry; A/B Cornell parity is established.
+- [ ] Build is green; full pytest passes.
+
+---
+
+## Specification
+
+### Files to create
+
+| File | Purpose |
+|---|---|
+| `tests/test_spectral_lambertian.py` | pytest: spectral Lambertian render of a uniform-grey wall under D65 produces XYZ within 1% of the analytical D65×albedo expectation; spectral-mode render of a coloured Cornell box matches RGB-mode render within 1% mean per channel; cache is built once (private bookkeeping check via a debug counter or via timing parity to pkg10 LUT lookups). |
+
+### Files to modify
+
+| File | What changes |
+|---|---|
+| `plugins/materials/lambertian.cpp` | Add member `RGBAlbedoSpectrum albedo_spec_` (or equivalent — either eagerly initialised in the constructor from the existing `albedo_` `Vec3`, or lazily on first `evalSpectral` call behind a `std::once_flag`). Override `evalSpectral` returning `albedo_spec_.sample(lambdas) * (1.0f / float(M_PI))`. If the plugin currently exposes `emit`/emission for emissive subclasses, mirror with `emittedSpectral` using `RGBIlluminantSpectrum`. Keep `eval` unchanged. |
+| `.astroray_plan/docs/STATUS.md` | Mark pkg12 done; bump Pillar 2 % to ~55. |
+| `CHANGELOG.md` | Add pkg12 entry. |
+
+### Files explicitly NOT touched
+
+- Any other material plugin (those are pkg13).
+- `Material::eval`, `Material::evalSpectral` defaults — no signature
+  change in pkg12.
+- `Renderer`, `Integrator`, framebuffer code.
+
+### Key design decisions
+
+1. **Eager cache, not lazy.** `RGBAlbedoSpectrum` is 12 bytes (3 floats)
+   and the Jakob-Hanika lookup is cheap; build it in the constructor
+   and avoid the `std::once_flag` overhead per shading call.
+2. **`Vec3 albedo_` stays.** The RGB representation remains for the
+   existing `eval` path and for Blender/Python introspection.
+   `albedo_spec_` is computed alongside it. There is one source of
+   truth (`albedo_`) and one cache (`albedo_spec_`).
+3. **Procedural-texture Lambertian also gets the override.** If
+   `lambertian` supports a `Texture` for albedo (currently it does via
+   `texture_` indirection), the spectral override samples the texture's
+   RGB and upsamples per-call. Caching textures is a non-goal —
+   procedural textures vary per-uv. Track in pkg13 if the cache
+   strategy needs revisiting.
+4. **No public API changes.** `set_material("lambertian", {...})` still
+   takes RGB albedo. The user does not see Jakob-Hanika.
+5. **Test against the default fallback.** The strongest correctness
+   check is that the override produces values matching the pkg11
+   default fallback within 1e-5 — i.e., the optimisation is
+   numerically a no-op.
+
+---
+
+## Acceptance criteria
+
+- [ ] `evalSpectral` on a Lambertian instance with constant `albedo_`
+      returns values numerically identical (≤1e-5) to the pkg11 default
+      fallback for the same `(wo, wi, normal, uv, lambdas)` tuple.
+- [ ] Cornell box rendered in spectral mode matches RGB mode within 1%
+      mean per channel (same criterion as pkg11, must continue to hold).
+- [ ] Render-time profile of Lambertian-heavy Cornell scene shows the
+      spectral path is ≥3× faster than pkg11's default-fallback baseline
+      on the same scene (the entire point of this package).
+- [ ] No other plugin file changed.
+- [ ] All existing tests still pass.
+
+---
+
+## Non-goals
+
+- No migration of any other material. Pkg13.
+- No texture spectral overload. Pkg13 (it lands with the materials
+  that need it).
+- No public API changes; users still pass `Vec3 albedo`.
+- No move of `Material::evalSpectral` from a default-having virtual
+  to pure virtual. That happens in pkg14 as part of "flip the default."
+- No tuning, no perf chase beyond the cache.
+
+---
+
+## Progress
+
+- [ ] Branch `pkg12-spectral-lambertian` from `main`.
+- [ ] Add `RGBAlbedoSpectrum albedo_spec_` member; populate in ctor.
+- [ ] Override `evalSpectral`; mirror `emittedSpectral` if applicable.
+- [ ] Write `tests/test_spectral_lambertian.py`.
+- [ ] Profile against pkg11 baseline on Cornell box; confirm speedup.
+- [ ] Update STATUS.md, CHANGELOG.md.
+- [ ] Commit, push, PR.
+
+---
+
+## Lessons
+
+*(Fill in after the package is done.)*

--- a/.astroray_plan/packages/pkg13-spectral-materials.md
+++ b/.astroray_plan/packages/pkg13-spectral-materials.md
@@ -1,0 +1,210 @@
+# pkg13 — Spectral remaining materials and textures
+
+**Pillar:** 2
+**Track:** A
+**Status:** open
+**Estimated effort:** 2 sessions (~6–8 h)
+**Depends on:** pkg12
+
+---
+
+## Goal
+
+**Before:** only Lambertian has a native `evalSpectral` override.
+Every other material (Metal, Dielectric, Phong, Disney, DiffuseLight,
+NormalMapped, Emissive, Isotropic, OrenNayar, TwoSided) and every
+texture (Checker, Noise, Gradient, Voronoi, Brick, Musgrave, Magic,
+Wave, Image) goes through the pkg11 RGB→Jakob-Hanika fallback. This
+works but is wasteful and physically lossy in two specific places —
+Dielectric and Metal — where the index of refraction is wavelength-
+dependent.
+
+**After:** every plugin under `plugins/materials/` overrides
+`evalSpectral` (and emission counterparts where they exist). Two
+materials gain genuine wavelength-dependent physics:
+
+- **Dielectric** uses Sellmeier coefficients per λ for refractive
+  index, calls `lambdas.terminateSecondary()` at refraction events,
+  and produces visible chromatic dispersion in the prism scene.
+- **Metal** uses tabulated complex IOR (n, k) sampled per λ for the
+  shipped presets (gold, silver, copper, aluminium) — accurate
+  reflectance colour without the RGB→spectrum→RGB round-trip.
+
+Textures gain a `Texture::sampleSpectral(uv, lambdas)` virtual with a
+default that calls `Texture::sample(uv)` and upsamples; image textures
+override it (cache the upsampled spectrum per-texel via Jakob-Hanika
+on first access, evict by texel rather than texture). All other
+materials override with the same caching pattern as pkg12.
+
+---
+
+## Context
+
+Phase 2C concludes here. Once this package merges, every shading event
+in the spectral pipeline runs without the pkg11 fallback path —
+the fallback stays as the safety net for new materials, but the shipped
+tree no longer relies on it. The two physics upgrades (dispersive
+glass, complex-IOR metal) are the "irreducible evidence" the spectral
+pipeline does work the spectral pipeline can't be faked in RGB. After
+pkg13 the only remaining piece is the env map (pkg14).
+
+This is the largest package in Pillar 2; consider splitting into
+pkg13a (materials) and pkg13b (textures + Metal/Dielectric physics)
+if the diff exceeds ~800 lines. The plan keeps it as one package
+because the two changes share the same caching pattern and are easier
+to review side by side.
+
+---
+
+## Reference
+
+- Design doc: `.astroray_plan/docs/spectral-core.md §Phase 2C`
+- Spectral types: `include/astroray/spectrum.h`
+- Pattern reference: pkg12's Lambertian override
+- Sellmeier coefficients (BK7, fused silica, etc.): public optical
+  data, mirrored under `data/spectra/iors/` (new subdirectory)
+- Refractive Index Database (refractiveindex.info) — source for the
+  Metal preset (n, k)(λ) tables; data is CC-BY, attribution in
+  `THIRD_PARTY.md`
+- `plugins/materials/*.cpp` — every existing material plugin
+- `plugins/textures/*.cpp` — every existing texture plugin
+
+---
+
+## Prerequisites
+
+- [ ] pkg12 is merged on `main`; spectral Lambertian is the default
+      pattern reference.
+- [ ] Build is green; full pytest passes.
+- [ ] Refractive-index data files acquired and license-cleared.
+
+---
+
+## Specification
+
+### Files to create
+
+| File | Purpose |
+|---|---|
+| `include/astroray/texture.h` *(or wherever `Texture` lives)* | Add `virtual SampledSpectrum sampleSpectral(const Vec2& uv, const SampledWavelengths& lambdas) const` with default fallback (call `sample(uv)`, upsample via `RGBAlbedoSpectrum`). |
+| `data/spectra/iors/dielectrics.inc` | `constexpr` Sellmeier coefficients for shipped glass presets (BK7, fused silica, water). |
+| `data/spectra/iors/metals.inc` | `constexpr` (λ, n, k) tables for gold, silver, copper, aluminium at 1 nm step over 360–830 nm. |
+| `tests/test_spectral_materials.py` | pytest: every material's `evalSpectral` matches the pkg11 default fallback ≤1e-5 for non-physics materials; Dielectric prism produces non-zero R/G/B angular spread; Metal gold reflectance peak in the 550–600 nm band; image-texture spectral cache returns identical results across multiple lookups. |
+| `tests/test_spectral_textures.py` | pytest: every texture's `sampleSpectral` matches its `sample` upsampled, except procedurals where it's an exact match by construction. |
+| `scripts/generate_iors.py` | Repeatable script that writes `dielectrics.inc` / `metals.inc` from the upstream sources. Documents the pinned source URLs. |
+
+### Files to modify
+
+| File | What changes |
+|---|---|
+| `plugins/materials/lambertian.cpp` | (already done in pkg12 — left here for reference, no change in pkg13) |
+| `plugins/materials/metal.cpp` | Override `evalSpectral`. Replace RGB Fresnel with complex-IOR Fresnel sampled per λ from `metals.inc`. Allow material spec to select a preset (`"gold"`, etc.) or fall back to RGB→spectrum upsample for arbitrary tints. |
+| `plugins/materials/dielectric.cpp` | Override `evalSpectral`. Sellmeier-based IOR per λ. On refraction events call `lambdas.terminateSecondary()`. Schlick / dielectric Fresnel becomes per-λ. |
+| `plugins/materials/phong.cpp` | Override `evalSpectral` with same caching pattern as Lambertian (RGB diffuse + RGB specular each cached as `RGBAlbedoSpectrum` — specular probably as `RGBUnboundedSpectrum` if HDR is allowed). |
+| `plugins/materials/disney.cpp` | Override `evalSpectral`. Per-component cache (basecolor as albedo, sheen tint as albedo, specular tint as unbounded). Disney's existing internal RGB math runs once per-λ; check that the per-bounce cost stays under the 1.5× budget — if not, fall back to upsampling the final RGB. |
+| `plugins/materials/diffuse_light.cpp` | Override `emittedSpectral` using `RGBIlluminantSpectrum` cache. |
+| `plugins/materials/normal_mapped.cpp` | Override `evalSpectral` by delegating to the wrapped material's spectral path. |
+| `plugins/materials/emissive.cpp` | Override `emittedSpectral` (illuminant cache). |
+| `plugins/materials/isotropic.cpp` | Override `evalSpectral` (volumetric albedo as `RGBAlbedoSpectrum`). |
+| `plugins/materials/oren_nayar.cpp` | Override `evalSpectral` (albedo cache, RGB roughness math runs per-λ). |
+| `plugins/materials/two_sided.cpp` | Override `evalSpectral` by delegating to the wrapped material. |
+| `plugins/textures/image.cpp` | Override `sampleSpectral` with per-texel `RGBAlbedoSpectrum` cache (lazy populated, sized to image resolution; consider a small LRU if memory budget bites). |
+| `plugins/textures/{checker,noise,gradient,voronoi,brick,musgrave,magic,wave}.cpp` | Override `sampleSpectral` calling existing `sample` and upsampling per-call (no cache — UV-varying). |
+| `THIRD_PARTY.md` | Add provenance for refractive-index data. |
+| `.astroray_plan/docs/STATUS.md` | Mark pkg13 done; bump Pillar 2 % to ~85. |
+| `CHANGELOG.md` | Add pkg13 entry. |
+
+### Files explicitly NOT touched
+
+- `Renderer`, `Integrator`, framebuffer, NEE/MIS code (all pkg11).
+- `plugins/passes/*.cpp` and the env map (env map is pkg14).
+- `path_tracer` legacy plugin (still the default until pkg14).
+- `spectral.h` and the GR renderer.
+- Any new material/texture plugin not currently in-tree.
+
+### Key design decisions
+
+1. **Two flavours of override.** "Dumb" override (Lambertian, Phong,
+   Disney, OrenNayar, Isotropic, NormalMapped, TwoSided, DiffuseLight,
+   Emissive) just caches one or more `RGB*Spectrum` instances and
+   evaluates per-λ. "Physics" override (Dielectric, Metal) actually
+   uses the wavelength: tabulated IOR or Sellmeier per-λ.
+2. **Texture cache lives in the texture instance.** Image textures
+   own a parallel spectral atlas built lazily on first `sampleSpectral`
+   call, sized to the source image. Memory hit is acceptable because
+   image textures are already the dominant memory consumer; the
+   spectral atlas is 3× the source's float storage.
+3. **Procedural textures don't cache.** Their `sampleSpectral` is just
+   `RGBAlbedoSpectrum(sample(uv)).sample(lambdas)`. Fast enough; no
+   cache because UV varies per-pixel.
+4. **Hero-wavelength termination is the dispersive interface contract.**
+   Dielectric is the only currently-shipped material that calls
+   `lambdas.terminateSecondary()`. Document this in the dielectric
+   plugin's header comment so future authors know when to call it.
+5. **Metal preset selection.** The material spec gains an optional
+   `"preset"` string param. If unset, falls back to the existing RGB
+   tint upsampled (preserves backward compatibility with scenes that
+   set arbitrary RGB metal tints).
+6. **No new public API.** Existing scene files still load; users opt
+   into wavelength-correct Metal/Dielectric by setting the preset
+   string.
+7. **Performance budget.** This package is where the 1.5× spectral-vs-
+   RGB ceiling can be breached. Profile after each material migrates;
+   if the cumulative drift breaches the budget, fall back to
+   upsampling for the offending material and document why.
+
+---
+
+## Acceptance criteria
+
+- [ ] Every material plugin overrides `evalSpectral`; for materials
+      without a physics upgrade, override values match the pkg11
+      default fallback ≤1e-5 on a sweep of `(wo, wi, normal, uv,
+      lambdas)` tuples.
+- [ ] Every texture plugin overrides `sampleSpectral` with the same
+      ≤1e-5 match against the upsampled `sample`.
+- [ ] Glass-prism scene renders rainbow dispersion (R/G/B exit angle
+      spread > 0).
+- [ ] Gold Metal preset shows correct yellow-tone reflectance peak
+      in the 550–620 nm band (not the muddy cyan-ish result the RGB
+      upsample of a yellow `Vec3` gives).
+- [ ] Cornell box render time stays ≤1.5× the RGB baseline.
+- [ ] All existing tests still pass.
+- [ ] No legacy `eval`/`sample` signatures changed.
+
+### Non-goals
+
+- No deletion of the pkg11 default fallback. It remains the safety net
+  for future materials.
+- No deletion of `path_tracer` (legacy RGB integrator). pkg14.
+- No env map work. pkg14.
+- No measured-BRDF (RGL/MERL) loader. Future package.
+- No Hošek-Wilkie sky model. Future package.
+- No new material types (e.g., subsurface, volumetric Henyey-Greenstein
+  upgrade). Out of scope.
+- No public API change to material/texture spec dicts beyond the
+  optional Metal `preset` string.
+
+---
+
+## Progress
+
+- [ ] Branch `pkg13-spectral-materials` from `main`.
+- [ ] Acquire IOR datasets, write `scripts/generate_iors.py`, generate
+      `dielectrics.inc` and `metals.inc`, attribute in `THIRD_PARTY.md`.
+- [ ] Add `Texture::sampleSpectral` virtual with default.
+- [ ] Migrate "dumb" materials (Phong, Disney, DiffuseLight,
+      NormalMapped, Emissive, Isotropic, OrenNayar, TwoSided).
+- [ ] Migrate physics materials (Metal, Dielectric).
+- [ ] Migrate textures (image cache + procedural overrides).
+- [ ] Write `tests/test_spectral_materials.py`,
+      `tests/test_spectral_textures.py`.
+- [ ] Profile cumulative spectral cost on Cornell + a glossy scene.
+- [ ] Update STATUS.md, CHANGELOG.md.
+- [ ] Commit per granularity plan; push branch; open PR.
+
+---
+
+## Lessons
+
+*(Fill in after the package is done.)*

--- a/.astroray_plan/packages/pkg14-spectral-envmap.md
+++ b/.astroray_plan/packages/pkg14-spectral-envmap.md
@@ -1,0 +1,215 @@
+# pkg14 — Spectral env map and flip the default
+
+**Pillar:** 2
+**Track:** A
+**Status:** open
+**Estimated effort:** 1 week (~3 sessions)
+**Depends on:** pkg13
+
+---
+
+## Goal
+
+**Before:** every shading event runs spectrally, but the environment
+map (HDRI sampling, importance sampling for IBL) still returns RGB.
+The pkg11 fallback upsamples that RGB at every env-map ray miss. The
+legacy `path_tracer` plugin remains the registry default; users have
+to call `set_integrator("spectral_path_tracer")` to opt into spectral
+mode.
+
+**After:** the env map is spectral-native. HDRI texels become
+`RGBIlluminantSpectrum` instances, cached at load time so importance
+sampling and ray-miss evaluation both run without per-call upsampling.
+A Hošek-Wilkie analytical sky model is added as a separate plugin
+(spectral-native by construction) for procedural skies. Once the env
+map lands, the legacy RGB `pathTrace` and the `path_tracer` plugin are
+deleted; `spectral_path_tracer` is renamed `path_tracer` and registered
+as the default. Pillar 2 closes with one code path, not two.
+
+This is two packages stacked in one (envmap + flip default). The
+spectral-core design doc explicitly bundles them as Phase 2D + 2E
+because flipping the default before the env map means the renderer
+silently runs the slow fallback for every miss, and shipping the env
+map without flipping the default leaves a half-finished pipeline.
+
+---
+
+## Context
+
+Phase 2D + 2E of Pillar 2 — the closing package. After pkg13 every
+shading event is spectral; after pkg14 every light-source evaluation is
+too. Flipping the default is the smallest change in this package by
+line count but the most consequential: the legacy `pathTrace` and
+`path_tracer` plugin are deleted outright, every existing scene now
+runs through the spectral pipeline, and the registry default name
+"path_tracer" now points at the spectral implementation. The 1% A/B
+parity check from pkg11–13 is what makes this safe.
+
+---
+
+## Reference
+
+- Design doc: `.astroray_plan/docs/spectral-core.md §Phase 2D & §Phase 2E`
+- Hošek-Wilkie 2012 reference: Hošek and Wilkie, "An Analytic Model for
+  Full Spectral Sky-Dome Radiance" — coefficient tables in the original
+  supplemental materials (BSD-3 license)
+- Existing env map: search `module/blender_module.cpp` for
+  `set_environment` / `set_environment_map` / `loadHDR` and follow into
+  `src/` to find the loader; the env map is currently a `Vec3` HDR
+  texture
+- pkg10 RGBIlluminantSpectrum: `include/astroray/spectrum.h`
+- pkg11 SpectralPathTracer integrator: `plugins/integrators/spectral_path_tracer.cpp`
+
+---
+
+## Prerequisites
+
+- [ ] pkg13 is merged on `main`; every material/texture has a spectral
+      override.
+- [ ] Build is green; full pytest passes; Cornell A/B parity ≤1% holds.
+- [ ] A pre-pkg14 baseline render of every showcase scene is captured
+      so the "flip default" step can be A/B-verified without ambiguity.
+
+---
+
+## Specification
+
+### Files to create
+
+| File | Purpose |
+|---|---|
+| `plugins/integrators/sky_hosek_wilkie.cpp` *(optional, time-permitting)* | Hošek-Wilkie 2012 spectral sky as a separate environment plugin. Registers as `"hosek_wilkie_sky"`. Scene picks one or the other. If timeline tightens, defer to a later package and ship pkg14 with HDRI env map only. |
+| `data/spectra/hosek_wilkie_coeffs.inc` *(only if HW lands here)* | `constexpr` table of Hošek-Wilkie radiance coefficients (turbidity × albedo × λ × parameter). |
+| `tests/test_spectral_envmap.py` | pytest: HDRI env map sample under `evalSpectral` produces values matching the upsampled-`sample` fallback ≤1e-5 on a sweep of directions; importance sampling PDFs unchanged from RGB version (sampling pattern and PDFs are luminance-driven, identical math); A/B Cornell + outdoor-HDRI scene matches pre-pkg14 render within 1% mean per channel. |
+
+### Files to modify
+
+| File | What changes |
+|---|---|
+| `include/astroray/environment.h` *(or wherever the env map lives)* | Add `virtual SampledSpectrum evalSpectral(const Vec3& dir, const SampledWavelengths& lambdas) const = 0`. The default RGB `eval(dir)` may stay for backward compat or be deleted (decide during implementation; deleting is cleaner if the codebase has only one consumer left). |
+| `src/environment.cpp` (HDRI implementation) | At load time, build a parallel `RGBIlluminantSpectrum` atlas next to the RGB HDR data. `evalSpectral` reads from the spectral atlas; importance sampling logic unchanged (still luminance-driven). Memory cost is 3× the source HDR's float storage — acceptable given HDRI is loaded once. |
+| `plugins/integrators/spectral_path_tracer.cpp` | Switch env-map ray-miss handling from "RGB then upsample" to direct `envMap->evalSpectral(dir, lambdas)`. Delete the upsample fallback path inside this integrator. |
+| `plugins/integrators/path_tracer.cpp` | **DELETE.** Legacy RGB integrator removed in this package. |
+| `src/path_tracer.cpp` *(or wherever legacy `pathTrace` lives in core)* | **DELETE** the legacy `pathTrace` function. The spectral integrator becomes the only path. |
+| `plugins/integrators/spectral_path_tracer.cpp` | Rename registry name from `"spectral_path_tracer"` to `"path_tracer"` so the default name preserves backward compatibility for scene files / Python users. The plugin file itself can keep its descriptive filename or be renamed — pick one in the implementing PR. |
+| `include/astroray/integrator.h` | Delete the RGB `sample()` virtual now that no integrator returns RGB. Make `sampleSpectral()` pure virtual. Remove the `IntegratorKind` enum added in pkg11 — it served only to discriminate the two paths. |
+| `include/astroray/material.h` | Make `evalSpectral` (and `emittedSpectral` if applicable) pure virtual. Delete the default fallback. Delete the legacy `Vec3 eval` virtual now that nothing calls it. |
+| `include/astroray/texture.h` | Same — make `sampleSpectral` pure virtual; delete `Vec3 sample`. |
+| `plugins/materials/*.cpp`, `plugins/textures/*.cpp` | Drop the now-unused `Vec3 eval` / `Vec3 sample` overrides where they exist as RGB-original code. Keep them only where the spectral override delegates back to RGB internally — that case rewrites to spectral-native math. |
+| `module/blender_module.cpp` | Delete RGB-only debug bindings (`is_spectral_mode()` from pkg11, any `pathTrace`-direct call, etc.). Update `integrator_type` enum in the Blender addon UI (drop the spectral toggle since spectral is now the only mode). |
+| `include/astroray/spectral.h` | **Audit.** If the GR renderer is the only remaining consumer (it is, per pkg10), keep as-is. If anything in the rendering pipeline still includes it, that's a leftover bug — fix in this package. |
+| `THIRD_PARTY.md` | Add provenance for Hošek-Wilkie coefficients if that plugin lands here. |
+| `.astroray_plan/docs/STATUS.md` | Mark pkg14 done; mark Pillar 2 100%; declare Pillar 2 complete; surface Pillar 3 as next. |
+| `CHANGELOG.md` | Add pkg14 entry; close the "Pillar 2 — Spectral core (in progress)" header to "Pillar 2 — Spectral core COMPLETE (pkg10–14)". |
+
+### Files explicitly NOT touched
+
+- `include/astroray/spectral.h` (GR renderer dependency stays).
+- The GR renderer itself — its `SpectralSample`-based pipeline is
+  orthogonal and stays as-is. Unifying the two spectral pipelines is
+  a future package, not pkg14.
+- Any plugin under `plugins/passes/` — they continue to operate on the
+  RGB framebuffer (the XYZ→sRGB conversion still happens once at write).
+
+### Key design decisions
+
+1. **Env map atlas, not per-call upsample.** HDRI textures are loaded
+   once; the spectral atlas is 3× the float storage. Worth it for the
+   per-pixel constant-time lookup. Procedural / analytic skies (Hošek-
+   Wilkie) compute spectrally on demand — no atlas needed.
+2. **Importance sampling stays luminance-driven.** The PDFs of HDRI
+   importance sampling are computed from the source's luminance map.
+   Replacing that with a spectral importance scheme is a non-goal —
+   it would be its own package and the Pillar 2 ≤1.5× perf budget
+   doesn't allow for the variance penalty.
+3. **Hošek-Wilkie is best-effort in pkg14.** If it lands cleanly,
+   great. If it adds risk to the "flip default" step, defer to a
+   follow-up package — the env map atlas is the load-bearing piece;
+   the analytic sky model is value-add.
+4. **Flip the default in the same PR as the env map.** They have to
+   land together because the spectral pipeline isn't complete until
+   the env map is spectral, and the legacy path can't be deleted
+   until the spectral pipeline is complete. Bundling means one
+   reviewable A/B parity check covers both halves.
+5. **Delete legacy code, do not leave it as #ifdef.** The plugin
+   architecture lets us reintroduce a "rgb_path_tracer" plugin
+   later if anyone wants to compare; it would be a clean fork from
+   the spectral version, not a half-resurrected dead path.
+6. **Rename registry name `spectral_path_tracer` → `path_tracer`.**
+   Backward compat for scene files and Blender UI — users see
+   "path_tracer" everywhere. Internally the file is still
+   `plugins/integrators/spectral_path_tracer.cpp` (or rename it
+   too — bikeshed during the PR).
+7. **`Material::eval` removal is the breaking change for plugin
+   authors.** Document it in `CONTRIBUTING.md` and the migration
+   notes section of `CHANGELOG.md`.
+
+---
+
+## Acceptance criteria
+
+- [ ] HDRI env map produces spectral results within ≤1e-5 of the
+      pkg11-style upsample-from-RGB fallback (which is now deleted but
+      can be reproduced in the test by upsampling the source RGB
+      manually).
+- [ ] An outdoor scene (existing showcase, e.g. `Scene2_envmap`)
+      renders within 1% mean per channel of the pre-pkg14 baseline.
+- [ ] All five showcase renders in the README match their pre-pkg14
+      baselines within 1% mean per channel.
+- [ ] No reference to `Vec3 eval` / `Vec3 sample` remains in
+      `Material` / `Texture` / `Integrator` interface headers.
+- [ ] `astroray.integrator_registry_names()` returns `["path_tracer",
+      "ambient_occlusion"]` (no `"spectral_path_tracer"` entry — the
+      rename is complete).
+- [ ] `pathTrace` symbol no longer exists in the core library.
+- [ ] All existing tests still pass.
+- [ ] Cornell box at 32 spp render time is no more than 1.5× the
+      pre-pkg11 RGB-only baseline.
+- [ ] Pillar 2 acceptance criteria from `spectral-core.md` all met:
+      RGB/spectral parity to noise, prism dispersion visible, ≤1.5× perf
+      ceiling, all existing tests pass.
+
+---
+
+## Non-goals
+
+- No GR-renderer unification. `spectral.h` (CIE 1931 2°) and the new
+  `spectrum.h` (CIE 1964 10°) coexist deliberately; a unification
+  package can come later if it's worth doing at all.
+- No measured-BRDF loader (RGL/MERL). Pillar 3+.
+- No spectral AOV pass. Plugin, separate package.
+- No Tódová-Wilkie 2025 metameric illuminants. Plugin, separate package.
+- No new wavelength-sample-count tuning. `kSpectrumSamples = 4` stays.
+- No volumetric / participating media spectral upgrade beyond the
+  existing `Isotropic` material (Pillar 3 scope).
+- No OpenEXR output upgrade. Pillar 5.
+
+---
+
+## Progress
+
+- [ ] Branch `pkg14-spectral-envmap` from `main`.
+- [ ] Capture pre-pkg14 baseline renders of every showcase scene.
+- [ ] Add `Environment::evalSpectral` virtual + HDRI atlas
+      implementation.
+- [ ] Wire spectral integrator's env-map miss to `evalSpectral`.
+- [ ] (Optional) implement Hošek-Wilkie sky plugin + coeff table.
+- [ ] Delete `plugins/integrators/path_tracer.cpp`, legacy
+      `pathTrace`, `Vec3 eval`/`Vec3 sample` virtuals, RGB integrator
+      bookkeeping in Renderer.
+- [ ] Rename `spectral_path_tracer` registry name → `path_tracer`.
+- [ ] Drop now-dead RGB overrides across all material/texture plugins.
+- [ ] Update Blender addon UI (remove integrator-mode toggle).
+- [ ] Run full pytest; render every showcase scene; compare to
+      baseline within 1% per channel.
+- [ ] Profile spectral Cornell vs pre-pkg11 RGB baseline; confirm
+      ≤1.5× ratio.
+- [ ] Update STATUS.md, CHANGELOG.md, CONTRIBUTING.md.
+- [ ] Commit per granularity plan; push branch; open PR with the
+      "Pillar 2 complete" summary.
+
+---
+
+## Lessons
+
+*(Fill in after the package is done.)*


### PR DESCRIPTION
## Summary

- Adds the four package files that close out Pillar 2 — pkg11 (spectral path tracer), pkg12 (spectral Lambertian), pkg13 (remaining materials + textures, plus Dielectric/Metal physics), pkg14 (spectral env map + flip the default).
- Each follows [TEMPLATE.md](.astroray_plan/packages/TEMPLATE.md): goal, context, reference, prerequisites, files-to-create / files-to-modify / key design decisions, acceptance criteria, non-goals, progress checklist.
- Plan-only — no code changes. Lands on top of [pkg10 (#96)](https://github.com/HendrikGC02/Astroray/pull/96) which is still open.

## Phase mapping (per [spectral-core.md](.astroray_plan/docs/spectral-core.md))

| Package | Phase | What it does |
|---|---|---|
| pkg11 | 2B | Parallel `spectral_path_tracer` integrator; `Material::evalSpectral` virtual with Jakob-Hanika fallback so unmigrated materials work day one |
| pkg12 | 2C begin | Lambertian gains a native `evalSpectral` override; pattern reference for pkg13 |
| pkg13 | 2C cont. | Every other material + every texture overrides spectral; Dielectric (Sellmeier IOR, dispersion) and Metal (tabulated n,k) gain real wavelength-dependent physics |
| pkg14 | 2D + 2E | HDRI env map → spectral atlas; legacy `pathTrace` deleted; `spectral_path_tracer` renamed to `path_tracer` and registered as default — Pillar 2 complete |

## Test plan

- [ ] PR review only — no build, no tests run on this PR
- [ ] Each package file is self-consistent and matches TEMPLATE.md structure
- [ ] Each package's Non-goals match the bounds set in spectral-core.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)