### PR TITLE
pkg13c: add oren_nayar, isotropic, two_sided, emissive material plugins

### DIFF
--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Astroray Status
 
-**Last updated:** 2026-04-26 (pkg13 physics/infra thread complete — Metal, Dielectric, Mirror, Subsurface evalSpectral; Texture::sampleSpectral; ImageTexture cache)
+**Last updated:** 2026-04-26 (pkg13 fully complete — all four threads merged: physics/infra #103, pkg13a Copilot #104, pkg13b Copilot #106, pkg13c missing plugins #107)
 
 This is the source-of-truth for "where are we?" Updated by the overseer
 at the start of each week, and by the project owner when a significant
@@ -17,7 +17,7 @@ personally should pick up.
 | # | Name | Status | % | Next milestone | Blocked on |
 |---|---|---|---|---|---|
 | 1 | Plugin architecture | **Done** | 100% | — | — |
-| 2 | Spectral core | **In progress** | ~75% | Copilot thread (issues #98, #99) + pkg14 env map | ~~Pillar 1~~ |
+| 2 | Spectral core | **In progress** | ~90% | pkg14 spectral env map | ~~Pillar 1~~ |
 | 3 | Light transport | Queued | 0% | — | Pillars 1, 2 |
 | 4 | Astrophysics platform | Queued | 0% | Kerr | Pillars 1, 2 |
 | 5 | Production polish | Ongoing | — | OpenEXR output | — |
@@ -40,7 +40,7 @@ personally should pick up.
 | pkg10 | Spectral types (scaffolding) | done |
 | pkg11 | Spectral path tracer | done |
 | pkg12 | Spectral Lambertian override | done |
-| pkg13 | Spectral physics/infra thread (Metal, Dielectric, Mirror, Subsurface, Texture virtual, ImageTexture cache) | in progress — Copilot issues #98/#99 open |
+| pkg13 | Spectral remaining materials & textures (all threads: physics/infra, pkg13a, pkg13b, pkg13c) | **done** |
 | pkg14 | Spectral environment map | queued |
 
 ---
@@ -51,8 +51,8 @@ personally should pick up.
 
 ### Track A (Claude Code)
 
-- Package in flight: pkg13 (physics/infra thread in PR; Copilot threads in issues #98/#99)
-- Next session goal: merge Copilot PRs for #98/#99, then pkg14 spectral env map
+- Package in flight: pkg14 (spectral environment map)
+- Next session goal: implement spectral env map sampling in the spectral path tracer
 
 ### Track B (Copilot cloud)
 
@@ -76,6 +76,10 @@ personally should pick up.
 
 | Date | PR | Track | Pillar | Description |
 |---|---|---|---|---|
+| 2026-04-26 | pkg13c-missing-material-plugins | A | 2 | Created 4 missing material plugins: `oren_nayar` (OrenNayar diffuse + spectral override), `isotropic` (uniform volumetric phase function + spectral override), `two_sided` (wraps inner material, renders both faces + spectral delegation), `emissive` (two-sided omnidirectional emitter + `emittedSpectral`). Closes issue #105. 5 new tests; 223 passed, 1 skipped. **pkg13 fully complete.** |
+| 2026-04-26 | #106 pkg13b Copilot | B | 2 | 8 procedural texture `sampleSpectral` overrides (checker, noise, gradient, voronoi, brick, musgrave, magic, wave). |
+| 2026-04-26 | #104 pkg13a Copilot | B | 2 | `evalSpectral` overrides for Phong, Disney, NormalMapped, `emittedSpectral` for DiffuseLight. |
+| 2026-04-26 | #103 pkg13 physics/infra | A | 2 | `Texture::sampleSpectral` virtual + ImageTexture eager cache; Metal per-λ Schlick Fresnel; Dielectric/Mirror delta overrides; Subsurface cached albedo + transmission spectrum. 206 passed (+8 new). |
 | 2026-04-25 | pkg12-spectral-lambertian | A | 2 | First concrete `evalSpectral` override: `LambertianPlugin` gains `RGBAlbedoSpectrum albedo_spec_` (eager ctor cache) and `evalSpectral` returning `albedo_spec_.sample(lambdas) * cosTheta / PI`. Cache eliminates per-call Jakob-Hanika LUT lookup. Cornell A/B within 3%. 5 new tests; 198 passed, 1 skipped. |
 | 2026-04-25 | pkg11-spectral-path-tracer | A | 2 | Spectral path tracer plugin (`set_integrator("spectral_path_tracer")`), `IntegratorKind` enum, `Material::evalSpectral`/`emittedSpectral` defaults via Jakob-Hanika upsample, `Renderer::pathTraceSpectral` helper + XYZ accumulator + single sRGB conversion. Cornell A/B match within ~3% per channel; 1.34× wall-clock vs RGB. Legacy `path` integrator stays the default. 193 tests (+4 new). |
 | 2026-04-24 | pkg10-spectral-types | A | 2 | Spectral scaffolding: `SampledWavelengths`, `SampledSpectrum`, three `RGB*Spectrum` upsamplers over a shipped Jakob-Hanika LUT, CIE 1964 10° CMF + D65 SPD, Python bindings, 189 tests (+20 new). No integration — renderer is untouched. |
@@ -90,7 +94,7 @@ personally should pick up.
 
 | Package | Track | Status | Blocker |
 |---|---|---|---|
-| pkg13-spectral-materials | A | in review (physics/infra PR open) | Copilot issues #98/#99 |
+| pkg14-spectral-env-map | A | queued | pkg13 (now complete) |
 
 ---
 
@@ -110,6 +114,7 @@ personally should pick up.
 
 Brief notes on notable events.
 
+- **2026-04-26** — pkg13 fully complete. All four threads merged: (1) physics/infra PR #103 — Texture::sampleSpectral, ImageTexture cache, Metal/Dielectric/Mirror/Subsurface evalSpectral; (2) Copilot PR #104 — Phong/Disney/NormalMapped/DiffuseLight evalSpectral/emittedSpectral; (3) Copilot PR #106 — 8 procedural texture sampleSpectral overrides; (4) pkg13c PR — 4 new plugins: oren_nayar, isotropic, two_sided, emissive. Every shading event in the spectral pipeline now has a concrete override. Test suite: 223 passed, 1 skipped. Pillar 2 ~90%.
 - **2026-04-24** — pkg10 merged: Pillar 2 scaffolding. New `include/astroray/spectrum.h` defines `SampledWavelengths`, `SampledSpectrum`, `RGBAlbedoSpectrum`, `RGBUnboundedSpectrum`, `RGBIlluminantSpectrum` (float, 4 samples, 360-830 nm). `src/spectrum.cpp` loads the shipped Jakob-Hanika sRGB LUT lazily from `data/spectra/rgb_to_spectrum_srgb.coeff` and embeds the CIE 1964 10° CMF and D65 SPD as `constexpr` tables. New `astroray_core_impl` CMake target; `ASTRORAY_DATA_DIR` compile definition + env-var override for runtime data discovery. Python bindings expose every type plus a top-level `rgb_to_spectrum()` helper. No integration into any material, integrator, pass, or env map — that is pkg11+. Test suite: 189 passed, 1 skipped (20 new spectrum tests).
 - **2026-04-22** — pkg06 merged: Pass registry closes Pillar 1. `Pass` abstract base + `Framebuffer` named-buffer API in `include/astroray/pass.h` / `raytracer.h`. Five plugins in `plugins/passes/` (OIDN denoiser, depth/normal/albedo AOV). `add_pass`/`clear_passes` Python bindings. `pass_registry_names()` module function. Blender `use_denoising` property wired to `add_pass("oidn_denoiser")`. Inline OIDN code removed from `blender_module.cpp`. Test suite: 169 passed, 1 skipped.
 - **2026-04-22** — pkg05 merged: `Integrator` abstract base class in `include/astroray/integrator.h`; PathTracer and AmbientOcclusion plugins in `plugins/integrators/`; `SampleResult` + `Renderer::traceFull()` for AOV preservation; `set_integrator` Python binding + `integrator_registry_names()`; Blender `integrator_type` EnumProperty wired into render. Test suite: 165 passed, 1 skipped.

--- a/.astroray_plan/packages/pkg13-spectral-materials.md
+++ b/.astroray_plan/packages/pkg13-spectral-materials.md
@@ -172,10 +172,16 @@ to review side by side.
 - [x] All 206 existing tests pass (+8 new in `test_spectral_materials.py`).
 - [x] No legacy `eval`/`sample` signatures changed.
 
-**Copilot thread (issues #98, #99 — still open):**
-- [ ] Phong, Disney, NormalMapped, DiffuseLight (`emittedSpectral`)
-      overrides — issue #98.
-- [ ] 8 procedural texture `sampleSpectral` overrides — issue #99.
+**Copilot thread (issues #98, #99 — merged):**
+- [x] Phong, Disney, NormalMapped, DiffuseLight (`emittedSpectral`)
+      overrides — PR #104 merged.
+- [x] 8 procedural texture `sampleSpectral` overrides — PR #106 merged.
+
+**pkg13c thread (issue #105 — Claude Code, PR #107):**
+- [x] `oren_nayar.cpp` — OrenNayar diffuse + cached `evalSpectral`.
+- [x] `isotropic.cpp` — uniform phase function (1/4π) + cached `evalSpectral`.
+- [x] `two_sided.cpp` — inner material delegation, both faces + `evalSpectral`.
+- [x] `emissive.cpp` — two-sided emitter + `emittedSpectral`.
 
 **Deferred (future package):**
 - [ ] Glass-prism dispersion (requires `sampleSpectral` on `Material`
@@ -211,9 +217,16 @@ to review side by side.
 - [x] Update STATUS.md, CHANGELOG.md.
 - [x] Commit, push, PR.
 
-**Copilot progress (issues #98, #99):**
-- [ ] Issue #98 — dumb material overrides (Phong, Disney, NormalMapped, DiffuseLight).
-- [ ] Issue #99 — procedural texture overrides (8 files).
+**Copilot progress (issues #98, #99 — DONE):**
+- [x] Issue #98 → PR #104 merged — dumb material overrides (Phong, Disney, NormalMapped, DiffuseLight).
+- [x] Issue #99 → PR #106 merged — procedural texture overrides (8 files).
+
+**pkg13c progress (issue #105 — DONE):**
+- [x] Branch `pkg13c-missing-material-plugins`.
+- [x] Create oren_nayar.cpp, isotropic.cpp, two_sided.cpp, emissive.cpp.
+- [x] 5 new tests in `test_spectral_materials.py`; 223 passed, 1 skipped.
+- [x] Update STATUS.md, CHANGELOG.md, pkg13 plan.
+- [x] Commit, push, PR.
 
 ---
 
@@ -233,3 +246,9 @@ to review side by side.
 - **ImageTexture cache built eagerly in `setData()`.** No thread-safety
   concerns — cache is write-once at load time, read-only during rendering.
   Memory cost: 12 bytes × texel count (3 floats for Jakob-Hanika coefficients).
+- **pkg13 issue plan vs reality mismatch.** The pkg13a issue listed oren_nayar,
+  isotropic, two_sided, emissive as files to modify, but they never existed in
+  the codebase. When assigning issues to Copilot, verify all referenced files
+  exist first; file-not-found silently narrows the PR scope. A follow-up issue
+  (#105) caught the gap and a third Claude Code thread (pkg13c) created the 4
+  plugins from scratch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,25 +8,44 @@ All notable changes to this project will be documented in this file.
 
 ### Pillar 2 — Spectral core (in progress)
 
-- **pkg13** — Spectral physics/infra thread (Claude Code). Three deliverables
-  on this PR; Copilot issues #98 and #99 add the remaining dumb-material and
-  procedural-texture overrides in separate PRs. (1) `Texture::sampleSpectral`
-  virtual added to `Texture` base in `include/advanced_features.h`: default
-  upsamples `value(uv, p)` via `RGBAlbedoSpectrum`; non-virtual helper handles
-  coord-mode dispatch. `ImageTexture` overrides with an eager per-texel
-  `RGBAlbedoSpectrum` cache built in `setData()` (12 bytes/texel, zero
-  lock overhead). (2) `MetalPlugin` gains `albedo_spec_` member (same
-  cache pattern as pkg12 Lambertian) and overrides `evalSpectral` with a
-  per-λ Schlick Fresnel inside the GGX microfacet model — `F0` becomes a
-  `SampledSpectrum` evaluated from the cached albedo. Near-delta and roughness
-  paths both covered. (3) `DielectricPlugin` and `MirrorPlugin` gain trivial
-  zero `evalSpectral` overrides (delta lobes; eval is never called
-  meaningfully). `SubsurfacePlugin` gains `albedo_spec_` cache and overrides
-  `evalSpectral` with per-call transmission spectrum from scatter distance.
-  Note: dispersive glass (Sellmeier + `terminateSecondary`) requires a
-  `sampleSpectral(rec, wo, gen, lambdas)` interface extension not yet present
-  — deferred. Metal complex-IOR presets (gold/silver) similarly deferred. Test
-  suite: 206 passed, 1 skipped (+8 new in `tests/test_spectral_materials.py`).
+- **pkg13c** — Four new material plugins completing pkg13 (closes issue #105).
+  `plugins/materials/oren_nayar.cpp`: OrenNayar diffuse model (A/B coefficients
+  precomputed in ctor from roughness; `evalSpectral` uses cached
+  `RGBAlbedoSpectrum albedo_spec_`; cosine hemisphere sampling).
+  `plugins/materials/isotropic.cpp`: uniform volumetric phase function (1/4π);
+  `evalSpectral` returns `albedo_spec_.sample(lambdas) * 1/4π`; `sample` picks
+  a uniformly random direction on the unit sphere. `plugins/materials/two_sided.cpp`:
+  wraps an inner material (registry lookup via `inner_type` param), flips hit
+  record normal on back-face hits, delegates all `eval`/`sample`/`pdf`/
+  `evalSpectral` calls to the inner material. `plugins/materials/emissive.cpp`:
+  omnidirectional emitter — emits from both faces (unlike `DiffuseLight` which
+  gates on `frontFace`); `emittedSpectral` returns cached `RGBIlluminantSpectrum`.
+  5 new tests in `test_spectral_materials.py`; 223 passed, 1 skipped.
+  **pkg13 is now fully complete.** Every plugin in `plugins/materials/` and
+  `plugins/textures/` has a concrete spectral override; the pkg11 Jakob-Hanika
+  fallback remains only as the safety net for future materials.
+- **pkg13 (Copilot — pkg13a #104, pkg13b #106)** — Dumb-material overrides
+  (Phong `evalSpectral` with cached diffuse+specular spectra;
+  Disney `evalSpectral` via final-RGB upsample; NormalMapped `evalSpectral`
+  delegation; DiffuseLight `emittedSpectral` with `RGBIlluminantSpectrum` cache)
+  and 8 procedural texture `sampleSpectral` overrides (checker, noise, gradient,
+  voronoi, brick, musgrave, magic, wave — all call `sample(uv, p)` and upsample
+  per-call, no cache needed for UV-varying procedurals).
+- **pkg13 (physics/infra — Claude Code #103)** — Three deliverables.
+  (1) `Texture::sampleSpectral` virtual added to `Texture` base in
+  `include/advanced_features.h`: default upsamples `value(uv, p)` via
+  `RGBAlbedoSpectrum`; non-virtual helper handles coord-mode dispatch.
+  `ImageTexture` overrides with an eager per-texel `RGBAlbedoSpectrum` cache
+  built in `setData()` (12 bytes/texel, zero lock overhead). (2) `MetalPlugin`
+  gains `albedo_spec_` member and overrides `evalSpectral` with a per-λ Schlick
+  Fresnel inside the GGX microfacet model — `F0` becomes a `SampledSpectrum`
+  evaluated from the cached albedo. Near-delta and roughness paths both covered.
+  (3) `DielectricPlugin` and `MirrorPlugin` gain trivial zero `evalSpectral`
+  overrides (delta lobes). `SubsurfacePlugin` gains `albedo_spec_` cache and
+  overrides `evalSpectral` with per-call transmission spectrum from scatter
+  distance. Dispersive glass (Sellmeier + `terminateSecondary`) and metal
+  complex-IOR presets (gold/silver) remain deferred. 206 passed, 1 skipped
+  (+8 new in `tests/test_spectral_materials.py`).
 - **pkg12** — Spectral Lambertian override. `LambertianPlugin` in
   `plugins/materials/lambertian.cpp` gains an `astroray::RGBAlbedoSpectrum
   albedo_spec_` member, eagerly initialised from `albedo_` in the constructor

--- a/plugins/materials/emissive.cpp
+++ b/plugins/materials/emissive.cpp
@@ -1,0 +1,33 @@
+#include "astroray/register.h"
+#include "raytracer.h"
+
+// Omnidirectional emitter — emits from both faces.
+// Unlike DiffuseLight ("light"/"emission"/"diffuse_light") which only emits
+// from the front face, EmissivePlugin emits regardless of face orientation.
+// Useful for self-luminous objects that should glow from all sides.
+class EmissivePlugin : public Material {
+    Vec3 color_;
+    float intensity_;
+    astroray::RGBIlluminantSpectrum emission_spec_;
+
+public:
+    explicit EmissivePlugin(const astroray::ParamDict& p)
+        : color_(p.getVec3("albedo", Vec3(1.0f))),
+          intensity_(p.getFloat("intensity", 1.0f)),
+          emission_spec_({color_.x * intensity_, color_.y * intensity_, color_.z * intensity_}) {}
+
+    Vec3 emitted(const HitRecord& rec) const override {
+        return color_ * intensity_;  // no front-face gate
+    }
+
+    astroray::SampledSpectrum emittedSpectral(
+            const HitRecord& rec,
+            const astroray::SampledWavelengths& lambdas) const override {
+        return emission_spec_.sample(lambdas);  // no front-face gate
+    }
+
+    Vec3 getEmission() const override { return color_ * intensity_; }
+    bool isEmissive() const override { return true; }
+};
+
+ASTRORAY_REGISTER_MATERIAL("emissive", EmissivePlugin)

--- a/plugins/materials/isotropic.cpp
+++ b/plugins/materials/isotropic.cpp
@@ -1,0 +1,46 @@
+#include "astroray/register.h"
+#include "raytracer.h"
+
+// Isotropic phase function for volumetric scattering.
+// Scatters light uniformly in all directions with phase function p = 1/(4*PI).
+class IsotropicPlugin : public Material {
+    Vec3 albedo_;
+    astroray::RGBAlbedoSpectrum albedo_spec_;
+
+    static constexpr float kInv4Pi = 1.0f / (4.0f * float(M_PI));
+
+public:
+    explicit IsotropicPlugin(const astroray::ParamDict& p)
+        : albedo_(p.getVec3("albedo", Vec3(1.0f))),
+          albedo_spec_({albedo_.x, albedo_.y, albedo_.z}) {}
+
+    Vec3 eval(const HitRecord& rec, const Vec3& wo, const Vec3& wi) const override {
+        return albedo_ * kInv4Pi;
+    }
+
+    astroray::SampledSpectrum evalSpectral(
+            const HitRecord& rec, const Vec3& wo, const Vec3& wi,
+            const astroray::SampledWavelengths& lambdas) const override {
+        return albedo_spec_.sample(lambdas) * kInv4Pi;
+    }
+
+    BSDFSample sample(const HitRecord& rec, const Vec3& wo, std::mt19937& gen) const override {
+        BSDFSample s;
+        std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+        float u1 = dist(gen), u2 = dist(gen);
+        float cosTheta = 1.0f - 2.0f * u1;
+        float sinTheta = std::sqrt(std::max(0.0f, 1.0f - cosTheta * cosTheta));
+        float phi = 2.0f * float(M_PI) * u2;
+        s.wi = Vec3(sinTheta * std::cos(phi), sinTheta * std::sin(phi), cosTheta);
+        s.f = albedo_ * kInv4Pi;
+        s.pdf = kInv4Pi;
+        s.isDelta = false;
+        return s;
+    }
+
+    float pdf(const HitRecord& rec, const Vec3& wo, const Vec3& wi) const override {
+        return kInv4Pi;
+    }
+};
+
+ASTRORAY_REGISTER_MATERIAL("isotropic", IsotropicPlugin)

--- a/plugins/materials/oren_nayar.cpp
+++ b/plugins/materials/oren_nayar.cpp
@@ -1,0 +1,87 @@
+#include "astroray/register.h"
+#include "raytracer.h"
+
+class OrenNayarPlugin : public Material {
+    Vec3 albedo_;
+    float roughness_;
+    astroray::RGBAlbedoSpectrum albedo_spec_;
+
+    // Precomputed Oren-Nayar A and B coefficients
+    float A_, B_;
+
+public:
+    explicit OrenNayarPlugin(const astroray::ParamDict& p)
+        : albedo_(p.getVec3("albedo", Vec3(0.8f))),
+          roughness_(p.getFloat("roughness", 0.5f)),
+          albedo_spec_({albedo_.x, albedo_.y, albedo_.z}) {
+        float s2 = roughness_ * roughness_;
+        A_ = 1.0f - 0.5f * s2 / (s2 + 0.33f);
+        B_ = 0.45f * s2 / (s2 + 0.09f);
+    }
+
+    Vec3 eval(const HitRecord& rec, const Vec3& wo, const Vec3& wi) const override {
+        float NdotL = wi.dot(rec.normal);
+        float NdotV = wo.dot(rec.normal);
+        if (NdotL <= 0.0f || NdotV <= 0.0f) return Vec3(0.0f);
+
+        // Project wi and wo onto the tangent plane to get the azimuthal difference
+        Vec3 wiPerp = (wi - rec.normal * NdotL);
+        Vec3 woPerp = (wo - rec.normal * NdotV);
+        float lenWi = wiPerp.length(), lenWo = woPerp.length();
+        float cosPhiDiff = (lenWi > 1e-6f && lenWo > 1e-6f)
+            ? std::max(0.0f, wiPerp.dot(woPerp) / (lenWi * lenWo))
+            : 0.0f;
+
+        float cosAlpha = std::min(NdotL, NdotV);
+        float sinAlpha = std::sqrt(std::max(0.0f, 1.0f - cosAlpha * cosAlpha));
+        float maxNdot  = std::max(NdotL, NdotV);
+        float tanBeta  = (maxNdot > 1e-6f)
+            ? std::sqrt(std::max(0.0f, 1.0f - maxNdot * maxNdot)) / maxNdot
+            : 0.0f;
+
+        float f = (A_ + B_ * cosPhiDiff * sinAlpha * tanBeta) / float(M_PI);
+        return albedo_ * f * NdotL;
+    }
+
+    astroray::SampledSpectrum evalSpectral(
+            const HitRecord& rec, const Vec3& wo, const Vec3& wi,
+            const astroray::SampledWavelengths& lambdas) const override {
+        float NdotL = wi.dot(rec.normal);
+        float NdotV = wo.dot(rec.normal);
+        if (NdotL <= 0.0f || NdotV <= 0.0f) return astroray::SampledSpectrum(0.0f);
+
+        Vec3 wiPerp = wi - rec.normal * NdotL;
+        Vec3 woPerp = wo - rec.normal * NdotV;
+        float lenWi = wiPerp.length(), lenWo = woPerp.length();
+        float cosPhiDiff = (lenWi > 1e-6f && lenWo > 1e-6f)
+            ? std::max(0.0f, wiPerp.dot(woPerp) / (lenWi * lenWo))
+            : 0.0f;
+
+        float cosAlpha = std::min(NdotL, NdotV);
+        float sinAlpha = std::sqrt(std::max(0.0f, 1.0f - cosAlpha * cosAlpha));
+        float maxNdot  = std::max(NdotL, NdotV);
+        float tanBeta  = (maxNdot > 1e-6f)
+            ? std::sqrt(std::max(0.0f, 1.0f - maxNdot * maxNdot)) / maxNdot
+            : 0.0f;
+
+        float f = (A_ + B_ * cosPhiDiff * sinAlpha * tanBeta) / float(M_PI);
+        return albedo_spec_.sample(lambdas) * (f * NdotL);
+    }
+
+    BSDFSample sample(const HitRecord& rec, const Vec3& wo, std::mt19937& gen) const override {
+        BSDFSample s;
+        Vec3 localWi = Vec3::randomCosineDirection(gen);
+        s.wi = rec.tangent * localWi.x + rec.bitangent * localWi.y + rec.normal * localWi.z;
+        s.f = eval(rec, wo, s.wi);
+        s.pdf = std::max(0.0f, s.wi.dot(rec.normal)) / float(M_PI);
+        s.isDelta = false;
+        return s;
+    }
+
+    float pdf(const HitRecord& rec, const Vec3& wo, const Vec3& wi) const override {
+        float cosTheta = wi.dot(rec.normal);
+        return cosTheta > 0.0f ? cosTheta / float(M_PI) : 0.0f;
+    }
+};
+
+ASTRORAY_REGISTER_MATERIAL("oren_nayar", OrenNayarPlugin)

--- a/plugins/materials/two_sided.cpp
+++ b/plugins/materials/two_sided.cpp
@@ -1,0 +1,47 @@
+#include "astroray/register.h"
+#include "raytracer.h"
+
+// Wraps another material and renders both faces.
+// On the back face, flips the hit record normal so the inner material
+// sees a front-face hit — allowing e.g. a Lambertian cloth to be
+// shaded correctly from both sides.
+class TwoSidedPlugin : public Material {
+    std::shared_ptr<Material> inner_;
+
+    static HitRecord flipToFront(const HitRecord& rec) {
+        HitRecord out = rec;
+        out.normal = -rec.normal;
+        out.frontFace = true;
+        buildOrthonormalBasis(out.normal, out.tangent, out.bitangent);
+        return out;
+    }
+
+public:
+    explicit TwoSidedPlugin(const astroray::ParamDict& p)
+        : inner_(astroray::MaterialRegistry::instance().create(
+              p.getString("inner_type", "lambertian"), p)) {}
+
+    Vec3 eval(const HitRecord& rec, const Vec3& wo, const Vec3& wi) const override {
+        const HitRecord& r = rec.frontFace ? rec : flipToFront(rec);
+        return inner_->eval(r, wo, wi);
+    }
+
+    astroray::SampledSpectrum evalSpectral(
+            const HitRecord& rec, const Vec3& wo, const Vec3& wi,
+            const astroray::SampledWavelengths& lambdas) const override {
+        const HitRecord flipped = rec.frontFace ? rec : flipToFront(rec);
+        return inner_->evalSpectral(flipped, wo, wi, lambdas);
+    }
+
+    BSDFSample sample(const HitRecord& rec, const Vec3& wo, std::mt19937& gen) const override {
+        const HitRecord flipped = rec.frontFace ? rec : flipToFront(rec);
+        return inner_->sample(flipped, wo, gen);
+    }
+
+    float pdf(const HitRecord& rec, const Vec3& wo, const Vec3& wi) const override {
+        const HitRecord flipped = rec.frontFace ? rec : flipToFront(rec);
+        return inner_->pdf(flipped, wo, wi);
+    }
+};
+
+ASTRORAY_REGISTER_MATERIAL("two_sided", TwoSidedPlugin)

--- a/tests/test_spectral_materials.py
+++ b/tests/test_spectral_materials.py
@@ -180,6 +180,73 @@ def test_subsurface_spectral_no_nan(test_results_dir):
 # Texture::sampleSpectral — default and image cache
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# pkg13c — OrenNayar, Isotropic, TwoSided, Emissive
+# ---------------------------------------------------------------------------
+
+def test_oren_nayar_spectral_no_nan(test_results_dir):
+    def scene(r):
+        create_cornell_box(r)
+        mat = r.create_material("oren_nayar", [0.8, 0.6, 0.3], {"roughness": 0.6})
+        r.add_sphere([0, -1, 0], 1.0, mat)
+
+    pixels = _render("spectral_path_tracer", scene)
+    save_image(pixels, os.path.join(test_results_dir, 'pkg13c_oren_nayar_spectral.png'))
+    assert not np.any(np.isnan(pixels))
+    assert not np.any(np.isinf(pixels))
+    assert pixels.min() >= 0.0
+    assert float(pixels.mean()) > 0.001
+
+
+def test_isotropic_spectral_no_nan(test_results_dir):
+    def scene(r):
+        create_cornell_box(r)
+        mat = r.create_material("isotropic", [0.9, 0.9, 0.9], {})
+        r.add_sphere([0, -1, 0], 1.0, mat)
+
+    pixels = _render("spectral_path_tracer", scene)
+    save_image(pixels, os.path.join(test_results_dir, 'pkg13c_isotropic_spectral.png'))
+    assert not np.any(np.isnan(pixels))
+    assert not np.any(np.isinf(pixels))
+    assert pixels.min() >= 0.0
+
+
+def test_two_sided_spectral_no_nan(test_results_dir):
+    def scene(r):
+        create_cornell_box(r)
+        mat = r.create_material("two_sided", [0.7, 0.4, 0.9],
+                                {"inner_type": "lambertian"})
+        r.add_sphere([0, -1, 0], 1.0, mat)
+
+    pixels = _render("spectral_path_tracer", scene)
+    save_image(pixels, os.path.join(test_results_dir, 'pkg13c_two_sided_spectral.png'))
+    assert not np.any(np.isnan(pixels))
+    assert not np.any(np.isinf(pixels))
+    assert pixels.min() >= 0.0
+
+
+def test_emissive_spectral_emits(test_results_dir):
+    """Emissive plugin (two-sided) should produce nonzero luminance."""
+    def scene(r):
+        create_cornell_box(r)
+        mat = r.create_material("emissive", [1.0, 0.8, 0.4], {"intensity": 3.0})
+        r.add_sphere([0, -1, 0], 0.5, mat)
+
+    pixels = _render("spectral_path_tracer", scene)
+    save_image(pixels, os.path.join(test_results_dir, 'pkg13c_emissive_spectral.png'))
+    assert not np.any(np.isnan(pixels))
+    assert not np.any(np.isinf(pixels))
+    assert float(pixels.mean()) > 0.01, "emissive sphere should illuminate the scene"
+
+
+def test_new_materials_in_registry():
+    """All pkg13c materials appear in the material registry."""
+    names = astroray.material_registry_names()
+    for name in ("oren_nayar", "isotropic", "two_sided", "emissive"):
+        assert name in names, f"{name!r} not in registry; have {names}"
+
+
+# ---------------------------------------------------------------------------
 def test_texture_sample_spectral_default_matches_upsample():
     """Texture.sampleSpectral default matches RGBAlbedoSpectrum(value).sample."""
     for u_val in [0.0, 0.25, 0.5, 0.75]:


### PR DESCRIPTION
Closes #105. Completes pkg13.

## Summary

- **`oren_nayar.cpp`** — OrenNayar diffuse model. Precomputes A/B coefficients from `roughness` in the constructor. `evalSpectral` uses cached `RGBAlbedoSpectrum albedo_spec_`, same pattern as Lambertian (pkg12). Cosine hemisphere sampling.
- **`isotropic.cpp`** — Uniform volumetric phase function (p = 1/4π). `evalSpectral` returns `albedo_spec_.sample(lambdas) * 1/4π`. `sample` picks a uniformly random direction on the unit sphere (not hemisphere). Suitable for volumetric scattering via ConstantMedium.
- **`two_sided.cpp`** — Wraps an inner material (registry lookup via `inner_type` param, same pattern as NormalMappedPlugin). On back-face hits, flips the hit record normal and tangent frame, then delegates all `eval`/`sample`/`pdf`/`evalSpectral` calls to the inner material.
- **`emissive.cpp`** — Omnidirectional emitter. Unlike `DiffuseLight` / `"light"` / `"emission"` which gate on `frontFace`, `EmissivePlugin::emitted` and `emittedSpectral` return the emission on both faces. Cached `RGBIlluminantSpectrum`. Registered as `"emissive"`.

## Test plan

- [x] 5 new tests in `tests/test_spectral_materials.py`: no-NaN/Inf renders for oren_nayar, isotropic, two_sided; emissive emits nonzero luminance; all 4 names appear in the material registry.
- [x] Full suite: 223 passed, 1 skipped (no regressions).
- [x] Build clean (no new warnings from new files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)