### PR TITLE
feat: add shared material closure graphs

### DIFF
--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -74,7 +74,7 @@ personally should pick up.
 |---|---|---|
 | pkg34 | Material backend capabilities + no silent GPU fallback | **done** |
 | pkg35 | Spectral GPU material kernels | **done** |
-| pkg36 | Shared material closure graph | open |
+| pkg36 | Shared material closure graph | **done** |
 | pkg37 | Blender addon backend refresh + runtime diagnostics | open |
 
 **Visual diagnostics & production polish (Pillar 5):**
@@ -113,9 +113,9 @@ personally should pick up.
 
 - pkg29 prism validation is complete.
 - Complete: pkg32 visual diagnostics, pkg33 OIDN, pkg34 backend capability
-  guardrails, and pkg35 spectral GPU material payloads.
-- Next up: pkg36 shared material closure graph or pkg37 Blender addon backend
-  refresh.
+  guardrails, pkg35 spectral GPU material payloads, and pkg36 shared closure
+  graphs.
+- Next up: pkg37 Blender addon backend refresh.
 - Pillar 4 can begin with pkg40 once the current registry/reference cleanup is merged.
 
 ### Track B (Copilot cloud)
@@ -211,6 +211,12 @@ personally should pick up.
 Brief notes on notable events.
 
 - **2026-05-03** — pkg38 complete. Spectral material profile database built from USGS Spectral Library v7, ECOSTRESS/JHU spectra, Rakic 1998 Lorentz-Drude model for polished metals (Al, Au), and Bashkatov 2005 digitised skin measurements. 40 materials across 7 categories (vegetation, earth, building, metal, fabric, paint, human), 441 wavelengths at 5nm from 300-2500nm. ASPR binary format (72 KB), profiles_metadata.json, sources.md provenance. 18 tests all pass; Wood effect 3.8x/5.9x, water R(1000nm)=0.008, Al/Au mean R>0.90.
+- **2026-05-03** — pkg36 complete. Added shared material closure graphs,
+  Python graph inspection, and CUDA closure-graph lowering. Lambertian,
+  metal, flat dielectric, Disney plastic/glass, and a new `closure_matte`
+  plugin now exercise the same graph path for backend metadata and GPU upload;
+  graphless materials remain explicit CPU-only escape hatches. Focused
+  validation: CUDA build passed; closure/backend/GPU material tests passed.
 - **2026-05-03** — pkg35 complete. Added compact CUDA sampled-wavelength and
   sampled-spectrum payloads, spectral BSDF/emitter dispatch helpers for core
   RGB-derived GPU materials, Python `gpu_spectral` capability metadata, and

--- a/.astroray_plan/packages/pkg36-material-closure-graph.md
+++ b/.astroray_plan/packages/pkg36-material-closure-graph.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 2/5 bridge
 **Track:** A
-**Status:** open
+**Status:** implemented
 **Estimated effort:** 2-3 sessions (~9 h)
 **Depends on:** pkg34, pkg35
 
@@ -63,11 +63,11 @@ arbitrary plugin C++ into CUDA.
 
 ## Acceptance criteria
 
-- [ ] Lambertian, metal, flat dielectric, Disney plastic, and Disney glass
+- [x] Lambertian, metal, flat dielectric, Disney plastic, and Disney glass
       can be represented by closure graphs.
-- [ ] A new simple material plugin can be added by returning a closure
+- [x] A new simple material plugin can be added by returning a closure
       graph without editing CUDA kernels.
-- [ ] Existing hand-written material plugins still work as CPU-only escape
+- [x] Existing hand-written material plugins still work as CPU-only escape
       hatches when no graph is provided.
 
 ---

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,7 @@ set_target_properties(stb_impl PROPERTIES
 add_library(astroray_core_impl STATIC
     src/spectrum.cpp
     src/default_integrator.cpp
+    src/material_closure.cpp
 )
 target_include_directories(astroray_core_impl
     PUBLIC  ${INCLUDE_DIR}

--- a/include/astroray/gpu_materials.h
+++ b/include/astroray/gpu_materials.h
@@ -669,6 +669,185 @@ __device__ inline float gpu_disney_pdf(
 // ===  Dispatch: switch on GMaterialType  ====================================
 // ===========================================================================
 
+__device__ inline bool gpu_closure_is_sampleable(GClosureType type) {
+    return type == GCLOSURE_DIFFUSE ||
+           type == GCLOSURE_GGX_CONDUCTOR ||
+           type == GCLOSURE_DIELECTRIC_TRANSMISSION ||
+           type == GCLOSURE_THIN_GLASS;
+}
+
+__device__ inline GMaterial gpu_closure_as_material(const GMaterial& parent, const GMaterialClosure& closure) {
+    GMaterial tmp = parent;
+    tmp.type = GMAT_LAMBERTIAN;
+    tmp.baseColor = closure.color;
+    tmp.roughness = closure.roughness;
+    tmp.metallic = closure.metallic;
+    tmp.ior = closure.ior;
+    tmp.transmission = fminf(fmaxf(closure.transmission, 0.0f), 1.0f);
+    tmp.clearcoat = 0.0f;
+    tmp.clearcoatGloss = closure.clearcoatGloss;
+    tmp.emissionIntensity = 0.0f;
+    tmp.specular = 0.5f;
+    tmp.specularTint = 0.0f;
+    tmp.sheen = 0.0f;
+    tmp.sheenTint = 0.5f;
+    tmp.subsurface = 0.0f;
+    tmp.anisotropic = 0.0f;
+    tmp.anisotropicRotation = 0.0f;
+
+    switch (closure.type) {
+        case GCLOSURE_DIFFUSE:
+            tmp.type = GMAT_LAMBERTIAN;
+            break;
+        case GCLOSURE_GGX_CONDUCTOR:
+            tmp.type = GMAT_METAL;
+            tmp.metallic = 1.0f;
+            break;
+        case GCLOSURE_DIELECTRIC_TRANSMISSION:
+            tmp.type = closure.roughness > 0.03f ? GMAT_DISNEY : GMAT_DIELECTRIC;
+            tmp.metallic = 0.0f;
+            break;
+        case GCLOSURE_THIN_GLASS:
+            tmp.type = GMAT_THIN_GLASS;
+            break;
+        default:
+            tmp.type = GMAT_LAMBERTIAN;
+            break;
+    }
+    return tmp;
+}
+
+__device__ inline GVec3 gpu_closure_eval(
+    const GMaterial& parent, const GMaterialClosure& closure,
+    GHitRecord& rec, const GVec3& wo, const GVec3& wi)
+{
+    if (closure.weight <= 0.0f) return GVec3(0.0f);
+    GMaterial tmp = gpu_closure_as_material(parent, closure);
+    GVec3 result(0.0f);
+    switch (tmp.type) {
+        case GMAT_LAMBERTIAN: result = gpu_lambertian_eval(tmp, rec, wo, wi); break;
+        case GMAT_METAL: result = gpu_metal_eval(tmp, rec, wo, wi); break;
+        case GMAT_DISNEY: result = gpu_disney_eval(tmp, rec, wo, wi); break;
+        default: result = GVec3(0.0f); break;
+    }
+    return result * closure.weight;
+}
+
+__device__ inline float gpu_closure_pdf(
+    const GMaterial& parent, const GMaterialClosure& closure,
+    const GHitRecord& rec, const GVec3& wo, const GVec3& wi)
+{
+    if (!gpu_closure_is_sampleable(closure.type) || closure.weight <= 0.0f)
+        return 0.0f;
+    GMaterial tmp = gpu_closure_as_material(parent, closure);
+    switch (tmp.type) {
+        case GMAT_LAMBERTIAN: return gpu_lambertian_pdf(tmp, rec, wo, wi);
+        case GMAT_METAL: return gpu_metal_pdf(tmp, rec, wo, wi);
+        case GMAT_DISNEY: return gpu_disney_pdf(tmp, rec, wo, wi);
+        default: return 0.0f;
+    }
+}
+
+__device__ inline GVec3 gpu_closure_graph_eval(
+    const GMaterial& mat, GHitRecord& rec, const GVec3& wo, const GVec3& wi)
+{
+    GVec3 sum(0.0f);
+    int count = mat.closureCount < G_MAX_MATERIAL_CLOSURES ? mat.closureCount : G_MAX_MATERIAL_CLOSURES;
+    for (int i = 0; i < count; ++i) {
+        const GMaterialClosure& closure = mat.closures[i];
+        if (closure.type != GCLOSURE_EMISSION)
+            sum += gpu_closure_eval(mat, closure, rec, wo, wi);
+    }
+    return sum;
+}
+
+__device__ inline float gpu_closure_graph_pdf(
+    const GMaterial& mat, const GHitRecord& rec, const GVec3& wo, const GVec3& wi)
+{
+    float totalWeight = 0.0f;
+    int count = mat.closureCount < G_MAX_MATERIAL_CLOSURES ? mat.closureCount : G_MAX_MATERIAL_CLOSURES;
+    for (int i = 0; i < count; ++i) {
+        const GMaterialClosure& closure = mat.closures[i];
+        if (gpu_closure_is_sampleable(closure.type))
+            totalWeight += fmaxf(closure.weight, 0.0f);
+    }
+    if (totalWeight <= 0.0f) return 0.0f;
+
+    float sum = 0.0f;
+    for (int i = 0; i < count; ++i) {
+        const GMaterialClosure& closure = mat.closures[i];
+        if (!gpu_closure_is_sampleable(closure.type)) continue;
+        float selectionPdf = fmaxf(closure.weight, 0.0f) / totalWeight;
+        sum += selectionPdf * gpu_closure_pdf(mat, closure, rec, wo, wi);
+    }
+    return sum;
+}
+
+__device__ inline GBSDFSample gpu_closure_graph_sample(
+    const GMaterial& mat, GHitRecord& rec, const GVec3& wo, curandState* rng)
+{
+    GBSDFSample s;
+    s.wi = GVec3(0, 1, 0);
+    s.f = GVec3(0.0f);
+    s.fSpectral = GSampledSpectrum(0.0f);
+    s.pdf = 0.0f;
+    s.isDelta = false;
+
+    float totalWeight = 0.0f;
+    int count = mat.closureCount < G_MAX_MATERIAL_CLOSURES ? mat.closureCount : G_MAX_MATERIAL_CLOSURES;
+    for (int i = 0; i < count; ++i) {
+        const GMaterialClosure& closure = mat.closures[i];
+        if (gpu_closure_is_sampleable(closure.type))
+            totalWeight += fmaxf(closure.weight, 0.0f);
+    }
+    if (totalWeight <= 0.0f) return s;
+
+    float xi = curand_uniform(rng) * totalWeight;
+    int chosen = -1;
+    float accum = 0.0f;
+    for (int i = 0; i < count; ++i) {
+        const GMaterialClosure& closure = mat.closures[i];
+        if (!gpu_closure_is_sampleable(closure.type)) continue;
+        accum += fmaxf(closure.weight, 0.0f);
+        if (xi <= accum) {
+            chosen = i;
+            break;
+        }
+    }
+    if (chosen < 0) return s;
+
+    const GMaterialClosure& closure = mat.closures[chosen];
+    GMaterial tmp = gpu_closure_as_material(mat, closure);
+    switch (tmp.type) {
+        case GMAT_LAMBERTIAN: s = gpu_lambertian_sample(tmp, rec, wo, rng); break;
+        case GMAT_METAL: s = gpu_metal_sample(tmp, rec, wo, rng); break;
+        case GMAT_DIELECTRIC: s = gpu_dielectric_sample(tmp, rec, wo, rng); break;
+        case GMAT_DISNEY: s = gpu_disney_sample(tmp, rec, wo, rng); break;
+        case GMAT_THIN_GLASS: s = gpu_thin_glass_sample(tmp, rec, wo, rng); break;
+        default: return s;
+    }
+
+    if (s.pdf <= 0.0f || s.f.length2() <= 0.0f) return s;
+    if (s.isDelta) {
+        s.f *= closure.weight;
+    } else {
+        s.f = gpu_closure_graph_eval(mat, rec, wo, s.wi);
+        s.pdf = gpu_closure_graph_pdf(mat, rec, wo, s.wi);
+    }
+    return s;
+}
+
+__device__ inline GVec3 gpu_closure_graph_emitted(const GMaterial& mat, bool frontFace) {
+    GVec3 sum(0.0f);
+    int count = mat.closureCount < G_MAX_MATERIAL_CLOSURES ? mat.closureCount : G_MAX_MATERIAL_CLOSURES;
+    for (int i = 0; i < count; ++i) {
+        const GMaterialClosure& closure = mat.closures[i];
+        if (closure.type == GCLOSURE_EMISSION && (frontFace || closure.twoSidedEmission))
+            sum += closure.color * closure.transmission * closure.weight;
+    }
+    return sum;
+}
+
 __device__ inline GVec3 gpu_material_eval(
     const GMaterial& mat, GHitRecord& rec, const GVec3& wo, const GVec3& wi)
 {
@@ -679,6 +858,7 @@ __device__ inline GVec3 gpu_material_eval(
         case GMAT_DIFFUSE_LIGHT: return GVec3(0.f); // emissive only
         case GMAT_DISNEY:        return gpu_disney_eval(mat, rec, wo, wi);
         case GMAT_THIN_GLASS:    return GVec3(0.f); // mostly-delta pane
+        case GMAT_CLOSURE_GRAPH: return gpu_closure_graph_eval(mat, rec, wo, wi);
         default:                 return GVec3(0.f);
     }
 }
@@ -700,6 +880,7 @@ __device__ inline GBSDFSample gpu_material_sample(
         case GMAT_DIELECTRIC:    return gpu_dielectric_sample(mat, rec, wo, rng);
         case GMAT_DISNEY:        return gpu_disney_sample(mat, rec, wo, rng);
         case GMAT_THIN_GLASS:    return gpu_thin_glass_sample(mat, rec, wo, rng);
+        case GMAT_CLOSURE_GRAPH: return gpu_closure_graph_sample(mat, rec, wo, rng);
         default: { GBSDFSample s; s.f=GVec3(0); s.fSpectral=GSampledSpectrum(0.f); s.wi=GVec3(0,1,0); s.pdf=0; s.isDelta=false; return s; }
     }
 }
@@ -720,6 +901,7 @@ __device__ inline float gpu_material_pdf(
         case GMAT_LAMBERTIAN: return gpu_lambertian_pdf(mat, rec, wo, wi);
         case GMAT_METAL:      return gpu_metal_pdf(mat, rec, wo, wi);
         case GMAT_DISNEY:     return gpu_disney_pdf(mat, rec, wo, wi);
+        case GMAT_CLOSURE_GRAPH: return gpu_closure_graph_pdf(mat, rec, wo, wi);
         default:              return 0.f;
     }
 }
@@ -729,6 +911,8 @@ __device__ inline GVec3 gpu_material_emitted(
 {
     if (mat.type == GMAT_DIFFUSE_LIGHT && frontFace)
         return mat.baseColor * mat.emissionIntensity;
+    if (mat.type == GMAT_CLOSURE_GRAPH)
+        return gpu_closure_graph_emitted(mat, frontFace);
     return GVec3(0.f);
 }
 

--- a/include/astroray/gpu_types.h
+++ b/include/astroray/gpu_types.h
@@ -240,7 +240,8 @@ enum GMaterialType : uint8_t {
     GMAT_DIELECTRIC   = 2,
     GMAT_DIFFUSE_LIGHT = 3,
     GMAT_DISNEY       = 4,
-    GMAT_THIN_GLASS   = 5
+    GMAT_THIN_GLASS   = 5,
+    GMAT_CLOSURE_GRAPH = 6
 };
 
 enum GSpectralMode : uint8_t {
@@ -249,11 +250,38 @@ enum GSpectralMode : uint8_t {
     GSPEC_RGB_ILLUMINANT = 2
 };
 
+enum GClosureType : uint8_t {
+    GCLOSURE_NONE = 0,
+    GCLOSURE_DIFFUSE = 1,
+    GCLOSURE_GGX_CONDUCTOR = 2,
+    GCLOSURE_DIELECTRIC_TRANSMISSION = 3,
+    GCLOSURE_CLEARCOAT = 4,
+    GCLOSURE_SHEEN = 5,
+    GCLOSURE_EMISSION = 6,
+    GCLOSURE_THIN_GLASS = 7
+};
+
+static constexpr int G_MAX_MATERIAL_CLOSURES = 8;
+
+struct GMaterialClosure {
+    GClosureType type;
+    uint8_t twoSidedEmission;
+    uint8_t _pad0[2];
+    GVec3 color;
+    float weight;
+    float roughness;
+    float metallic;
+    float ior;
+    float transmission;
+    float clearcoatGloss;
+    float _pad1[2];
+};
+
 struct alignas(64) GMaterial {
     GMaterialType type;
     GSpectralMode spectralMode;
     bool spectralGpu;
-    uint8_t _pad[1];
+    uint8_t closureCount;
 
     GVec3  baseColor;
     float  roughness;
@@ -273,7 +301,7 @@ struct alignas(64) GMaterial {
     float  anisotropic;
     float  anisotropicRotation;
 
-    float  _padding[1]; // fill to 64 bytes
+    GMaterialClosure closures[G_MAX_MATERIAL_CLOSURES];
 };
 
 // ---------------------------------------------------------------------------

--- a/include/astroray/material_closure.h
+++ b/include/astroray/material_closure.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <string>
+
+namespace astroray {
+
+struct ClosureColor {
+    float x = 1.0f;
+    float y = 1.0f;
+    float z = 1.0f;
+};
+
+enum class MaterialClosureType : uint8_t {
+    None = 0,
+    Diffuse = 1,
+    GGXConductor = 2,
+    DielectricTransmission = 3,
+    Clearcoat = 4,
+    Sheen = 5,
+    Emission = 6,
+    ThinGlass = 7,
+};
+
+struct MaterialClosure {
+    MaterialClosureType type = MaterialClosureType::None;
+    ClosureColor color{};
+    float weight = 1.0f;
+    float roughness = 0.0f;
+    float metallic = 0.0f;
+    float ior = 1.5f;
+    float transmission = 0.0f;
+    float clearcoatGloss = 1.0f;
+    bool twoSidedEmission = false;
+};
+
+class MaterialClosureGraph {
+public:
+    static constexpr int kMaxClosures = 8;
+
+    bool add(const MaterialClosure& closure);
+    bool empty() const { return count_ == 0; }
+    int count() const { return count_; }
+    const MaterialClosure& closure(int index) const { return closures_[index]; }
+    const std::array<MaterialClosure, kMaxClosures>& closures() const { return closures_; }
+
+private:
+    std::array<MaterialClosure, kMaxClosures> closures_{};
+    int count_ = 0;
+};
+
+MaterialClosure makeDiffuseClosure(ClosureColor color, float weight = 1.0f);
+MaterialClosure makeGGXConductorClosure(ClosureColor color, float roughness, float weight = 1.0f);
+MaterialClosure makeDielectricTransmissionClosure(
+    ClosureColor color,
+    float ior,
+    float roughness = 0.0f,
+    float transmission = 1.0f,
+    float weight = 1.0f);
+MaterialClosure makeEmissionClosure(
+    ClosureColor color,
+    float intensity,
+    bool twoSided = false,
+    float weight = 1.0f);
+MaterialClosure makeThinGlassClosure(
+    ClosureColor color,
+    float ior,
+    float roughness = 0.0f,
+    float transmission = 1.0f,
+    float weight = 1.0f);
+
+const char* closureTypeName(MaterialClosureType type);
+bool validateClosureGraph(const MaterialClosureGraph& graph, std::string* reason = nullptr);
+
+} // namespace astroray

--- a/include/raytracer.h
+++ b/include/raytracer.h
@@ -19,6 +19,7 @@
 #include <unordered_map>
 #include "stb_image.h"
 #include "astroray/gr_types.h"
+#include "astroray/material_closure.h"
 #include "astroray/spectrum.h"
 
 // Forward declaration needed by HitRecord
@@ -475,6 +476,7 @@ struct MaterialBackendCapabilities {
     bool gpu = false;
     bool gpuSpectral = false;
     bool gpuApproximate = false;
+    bool closureGraph = false;
     std::string gpuType;
     std::string notes = "no GPU lowering declared";
 };
@@ -495,13 +497,25 @@ public:
     virtual bool isGlossy() const { return false; }
     virtual Vec3 getAlbedo() const { return Vec3(0.5f); }
     virtual std::string getGPUTypeName() const { return ""; }
+    virtual astroray::MaterialClosureGraph closureGraph() const { return {}; }
     virtual MaterialBackendCapabilities backendCapabilities() const {
         MaterialBackendCapabilities caps;
-        caps.gpuType = getGPUTypeName();
-        if (!caps.gpuType.empty()) {
+        auto graph = closureGraph();
+        std::string validationReason;
+        caps.closureGraph = !graph.empty() &&
+            astroray::validateClosureGraph(graph, &validationReason);
+        if (caps.closureGraph) {
             caps.gpu = true;
             caps.gpuSpectral = true;
-            caps.notes = "spectral RGB-derived GPU lowering";
+            caps.gpuType = "closure_graph";
+            caps.notes = "spectral closure-graph GPU lowering";
+        } else {
+            caps.gpuType = getGPUTypeName();
+            if (!caps.gpuType.empty()) {
+                caps.gpu = true;
+                caps.gpuSpectral = true;
+                caps.notes = "spectral RGB-derived GPU lowering";
+            }
         }
         return caps;
     }
@@ -553,6 +567,11 @@ class Lambertian : public Material {
 public:
     Lambertian(const Vec3& a) : albedo(a), albedoSpec_({a.x, a.y, a.z}) {}
     Vec3 getAlbedo() const { return albedo; }
+    astroray::MaterialClosureGraph closureGraph() const override {
+        astroray::MaterialClosureGraph graph;
+        graph.add(astroray::makeDiffuseClosure({albedo.x, albedo.y, albedo.z}));
+        return graph;
+    }
     std::string getGPUTypeName() const override { return "lambertian"; }
 
     BSDFSample sample(const HitRecord& rec, const Vec3& wo, std::mt19937& gen) const override {

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -418,8 +418,35 @@ public:
         out["gpu"] = caps.gpu;
         out["gpu_spectral"] = caps.gpuSpectral;
         out["gpu_approximate"] = caps.gpuApproximate;
+        out["closure_graph"] = caps.closureGraph;
+        out["closure_count"] = it->second->closureGraph().count();
         out["gpu_type"] = caps.gpuType;
         out["notes"] = caps.notes;
+        return out;
+    }
+
+    py::list getMaterialClosureGraph(int materialId) const {
+        auto it = materials.find(materialId);
+        if (it == materials.end() || !it->second) {
+            throw std::runtime_error("Unknown material id");
+        }
+
+        py::list out;
+        astroray::MaterialClosureGraph graph = it->second->closureGraph();
+        for (int i = 0; i < graph.count(); ++i) {
+            const astroray::MaterialClosure& c = graph.closure(i);
+            py::dict item;
+            item["type"] = astroray::closureTypeName(c.type);
+            item["color"] = py::make_tuple(c.color.x, c.color.y, c.color.z);
+            item["weight"] = c.weight;
+            item["roughness"] = c.roughness;
+            item["metallic"] = c.metallic;
+            item["ior"] = c.ior;
+            item["transmission"] = c.transmission;
+            item["clearcoat_gloss"] = c.clearcoatGloss;
+            item["two_sided_emission"] = c.twoSidedEmission;
+            out.append(item);
+        }
         return out;
     }
 
@@ -953,6 +980,8 @@ PYBIND11_MODULE(astroray, m) {
         .def("set_use_gpu", &PyRenderer::setUseGPU, "enable"_a)
         .def("get_material_backend_capabilities",
              &PyRenderer::getMaterialBackendCapabilities, "material_id"_a)
+        .def("get_material_closure_graph",
+             &PyRenderer::getMaterialClosureGraph, "material_id"_a)
         .def_property_readonly("gpu_available",   &PyRenderer::getGPUAvailable)
         .def_property_readonly("gpu_device_name", &PyRenderer::getGPUDeviceName)
         .def("sample_texture", &PyRenderer::sampleTexture,

--- a/plugins/materials/closure_matte.cpp
+++ b/plugins/materials/closure_matte.cpp
@@ -1,0 +1,51 @@
+#include "astroray/register.h"
+#include "raytracer.h"
+
+class ClosureMattePlugin : public Material {
+    Vec3 albedo_;
+    astroray::RGBAlbedoSpectrum albedoSpec_;
+
+public:
+    explicit ClosureMattePlugin(const astroray::ParamDict& p)
+        : albedo_(p.getVec3("albedo", Vec3(0.75f))),
+          albedoSpec_({albedo_.x, albedo_.y, albedo_.z}) {}
+
+    Vec3 getAlbedo() const override { return albedo_; }
+
+    astroray::MaterialClosureGraph closureGraph() const override {
+        astroray::MaterialClosureGraph graph;
+        graph.add(astroray::makeDiffuseClosure({albedo_.x, albedo_.y, albedo_.z}));
+        return graph;
+    }
+
+    Vec3 eval(const HitRecord& rec, const Vec3&, const Vec3& wi) const {
+        float cosTheta = wi.dot(rec.normal);
+        return cosTheta > 0.0f ? albedo_ * (cosTheta / float(M_PI)) : Vec3(0);
+    }
+
+    astroray::SampledSpectrum evalSpectral(
+            const HitRecord& rec, const Vec3&, const Vec3& wi,
+            const astroray::SampledWavelengths& lambdas) const override {
+        float cosTheta = wi.dot(rec.normal);
+        if (cosTheta <= 0.0f) return astroray::SampledSpectrum(0.0f);
+        return albedoSpec_.sample(lambdas) * (cosTheta / float(M_PI));
+    }
+
+    BSDFSample sample(const HitRecord& rec, const Vec3& wo, std::mt19937& gen) const override {
+        (void)wo;
+        Vec3 localWi = Vec3::randomCosineDirection(gen);
+        BSDFSample s;
+        s.wi = rec.tangent * localWi.x + rec.bitangent * localWi.y + rec.normal * localWi.z;
+        s.f = eval(rec, Vec3(0), s.wi);
+        s.pdf = pdf(rec, Vec3(0), s.wi);
+        s.isDelta = false;
+        return s;
+    }
+
+    float pdf(const HitRecord& rec, const Vec3&, const Vec3& wi) const override {
+        float cosTheta = wi.dot(rec.normal);
+        return cosTheta > 0.0f ? cosTheta / float(M_PI) : 0.0f;
+    }
+};
+
+ASTRORAY_REGISTER_MATERIAL("closure_matte", ClosureMattePlugin)

--- a/plugins/materials/dielectric.cpp
+++ b/plugins/materials/dielectric.cpp
@@ -97,9 +97,16 @@ public:
     Vec3 getAlbedo() const override { return tint_; }
     std::string getGPUTypeName() const override { return "dielectric"; }
     float getIOR() const override { return ior_; }
+    astroray::MaterialClosureGraph closureGraph() const override {
+        astroray::MaterialClosureGraph graph;
+        if (!dispersive_) {
+            graph.add(astroray::makeDielectricTransmissionClosure(
+                {tint_.x, tint_.y, tint_.z}, ior_));
+        }
+        return graph;
+    }
     MaterialBackendCapabilities backendCapabilities() const override {
         MaterialBackendCapabilities caps;
-        caps.gpuType = "dielectric";
         if (dispersive_) {
             caps.gpu = false;
             caps.gpuSpectral = false;
@@ -107,7 +114,9 @@ public:
         } else {
             caps.gpu = true;
             caps.gpuSpectral = true;
-            caps.notes = "spectral flat-IOR dielectric GPU lowering";
+            caps.closureGraph = true;
+            caps.gpuType = "closure_graph";
+            caps.notes = "spectral flat-IOR dielectric closure-graph GPU lowering";
         }
         return caps;
     }

--- a/plugins/materials/disney.cpp
+++ b/plugins/materials/disney.cpp
@@ -175,13 +175,34 @@ public:
 
     Vec3 getAlbedo() const override { return baseColor_; }
     std::string getGPUTypeName() const override { return "disney"; }
+    astroray::MaterialClosureGraph closureGraph() const override {
+        astroray::MaterialClosureGraph graph;
+        const astroray::ClosureColor base{baseColor_.x, baseColor_.y, baseColor_.z};
+        const float diffuseWeight = (1.0f - metallic_) * (1.0f - transmission_);
+        if (diffuseWeight > 1e-4f) {
+            graph.add(astroray::makeDiffuseClosure(base, diffuseWeight));
+        }
+        const float conductorWeight = transmission_ < 0.999f ? 1.0f : 0.0f;
+        if (conductorWeight > 1e-4f) {
+            graph.add(astroray::makeGGXConductorClosure(base, roughness_, conductorWeight));
+        }
+        if (transmission_ > 1e-4f) {
+            graph.add(astroray::makeDielectricTransmissionClosure(
+                base, ior_, roughness_, transmission_, transmission_));
+        }
+        if (graph.empty()) {
+            graph.add(astroray::makeDiffuseClosure(base, 1.0f));
+        }
+        return graph;
+    }
     MaterialBackendCapabilities backendCapabilities() const override {
         MaterialBackendCapabilities caps;
         caps.gpu = true;
         caps.gpuSpectral = true;
         caps.gpuApproximate = true;
-        caps.gpuType = "disney";
-        caps.notes = "spectral RGB-derived Disney GPU preview; closure composition remains approximate until pkg36";
+        caps.closureGraph = true;
+        caps.gpuType = "closure_graph";
+        caps.notes = "spectral Disney closure-graph GPU lowering; advanced Disney lobes remain approximated";
         return caps;
     }
     float getRoughness() const override { return roughness_; }

--- a/plugins/materials/lambertian.cpp
+++ b/plugins/materials/lambertian.cpp
@@ -39,6 +39,11 @@ public:
     }
 
     Vec3 getAlbedo() const override { return albedo_; }
+    astroray::MaterialClosureGraph closureGraph() const override {
+        astroray::MaterialClosureGraph graph;
+        graph.add(astroray::makeDiffuseClosure({albedo_.x, albedo_.y, albedo_.z}));
+        return graph;
+    }
     std::string getGPUTypeName() const override { return "lambertian"; }
 };
 

--- a/plugins/materials/metal.cpp
+++ b/plugins/materials/metal.cpp
@@ -20,6 +20,12 @@ public:
 
     bool isGlossy() const override { return true; }
     Vec3 getAlbedo() const override { return albedo_; }
+    astroray::MaterialClosureGraph closureGraph() const override {
+        astroray::MaterialClosureGraph graph;
+        graph.add(astroray::makeGGXConductorClosure(
+            {albedo_.x, albedo_.y, albedo_.z}, roughness_));
+        return graph;
+    }
     std::string getGPUTypeName() const override { return "metal"; }
     float getRoughness() const override { return roughness_; }
 

--- a/src/gpu/scene_upload.cu
+++ b/src/gpu/scene_upload.cu
@@ -50,6 +50,21 @@ static GBVHNode convertNode(const LinearBVHNode& n) {
 // ---------------------------------------------------------------------------
 // Convert a CPU Material shared_ptr → GMaterial flat struct
 // ---------------------------------------------------------------------------
+static GClosureType convertClosureType(astroray::MaterialClosureType type) {
+    switch (type) {
+        case astroray::MaterialClosureType::Diffuse: return GCLOSURE_DIFFUSE;
+        case astroray::MaterialClosureType::GGXConductor: return GCLOSURE_GGX_CONDUCTOR;
+        case astroray::MaterialClosureType::DielectricTransmission: return GCLOSURE_DIELECTRIC_TRANSMISSION;
+        case astroray::MaterialClosureType::Clearcoat: return GCLOSURE_CLEARCOAT;
+        case astroray::MaterialClosureType::Sheen: return GCLOSURE_SHEEN;
+        case astroray::MaterialClosureType::Emission: return GCLOSURE_EMISSION;
+        case astroray::MaterialClosureType::ThinGlass: return GCLOSURE_THIN_GLASS;
+        case astroray::MaterialClosureType::None:
+        default:
+            return GCLOSURE_NONE;
+    }
+}
+
 static GMaterial convertMaterial(const std::shared_ptr<Material>& mat) {
     MaterialBackendCapabilities caps = mat->backendCapabilities();
     if (!caps.gpu) {
@@ -73,6 +88,36 @@ static GMaterial convertMaterial(const std::shared_ptr<Material>& mat) {
     g.subsurface       = 0.f;
     g.anisotropic      = 0.f;
     g.anisotropicRotation = 0.f;
+
+    astroray::MaterialClosureGraph graph = mat->closureGraph();
+    std::string graphReason;
+    if (!graph.empty() && astroray::validateClosureGraph(graph, &graphReason)) {
+        g.type = GMAT_CLOSURE_GRAPH;
+        g.spectralMode = GSPEC_RGB_ALBEDO;
+        Vec3 a = mat->getAlbedo();
+        g.baseColor = GVec3(a.x, a.y, a.z);
+        g.roughness = mat->getRoughness();
+        g.ior = mat->getIOR();
+        g.transmission = mat->getTransmission();
+        g.closureCount = static_cast<uint8_t>(
+            std::min(graph.count(), G_MAX_MATERIAL_CLOSURES));
+
+        for (int i = 0; i < g.closureCount; ++i) {
+            const astroray::MaterialClosure& c = graph.closure(i);
+            GMaterialClosure gc{};
+            gc.type = convertClosureType(c.type);
+            gc.twoSidedEmission = c.twoSidedEmission ? 1 : 0;
+            gc.color = GVec3(c.color.x, c.color.y, c.color.z);
+            gc.weight = c.weight;
+            gc.roughness = c.roughness;
+            gc.metallic = c.metallic;
+            gc.ior = c.ior;
+            gc.transmission = c.transmission;
+            gc.clearcoatGloss = c.clearcoatGloss;
+            g.closures[i] = gc;
+        }
+        return g;
+    }
 
     std::string gpuType = caps.gpuType.empty() ? mat->getGPUTypeName() : caps.gpuType;
     if (gpuType == "disney") {

--- a/src/material_closure.cpp
+++ b/src/material_closure.cpp
@@ -1,0 +1,136 @@
+#include "astroray/material_closure.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace astroray {
+
+namespace {
+
+static ClosureColor sanitizeColor(ClosureColor color) {
+    color.x = std::clamp(color.x, 0.0f, 1.0e6f);
+    color.y = std::clamp(color.y, 0.0f, 1.0e6f);
+    color.z = std::clamp(color.z, 0.0f, 1.0e6f);
+    return color;
+}
+
+static float sanitizeWeight(float weight) {
+    return std::isfinite(weight) ? std::clamp(weight, 0.0f, 1.0e6f) : 0.0f;
+}
+
+} // namespace
+
+bool MaterialClosureGraph::add(const MaterialClosure& closure) {
+    if (count_ >= kMaxClosures || closure.type == MaterialClosureType::None)
+        return false;
+    closures_[count_++] = closure;
+    return true;
+}
+
+MaterialClosure makeDiffuseClosure(ClosureColor color, float weight) {
+    MaterialClosure c;
+    c.type = MaterialClosureType::Diffuse;
+    c.color = sanitizeColor(color);
+    c.weight = sanitizeWeight(weight);
+    c.roughness = 1.0f;
+    return c;
+}
+
+MaterialClosure makeGGXConductorClosure(ClosureColor color, float roughness, float weight) {
+    MaterialClosure c;
+    c.type = MaterialClosureType::GGXConductor;
+    c.color = sanitizeColor(color);
+    c.weight = sanitizeWeight(weight);
+    c.roughness = std::clamp(std::isfinite(roughness) ? roughness : 0.0f, 0.001f, 1.0f);
+    c.metallic = 1.0f;
+    return c;
+}
+
+MaterialClosure makeDielectricTransmissionClosure(
+        ClosureColor color,
+        float ior,
+        float roughness,
+        float transmission,
+        float weight) {
+    MaterialClosure c;
+    c.type = MaterialClosureType::DielectricTransmission;
+    c.color = sanitizeColor(color);
+    c.weight = sanitizeWeight(weight);
+    c.roughness = std::clamp(std::isfinite(roughness) ? roughness : 0.0f, 0.0f, 1.0f);
+    c.ior = std::max(std::isfinite(ior) ? ior : 1.5f, 1.0f);
+    c.transmission = std::clamp(std::isfinite(transmission) ? transmission : 1.0f, 0.0f, 1.0f);
+    return c;
+}
+
+MaterialClosure makeEmissionClosure(
+        ClosureColor color,
+        float intensity,
+        bool twoSided,
+        float weight) {
+    MaterialClosure c;
+    c.type = MaterialClosureType::Emission;
+    c.color = sanitizeColor(color);
+    c.weight = sanitizeWeight(weight);
+    c.transmission = std::max(std::isfinite(intensity) ? intensity : 0.0f, 0.0f);
+    c.twoSidedEmission = twoSided;
+    return c;
+}
+
+MaterialClosure makeThinGlassClosure(
+        ClosureColor color,
+        float ior,
+        float roughness,
+        float transmission,
+        float weight) {
+    MaterialClosure c = makeDielectricTransmissionClosure(
+        color, ior, roughness, transmission, weight);
+    c.type = MaterialClosureType::ThinGlass;
+    return c;
+}
+
+const char* closureTypeName(MaterialClosureType type) {
+    switch (type) {
+        case MaterialClosureType::Diffuse: return "diffuse";
+        case MaterialClosureType::GGXConductor: return "ggx_conductor";
+        case MaterialClosureType::DielectricTransmission: return "dielectric_transmission";
+        case MaterialClosureType::Clearcoat: return "clearcoat";
+        case MaterialClosureType::Sheen: return "sheen";
+        case MaterialClosureType::Emission: return "emission";
+        case MaterialClosureType::ThinGlass: return "thin_glass";
+        case MaterialClosureType::None:
+        default:
+            return "none";
+    }
+}
+
+bool validateClosureGraph(const MaterialClosureGraph& graph, std::string* reason) {
+    if (graph.empty()) {
+        if (reason) *reason = "closure graph is empty";
+        return false;
+    }
+
+    for (int i = 0; i < graph.count(); ++i) {
+        const MaterialClosure& c = graph.closure(i);
+        if (c.type == MaterialClosureType::None) {
+            if (reason) *reason = "closure graph contains a none closure";
+            return false;
+        }
+        if (!std::isfinite(c.weight) || c.weight < 0.0f) {
+            if (reason) *reason = "closure graph contains an invalid weight";
+            return false;
+        }
+        if (!std::isfinite(c.roughness) || c.roughness < 0.0f || c.roughness > 1.0f) {
+            if (reason) *reason = "closure graph contains an invalid roughness";
+            return false;
+        }
+        if ((c.type == MaterialClosureType::DielectricTransmission ||
+             c.type == MaterialClosureType::ThinGlass) &&
+            (!std::isfinite(c.ior) || c.ior < 1.0f)) {
+            if (reason) *reason = "closure graph contains an invalid IOR";
+            return false;
+        }
+    }
+    return true;
+}
+
+} // namespace astroray

--- a/tests/base_helpers.py
+++ b/tests/base_helpers.py
@@ -24,6 +24,7 @@ def _candidate_build_dirs() -> list[str]:
     env_dir = os.environ.get('ASTRORAY_BUILD_DIR')
     if env_dir:
         candidates.append(env_dir)
+        candidates.append(os.path.join(env_dir, 'Release'))
     candidates.extend([
         DEFAULT_BUILD_DIR,
         os.path.join(DEFAULT_BUILD_DIR, 'Release'),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ def _candidate_build_dirs() -> list[str]:
     env_dir = os.environ.get('ASTRORAY_BUILD_DIR')
     if env_dir:
         candidates.append(env_dir)
+        candidates.append(os.path.join(env_dir, 'Release'))
 
     candidates.extend([
         DEFAULT_BUILD_DIR,

--- a/tests/runtime_setup.py
+++ b/tests/runtime_setup.py
@@ -17,6 +17,7 @@ def candidate_build_dirs() -> list[str]:
     env_dir = os.environ.get("ASTRORAY_BUILD_DIR")
     if env_dir:
         candidates.append(Path(env_dir))
+        candidates.append(Path(env_dir) / "Release")
     candidates.extend([DEFAULT_BUILD_DIR, DEFAULT_BUILD_DIR / "Release"])
 
     seen: set[str] = set()

--- a/tests/test_material_backend_capabilities.py
+++ b/tests/test_material_backend_capabilities.py
@@ -38,7 +38,8 @@ def test_backend_capabilities_report_gpu_supported_material():
     assert caps["gpu"] is True
     assert caps["gpu_spectral"] is True
     assert caps["gpu_approximate"] is False
-    assert caps["gpu_type"] == "lambertian"
+    assert caps["closure_graph"] is True
+    assert caps["gpu_type"] == "closure_graph"
 
 
 def test_backend_capabilities_report_cpu_only_material():
@@ -57,8 +58,9 @@ def test_backend_capabilities_report_explicit_preview_approximation():
     assert caps["gpu"] is True
     assert caps["gpu_spectral"] is True
     assert caps["gpu_approximate"] is True
-    assert caps["gpu_type"] == "disney"
-    assert "preview" in caps["notes"]
+    assert caps["closure_graph"] is True
+    assert caps["gpu_type"] == "closure_graph"
+    assert "closure-graph" in caps["notes"]
 
 
 def test_dispersive_dielectric_is_cpu_only_until_spectral_gpu_support():

--- a/tests/test_material_closure_graph.py
+++ b/tests/test_material_closure_graph.py
@@ -1,0 +1,100 @@
+"""pkg36 — shared material closure graph coverage."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import astroray
+from base_helpers import create_renderer, render_image, setup_camera
+
+
+def _renderer(width=32, height=24):
+    r = create_renderer()
+    r.setup_camera(
+        look_from=[0, 0, 4],
+        look_at=[0, 0, 0],
+        vup=[0, 1, 0],
+        vfov=40,
+        aspect_ratio=width / height,
+        aperture=0.0,
+        focus_dist=4.0,
+        width=width,
+        height=height,
+    )
+    r.set_background_color([0.05, 0.06, 0.08])
+    return r
+
+
+@pytest.mark.parametrize(
+    "material_type,color,params,expected_types",
+    [
+        ("lambertian", [0.7, 0.2, 0.1], {}, {"diffuse"}),
+        ("metal", [0.9, 0.7, 0.4], {"roughness": 0.35}, {"ggx_conductor"}),
+        ("dielectric", [1.0, 1.0, 1.0], {"ior": 1.5}, {"dielectric_transmission"}),
+        ("disney", [0.8, 0.45, 0.25], {"roughness": 0.45}, {"diffuse", "ggx_conductor"}),
+        ("disney", [0.9, 0.95, 1.0], {"transmission": 1.0, "roughness": 0.25}, {"dielectric_transmission"}),
+    ],
+)
+def test_core_materials_export_closure_graphs(material_type, color, params, expected_types):
+    r = _renderer()
+    mat = r.create_material(material_type, color, params)
+
+    graph = r.get_material_closure_graph(mat)
+    caps = r.get_material_backend_capabilities(mat)
+    types = {closure["type"] for closure in graph}
+
+    assert expected_types.issubset(types)
+    assert caps["closure_graph"] is True
+    assert caps["closure_count"] == len(graph)
+    assert caps["gpu"] is True
+    assert caps["gpu_type"] == "closure_graph"
+
+
+def test_dispersive_dielectric_does_not_export_flat_closure_graph():
+    r = _renderer()
+    mat = r.create_material("dielectric", [1.0, 1.0, 1.0], {"sellmeier_preset": "bk7"})
+    caps = r.get_material_backend_capabilities(mat)
+
+    assert r.get_material_closure_graph(mat) == []
+    assert caps["closure_graph"] is False
+    assert caps["gpu"] is False
+
+
+def test_closure_only_plugin_gets_gpu_capability_without_gpu_type_name():
+    assert "closure_matte" in astroray.material_registry_names()
+
+    r = _renderer()
+    mat = r.create_material("closure_matte", [0.2, 0.65, 0.9], {})
+    graph = r.get_material_closure_graph(mat)
+    caps = r.get_material_backend_capabilities(mat)
+
+    assert [closure["type"] for closure in graph] == ["diffuse"]
+    assert caps["closure_graph"] is True
+    assert caps["gpu"] is True
+    assert caps["gpu_type"] == "closure_graph"
+
+
+def test_materials_without_graph_remain_cpu_only_escape_hatches():
+    r = _renderer()
+    mat = r.create_material("mirror", [1.0, 1.0, 1.0], {})
+    caps = r.get_material_backend_capabilities(mat)
+
+    assert r.get_material_closure_graph(mat) == []
+    assert caps["closure_graph"] is False
+    assert caps["gpu"] is False
+
+
+def test_closure_only_plugin_renders_on_gpu_when_available():
+    r = _renderer(48, 36)
+    if not bool(astroray.__features__.get("cuda", False)) or not bool(getattr(r, "gpu_available", False)):
+        pytest.skip("CUDA GPU not available")
+
+    mat = r.create_material("closure_matte", [0.2, 0.65, 0.9], {})
+    r.add_sphere([0, 0, 0], 1.0, mat)
+    r.set_use_gpu(True)
+    setup_camera(r, look_from=[0, 0, 4], look_at=[0, 0, 0], vfov=40, width=48, height=36)
+
+    pixels = render_image(r, samples=16, max_depth=3)
+    assert np.isfinite(pixels).all()
+    assert float(np.mean(pixels)) > 0.0

--- a/tests/test_spectral_gpu_materials.py
+++ b/tests/test_spectral_gpu_materials.py
@@ -72,6 +72,7 @@ def test_pkg35_capabilities_mark_spectral_gpu_and_cpu_only_emitters():
     flat_caps = renderer.get_material_backend_capabilities(flat)
     assert flat_caps["gpu"] is True
     assert flat_caps["gpu_spectral"] is True
+    assert flat_caps["closure_graph"] is True
     assert "flat-IOR" in flat_caps["notes"]
 
     dispersive = renderer.create_material("dielectric", [1.0, 1.0, 1.0], {"sellmeier_preset": "bk7"})


### PR DESCRIPTION
## Summary
- Add a fixed-size material closure graph model plus validation helpers.
- Export closure graphs for Lambertian, metal, flat dielectric, Disney plastic/glass, and a new closure-only `closure_matte` plugin.
- Lower closure graphs into CUDA material records and dispatch generic graph eval/sample/pdf/emission on GPU.
- Expose closure graph inspection and closure capability metadata in Python.
- Fix test bootstrap so `ASTRORAY_BUILD_DIR=build_tcnn` also prefers `build_tcnn/Release` before stale default build artifacts.

## Validation
- `cmake --build build_tcnn --config Release --target astroray -j`
- `cmake --build build_tcnn --config Release --target raytracer_standalone -j`
- `$env:ASTRORAY_BUILD_DIR='build_tcnn'; pytest tests/test_material_closure_graph.py tests/test_material_backend_capabilities.py tests/test_spectral_gpu_materials.py -q`
- `$env:ASTRORAY_BUILD_DIR='build_tcnn'; pytest tests/test_python_bindings.py::test_gpu_renders_match_cpu tests/test_material_closure_graph.py tests/test_spectral_gpu_materials.py -q`
- `$env:ASTRORAY_BUILD_DIR='build_tcnn'; pytest tests/ -q` -> `337 passed, 8 skipped, 18 xfailed`

## Note
- `cmake --build build_tcnn --config Release -j` still fails on the pre-existing Blender module target with unresolved `astroray::makeNormalMapped`; the Python module and standalone renderer targets build cleanly.