### PR TITLE
test: refresh spectral checks and render triage

### DIFF
--- a/.astroray_plan/docs/light-transport.md
+++ b/.astroray_plan/docs/light-transport.md
@@ -68,22 +68,17 @@ class Integrator {
 public:
     virtual ~Integrator() = default;
 
-    // Called once per sample per pixel. Returns CIE XYZ radiance.
-    virtual Vec3 sample(const Ray& cameraRay, std::mt19937& gen) = 0;
-
     // Chance to build per-frame data structures (ReSTIR reservoirs,
     // neural cache training buffers).
-    virtual void beginFrame(const Scene&, const Camera&) {}
+    virtual void beginFrame(Renderer&, const Camera&) {}
     virtual void endFrame() {}
 
-    // Spectral variant; default implementation calls the RGB path and
-    // upsamples. Spectral-native integrators override.
-    virtual SampledSpectrum sampleSpectral(const Ray&,
-                                           const SampledWavelengths&,
-                                           std::mt19937&);
+    // Full-path sample: returns XYZ color plus first-hit AOV data and render
+    // passes. The current path_tracer implementation is spectral-first.
+    virtual SampleResult sampleFull(const Ray& ray, std::mt19937& gen) = 0;
 };
 
-ASTRORAY_REGISTER_INTEGRATOR("path", PathTracer)
+ASTRORAY_REGISTER_INTEGRATOR("path_tracer", PathTracer)
 ASTRORAY_REGISTER_INTEGRATOR("restir-di", ReSTIRDI)
 ASTRORAY_REGISTER_INTEGRATOR("neural-cache", NeuralCache)
 ```

--- a/.astroray_plan/docs/production.md
+++ b/.astroray_plan/docs/production.md
@@ -116,16 +116,18 @@ scratch. Package `pkg63-example-scenes.md`.
 
 ### 5.10 Test coverage
 
-Current: 66 tests. Target: 200+, covering every plugin and every
-integrator. Continuous Ralph-loop work.
+Current: 227 collected tests as of 2026-04-28. Target: keep expanding coverage
+around every plugin and every integrator. Continuous Ralph-loop work.
 
 Specific gaps:
 - GPU vs CPU equivalence for every material and integrator
-- Spectral vs RGB equivalence for every material under a white
-  illuminant
+- Spectral regression/reference checks for every material under a white
+  illuminant; the legacy RGB renderer path was deleted in pkg14
 - Multi-GPU correctness (when we have it)
 - Plugin registration correctness (regex-scan that every `.cpp` under
   `plugins/` has an `ASTRORAY_REGISTER_*` call)
+- Render-output triage for suspicious PNGs before promoting observations
+  into hard assertions
 
 Package `pkg64-test-expansion.md`, continuously updated.
 

--- a/.astroray_plan/docs/spectral-core.md
+++ b/.astroray_plan/docs/spectral-core.md
@@ -112,10 +112,10 @@ integration yet.
 
 ### Phase 2B: Shadow path tracer (1 week)
 
-Package `pkg11-spectral-path-tracer.md` — parallel `pathTraceSpectral`
-using `SampledSpectrum` throughout. Materials get both a `Vec3 eval`
-and a `SampledSpectrum evalSpectral` path. The legacy `pathTrace`
-remains for A/B comparison.
+Package `pkg11-spectral-path-tracer.md` — originally introduced a parallel
+`pathTraceSpectral` using `SampledSpectrum` throughout. This phase is complete;
+pkg14 later deleted the legacy RGB path and renamed the spectral path to the
+canonical `path_tracer`.
 
 ### Phase 2C: Migrate materials (1 week)
 
@@ -137,17 +137,15 @@ they just operate on `SampledSpectrum`. One code path, not two.
 
 ## Acceptance criteria
 
-- [ ] A scene rendered in spectral mode and RGB mode produces mean
-      brightness within 1% (they should be identical to noise, not
-      close — the spectral path handles RGB inputs identically).
-- [ ] A prism scene (single glass wedge under broad-spectrum light)
-      shows visible rainbow dispersion in spectral mode, solid
-      refraction in RGB mode. Irreducible evidence the spectral
-      pipeline works.
-- [ ] Spectral rendering is no more than 1.5× slower than RGB on the
-      Cornell box benchmark (4 wavelengths vs 3 channels + overhead).
-- [ ] All existing tests pass with the internal spectral pipeline
-      enabled.
+- [x] Legacy RGB path deleted; `path_tracer` is the spectral-first default.
+- [x] Spectral materials/textures/env maps have concrete overrides or tested
+      upsample fallbacks.
+- [x] Same-seed spectral renders are deterministic for the current regression
+      scenes.
+- [ ] Dispersion/prism validation remains future work; it requires a
+      wavelength-dependent dielectric transport path rather than an RGB path.
+- [ ] Performance tracking should compare against historical baselines or
+      external renderers, not a deleted in-tree RGB integrator.
 
 ## Non-goals
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -73,3 +73,35 @@ non-empty PNG.
 
 - `autonomous_loop.sh` — local autonomous engineering loop helper.
 - `build_cuda.bat` — Windows helper for CUDA-related builds.
+- `render_output_triage.py` — diagnostic PNG summary for `test_results/`.
+  It reports image size, brightness, saturation, low color counts, and likely
+  all-black outputs. This is for agent review, not a hard CI gate.
+
+  ```bash
+  python scripts/render_output_triage.py
+  python scripts/render_output_triage.py --flagged-only
+  ```
+
+- `start_local_agent_server.sh` — WSL helper for starting a local
+  OpenAI-compatible `llama.cpp` server. It sets `LD_LIBRARY_PATH` for the
+  current user install and defaults to the safer Qwen2.5 Coder 14B model.
+
+  ```bash
+  # From WSL, in the repo root
+  bash scripts/start_local_agent_server.sh
+
+  # Larger, tighter model for planning/prototyping
+  bash scripts/start_local_agent_server.sh --model qwen35-35b-q3 --ctx-size 16384
+
+  # Client settings for Aider/Ralph-style tools
+  export OPENAI_API_BASE=http://127.0.0.1:8080/v1
+  export OPENAI_API_KEY=dummy
+  ```
+
+  On this workstation, WSL sees an RTX 5070 Ti with 16GB VRAM and 64GB RAM.
+  The practical model order is:
+
+  1. `qwen2.5-coder-14b-q5` — safest default for tool-calling and longer context.
+  2. `qwen35-35b-q3` — worth testing for planning/reasoning, but tight on VRAM.
+  3. `qwen3-coder-30b-q4` — already available through Ollama; direct
+     `llama.cpp` use needs CPU MoE offload on a 16GB card.

--- a/scripts/render_output_triage.py
+++ b/scripts/render_output_triage.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+"""Summarize render PNGs for quick visual-test triage.
+
+This is intentionally diagnostic, not a CI gate. It helps agents spot
+all-black images, tiny binary masks, and unexpectedly saturated renders before
+turning any one observation into a real pytest assertion.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from PIL import Image
+
+
+def analyze_png(path: Path) -> dict[str, Any]:
+    with Image.open(path) as image:
+        rgb = image.convert("RGB")
+        arr = np.asarray(rgb, dtype=np.float32) / 255.0
+
+    mean = float(arr.mean())
+    min_value = float(arr.min())
+    max_value = float(arr.max())
+    saturated_fraction = float((arr >= 0.999).mean())
+    black_fraction = float((arr <= 0.001).mean())
+    unique_values = int(np.unique((arr * 255.0).astype(np.uint8).reshape(-1, 3), axis=0).shape[0])
+
+    flags: list[str] = []
+    if max_value <= 0.001:
+        flags.append("all-black")
+    elif mean < 0.01:
+        flags.append("very-dark")
+    if saturated_fraction > 0.25:
+        flags.append("saturated")
+    if unique_values <= 8:
+        flags.append("low-color-count")
+    if path.stat().st_size < 1024:
+        flags.append("tiny-file")
+
+    return {
+        "path": str(path),
+        "width": rgb.width,
+        "height": rgb.height,
+        "bytes": path.stat().st_size,
+        "mean": mean,
+        "min": min_value,
+        "max": max_value,
+        "black_fraction": black_fraction,
+        "saturated_fraction": saturated_fraction,
+        "unique_rgb": unique_values,
+        "flags": flags,
+    }
+
+
+def format_table(rows: list[dict[str, Any]], flagged_only: bool) -> str:
+    if flagged_only:
+        rows = [row for row in rows if row["flags"]]
+
+    lines = [
+        "| file | size | bytes | mean | min | max | unique | flags |",
+        "|---|---:|---:|---:|---:|---:|---:|---|",
+    ]
+    for row in rows:
+        name = Path(row["path"]).name
+        flags = ", ".join(row["flags"]) if row["flags"] else "-"
+        lines.append(
+            f"| {name} | {row['width']}x{row['height']} | {row['bytes']} | "
+            f"{row['mean']:.4f} | {row['min']:.4f} | {row['max']:.4f} | "
+            f"{row['unique_rgb']} | {flags} |"
+        )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "directory",
+        nargs="?",
+        default="test_results",
+        help="Directory containing PNG render outputs.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of a Markdown table.")
+    parser.add_argument(
+        "--flagged-only",
+        action="store_true",
+        help="Show only outputs with triage flags.",
+    )
+    args = parser.parse_args()
+
+    directory = Path(args.directory)
+    paths = sorted(directory.glob("*.png"))
+    rows = [analyze_png(path) for path in paths]
+
+    if args.json:
+        print(json.dumps(rows, indent=2))
+    else:
+        print(format_table(rows, args.flagged_only))
+        print(f"\nAnalyzed {len(rows)} PNG files under {directory}.")
+        if args.flagged_only:
+            print("Flags are hints for review, not automatic failures.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/start_local_agent_server.sh
+++ b/scripts/start_local_agent_server.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Start a local OpenAI-compatible llama.cpp server for Astroray agent work.
+#
+# Run from WSL:
+#   bash scripts/start_local_agent_server.sh
+#   bash scripts/start_local_agent_server.sh --model qwen35-35b-q3
+#
+# The defaults are conservative for a 16GB RTX 5070 Ti. Use larger models for
+# planning/prototyping, and keep frontier Codex/Claude in the review loop for
+# renderer invariants.
+
+set -euo pipefail
+
+HOST="127.0.0.1"
+PORT="8080"
+CTX_SIZE=""
+GPU_LAYERS="99"
+MODEL_PROFILE="qwen25-coder-14b-q5"
+LLAMA_BIN="${LLAMA_SERVER:-$HOME/.local/bin/llama-server}"
+LLAMA_LIB_DIR="${LLAMA_LIB_DIR:-$HOME/.local/lib}"
+API_KEY="${OPENAI_API_KEY:-dummy}"
+DRY_RUN=0
+
+usage() {
+  cat <<'EOF'
+Usage: bash scripts/start_local_agent_server.sh [options]
+
+Options:
+  --model NAME       Model profile or path. Profiles:
+                       qwen25-coder-14b-q5  (default, safest)
+                       qwen35-35b-q3        (larger reasoning/prototype model)
+                       qwen3-coder-30b-q4   (coding model; uses CPU MoE offload)
+  --host HOST        Bind host (default: 127.0.0.1)
+  --port PORT        Bind port (default: 8080)
+  --ctx-size N       Context size (default: profile-specific or 32768)
+  --gpu-layers N     GPU layer offload count (default: 99)
+  --dry-run          Print the command without starting the server
+  -h, --help         Show this help
+
+Client config:
+  OPENAI_API_BASE=http://127.0.0.1:8080/v1
+  OPENAI_API_KEY=dummy
+  model name can be any non-empty value accepted by the client.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --model) MODEL_PROFILE="$2"; shift 2 ;;
+    --host) HOST="$2"; shift 2 ;;
+    --port) PORT="$2"; shift 2 ;;
+    --ctx-size) CTX_SIZE="$2"; shift 2 ;;
+    --gpu-layers) GPU_LAYERS="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+EXTRA_ARGS=()
+case "$MODEL_PROFILE" in
+  qwen25-coder-14b-q5)
+    MODEL_PATH="$HOME/.models/qwen2.5-coder-14b-instruct-q5_k_m.gguf"
+    CTX_SIZE="${CTX_SIZE:-32768}"
+    ;;
+  qwen35-35b-q3)
+    MODEL_PATH="$HOME/.models/Qwen3.5-35B-A3B-Q3_K_S.gguf"
+    CTX_SIZE="${CTX_SIZE:-16384}"
+    ;;
+  qwen3-coder-30b-q4)
+    MODEL_PATH="$HOME/.models/qwen3-coder-30b/Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf"
+    # The Q4 file is larger than 16GB before context. Keep some MoE weights on
+    # CPU so the server can run on a 16GB card.
+    EXTRA_ARGS+=(--n-cpu-moe 16)
+    CTX_SIZE="${CTX_SIZE:-16384}"
+    ;;
+  /*|~/*|.*)
+    MODEL_PATH="$MODEL_PROFILE"
+    ;;
+  *)
+    echo "Unknown model profile: $MODEL_PROFILE" >&2
+    usage
+    exit 2
+    ;;
+esac
+
+MODEL_PATH="${MODEL_PATH/#\~/$HOME}"
+if [[ ! -x "$LLAMA_BIN" ]]; then
+  echo "llama-server not executable: $LLAMA_BIN" >&2
+  exit 1
+fi
+if [[ ! -f "$MODEL_PATH" ]]; then
+  echo "Model file not found: $MODEL_PATH" >&2
+  exit 1
+fi
+
+export LD_LIBRARY_PATH="$LLAMA_LIB_DIR:${LD_LIBRARY_PATH:-}"
+
+CMD=(
+  "$LLAMA_BIN"
+  --model "$MODEL_PATH"
+  --host "$HOST"
+  --port "$PORT"
+  --api-key "$API_KEY"
+  --ctx-size "$CTX_SIZE"
+  --n-gpu-layers "$GPU_LAYERS"
+  --flash-attn on
+  --cache-type-k q8_0
+  --cache-type-v q4_0
+  --jinja
+  "${EXTRA_ARGS[@]}"
+)
+
+echo "Starting llama.cpp server"
+echo "  model: $MODEL_PROFILE"
+echo "  file:  $MODEL_PATH"
+echo "  url:   http://$HOST:$PORT/v1"
+echo "  ctx:   $CTX_SIZE"
+echo
+
+if [[ "$DRY_RUN" == 1 ]]; then
+  printf '%q ' "${CMD[@]}"
+  echo
+  exit 0
+fi
+
+exec "${CMD[@]}"

--- a/tests/test_spectral_envmap.py
+++ b/tests/test_spectral_envmap.py
@@ -4,12 +4,10 @@
 Pillar 2 / pkg14 — spectral environment map tests.
 
 Covers:
-  1. Atlas parity: evalSpectral vs RGBIlluminantSpectrum(lookup).sample over a
-     sweep of directions. Bilinear interpolation in spectral space vs. RGB space
-     is not algebraically identical, but for smooth HDRIs the per-channel error
-     is well within the 1e-3 tolerance chosen here (1e-5 per-channel would require
-     single-pixel comparison at integer coordinates; smooth bilinear regions easily
-     satisfy this but high-contrast edges do not — see note below).
+  1. Atlas-vs-upsample fallback parity: evalSpectral vs eval_env_rgb_upsample
+     over a sweep of directions. Bilinear interpolation in spectral space vs.
+     RGB-then-upsampling is not algebraically identical, but for smooth HDRIs
+     the per-channel error is well within the 1e-3 tolerance chosen here.
   2. After pkg14 commit 3: integrator_registry_names returns exactly
      {"path_tracer", "ambient_occlusion"}.
   3. Rendering an open (no-geometry) scene with a loaded env map produces
@@ -57,8 +55,8 @@ def _sphere_directions(n: int):
 # ---------------------------------------------------------------------------
 
 @pytest.mark.skipif(not HAS_ENV, reason="test_env.hdr not found")
-def test_eval_spectral_atlas_parity():
-    """evalSpectral via atlas matches RGBIlluminantSpectrum upsample to within 1e-3."""
+def test_eval_spectral_atlas_matches_upsample_fallback():
+    """evalSpectral via atlas matches RGBIlluminantSpectrum fallback to 1e-3."""
     r = astroray.Renderer()
     assert r.load_environment_map(ENV_HDR), "failed to load env map"
 

--- a/tests/test_spectral_lambertian.py
+++ b/tests/test_spectral_lambertian.py
@@ -5,10 +5,8 @@ Pillar 2 / pkg12 — spectral Lambertian override tests.
 
 Covers:
   1. NaN/Inf guard: spectral render of an all-Lambertian Cornell box is valid.
-  2. A/B match: spectral and RGB renders agree within 3% per channel — tighter
-     than pkg11's 5% tolerance because LambertianPlugin now uses a direct
-     evalSpectral override (cached RGBAlbedoSpectrum) rather than the
-     per-call Jakob-Hanika fallback.
+  2. Deterministic A/B match: two path_tracer renders with the same seed agree
+     exactly after pkg14 deleted the legacy RGB path.
   3. Numerical equivalence: for the same albedo and wavelengths, the override
      formula (RGBAlbedoSpectrum(albedo).sample * cosTheta/PI) matches the
      default fallback (RGBAlbedoSpectrum(albedo * cosTheta/PI).sample) within
@@ -64,32 +62,31 @@ def test_spectral_lambertian_no_nan_no_inf():
     assert 0.001 < float(spec.mean()) < 0.95
 
 
-def test_spectral_vs_rgb_cornell_a_b(test_results_dir):
-    """Spectral Lambertian Cornell must agree with RGB within 3% per channel.
+def test_spectral_lambertian_cornell_deterministic_a_b(test_results_dir):
+    """Spectral Lambertian Cornell is deterministic for a fixed seed.
 
-    With LambertianPlugin overriding evalSpectral (cached RGBAlbedoSpectrum),
-    the only residual difference from the RGB path is hero-wavelength MC
-    noise.  3% per channel at 64 spp is conservative.
+    With pkg14, `path_tracer` is the only full path-tracing integrator. This
+    test verifies same-seed repeatability and guards against accidental
+    nondeterminism in the spectral path.
     """
-    rgb = _render_cornell("path_tracer", seed=42)
-    spec = _render_cornell("path_tracer", seed=42)
+    baseline = _render_cornell("path_tracer", seed=42)
+    repeat = _render_cornell("path_tracer", seed=42)
 
-    save_image(rgb,  os.path.join(test_results_dir, 'pkg12_cornell_rgb.png'))
-    save_image(spec, os.path.join(test_results_dir, 'pkg12_spectral_lambertian_cornell.png'))
-    diff = np.clip(np.abs(rgb - spec) * 5.0, 0.0, 1.0)
+    save_image(baseline, os.path.join(test_results_dir, 'pkg12_cornell_baseline.png'))
+    save_image(repeat, os.path.join(test_results_dir, 'pkg12_cornell_repeat.png'))
+    diff = np.clip(np.abs(baseline - repeat) * 5.0, 0.0, 1.0)
     save_image(diff, os.path.join(test_results_dir, 'pkg12_cornell_diff_x5.png'))
 
-    rgb_mean = rgb.reshape(-1, 3).mean(axis=0)
-    spec_mean = spec.reshape(-1, 3).mean(axis=0)
-    print(f"\n  RGB  mean: {rgb_mean}")
-    print(f"  Spec mean: {spec_mean}")
-    assert np.all(spec_mean > 0.01), f"spectral image too dark, mean={spec_mean}"
+    baseline_mean = baseline.reshape(-1, 3).mean(axis=0)
+    repeat_mean = repeat.reshape(-1, 3).mean(axis=0)
+    print(f"\n  Baseline mean: {baseline_mean}")
+    print(f"  Repeat mean:   {repeat_mean}")
+    assert np.all(repeat_mean > 0.01), f"spectral image too dark, mean={repeat_mean}"
 
-    rel_delta = np.abs(rgb_mean - spec_mean) / (rgb_mean + 1e-3)
+    rel_delta = np.abs(baseline_mean - repeat_mean) / (baseline_mean + 1e-3)
     print(f"  rel delta: {rel_delta}")
-    assert np.all(rel_delta < 0.03), (
-        f"spectral mean diverges from RGB by {rel_delta} (threshold 0.03); "
-        f"rgb={rgb_mean}, spec={spec_mean}")
+    assert np.allclose(baseline, repeat, rtol=0.0, atol=1e-7), \
+        "same seed should produce deterministic spectral Lambertian output"
 
 
 def test_spectral_formula_properties():

--- a/tests/test_spectral_materials.py
+++ b/tests/test_spectral_materials.py
@@ -7,15 +7,14 @@ Subsurface, and the Texture::sampleSpectral infrastructure.
 Covers:
   1. Metal evalSpectral: non-negative, no NaN/Inf; roughness path produces
      per-λ Fresnel variation (warm-tinted albedo peaks differently across
-     wavelengths); Cornell A/B within 5% with a metal sphere.
+     wavelengths); same-seed Cornell A/B is deterministic with a metal sphere.
   2. Dielectric / Mirror evalSpectral: returns 0 (delta lobes).
   3. Subsurface evalSpectral: non-negative, no NaN/Inf.
-  4. Texture.sampleSpectral default: matches RGBAlbedoSpectrum(value).sample
-     to float precision.
-  5. Image texture sampleSpectral: consistent across repeated calls (cache
-     stability); matches default fallback within 1e-6.
+  4. Texture plugin registry still exposes the expected procedural/image
+     plugins used by spectral texture tests.
+  5. RGBAlbedoSpectrum sampling is stable across repeated calls.
   6. pkg13a non-physics overrides (Phong, Disney, DiffuseLight, NormalMapped):
-     spectral renders are finite and keep Cornell A/B parity against RGB.
+     spectral renders are finite and deterministic for a fixed seed.
 """
 import math
 import os
@@ -114,21 +113,21 @@ def test_metal_spectral_formula_non_negative():
             assert F_i <= 1.0 + 1e-6, f"Schlick F > 1 at cosTheta={cosTheta}, sample {i}"
 
 
-def test_metal_spectral_vs_rgb_a_b(test_results_dir):
-    """Spectral and RGB Cornell+metal sphere agree within 5% per channel."""
-    rgb = _render("path_tracer", _metal_scene, seed=7)
-    spec = _render("path_tracer", _metal_scene, seed=7)
-    save_image(rgb,  os.path.join(test_results_dir, 'pkg13_metal_rgb.png'))
-    save_image(spec, os.path.join(test_results_dir, 'pkg13_metal_spectral.png'))
+def test_metal_spectral_deterministic_a_b(test_results_dir):
+    """Cornell+metal spectral render is deterministic for a fixed seed."""
+    baseline = _render("path_tracer", _metal_scene, seed=7)
+    repeat = _render("path_tracer", _metal_scene, seed=7)
+    save_image(baseline, os.path.join(test_results_dir, 'pkg13_metal_baseline.png'))
+    save_image(repeat, os.path.join(test_results_dir, 'pkg13_metal_repeat.png'))
 
-    rgb_mean = rgb.reshape(-1, 3).mean(axis=0)
-    spec_mean = spec.reshape(-1, 3).mean(axis=0)
-    rel_delta = np.abs(rgb_mean - spec_mean) / (rgb_mean + 1e-3)
-    print(f"\n  Metal RGB  mean: {rgb_mean}")
-    print(f"  Metal Spec mean: {spec_mean}")
+    baseline_mean = baseline.reshape(-1, 3).mean(axis=0)
+    repeat_mean = repeat.reshape(-1, 3).mean(axis=0)
+    rel_delta = np.abs(baseline_mean - repeat_mean) / (baseline_mean + 1e-3)
+    print(f"\n  Metal baseline mean: {baseline_mean}")
+    print(f"  Metal repeat mean:   {repeat_mean}")
     print(f"  rel delta:       {rel_delta}")
-    assert np.all(rel_delta < 0.05), (
-        f"metal spectral diverges from RGB by {rel_delta} (threshold 0.05)")
+    assert np.allclose(baseline, repeat, rtol=0.0, atol=1e-7), \
+        "same seed should produce deterministic metal spectral output"
 
 
 # ---------------------------------------------------------------------------
@@ -247,23 +246,16 @@ def test_new_materials_in_registry():
 
 
 # ---------------------------------------------------------------------------
-def test_texture_sample_spectral_default_matches_upsample():
-    """Texture.sampleSpectral default matches RGBAlbedoSpectrum(value).sample."""
-    for u_val in [0.0, 0.25, 0.5, 0.75]:
-        wl = astroray.SampledWavelengths.sample_uniform(u_val)
-        # sample_texture returns the RGB value from a checker texture.
-        # We verify through the registry that procedural textures exist.
-        tex_names = astroray.texture_registry_names()
-        assert "checker" in tex_names, f"checker not registered; have {tex_names}"
-        assert "image" in tex_names
+def test_texture_plugins_needed_for_spectral_tests_registered():
+    """Texture plugins used by spectral texture tests are registered."""
+    tex_names = astroray.texture_registry_names()
+    for name in ("checker", "noise", "gradient", "voronoi", "brick",
+                 "musgrave", "magic", "wave", "image"):
+        assert name in tex_names, f"{name!r} not registered; have {tex_names}"
 
 
-def test_image_texture_spectral_cache_stable():
-    """Image texture sampleSpectral returns identical results on repeated calls.
-
-    Since the spectral cache is built eagerly in setData(), the same texel
-    lookup must be bit-identical across calls.
-    """
+def test_rgb_albedo_spectrum_sample_stable():
+    """RGBAlbedoSpectrum returns identical samples on repeated calls."""
     wl = astroray.SampledWavelengths.sample_uniform(0.5)
     rsp = astroray.RGBAlbedoSpectrum([0.6, 0.3, 0.1])
     s1 = rsp.sample(wl)
@@ -281,17 +273,13 @@ def test_image_texture_spectral_cache_stable():
         (_diffuse_light_scene, "diffuse_light"),
     ],
 )
-def test_pkg13a_material_spectral_vs_rgb_parity(scene_fn, tag, test_results_dir):
-    # Keep this threshold aligned with existing pkg11/pkg13 Monte Carlo parity tests.
-    parity_threshold = 0.05
-    rgb = _render("path_tracer", scene_fn, seed=17)
-    spec = _render("path_tracer", scene_fn, seed=17)
-    save_image(rgb, os.path.join(test_results_dir, f'pkg13a_{tag}_rgb.png'))
-    save_image(spec, os.path.join(test_results_dir, f'pkg13a_{tag}_spectral.png'))
+def test_pkg13a_material_spectral_deterministic_a_b(scene_fn, tag, test_results_dir):
+    baseline = _render("path_tracer", scene_fn, seed=17)
+    repeat = _render("path_tracer", scene_fn, seed=17)
+    save_image(baseline, os.path.join(test_results_dir, f'pkg13a_{tag}_baseline.png'))
+    save_image(repeat, os.path.join(test_results_dir, f'pkg13a_{tag}_repeat.png'))
 
-    assert not np.any(np.isnan(spec)), f"{tag} spectral render contains NaN"
-    assert not np.any(np.isinf(spec)), f"{tag} spectral render contains Inf"
-    rgb_mean = rgb.reshape(-1, 3).mean(axis=0)
-    spec_mean = spec.reshape(-1, 3).mean(axis=0)
-    rel_delta = np.abs(rgb_mean - spec_mean) / (rgb_mean + 1e-3)
-    assert np.all(rel_delta < parity_threshold), f"{tag} spectral parity drift too high: {rel_delta}"
+    assert not np.any(np.isnan(repeat)), f"{tag} spectral render contains NaN"
+    assert not np.any(np.isinf(repeat)), f"{tag} spectral render contains Inf"
+    assert np.allclose(baseline, repeat, rtol=0.0, atol=1e-7), \
+        f"{tag} same-seed spectral render is not deterministic"

--- a/tests/test_spectral_path_tracer.py
+++ b/tests/test_spectral_path_tracer.py
@@ -4,12 +4,10 @@
 Pillar 2 / pkg11 — spectral path tracer integration tests.
 
 Covers:
-  1. Plugin registration: "spectral_path_tracer" appears in the registry.
-  2. Cornell A/B match: rendering Cornell with the legacy RGB `path` and the
-     new `spectral_path_tracer` produces near-identical mean RGB. The default
-     evalSpectral / emittedSpectral fall back to a Jakob-Hanika upsample of
-     the existing RGB BSDF / emission, so any chromatic delta is the
-     hero-wavelength MC noise floor — it should be small at 32 spp.
+  1. Plugin registration: "path_tracer" is the canonical spectral-first
+     integrator after pkg14.
+  2. Cornell deterministic A/B: rendering the same scene twice with the same
+     seed produces identical output and a non-trivial image.
 
 Both renders are also written to PNG under test_results/ for visual review.
 
@@ -76,8 +74,8 @@ def test_spectral_path_tracer_registered():
 def test_cornell_ab_match(test_results_dir):
     """path_tracer Cornell render is valid and consistent across two identical seeds.
 
-    Since pkg14 deleted the legacy RGB path, this test verifies the spectral
-    integrator produces a non-trivial, non-NaN render of the Cornell box.
+    Since pkg14 deleted the legacy RGB path, this is a deterministic
+    same-integrator A/B check rather than an RGB-vs-spectral parity test.
     """
     render_a = _render_cornell("path_tracer")
     render_b = _render_cornell("path_tracer")
@@ -89,6 +87,8 @@ def test_cornell_ab_match(test_results_dir):
     print(f"\n  Cornell mean: {mean_a}")
     assert np.all(mean_a > 0.01), f"spectral image too dark, mean={mean_a}"
     assert not np.any(np.isnan(render_a)), "render contains NaN"
+    assert np.allclose(render_a, render_b, rtol=0.0, atol=1e-7), \
+        "same seed should produce deterministic path_tracer output"
 
 
 def test_spectral_render_no_nan_no_inf():


### PR DESCRIPTION
## Summary
- Rename and strengthen stale spectral tests that still claimed RGB-vs-spectral parity after pkg14 deleted the legacy RGB path
- Add deterministic same-seed A/B assertions for spectral Cornell/material renders
- Add `scripts/render_output_triage.py` for repeatable visual-output review of `test_results/*.png`
- Add `scripts/start_local_agent_server.sh` for WSL llama.cpp local-agent bring-up with 5070 Ti-friendly defaults
- Refresh plan docs that still described the old dual RGB/spectral renderer architecture

## Verification
- `pytest tests/test_spectral_lambertian.py tests/test_spectral_materials.py tests/test_spectral_path_tracer.py tests/test_spectral_envmap.py -v --tb=short` -> 29 passed
- `pytest tests/ -v --tb=short` -> 207 passed, 1 skipped, 19 xfailed
- `python scripts/render_output_triage.py --flagged-only` -> highlights current all-black BH smoke output and expected black/mask files
- `bash scripts/start_local_agent_server.sh --model qwen35-35b-q3 --dry-run` in WSL -> emits valid llama-server command with 16k context

Closes #112.
Closes #113.