### PR TITLE
docs: pkg60 (Disney energy comp) + pkg63 (HDRI parity) specs

### DIFF
--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -120,10 +120,23 @@ is currently the weakest link.
 | pkg57 | Native Astroray shader nodes (with Cycles compat) | open | A |
 | pkg58 | Spectral profile dropdown + IR/UV reference scenes | **done** | B |
 | pkg59 | Shader-graph vector / UV plumbing (Principled image-texture routing fixed; broader vector/UV/Mapping spec remains) | partial | A |
+| pkg60 | Disney v2 energy compensation (no-glow materials) | open | A/E |
 | pkg61 | GPU per-vertex normals (shade-smooth parity) | **done** | A/E |
 | pkg62 | Viewport pass selector + live OIDN preview | **done** | B |
+| pkg63 | World / HDRI parity (Mapping XYZ rotation, color tint, MIS env-map) | open | A |
 | pkg64 | Spectral caustics (prism-accurate) — research-grade | open (research blocked) | A |
 | pkg67 | Metric-aware path tracer (GR + spectral unification) — research-grade | open (research blocked) | A |
+
+**Deferred / not-yet-spec'd from the 2026-05-08 triage** (mentioned in the
+original roadmap but no full spec written; capture intent before they're
+forgotten):
+
+| Pkg | Title | Why no spec yet |
+|---|---|---|
+| pkg55 | Wavefront SoA GPU refactor | Very large; defer until pkg54 megakernel lands and we have measured GPU spectral parity numbers. |
+| pkg56 | Incremental scene sync (depsgraph diff, BVH refit-only) | Large; would unlock pkg52's persistence value on big scenes but is its own architecture pass. |
+| pkg65 | scripts/ directory cleanup (`build/`, `diagnostics/`, `benchmarks/`, `data/`, `dev/` subfolders) | Trivial — can be done from a one-line description; no spec needed. |
+| pkg66 | Material iteration UX (one-sphere-per-material live preview operator) | Small; partly covered by `scripts/material_contact_sheet.py`. |
 
 **Astrophysics platform (Pillar 4):**
 

--- a/.astroray_plan/packages/pkg60-disney-energy-compensation.md
+++ b/.astroray_plan/packages/pkg60-disney-energy-compensation.md
@@ -1,0 +1,119 @@
+# pkg60 — Disney v2 Energy Compensation (No-Glow Materials)
+
+**Pillar:** 5
+**Track:** A or E (well-defined port — strong Codex fit)
+**Status:** open
+**Estimated effort:** 1-2 sessions (~6 h)
+**Depends on:** none — pure port of well-known math
+
+---
+
+## Goal
+
+**Before:** Astroray's Disney BRDF (`plugins/materials/disney.cpp`) has no energy compensation between its lobes. Stacking high roughness + sheen + clearcoat or driving roughness above ~0.6 makes the closure return more energy than the incoming radiance, and surfaces visibly *glow* — the project-owner-reported "materials seem to glow" bug from the 2026-05-08 triage.
+
+**After:** Disney closures are energy-conserving across the (roughness, metallic, sheen, clearcoat) parameter grid, matching Cycles' Principled BSDF v2 behavior to within a small tolerance. A regression test integrates the BSDF over the hemisphere on a Halton grid and asserts the directional-hemispherical reflectance is ≤ 1.0 across the parameter range.
+
+---
+
+## Context
+
+This is the most user-visible material bug after pkg59. Cycles ran into the same problem and shipped energy-compensation tables in the v2 Principled BSDF (Burley 2015 + Kulla & Conty 2017 directional-albedo tables, integrated into Cycles by Brecht Van Lommel circa Blender 4.0). The compensation is per-lobe: each microfacet lobe (GGX rough metal, GGX rough dielectric, sheen, clearcoat) gets a 32×32 LUT of `(cosTheta_o, alpha)` → directional albedo, and the sampler multiplies in `(1 - albedo) / albedo` to recover the energy lost to multiple scattering.
+
+The Cycles tables are CC0 / Apache-2.0 (Blender Foundation), so we can ship them directly under our license.
+
+---
+
+## Reference
+
+- **Math:** Kulla & Conty, "Revisiting Physically Based Shading at Imageworks", SIGGRAPH 2017 Course (open access). §"Energy Compensation".
+- **Cycles reference implementation** (CC0 / Apache-2.0):
+  - LUT generation: `intern/cycles/kernel/closure/bsdf_microfacet.h`, function `microfacet_ggx_E`.
+  - LUT data: `intern/cycles/kernel/data_template.h` and the corresponding `.bin` files in `intern/cycles/kernel/closure/precomputed_tables/`.
+  - Sheen compensation: `intern/cycles/kernel/closure/bsdf_sheen.h` (Conty & Kulla 2017 sheen + compensation).
+- **Burley 2015** "Extending the Disney BRDF to a BSDF with Integrated Subsurface Scattering" (proceedings).
+- Existing Astroray Disney code: [plugins/materials/disney.cpp](plugins/materials/disney.cpp).
+
+The implementer must do a fresh WebSearch + WebFetch pass (per CLAUDE.md §6) to confirm the exact Cycles file paths, license headers, and table dimensions before porting.
+
+---
+
+## Prerequisites
+
+- [ ] Existing Disney BSDF tests pass (`tests/test_disney*.py`) — establishes the no-regression baseline.
+- [ ] Confirm Cycles table license is compatible (Apache-2.0 / CC0). Save findings to `.astroray_plan/docs/disney-energy-compensation-research.md`.
+- [ ] Identify which Astroray Disney lobes need compensation: GGX rough metal (definitely), GGX rough dielectric (definitely), sheen (definitely), clearcoat (definitely).
+- [ ] Decide table format: Cycles uses a binary blob in `data/`. We can either embed as `constexpr` arrays or ship a `.bin` next to `data/spectra/rgb_to_spectrum_srgb.coeff`.
+
+---
+
+## Specification
+
+### Files to create
+
+| File | Purpose |
+|---|---|
+| `data/disney_compensation/ggx_E.bin` | 32×32 LUT for GGX rough metal/dielectric directional albedo. |
+| `data/disney_compensation/sheen_E.bin` | Sheen lobe directional albedo. |
+| `data/disney_compensation/clearcoat_E.bin` | Clearcoat (fixed alpha=0.25) 1D LUT. |
+| `include/astroray/energy_compensation.h` | Loader + bilinear sample helpers for the LUTs. |
+| `src/energy_compensation.cpp` | Implementation; lazy-load on first use; `ASTRORAY_DATA_DIR` resolution. |
+| `tests/test_disney_energy_conservation.py` | Halton-grid hemisphere integration; asserts directional-hemispherical reflectance ≤ 1.0 across the parameter range. |
+| `.astroray_plan/docs/disney-energy-compensation-research.md` | WebSearch findings + license confirmation + math derivation. |
+
+### Files to modify
+
+| File | What changes |
+|---|---|
+| [plugins/materials/disney.cpp](plugins/materials/disney.cpp) | In each lobe's `eval()` and `sample()`, multiply by the compensation factor `1 + (1 - E(cosTheta_o, alpha)) / E(cosTheta_o, alpha)` for metallic/dielectric. Sheen lobe gets its own compensation per Conty & Kulla. |
+| `CMakeLists.txt` | Install rule for `data/disney_compensation/` next to existing data files. |
+| [.astroray_plan/docs/STATUS.md](.astroray_plan/docs/STATUS.md) | Mark pkg60 active/done. |
+
+### Key design decisions
+
+1. **Port, do not derive.** Use the Cycles LUTs directly (license permitting). Generating new LUTs from scratch would require running a high-spp ground-truth Monte Carlo integration over the parameter grid — exactly the kind of work CLAUDE.md §6 says to borrow rather than redo.
+2. **CPU first.** Apply compensation only on the spectral CPU integrator. GPU compensation is a follow-up package — do not extend `gpu_materials.h` here.
+3. **LUTs are 32×32 (or whatever Cycles ships).** Bilinear interpolation. ~12 KB per LUT total. Embed as binary, not constexpr — easier to swap.
+4. **Cite in code.** Each multiplication site must cite "Kulla & Conty 2017 §X" and "Cycles `bsdf_microfacet.h:microfacet_ggx_E`". Per CLAUDE.md §6.
+5. **Energy-conservation test is the hard gate.** Render is not enough; we need a numerical proof that the BRDF integrates to ≤ 1.0 over the upper hemisphere across at least the parameter grid `(roughness ∈ {0.1, 0.3, 0.5, 0.7, 0.9}, metallic ∈ {0, 1}, sheen ∈ {0, 0.5, 1}, clearcoat ∈ {0, 0.5, 1})` at incident angles `cosTheta ∈ {0.1, 0.5, 0.9}`. 60 parameter combos × 3 angles = 180 integrations. 4096-sample Halton hemisphere integration each.
+6. **Visual regression on the contact sheet.** `scripts/material_contact_sheet.py` should still produce visually-similar images at low roughness (where compensation is small); high-roughness rows should look slightly brighter (recovered multi-scatter energy) but never blown out.
+
+---
+
+## Acceptance criteria
+
+- [ ] `.astroray_plan/docs/disney-energy-compensation-research.md` exists with paper citations + Cycles file paths + license confirmation.
+- [ ] Per-lobe directional-hemispherical reflectance ≤ 1.0 + ε (ε = 0.02) at every grid point.
+- [ ] No grid point has reflectance > 1.05 (loose upper bound — anything greater is a real bug).
+- [ ] Cornell-box reference render at 256 spp shows no visible glow on any object's high-roughness configuration.
+- [ ] Existing `tests/test_disney*.py` pass with within-noise differences (SSIM ≥ 0.95) at low roughness.
+- [ ] Material contact sheet (`scripts/material_contact_sheet.py`) regenerated and saved to `tests/reference/disney_contact_sheet_post_compensation.png`.
+
+---
+
+## Non-goals
+
+- Do not port to GPU. Separate package after pkg54 is in.
+- Do not change the Disney BRDF parameter set (no new sliders).
+- Do not implement subsurface compensation (separate Burley 2015 chapter).
+- Do not touch the spectral pipeline beyond what's needed for the compensation factor.
+
+---
+
+## Progress
+
+- [ ] Research note (WebSearch + WebFetch).
+- [ ] Owner sign-off on research note.
+- [ ] Port LUTs (or regenerate from Cycles' ground-truth code if license needs it).
+- [ ] Implement loader + bilinear sample in `src/energy_compensation.cpp`.
+- [ ] Wire into Disney lobes.
+- [ ] Hemisphere-integration test with 60 × 3 grid.
+- [ ] Cornell box visual regression.
+- [ ] Material contact sheet regen.
+- [ ] STATUS.md update.
+
+---
+
+## Lessons
+
+*(Fill in after the package is done.)*

--- a/.astroray_plan/packages/pkg63-world-hdri-parity.md
+++ b/.astroray_plan/packages/pkg63-world-hdri-parity.md
@@ -1,0 +1,114 @@
+# pkg63 — World / HDRI Parity (Mapping rotation, MIS env-map, color tint)
+
+**Pillar:** 5
+**Track:** A
+**Status:** open
+**Estimated effort:** 1 week (~20 h, multiple sessions)
+**Depends on:** pkg14 (spectral env map, done)
+
+---
+
+## Goal
+
+**Before:** The Blender addon's `setup_world` ([blender_addon/__init__.py](blender_addon/__init__.py:1827) area) reads only TEX_ENVIRONMENT → BACKGROUND → OUTPUT_WORLD with a single Z-rotation. Color multiplication on Background.Color is dropped, X/Y rotation in the Mapping node is dropped, Color-via-Mix node trees are dropped. The env map has no MIS importance sampling, so big-light HDRIs (sun-disc, window) produce extreme firefly noise that takes 2-4× more samples to converge. Project-owner triage: *"the current HDRI solution only works partially"*.
+
+**After:** Full Cycles-equivalent HDRI conversion: Mapping(Location, Rotation, Scale) on all three axes, Background color tint composed with TEX_ENVIRONMENT output, color via simple node-tree expressions (Mix/Color Ramp), and a CDF-built MIS importance sampler so HDRIs with bright concentrated regions converge in noise-floor time instead of firefly time.
+
+---
+
+## Context
+
+This is the final big "Cycles parity" item in the Pillar 5 push. After pkg52/pkg62/pkg58 the addon handles cameras, passes, and spectral profiles correctly; pkg59 handles UVs; pkg60 handles materials; pkg63 closes the world/lighting gap. After this lands, an arbitrary Cycles scene should render in Astroray with no visible "this looks wrong" lighting issues for HDRIs.
+
+The MIS env-map is the highest-leverage part: noise reduction is multiplicative with sample count and most production HDRIs (Poly Haven, IBL Maker output, sky models) have concentrated brightness.
+
+---
+
+## Reference
+
+- **Math:** Pharr, Jakob, Humphreys, *Physically Based Rendering* (4th ed.), Chapter 12.6 "Infinite Area Lights" — CDF-based importance sampling of an env map.
+- **Cycles reference implementation** (Apache-2.0):
+  - `intern/cycles/scene/light.cpp` — `LightManager::device_update_background` builds the conditional/marginal CDFs.
+  - `intern/cycles/kernel/light/background.h` — sampling and PDF evaluation.
+- Existing Astroray env code: [include/astroray/](include/astroray/) (search `EnvironmentMap`), `src/spectrum.cpp`. The spectral atlas from pkg14 is already on the device.
+- Existing addon world conversion: [`setup_world`](blender_addon/__init__.py:1827).
+
+The implementer must do a fresh WebSearch + WebFetch pass to confirm the PBRT v4 algorithm and Cycles file paths before porting.
+
+---
+
+## Prerequisites
+
+- [ ] pkg14 spectral env map is in (done).
+- [ ] Confirm `EnvironmentMap` exposes the spectral atlas via a stable C++ API (head pointer + dimensions). If not, surface that API first.
+- [ ] Confirm what direction convention Astroray's env map uses (latlong / equirectangular, +Z up, etc.) — Cycles uses latlong with +Z up.
+
+---
+
+## Specification
+
+### Files to create
+
+| File | Purpose |
+|---|---|
+| `tests/test_blender_world_hdri.py` | Stubbed Blender API tests for: Mapping XYZ rotation, Background color tint, color-via-Mix-node trees, env-map MIS sampling correctness. |
+| `tests/scenes/hdri_mis.py` | Test scene: a sun-disc HDRI on a Cornell box; with MIS, converges in <100 spp; without, fireflies for >1000 spp. |
+| `.astroray_plan/docs/world-hdri-research.md` | WebSearch findings: PBRT v4 §12.6 reference, Cycles file paths, math for the conditional/marginal CDF. |
+
+### Files to modify
+
+| File | What changes |
+|---|---|
+| [blender_addon/__init__.py](blender_addon/__init__.py) | Rewrite `setup_world` to: (1) walk Mapping for Location, Rotation (X/Y/Z), Scale; (2) follow Color input on Background through Mix/RGB nodes (reuse `_eval_color_socket_node` from pkg59 area); (3) compose tint with the env-map sample at lookup time. |
+| `include/astroray/spectral.h` (or wherever `EnvironmentMap` lives) | Add `EnvironmentMap::buildImportanceCDF()` (1D marginal over rows + 2D conditional per row, weighted by sin(theta)). Add `EnvironmentMap::sample(u, v) -> (direction, pdf)` and `EnvironmentMap::pdf(direction)`. |
+| `module/blender_module.cpp` | Bind XYZ rotation: `set_environment_rotation(rx, ry, rz)`. The current `load_environment_map(path, strength, rotation, ...)` only takes one float. |
+| `plugins/integrators/path_tracer.cpp` (or its spectral variant) | Use `envMap.sample/pdf` for env-MIS in the NEE light pick. Compose with existing area-light MIS via balance heuristic. |
+| [.astroray_plan/docs/STATUS.md](.astroray_plan/docs/STATUS.md) | Mark pkg63 active/done. |
+
+### Key design decisions
+
+1. **Port the algorithm, do not invent.** PBRT v4 §12.6 is the canonical reference; Cycles' implementation is the canonical port. CLAUDE.md §6 applies.
+2. **CDF is built at load time.** Image-resolution dependent (~512×256 typical → ~256 KB CDF). Built once, immutable. Spectral atlas does not need a per-wavelength CDF — luminance at canonical λ_ref is enough.
+3. **MIS via balance heuristic.** Each sample picks env-light vs surface-BSDF using the standard heuristic; matches what Cycles does and what existing Astroray ReSTIR work uses.
+4. **Mapping rotation order matches Blender's.** Blender uses XYZ Euler order on the Mapping node. Bake the 3x3 rotation matrix into the env lookup at convert time, not per-sample.
+5. **Color tint composes multiplicatively.** Cycles: `final = env_sample * background_color * background_strength`. Same here.
+6. **Color node-tree depth limit.** Reuse `_eval_color_socket_node`'s 8-deep limit (already in place from pkg59 work). Anything deeper falls back to a constant.
+
+---
+
+## Acceptance criteria
+
+- [ ] `.astroray_plan/docs/world-hdri-research.md` exists with PBRT v4 + Cycles citations and a license check.
+- [ ] Mapping(rotation X/Y/Z) on the env map produces visually correct rotated framing in three test renders (one per axis).
+- [ ] Background color tint multiplies the env sample (test: rendering with Background.Color = (0.5, 0.5, 0.5) gives half-brightness vs (1, 1, 1)).
+- [ ] Color via a `Mix(fac=0.5, A=blue, B=red)` Mix node produces a purple env tint.
+- [ ] HDRI with concentrated bright region (sun-disc test scene) converges to RMSE < 0.05 vs reference at ≤ 256 spp with MIS, but takes ≥ 1024 spp without MIS. The 4× ratio is the hard gate.
+- [ ] Existing addon and integrator tests still pass.
+
+---
+
+## Non-goals
+
+- Do not port the env CDF to GPU. Separate package (would pair naturally with pkg54).
+- Do not implement Sky Texture node conversion (Hosek-Wilkie / Nishita). Separate package — needs its own research note.
+- Do not change the env-map's spectral atlas representation from pkg14.
+- Do not implement env-map ReSTIR (Pillar 3 territory; needs separate validation).
+
+---
+
+## Progress
+
+- [ ] Research note (WebSearch + WebFetch).
+- [ ] Owner sign-off on research note.
+- [ ] CDF builder + sample/pdf methods on `EnvironmentMap`.
+- [ ] Path-tracer NEE wires env-MIS via balance heuristic.
+- [ ] Addon: Mapping XYZ rotation, color tint, color-node-tree expansion.
+- [ ] `set_environment_rotation` Python binding.
+- [ ] Test scene + MIS convergence comparison.
+- [ ] STATUS.md update.
+
+---
+
+## Lessons
+
+*(Fill in after the package is done.)*


### PR DESCRIPTION
Closes the spec gap from the 2026-05-08 triage — 10/15 packages had full specs, this adds the two highest-value missing ones plus a 'deferred' sub-table to capture pkg55/56/65/66 before they fall off the radar.

## pkg60 — Disney v2 Energy Compensation

Addresses the project-owner-reported "materials seem to glow" bug. Pure port from Cycles + Kulla & Conty 2017 LUTs (Apache-2.0 / CC0). Strong Codex fit. Acceptance gate: directional-hemispherical reflectance ≤ 1.0 across a 60-point parameter grid.

## pkg63 — World / HDRI Parity

Addresses "HDRI only works partially". Mapping XYZ rotation, color tint via node-tree expressions, and PBRT-v4-style CDF-based MIS env sampling. Hard gate: 4× spp ratio between with-MIS and without-MIS on a sun-disc test scene.

## Deferred capture

STATUS.md gains a 'Deferred / not-yet-spec'd' sub-table for pkg55 (wavefront refactor — defer until pkg54 lessons), pkg56 (incremental sync), pkg65 (scripts cleanup — one-liner), pkg66 (material iteration UX). Captures intent without committing to full specs prematurely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
