### PR TITLE
[codex] Add pkg29a caustic validation

### DIFF
--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -66,7 +66,7 @@ personally should pick up.
 | pkg30 | Spectral BSDF sampling interface (`sampleSpectral` on Material) | implemented |
 | pkg31 | Spectral dielectric with Sellmeier dispersion | implemented |
 | pkg29 | Spectral dielectric prism validation | implemented |
-| pkg29a | Scoped caustic validation for spectral optics | design |
+| pkg29a | Scoped caustic validation for spectral optics | implemented |
 
 **Material backend parity bridge (Pillar 2/5 follow-up):**
 
@@ -178,9 +178,9 @@ personally should pick up.
 - ReSTIR work is now scoped at package-file level in issue #114; implementation should start at `pkg20` after review.
 - Windows verification is sensitive to stale build caches; test bootstrap now supports `ASTRORAY_BUILD_DIR` and standard `build/Release` layouts, but the old `build/` cache on this workstation still points at a missing MinGW install.
 - Prism-style spectral dispersion now has a deterministic validation scene and
-  saved render outputs. It is not a caustic-perfect showcase yet; pkg29a scopes
-  the caustic validation scenes and first transport experiment, while pkg32
-  turns mature diagnostics into polished visual outputs.
+  saved render outputs. pkg29a adds caustic validation scenes, metrics, and an
+  opt-in specular-chain connection experiment; it is still not a final
+  caustic-perfect showcase.
 - GPU material support is currently explicit only for a small flattened set
   of material types. pkg34-pkg36 define the bridge from CPU material plugins
   to truthful GPU/default rendering.
@@ -211,6 +211,11 @@ Brief notes on notable events.
 - **2026-05-03** — Optical material cleanup started for pkg29 follow-up. Added
   a scoped pkg29a caustic-validation design for issue #145, plus issue #142/#146
   work on optical-glass presets and thin architectural glass.
+- **2026-05-03** — pkg29a complete. Added `caustic_path_tracer`, three caustic
+  validation scenes, saved PNG diagnostics, JSON/CSV stats, and
+  `scripts/benchmark_caustic_transport.py`. The opt-in integrator records
+  `caustic_connections` and `caustic_energy` while leaving `path_tracer` as
+  the default/reference.
 - **2026-05-03** — Codex material triage recorded: convergence tracker repair,
   GGX/rough-metal sampling cleanup, and Disney rough-glass transmission with
   CPU/CUDA material support and high-sample GPU contact-sheet diagnostics.

--- a/.astroray_plan/packages/pkg29a-scoped-caustic-validation.md
+++ b/.astroray_plan/packages/pkg29a-scoped-caustic-validation.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 2 / 3 bridge follow-up  
 **Track:** A  
-**Status:** design  
+**Status:** implemented
 **Estimated effort:** 2-4 sessions  
 **Depends on:** pkg29, pkg31, issue #142, issue #146  
 **GitHub:** #145
@@ -54,16 +54,16 @@ Good first candidates:
 
 ## Acceptance Criteria
 
-- [ ] Issue #145 has this scoped design linked and no longer describes an
+- [x] Issue #145 has this scoped design linked and no longer describes an
       unbounded caustics rewrite.
-- [ ] Saved diagnostic renders exist for prism-to-screen, glass caustic, and
+- [x] Saved diagnostic renders exist for prism-to-screen, glass caustic, and
       narrowband emitter scenes.
-- [ ] Quantitative stats are emitted as JSON/CSV: render time, mean luminance,
+- [x] Quantitative stats are emitted as JSON/CSV: render time, mean luminance,
       receiver energy, high-percentile luminance, and red/blue centroid spread
       where applicable.
-- [ ] A focused pytest suite validates finite renders and checks that the
+- [x] A focused pytest suite validates finite renders and checks that the
       caustic mode does not regress pkg29/pkg31 spectral behavior.
-- [ ] `path_tracer` remains available as the CPU reference and default.
+- [x] `path_tracer` remains available as the CPU reference and default.
 
 ---
 
@@ -75,3 +75,31 @@ Good first candidates:
   equal-time quality without bias surprises.
 - Do not require CUDA; GPU acceleration is welcome for high-sample diagnostic
   renders but cannot be the only validation path.
+
+---
+
+## Completion Notes
+
+Implemented in issue #145 / pkg29a:
+
+- Added `caustic_path_tracer`, an opt-in integrator registered beside
+  `path_tracer`. It keeps the default reference path untouched and adds a
+  small specular-chain connection attempt immediately after delta BSDF events.
+- Added instrumentation through `get_integrator_stats()`:
+  `caustic_connections`, `caustic_energy`, and `caustic_chain_iters`.
+- Added `tests/scenes/caustic_validation.py` with three validation scenes:
+  `prism_to_screen`, `glass_caustic`, and `line_emitter`.
+- Added `tests/test_caustic_validation.py`, which saves diagnostic PNGs and
+  per-scene JSON/CSV stats under `test_results/`.
+- Added `scripts/benchmark_caustic_transport.py` for repeatable local visual
+  diagnostics and metric collection outside pytest.
+
+Smoke benchmark with `--samples 8 --max-depth 10` wrote:
+
+- `test_results/pkg29a_caustics_smoke/caustic_transport_stats.json`
+- `test_results/pkg29a_caustics_smoke/caustic_transport_stats.csv`
+
+Representative smoke result: `prism_to_screen` red/blue centroid spread rose
+from `0.685px` with `path_tracer` to `1.108px` with `caustic_path_tracer`.
+This is not a final caustics solver, but it creates the measurable validation
+loop needed for the next quality pass.

--- a/include/raytracer.h
+++ b/include/raytracer.h
@@ -1914,6 +1914,213 @@ public:
         return color;
     }
 
+    // Opt-in caustic validation kernel for pkg29a. The base path tracer remains
+    // the default/reference; this variant adds a small specular-chain connection
+    // attempt immediately after delta BSDF events so prism/glass diagnostics can
+    // measure whether structured caustic energy is improving.
+    astroray::SampledSpectrum pathTraceSpectralCaustic(
+            const Ray& r, int maxDepth, int chainIters,
+            astroray::SampledWavelengths& lambdas,
+            std::mt19937& gen,
+            int* outBounces = nullptr,
+            float* outWeight = nullptr,
+            int* outCausticConnections = nullptr,
+            float* outCausticEnergy = nullptr) {
+        if (lights.empty() || chainIters <= 0) {
+            return pathTraceSpectral(r, maxDepth, lambdas, gen, outBounces, outWeight);
+        }
+
+        const int rrDepth = 3;
+        astroray::SampledSpectrum color(0.0f);
+        astroray::SampledSpectrum throughput(1.0f);
+        Ray ray = r;
+        bool wasSpecular = true;
+        std::uniform_real_distribution<float> dist01(0.0f, 1.0f);
+        int lastBounce = 0;
+        float weightSum = 0.0f;
+        int causticConnections = 0;
+        float causticEnergy = 0.0f;
+
+        for (int bounce = 0; bounce < maxDepth; ++bounce) {
+            lastBounce = bounce;
+            HitRecord rec;
+            if (!bvh->hit(ray, 0.001f, std::numeric_limits<float>::max(), rec)) {
+                if (bounce <= worldMaxBounces) {
+                    astroray::SampledSpectrum envSpec(0.0f);
+                    if (envMap && envMap->loaded()) {
+                        envSpec = envMap->evalSpectral(ray.direction.normalized(), lambdas);
+                    } else if (backgroundColor.x >= 0) {
+                        envSpec = astroray::RGBIlluminantSpectrum(
+                            {backgroundColor.x, backgroundColor.y, backgroundColor.z}).sample(lambdas);
+                    } else {
+                        float t = 0.5f * (ray.direction.normalized().y + 1.0f);
+                        Vec3 bg = (Vec3(1) * (1 - t) + Vec3(0.5f, 0.7f, 1.0f) * t) * 0.2f;
+                        envSpec = astroray::RGBIlluminantSpectrum({bg.x, bg.y, bg.z}).sample(lambdas);
+                    }
+                    color += throughput * envSpec;
+                }
+                break;
+            }
+            if (rec.hitObject && rec.hitObject->isGRObject()) {
+                auto grResult = rec.hitObject->traceGRSpectral(ray, lambdas, gen);
+                if (grResult.hasEmission) {
+                    astroray::SampledSpectrum grEmission(0.0f);
+                    for (int i = 0; i < astroray::kSpectrumSamples; ++i) {
+                        grEmission[i] = finiteClamped(grResult.emission[i], 0.0f, 20.0f);
+                    }
+                    color += throughput * grEmission;
+                }
+                if (grResult.captured) break;
+                Vec3 exitDir = grResult.exitDirection;
+                float exitLen2 = exitDir.length2();
+                if (!finiteFloat(exitDir.x) || !finiteFloat(exitDir.y) ||
+                    !finiteFloat(exitDir.z) || !finiteFloat(exitLen2) || exitLen2 < 1e-10f) {
+                    break;
+                }
+                Ray next(rec.point, exitDir, ray.time, ray.screenU, ray.screenV);
+                next.hasCameraFrame = ray.hasCameraFrame;
+                next.cameraOrigin = ray.cameraOrigin;
+                next.cameraU = ray.cameraU;
+                next.cameraV = ray.cameraV;
+                next.cameraW = ray.cameraW;
+                ray = next;
+                wasSpecular = true;
+                continue;
+            }
+            if (!rec.material) break;
+
+            astroray::SampledSpectrum Le_spec = rec.material->emittedSpectral(rec, lambdas);
+            if (!Le_spec.isZero()) {
+                if (bounce == 0 || wasSpecular) color += throughput * Le_spec;
+                break;
+            }
+
+            Vec3 wo = -ray.direction.normalized();
+
+            if (!rec.isDelta && !lights.empty()) {
+                LightSample ls = lights.sample(rec.point, gen);
+                if (ls.pdf > 0) {
+                    Vec3 wi = (ls.position - rec.point).normalized();
+                    HitRecord shadow;
+                    bool hitOccluder = bvh->hit(Ray(rec.point, wi), 0.001f, ls.distance - 0.001f, shadow);
+                    bool occluded = hitOccluder && !(shadow.hitObject && shadow.hitObject->isInfiniteLight());
+                    if (!occluded) {
+                        astroray::SampledSpectrum f_spec =
+                            rec.material->evalSpectral(rec, wo, wi, lambdas);
+                        astroray::SampledSpectrum L_spec =
+                            astroray::RGBIlluminantSpectrum({ls.emission.x, ls.emission.y, ls.emission.z}).sample(lambdas);
+                        float bsdfPdf = rec.material->pdf(rec, wo, wi);
+                        float a = ls.pdf, b = bsdfPdf;
+                        float wt = (a * a) / (a * a + b * b + 1e-8f);
+                        color += throughput * f_spec * L_spec * (wt / (ls.pdf + 0.001f));
+                    }
+                }
+            }
+
+            if (bounce > rrDepth) {
+                astroray::XYZ thrXYZ = throughput.toXYZ(lambdas);
+                float p = std::min(0.95f, std::max(0.0f, thrXYZ.Y));
+                if (dist01(gen) > p) break;
+                if (p > 0.0f) throughput = throughput * (1.0f / p);
+            }
+
+            BSDFSampleSpectral bss = rec.material->sampleSpectral(rec, wo, gen, lambdas);
+            if (bss.pdf <= 0.0f) break;
+
+            astroray::SampledSpectrum nextThroughput =
+                throughput * bss.f_spectral * (1.0f / (bss.pdf + 0.001f));
+
+            if (bss.isDelta) {
+                LightSample ls = lights.sample(rec.point, gen);
+                if (ls.pdf > 0.0f) {
+                    Ray walkRay(rec.point, bss.wi, ray.time, ray.screenU, ray.screenV);
+                    walkRay.hasCameraFrame = ray.hasCameraFrame;
+                    walkRay.cameraOrigin = ray.cameraOrigin;
+                    walkRay.cameraU = ray.cameraU;
+                    walkRay.cameraV = ray.cameraV;
+                    walkRay.cameraW = ray.cameraW;
+
+                    astroray::SampledSpectrum walkThroughput = nextThroughput;
+                    astroray::SampledWavelengths walkLambdas = lambdas;
+                    for (int stepIndex = 0; stepIndex < chainIters; ++stepIndex) {
+                        HitRecord wrec;
+                        if (!bvh->hit(walkRay, 0.001f, std::numeric_limits<float>::max(), wrec) ||
+                            !wrec.material) {
+                            break;
+                        }
+
+                        astroray::SampledSpectrum Le = wrec.material->emittedSpectral(wrec, walkLambdas);
+                        if (!Le.isZero()) {
+                            astroray::SampledSpectrum contribution = walkThroughput * Le;
+                            color += contribution;
+                            causticConnections += 1;
+                            causticEnergy += contribution.maxValue();
+                            break;
+                        }
+
+                        Vec3 toLight = ls.position - wrec.point;
+                        float dist2 = toLight.length2();
+                        if (dist2 <= 1e-10f) break;
+                        float dist = std::sqrt(dist2);
+                        Vec3 wiToLight = toLight * (1.0f / dist);
+                        HitRecord occ;
+                        bool blocked = bvh->hit(Ray(wrec.point, wiToLight), 0.001f, dist - 0.001f, occ);
+                        if (!blocked) {
+                            Vec3 wwo = -walkRay.direction.normalized();
+                            astroray::SampledSpectrum f_spec =
+                                wrec.material->evalSpectral(wrec, wwo, wiToLight, walkLambdas);
+                            if (!f_spec.isZero()) {
+                                astroray::SampledSpectrum Li =
+                                    astroray::RGBIlluminantSpectrum({ls.emission.x, ls.emission.y, ls.emission.z}).sample(walkLambdas);
+                                float geom = std::max(0.0f, std::abs(ls.normal.dot(-wiToLight))) /
+                                             std::max(dist2, 1e-4f);
+                                astroray::SampledSpectrum contribution =
+                                    walkThroughput * f_spec * Li * (geom / (ls.pdf + 0.001f));
+                                color += contribution;
+                                causticConnections += 1;
+                                causticEnergy += contribution.maxValue();
+                                break;
+                            }
+                        }
+
+                        Vec3 wwo = -walkRay.direction.normalized();
+                        BSDFSampleSpectral step = wrec.material->sampleSpectral(wrec, wwo, gen, walkLambdas);
+                        if (!step.isDelta || step.pdf <= 0.0f) break;
+                        walkThroughput *= step.f_spectral * (1.0f / (step.pdf + 0.001f));
+                        Ray next(wrec.point, step.wi, walkRay.time, walkRay.screenU, walkRay.screenV);
+                        next.hasCameraFrame = walkRay.hasCameraFrame;
+                        next.cameraOrigin = walkRay.cameraOrigin;
+                        next.cameraU = walkRay.cameraU;
+                        next.cameraV = walkRay.cameraV;
+                        next.cameraW = walkRay.cameraW;
+                        walkRay = next;
+                    }
+                }
+            }
+
+            wasSpecular = bss.isDelta;
+            throughput = nextThroughput;
+
+            Ray next(rec.point, bss.wi, ray.time, ray.screenU, ray.screenV);
+            next.hasCameraFrame = ray.hasCameraFrame;
+            next.cameraOrigin = ray.cameraOrigin;
+            next.cameraU = ray.cameraU;
+            next.cameraV = ray.cameraV;
+            next.cameraW = ray.cameraW;
+            ray = next;
+
+            weightSum += throughput.maxValue();
+            float maxC = throughput.maxValue();
+            if (maxC > 10.0f) throughput = throughput * (10.0f / maxC);
+        }
+
+        if (outBounces) *outBounces = lastBounce;
+        if (outWeight) *outWeight = weightSum;
+        if (outCausticConnections) *outCausticConnections = causticConnections;
+        if (outCausticEnergy) *outCausticEnergy = causticEnergy;
+        return color;
+    }
+
 public:
     void addObject(std::shared_ptr<Hittable> obj) {
         scene.push_back(obj);

--- a/plugins/integrators/caustic_path_tracer.cpp
+++ b/plugins/integrators/caustic_path_tracer.cpp
@@ -1,0 +1,64 @@
+#include "astroray/register.h"
+#include "astroray/integrator.h"
+#include "astroray/spectrum.h"
+
+class CausticPathTracer : public Integrator {
+    int maxDepth_;
+    int chainIters_;
+    Renderer* renderer_ = nullptr;
+    float causticConnections_ = 0.0f;
+    float causticEnergy_ = 0.0f;
+
+public:
+    explicit CausticPathTracer(const astroray::ParamDict& p)
+        : maxDepth_(p.getInt("max_depth", 50)),
+          chainIters_(p.getInt("caustic_chain_iters", 3)) {}
+
+    void beginFrame(Renderer& scene, const Camera&) override {
+        renderer_ = &scene;
+        causticConnections_ = 0.0f;
+        causticEnergy_ = 0.0f;
+    }
+
+    std::unordered_map<std::string, float> debugStats() const override {
+        return {
+            {"caustic_connections", causticConnections_},
+            {"caustic_energy", causticEnergy_},
+            {"caustic_chain_iters", static_cast<float>(chainIters_)},
+        };
+    }
+
+    SampleResult sampleFull(const Ray& ray, std::mt19937& gen) override {
+        SampleResult r;
+        if (!renderer_) return r;
+
+        if (const auto* bvh = renderer_->getBVH().get()) {
+            HitRecord rec;
+            if (bvh->hit(ray, 0.001f, std::numeric_limits<float>::max(), rec) && rec.material) {
+                r.albedo = rec.material->getAlbedo();
+                r.depth = rec.t;
+            }
+        }
+
+        std::uniform_real_distribution<float> dist01(0.0f, 1.0f);
+        astroray::SampledWavelengths lambdas =
+            astroray::SampledWavelengths::sampleUniform(dist01(gen));
+
+        int bounces = 0;
+        float weight = 0.0f;
+        int connections = 0;
+        float energy = 0.0f;
+        astroray::SampledSpectrum rad = renderer_->pathTraceSpectralCaustic(
+            ray, maxDepth_, chainIters_, lambdas, gen, &bounces, &weight,
+            &connections, &energy);
+        astroray::XYZ xyz = rad.toXYZ(lambdas);
+        r.color = Vec3(xyz.X, xyz.Y, xyz.Z);
+        r.bounceCount = static_cast<float>(bounces);
+        r.sampleWeight = weight;
+        causticConnections_ += static_cast<float>(connections);
+        causticEnergy_ += energy;
+        return r;
+    }
+};
+
+ASTRORAY_REGISTER_INTEGRATOR("caustic_path_tracer", CausticPathTracer)

--- a/scripts/benchmark_caustic_transport.py
+++ b/scripts/benchmark_caustic_transport.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+"""Render pkg29a caustic validation scenes and write image/stat diagnostics."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TESTS_DIR = ROOT / "tests"
+if str(TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(TESTS_DIR))
+
+from runtime_setup import configure_test_imports  # noqa: E402
+
+configure_test_imports()
+
+import astroray  # noqa: E402
+from base_helpers import save_image  # noqa: E402
+from scenes.caustic_validation import SCENES, image_metrics, render_scene  # noqa: E402
+
+
+def write_csv(rows: list[dict[str, object]], path: Path) -> None:
+    keys = sorted({key for row in rows for key in row})
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=keys)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--samples", type=int, default=32)
+    parser.add_argument("--max-depth", type=int, default=12)
+    parser.add_argument("--seed", type=int, default=145)
+    parser.add_argument("--output-dir", type=Path,
+                        default=ROOT / "test_results" / "pkg29a_caustics")
+    args = parser.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    rows: list[dict[str, object]] = []
+    for scene_name in sorted(SCENES):
+        for integrator in ("path_tracer", "caustic_path_tracer"):
+            print(f"Rendering {scene_name} / {integrator} ...", flush=True)
+            record = render_scene(
+                astroray, scene_name, integrator,
+                samples=args.samples, max_depth=args.max_depth, seed=args.seed)
+            image_path = args.output_dir / f"{scene_name}_{integrator}.png"
+            save_image(record.pixels, str(image_path))
+            row = {
+                "scene": scene_name,
+                "integrator": integrator,
+                "seconds": f"{record.seconds:.4f}",
+                **{k: f"{v:.6f}" for k, v in image_metrics(record.pixels, scene_name).items()},
+                **{k: f"{v:.6f}" for k, v in record.stats.items()},
+            }
+            rows.append(row)
+            print(f"  -> {record.seconds:.2f}s, max={row['max_luminance']}")
+
+    json_path = args.output_dir / "caustic_transport_stats.json"
+    csv_path = args.output_dir / "caustic_transport_stats.csv"
+    json_path.write_text(json.dumps(rows, indent=2, sort_keys=True), encoding="utf-8")
+    write_csv(rows, csv_path)
+    print(f"\nWrote {json_path}")
+    print(f"Wrote {csv_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scenes/caustic_validation.py
+++ b/tests/scenes/caustic_validation.py
@@ -1,0 +1,139 @@
+"""pkg29a validation scenes for spectral caustic transport."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Callable
+
+import numpy as np
+
+from scenes.prism_reference import add_triangular_prism, red_blue_centroid_separation
+
+
+WIDTH = 96
+HEIGHT = 96
+SAMPLES = 24
+MAX_DEPTH = 12
+
+
+@dataclass(frozen=True)
+class RenderRecord:
+    scene: str
+    integrator: str
+    pixels: np.ndarray
+    seconds: float
+    stats: dict[str, float]
+
+
+def _setup_camera(r, width: int = WIDTH, height: int = HEIGHT) -> None:
+    r.setup_camera(
+        [0.0, 0.0, 4.2], [0.0, -0.05, 0.0], [0.0, 1.0, 0.0],
+        38.0, width / height, 0.0, 4.2, width, height)
+
+
+def _add_screen(r, z: float = -1.85) -> int:
+    white = r.create_material("lambertian", [0.88, 0.88, 0.84], {})
+    r.add_triangle([-1.8, -1.15, z], [1.8, -1.15, z], [1.8, 1.15, z], white)
+    r.add_triangle([-1.8, -1.15, z], [1.8, 1.15, z], [-1.8, 1.15, z], white)
+    return white
+
+
+def _add_floor(r, y: float = -1.2) -> int:
+    floor = r.create_material("lambertian", [0.72, 0.72, 0.68], {})
+    r.add_triangle([-2.4, y, -2.2], [2.4, y, -2.2], [2.4, y, 1.6], floor)
+    r.add_triangle([-2.4, y, -2.2], [2.4, y, 1.6], [-2.4, y, 1.6], floor)
+    return floor
+
+
+def make_prism_to_screen_scene(astroray):
+    r = astroray.Renderer()
+    r.set_background_color([0.02, 0.025, 0.03])
+    _add_screen(r)
+
+    slit = r.create_material("light", [1.0, 1.0, 1.0], {"intensity": 9.0})
+    r.add_triangle([-0.18, 1.22, 1.35], [0.18, 1.22, 1.35], [0.18, 1.40, 1.35], slit)
+    r.add_triangle([-0.18, 1.22, 1.35], [0.18, 1.40, 1.35], [-0.18, 1.40, 1.35], slit)
+
+    glass = r.create_material("dielectric", [1.0, 1.0, 1.0], {"glass_preset": "bk7"})
+    add_triangular_prism(r, glass)
+    _setup_camera(r)
+    return r
+
+
+def make_glass_caustic_scene(astroray):
+    r = astroray.Renderer()
+    r.set_background_color([0.02, 0.025, 0.03])
+    _add_floor(r)
+
+    light = r.create_material("light", [1.0, 0.97, 0.90], {"intensity": 12.0})
+    r.add_sphere([0.0, 1.55, 1.0], 0.22, light)
+    glass = r.create_material("dielectric", [1.0, 1.0, 1.0], {"ior": 1.52})
+    r.add_sphere([0.0, -0.35, 0.15], 0.72, glass)
+    _setup_camera(r)
+    return r
+
+
+def make_line_emitter_scene(astroray):
+    r = astroray.Renderer()
+    r.set_background_color([0.01, 0.012, 0.018])
+    _add_screen(r)
+
+    line = r.create_material(
+        "line_emitter", [1.0, 1.0, 1.0],
+        {"wavelength_nm": 532.0, "bandwidth_nm": 8.0, "intensity": 5.0})
+    r.add_sphere([-0.45, 0.85, 1.15], 0.12, line)
+    glass = r.create_material("thin_glass", [0.92, 1.0, 0.95], {"ior": 1.5, "transmission": 0.96})
+    r.add_triangle([-0.85, -0.75, 0.45], [0.85, -0.75, 0.45], [0.85, 0.85, 0.45], glass)
+    r.add_triangle([-0.85, -0.75, 0.45], [0.85, 0.85, 0.45], [-0.85, 0.85, 0.45], glass)
+    _setup_camera(r)
+    return r
+
+
+SCENES: dict[str, Callable[[object], object]] = {
+    "prism_to_screen": make_prism_to_screen_scene,
+    "glass_caustic": make_glass_caustic_scene,
+    "line_emitter": make_line_emitter_scene,
+}
+
+
+def render_scene(
+    astroray,
+    scene_name: str,
+    integrator: str,
+    *,
+    samples: int = SAMPLES,
+    max_depth: int = MAX_DEPTH,
+    seed: int = 145,
+) -> RenderRecord:
+    r = SCENES[scene_name](astroray)
+    r.set_seed(seed)
+    if integrator == "caustic_path_tracer":
+        r.set_integrator_param("max_depth", max_depth)
+        r.set_integrator_param("caustic_chain_iters", 3)
+    r.set_integrator(integrator)
+
+    start = time.perf_counter()
+    pixels = np.asarray(r.render(samples, max_depth, None, True), dtype=np.float32)
+    seconds = time.perf_counter() - start
+    stats = {str(k): float(v) for k, v in r.get_integrator_stats().items()}
+    return RenderRecord(scene_name, integrator, pixels, seconds, stats)
+
+
+def image_metrics(pixels: np.ndarray, scene_name: str) -> dict[str, float]:
+    lum = 0.2126 * pixels[..., 0] + 0.7152 * pixels[..., 1] + 0.0722 * pixels[..., 2]
+    h, w = lum.shape
+    yy, xx = np.mgrid[:h, :w]
+    receiver = (xx > w * 0.20) & (xx < w * 0.80) & (yy > h * 0.22) & (yy < h * 0.82)
+    out: dict[str, float] = {
+        "mean_luminance": float(np.mean(lum)),
+        "p99_luminance": float(np.percentile(lum, 99.0)),
+        "max_luminance": float(np.max(lum)),
+        "receiver_energy": float(np.sum(lum[receiver])),
+        "nonzero_fraction": float(np.count_nonzero(lum > 1e-5) / lum.size),
+    }
+    if scene_name == "prism_to_screen":
+        out["red_blue_centroid_spread"] = red_blue_centroid_separation(pixels)
+    else:
+        out["red_blue_centroid_spread"] = 0.0
+    return out

--- a/tests/test_caustic_validation.py
+++ b/tests/test_caustic_validation.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+"""pkg29a — scoped caustic validation diagnostics."""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+import sys
+
+import numpy as np
+import pytest
+
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+sys.path.insert(0, os.path.dirname(__file__))
+
+try:
+    import astroray  # noqa: E402
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+from base_helpers import save_image  # noqa: E402
+from scenes.caustic_validation import SCENES, image_metrics, render_scene  # noqa: E402
+
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray not built")
+
+
+def test_caustic_integrator_registered():
+    assert "caustic_path_tracer" in astroray.integrator_registry_names()
+
+
+@pytest.mark.parametrize("scene_name", sorted(SCENES))
+def test_caustic_validation_scenes_save_images_and_stats(scene_name, test_results_dir):
+    records = [
+        render_scene(astroray, scene_name, "path_tracer", samples=8, max_depth=10),
+        render_scene(astroray, scene_name, "caustic_path_tracer", samples=8, max_depth=10),
+    ]
+
+    rows = []
+    for record in records:
+        pixels = record.pixels
+        assert pixels.shape == (96, 96, 3)
+        assert np.isfinite(pixels).all()
+        assert float(pixels.mean()) > 0.001
+
+        save_image(
+            pixels,
+            os.path.join(test_results_dir, f"pkg29a_{scene_name}_{record.integrator}.png"),
+        )
+
+        metrics = image_metrics(pixels, scene_name)
+        row = {
+            "scene": scene_name,
+            "integrator": record.integrator,
+            "seconds": record.seconds,
+            **metrics,
+            **record.stats,
+        }
+        rows.append(row)
+
+    json_path = os.path.join(test_results_dir, f"pkg29a_{scene_name}_stats.json")
+    csv_path = os.path.join(test_results_dir, f"pkg29a_{scene_name}_stats.csv")
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(rows, f, indent=2, sort_keys=True)
+    with open(csv_path, "w", newline="", encoding="utf-8") as f:
+        keys = sorted({key for row in rows for key in row})
+        writer = csv.DictWriter(f, fieldnames=keys)
+        writer.writeheader()
+        writer.writerows(rows)
+
+    caustic_row = next(row for row in rows if row["integrator"] == "caustic_path_tracer")
+    assert "caustic_connections" in caustic_row
+    assert "caustic_energy" in caustic_row
+    assert caustic_row["max_luminance"] > 0.01

--- a/tests/test_oidn_denoiser.py
+++ b/tests/test_oidn_denoiser.py
@@ -1,8 +1,9 @@
 """Tests for pkg33: OIDN FetchContent integration.
 
-Verifies that the oidn_denoiser pass is present in the registry (meaning the
-build found/fetched OIDN), that it actually reduces noise, and produces a
-side-by-side comparison image in test_results/.
+Verifies that an OIDN-enabled build registers and runs the oidn_denoiser pass,
+that it actually reduces noise, and produces a side-by-side comparison image
+in test_results/. Builds without OIDN keep a graceful no-op pass for API
+compatibility, so functional denoising checks are gated by the feature flag.
 """
 import os
 import sys
@@ -22,7 +23,9 @@ except ImportError:
 
 pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray module not available")
 
-OIDN_ENABLED = AVAILABLE and "oidn_denoiser" in (astroray.pass_registry_names() if AVAILABLE else [])
+OIDN_ENABLED = AVAILABLE and bool(
+    astroray.__features__.get("oidn_denoiser", False) if AVAILABLE else False
+)
 
 
 def _cornell_renderer(width: int = 256, height: int = 256) -> "astroray.Renderer":
@@ -67,6 +70,8 @@ def _to_uint8(img_float: np.ndarray) -> np.ndarray:
 
 def test_oidn_in_pass_registry():
     """oidn_denoiser must appear in the pass registry when built with OIDN."""
+    if not OIDN_ENABLED:
+        pytest.skip("OIDN not compiled in")
     names = astroray.pass_registry_names()
     assert "oidn_denoiser" in names, (
         f"'oidn_denoiser' missing from registry {names}; "


### PR DESCRIPTION
## Summary

Closes #145.

Adds pkg29a's scoped caustic validation loop:

- registers an opt-in `caustic_path_tracer` integrator that leaves `path_tracer` as the default/reference
- adds prism-to-screen, glass-caustic, and narrowband line-emitter validation scenes
- writes diagnostic PNGs plus JSON/CSV metrics for render time, luminance, receiver energy, p99/max luminance, and prism red/blue centroid spread
- adds `scripts/benchmark_caustic_transport.py` for repeatable local visual/stat runs
- updates pkg29a and STATUS documentation to mark the package implemented
- rebases over pkg33/OIDN and fixes the OIDN functional-test gate so no-OIDN CI skips the denoising assertions instead of treating the no-op compatibility pass as enabled OIDN

This is intentionally a scoped transport experiment, not the final caustic solver. It gives us measurable scenes and baseline stats for the next quality pass toward prism and laser optics.

## Validation

- `cmake -S . -B build_tcnn`
- `cmake --build build_tcnn --config Release --target astroray -j`
- `cmake --build build --config Release --target astroray -j`
- `ASTRORAY_BUILD_DIR=build_tcnn/Release pytest tests/test_oidn_denoiser.py tests/test_caustic_validation.py tests/test_integrator_plugin.py tests/test_spectral_prism.py tests/test_spectral_materials.py -q` -> 35 passed
- `ASTRORAY_BUILD_DIR=build_tcnn/Release pytest tests/ -q` -> 316 passed, 8 skipped, 14 xfailed, 3 xpassed, 1 known ReSTIR temporal-variance baseline failure (`0.0723` temporal vs `0.0719` no-reuse)
- `python scripts/benchmark_caustic_transport.py --samples 8 --max-depth 10 --output-dir test_results/pkg29a_caustics_smoke`
