### PR TITLE
docs: add Codex agent workflow setup

### DIFF
--- a/.astroray_plan/README.md
+++ b/.astroray_plan/README.md
@@ -6,10 +6,12 @@ engine is in this folder. Drop it into the repo root as `.astroray_plan/`.
 
 ## Start here
 
-1. **[`docs/ROADMAP.md`](docs/ROADMAP.md)** — master roadmap. Four tracks,
+1. **[`docs/ROADMAP.md`](docs/ROADMAP.md)** — master roadmap. Agent tracks,
    five pillars, 12-week view. Read first.
 2. **[`docs/STATUS.md`](docs/STATUS.md)** — current state. Updated weekly.
-3. Pick a package from **[`packages/`](packages/)** and go.
+3. **[`docs/NEXT_STAGE_REPORT.md`](docs/NEXT_STAGE_REPORT.md)** — current
+   Codex orientation report and recommended next work.
+4. Pick a package from **[`packages/`](packages/)** and go.
 
 ## Structure
 
@@ -19,6 +21,8 @@ engine is in this folder. Drop it into the repo root as `.astroray_plan/`.
 ├── docs/                          ← design documentation
 │   ├── ROADMAP.md                ← start here
 │   ├── STATUS.md                 ← current state
+│   ├── NEXT_STAGE_REPORT.md      ← Codex orientation + next-stage report
+│   ├── local-agent-integration.md← local model integration plan
 │   ├── plugin-architecture.md    ← Pillar 1 design
 │   ├── spectral-core.md          ← Pillar 2 design
 │   ├── light-transport.md        ← Pillar 3 design
@@ -27,6 +31,7 @@ engine is in this folder. Drop it into the repo root as `.astroray_plan/`.
 │   └── external-references.md    ← libraries, data, papers
 ├── agents/                        ← per-agent handbooks
 │   ├── claude-code.md            ← track A
+│   ├── codex.md                  ← Codex repo/GitHub/coordination workflow
 │   ├── copilot-cloud.md          ← track B
 │   ├── copilot-instructions.md   ← copy to .github/copilot-instructions.md
 │   ├── copilot-setup-steps.yml   ← copy to .github/workflows/
@@ -49,7 +54,7 @@ engine is in this folder. Drop it into the repo root as `.astroray_plan/`.
 └── logs/                          ← auto-generated Ralph reports
 ```
 
-## The four tracks at a glance
+## The agent tracks at a glance
 
 | Track | What it is | When to use | Cost |
 |---|---|---|---|
@@ -57,6 +62,7 @@ engine is in this folder. Drop it into the repo root as `.astroray_plan/`.
 | **B. Copilot cloud** | Self-contained features | New plugins matching an existing pattern | Education Premium |
 | **C. Cline + local model** | Prototype and experimentation | "Does X even work?" exploration | Free (your RTX 5070 Ti) |
 | **D. Ralph loop** | Background grind (tests, docs) | Small, mechanical, verifiable tasks | Free (your GPU, idle time) |
+| **E. Codex** | Repo setup, PR/issue orchestration, targeted fixes, reviews | Handoffs, CI/debug, scoped implementation, next-step reports | ChatGPT/Codex plan or local mode |
 
 ## Weekly rhythm
 

--- a/.astroray_plan/agents/codex.md
+++ b/.astroray_plan/agents/codex.md
@@ -1,0 +1,97 @@
+# Codex Handbook
+
+**Role:** repo-integrated engineering agent. Codex is best used for fast local
+orientation, scoped implementation, GitHub issue/PR triage, CI/debug follow-up,
+and preparing handoff specs for Claude Code, Copilot coding agents, or local
+model workers.
+
+Codex should complement Claude Code, not replace it:
+
+- Use **Claude Code** for long, core track-A changes where cross-file physics
+  invariants must be held in one model's head.
+- Use **Codex** for local repo setup, issue shaping, PR review, CI diagnosis,
+  targeted fixes, reports, and small-to-medium implementation packages.
+- Use **GitHub Copilot coding agents** for narrow plugin-pattern issues with
+  exact file scope and machine-checkable acceptance criteria.
+- Use **local model workers** for prototypes, mechanical test/doc tasks, and
+  overnight queues where a wrong answer can be discarded cheaply.
+
+## Starting A Codex Session
+
+1. Read `AGENTS.md`.
+2. Read `.astroray_plan/docs/STATUS.md`.
+3. If choosing next work, read `.astroray_plan/docs/ROADMAP.md` and the relevant
+   pillar design doc.
+4. Check `git status --short --branch`.
+5. For coding changes, create a `codex/<topic>` branch unless the user says
+   otherwise.
+
+## Default Codex Workflows
+
+### Repo Orientation
+
+- Summarize current status from `.astroray_plan/docs/STATUS.md`.
+- Compare docs against live repo state with `pytest --collect-only -q`, `git log`,
+  and open GitHub issues/PRs.
+- Record stale instructions as doc fixes instead of relying on memory.
+
+### Implementation
+
+- Keep changes narrowly scoped.
+- Prefer plugins and tests over edits to `include/raytracer.h`.
+- Re-run CMake when adding plugin files because plugin discovery uses CMake globbing.
+- Run focused tests first, then the full suite when the change touches shared paths.
+
+### GitHub Handoff
+
+Codex should write issues for other agents in this shape:
+
+```markdown
+## Goal
+One concrete deliverable.
+
+## Context
+Relevant package, closest existing file, and why this is safe for this agent.
+
+## Files Allowed
+Exact paths or path globs.
+
+## Acceptance Criteria
+- [ ] Machine-checkable result.
+- [ ] Focused test.
+- [ ] Full test command.
+
+## Non-goals
+Explicit files and behaviors not to touch.
+```
+
+Use Copilot only for tasks that match an existing plugin/test pattern. Use
+Claude Code when the task changes renderer invariants, GR math, integrator
+contracts, or build architecture. Use local model workers for disposable
+experiments and mechanical queue items.
+
+## Verification Baseline
+
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DASTRORAY_ENABLE_CUDA=OFF
+cmake --build build -j
+pytest --collect-only -q
+pytest tests/ -v --tb=short
+```
+
+On Windows, stale `.pyd` files can shadow the fresh build. Before debugging
+surprising behavior, run:
+
+```powershell
+Get-ChildItem -Recurse -Filter 'astroray*.pyd'
+```
+
+The authoritative test module should normally be under `build/`.
+
+## Current Codex Priorities
+
+1. Keep agent instructions current as the architecture changes.
+2. Shape Pillar 3 into small packages before implementation starts.
+3. Turn rendering-output observations into explicit tests where possible.
+4. Use GitHub issues/PRs as the coordination layer so the user does not have to
+   manually shuttle context between agents.

--- a/.astroray_plan/agents/copilot-instructions.md
+++ b/.astroray_plan/agents/copilot-instructions.md
@@ -9,9 +9,8 @@ with a Blender 5.1 addon. Read this file before doing anything.
 Astroray/
 ├── include/
 │   ├── raytracer.h          ← core types and Material base class
-│   └── advanced_features.h  ← GR integrator, spectral, advanced BSDFs
-├── src/
-│   └── renderer.cpp         ← Renderer, PyRenderer, path tracer
+│   ├── advanced_features.h  ← advanced BSDFs and compatibility classes
+│   └── astroray/            ← registries, integrators, passes, GR, spectral
 ├── plugins/                 ← one file per plugin (see below)
 │   ├── materials/
 │   ├── shapes/
@@ -19,7 +18,7 @@ Astroray/
 │   ├── integrators/
 │   └── passes/
 ├── tests/
-│   └── test_*.py            ← pytest test suite
+│   └── test_*.py            ← pytest test suite, 227 collected tests
 ├── blender_addon/           ← Blender 5.1 Python addon
 ├── CMakeLists.txt
 └── .astroray_plan/          ← development plan (read-only for you)
@@ -28,7 +27,7 @@ Astroray/
 ## How to build
 
 ```bash
-cmake -B build -DCMAKE_BUILD_TYPE=Release
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DASTRORAY_ENABLE_CUDA=OFF
 cmake --build build -j
 ```
 
@@ -62,7 +61,6 @@ You may only:
 
 - `include/raytracer.h` — unless the issue explicitly says so.
 - `include/advanced_features.h` — unless the issue explicitly says so.
-- `src/renderer.cpp` — unless the issue explicitly says so.
 - `blender_addon/` — not your concern in plugin issues.
 - Any file not mentioned in the issue spec.
 
@@ -84,6 +82,11 @@ ASTRORAY_REGISTER_PASS("name", ClassName)       // for passes
 The constructor takes `const ParamDict&`. Use `getFloat`, `getVec3`,
 `getInt`, `getBool`, `getString` with sensible defaults.
 
+Use the current base-class signatures in `include/raytracer.h`,
+`include/astroray/integrator.h`, and `include/astroray/pass.h`. Spectral
+materials must implement the current spectral contract; do not resurrect the
+deleted legacy RGB path tracer or `Material::eval` virtual.
+
 ## Work package spec location
 
 The work package that describes your task is in
@@ -96,4 +99,4 @@ Read it, but do not modify it.
 - Dormand-Prince Butcher tableau coefficients are ported exactly from
   the Python reference. Do not "clean up" the numbers.
 - Double precision in the GR integrator, float everywhere else.
-- Auto-exposure: 99th-percentile luminance scaled to 0.8.
+- `path_tracer` is the current spectral-first default integrator name.

--- a/.astroray_plan/docs/NEXT_STAGE_REPORT.md
+++ b/.astroray_plan/docs/NEXT_STAGE_REPORT.md
@@ -148,24 +148,24 @@ to Copilot.
 
 ## Suggested Immediate Issues
 
-1. `fix: restore black-hole GR dispatch in spectral path_tracer`
+1. #111 `fix: restore black-hole GR dispatch in spectral path_tracer`
    - Track: A/Codex
    - Blocks: Pillar 4
    - Non-goal: Kerr
 
-2. `test: remove stale RGB-vs-spectral assumptions after pkg14`
+2. #112 `test: remove stale RGB-vs-spectral assumptions after pkg14`
    - Track: Codex/Ralph
    - Scope: tests and comments only unless an assertion is wrong
 
-3. `chore: add render-output triage script for test_results PNGs`
+3. #113 `chore: add render-output triage script for test_results PNGs`
    - Track: Codex/Ralph
    - Output: text report, no CI failure yet
 
-4. `plan: add pkg20-pkg23 Pillar 3 ReSTIR package specs`
+4. #114 `plan: add pkg20-pkg23 Pillar 3 ReSTIR package specs`
    - Track: Codex/Claude Code
    - Output: package markdown files
 
-5. `proto: tiny-cuda-nn dummy inference branch`
+5. #115 `proto: tiny-cuda-nn dummy inference branch`
    - Track: Cline/local model
    - Output: prototype branch notes, not a mergeable PR
 

--- a/.astroray_plan/docs/NEXT_STAGE_REPORT.md
+++ b/.astroray_plan/docs/NEXT_STAGE_REPORT.md
@@ -1,0 +1,192 @@
+# Astroray Next Stage Report
+
+**Date:** 2026-04-28  
+**Prepared by:** Codex  
+**Scope:** repo orientation, Codex setup, next-stage planning, agent workflow,
+local-model integration, and rendering/test-result review.
+
+## Current State
+
+Astroray is at a clean transition point:
+
+- Pillar 1, plugin architecture, is done.
+- Pillar 2, spectral core, is done.
+- Pillar 3, light transport, is the next primary engineering pillar.
+- Pillar 4, astrophysics platform, can start in parallel only where work is
+  independent of ReSTIR/NRC transport decisions.
+- Pillar 5, production polish, should continue opportunistically.
+
+Live repo observations:
+
+- Branch at orientation time: `main`, clean.
+- GitHub PRs: none open.
+- GitHub issues: five open production/Cycles-parity issues: #29, #30, #36,
+  #38, #39.
+- Tests collected locally on 2026-04-28: 227.
+- Current full-suite baseline on 2026-04-28:
+  `207 passed, 1 skipped, 19 xfailed`.
+- The latest saved historical pytest log in `test_results/` is older
+  (2026-04-15, 112 tests), so it should not be used as the current baseline.
+
+## Setup Changes Made
+
+- Added `.astroray_plan/agents/codex.md` so Codex has a first-class role beside
+  Claude Code, Copilot, Cline, and Ralph.
+- Added `.astroray_plan/docs/local-agent-integration.md` with a practical
+  Ollama/LM Studio/Cline/Codex integration plan.
+- Updated `AGENTS.md`, `CLAUDE.md`, README test count, and Copilot instructions
+  to reflect the current plugin/spectral architecture.
+- Corrected stale Copilot guidance that referenced removed architecture such as
+  `src/renderer.cpp` and the deleted legacy RGB path tracer.
+
+## Rendering And Test Findings
+
+### 1. GR black-hole dispatch is the biggest visible correctness gap
+
+The black-hole-only smoke render currently passes while producing a fully black
+PNG. Two stronger GR tests are marked xfail with the reason:
+`black hole GR dispatch not ported to pathTraceSpectral`.
+
+Impact:
+
+- Pillar 2's spectral path-tracer flip left GR rendering partially disconnected.
+- The xfails are honest, but the passing smoke test is too weak.
+- This should be fixed before Pillar 4 Kerr work, otherwise Kerr development
+  will build on a broken integration point.
+
+Recommended next work:
+
+1. Create `pkg15-gr-spectral-dispatch.md`.
+2. Port black-hole GR dispatch into the current `path_tracer` integrator path.
+3. Strengthen `test_black_hole_creation` so it checks visible signal, not just
+   finite pixels.
+4. Un-xfail `test_black_hole_shadow_is_dark` and
+   `test_black_hole_extreme_disk_remains_finite`.
+
+Owner: Claude Code or Codex. This is not a Copilot task.
+
+### 2. Spectral-vs-RGB A/B tests are stale after pkg14
+
+Some tests still describe "RGB vs spectral" parity, but the legacy RGB path was
+deleted and `path_tracer` is now the spectral-first default. At least one test
+renders `path_tracer` twice and compares the images to each other.
+
+Impact:
+
+- The tests still catch determinism/noise problems, but no longer validate
+  parity against an independent RGB implementation.
+- Future agents may falsely believe an RGB reference path still exists.
+
+Recommended next work:
+
+1. Rename stale tests and comments from RGB-vs-spectral to deterministic
+   spectral A/B where that is what they do.
+2. Add explicit golden metric tests around important spectral conversions
+   rather than relying on a deleted renderer path.
+3. Keep saved diff PNGs where useful, but do not present them as RGB parity.
+
+Owner: Codex or Ralph for comments/names; Claude Code for any assertion redesign.
+
+### 3. Some test-result PNGs are intentionally black or binary, but the suite
+needs an image-quality triage command
+
+The PNG review found expected black images such as black-background tests and
+diff images, plus area-light footprint images that are binary masks by design.
+The suspicious part is not the presence of black files; it is that the repo has
+no standard command to distinguish expected black outputs from accidental black
+renders.
+
+Recommended next work:
+
+1. Add a small non-shipping script under `scripts/` that reports image
+   dimensions, mean brightness, max value, and tiny file sizes for
+   `test_results/*.png`.
+2. Use the report in PR review, not as a hard CI gate at first.
+3. Promote individual checks into pytest only after a pattern is confirmed.
+
+Owner: Codex or Ralph.
+
+## Next Engineering Stage
+
+### Phase 0: Stabilize after the spectral flip
+
+Do this before ReSTIR:
+
+- Fix GR dispatch in the current spectral `path_tracer`.
+- Clean stale RGB-vs-spectral test wording.
+- Update package docs so pkg14 completion is reflected everywhere agents look.
+- Add a render-output triage script.
+
+### Phase 1: Scope Pillar 3 into small packages
+
+Create concrete package files before coding:
+
+- `pkg20-reservoir-core.md`: reservoir struct, invariants, tests.
+- `pkg21-light-sample-abstraction.md`: direct-light sample representation
+  usable by ReSTIR without changing material conventions.
+- `pkg22-restir-initial-sampling.md`: initial candidate generation only.
+- `pkg23-restir-temporal-spatial-design.md`: design and CPU/GPU boundary.
+- `pkg25-tiny-cuda-nn-prototype.md`: local prototype only, no production code.
+
+Do not begin with full temporal/spatial ReSTIR. Start with a reservoir unit and
+a validation scene.
+
+### Phase 2: Parallelize safely
+
+- Claude Code: GR dispatch fix and ReSTIR design/implementation packages.
+- Codex: package writing, PR review, CI triage, test cleanup, docs alignment.
+- Copilot: only plugin-pattern issues with exact file scope.
+- Cline/local model: tiny-cuda-nn build experiment and disposable prototypes.
+- Ralph/local model: registry tests, doc cleanup, render-output statistics.
+
+### Phase 3: Refresh GitHub issues
+
+Current open issues are useful, but they are mostly production/Cycles-parity
+work. They do not yet represent the next pillar. Create new Pillar 3 issues
+from the packages above, label them by track, and assign only the narrow ones
+to Copilot.
+
+## Suggested Immediate Issues
+
+1. `fix: restore black-hole GR dispatch in spectral path_tracer`
+   - Track: A/Codex
+   - Blocks: Pillar 4
+   - Non-goal: Kerr
+
+2. `test: remove stale RGB-vs-spectral assumptions after pkg14`
+   - Track: Codex/Ralph
+   - Scope: tests and comments only unless an assertion is wrong
+
+3. `chore: add render-output triage script for test_results PNGs`
+   - Track: Codex/Ralph
+   - Output: text report, no CI failure yet
+
+4. `plan: add pkg20-pkg23 Pillar 3 ReSTIR package specs`
+   - Track: Codex/Claude Code
+   - Output: package markdown files
+
+5. `proto: tiny-cuda-nn dummy inference branch`
+   - Track: Cline/local model
+   - Output: prototype branch notes, not a mergeable PR
+
+## Local Model Recommendation
+
+Use Ollama first, LM Studio second. As of the checked docs, Codex CLI supports
+local/offline model runs through local Responses-compatible endpoints, and
+Cline has first-class Ollama/LM Studio local model guidance. The practical
+model target is `qwen3-coder:30b` if hardware allows; use smaller models only
+for mechanical tasks.
+
+Important caveat: local models are cost savers, not final authority. They should
+draft and grind. Codex or Claude Code should review and integrate.
+
+Sources:
+
+- OpenAI Codex agent loop and local endpoint behavior:
+  https://openai.com/index/unrolling-the-codex-agent-loop/
+- Cline local model guidance:
+  https://docs.cline.bot/running-models-locally/overview
+- Ollama Cline integration:
+  https://docs.ollama.com/integrations/cline
+- Ollama Qwen3 Coder tags:
+  https://ollama.com/library/qwen3-coder

--- a/.astroray_plan/docs/ROADMAP.md
+++ b/.astroray_plan/docs/ROADMAP.md
@@ -23,12 +23,11 @@ itself with a concrete caller today.
 
 ---
 
-## The four tracks
+## The agent tracks
 
-Work happens on four independent tracks. Each has its own agent and
-acceptance criteria. Progress on one track rarely blocks another — that
-is by design, so your single-developer throughput multiplies without
-coordination overhead.
+Work happens on independent tracks. Each has its own agent and acceptance
+criteria. Progress on one track rarely blocks another — that is by design, so
+your single-developer throughput multiplies without coordination overhead.
 
 | Track | Owner agent | Runs on | Purpose |
 |---|---|---|---|
@@ -36,6 +35,7 @@ coordination overhead.
 | **B. Feature breadth** | GitHub Copilot cloud | GitHub Actions | Self-contained features shipped as plugins |
 | **C. Experiments** | Cline + local model | Your machine, VS Code | Exploratory changes, prototypes |
 | **D. Grind work** | Ralph loop + local model | Background on your machine | Test coverage, docs, lint fixes |
+| **E. Coordination/review** | Codex | Codex app/CLI + GitHub connector | Repo setup, PR/issue triage, CI/debug, targeted fixes, handoff specs |
 
 The overseer (see `agents/overseer.md`) coordinates by deciding what
 goes on which track, not by touching code.
@@ -45,6 +45,8 @@ goes on which track, not by touching code.
 - Track B handles anything that *matches a pattern* that is already right.
 - Track C explores things that *might* be right.
 - Track D mechanically converts known-right work into more of it.
+- Track E keeps the other tracks aligned and turns context into actionable
+  issues, reports, and PRs.
 
 ---
 

--- a/.astroray_plan/docs/local-agent-integration.md
+++ b/.astroray_plan/docs/local-agent-integration.md
@@ -1,0 +1,91 @@
+# Local Agent Integration Plan
+
+**Status:** proposed  
+**Purpose:** let Codex, Claude Code, Cline, and background workers use local
+models where that saves paid subscription/API budget, while preserving a clear
+quality gate before anything reaches `main`.
+
+## Recommended Architecture
+
+Use **Ollama as the default local runtime** and keep **LM Studio as the GUI
+fallback**. Both expose local model servers that current agent tools can use.
+
+```
+Codex CLI/App (paid frontier when needed)
+        |
+        |-- local/offline mode for cheap drafts via Ollama or LM Studio
+        |
+Cline / Ralph / future queue worker
+        |
+        |-- Ollama at http://localhost:11434
+        |-- model: Qwen3 Coder 30B or best local coding model that fits VRAM/RAM
+```
+
+Sources checked on 2026-04-28:
+
+- OpenAI's Codex agent-loop documentation says Codex CLI can use configurable
+  Responses API endpoints and, with `--oss`, defaults to a local Ollama/LM
+  Studio endpoint for gpt-oss-compatible local runs:
+  https://openai.com/index/unrolling-the-codex-agent-loop/
+- Cline's local-model documentation recommends LM Studio or Ollama, with Qwen3
+  Coder 30B as the primary sub-70B local coding model:
+  https://docs.cline.bot/running-models-locally/overview
+- Ollama's Cline integration docs specify selecting Ollama as Cline's provider
+  and using at least a 32K context window for coding tools:
+  https://docs.ollama.com/integrations/cline
+- Ollama's Qwen3 Coder library lists `qwen3-coder:30b` as a 30B local tag:
+  https://ollama.com/library/qwen3-coder
+
+## Tool Roles
+
+| Tool | Local model role | Paid model role |
+|---|---|---|
+| Codex | quick local drafts, issue shaping, simple edits | PR-quality changes, review, GitHub operations |
+| Claude Code | experimental only through compatible local endpoints | core track-A implementation |
+| Cline | main local prototype interface | optional fallback if local model fails |
+| Ralph loop | overnight mechanical queue | none by default |
+
+## Setup Steps
+
+1. Install Ollama.
+2. Pull one serious coding model and one small fallback:
+   ```bash
+   ollama pull qwen3-coder:30b
+   ollama pull qwen2.5-coder:7b
+   ```
+3. Confirm the server is running:
+   ```bash
+   ollama list
+   ```
+4. Configure Cline:
+   - Provider: `Ollama`
+   - Base URL: `http://localhost:11434`
+   - Context window: at least `32768`
+   - Use compact prompts if available
+5. Test Codex local mode from a terminal before relying on it for repo work:
+   ```bash
+   codex --oss
+   ```
+6. Add a future queue worker only after local Cline/Ollama behavior is stable.
+
+## Guardrails
+
+- Local models may draft code, but a frontier model or human should review any
+  change touching `include/raytracer.h`, GR math, spectral conversion, sampling,
+  MIS, CMake dependency plumbing, or Blender export behavior.
+- Local-model branches use `proto/<topic>` or `ralph/<task>`, not `main`.
+- Codex or Claude Code should turn successful prototypes into clean PRs.
+- Failed local-model attempts should produce notes, not hidden state. If a task
+  fails twice, rewrite the task spec before trying again.
+
+## First Practical Use
+
+Use local models for these near-term tasks:
+
+- generate additional low-risk tests around plugin registry contracts
+- inspect rendered PNGs and produce candidate assertions for Codex/Claude review
+- draft package specs for Pillar 3 subpackages
+- prototype tiny-cuda-nn build wiring in a throwaway branch
+
+Do **not** start local models on ReSTIR correctness, GR dispatch, or spectral
+path changes until the task has a tight spec and an owner model for review.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,9 +9,8 @@ with a Blender 5.1 addon. Read this file before doing anything.
 Astroray/
 ├── include/
 │   ├── raytracer.h          ← core types and Material base class
-│   └── advanced_features.h  ← GR integrator, spectral, advanced BSDFs
-├── src/
-│   └── renderer.cpp         ← Renderer, PyRenderer, path tracer
+│   ├── advanced_features.h  ← advanced BSDFs and compatibility classes
+│   └── astroray/            ← registries, integrators, passes, GR, spectral
 ├── plugins/                 ← one file per plugin (see below)
 │   ├── materials/
 │   ├── shapes/
@@ -19,7 +18,7 @@ Astroray/
 │   ├── integrators/
 │   └── passes/
 ├── tests/
-│   └── test_*.py            ← pytest test suite
+│   └── test_*.py            ← pytest test suite, 227 collected tests
 ├── blender_addon/           ← Blender 5.1 Python addon
 ├── CMakeLists.txt
 └── .astroray_plan/          ← development plan (read-only for you)
@@ -28,7 +27,7 @@ Astroray/
 ## How to build
 
 ```bash
-cmake -B build -DCMAKE_BUILD_TYPE=Release
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DASTRORAY_ENABLE_CUDA=OFF
 cmake --build build -j
 ```
 
@@ -62,7 +61,6 @@ You may only:
 
 - `include/raytracer.h` — unless the issue explicitly says so.
 - `include/advanced_features.h` — unless the issue explicitly says so.
-- `src/renderer.cpp` — unless the issue explicitly says so.
 - `blender_addon/` — not your concern in plugin issues.
 - Any file not mentioned in the issue spec.
 
@@ -84,6 +82,11 @@ ASTRORAY_REGISTER_PASS("name", ClassName)       // for passes
 The constructor takes `const ParamDict&`. Use `getFloat`, `getVec3`,
 `getInt`, `getBool`, `getString` with sensible defaults.
 
+Use the current base-class signatures in `include/raytracer.h`,
+`include/astroray/integrator.h`, and `include/astroray/pass.h`. Spectral
+materials must implement the current spectral contract; do not resurrect the
+deleted legacy RGB path tracer or `Material::eval` virtual.
+
 ## Work package spec location
 
 The work package that describes your task is in
@@ -96,4 +99,4 @@ Read it, but do not modify it.
 - Dormand-Prince Butcher tableau coefficients are ported exactly from
   the Python reference. Do not "clean up" the numbers.
 - Double precision in the GR integrator, float everywhere else.
-- Auto-exposure: 99th-percentile luminance scaled to 0.8.
+- `path_tracer` is the current spectral-first default integrator name.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@ Astroray/
 ├── apps/                    # Standalone CLI entrypoint
 ├── blender_addon/           # Blender RenderEngine addon + shader_blending.py
 ├── docs/                    # Project docs, ADRs, agent context
+├── plugins/                 # Plugin implementations compiled into both targets
 ├── include/                 # Header-only renderer core
 │   ├── raytracer.h          # Core: Vec3, Ray, Materials, BVH, Camera, Renderer
 │   ├── advanced_features.h  # DisneyBRDF, textures, transforms, volumes
@@ -12,9 +13,18 @@ Astroray/
 ├── module/                  # pybind11 Python bindings (blender_module.cpp)
 ├── scripts/                 # build_blender_addon.py and utilities
 ├── src/                     # C++ implementation units
-├── tests/                   # pytest suite (66 tests)
+├── tests/                   # pytest suite (227 collected tests as of 2026-04-28)
 └── CMakeLists.txt
 ```
+
+## Agent Operating Model
+
+- `AGENTS.md` is the shared repo contract for Codex and other coding agents.
+- `CLAUDE.md` remains Claude Code's behavioral guide. Do not delete or replace it.
+- `.github/copilot-instructions.md` constrains GitHub Copilot coding agents.
+- `.astroray_plan/docs/STATUS.md` is the current planning source of truth.
+- `.astroray_plan/agents/codex.md` describes Codex's role in this repo.
+- Keep agent-specific notes additive. If a rule belongs to all agents, put it here.
 
 ## Build & Test Commands
 
@@ -24,10 +34,13 @@ mkdir -p build && cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release
 make -j$(nproc)
 
+# Windows (MinGW/MSYS2 or Ninja)
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DASTRORAY_ENABLE_CUDA=OFF
+cmake --build build -j
+
 # Windows (MSVC) — open a Developer Command Prompt first
-mkdir build && cd build
-cmake .. -DCMAKE_BUILD_TYPE=Release -DASTRORAY_ENABLE_CUDA=OFF
-cmake --build . --config Release -j
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DASTRORAY_ENABLE_CUDA=OFF
+cmake --build build --config Release -j
 
 # Run all tests (from repo root)
 pytest tests/ -v --tb=short
@@ -36,8 +49,9 @@ pytest tests/ -v --tb=short
 pytest tests/test_python_bindings.py -v      # ~45 tests, Python API
 pytest tests/test_material_properties.py -v  # material parameter tests
 pytest tests/test_standalone_renderer.py -v  # standalone binary tests
+pytest tests/test_spectral_*.py -v           # spectral pipeline tests
 
-# Standalone binary CLI (supported flags only):
+# Standalone binary CLI (supported flags only)
 ./build/bin/raytracer --scene 1|2 --width N --height N --samples N --depth N --output file.png --help
 ```
 
@@ -50,13 +64,19 @@ C++ path tracer with physically-based rendering. Key concepts:
 Vec3, Ray, Material, Hittable, BVH, Monte Carlo estimation (NOT ML).
 Python module (`astroray`) via pybind11. Module is at `build/astroray.cpython-*.so` (Linux) or `build/astroray.cp*-win_amd64.pyd` (Windows).
 
+Pillars 1 and 2 are complete: plugin architecture and the spectral core are
+now the baseline. The active next-stage queue is Pillar 3 (light transport),
+with Pillar 4 astrophysics and Pillar 5 production polish queued/ongoing.
+
 ## Test Structure
 
 - `tests/conftest.py` — pytest path setup (adds build/, tests/, project root)
 - `tests/base_helpers.py` — shared helpers: `create_renderer()`, `setup_camera()`, `render_image()`, `create_cornell_box()`, `assert_valid_image()`
-- `tests/test_python_bindings.py` — main suite covering all materials, Cornell box, Disney BRDF, convergence, GR black hole, pixel filters, seed determinism
+- `tests/test_python_bindings.py` — main suite covering materials, Cornell box, Blender feature parity, GR black hole, AOVs, pixel filters, seed determinism
 - `tests/test_material_properties.py` — material parameter validation
 - `tests/test_standalone_renderer.py` — C++ binary (correct CLI flags only)
+- `tests/test_spectral_*.py` and `tests/test_spectrum.py` — spectral pipeline, spectral materials/textures/env maps
+- `tests/test_*_plugins.py` — registry/plugin contract coverage
 
 All tests write images/charts to `test_results/` (gitignored).
 
@@ -75,7 +95,17 @@ All tests write images/charts to `test_results/` (gitignored).
 - `include/raytracer.h` — core data structures; do not refactor casually
 - `include/advanced_features.h` — textures, transforms, Disney BRDF, mesh support
 - `include/astroray/` — GR subsystem (metric, integrator, accretion disk, spectral)
+- `plugins/` — material, texture, shape, integrator, and pass plugins
 - `blender_addon/shader_blending.py` — must be packaged with the addon (see `scripts/build_blender_addon.py`)
+
+## Current Known Rendering/Test Gaps
+
+- Standalone black-hole smoke can pass with a fully black output; it currently
+  verifies crash-freedom more than visible GR correctness.
+- GR shadow tests are xfailed after the spectral path-tracer flip until GR
+  dispatch is ported into the current integrator path.
+- Some older "RGB vs spectral" wording is stale because `path_tracer` is now
+  spectral-first and the legacy RGB path was deleted in pkg14.
 
 ## Issue Tracking
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,3 +59,11 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 ---
 
 **These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
+
+## 5. Astroray Coordination
+
+- Project status lives in `.astroray_plan/docs/STATUS.md`.
+- Work packages live in `.astroray_plan/packages/`.
+- Codex-specific workflow notes live in `.astroray_plan/agents/codex.md`.
+- Shared repo invariants live in `AGENTS.md`; follow them in addition to this file.
+- Keep Claude Code on track-A/core work unless a task is explicitly scoped as a small local fix.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Astroray/
 │   ├── shapes/              # sphere, triangle, mesh, black_hole, …
 │   └── textures/            # checker, noise, voronoi, brick, …
 ├── scripts/                 # build_blender_addon.py and other utilities
-├── tests/                   # pytest suite (169 tests)
+├── tests/                   # pytest suite (227 collected tests as of 2026-04-28)
 └── CMakeLists.txt
 ```
 


### PR DESCRIPTION
## Summary
- Add a Codex handbook to the Astroray plan alongside Claude Code, Copilot, Cline, and Ralph
- Add a next-stage report covering Pillar 3 readiness, rendering/test gaps, and agent handoff recommendations
- Add a local-model integration plan for Ollama/LM Studio/Cline/Codex workflows
- Refresh shared agent, Claude, Copilot, README, and roadmap docs for the current spectral/plugin architecture
- Create follow-up issues #111-#115 for the first next-stage work queue

## Verification
- `pytest --collect-only -q` -> 227 tests collected
- `pytest tests/ -v --tb=short` -> 207 passed, 1 skipped, 19 xfailed

## Notes
This is documentation/setup only. No renderer code was changed.