### PR TITLE
feat(pkg11): spectral path tracer — Pillar 2 first integrator

### DIFF
--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Astroray Status
 
-**Last updated:** 2026-04-24 (pkg10 complete — Pillar 2 scaffolding in place)
+**Last updated:** 2026-04-25 (pkg11 complete — first spectral integrator opt-in)
 
 This is the source-of-truth for "where are we?" Updated by the overseer
 at the start of each week, and by the project owner when a significant
@@ -17,7 +17,7 @@ personally should pick up.
 | # | Name | Status | % | Next milestone | Blocked on |
 |---|---|---|---|---|---|
 | 1 | Plugin architecture | **Done** | 100% | — | — |
-| 2 | Spectral core | **In progress** | ~20% | Spectral path tracer (pkg11) | ~~Pillar 1~~ |
+| 2 | Spectral core | **In progress** | ~40% | Spectral Lambertian (pkg12) | ~~Pillar 1~~ |
 | 3 | Light transport | Queued | 0% | — | Pillars 1, 2 |
 | 4 | Astrophysics platform | Queued | 0% | Kerr | Pillars 1, 2 |
 | 5 | Production polish | Ongoing | — | OpenEXR output | — |
@@ -38,7 +38,7 @@ personally should pick up.
 | Package | Description | Status |
 |---|---|---|
 | pkg10 | Spectral types (scaffolding) | done |
-| pkg11 | Spectral path tracer | queued |
+| pkg11 | Spectral path tracer | done |
 | pkg12 | Migrate materials to spectral | queued |
 | pkg13 | Migrate remaining materials + textures to spectral | queued |
 | pkg14 | Spectral environment map | queued |
@@ -51,8 +51,8 @@ personally should pick up.
 
 ### Track A (Claude Code)
 
-- Package in flight: none (pkg10 done — Pillar 2 scaffolding in place)
-- Next session goal: Spectral path tracer (pkg11) — first consumer of the pkg10 types
+- Package in flight: none (pkg11 done — first spectral integrator opt-in)
+- Next session goal: Spectral Lambertian (pkg12) — first concrete `evalSpectral` override
 
 ### Track B (Copilot cloud)
 
@@ -76,6 +76,7 @@ personally should pick up.
 
 | Date | PR | Track | Pillar | Description |
 |---|---|---|---|---|
+| 2026-04-25 | pkg11-spectral-path-tracer | A | 2 | Spectral path tracer plugin (`set_integrator("spectral_path_tracer")`), `IntegratorKind` enum, `Material::evalSpectral`/`emittedSpectral` defaults via Jakob-Hanika upsample, `Renderer::pathTraceSpectral` helper + XYZ accumulator + single sRGB conversion. Cornell A/B match within ~3% per channel; 1.34× wall-clock vs RGB. Legacy `path` integrator stays the default. 193 tests (+4 new). |
 | 2026-04-24 | pkg10-spectral-types | A | 2 | Spectral scaffolding: `SampledWavelengths`, `SampledSpectrum`, three `RGB*Spectrum` upsamplers over a shipped Jakob-Hanika LUT, CIE 1964 10° CMF + D65 SPD, Python bindings, 189 tests (+20 new). No integration — renderer is untouched. |
 | 2026-04-22 | feat/pkg06-pass-registry | A | 1 | Pass registry; OIDN + 3 AOV plugins; Framebuffer API; add_pass/clear_passes bindings; 169 tests passing. **Pillar 1 complete.** |
 | 2026-04-22 | feat/pkg05-integrator-interface | A | 1 | Integrator base class, PathTracer + AO plugins, Blender UI selector; 165 tests passing |

--- a/.astroray_plan/packages/pkg11-spectral-path-tracer.md
+++ b/.astroray_plan/packages/pkg11-spectral-path-tracer.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 2
 **Track:** A
-**Status:** open
+**Status:** done
 **Estimated effort:** 1 week (~3 sessions)
 **Depends on:** pkg10
 
@@ -161,24 +161,50 @@ a time, each step keeping the test suite green.
 
 ## Progress
 
-- [ ] Branch `pkg11-spectral-path-tracer` from `main`.
-- [ ] Add `evalSpectral` (and `emittedSpectral` if applicable) defaults
-      to `Material` interface with Jakob-Hanika upsample.
-- [ ] Wire `IntegratorKind` enum + `Renderer::spectralMode_` switch
+- [x] Branch `pkg11-spectral-path-tracer` from `main`.
+- [x] Add `evalSpectral` and `emittedSpectral` defaults to `Material`
+      with Jakob-Hanika upsample.
+- [x] Wire `IntegratorKind` enum + `Renderer::spectralMode_` switch
       and XYZ accumulator path.
-- [ ] Implement `plugins/integrators/spectral_path_tracer.cpp`.
-- [ ] Add Blender UI option for the spectral integrator.
-- [ ] Build a glass-prism reference scene under `tests/scenes/` (or
-      reuse an existing Cornell box variant) and capture pre-pkg11
-      baseline.
-- [ ] Write `tests/test_spectral_path_tracer.py`.
-- [ ] Run full pytest; render Cornell + prism A/B comparison.
-- [ ] Profile spectral vs RGB on Cornell — confirm ≤1.5× ratio.
-- [ ] Update STATUS.md, CHANGELOG.md.
-- [ ] Commit per granularity plan; push branch; open PR.
+- [x] Implement `plugins/integrators/spectral_path_tracer.cpp`.
+- [ ] ~~Add Blender UI option for the spectral integrator.~~ Auto-exposed
+      via existing `set_integrator(name)` binding from pkg05 — explicit
+      Blender UI dropdown deferred (no changes to `module/blender_module.cpp`).
+- [ ] ~~Build a glass-prism reference scene + capture pre-pkg11 baseline.~~
+      **Deferred to pkg13** (no dispersive material override in pkg11 —
+      direction-spread dispersion is physically impossible until a
+      wavelength-dependent dielectric ships).
+- [x] Write `tests/test_spectral_path_tracer.py` (4 tests).
+- [x] Run full pytest; render Cornell A/B comparison
+      (`test_results/pkg11_cornell_{rgb,spectral,diff_x5}.png`).
+- [x] Profile spectral vs RGB on Cornell — **1.34×** ratio (target 1.5×).
+- [x] Update STATUS.md, CHANGELOG.md.
+- [x] Commit; push branch; open PR.
 
 ---
 
 ## Lessons
 
-*(Fill in after the package is done.)*
+- **The default `evalSpectral`/`emittedSpectral` fallback was the
+  load-bearing design choice.** It let pkg11 ship without touching a
+  single concrete material file, and the Cornell A/B match fell into
+  place at sub-3% per-channel delta on first run.
+- **Mirroring the bounce loop in `Renderer::pathTraceSpectral` paid off
+  over duplicating it inside the plugin.** Reused BVH access, lights,
+  envMap, worldTransmittance, etc.; the plugin file ended up at ~30
+  lines.
+- **`IntegratorKind` enum was the right call over `bool isSpectral()`
+  even though the latter would be one-line shorter.** Pkg14 still has to
+  remove all the call sites; the enum is no harder to grep for and
+  signals intent better. Cost was minimal.
+- **MinGW PATH order issue (Git Bash's older `mingw64/bin` first) was
+  unmasked by my changes** — new template instantiations in raytracer.h
+  needed libstdc++ symbols Git's older DLL lacks. Fixed in `conftest.py`
+  by promoting `C:\Program Files\mingw64\bin` to the front of PATH.
+  Worth flagging in a project README for new contributors.
+- **The spectral firefly clamp on XYZ Y vs sRGB luminance** was a
+  one-line branch in the per-pixel loop; threshold of 20.0f preserves
+  image character with no visible delta.
+- **Skipping GR-object dispatch + AOV passes + per-closure bounce limits
+  in `pathTraceSpectral` kept pkg11 surgical.** Cornell-class scenes are
+  served; later packages can fold those in if/when actually needed.

--- a/.astroray_plan/packages/pkg13-spectral-materials.md
+++ b/.astroray_plan/packages/pkg13-spectral-materials.md
@@ -89,7 +89,7 @@ to review side by side.
 | `include/astroray/texture.h` *(or wherever `Texture` lives)* | Add `virtual SampledSpectrum sampleSpectral(const Vec2& uv, const SampledWavelengths& lambdas) const` with default fallback (call `sample(uv)`, upsample via `RGBAlbedoSpectrum`). |
 | `data/spectra/iors/dielectrics.inc` | `constexpr` Sellmeier coefficients for shipped glass presets (BK7, fused silica, water). |
 | `data/spectra/iors/metals.inc` | `constexpr` (λ, n, k) tables for gold, silver, copper, aluminium at 1 nm step over 360–830 nm. |
-| `tests/test_spectral_materials.py` | pytest: every material's `evalSpectral` matches the pkg11 default fallback ≤1e-5 for non-physics materials; Dielectric prism produces non-zero R/G/B angular spread; Metal gold reflectance peak in the 550–600 nm band; image-texture spectral cache returns identical results across multiple lookups. |
+| `tests/test_spectral_materials.py` | pytest: every material's `evalSpectral` matches the pkg11 default fallback ≤1e-5 for non-physics materials; Dielectric prism produces non-zero R/G/B angular spread (**this is the prism/dispersion test originally scoped for pkg11 and deferred here, since wavelength-dependent IOR is the only way to get direction-spread dispersion** — also build the prism scene under `tests/scenes/`); Metal gold reflectance peak in the 550–600 nm band; image-texture spectral cache returns identical results across multiple lookups. |
 | `tests/test_spectral_textures.py` | pytest: every texture's `sampleSpectral` matches its `sample` upsampled, except procedurals where it's an exact match by construction. |
 | `scripts/generate_iors.py` | Repeatable script that writes `dielectrics.inc` / `metals.inc` from the upstream sources. Documents the pinned source URLs. |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,35 @@ All notable changes to this project will be documented in this file.
 
 ### Pillar 2 — Spectral core (in progress)
 
+- **pkg11** — Spectral path tracer (opt-in). New `spectral_path_tracer`
+  integrator plugin under `plugins/integrators/`, registered alongside
+  the legacy `path` and `ambient_occlusion`. Activated via
+  `r.set_integrator("spectral_path_tracer")`; the legacy `path` remains
+  the registry default (pkg14 will flip it). Adds `IntegratorKind` enum +
+  `Integrator::kind()` virtual; `Material::evalSpectral` and
+  `Material::emittedSpectral` virtuals with Jakob-Hanika upsampling
+  defaults so every existing material renders correctly under the spectral
+  path without per-material edits (concrete spectral overrides land in
+  pkg12+). New `Renderer::pathTraceSpectral` mirrors the legacy `pathTrace`
+  recursion but carries `SampledSpectrum` throughput, samples one hero
+  wavelength bundle per primary ray via `SampledWavelengths::sampleUniform`,
+  applies the same `wasSpecular || bounce==0` emission gate, MIS power
+  heuristic on area-light NEE, and Russian roulette after depth 3. The
+  `Renderer` now stores a `spectralMode_` flag (set from the integrator's
+  `kind()`); when active, the per-pixel accumulator stores XYZ, the per-
+  sample firefly clamp gates on Y instead of sRGB luminance (threshold
+  unchanged at 20.0), and a single `xyzToLinearSRGB` conversion happens
+  before gamma — preserving the "gamma once" invariant. Existing `Material`
+  signatures untouched; `plugins/materials/*.cpp` and `plugins/passes/*.cpp`
+  unchanged. Cornell box A/B at 32 spp matches RGB within ~3% per channel
+  (rel. delta `[0.012, 0.015, 0.028]`); spectral wall-clock 1.34× of RGB
+  on the same scene (well under the 1.5× pkg11 ceiling). Test suite: 193
+  passed, 1 skipped (4 new tests under `tests/test_spectral_path_tracer.py`,
+  including a Cornell A/B match assertion and PNG outputs in
+  `test_results/pkg11_cornell_*.png`). Conftest fix: prepend
+  `C:\Program Files\mingw64\bin` to PATH so subprocess-launched
+  `raytracer.exe` finds the modern libstdc++ ahead of Git Bash's older
+  copy. Prism / dispersion criterion deferred to pkg13.
 - **pkg10** — Spectral core scaffolding. New `include/astroray/spectrum.h`
   declares `SampledWavelengths`, `SampledSpectrum`, `RGBAlbedoSpectrum`,
   `RGBUnboundedSpectrum`, and `RGBIlluminantSpectrum` (float precision,

--- a/include/astroray/integrator.h
+++ b/include/astroray/integrator.h
@@ -4,12 +4,24 @@
 #include "astroray/param_dict.h"
 #include <random>
 
+// Discriminates RGB- vs spectral-native integrators. The Renderer reads
+// kind() once per setIntegrator() call to switch its per-pixel accumulator
+// between RGB and XYZ. pkg14 deletes this enum when the legacy RGB path
+// is removed.
+enum class IntegratorKind { RGB, Spectral };
+
 class Integrator {
 public:
     virtual ~Integrator() = default;
 
     // Returns RGB radiance. Called once per sample per pixel.
     virtual Vec3 sample(const Ray& cameraRay, std::mt19937& gen) = 0;
+
+    // Capability flag: spectral integrators advertise IntegratorKind::Spectral
+    // and must populate SampleResult::color with the XYZ projection of the
+    // path's spectral radiance. Default RGB keeps every existing plugin
+    // working unchanged.
+    virtual IntegratorKind kind() const { return IntegratorKind::RGB; }
 
     // Optional per-frame setup (reservoirs, cache warmup).
     virtual void beginFrame(Renderer&, const Camera&) {}

--- a/include/raytracer.h
+++ b/include/raytracer.h
@@ -18,6 +18,7 @@
 #include <string>
 #include <unordered_map>
 #include "stb_image.h"
+#include "astroray/spectrum.h"
 
 // Forward declaration needed by HitRecord
 class Hittable;
@@ -482,6 +483,25 @@ public:
     virtual bool isTransmissive() const { return false; }
     virtual bool isGlossy() const { return false; }
     virtual Vec3 getAlbedo() const { return Vec3(0.5f); }
+
+    // Pillar 2 spectral hooks. Defaults Jakob-Hanika upsample the RGB result
+    // so that pkg11 ships a runnable spectral path before any concrete
+    // material implements a wavelength-dependent BSDF (pkg12 onward).
+    virtual astroray::SampledSpectrum evalSpectral(
+            const HitRecord& rec, const Vec3& wo, const Vec3& wi,
+            const astroray::SampledWavelengths& lambdas) const {
+        Vec3 rgb = eval(rec, wo, wi);
+        return astroray::RGBAlbedoSpectrum({rgb.x, rgb.y, rgb.z}).sample(lambdas);
+    }
+    virtual astroray::SampledSpectrum emittedSpectral(
+            const HitRecord& rec,
+            const astroray::SampledWavelengths& lambdas) const {
+        Vec3 rgb = emitted(rec);
+        if (rgb.x == 0.0f && rgb.y == 0.0f && rgb.z == 0.0f) {
+            return astroray::SampledSpectrum(0.0f);
+        }
+        return astroray::RGBIlluminantSpectrum({rgb.x, rgb.y, rgb.z}).sample(lambdas);
+    }
 };
 
 class Lambertian : public Material {
@@ -1474,6 +1494,7 @@ class Renderer {
     Vec3 worldVolumeColor = Vec3(1.0f);
     float worldVolumeAnisotropy = 0.0f;
     std::shared_ptr<Integrator> integrator_;
+    bool spectralMode_ = false;  // true when integrator_->kind() == IntegratorKind::Spectral
     std::vector<std::shared_ptr<Pass>> passes_;
 
     Vec3 clampLuminance(const Vec3& c, float maxLum) const {
@@ -1495,8 +1516,11 @@ class Renderer {
     }
     
 public:
-    void setIntegrator(std::shared_ptr<Integrator> i) { integrator_ = std::move(i); }
+    // Definition deferred to below the integrator.h include — it reads
+    // the integrator's kind() virtual and that needs Integrator's full type.
+    void setIntegrator(std::shared_ptr<Integrator> i);
     void addPass(std::shared_ptr<Pass> p)  { passes_.push_back(std::move(p)); }
+    bool spectralMode() const { return spectralMode_; }
     void clearPasses()                      { passes_.clear(); }
 
     // Full-path trace: returns color plus AOVs and render passes in a SampleResult.
@@ -2005,7 +2029,123 @@ Vec3 pathTrace(const Ray& r, int maxDepth, const PathBounceLimits& bounceLimits,
         if (passOut) *passOut = passAccum;
         return color;
     }
-    
+
+    // Pillar 2 spectral path tracer kernel. Mirrors pathTrace() but uses
+    // SampledSpectrum for radiance and throughput, with material lookups
+    // via evalSpectral / emittedSpectral. Pkg11 ships a focused subset of
+    // the RGB pathTrace's features: BVH traversal, area-light NEE with MIS,
+    // emission gating (wasSpecular || bounce==0), Russian roulette after
+    // depth 3, and BSDF sampling via the wavelength-independent sample()
+    // (dispersive sampling lands in pkg13).
+    //
+    // GR-object dispatch, AOV passes, glossy filter, caustic filtering,
+    // volumes, and per-closure bounce limits are deliberately NOT replicated
+    // here; the spectral integrator is opt-in and only the Cornell-class
+    // A/B match is in scope for pkg11. Future packages can fold those in.
+    astroray::SampledSpectrum pathTraceSpectral(
+            const Ray& r, int maxDepth,
+            const astroray::SampledWavelengths& lambdas,
+            std::mt19937& gen) {
+        const int rrDepth = 3;
+        astroray::SampledSpectrum color(0.0f);
+        astroray::SampledSpectrum throughput(1.0f);
+        Ray ray = r;
+        bool wasSpecular = true;
+        std::uniform_real_distribution<float> dist01(0.0f, 1.0f);
+
+        for (int bounce = 0; bounce < maxDepth; ++bounce) {
+            HitRecord rec;
+            if (!bvh->hit(ray, 0.001f, std::numeric_limits<float>::max(), rec)) {
+                if (bounce <= worldMaxBounces && (bounce == 0 || wasSpecular)) {
+                    Vec3 envColor;
+                    if (envMap && envMap->loaded()) {
+                        envColor = envMap->lookup(ray.direction.normalized());
+                    } else if (backgroundColor.x >= 0) {
+                        envColor = backgroundColor;
+                    } else {
+                        float t = 0.5f * (ray.direction.normalized().y + 1.0f);
+                        envColor = (Vec3(1) * (1 - t) + Vec3(0.5f, 0.7f, 1.0f) * t) * 0.2f;
+                    }
+                    astroray::SampledSpectrum envSpec =
+                        astroray::RGBIlluminantSpectrum({envColor.x, envColor.y, envColor.z}).sample(lambdas);
+                    color += throughput * envSpec;
+                }
+                break;
+            }
+            // Skip GR objects entirely in pkg11 (Cornell scope).
+            if (rec.hitObject && rec.hitObject->isGRObject()) break;
+            if (!rec.material) break;
+
+            // Emission (gated on camera ray or post-specular bounce).
+            astroray::SampledSpectrum Le_spec =
+                rec.material->emittedSpectral(rec, lambdas);
+            if (!Le_spec.isZero()) {
+                if (bounce == 0 || wasSpecular) {
+                    color += throughput * Le_spec;
+                }
+                break;
+            }
+
+            Vec3 wo = -ray.direction.normalized();
+
+            // Area-light NEE (MIS via power heuristic). Skipped on delta lobes.
+            if (!rec.isDelta && !lights.empty()) {
+                LightSample ls = lights.sample(rec.point, gen);
+                if (ls.pdf > 0) {
+                    Vec3 wi = (ls.position - rec.point).normalized();
+                    HitRecord shadow;
+                    bool hitOccluder = bvh->hit(Ray(rec.point, wi), 0.001f, ls.distance - 0.001f, shadow);
+                    bool occluded = hitOccluder && !(shadow.hitObject && shadow.hitObject->isInfiniteLight());
+                    if (!occluded) {
+                        astroray::SampledSpectrum f_spec =
+                            rec.material->evalSpectral(rec, wo, wi, lambdas);
+                        astroray::SampledSpectrum L_spec =
+                            astroray::RGBIlluminantSpectrum({ls.emission.x, ls.emission.y, ls.emission.z}).sample(lambdas);
+                        float bsdfPdf = rec.material->pdf(rec, wo, wi);
+                        float a = ls.pdf, b = bsdfPdf;
+                        float wt = (a * a) / (a * a + b * b + 1e-8f);
+                        color += throughput * f_spec * L_spec * (wt / (ls.pdf + 0.001f));
+                    }
+                }
+            }
+
+            // Russian roulette on luminance of throughput's XYZ.
+            if (bounce > rrDepth) {
+                astroray::XYZ thrXYZ = throughput.toXYZ(lambdas);
+                float p = std::min(0.95f, std::max(0.0f, thrXYZ.Y));
+                if (dist01(gen) > p) break;
+                if (p > 0.0f) throughput = throughput * (1.0f / p);
+            }
+
+            // BSDF sample (direction + pdf are wavelength-independent in pkg11;
+            // pkg13 introduces sampleSpectral on dispersive materials).
+            BSDFSample bs = rec.material->sample(rec, wo, gen);
+            if (bs.pdf <= 0.0f) break;
+            astroray::SampledSpectrum f_bs =
+                rec.material->evalSpectral(rec, wo, bs.wi, lambdas);
+            wasSpecular = bs.isDelta;
+            // For delta lobes evalSpectral returns zero (RGB eval is zero on
+            // deltas); fall back to upsampling bs.f so specular materials
+            // still propagate radiance until pkg13 overrides.
+            if (bs.isDelta && f_bs.isZero()) {
+                f_bs = astroray::RGBAlbedoSpectrum({bs.f.x, bs.f.y, bs.f.z}).sample(lambdas);
+            }
+            throughput *= f_bs * (1.0f / (bs.pdf + 0.001f));
+
+            Ray next(rec.point, bs.wi, ray.time, ray.screenU, ray.screenV);
+            next.hasCameraFrame = ray.hasCameraFrame;
+            next.cameraOrigin = ray.cameraOrigin;
+            next.cameraU = ray.cameraU;
+            next.cameraV = ray.cameraV;
+            next.cameraW = ray.cameraW;
+            ray = next;
+
+            float maxC = throughput.maxValue();
+            if (maxC > 10.0f) throughput = throughput * (10.0f / maxC);
+        }
+        return color;
+    }
+
 public:
     void addObject(std::shared_ptr<Hittable> obj) {
         scene.push_back(obj);
@@ -2113,8 +2253,11 @@ inline void Renderer::render(Camera& cam, int maxSamples, int maxDepth,
                                                  s == 0 ? &sAlb : nullptr, s == 0 ? &sNorm : nullptr, &sAlpha,
                                                  &sDepth, &sPosition, &sUv, &sObjectIndex, &sMaterialIndex, &sPass);
                             }
-                            // Per-sample firefly suppression
-                            float sLum = luminance(sCol);
+                            // Per-sample firefly suppression. In spectral mode
+                            // sCol is XYZ and Y is photometric luminance; in
+                            // RGB mode use the standard sRGB luminance formula.
+                            // Threshold stays at 20.0f (image-character invariant).
+                            float sLum = spectralMode_ ? sCol.y : luminance(sCol);
                             if (sLum > 20.0f) sCol = sCol * (20.0f / sLum);
                             color += sCol;
                             for (int passIndex = 0; passIndex < PASS_COUNT; ++passIndex) {
@@ -2157,6 +2300,11 @@ inline void Renderer::render(Camera& cam, int maxSamples, int maxDepth,
                         passColor[PASS_VOLUME_INDIRECT] *= filmExposure;
                         passColor[PASS_EMISSION] *= filmExposure;
                         passColor[PASS_ENVIRONMENT] *= filmExposure;
+                        // Spectral mode: convert accumulated XYZ to linear sRGB
+                        // exactly once before gamma. RGB mode is unchanged.
+                        if (spectralMode_) {
+                            color = xyzToLinearSRGB(color);
+                        }
                         if (applyGamma) {
                             color.x = std::pow(std::clamp(color.x, 0.0f, 1.0f), 1.0f / 2.2f);
                             color.y = std::pow(std::clamp(color.y, 0.0f, 1.0f), 1.0f / 2.2f);
@@ -2212,5 +2360,12 @@ inline void Renderer::render(Camera& cam, int maxSamples, int maxDepth,
             for (auto& pass : passes_)
                 pass->execute(fb);
         }
+}
+
+// Out-of-line because it reads Integrator::kind(), which requires the full
+// Integrator type pulled in by the integrator.h include above.
+inline void Renderer::setIntegrator(std::shared_ptr<Integrator> i) {
+    spectralMode_ = (i && i->kind() == IntegratorKind::Spectral);
+    integrator_ = std::move(i);
 }
 

--- a/plugins/integrators/spectral_path_tracer.cpp
+++ b/plugins/integrators/spectral_path_tracer.cpp
@@ -1,0 +1,46 @@
+#include "astroray/register.h"
+#include "astroray/integrator.h"
+#include "astroray/spectrum.h"
+
+// Pillar 2 spectral path tracer (pkg11). Opt-in via
+// `set_integrator("spectral_path_tracer")`. The legacy RGB `path_tracer`
+// remains the registry default until pkg14 flips it.
+//
+// SampleResult.color is populated with the XYZ projection of the path's
+// spectral radiance; the Renderer (when its integrator advertises
+// IntegratorKind::Spectral) treats the per-pixel accumulator as XYZ and
+// converts to linear sRGB exactly once before gamma.
+class SpectralPathTracer : public Integrator {
+    int maxDepth_;
+    Renderer* renderer_ = nullptr;
+public:
+    explicit SpectralPathTracer(const astroray::ParamDict& p)
+        : maxDepth_(p.getInt("max_depth", 50)) {}
+
+    IntegratorKind kind() const override { return IntegratorKind::Spectral; }
+
+    void beginFrame(Renderer& scene, const Camera&) override {
+        renderer_ = &scene;
+    }
+
+    Vec3 sample(const Ray&, std::mt19937&) override {
+        // Unused: the Renderer dispatches through sampleFull when kind() is
+        // Spectral. Returning zero keeps the pure-virtual contract honest.
+        return Vec3(0);
+    }
+
+    SampleResult sampleFull(const Ray& ray, std::mt19937& gen) override {
+        SampleResult r;
+        if (!renderer_) return r;
+        std::uniform_real_distribution<float> dist01(0.0f, 1.0f);
+        astroray::SampledWavelengths lambdas =
+            astroray::SampledWavelengths::sampleUniform(dist01(gen));
+        astroray::SampledSpectrum rad =
+            renderer_->pathTraceSpectral(ray, maxDepth_, lambdas, gen);
+        astroray::XYZ xyz = rad.toXYZ(lambdas);
+        r.color = Vec3(xyz.X, xyz.Y, xyz.Z);
+        return r;
+    }
+};
+
+ASTRORAY_REGISTER_INTEGRATOR("spectral_path_tracer", SpectralPathTracer)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,14 @@ if sys.platform == 'win32' and hasattr(os, 'add_dll_directory'):
     _mingw_bin = os.environ.get('MINGW_BIN_DIR', r'C:\Program Files\mingw64\bin')
     if os.path.isdir(_mingw_bin):
         os.add_dll_directory(_mingw_bin)
+        # add_dll_directory only affects Python's loader; subprocess-launched
+        # binaries (raytracer.exe in test_standalone_renderer.py) use PATH
+        # for DLL search. Git Bash puts an older mingw64/bin earlier in PATH
+        # which can lack newer libstdc++ symbols, so promote the modern one
+        # to the front whenever it isn't already first.
+        _path_entries = os.environ.get('PATH', '').split(os.pathsep)
+        if not _path_entries or os.path.normcase(_path_entries[0].rstrip(os.sep)) != os.path.normcase(_mingw_bin.rstrip(os.sep)):
+            os.environ['PATH'] = _mingw_bin + os.pathsep + os.environ.get('PATH', '')
     # msys2 ucrt64 toolchain (libgomp-1.dll etc.)
     _ucrt64_bin = r'C:\msys64\ucrt64\bin'
     if os.path.isdir(_ucrt64_bin):

--- a/tests/test_spectral_path_tracer.py
+++ b/tests/test_spectral_path_tracer.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Pillar 2 / pkg11 — spectral path tracer integration tests.
+
+Covers:
+  1. Plugin registration: "spectral_path_tracer" appears in the registry.
+  2. Cornell A/B match: rendering Cornell with the legacy RGB `path` and the
+     new `spectral_path_tracer` produces near-identical mean RGB. The default
+     evalSpectral / emittedSpectral fall back to a Jakob-Hanika upsample of
+     the existing RGB BSDF / emission, so any chromatic delta is the
+     hero-wavelength MC noise floor — it should be small at 32 spp.
+
+Both renders are also written to PNG under test_results/ for visual review.
+
+The prism / dispersion criterion from the original plan is deferred to
+pkg13 (no dispersive material override exists yet — direction-spread
+dispersion is physically impossible until a wavelength-dependent dielectric
+ships).
+"""
+import os
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'build'))
+sys.path.insert(0, os.path.dirname(__file__))
+
+try:
+    import astroray  # noqa: E402
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+from base_helpers import (  # noqa: E402
+    create_cornell_box, save_image, setup_camera,
+)
+
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray not built")
+
+
+SPP = 32
+WIDTH = 200
+HEIGHT = 150
+MAX_DEPTH = 8
+
+
+def _output_dir():
+    d = os.path.join(os.path.dirname(__file__), '..', 'test_results')
+    os.makedirs(d, exist_ok=True)
+    return d
+
+
+def _render_cornell(integrator_name: str, seed: int = 1) -> np.ndarray:
+    r = astroray.Renderer()
+    create_cornell_box(r)
+    setup_camera(r, look_from=[0, 0, 5.5], look_at=[0, 0, 0],
+                 vfov=38, width=WIDTH, height=HEIGHT)
+    r.set_integrator(integrator_name)
+    r.set_seed(seed)
+    pixels = r.render(SPP, MAX_DEPTH, None, True)
+    return np.asarray(pixels, dtype=np.float32)
+
+
+def test_spectral_path_tracer_registered():
+    """The plugin must be in the integrator registry under the canonical name."""
+    names = astroray.integrator_registry_names()
+    assert "spectral_path_tracer" in names, (
+        f"spectral_path_tracer not registered; available: {names}")
+
+
+def test_cornell_ab_match(test_results_dir):
+    """RGB and spectral integrators must agree on Cornell within tolerance.
+
+    Default evalSpectral upsamples the legacy RGB eval(); the only divergence
+    is the Jakob-Hanika roundtrip noise on 4 hero wavelengths. At 32 spp the
+    per-channel mean delta should comfortably stay under ~5%.
+    """
+    rgb = _render_cornell("path")
+    spec = _render_cornell("spectral_path_tracer")
+
+    save_image(rgb, os.path.join(test_results_dir, 'pkg11_cornell_rgb.png'))
+    save_image(spec, os.path.join(test_results_dir, 'pkg11_cornell_spectral.png'))
+    diff = np.clip(np.abs(rgb - spec) * 5.0, 0.0, 1.0)
+    save_image(diff, os.path.join(test_results_dir, 'pkg11_cornell_diff_x5.png'))
+
+    rgb_mean = rgb.reshape(-1, 3).mean(axis=0)
+    spec_mean = spec.reshape(-1, 3).mean(axis=0)
+    print(f"\n  RGB  mean: {rgb_mean}")
+    print(f"  Spec mean: {spec_mean}")
+    assert np.all(spec_mean > 0.01), \
+        f"spectral image too dark, mean={spec_mean}"
+
+    rel_delta = np.abs(rgb_mean - spec_mean) / (rgb_mean + 1e-3)
+    print(f"  rel delta: {rel_delta}")
+    # 5% per-channel tolerance — accommodates 4-hero-wavelength MC noise at
+    # 32 spp. The Jakob-Hanika upsample is faithful in mean; any larger
+    # divergence indicates a real bug.
+    assert np.all(rel_delta < 0.05), (
+        f"spectral mean diverges from RGB by {rel_delta} (threshold 0.05); "
+        f"rgb={rgb_mean}, spec={spec_mean}")
+
+
+def test_spectral_render_no_nan_no_inf():
+    """The spectral path must not emit NaN/Inf — would indicate divide-by-zero
+    in the SampledSpectrum operators or a malformed Jakob-Hanika upsample."""
+    spec = _render_cornell("spectral_path_tracer", seed=2)
+    assert not np.any(np.isnan(spec)), "spectral render contains NaN"
+    assert not np.any(np.isinf(spec)), "spectral render contains Inf"
+    # And not entirely black / white.
+    assert 0.001 < float(spec.mean()) < 0.95
+
+
+def test_legacy_default_unchanged():
+    """A Renderer with no set_integrator() call must still run the legacy
+    pathTrace pipeline (this is the pkg14 invariant — pkg11 must not flip
+    the default by accident)."""
+    r = astroray.Renderer()
+    create_cornell_box(r)
+    setup_camera(r, look_from=[0, 0, 5.5], look_at=[0, 0, 0],
+                 vfov=38, width=WIDTH, height=HEIGHT)
+    r.set_seed(3)
+    pixels = np.asarray(r.render(SPP, MAX_DEPTH, None, True), dtype=np.float32)
+    assert pixels.shape == (HEIGHT, WIDTH, 3)
+    assert not np.any(np.isnan(pixels))
+    assert 0.001 < float(pixels.mean()) < 0.95


### PR DESCRIPTION
## Summary

- New `spectral_path_tracer` plugin (opt-in via `set_integrator("spectral_path_tracer")`); legacy `path` stays the registry default until pkg14.
- `Material::evalSpectral` + `emittedSpectral` virtuals with Jakob-Hanika upsample defaults, so every existing material works under the spectral pipeline with no per-material edits (concrete overrides land in pkg12+).
- `Renderer::pathTraceSpectral` mirrors `pathTrace`; `Renderer::spectralMode_` flips XYZ accumulator + per-sample firefly clamp on Y + single `xyzToLinearSRGB` conversion before gamma. "Gamma once" invariant preserved.
- Cornell A/B at 32 spp: per-channel mean rel delta `[0.012, 0.015, 0.028]`; spectral wall-clock 1.34× of RGB (target ≤ 1.5×).
- Conftest fix: promote `C:\Program Files\mingw64\bin` to the front of `PATH` so subprocess-launched `raytracer.exe` finds the modern libstdc++.

## Design choices (settled before coding)

- **Mode switch:** `IntegratorKind` enum + `Integrator::kind()` virtual.
- **Bounce loop home:** `Renderer::pathTraceSpectral` helper (mirrors how `path_tracer.cpp` is a thin wrapper around `Renderer::traceFull`).
- **Prism / dispersion criterion:** deferred to pkg13. Direction-spread dispersion needs wavelength-dependent IOR, which only ships with the dielectric override in pkg13. The criterion is folded into pkg13's plan.

## Test plan

- [x] `pytest tests/` — **193 passed, 1 skipped** (4 new tests in `test_spectral_path_tracer.py`).
- [x] `astroray.integrator_registry_names()` includes `"spectral_path_tracer"`.
- [x] Cornell A/B match within tolerance (5% per-channel; actual ~3%).
- [x] Spectral render has no NaN/Inf and is non-degenerate.
- [x] Default integrator (no `set_integrator` call) renders unchanged.
- [x] Wall-clock profile: spectral 1.34× RGB on Cornell at 32 spp.
- [x] PNGs written to `test_results/pkg11_cornell_{rgb,spectral,diff_x5}.png` for visual review.

## Out of scope (re-confirmed)

- No `plugins/materials/*.cpp` edits.
- No `plugins/passes/*.cpp` edits.
- No `include/astroray/spectral.h` edits (GR pipeline untouched).
- No legacy `path_tracer` removal (pkg14).
- No HDRI/env-map spectral path (pkg14).
- No `kSpectrumSamples` tuning, no MIS rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)