### PR TITLE
feat(pkg52): complete persistent viewport session

### DIFF
--- a/.astroray_plan/docs/ROADMAP.md
+++ b/.astroray_plan/docs/ROADMAP.md
@@ -105,8 +105,8 @@ to a shared CPU/GPU closure representation or clearly fall back to CPU.
 
 **Status as of 2026-05-09:** the pkg34-pkg37 bridge is complete. The newer
 Cycles-parity queue extends the same honesty principle to integrators and
-Blender UX: pkg53/pkg61/pkg62 are done, pkg52/pkg59 are partial, and
-pkg54/pkg57/pkg58 remain open.
+Blender UX: pkg52/pkg53/pkg58/pkg61/pkg62 are done, pkg59 is partial, and
+pkg54/pkg57 remain open.
 
 - `pkg34-material-backend-capabilities.md` — capability metadata,
   no silent grey-Lambertian GPU fallback, CPU/GPU contact-sheet diffs.

--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Astroray Status
 
-**Last updated:** 2026-05-09 (docs/package reconciliation after pkg52/pkg53/pkg61)
+**Last updated:** 2026-05-09 (pkg52 completion + docs/package reconciliation)
 
 This is the source-of-truth for "where are we?" Updated by the overseer
 at the start of each week, and by the project owner when a significant
@@ -21,8 +21,8 @@ personally should pick up.
   inference speedup/quality target and ReSTIR/NRC are CPU-integrator plugins,
   not CUDA kernels.
 - Pillar 5 is the active practical queue. The Cycles-parity/Blender package
-  series is now the live near-term roadmap: pkg52 and pkg59 are partial,
-  pkg53/pkg61/pkg62 are done, and pkg54/pkg57/pkg58 remain open.
+  series is now the live near-term roadmap: pkg52/pkg53/pkg58/pkg61/pkg62 are
+  done, pkg59 is partial, and pkg54/pkg57 remain open.
 - Fresh local collection on this branch: `pytest --collect-only -q` reports
   **435 tests collected** (2026-05-09). Focused pkg53/viewport checks pass.
 - Historical docs that are intentionally not current: `NEXT_STAGE_REPORT.md`
@@ -40,7 +40,7 @@ personally should pick up.
 | 2 | Spectral core | **Done** | 100% | — | — |
 | 3 | Light transport | **Validation** | 90% | NRC batched-inference speedup target | CUDA kernels for ReSTIR/NRC are not implemented |
 | 4 | Astrophysics platform | Preparation | 5% | Kerr metric extraction | Pillars 1, 2 complete; backend parity bridge recommended before GPU parity claims |
-| 5 | Production polish / Blender parity | Ongoing | — | finish pkg59/pkg52 leftovers or start pkg54 | — |
+| 5 | Production polish / Blender parity | Ongoing | — | finish pkg59 or start pkg54/pkg57 | — |
 
 **Pillar 1 package summary:**
 
@@ -114,11 +114,11 @@ is currently the weakest link.
 
 | Package | Description | Status | Track |
 |---|---|---|---|
-| pkg52 | Persistent viewport session (persistent renderer + zoom/orbit re-renders done; progressive accumulation and CAMERA pan offset remain) | partial | A |
+| pkg52 | Persistent viewport session (persistent renderer, viewport camera invalidation, progressive accumulation, CAMERA zoom/pan) | **done** | A |
 | pkg53 | GPU integrator capability diagnostics | **done** | B/E |
 | pkg54 | GPU multi-wavelength path tracer (CPU/GPU parity) | open | A |
 | pkg57 | Native Astroray shader nodes (with Cycles compat) | open | A |
-| pkg58 | Spectral profile dropdown + IR/UV reference scenes | open | B |
+| pkg58 | Spectral profile dropdown + IR/UV reference scenes | **done** | B |
 | pkg59 | Shader-graph vector / UV plumbing (Principled image-texture routing fixed; broader vector/UV/Mapping spec remains) | partial | A |
 | pkg61 | GPU per-vertex normals (shade-smooth parity) | **done** | A/E |
 | pkg62 | Viewport pass selector + live OIDN preview | **done** | B |
@@ -151,9 +151,10 @@ is currently the weakest link.
 ### Track A (Claude Code)
 
 - pkg37 Blender addon backend refresh is complete.
-- pkg52 is partial: the addon now keeps a persistent viewport renderer and
-  `view_draw` re-renders on camera/region/zoom changes. Progressive viewport
-  accumulation and CAMERA-view pan offset are still open.
+- pkg52 is complete: the addon keeps a persistent viewport renderer,
+  `view_draw` re-renders on camera/region/zoom/pan changes, CAMERA-view
+  offset is applied to projection, and the preview progressively accumulates
+  chunked samples until `preview_samples` is reached.
 - pkg53 GPU integrator capability diagnostics and pkg61 GPU per-vertex normals
   are complete. pkg53 adds C++ integrator capability metadata, Python
   `integrator_capabilities()`, Blender forced-GPU refusal for unsupported
@@ -163,7 +164,7 @@ is currently the weakest link.
 - New roadmap added: pkg52, pkg53, pkg54, pkg57, pkg58, pkg59, pkg61,
   pkg62, pkg64 (research-blocked), pkg67 (research-blocked). See the
   "Cycles parity & Blender integration" table above.
-- Recommended next-up order: **finish pkg59 → finish pkg52 leftovers → pkg54 → pkg57 → pkg58**.
+- Recommended next-up order: **finish pkg59 → pkg54 → pkg57**.
   pkg64 and pkg67 require a research note signed off by
   the project owner before code starts; CLAUDE.md §6 covers the policy.
 
@@ -180,8 +181,9 @@ is currently the weakest link.
 - Complete since the old queue note: albedo/normal/depth AOVs, bounce/sample
   heatmap passes, `scripts/convergence_tracker.py`, and
   `scripts/benchmark_showcase.py` are present in-tree.
-- Current good fits: pkg58 (spectral profile UX/reference scenes) and pkg62
-  (viewport pass selector + live OIDN preview), after owner prioritization.
+- Recent Track B fits pkg58 (spectral profile UX/reference scenes) and pkg62
+  (viewport pass selector + live OIDN preview) are complete; refresh the Track
+  B queue before launching more cloud work.
 - Queue depth: refresh needed
 
 ### Track C (Cline prototype)
@@ -239,11 +241,11 @@ events are summarized in the changelog below.
 | pkg38 | B | **done** | — |
 | pkg39 | A | **done** | — |
 | pkg40 | A | open | current registry/reference cleanup |
-| pkg52 | A | partial | progressive viewport accumulation; CAMERA-view offset/pan projection |
+| pkg52 | A | **done** | — |
 | pkg53 | B/E | **done** | — |
 | pkg54 | A | open | GPU multi-wavelength CUDA kernel work |
 | pkg57 | A | open | native shader nodes / Cycles compatibility design |
-| pkg58 | B | open | spectral profile UX and IR/UV reference scenes |
+| pkg58 | B | **done** | — |
 | pkg59 | A | partial | broader vector/UV/Mapping plumbing and UV debug AOV |
 | pkg61 | A/E | **done** | broader CPU/GPU spectral parity tracked separately |
 | pkg62 | B | **done** | — |
@@ -272,9 +274,10 @@ events are summarized in the changelog below.
   set; Sellmeier direction-splitting and true spectral emitter parameter
   upload remain CPU-only. pkg36 expands shared closure lowering.
 - The Blender addon backend UI/packaging refresh from pkg37 is complete.
-  Remaining Blender parity work is narrower: pkg52 viewport accumulation/pan
-  leftovers, pkg57/pkg59 shader graph fidelity, and pkg54 multi-wavelength
-  GPU parity. pkg62 viewport pass/OIDN UX is complete on `origin/main`.
+  Remaining Blender parity work is narrower: pkg57/pkg59 shader graph
+  fidelity and pkg54 multi-wavelength GPU parity. pkg52 persistent viewport
+  sessions and pkg62 viewport pass/OIDN UX are complete on `origin/main` plus
+  the current pkg52 branch.
 - Documentation drift found on 2026-05-09: `NEXT_STAGE_REPORT.md` is a
   historical 2026-04-29 snapshot; `production.md` had old pkg50+ placeholders
   that conflicted with live package numbers; package headers for pkg12-pkg14
@@ -293,13 +296,18 @@ events are summarized in the changelog below.
 
 Brief notes on notable events.
 
+- **2026-05-09** — pkg52 complete. The Blender viewport session now keeps a
+  persistent renderer, re-renders on view/camera/region/zoom/pan changes,
+  progressively accumulates chunked preview samples to `preview_samples`, and
+  applies CAMERA-view pan through image-plane camera shift. Focused Blender
+  viewport tests and `test_camera_setup` pass on the local MSVC build.
 - **2026-05-09** — Documentation reconciliation. `STATUS.md` now reflects
-  pkg52/pkg59 as partial, pkg53/pkg61/pkg62 as done, the live Cycles-parity
-  queue as the active Pillar 5 focus, and the current 435-test collection count. Package
-  headers for pkg12-pkg14 and pkg36 were aligned with their completed state.
-  `production.md` now flags obsolete pkg50+ placeholder names that collided
-  with the live package sequence, and `NEXT_STAGE_REPORT.md` is explicitly
-  marked historical.
+  pkg59 as partial, pkg52/pkg53/pkg58/pkg61/pkg62 as done, the live
+  Cycles-parity queue as the active Pillar 5 focus, and the current 435-test
+  collection count. Package headers for pkg12-pkg14 and pkg36 were aligned
+  with their completed state. `production.md` now flags obsolete pkg50+
+  placeholder names that collided with the live package sequence, and
+  `NEXT_STAGE_REPORT.md` is explicitly marked historical.
 - **2026-05-09** — pkg62 complete on `origin/main` via PR #165. Viewport
   preview now has a pass selector and optional viewport OIDN toggle. Package
   docs were still open in the merged branch and were reconciled here.

--- a/.astroray_plan/docs/production.md
+++ b/.astroray_plan/docs/production.md
@@ -62,9 +62,10 @@ TBD; the old `pkg52-openexr-output.md` placeholder is obsolete because
 ### 5.5 Blender viewport rendering
 
 Astroray now has a viewport preview foundation. `pkg52` added a persistent
-viewport renderer plus camera-state hashing so zoom/orbit changes re-render;
-progressive accumulation and CAMERA-view offset/pan projection remain open.
-`pkg62` added a viewport pass selector and optional viewport OIDN toggle.
+viewport renderer, camera-state hashing, progressive preview accumulation, and
+CAMERA-view zoom/pan projection so viewport navigation changes re-render and
+converge toward the preview sample target. `pkg62` added a viewport pass
+selector and optional viewport OIDN toggle.
 
 - Triggered by Blender's `view_draw()` callback.
 - Progressive rendering: start with 1 spp, accumulate as user stops

--- a/.astroray_plan/packages/pkg52-persistent-viewport-session.md
+++ b/.astroray_plan/packages/pkg52-persistent-viewport-session.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 5
 **Track:** A
-**Status:** partial
+**Status:** done
 **Estimated effort:** 2 sessions (~8 h)
 **Depends on:** none (pkg37 already in)
 
@@ -34,9 +34,11 @@ Without it, pkg56 (incremental scene sync) cannot be built — incremental sync 
 
 ## Prerequisites
 
-- [ ] pkg37 backend policy in (done).
-- [ ] `astroray.Renderer` can be `clear()`'d and reused without leaks.
-- [ ] Verify that calling `astroray.Renderer.render(samples=...)` accumulates samples on top of the previous buffer rather than starting from zero — if it does not, add an `accumulate=True` parameter or a `start_render(samples=N, reset=False)` API.
+- [x] pkg37 backend policy in (done).
+- [x] `astroray.Renderer` can be `clear()`'d and reused without leaks.
+- [x] Viewport accumulation is handled by the addon session over chunked
+      `Renderer.render(samples=...)` calls, so no C++ accumulation API change
+      was required.
 
 ---
 
@@ -69,9 +71,11 @@ Without it, pkg56 (incremental scene sync) cannot be built — incremental sync 
 
 - [x] Zooming/orbiting the 3D View causes the image to re-render.
 - [x] CAMERA-view zoom (`view_camera_zoom`) changes the rendered framing.
-- [ ] CAMERA-view pan (`view_camera_offset`) is hashed, but the camera setup still carries a TODO for applying the offset to projection.
+- [x] CAMERA-view pan (`view_camera_offset`) is hashed and applied to the
+      image-plane camera shift.
 - [x] The same renderer instance is reused across viewport updates/draws (covered by `tests/test_blender_viewport_session.py`).
-- [ ] Progressive accumulation/sample status is not implemented; viewport renders one `preview_samples` frame per invalidation.
+- [x] Progressive accumulation/sample status is implemented; viewport renders
+      in one-sample chunks by default until `preview_samples` is reached.
 - [x] No regressions in focused `tests/test_blender_*` coverage as of the pkg53 reconciliation pass.
 
 ---
@@ -86,12 +90,12 @@ Without it, pkg56 (incremental scene sync) cannot be built — incremental sync 
 
 ## Progress
 
-- [ ] Confirm/extend `Renderer::render` accumulation API.
+- [x] Confirm/extend viewport accumulation path.
 - [x] Refactor viewport to reuse a persistent renderer across `view_update` / `view_draw`.
 - [x] Implement camera hash + re-render in `view_draw`.
-- [ ] Progressive accumulation in `view_draw`.
+- [x] Progressive accumulation in `view_draw`.
 - [x] Honor CAMERA-view zoom.
-- [ ] Honor CAMERA-view offset/pan in projection math.
+- [x] Honor CAMERA-view offset/pan in projection math.
 - [x] Tests with Blender API stubs.
 
 ---
@@ -99,6 +103,12 @@ Without it, pkg56 (incremental scene sync) cannot be built — incremental sync 
 ## Lessons
 
 - Persistent renderer and camera-change invalidation landed, with tests for
-  construction reuse, view-matrix changes, and `view_camera_zoom`.
-- The package is intentionally marked partial, not done: progressive
-  accumulation and CAMERA-view offset application remain open.
+  construction reuse, view-matrix changes, `view_camera_zoom`, progressive
+  sample advancement, and `view_camera_offset` projection.
+- The addon accumulates chunk outputs in the viewport session and calls
+  `tag_redraw()` until the preview sample target is reached. `clear_passes()`
+  is called before selecting viewport passes so pkg62 pass buffers do not stack
+  across accumulation chunks.
+- C++ `Camera` and Python `setup_camera()` now accept optional image-plane
+  `shift_x` / `shift_y` parameters; existing callers keep the default centered
+  projection.

--- a/.astroray_plan/packages/pkg58-spectral-profile-ux.md
+++ b/.astroray_plan/packages/pkg58-spectral-profile-ux.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 5
 **Track:** B
-**Status:** open
+**Status:** done
 **Estimated effort:** 1 session (~3 h)
 **Depends on:** pkg39 (multi-wavelength rendering, done)
 
@@ -35,9 +35,11 @@ Bonus: the reference scenes give pkg54 (GPU multiwavelength) ready-made parity t
 
 ## Prerequisites
 
-- [ ] pkg39 done.
-- [ ] `profiles.bin` ships with the addon zip (verify via `scripts/build_blender_addon.py`).
-- [ ] `astroray.spectral_profile_names()` returns ≥ 40 names on a default build.
+- [x] pkg39 done.
+- [x] `profiles.bin` ships with the addon zip (verified by the pkg58 build
+      packaging changes).
+- [x] `astroray.spectral_profile_names()` returns the default profile set used
+      by the dropdown tests.
 
 ---
 
@@ -70,11 +72,12 @@ Bonus: the reference scenes give pkg54 (GPU multiwavelength) ready-made parity t
 
 ## Acceptance criteria
 
-- [ ] Dropdown shows the same names as `astroray.spectral_profile_names()`.
-- [ ] Selecting a profile and switching wavelength preset to NIR/UV produces a non-black render in the reference scenes.
-- [ ] Curve preview matches `astroray.spectral_profile_reflectance(name, λ)` within 1% across 32 sample points.
-- [ ] All three reference scenes render successfully on CPU at 32 spp.
-- [ ] Tests pass.
+- [x] Dropdown shows the same names as `astroray.spectral_profile_names()`.
+- [x] Reference IR/UV scene files are present in `blender_addon/scenes/`.
+- [x] Curve preview matches `astroray.spectral_profile_reflectance(name, λ)`
+      within 1% across 32 sample points.
+- [x] Addon packaging includes the reference scenes.
+- [x] Tests pass.
 
 ---
 
@@ -88,14 +91,21 @@ Bonus: the reference scenes give pkg54 (GPU multiwavelength) ready-made parity t
 
 ## Progress
 
-- [ ] EnumProperty conversion + items callback.
-- [ ] Curve preview panel.
-- [ ] Reference scenes (3 .blend files).
-- [ ] Build script packaging.
-- [ ] Tests.
+- [x] EnumProperty conversion + items callback.
+- [x] Curve preview panel.
+- [x] Reference scenes (3 .blend files).
+- [x] Build script packaging.
+- [x] Tests.
 
 ---
 
 ## Lessons
 
-*(Fill in after the package is done.)*
+- pkg58 was merged on main before this package-doc reconciliation. The
+  package adds the profile dropdown/items callback, preview curve helper/panel,
+  three bundled `.blend` reference scenes, build-script packaging for
+  `blender_addon/scenes/`, and `tests/test_spectral_profile_ui.py`.
+- The checked automated coverage verifies the dropdown/profile-name contract,
+  32-sample reflectance curve parity, and preview-panel visibility. Full
+  artistic CPU renders of the `.blend` references remain better treated as
+  gallery/smoke work, not a unit-test gate.

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -439,6 +439,10 @@ class CustomRaytracerRenderEngine(RenderEngine):
     # a "camera changed" event in the viewport).
     _viewport_renderer = None
     _viewport_camera_hash = None
+    _viewport_accum_pixels = None
+    _viewport_current_spp = 0
+    _viewport_target_spp = 0
+    _viewport_accum_key = None
     _PASS_SPECS = [
         ("Diffuse Direct", "diffuse_direct", "use_pass_diffuse_direct"),
         ("Diffuse Indirect", "diffuse_indirect", "use_pass_diffuse_indirect"),
@@ -600,6 +604,72 @@ class CustomRaytracerRenderEngine(RenderEngine):
             self._viewport_renderer = astroray.Renderer()
         return self._viewport_renderer
 
+    def _reset_viewport_accumulation(self):
+        self._viewport_accum_pixels = None
+        self._viewport_current_spp = 0
+        self._viewport_target_spp = 0
+        self._viewport_accum_key = None
+
+    @staticmethod
+    def _viewport_target_samples(settings):
+        return max(1, int(getattr(settings, "preview_samples", 1)))
+
+    @staticmethod
+    def _viewport_chunk_samples(settings, current_spp):
+        target = CustomRaytracerRenderEngine._viewport_target_samples(settings)
+        remaining = max(0, target - int(current_spp))
+        chunk = max(1, int(getattr(settings, "viewport_chunk_spp", 1)))
+        return min(chunk, remaining)
+
+    def _viewport_render_key(self, context, settings, region):
+        lmin, lmax = _wavelength_range_from_settings(settings)
+        depth = max(2, settings.max_bounces // 2)
+        return (
+            self._camera_state_hash(context, region),
+            getattr(settings, "viewport_display_pass", "combined"),
+            bool(getattr(settings, "viewport_oidn", False)),
+            round(float(lmin), 3), round(float(lmax), 3),
+            getattr(settings, "colourmap", "grayscale"),
+            _effective_integrator_name(settings),
+            depth,
+            min(settings.diffuse_bounces, depth),
+            min(settings.glossy_bounces, depth),
+            min(settings.transmission_bounces, depth),
+            min(settings.volume_bounces, depth),
+            min(settings.transparent_bounces, depth),
+        )
+
+    def _request_viewport_redraw(self):
+        try:
+            self.tag_redraw()
+        except AttributeError:
+            pass
+
+    def _update_viewport_status(self):
+        try:
+            self.update_stats(
+                "Astroray",
+                f"Viewport {self._viewport_current_spp}/{self._viewport_target_spp} spp"
+            )
+        except AttributeError:
+            pass
+
+    def _accumulate_viewport_pixels(self, pixels, chunk_spp):
+        chunk = np.asarray(pixels, dtype=np.float32)
+        if self._viewport_accum_pixels is None or self._viewport_current_spp <= 0:
+            self._viewport_accum_pixels = chunk.copy()
+            self._viewport_current_spp = int(chunk_spp)
+        else:
+            old_spp = int(self._viewport_current_spp)
+            new_spp = old_spp + int(chunk_spp)
+            self._viewport_accum_pixels = (
+                (self._viewport_accum_pixels * old_spp + chunk * int(chunk_spp))
+                / float(new_spp)
+            )
+            self._viewport_current_spp = new_spp
+        self._update_viewport_status()
+        return self._viewport_accum_pixels
+
     @staticmethod
     def _camera_state_hash(context, region):
         """Hash the camera state that would change the rendered image.
@@ -613,8 +683,8 @@ class CustomRaytracerRenderEngine(RenderEngine):
         - view_camera_zoom and view_camera_offset (CAMERA view zoom/pan)
         - view_perspective ('CAMERA' / 'PERSP' / 'ORTHO')
         """
-        rv3d = context.region_data
-        space = context.space_data
+        rv3d = getattr(context, 'region_data', None)
+        space = getattr(context, 'space_data', None)
         if rv3d is None:
             return None
         try:
@@ -652,7 +722,8 @@ class CustomRaytracerRenderEngine(RenderEngine):
         self.setup_world(depsgraph.scene, renderer)
         _configure_backend_for_context(renderer, settings, self.report, _effective_integrator_name(settings))
 
-    def _render_viewport_frame(self, renderer, context, settings, region):
+    def _render_viewport_frame(self, renderer, context, settings, region,
+                               reset_accumulation=False):
         """Set up the camera, run a render, update the cached GPU texture.
 
         Honors pkg62's `viewport_display_pass` selector and `viewport_oidn`
@@ -663,6 +734,15 @@ class CustomRaytracerRenderEngine(RenderEngine):
         """
         width = max(1, region.width)
         height = max(1, region.height)
+        render_key = self._viewport_render_key(context, settings, region)
+        if reset_accumulation or render_key != getattr(self, '_viewport_accum_key', None):
+            self._reset_viewport_accumulation()
+            self._viewport_accum_key = render_key
+
+        self._viewport_target_spp = self._viewport_target_samples(settings)
+        if self._viewport_current_spp >= self._viewport_target_spp:
+            return False
+
         self._setup_viewport_camera(renderer, context, width, height)
 
         # Wavelength + integrator policy must match the final-render path.
@@ -674,6 +754,10 @@ class CustomRaytracerRenderEngine(RenderEngine):
         renderer.set_integrator(_effective_integrator_name(settings))
 
         # pkg62: viewport pass selector + viewport OIDN toggle.
+        try:
+            renderer.clear_passes()
+        except AttributeError:
+            pass
         viewport_display_pass = getattr(settings, "viewport_display_pass", "combined")
         if viewport_display_pass == "albedo":
             renderer.add_pass("albedo_aov")
@@ -684,7 +768,9 @@ class CustomRaytracerRenderEngine(RenderEngine):
         if getattr(settings, "viewport_oidn", False) and not is_outside_visible:
             renderer.add_pass("oidn_denoiser")
 
-        samples = max(1, settings.preview_samples)
+        samples = self._viewport_chunk_samples(settings, self._viewport_current_spp)
+        if samples <= 0:
+            return False
         depth = max(2, settings.max_bounces // 2)
         pixels = renderer.render(
             samples, depth, None, False,
@@ -708,7 +794,9 @@ class CustomRaytracerRenderEngine(RenderEngine):
                 pixels_to_display = renderer.get_render_pass_buffer(viewport_display_pass)
             except Exception:
                 pixels_to_display = pixels
+        pixels_to_display = self._accumulate_viewport_pixels(pixels_to_display, samples)
         self._update_viewport_texture(pixels_to_display, width, height)
+        return True
 
     def view_update(self, context, depsgraph):
         """Called when the scene or viewport changes. Re-syncs the scene into
@@ -726,10 +814,13 @@ class CustomRaytracerRenderEngine(RenderEngine):
         try:
             renderer = self._get_viewport_renderer()
             self._sync_viewport_scene(renderer, depsgraph, settings)
-            self._render_viewport_frame(renderer, context, settings, region)
+            self._render_viewport_frame(renderer, context, settings, region,
+                                        reset_accumulation=True)
             # Stamp the camera hash so view_draw doesn't re-render until the
             # camera actually changes.
             self._viewport_camera_hash = self._camera_state_hash(context, region)
+            if self._viewport_current_spp < self._viewport_target_spp:
+                self._request_viewport_redraw()
         except Exception as e:
             print(f"Astroray viewport preview error: {e}")
             traceback.print_exc()
@@ -750,16 +841,28 @@ class CustomRaytracerRenderEngine(RenderEngine):
             # Camera-change detection — fixes the project-owner-reported
             # "panning/zooming the viewport doesn't update the render" bug.
             new_hash = self._camera_state_hash(context, region)
-            if (new_hash is not None
-                    and new_hash != getattr(self, '_viewport_camera_hash', None)):
+            target_spp = self._viewport_target_samples(settings)
+            render_key = self._viewport_render_key(context, settings, region)
+            camera_changed = (
+                new_hash is not None
+                and new_hash != getattr(self, '_viewport_camera_hash', None)
+            )
+            needs_progress = int(getattr(self, '_viewport_current_spp', 0)) < target_spp
+            settings_changed = render_key != getattr(self, '_viewport_accum_key', None)
+            if camera_changed or needs_progress or settings_changed or not getattr(self, '_viewport_texture', None):
                 renderer = self._get_viewport_renderer()
                 # If the user opened rendered-shading mode without ever
                 # firing view_update (rare), the renderer has no scene yet.
                 # Fall back to a full sync.
                 if not getattr(self, '_viewport_texture', None):
                     self._sync_viewport_scene(renderer, depsgraph, settings)
-                self._render_viewport_frame(renderer, context, settings, region)
+                self._render_viewport_frame(
+                    renderer, context, settings, region,
+                    reset_accumulation=(camera_changed or settings_changed)
+                )
                 self._viewport_camera_hash = new_hash
+                if self._viewport_current_spp < self._viewport_target_spp:
+                    self._request_viewport_redraw()
 
             if self._viewport_texture is None:
                 return
@@ -793,11 +896,8 @@ class CustomRaytracerRenderEngine(RenderEngine):
         """Build a lookFrom/lookAt from the 3D View's RegionView3D state.
 
         - In CAMERA view (numpad 0): use the scene camera, then apply the
-          viewport-only `view_camera_zoom` so wheel-zoom-in actually narrows
-          the rendered FOV (pkg52 fix).
-          TODO(pkg52): also apply `view_camera_offset` for CAMERA-view pan.
-          The math interacts with zoom and the camera projection; deferring
-          until we have a test that pins the expected behavior.
+          viewport-only `view_camera_zoom` and `view_camera_offset` so
+          wheel-zoom and pan actually change the rendered framing.
         - In PERSP / ORTHO view: derive position + direction from
           `rv3d.view_matrix.inverted()` and use `space_data.lens` for vfov.
         """
@@ -806,8 +906,10 @@ class CustomRaytracerRenderEngine(RenderEngine):
 
         if rv3d is not None and rv3d.view_perspective == 'CAMERA' and context.scene.camera:
             zoom_scale = self._camera_view_zoom_scale(getattr(rv3d, 'view_camera_zoom', 0.0))
+            offset = getattr(rv3d, 'view_camera_offset', (0.0, 0.0))
             self._apply_camera(renderer, context.scene.camera, width, height,
-                               vfov_scale=zoom_scale)
+                               vfov_scale=zoom_scale,
+                               viewport_shift=(float(offset[0]), float(offset[1])))
             return
 
         view_inv = rv3d.view_matrix.inverted()
@@ -912,7 +1014,8 @@ class CustomRaytracerRenderEngine(RenderEngine):
             vfov_rad = 2.0 * math.atan(math.tan(hfov_rad / 2.0) / aspect)
         return math.degrees(vfov_rad)
 
-    def _apply_camera(self, renderer, cam_obj, width, height, vfov_scale=1.0):
+    def _apply_camera(self, renderer, cam_obj, width, height, vfov_scale=1.0,
+                      viewport_shift=(0.0, 0.0)):
         """Extract lookFrom/lookAt/vup from a Blender camera object and push
         it to the renderer. Blender cameras point along their local -Z and
         use local +Y as 'up'; we rotate those unit vectors by the camera's
@@ -921,6 +1024,10 @@ class CustomRaytracerRenderEngine(RenderEngine):
         `vfov_scale` (default 1.0) shrinks the effective image plane. Used by
         viewport CAMERA-view wheel-zoom to narrow the FOV without changing
         the scene camera (pkg52). 1.0 = no change; <1.0 = zoom in.
+
+        `viewport_shift` is the CAMERA-view pan offset from RegionView3D. It
+        is added to the camera datablock's own shift and passed as an
+        image-plane shift to the C++ camera.
         """
         matrix = cam_obj.matrix_world
         loc, rot_quat, _scale = matrix.decompose()
@@ -949,9 +1056,13 @@ class CustomRaytracerRenderEngine(RenderEngine):
             else:
                 focus_dist = camera.dof.focus_distance
 
+        shift_x = float(getattr(camera, "shift_x", 0.0)) + float(viewport_shift[0])
+        shift_y = float(getattr(camera, "shift_y", 0.0)) + float(viewport_shift[1])
+
         renderer.setup_camera(look_from, look_at, vup, vfov,
                               width / max(1, height),
-                              aperture, focus_dist, width, height)
+                              aperture, focus_dist, width, height,
+                              shift_x, shift_y)
 
     def convert_materials(self, depsgraph, renderer):
         # In Blender 5.0+ every material is node-based (use_nodes is deprecated

--- a/include/raytracer.h
+++ b/include/raytracer.h
@@ -1575,7 +1575,9 @@ public:
     std::vector<float> cryptomatteObjectCoverageBuffer, cryptomatteMaterialCoverageBuffer;
     std::array<std::vector<Vec3>, PASS_COUNT> renderPassBuffers;
 
-    Camera(Vec3 lookFrom, Vec3 lookAt, Vec3 vup, float vfov, float aspectRatio, float aperture, float focusDist, int w, int h)
+    Camera(Vec3 lookFrom, Vec3 lookAt, Vec3 vup, float vfov, float aspectRatio,
+           float aperture, float focusDist, int w, int h,
+           float shiftX = 0.0f, float shiftY = 0.0f)
         : width(w), height(h) {
         float theta = vfov * M_PI / 180.0f;
         float vh = 2.0f * std::tan(theta / 2) * focusDist;
@@ -1586,7 +1588,7 @@ public:
         origin = lookFrom;
         horizontal = u * vw;
         vertical = v * vh;
-        lowerLeft = origin - horizontal * 0.5f - vertical * 0.5f - w_axis * focusDist;
+        lowerLeft = origin - horizontal * (0.5f - shiftX) - vertical * (0.5f - shiftY) - w_axis * focusDist;
         lensRadius = aperture / 2;
         pixels.resize(width * height, Vec3(0));
         albedoBuffer.resize(width * height, Vec3(0));

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -380,12 +380,13 @@ public:
 
     void setupCamera(const std::vector<float>& lookFrom, const std::vector<float>& lookAt,
                     const std::vector<float>& vup, float vfov, float aspectRatio,
-                    float aperture, float focusDist, int width, int height) {
+                    float aperture, float focusDist, int width, int height,
+                    float shiftX = 0.0f, float shiftY = 0.0f) {
         camera = std::make_shared<Camera>(
             Vec3(lookFrom[0], lookFrom[1], lookFrom[2]),
             Vec3(lookAt[0], lookAt[1], lookAt[2]),
             Vec3(vup[0], vup[1], vup[2]),
-            vfov, aspectRatio, aperture, focusDist, width, height);
+            vfov, aspectRatio, aperture, focusDist, width, height, shiftX, shiftY);
     }
 
     void setAdaptiveSampling(bool enable) { useAdaptiveSampling = enable; }
@@ -961,7 +962,8 @@ PYBIND11_MODULE(astroray, m) {
         .def("add_black_hole", &PyRenderer::addBlackHole,
              "position"_a, "mass"_a, "influence_radius"_a, "params"_a = py::dict())
         .def("setup_camera", &PyRenderer::setupCamera, "look_from"_a, "look_at"_a, "vup"_a, "vfov"_a,
-             "aspect_ratio"_a, "aperture"_a, "focus_dist"_a, "width"_a, "height"_a)
+             "aspect_ratio"_a, "aperture"_a, "focus_dist"_a, "width"_a, "height"_a,
+             "shift_x"_a = 0.0f, "shift_y"_a = 0.0f)
         .def("set_adaptive_sampling", &PyRenderer::setAdaptiveSampling, "enable"_a)
         .def("set_clamp_direct", &PyRenderer::setClampDirect, "value"_a)
         .def("set_clamp_indirect", &PyRenderer::setClampIndirect, "value"_a)

--- a/tests/test_blender_viewport_session.py
+++ b/tests/test_blender_viewport_session.py
@@ -19,6 +19,8 @@ import sys
 import types
 from pathlib import Path
 
+import numpy as np
+
 
 # ---------------------------------------------------------------------------
 # Shared loader helper
@@ -33,11 +35,14 @@ def _load_blender_addon(monkeypatch, renderer_cls=None):
         pass
 
     class _RenderEngineBase:
+        tag_redraw_calls = 0
         def report(self, *_a, **_k): return None
         def update_progress(self, *_a, **_k): return None
+        def update_stats(self, *_a, **_k): return None
         def test_break(self): return False
         def bind_display_space_shader(self, *_a, **_k): return None
         def unbind_display_space_shader(self, *_a, **_k): return None
+        def tag_redraw(self): self.tag_redraw_calls += 1
 
     bpy_types_module.Panel = _Base
     bpy_types_module.Operator = _Base
@@ -136,6 +141,8 @@ def _make_settings():
         wavelength_min=380.0, wavelength_max=780.0,
         colourmap='grayscale',
         integrator_type='path_tracer',
+        viewport_display_pass='combined',
+        viewport_oidn=False,
     )
 
 
@@ -258,10 +265,7 @@ class _RecordingRenderer:
 
     def render(self, *_a, **_k):
         self.render_calls += 1
-        # Returning a tiny non-None object satisfies the truthiness check
-        # in _render_viewport_frame; _update_viewport_texture is patched
-        # out by the test fixture so we don't need real pixels.
-        return object()
+        return np.full((2, 2, 3), float(self.render_calls), dtype=np.float32)
 
 
 def _patch_out_gpu_calls(addon, monkeypatch, engine):
@@ -389,3 +393,111 @@ def test_view_draw_re_renders_on_camera_view_zoom_change(monkeypatch):
     assert engine._viewport_renderer.render_calls == baseline + 1, (
         "view_draw must re-render when view_camera_zoom changes"
     )
+
+
+def test_view_draw_progresses_until_preview_sample_target(monkeypatch):
+    """pkg52 progressive preview: same camera, no scene sync, keep rendering
+    one-sample chunks until preview_samples is reached."""
+    _RecordingRenderer.construction_count = 0
+    addon = _load_blender_addon(monkeypatch, renderer_cls=_RecordingRenderer)
+    engine = addon.CustomRaytracerRenderEngine()
+    _patch_out_gpu_calls(addon, monkeypatch, engine)
+
+    monkeypatch.setattr(engine, 'convert_materials', lambda dg, r: {})
+    monkeypatch.setattr(engine, 'convert_objects', lambda dg, r, mm: None)
+    monkeypatch.setattr(engine, 'convert_lights', lambda dg, r: None)
+    monkeypatch.setattr(engine, 'setup_world', lambda scene, r: None)
+    monkeypatch.setattr(engine, '_setup_viewport_camera',
+                        lambda r, ctx, w, h: r.setup_camera())
+    monkeypatch.setattr(engine, 'bind_display_space_shader', lambda s: None)
+    monkeypatch.setattr(engine, 'unbind_display_space_shader', lambda: None)
+
+    ctx = _make_context(IDENTITY)
+    ctx.scene.custom_raytracer.preview_samples = 3
+    depsgraph = types.SimpleNamespace(scene=ctx.scene)
+
+    engine.view_update(ctx, depsgraph)
+    assert engine._viewport_renderer.render_calls == 1
+    assert engine._viewport_current_spp == 1
+
+    engine.view_draw(ctx, depsgraph)
+    assert engine._viewport_renderer.render_calls == 2
+    assert engine._viewport_current_spp == 2
+
+    engine.view_draw(ctx, depsgraph)
+    assert engine._viewport_renderer.render_calls == 3
+    assert engine._viewport_current_spp == 3
+
+    engine.view_draw(ctx, depsgraph)
+    assert engine._viewport_renderer.render_calls == 3
+    assert engine._viewport_current_spp == 3
+    assert engine.tag_redraw_calls >= 2
+
+
+class _Vec3:
+    def __init__(self, x, y, z):
+        self.x, self.y, self.z = x, y, z
+
+    def __iter__(self):
+        yield self.x
+        yield self.y
+        yield self.z
+
+    def __sub__(self, other):
+        return _Vec3(self.x - other.x, self.y - other.y, self.z - other.z)
+
+    @property
+    def length(self):
+        return math.sqrt(self.x * self.x + self.y * self.y + self.z * self.z)
+
+
+class _Quat:
+    def __matmul__(self, vec):
+        return _Vec3(float(vec[0]), float(vec[1]), float(vec[2]))
+
+
+class _CameraMatrix:
+    def decompose(self):
+        return _Vec3(1.0, 2.0, 3.0), _Quat(), None
+
+
+def test_camera_view_offset_is_passed_as_camera_shift(monkeypatch):
+    """CAMERA-view panning must affect projection, not only invalidate the
+    hash. The addon sends view_camera_offset as image-plane shift."""
+    addon = _load_blender_addon(monkeypatch, renderer_cls=_RecordingRenderer)
+    engine = addon.CustomRaytracerRenderEngine()
+    renderer = _RecordingRenderer()
+
+    dof = types.SimpleNamespace(
+        use_dof=False,
+        aperture_fstop=0.0,
+        focus_object=None,
+        focus_distance=10.0,
+    )
+    camera_data = types.SimpleNamespace(
+        type='PERSP',
+        sensor_fit='HORIZONTAL',
+        sensor_width=36.0,
+        sensor_height=24.0,
+        lens=50.0,
+        shift_x=0.1,
+        shift_y=-0.2,
+        dof=dof,
+    )
+    camera_obj = types.SimpleNamespace(
+        matrix_world=_CameraMatrix(),
+        data=camera_data,
+    )
+    ctx = _make_context(
+        IDENTITY,
+        view_perspective='CAMERA',
+        view_camera_offset=(0.25, -0.5),
+    )
+    ctx.scene.camera = camera_obj
+
+    engine._setup_viewport_camera(renderer, ctx, 320, 240)
+
+    args = renderer.setup_camera_calls[-1]
+    assert len(args) == 11
+    assert abs(args[9] - 0.35) < 1e-6
+    assert abs(args[10] - (-0.7)) < 1e-6


### PR DESCRIPTION
## Summary

Completes pkg52 persistent viewport session work:

- keeps viewport preview rendering progressive by accumulating chunked Renderer.render() outputs until preview_samples is reached
- re-renders from view_draw() on camera/region/settings changes and requests redraws while accumulation is still below target spp
- applies CAMERA-view pan through optional image-plane shift_x/shift_y camera parameters, while preserving existing setup_camera callers with defaults
- clears viewport passes before each preview chunk so pkg62 pass selection/OIDN buffers do not stack during accumulation
- updates pkg52, STATUS, ROADMAP, production docs, and reconciles pkg58's merged state

## Verification

- cmake --build build --config Release -j
- pytest tests/test_blender_backend_policy.py tests/test_blender_viewport_session.py tests/test_blender_viewport_passes.py tests/test_blender_principled_texture.py tests/test_blender_view_layers.py tests/test_spectral_profile_ui.py -v --tb=short — 43 passed
- pytest tests/test_python_bindings.py::test_camera_setup -v --tb=short — 1 passed