### PR TITLE
docs: add ReSTIR package specs

### DIFF
--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Astroray Status
 
-**Last updated:** 2026-04-28 (Codex onboarding in progress; render-output triage and GR spectral dispatch fixes opened)
+**Last updated:** 2026-04-28 (Codex onboarding in progress; ReSTIR package specs in progress)
 
 This is the source-of-truth for "where are we?" Updated by the overseer
 at the start of each week, and by the project owner when a significant
@@ -72,8 +72,9 @@ personally should pick up.
 
 ### Track E (Codex)
 
-- In review: PR #116 (`codex/render-test-triage`) — Codex/Claude coordination docs, local-agent launcher, render-output triage, and refreshed spectral tests.
-- Active: issue #111 (`codex/gr-spectral-dispatch`) — restore black-hole GR dispatch in the spectral `path_tracer`.
+- Recently merged: PR #116 (`codex/render-test-triage`) and PR #117 (`codex/gr-spectral-dispatch`).
+- In review: PR #119 (`codex/native-gr-spectrum`) — native sampled-spectrum GR disk emission.
+- Active: issue #114 (`codex/restir-package-specs`) — Pillar 3 ReSTIR package specs.
 
 ---
 
@@ -100,22 +101,21 @@ personally should pick up.
 
 | Package | Track | Status | Blocker |
 |---|---|---|---|
-| render-output-triage | E | in review | PR #116 |
-| gr-spectral-dispatch | E | active | issue #111 |
+| native-gr-spectrum | E | in review | PR #119 |
+| pillar3-restir-specs | E | active | issue #114 |
 
 ---
 
 ## Known issues
 
 - `include/raytracer.h` and `include/advanced_features.h` still contain texture class bodies (`CheckerTexture`, `NoiseTexture`, etc.). These are used directly by `blender_module.cpp` and will be cleaned up in a future package if the plan calls for it.
-- Render-output triage in PR #116 flagged the stale all-black `test_black_hole.png`; issue #111 is the targeted fix.
+- ReSTIR work is now scoped at package-file level in issue #114; implementation should start at pkg20 after review.
 
 ---
 
 ## Decisions pending (for project owner)
 
 - Confirm whether lights should be migrated to plugins (currently out of scope per pkg04 non-goals) and if so, which package handles it.
-- Decide whether GR disk emission should grow a native sampled-spectrum result instead of the current RGB-to-spectral bridge used by `traceGR()`.
 
 ---
 
@@ -123,7 +123,7 @@ personally should pick up.
 
 Brief notes on notable events.
 
-- **2026-04-28** — Codex follow-up work started after pkg14. PR #116 adds shared agent docs, WSL local-agent launcher scaffolding, render-output triage, and refreshed deterministic spectral tests. Issue #111 is in progress to restore black-hole GR dispatch inside the spectral-only `path_tracer`.
+- **2026-04-28** — PR #116 and PR #117 merged. Codex docs/local-agent scaffolding, render-output triage, refreshed deterministic spectral tests, and restored spectral black-hole GR dispatch are now on `main`. PR #119 is in review for native spectral GR disk emission; issue #114 is active for Pillar 3 ReSTIR package specs.
 - **2026-04-26** — pkg14 complete. Spectral HDRI atlas built at load time; env-miss path wired to `evalSpectral`; legacy RGB `PathTracer` plugin and `pathTrace()` kernel deleted; registry entry renamed `"path_tracer"`; `Material::evalSpectral` is now pure virtual; `Material::eval` virtual removed. **Pillar 2 is 100% complete (pkg10–pkg14).**
 - **2026-04-26** — pkg13 fully complete. All four threads merged: (1) physics/infra PR #103 — Texture::sampleSpectral, ImageTexture cache, Metal/Dielectric/Mirror/Subsurface evalSpectral; (2) Copilot PR #104 — Phong/Disney/NormalMapped/DiffuseLight evalSpectral/emittedSpectral; (3) Copilot PR #106 — 8 procedural texture sampleSpectral overrides; (4) pkg13c PR — 4 new plugins: oren_nayar, isotropic, two_sided, emissive. Every shading event in the spectral pipeline now has a concrete override. Test suite: 223 passed, 1 skipped. Pillar 2 ~90%.
 - **2026-04-24** — pkg10 merged: Pillar 2 scaffolding. New `include/astroray/spectrum.h` defines `SampledWavelengths`, `SampledSpectrum`, `RGBAlbedoSpectrum`, `RGBUnboundedSpectrum`, `RGBIlluminantSpectrum` (float, 4 samples, 360-830 nm). `src/spectrum.cpp` loads the shipped Jakob-Hanika sRGB LUT lazily from `data/spectra/rgb_to_spectrum_srgb.coeff` and embeds the CIE 1964 10° CMF and D65 SPD as `constexpr` tables. New `astroray_core_impl` CMake target; `ASTRORAY_DATA_DIR` compile definition + env-var override for runtime data discovery. Python bindings expose every type plus a top-level `rgb_to_spectrum()` helper. No integration into any material, integrator, pass, or env map — that is pkg11+. Test suite: 189 passed, 1 skipped (20 new spectrum tests).

--- a/.astroray_plan/docs/light-transport.md
+++ b/.astroray_plan/docs/light-transport.md
@@ -147,14 +147,16 @@ new interface. `pkg05-integrator-interface.md` lands as part of Pillar
 
 ### Phase 3B: ReSTIR DI (2–3 weeks, track A)
 
-- `pkg20-reservoir-datastructure.md` — types, temporal buffers.
-- `pkg21-restir-initial-sampling.md` — kernel 1 (candidate generation
-  and RIS).
-- `pkg22-restir-temporal-reuse.md` — kernel 2 (reproject previous-frame
-  reservoirs).
-- `pkg23-restir-spatial-reuse.md` — kernel 3 (neighborhood reuse).
-- `pkg24-restir-validation.md` — visibility reuse, correctness checks
-  against vanilla path tracer.
+- `pkg20-reservoir-core.md` — reservoir type, invariants, and unit
+  tests.
+- `pkg21-light-sample-abstraction.md` — reusable direct-light candidate
+  payload and spectral target-weight helpers.
+- `pkg22-restir-initial-sampling.md` — opt-in `restir-di` prototype with
+  initial candidate generation only.
+- `pkg23-restir-temporal-spatial-design.md` — temporal/spatial reuse
+  design, history ownership, validation gates, and CPU/GPU boundary.
+- `pkg24-restir-validation.md` — validation scenes and bias/variance
+  checks against vanilla path tracer.
 
 ### Phase 3C: NRC prototype (1–2 weeks, track C)
 

--- a/.astroray_plan/packages/pkg20-reservoir-core.md
+++ b/.astroray_plan/packages/pkg20-reservoir-core.md
@@ -1,0 +1,118 @@
+# pkg20 — ReSTIR Reservoir Core
+
+**Pillar:** 3
+**Track:** A
+**Status:** open
+**Estimated effort:** 1 session (~3 h)
+**Depends on:** pkg14
+
+---
+
+## Goal
+
+**Before:** Astroray has direct-light sampling inside the spectral path
+tracer, but no reusable reservoir type or tests for ReSTIR-style
+weighted sample replacement.
+
+**After:** the repo has a small, deterministic reservoir core with clear
+invariants, unit tests, and no renderer integration. Later ReSTIR
+packages can depend on this type without designing the math again.
+
+---
+
+## Context
+
+ReSTIR DI depends on a correct reservoir update rule before any renderer
+work is useful. This package deliberately avoids scene sampling,
+visibility, temporal reuse, spatial reuse, and CUDA kernels. It creates
+the smallest tested primitive: a weighted reservoir that can ingest
+candidates and retain one representative sample with the right
+probability and aggregate weights.
+
+---
+
+## Reference
+
+- Design doc: `.astroray_plan/docs/light-transport.md §ReSTIR DI`
+- Paper: Bitterli et al. 2020, "Spatiotemporal reservoir resampling for
+  real-time ray tracing with dynamic direct lighting"
+- RTXDI SDK: https://github.com/NVIDIA-RTX/RTXDI
+
+---
+
+## Prerequisites
+
+- [ ] Pillar 2 is complete and `path_tracer` is spectral-first.
+- [ ] Full pytest passes on `main`.
+- [ ] ReSTIR package specs pkg20-pkg24 are merged or this package is
+      reviewed against issue #114.
+
+---
+
+## Specification
+
+### Files to create
+
+| File | Purpose |
+|---|---|
+| `include/astroray/restir/reservoir.h` | Header-only `Reservoir<T>` or concrete `LightReservoir` core with update, merge, reset, and invariant helpers. |
+| `tests/test_restir_reservoir.py` | Statistical and deterministic tests for update/merge behavior through a minimal binding or compiled helper. |
+
+### Files to modify
+
+| File | What changes |
+|---|---|
+| `CMakeLists.txt` | Add any tiny test helper target if Python cannot directly exercise the reservoir type. |
+| `module/blender_module.cpp` | Only if needed to expose a private test helper; production API exposure is a non-goal. |
+
+### Key design decisions
+
+- The reservoir stores `w_sum`, `M`, final weight `W`, and a selected
+  candidate. Names should match ReSTIR literature unless a stronger
+  local convention exists.
+- Randomness is injected by the caller as `std::mt19937&`; the reservoir
+  does not own RNG state.
+- Tests should favor deterministic seeded checks plus coarse
+  distribution sanity, not brittle exact stochastic histograms.
+- This package is **Copilot-safe** if the implementer is restricted to
+  the two new files and test helper plumbing. Claude/Codex should review
+  math and naming before merge.
+
+---
+
+## Acceptance criteria
+
+- [ ] Reservoir reset/update/merge invariants are covered by tests.
+- [ ] Zero, negative, NaN, and infinite candidate weights are handled
+      deterministically and do not poison stored state.
+- [ ] Seeded update sequences produce stable selected-candidate results.
+- [ ] A simple weighted selection distribution test passes with a loose
+      tolerance.
+- [ ] No renderer, integrator, scene, CUDA, or Blender UI behavior
+      changes.
+- [ ] Full pytest passes.
+
+---
+
+## Non-goals
+
+- Do not add a ReSTIR integrator.
+- Do not sample scene lights.
+- Do not add temporal or spatial reuse.
+- Do not add CUDA kernels.
+- Do not expose user-facing Python or Blender ReSTIR settings.
+
+---
+
+## Progress
+
+- [ ] Add reservoir type.
+- [ ] Add deterministic invariant tests.
+- [ ] Add loose statistical selection test.
+- [ ] Update status/changelog notes when merged.
+
+---
+
+## Lessons
+
+*(Fill in after the package is done.)*

--- a/.astroray_plan/packages/pkg21-light-sample-abstraction.md
+++ b/.astroray_plan/packages/pkg21-light-sample-abstraction.md
@@ -1,0 +1,116 @@
+# pkg21 — ReSTIR Light Sample Abstraction
+
+**Pillar:** 3
+**Track:** A
+**Status:** open
+**Estimated effort:** 1 session (~3 h)
+**Depends on:** pkg20
+
+---
+
+## Goal
+
+**Before:** direct-light sampling is embedded in the spectral path
+tracer's next-event-estimation loop and cannot be reused by ReSTIR
+candidate generation.
+
+**After:** direct-light candidates have a compact, renderer-agnostic
+representation that can be evaluated by vanilla NEE and future ReSTIR
+passes.
+
+---
+
+## Context
+
+ReSTIR resamples light candidates, not arbitrary path vertices. The
+candidate payload must include the sampled light, position/direction,
+emission, PDFs, and enough metadata to re-evaluate a target function
+later. This package extracts representation and evaluation helpers only;
+the path tracer should still render the same images.
+
+---
+
+## Reference
+
+- Design doc: `.astroray_plan/docs/light-transport.md §ReSTIR DI`
+- Existing code: `include/raytracer.h` `LightSample`, `LightList`,
+  `Renderer::pathTraceSpectral()`
+- Depends on: `.astroray_plan/packages/pkg20-reservoir-core.md`
+
+---
+
+## Prerequisites
+
+- [ ] pkg20 reservoir core is merged.
+- [ ] Full pytest passes on `main`.
+- [ ] A maintainer has confirmed the candidate payload fields before
+      implementation begins.
+
+---
+
+## Specification
+
+### Files to create
+
+| File | Purpose |
+|---|---|
+| `include/astroray/restir/light_sample.h` | ReSTIR candidate payload and helper functions for target luminance/validity. |
+| `tests/test_restir_light_sample.py` | Tests for finite payloads, zero-PDF rejection, and target-weight behavior. |
+
+### Files to modify
+
+| File | What changes |
+|---|---|
+| `include/raytracer.h` | Optional: factor existing `LightSample` fields or add adapter helpers. Keep changes narrow. |
+| `plugins/integrators/spectral_path_tracer.cpp` | Optional: use the helper for NEE weight evaluation only if it is behavior-preserving. |
+| `CMakeLists.txt` | Add test helper target only if needed. |
+
+### Key design decisions
+
+- The abstraction should be spectral-aware: target weights derive from
+  `SampledSpectrum.toXYZ(lambdas).Y` or an equivalent luminance helper.
+- Keep visibility separate. Candidate creation/evaluation should not
+  trace shadow rays in this package.
+- Existing `LightSample` can remain; this package may add adapters
+  instead of renaming core types.
+- This package is **Copilot-safe with constraints**: source extraction
+  and tests are mechanical, but Claude/Codex should review the target
+  weight definition and any path-tracer touch.
+
+---
+
+## Acceptance criteria
+
+- [ ] ReSTIR candidate payload has documented fields and validity rules.
+- [ ] Zero/negative/NaN PDFs and non-finite emissions are rejected or
+      sanitized consistently.
+- [ ] Spectral target-weight helper is covered by tests.
+- [ ] Existing path-tracer output remains unchanged within deterministic
+      tolerance if any NEE helper is refactored.
+- [ ] No reservoir use, temporal reuse, spatial reuse, CUDA kernels, or
+      new user-facing integrator is added.
+- [ ] Full pytest passes.
+
+---
+
+## Non-goals
+
+- Do not implement ReSTIR initial sampling.
+- Do not trace visibility or shadow rays inside candidate helpers.
+- Do not add frame history.
+- Do not change material or BSDF sampling behavior.
+
+---
+
+## Progress
+
+- [ ] Define candidate payload.
+- [ ] Add target-weight/validity helpers.
+- [ ] Add focused tests.
+- [ ] Optionally refactor NEE to use the helper with no visual change.
+
+---
+
+## Lessons
+
+*(Fill in after the package is done.)*

--- a/.astroray_plan/packages/pkg22-restir-initial-sampling.md
+++ b/.astroray_plan/packages/pkg22-restir-initial-sampling.md
@@ -1,0 +1,118 @@
+# pkg22 — ReSTIR Initial Sampling
+
+**Pillar:** 3
+**Track:** A
+**Status:** open
+**Estimated effort:** 2 sessions (~6 h)
+**Depends on:** pkg20, pkg21
+
+---
+
+## Goal
+
+**Before:** Astroray has reservoirs and light-candidate helpers, but no
+integrator path that uses them to generate per-pixel direct-light
+reservoirs.
+
+**After:** an opt-in `restir-di` prototype integrator performs initial
+candidate generation for direct lighting and renders finite images.
+There is no temporal or spatial reuse yet.
+
+---
+
+## Context
+
+Initial sampling is the first image-producing ReSTIR package. It should
+prove that the reservoir and candidate abstractions can replace the
+vanilla direct-light NEE slot without pulling in history buffers or
+neighbor reuse. The output may be noisier than final ReSTIR; correctness
+and finite behavior matter more than speed.
+
+---
+
+## Reference
+
+- Design doc: `.astroray_plan/docs/light-transport.md §Phase 3B`
+- Existing integrators: `plugins/integrators/spectral_path_tracer.cpp`,
+  `plugins/integrators/ambient_occlusion.cpp`
+- Depends on: pkg20 reservoir core, pkg21 light sample abstraction
+
+---
+
+## Prerequisites
+
+- [ ] pkg20 and pkg21 are merged.
+- [ ] `integrator_registry_names()` and `set_integrator()` tests are
+      green on `main`.
+- [ ] A small many-light validation scene is available or scoped in this
+      package.
+
+---
+
+## Specification
+
+### Files to create
+
+| File | Purpose |
+|---|---|
+| `plugins/integrators/restir_di.cpp` | Registers `"restir-di"` and implements initial candidate generation only. |
+| `tests/test_restir_initial_sampling.py` | Tests registration, finite rendering, deterministic seeded behavior, and simple brightness sanity. |
+
+### Files to modify
+
+| File | What changes |
+|---|---|
+| `CMakeLists.txt` | Compile the new integrator plugin. |
+| `include/astroray/restir/*.h` | Add helper functions only when needed by initial sampling. |
+| `module/blender_module.cpp` | Add integrator registry exposure only if the generic registry path does not already surface it. |
+
+### Key design decisions
+
+- Keep the classic `path_tracer` unchanged. `restir-di` is opt-in and
+  allowed to be prototype-quality.
+- Candidate count should be a small fixed constant first, exposed as a
+  parameter only after the algorithm is validated.
+- No GPU-first work here. CPU implementation is acceptable for tests and
+  algorithm validation.
+- This package is **Claude/Codex-only for implementation** because it
+  introduces the first image-producing ReSTIR path. Copilot can assist
+  with tests after the design is in place.
+
+---
+
+## Acceptance criteria
+
+- [ ] `"restir-di"` appears in `integrator_registry_names()`.
+- [ ] A simple scene renders finite, non-black pixels through
+      `set_integrator("restir-di")`.
+- [ ] Seeded renders are deterministic.
+- [ ] A scene with multiple small lights is not dramatically darker than
+      vanilla `path_tracer` at the same samples.
+- [ ] No temporal reuse, spatial reuse, frame history, or CUDA kernels
+      are added.
+- [ ] Full pytest passes.
+
+---
+
+## Non-goals
+
+- Do not optimize performance.
+- Do not add temporal or spatial reuse.
+- Do not change the default integrator.
+- Do not expose Blender UI controls beyond the existing integrator
+  selection path.
+
+---
+
+## Progress
+
+- [ ] Add `restir-di` plugin skeleton.
+- [ ] Implement initial candidate generation.
+- [ ] Add registration/render tests.
+- [ ] Add a small many-light validation scene or helper.
+
+---
+
+## Lessons
+
+*(Fill in after the package is done.)*

--- a/.astroray_plan/packages/pkg23-restir-temporal-spatial-design.md
+++ b/.astroray_plan/packages/pkg23-restir-temporal-spatial-design.md
@@ -1,0 +1,118 @@
+# pkg23 — ReSTIR Temporal and Spatial Reuse Design
+
+**Pillar:** 3
+**Track:** A
+**Status:** open
+**Estimated effort:** 2 sessions (~6 h)
+**Depends on:** pkg22
+
+---
+
+## Goal
+
+**Before:** `restir-di` can generate initial direct-light reservoirs per
+pixel, but each pixel/frame stands alone.
+
+**After:** the repo has reviewed design scaffolding for temporal and
+spatial reuse: frame buffers, reprojection inputs, neighbor selection,
+bias guards, and CPU/GPU boundaries. Implementation may include a
+minimal CPU spatial reuse pass if it stays small, but the main output is
+a concrete design ready for pkg24 validation and later CUDA work.
+
+---
+
+## Context
+
+Temporal and spatial reuse create most of ReSTIR's quality win, but they
+also create most of its bias and state-management risk. This package
+exists to prevent a large unreviewable jump from initial sampling to
+full reuse. It should make history ownership and validation strategy
+explicit before performance work begins.
+
+---
+
+## Reference
+
+- Design doc: `.astroray_plan/docs/light-transport.md §ReSTIR DI`
+- Previous package: `.astroray_plan/packages/pkg22-restir-initial-sampling.md`
+- RTXDI SDK history/reservoir management patterns
+
+---
+
+## Prerequisites
+
+- [ ] pkg22 is merged and `restir-di` initial sampling renders finite
+      images.
+- [ ] A target validation scene exists for direct-light reuse.
+- [ ] The project owner or maintainer confirms whether first reuse
+      implementation should be CPU-only, CUDA-only, or staged.
+
+---
+
+## Specification
+
+### Files to create
+
+| File | Purpose |
+|---|---|
+| `.astroray_plan/docs/restir-temporal-spatial-design.md` | Design note covering history buffers, reprojection data, spatial neighborhoods, validation gates, and GPU boundary. |
+| `include/astroray/restir/frame_state.h` | Optional skeleton for frame-indexed reservoir/history ownership if implementation begins here. |
+| `tests/test_restir_reuse_design.py` | Optional source/structure tests if skeleton types are added. |
+
+### Files to modify
+
+| File | What changes |
+|---|---|
+| `plugins/integrators/restir_di.cpp` | Optional minimal hook points for frame state; avoid shipping incomplete reuse behavior. |
+| `.astroray_plan/docs/light-transport.md` | Link the detailed design note and update package names. |
+| `.astroray_plan/docs/STATUS.md` | Mark pkg23 active/done as appropriate. |
+
+### Key design decisions
+
+- Treat temporal reuse as a state-ownership problem first. Define how
+  frame index, camera data, and previous reservoirs are invalidated.
+- Treat spatial reuse as an algorithmic pass over existing reservoirs,
+  not as another light-sampling path.
+- Bias checks are part of the design, not deferred to "later."
+- This package is **Claude/Codex-only**. It is too architecture-heavy
+  for an unsupervised Copilot implementation, though Copilot can draft
+  boilerplate once the design note is accepted.
+
+---
+
+## Acceptance criteria
+
+- [ ] Design note documents temporal inputs, invalidation rules,
+      spatial neighborhood policy, target weight re-evaluation, and bias
+      risks.
+- [ ] CPU/GPU split is explicit: what ships now, what moves to CUDA
+      later, and what data layout must remain stable.
+- [ ] pkg24 validation plan is concrete enough for another agent to
+      implement without redesigning.
+- [ ] If any code skeleton is added, it is covered by tests and does not
+      alter current render output.
+- [ ] Full pytest passes.
+
+---
+
+## Non-goals
+
+- Do not ship full temporal reuse without validation.
+- Do not add CUDA kernels unless explicitly approved before starting.
+- Do not change default rendering behavior.
+- Do not optimize memory layout prematurely.
+
+---
+
+## Progress
+
+- [ ] Draft design note.
+- [ ] Review CPU/GPU boundary.
+- [ ] Add optional frame-state skeleton.
+- [ ] Update light-transport docs with accepted package sequence.
+
+---
+
+## Lessons
+
+*(Fill in after the package is done.)*

--- a/.astroray_plan/packages/pkg24-restir-validation.md
+++ b/.astroray_plan/packages/pkg24-restir-validation.md
@@ -1,0 +1,113 @@
+# pkg24 — ReSTIR Validation
+
+**Pillar:** 3
+**Track:** A
+**Status:** open
+**Estimated effort:** 2 sessions (~6 h)
+**Depends on:** pkg22, pkg23
+
+---
+
+## Goal
+
+**Before:** ReSTIR DI has initial sampling and a temporal/spatial reuse
+design, but no robust validation harness for bias, variance, or visual
+regressions.
+
+**After:** Astroray has focused ReSTIR validation scenes and tests that
+compare `restir-di` against vanilla `path_tracer` using finite checks,
+brightness/error tolerances, and saved render outputs for visual review.
+
+---
+
+## Context
+
+ReSTIR can look better while being wrong. Validation must land before
+aggressive reuse or CUDA optimization, otherwise later agents will not
+know whether an image-quality improvement is unbiased, scene-specific,
+or a test artifact.
+
+---
+
+## Reference
+
+- Design doc: `.astroray_plan/docs/light-transport.md §Acceptance criteria`
+- Previous packages: pkg22 initial sampling, pkg23 reuse design
+- Existing render-output triage: `scripts/render_output_triage.py`
+
+---
+
+## Prerequisites
+
+- [ ] pkg22 initial sampling is merged.
+- [ ] pkg23 design note is merged or explicitly reviewed.
+- [ ] Baseline path-tracer validation scenes are deterministic enough
+      for tolerance-based comparisons.
+
+---
+
+## Specification
+
+### Files to create
+
+| File | Purpose |
+|---|---|
+| `tests/test_restir_validation.py` | ReSTIR-vs-path-tracer finite, brightness, and low-sample quality checks. |
+| `tests/restir_helpers.py` | Shared many-light scene builders and image metric helpers if tests grow beyond one file. |
+| `test_results/restir_*` | Generated PNGs/charts from tests; gitignored, used for visual QA. |
+
+### Files to modify
+
+| File | What changes |
+|---|---|
+| `scripts/render_output_triage.py` | Optional: add ReSTIR-specific labels or contact-sheet support if needed for review. |
+| `.astroray_plan/docs/light-transport.md` | Record accepted validation scenes and metrics. |
+| `.astroray_plan/docs/STATUS.md` | Mark pkg24 active/done and surface the next Pillar 3 package. |
+
+### Key design decisions
+
+- Use metrics that tolerate Monte Carlo noise: mean luminance,
+  center/edge comparisons, finite checks, and broad error thresholds.
+- Save images for human review, but do not require pixel-perfect
+  reference images in git.
+- Prefer small deterministic scenes over one expensive showcase.
+- This package is **Copilot-safe for test expansion** after Claude/Codex
+  defines the first validation scene and thresholds.
+
+---
+
+## Acceptance criteria
+
+- [ ] `restir-di` validation renders are finite and non-black.
+- [ ] Low-sample `restir-di` output is not systematically darker than
+      vanilla `path_tracer` on many-light scenes.
+- [ ] A converged comparison test catches obvious bias without requiring
+      impractically high sample counts.
+- [ ] Render-output triage can be run after validation tests and does
+      not flag the ReSTIR images as all-black or low-color-count unless
+      the test intentionally creates a mask/difference image.
+- [ ] Full pytest passes.
+
+---
+
+## Non-goals
+
+- Do not implement new ReSTIR algorithm stages.
+- Do not add CUDA optimization.
+- Do not add heavyweight binary reference images to git.
+- Do not claim production readiness solely from these tests.
+
+---
+
+## Progress
+
+- [ ] Add many-light helper scene.
+- [ ] Add finite/non-black validation.
+- [ ] Add ReSTIR-vs-path-tracer comparison.
+- [ ] Document accepted thresholds.
+
+---
+
+## Lessons
+
+*(Fill in after the package is done.)*


### PR DESCRIPTION
## Summary
- Adds pkg20-pkg24 ReSTIR DI package specs under `.astroray_plan/packages/`.
- Updates `light-transport.md` to point at the new package sequence.
- Updates `STATUS.md` with current Codex state: PR #119 in review and issue #114 active.

Closes #114.

## Package split
- `pkg20-reservoir-core.md`: reservoir type, invariants, deterministic/statistical tests.
- `pkg21-light-sample-abstraction.md`: reusable direct-light candidate payload and spectral target-weight helpers.
- `pkg22-restir-initial-sampling.md`: opt-in `restir-di` initial candidate generation only.
- `pkg23-restir-temporal-spatial-design.md`: temporal/spatial reuse design and CPU/GPU boundary.
- `pkg24-restir-validation.md`: validation scenes and bias/variance checks.

## Agent assignment notes
- Copilot-safe with constraints: pkg20, pkg21, pkg24 test expansion.
- Claude/Codex-only: pkg22 and pkg23, plus review of math/target weights before merge.

## Verification
- `git diff --check`
- Docs-only change; no runtime tests were needed.