### PR TITLE
fix: restore spectral black hole dispatch

### DIFF
--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Astroray Status
 
-**Last updated:** 2026-04-26 (pkg14 complete — Pillar 2 DONE; spectral env map atlas, flip default, legacy RGB path deleted)
+**Last updated:** 2026-04-28 (Codex onboarding in progress; render-output triage and GR spectral dispatch fixes opened)
 
 This is the source-of-truth for "where are we?" Updated by the overseer
 at the start of each week, and by the project owner when a significant
@@ -70,6 +70,11 @@ personally should pick up.
 - Last run: —
 - Queue depth: —
 
+### Track E (Codex)
+
+- In review: PR #116 (`codex/render-test-triage`) — Codex/Claude coordination docs, local-agent launcher, render-output triage, and refreshed spectral tests.
+- Active: issue #111 (`codex/gr-spectral-dispatch`) — restore black-hole GR dispatch in the spectral `path_tracer`.
+
 ---
 
 ## Recently merged (this week)
@@ -95,19 +100,22 @@ personally should pick up.
 
 | Package | Track | Status | Blocker |
 |---|---|---|---|
-| — | — | — | Pillar 3 not yet scoped |
+| render-output-triage | E | in review | PR #116 |
+| gr-spectral-dispatch | E | active | issue #111 |
 
 ---
 
 ## Known issues
 
 - `include/raytracer.h` and `include/advanced_features.h` still contain texture class bodies (`CheckerTexture`, `NoiseTexture`, etc.). These are used directly by `blender_module.cpp` and will be cleaned up in a future package if the plan calls for it.
+- Render-output triage in PR #116 flagged the stale all-black `test_black_hole.png`; issue #111 is the targeted fix.
 
 ---
 
 ## Decisions pending (for project owner)
 
 - Confirm whether lights should be migrated to plugins (currently out of scope per pkg04 non-goals) and if so, which package handles it.
+- Decide whether GR disk emission should grow a native sampled-spectrum result instead of the current RGB-to-spectral bridge used by `traceGR()`.
 
 ---
 
@@ -115,6 +123,7 @@ personally should pick up.
 
 Brief notes on notable events.
 
+- **2026-04-28** — Codex follow-up work started after pkg14. PR #116 adds shared agent docs, WSL local-agent launcher scaffolding, render-output triage, and refreshed deterministic spectral tests. Issue #111 is in progress to restore black-hole GR dispatch inside the spectral-only `path_tracer`.
 - **2026-04-26** — pkg14 complete. Spectral HDRI atlas built at load time; env-miss path wired to `evalSpectral`; legacy RGB `PathTracer` plugin and `pathTrace()` kernel deleted; registry entry renamed `"path_tracer"`; `Material::evalSpectral` is now pure virtual; `Material::eval` virtual removed. **Pillar 2 is 100% complete (pkg10–pkg14).**
 - **2026-04-26** — pkg13 fully complete. All four threads merged: (1) physics/infra PR #103 — Texture::sampleSpectral, ImageTexture cache, Metal/Dielectric/Mirror/Subsurface evalSpectral; (2) Copilot PR #104 — Phong/Disney/NormalMapped/DiffuseLight evalSpectral/emittedSpectral; (3) Copilot PR #106 — 8 procedural texture sampleSpectral overrides; (4) pkg13c PR — 4 new plugins: oren_nayar, isotropic, two_sided, emissive. Every shading event in the spectral pipeline now has a concrete override. Test suite: 223 passed, 1 skipped. Pillar 2 ~90%.
 - **2026-04-24** — pkg10 merged: Pillar 2 scaffolding. New `include/astroray/spectrum.h` defines `SampledWavelengths`, `SampledSpectrum`, `RGBAlbedoSpectrum`, `RGBUnboundedSpectrum`, `RGBIlluminantSpectrum` (float, 4 samples, 360-830 nm). `src/spectrum.cpp` loads the shipped Jakob-Hanika sRGB LUT lazily from `data/spectra/rgb_to_spectrum_srgb.coeff` and embeds the CIE 1964 10° CMF and D65 SPD as `constexpr` tables. New `astroray_core_impl` CMake target; `ASTRORAY_DATA_DIR` compile definition + env-var override for runtime data discovery. Python bindings expose every type plus a top-level `rgb_to_spectrum()` helper. No integration into any material, integrator, pass, or env map — that is pkg11+. Test suite: 189 passed, 1 skipped (20 new spectrum tests).

--- a/include/raytracer.h
+++ b/include/raytracer.h
@@ -18,6 +18,7 @@
 #include <string>
 #include <unordered_map>
 #include "stb_image.h"
+#include "astroray/gr_types.h"
 #include "astroray/spectrum.h"
 
 // Forward declaration needed by HitRecord
@@ -1696,13 +1697,29 @@ public:
         );
     }
 
+    static bool finiteFloat(float v) {
+        return gr_isfinite(static_cast<double>(v));
+    }
+
+    static float finiteOrZero(float v) {
+        return finiteFloat(v) ? v : 0.0f;
+    }
+
+    static float finiteClamped(float v, float lo, float hi) {
+        return finiteFloat(v) ? std::clamp(v, lo, hi) : 0.0f;
+    }
+
+    static Vec3 finiteVecOrZero(const Vec3& v) {
+        return Vec3(finiteOrZero(v.x), finiteOrZero(v.y), finiteOrZero(v.z));
+    }
+
 
     // Spectral path tracer kernel (Pillar 2, sole render path since pkg14).
     // Uses SampledSpectrum for radiance and throughput; material lookups via
-    // evalSpectral / emittedSpectral. Covers BVH traversal, area-light NEE
-    // with MIS, emission gating, Russian roulette, and BSDF sampling.
-    // GR-object dispatch, AOV passes, and per-closure bounce limits are
-    // not yet replicated; those are future-package scope.
+    // evalSpectral / emittedSpectral. Covers BVH traversal, GR-object dispatch,
+    // area-light NEE with MIS, emission gating, Russian roulette, and BSDF
+    // sampling. AOV passes and per-closure bounce limits are not yet replicated;
+    // those are future-package scope.
     astroray::SampledSpectrum pathTraceSpectral(
             const Ray& r, int maxDepth,
             const astroray::SampledWavelengths& lambdas,
@@ -1735,8 +1752,46 @@ public:
                 }
                 break;
             }
-            // Skip GR objects entirely in pkg11 (Cornell scope).
-            if (rec.hitObject && rec.hitObject->isGRObject()) break;
+            if (rec.hitObject && rec.hitObject->isGRObject()) {
+                auto grResult = rec.hitObject->traceGR(ray, gen);
+
+                if (grResult.hasEmission) {
+                    Vec3 emissionRgb(
+                        finiteClamped(grResult.color.x, 0.0f, 20.0f),
+                        finiteClamped(grResult.color.y, 0.0f, 20.0f),
+                        finiteClamped(grResult.color.z, 0.0f, 20.0f)
+                    );
+                    astroray::SampledSpectrum grEmission =
+                        astroray::RGBIlluminantSpectrum({
+                            emissionRgb.x,
+                            emissionRgb.y,
+                            emissionRgb.z
+                        }).sample(lambdas);
+                    if (emissionRgb.x > 0.0f || emissionRgb.y > 0.0f || emissionRgb.z > 0.0f) {
+                        color += throughput * grEmission;
+                    }
+                }
+                if (grResult.captured) {
+                    break;
+                }
+
+                Vec3 exitDir = grResult.exitDirection;
+                float exitLen2 = exitDir.length2();
+                if (!finiteFloat(exitDir.x) || !finiteFloat(exitDir.y) ||
+                    !finiteFloat(exitDir.z) || !finiteFloat(exitLen2) || exitLen2 < 1e-10f) {
+                    break;
+                }
+
+                Ray next(rec.point, exitDir, ray.time, ray.screenU, ray.screenV);
+                next.hasCameraFrame = ray.hasCameraFrame;
+                next.cameraOrigin = ray.cameraOrigin;
+                next.cameraU = ray.cameraU;
+                next.cameraV = ray.cameraV;
+                next.cameraW = ray.cameraW;
+                ray = next;
+                wasSpecular = true;
+                continue;
+            }
             if (!rec.material) break;
 
             // Emission (gated on camera ray or post-specular bounce).
@@ -1907,6 +1962,7 @@ inline void Renderer::render(Camera& cam, int maxSamples, int maxDepth,
                                 sMaterialIndex = ir.materialIndex;
                                 sPass = ir.passes;
                             }
+                            sCol = finiteVecOrZero(sCol);
                             // Per-sample firefly suppression: sCol is XYZ, Y is photometric luminance.
                             float sLum = sCol.y;
                             if (sLum > 20.0f) sCol = sCol * (20.0f / sLum);
@@ -1953,13 +2009,13 @@ inline void Renderer::render(Camera& cam, int maxSamples, int maxDepth,
                         passColor[PASS_ENVIRONMENT] *= filmExposure;
                         color = xyzToLinearSRGB(color);
                         if (applyGamma) {
-                            color.x = std::pow(std::clamp(color.x, 0.0f, 1.0f), 1.0f / 2.2f);
-                            color.y = std::pow(std::clamp(color.y, 0.0f, 1.0f), 1.0f / 2.2f);
-                            color.z = std::pow(std::clamp(color.z, 0.0f, 1.0f), 1.0f / 2.2f);
+                            color.x = std::pow(finiteClamped(color.x, 0.0f, 1.0f), 1.0f / 2.2f);
+                            color.y = std::pow(finiteClamped(color.y, 0.0f, 1.0f), 1.0f / 2.2f);
+                            color.z = std::pow(finiteClamped(color.z, 0.0f, 1.0f), 1.0f / 2.2f);
                         } else {
-                            color.x = std::max(color.x, 0.0f);
-                            color.y = std::max(color.y, 0.0f);
-                            color.z = std::max(color.z, 0.0f);
+                            color.x = std::max(finiteOrZero(color.x), 0.0f);
+                            color.y = std::max(finiteOrZero(color.y), 0.0f);
+                            color.z = std::max(finiteOrZero(color.z), 0.0f);
                         }
                         cam.pixels[idx] = color;
                         cam.albedoBuffer[idx] = albedo;

--- a/tests/test_python_bindings.py
+++ b/tests/test_python_bindings.py
@@ -1615,11 +1615,11 @@ def test_black_hole_creation():
     setup_camera(r, look_from=[0, 0, 200], look_at=[0, 0, 0],
                  vfov=12, width=160, height=120)
     pixels = render_image(r, samples=4)
-    assert_valid_image(pixels, 120, 160, min_mean=0.0, label='black_hole')
+    assert np.all(np.isfinite(pixels)), "black hole render contains NaN/Inf"
+    assert_valid_image(pixels, 120, 160, min_mean=1e-5, label='black_hole')
     save_image(pixels, os.path.join(OUTPUT_DIR, 'test_black_hole.png'))
 
 
-@pytest.mark.xfail(reason="black hole GR dispatch not ported to pathTraceSpectral — deferred", strict=False)
 def test_black_hole_shadow_is_dark():
     """The center of the black hole shadow should be darker than the edges."""
     r = create_renderer()
@@ -1638,6 +1638,7 @@ def test_black_hole_shadow_is_dark():
                  vfov=6, width=200, height=200)
     pixels = render_image(r, samples=8)
 
+    assert np.all(np.isfinite(pixels)), "black hole shadow render contains NaN/Inf"
     center_region = pixels[80:120, 80:120, :]
     center_mean   = float(np.mean(center_region))
     edge_mean     = float(np.mean(pixels[:20, :, :]))
@@ -1660,7 +1661,6 @@ def test_black_hole_with_geometry():
     save_image(pixels, os.path.join(OUTPUT_DIR, 'test_bh_cornell.png'))
 
 
-@pytest.mark.xfail(reason="black hole GR dispatch not ported to pathTraceSpectral — deferred", strict=False)
 def test_black_hole_extreme_disk_remains_finite():
     """Extreme disk params should not produce NaN/Inf and should keep a visible shadow."""
     r = create_renderer()


### PR DESCRIPTION
## Summary
- Restores GR-object dispatch inside the spectral-only `path_tracer` so black-hole influence-sphere hits call `traceGR()` again.
- Bridges existing GR disk RGB emission into sampled spectra, continues escaped rays along the GR exit direction, and treats captured rays as the shadow.
- Adds bit-pattern finite guards around GR bridge/output pixels and promotes black-hole smoke/shadow tests from xfail to active finite/non-black assertions.
- Updates `.astroray_plan/docs/STATUS.md` with the active Codex follow-up work.

Closes #111.

## Verification
- `cmake --build build --config Release -j`
- `pytest tests/test_python_bindings.py -k "black_hole" -v --tb=short -W error::RuntimeWarning`
- `pytest tests/ -v --tb=short` -> 209 passed, 1 skipped, 15 xfailed, 2 xpassed

## Visual QA
- Re-inspected `test_results/test_black_hole.png`, `test_bh_shadow.png`, `test_bh_extreme_finite.png`, and `test_bh_showcase.png`.
- Image stats confirm non-black outputs, dark center shadows, bright edges/background, and high color variation in the showcase render.