### PR TITLE
feat: add native spectral GR emission

### DIFF
--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Astroray Status
 
-**Last updated:** 2026-04-28 (Codex onboarding in progress; render-output triage and GR spectral dispatch fixes opened)
+**Last updated:** 2026-04-28 (Codex onboarding in progress; PRs #116/#117 merged, native GR spectral emission in progress)
 
 This is the source-of-truth for "where are we?" Updated by the overseer
 at the start of each week, and by the project owner when a significant
@@ -72,8 +72,8 @@ personally should pick up.
 
 ### Track E (Codex)
 
-- In review: PR #116 (`codex/render-test-triage`) — Codex/Claude coordination docs, local-agent launcher, render-output triage, and refreshed spectral tests.
-- Active: issue #111 (`codex/gr-spectral-dispatch`) — restore black-hole GR dispatch in the spectral `path_tracer`.
+- Recently merged: PR #116 (`codex/render-test-triage`) and PR #117 (`codex/gr-spectral-dispatch`).
+- Active: issue #118 (`codex/native-gr-spectrum`) — add native sampled-spectrum GR disk emission.
 
 ---
 
@@ -100,22 +100,21 @@ personally should pick up.
 
 | Package | Track | Status | Blocker |
 |---|---|---|---|
-| render-output-triage | E | in review | PR #116 |
-| gr-spectral-dispatch | E | active | issue #111 |
+| native-gr-spectrum | E | active | issue #118 |
+| pillar3-restir-specs | E | queued | issue #114 |
 
 ---
 
 ## Known issues
 
 - `include/raytracer.h` and `include/advanced_features.h` still contain texture class bodies (`CheckerTexture`, `NoiseTexture`, etc.). These are used directly by `blender_module.cpp` and will be cleaned up in a future package if the plan calls for it.
-- Render-output triage in PR #116 flagged the stale all-black `test_black_hole.png`; issue #111 is the targeted fix.
+- ReSTIR work is still unscoped at package-file level; issue #114 tracks pkg20+ planning.
 
 ---
 
 ## Decisions pending (for project owner)
 
 - Confirm whether lights should be migrated to plugins (currently out of scope per pkg04 non-goals) and if so, which package handles it.
-- Decide whether GR disk emission should grow a native sampled-spectrum result instead of the current RGB-to-spectral bridge used by `traceGR()`.
 
 ---
 
@@ -123,7 +122,7 @@ personally should pick up.
 
 Brief notes on notable events.
 
-- **2026-04-28** — Codex follow-up work started after pkg14. PR #116 adds shared agent docs, WSL local-agent launcher scaffolding, render-output triage, and refreshed deterministic spectral tests. Issue #111 is in progress to restore black-hole GR dispatch inside the spectral-only `path_tracer`.
+- **2026-04-28** — PR #116 and PR #117 merged. Codex docs/local-agent scaffolding, render-output triage, refreshed deterministic spectral tests, and restored spectral black-hole GR dispatch are now on `main`. Follow-up issue #118 is active to remove the temporary RGB bridge for GR disk emission.
 - **2026-04-26** — pkg14 complete. Spectral HDRI atlas built at load time; env-miss path wired to `evalSpectral`; legacy RGB `PathTracer` plugin and `pathTrace()` kernel deleted; registry entry renamed `"path_tracer"`; `Material::evalSpectral` is now pure virtual; `Material::eval` virtual removed. **Pillar 2 is 100% complete (pkg10–pkg14).**
 - **2026-04-26** — pkg13 fully complete. All four threads merged: (1) physics/infra PR #103 — Texture::sampleSpectral, ImageTexture cache, Metal/Dielectric/Mirror/Subsurface evalSpectral; (2) Copilot PR #104 — Phong/Disney/NormalMapped/DiffuseLight evalSpectral/emittedSpectral; (3) Copilot PR #106 — 8 procedural texture sampleSpectral overrides; (4) pkg13c PR — 4 new plugins: oren_nayar, isotropic, two_sided, emissive. Every shading event in the spectral pipeline now has a concrete override. Test suite: 223 passed, 1 skipped. Pillar 2 ~90%.
 - **2026-04-24** — pkg10 merged: Pillar 2 scaffolding. New `include/astroray/spectrum.h` defines `SampledWavelengths`, `SampledSpectrum`, `RGBAlbedoSpectrum`, `RGBUnboundedSpectrum`, `RGBIlluminantSpectrum` (float, 4 samples, 360-830 nm). `src/spectrum.cpp` loads the shipped Jakob-Hanika sRGB LUT lazily from `data/spectra/rgb_to_spectrum_srgb.coeff` and embeds the CIE 1964 10° CMF and D65 SPD as `constexpr` tables. New `astroray_core_impl` CMake target; `ASTRORAY_DATA_DIR` compile definition + env-var override for runtime data discovery. Python bindings expose every type plus a top-level `rgb_to_spectrum()` helper. No integration into any material, integrator, pass, or env map — that is pkg11+. Test suite: 189 passed, 1 skipped (20 new spectrum tests).

--- a/include/astroray/black_hole.h
+++ b/include/astroray/black_hole.h
@@ -95,6 +95,77 @@ private:
         return s;
     }
 
+    struct TraceState {
+        bool valid = false;
+        IntegrationResult integration{};
+    };
+
+    TraceState integrateIncomingRay(const Ray& incomingRay) const {
+        TraceState state;
+
+        Vec3 oc      = incomingRay.origin - position;
+        float a      = incomingRay.direction.length2();
+        float half_b = oc.dot(incomingRay.direction);
+        float c_     = oc.length2() - float(influenceRadius * influenceRadius);
+        float disc   = half_b * half_b - a * c_;
+        if (disc < 0.0f || a < 1e-15f) return state;
+        float sqrtd   = std::sqrt(disc);
+        float entry_t = (-half_b - sqrtd) / a;
+        if (entry_t < 0.001f) entry_t = (-half_b + sqrtd) / a;
+        if (entry_t < 0.001f) return state;
+
+        Vec3 hitPoint = incomingRay.at(entry_t);
+        GeodesicState s0 = buildInitialState(hitPoint, incomingRay.direction);
+        state.integration = integrateGeodesic(
+            *metric, disk.get(), s0, inclination,
+            /*maxSteps=*/5000, /*h_init=*/0.5,
+            /*atol=*/1e-8, /*rtol=*/1e-6,
+            /*r_max=*/r_obs_M * 1.05
+        );
+        state.valid = true;
+        return state;
+    }
+
+    Vec3 sanitizedExitDirection(const IntegrationResult& ir) const {
+        if (ir.escaped) {
+            Vec3 d = ir.exitDirection;
+            if (gr_isfinite(static_cast<double>(d.x)) &&
+                gr_isfinite(static_cast<double>(d.y)) &&
+                gr_isfinite(static_cast<double>(d.z)) &&
+                d.length2() > 1e-10f) {
+                return d.normalized();
+            }
+        }
+        return Vec3(0, 0, 1);
+    }
+
+    astroray::SampledSpectrum diskEmissionSpectral(
+            const IntegrationResult& ir,
+            const astroray::SampledWavelengths& lambdas) const {
+        astroray::SampledSpectrum emission(0.0f);
+        if (ir.nCrossings <= 0) return emission;
+
+        constexpr double span =
+            double(astroray::kLambdaMax - astroray::kLambdaMin);
+        for (int ci = 0; ci < ir.nCrossings; ++ci) {
+            const DiskCrossing& dc = ir.crossings[ci];
+            if (!dc.valid) continue;
+            double T = disk->temperatureAt(dc.r);
+            if (T <= 0.0 || !gr_isfinite(T)) continue;
+            if (!gr_isfinite(dc.g) || dc.g <= 0.0) continue;
+            double g = std::min(dc.g, 10.0);
+            double g4 = g * g * g * g;
+            for (int wi = 0; wi < astroray::kSpectrumSamples; ++wi) {
+                double B = planck(double(lambdas.lambda(wi)), T);
+                if (!gr_isfinite(B) || B <= 0.0) continue;
+                double scaled = g4 * B * double(exposureScale) / span;
+                if (!gr_isfinite(scaled) || scaled <= 0.0) continue;
+                emission[wi] = std::min(20.0f, emission[wi] + float(scaled));
+            }
+        }
+        return emission;
+    }
+
 public:
     BlackHole(Vec3 pos, double mass_solar, double influence_r,
               double disk_outer_M = 30.0, double mdot = 1.0,
@@ -159,28 +230,9 @@ public:
         result.color        = Vec3(0);
         result.exitDirection = Vec3(0, 0, 1);
 
-        // Find the entry t on the influence sphere
-        Vec3 oc      = incomingRay.origin - position;
-        float a      = incomingRay.direction.length2();
-        float half_b = oc.dot(incomingRay.direction);
-        float c_     = oc.length2() - float(influenceRadius * influenceRadius);
-        float disc   = half_b * half_b - a * c_;
-        if (disc < 0.0f || a < 1e-15f) return result;
-        float sqrtd   = std::sqrt(disc);
-        float entry_t = (-half_b - sqrtd) / a;
-        if (entry_t < 0.001f) entry_t = (-half_b + sqrtd) / a;
-        if (entry_t < 0.001f) return result;
-
-        Vec3 hitPoint = incomingRay.at(entry_t);
-
-        GeodesicState s0 = buildInitialState(hitPoint, incomingRay.direction);
-
-        IntegrationResult ir = integrateGeodesic(
-            *metric, disk.get(), s0, inclination,
-            /*maxSteps=*/5000, /*h_init=*/0.5,
-            /*atol=*/1e-8, /*rtol=*/1e-6,
-            /*r_max=*/r_obs_M * 1.05
-        );
+        TraceState trace = integrateIncomingRay(incomingRay);
+        if (!trace.valid) return result;
+        const IntegrationResult& ir = trace.integration;
 
         if (ir.captured) {
             result.captured = true;
@@ -194,38 +246,57 @@ public:
                 const DiskCrossing& dc = ir.crossings[ci];
                 if (!dc.valid) continue;
                 double T = disk->temperatureAt(dc.r);
-                if (T <= 0.0 || !std::isfinite(T)) continue;
-                if (!std::isfinite(dc.g) || dc.g <= 0.0) continue;
+                if (T <= 0.0 || !gr_isfinite(T)) continue;
+                if (!gr_isfinite(dc.g) || dc.g <= 0.0) continue;
                 double g = std::min(dc.g, 10.0);
                 for (int wi = 0; wi < 4; ++wi) {
                     double lam_emit = spec.wavelengths[wi];
                     double B  = planck(lam_emit, T);
-                    if (!std::isfinite(B) || B <= 0.0) continue;
+                    if (!gr_isfinite(B) || B <= 0.0) continue;
                     double g4 = g * g * g * g;
                     double contrib = g4 * B;
-                    if (!std::isfinite(contrib) || contrib <= 0.0) continue;
+                    if (!gr_isfinite(contrib) || contrib <= 0.0) continue;
                     spec.radiance[wi] += contrib;
                 }
             }
             Vec3 rgb = spectralToRGB(spec, exposureScale);
-            rgb.x = std::isfinite(rgb.x) ? std::max(0.0f, rgb.x) : 0.0f;
-            rgb.y = std::isfinite(rgb.y) ? std::max(0.0f, rgb.y) : 0.0f;
-            rgb.z = std::isfinite(rgb.z) ? std::max(0.0f, rgb.z) : 0.0f;
+            rgb.x = gr_isfinite(static_cast<double>(rgb.x)) ? std::max(0.0f, rgb.x) : 0.0f;
+            rgb.y = gr_isfinite(static_cast<double>(rgb.y)) ? std::max(0.0f, rgb.y) : 0.0f;
+            rgb.z = gr_isfinite(static_cast<double>(rgb.z)) ? std::max(0.0f, rgb.z) : 0.0f;
             if (rgb.x > 0 || rgb.y > 0 || rgb.z > 0) {
                 result.color       = rgb;
                 result.hasEmission = true;
             }
         }
 
-        // Exit direction
-        if (ir.escaped) {
-            Vec3 d = ir.exitDirection;
-            if (std::isfinite(d.x) && std::isfinite(d.y) && std::isfinite(d.z)
-                && d.length2() > 1e-10f) {
-                result.exitDirection = d.normalized();
-            }
+        result.exitDirection = sanitizedExitDirection(ir);
+
+        return result;
+    }
+
+    ASTRORAY_NOINLINE
+    GRSpectralResult traceGRSpectral(
+            const Ray& incomingRay,
+            const astroray::SampledWavelengths& lambdas,
+            std::mt19937& /*gen*/) const override {
+        GRSpectralResult result;
+        result.emission = astroray::SampledSpectrum(0.0f);
+        result.captured = false;
+        result.hasEmission = false;
+        result.exitDirection = Vec3(0, 0, 1);
+
+        TraceState trace = integrateIncomingRay(incomingRay);
+        if (!trace.valid) return result;
+        const IntegrationResult& ir = trace.integration;
+
+        if (ir.captured) {
+            result.captured = true;
+            return result;
         }
 
+        result.emission = diskEmissionSpectral(ir, lambdas);
+        result.hasEmission = !result.emission.isZero();
+        result.exitDirection = sanitizedExitDirection(ir);
         return result;
     }
 };

--- a/include/raytracer.h
+++ b/include/raytracer.h
@@ -542,6 +542,13 @@ public:
         bool hasEmission;      // disk was hit
     };
 
+    struct GRSpectralResult {
+        astroray::SampledSpectrum emission;  // disk emission at carried wavelengths
+        Vec3 exitDirection;                  // world-space exit direction
+        bool captured;                       // absorbed by horizon
+        bool hasEmission;                    // disk was hit
+    };
+
     virtual ~Hittable() = default;
     virtual bool hit(const Ray& r, float tMin, float tMax, HitRecord& rec) const = 0;
     virtual bool boundingBox(AABB& box) const = 0;
@@ -556,6 +563,18 @@ public:
     virtual bool isGRObject() const { return false; }
     virtual GRResult traceGR(const Ray& /*r*/, std::mt19937& /*gen*/) const {
         return {Vec3(0), Vec3(0, 0, 1), true, false};
+    }
+    virtual GRSpectralResult traceGRSpectral(
+            const Ray& r,
+            const astroray::SampledWavelengths& lambdas,
+            std::mt19937& gen) const {
+        GRResult rgb = traceGR(r, gen);
+        astroray::SampledSpectrum emission(0.0f);
+        if (rgb.hasEmission) {
+            emission = astroray::RGBIlluminantSpectrum(
+                {rgb.color.x, rgb.color.y, rgb.color.z}).sample(lambdas);
+        }
+        return {emission, rgb.exitDirection, rgb.captured, rgb.hasEmission};
     }
     void setObjectPassIndex(int value) { objectPassIndex = std::max(0, value); }
     void setMaterialPassIndex(int value) { materialPassIndex = std::max(0, value); }
@@ -1753,21 +1772,14 @@ public:
                 break;
             }
             if (rec.hitObject && rec.hitObject->isGRObject()) {
-                auto grResult = rec.hitObject->traceGR(ray, gen);
+                auto grResult = rec.hitObject->traceGRSpectral(ray, lambdas, gen);
 
                 if (grResult.hasEmission) {
-                    Vec3 emissionRgb(
-                        finiteClamped(grResult.color.x, 0.0f, 20.0f),
-                        finiteClamped(grResult.color.y, 0.0f, 20.0f),
-                        finiteClamped(grResult.color.z, 0.0f, 20.0f)
-                    );
-                    astroray::SampledSpectrum grEmission =
-                        astroray::RGBIlluminantSpectrum({
-                            emissionRgb.x,
-                            emissionRgb.y,
-                            emissionRgb.z
-                        }).sample(lambdas);
-                    if (emissionRgb.x > 0.0f || emissionRgb.y > 0.0f || emissionRgb.z > 0.0f) {
+                    astroray::SampledSpectrum grEmission(0.0f);
+                    for (int i = 0; i < astroray::kSpectrumSamples; ++i) {
+                        grEmission[i] = finiteClamped(grResult.emission[i], 0.0f, 20.0f);
+                    }
+                    if (!grEmission.isZero()) {
                         color += throughput * grEmission;
                     }
                 }

--- a/tests/test_python_bindings.py
+++ b/tests/test_python_bindings.py
@@ -1685,6 +1685,39 @@ def test_black_hole_extreme_disk_remains_finite():
     save_image(pixels, os.path.join(OUTPUT_DIR, 'test_bh_extreme_finite.png'))
 
 
+def test_black_hole_native_spectral_disk_visible():
+    """Native spectral GR disk emission should be finite and visible."""
+    r = create_renderer()
+    r.set_seed(11)
+    r.set_background_color([0.0, 0.0, 0.0])
+    r.add_black_hole([0, 0, 0], 10.0, 100.0, {
+        'disk_outer': 30.0,
+        'accretion_rate': 1.0,
+        'inclination': 75.0,
+    })
+    setup_camera(r, look_from=[0, 0, 200], look_at=[0, 0, 0],
+                 vfov=12, width=120, height=90)
+    pixels = render_image(r, samples=8)
+
+    assert np.all(np.isfinite(pixels)), "native spectral GR render contains NaN/Inf"
+    assert float(np.mean(pixels)) > 1e-4, "native spectral GR disk emission is black"
+    save_image(pixels, os.path.join(OUTPUT_DIR, 'test_bh_native_spectral_disk.png'))
+
+
+def test_black_hole_renderer_uses_native_spectral_gr_dispatch():
+    """The spectral renderer should not RGB-upsample GR disk emission."""
+    source = open(
+        os.path.join(os.path.dirname(__file__), '..', 'include', 'raytracer.h'),
+        encoding='utf-8',
+    ).read()
+    gr_block = source.split('traceGRSpectral(ray, lambdas, gen)', 1)[1].split(
+        'if (!rec.material) break;', 1
+    )[0]
+
+    assert 'traceGR(ray, gen)' not in gr_block
+    assert 'RGBIlluminantSpectrum' not in gr_block
+
+
 def test_black_hole_gr_feature_flag():
     """gr_black_holes feature flag is set in __features__."""
     assert 'gr_black_holes' in astroray.__features__, \


### PR DESCRIPTION
## Summary
- Adds `Hittable::GRSpectralResult` and `traceGRSpectral(...)` so spectral renderers can consume GR disk emission at the carried `SampledWavelengths`.
- Implements native sampled-spectrum disk emission in `BlackHole` while keeping the legacy RGB `traceGR()` path for compatibility.
- Updates `Renderer::pathTraceSpectral()` to call `traceGRSpectral()` instead of RGB-upsampling `traceGR()` output.
- Adds regression coverage for finite/non-black native spectral GR disk output and a source guard against reintroducing the renderer-side RGB bridge.
- Updates `.astroray_plan/docs/STATUS.md` for the merged Codex PRs and active issue #118.

Closes #118.

## Verification
- `cmake --build build --config Release -j`
- `pytest tests/test_python_bindings.py -k "black_hole" -v --tb=short -W error::RuntimeWarning`
- `pytest tests/ -v --tb=short` -> 211 passed, 1 skipped, 15 xfailed, 2 xpassed
- `python scripts/render_output_triage.py --flagged-only` used as image-output review aid

## Visual QA
- Inspected `test_results/test_bh_native_spectral_disk.png`; it shows a finite visible disk ring on black background.
- Rechecked black-hole smoke/shadow/showcase stats; outputs remain non-black with dark centers where expected.