### PR TITLE
chore: gitignore *.png wildcard + VS Code pytest settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,8 +100,6 @@ Thumbs.db
 *.pdb
 *.ilk
 *.log
-Scene1_1080p_1024s.png
-Scene2_1080p_1024s_envmap.png
-Scene2_1080p_1024s.png
+*.png
 *.deb
 .aider*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}


### PR DESCRIPTION
## Summary

- Replace the three explicit Scene\*.png entries in .gitignore with a `*.png` wildcard so render artefacts from any test scene are ignored automatically. Currently-tracked PNGs (e.g. `docs/images/readme/*.png`) stay tracked; new PNGs need `git add -f`.
- Add `.vscode/settings.json` enabling pytest discovery rooted at `tests/`. Personal-but-shared dev ergonomics; matches the existing pytest invocation in CI / docs.

## Test plan

- [ ] `git status` clean after a fresh test render produces a `*.png` under repo root.
- [ ] VS Code (with Python extension) discovers tests under `tests/` without further config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)