### PR TITLE
feat(pkg66): live one-sphere material preview operator

### DIFF
--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -416,6 +416,99 @@ class CustomRaytracerMaterialSettings(PropertyGroup):
         items=_spectral_profile_items,
         default="__none__",
     )
+    live_preview_resolution: EnumProperty(
+        name="Resolution",
+        description="Resolution for the one-sphere material preview",
+        items=[
+            ("64", "64 x 64", ""),
+            ("128", "128 x 128", ""),
+            ("256", "256 x 256", ""),
+        ],
+        default="64",
+    )
+    live_preview_samples: IntProperty(
+        name="Samples",
+        description="Samples per pixel for the one-sphere material preview",
+        min=1,
+        max=64,
+        default=8,
+    )
+
+
+def _preview_helpers():
+    try:
+        from _preview_helpers import render_material_preview, save_preview_png
+        return render_material_preview, save_preview_png
+    except ImportError:
+        helper_dir = Path(addon_dir).parent / "scripts" / "diagnostics"
+        if helper_dir.is_dir() and str(helper_dir) not in sys.path:
+            sys.path.insert(0, str(helper_dir))
+        from _preview_helpers import render_material_preview, save_preview_png
+        return render_material_preview, save_preview_png
+
+
+def _safe_preview_name(name: str) -> str:
+    safe = "".join(c if c.isalnum() or c in ("-", "_") else "_" for c in str(name))
+    return safe.strip("_") or "material"
+
+
+def _find_preview_hdri() -> str | None:
+    scenes_dir = Path(addon_dir) / "scenes"
+    if not scenes_dir.is_dir():
+        return None
+    for suffix in ("*.hdr", "*.exr", "*.hdri"):
+        match = next(scenes_dir.glob(suffix), None)
+        if match is not None:
+            return str(match)
+    return None
+
+
+def _save_preview_image(pixels, path: Path, resolution: int):
+    _, save_preview_png = _preview_helpers()
+    try:
+        return save_preview_png(pixels, path)
+    except Exception:
+        img = bpy.data.images.new("Astroray Material Preview", resolution, resolution, alpha=True, float_buffer=False)
+        rgba = np.ones((resolution, resolution, 4), dtype=np.float32)
+        rgba[..., :3] = np.clip(np.asarray(pixels, dtype=np.float32)[..., :3], 0.0, 1.0)
+        img.pixels.foreach_set(rgba.reshape(-1))
+        img.filepath_raw = str(path)
+        img.file_format = 'PNG'
+        img.save()
+        return path
+
+
+def _load_preview_image(path: str):
+    if not path or not os.path.exists(path):
+        return None
+    try:
+        return bpy.data.images.load(path, check_existing=True)
+    except Exception:
+        return None
+
+
+def _create_live_preview_material(renderer, mat):
+    if getattr(mat, "use_nodes", False) and getattr(mat, "node_tree", None):
+        engine = CustomRaytracerRenderEngine()
+        engine._volume_material_map = {}
+        return engine.convert_node_material(mat, renderer)
+
+    color = list(getattr(mat, "diffuse_color", [0.8, 0.8, 0.8])[:3])
+    mat_settings = getattr(mat, "custom_raytracer", None)
+    if mat_settings is None:
+        return renderer.create_material("disney", color, {})
+    if not getattr(mat_settings, "use_disney", True):
+        mat_type = getattr(mat_settings, "material_type", "lambertian") or "lambertian"
+        return renderer.create_material(mat_type, color, {})
+    params = {
+        "metallic": float(getattr(mat_settings, "metallic", 0.0)),
+        "roughness": float(getattr(mat_settings, "roughness", 0.5)),
+        "transmission": float(getattr(mat_settings, "transmission", 0.0)),
+        "ior": float(getattr(mat_settings, "ior", 1.45)),
+        "clearcoat": float(getattr(mat_settings, "clearcoat", 0.0)),
+        "clearcoat_gloss": float(getattr(mat_settings, "clearcoat_gloss", 1.0)),
+    }
+    return renderer.create_material("disney", color, params)
 
 class CustomRaytracerRenderEngine(RenderEngine):
     bl_idname = "CUSTOM_RAYTRACER"
@@ -3015,6 +3108,86 @@ class MATERIAL_PT_AstroraySpectralPreview(AstrorayPanelBase, Panel):
             vals = [s[1] for s in samples]
             layout.label(text=f"Reflectance: min {min(vals):.2f}, max {max(vals):.2f}")
 
+
+class MATERIAL_OT_astroray_live_preview(Operator):
+    bl_idname = "material.astroray_live_preview"
+    bl_label = "Render Preview"
+    bl_description = "Render the active material on an isolated Astroray preview sphere"
+
+    def execute(self, context):
+        if not RAYTRACER_AVAILABLE:
+            self.report({'ERROR'}, "astroray module not loaded")
+            return {'CANCELLED'}
+
+        obj = getattr(context, "active_object", None)
+        mat = getattr(obj, "active_material", None) if obj is not None else None
+        mat = mat or getattr(context, "material", None)
+        if mat is None:
+            self.report({'ERROR'}, "No active material")
+            return {'CANCELLED'}
+
+        mat_settings = getattr(mat, "custom_raytracer", None)
+        resolution = int(getattr(mat_settings, "live_preview_resolution", "64") or "64")
+        samples = int(getattr(mat_settings, "live_preview_samples", 8) or 8)
+
+        start = time.perf_counter()
+        renderer = astroray.Renderer()
+        mat_id = _create_live_preview_material(renderer, mat)
+        render_material_preview, _ = _preview_helpers()
+        pixels = render_material_preview(
+            renderer,
+            mat_id,
+            resolution,
+            samples,
+            max_depth=4,
+            hdri_path=_find_preview_hdri(),
+        )
+
+        out = Path("test_results") / f"material_preview_{_safe_preview_name(mat.name)}.png"
+        _save_preview_image(pixels, out, resolution)
+        mat["astroray_preview_path"] = str(out)
+        _load_preview_image(str(out))
+
+        elapsed = time.perf_counter() - start
+        self.report({'INFO'}, f"Rendered Astroray preview in {elapsed:.2f}s")
+        return {'FINISHED'}
+
+
+class MATERIAL_PT_AstrorayLivePreview(AstrorayPanelBase, Panel):
+    bl_label = "Live Material Preview"
+    bl_space_type = 'PROPERTIES'
+    bl_region_type = 'WINDOW'
+    bl_context = "material"
+    bl_parent_id = "MATERIAL_PT_custom_raytracer_surface"
+    bl_options = {'DEFAULT_CLOSED'}
+
+    @classmethod
+    def poll(cls, context):
+        return (context.scene.render.engine == 'CUSTOM_RAYTRACER'
+                and context.material is not None)
+
+    def draw(self, context):
+        layout = self.layout
+        mat = context.material
+        mat_settings = getattr(mat, "custom_raytracer", None)
+        if mat_settings is None:
+            layout.label(text="Material settings unavailable", icon='ERROR')
+            return
+
+        layout.use_property_split = True
+        layout.use_property_decorate = False
+        layout.prop(mat_settings, "live_preview_resolution")
+        layout.prop(mat_settings, "live_preview_samples")
+        layout.operator("material.astroray_live_preview", icon='RENDER_STILL')
+
+        img = _load_preview_image(mat.get("astroray_preview_path", ""))
+        if img is not None:
+            try:
+                layout.template_preview(img, show_buttons=False)
+            except Exception:
+                pass
+
+
 class CustomRaytracerPreferences(AddonPreferences):
     bl_idname = __name__
     debug_mode: BoolProperty(name="Debug Mode", default=False)
@@ -3097,6 +3270,8 @@ classes = [
     WORLD_PT_custom_raytracer_surface,
     MATERIAL_PT_custom_raytracer_surface,
     MATERIAL_PT_AstroraySpectralPreview,
+    MATERIAL_OT_astroray_live_preview,
+    MATERIAL_PT_AstrorayLivePreview,
     CustomRaytracerPreferences,
     ASTRORAY_OT_add_black_hole, OBJECT_PT_astroray_black_hole,
 ]

--- a/scripts/build/build_blender_addon.py
+++ b/scripts/build/build_blender_addon.py
@@ -780,6 +780,10 @@ def stage_and_zip(module_path: Path, backend: str = "cpu") -> Path:
             sys.exit(f"error: missing addon file {src}")
         shutil.copy2(src, STAGE_DIR / name)
 
+    preview_helpers = REPO_ROOT / "scripts" / "diagnostics" / "_preview_helpers.py"
+    if preview_helpers.exists():
+        shutil.copy2(preview_helpers, STAGE_DIR / "_preview_helpers.py")
+
     # pkg58: ship reference IR/UV scenes (optional in source tree).
     scenes_src = ADDON_SRC / "scenes"
     if scenes_src.is_dir():

--- a/scripts/diagnostics/_preview_helpers.py
+++ b/scripts/diagnostics/_preview_helpers.py
@@ -1,0 +1,58 @@
+"""Shared one-sphere material preview helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+
+def add_preview_scene(renderer, material_id: int, resolution: int, hdri_path: str | Path | None = None) -> None:
+    renderer.set_integrator("path_tracer")
+    if hasattr(renderer, "set_seed"):
+        renderer.set_seed(12661)
+
+    loaded_hdri = False
+    if hdri_path and hasattr(renderer, "load_environment_map"):
+        try:
+            loaded_hdri = bool(renderer.load_environment_map(str(hdri_path), 0.7, 0.0, True))
+        except TypeError:
+            loaded_hdri = bool(renderer.load_environment_map(str(hdri_path)))
+    if not loaded_hdri:
+        renderer.set_background_color([0.18, 0.19, 0.21])
+
+    sun = renderer.create_material("light", [1.0, 0.96, 0.88], {"intensity": 2.8})
+    if hasattr(renderer, "add_sun_light"):
+        renderer.add_sun_light([-0.45, -0.75, -0.48], 0.53, sun)
+    else:
+        renderer.add_sphere([-1.8, 2.4, 2.1], 0.25, sun)
+
+    renderer.add_sphere([0.0, 0.0, 0.0], 0.9, material_id)
+    renderer.setup_camera(
+        look_from=[0.0, 0.25, 3.3],
+        look_at=[0.0, 0.02, 0.0],
+        vup=[0.0, 1.0, 0.0],
+        vfov=32.0,
+        aspect_ratio=1.0,
+        aperture=0.0,
+        focus_dist=3.3,
+        width=resolution,
+        height=resolution,
+    )
+
+
+def render_material_preview(renderer, material_id: int, resolution: int, samples: int,
+                            max_depth: int = 4, hdri_path: str | Path | None = None) -> np.ndarray:
+    add_preview_scene(renderer, material_id, resolution, hdri_path)
+    return np.asarray(renderer.render(samples, max_depth, None, True), dtype=np.float32)
+
+
+def save_preview_png(pixels: np.ndarray, path: str | Path) -> Path:
+    from PIL import Image
+
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    pixels = np.asarray(pixels, dtype=np.float32)
+    img_uint8 = (np.clip(pixels[..., :3], 0.0, 1.0) * 255).astype(np.uint8)
+    Image.fromarray(img_uint8).save(out)
+    return out

--- a/scripts/diagnostics/material_contact_sheet.py
+++ b/scripts/diagnostics/material_contact_sheet.py
@@ -26,6 +26,7 @@ from runtime_setup import configure_test_imports  # noqa: E402
 configure_test_imports()
 
 import astroray  # noqa: E402
+from _preview_helpers import render_material_preview, save_preview_png  # noqa: E402
 
 
 MATERIALS = [
@@ -54,34 +55,6 @@ MATERIALS = [
     ("line_532nm", "line_emitter", [1.0, 1.0, 1.0], {"wavelength_nm": 532.0, "bandwidth_nm": 8.0, "intensity": 1.1}),
     ("line_460nm", "line_emitter", [1.0, 1.0, 1.0], {"wavelength_nm": 460.0, "bandwidth_nm": 8.0, "intensity": 1.1}),
 ]
-
-def _save_png(pixels: np.ndarray, path: Path) -> None:
-    from PIL import Image
-    path.parent.mkdir(parents=True, exist_ok=True)
-    img_uint8 = (np.clip(pixels, 0, 1) * 255).astype(np.uint8)
-    Image.fromarray(img_uint8).save(path)
-
-
-def _add_room(r, width: int, height: int) -> None:
-    floor = r.create_material("lambertian", [0.58, 0.58, 0.56], {})
-    light = r.create_material("light", [1.0, 0.96, 0.88], {"intensity": 7.0})
-    r.add_triangle([-4, -1, -4], [4, -1, -4], [4, -1, 4], floor)
-    r.add_triangle([-4, -1, -4], [4, -1, 4], [-4, -1, 4], floor)
-    r.add_triangle([-1.3, 3.2, -1.2], [1.3, 3.2, -1.2], [1.3, 3.2, 1.2], light)
-    r.add_triangle([-1.3, 3.2, -1.2], [1.3, 3.2, 1.2], [-1.3, 3.2, 1.2], light)
-    r.set_background_color([0.06, 0.07, 0.08])
-    r.setup_camera(
-        look_from=[0.0, 0.55, 4.0],
-        look_at=[0.0, -0.05, 0.0],
-        vup=[0.0, 1.0, 0.0],
-        vfov=34.0,
-        aspect_ratio=width / height,
-        aperture=0.0,
-        focus_dist=4.0,
-        width=width,
-        height=height,
-    )
-
 
 def _select_device(r, requested: str, caps: dict) -> tuple[str, str]:
     if requested == "cpu":
@@ -113,14 +86,10 @@ def _select_device(r, requested: str, caps: dict) -> tuple[str, str]:
 def render_tile(name: str, material_type: str, color: list[float], params: dict,
                 resolution: int, samples: int, max_depth: int, device: str) -> tuple[np.ndarray, str, str, dict]:
     r = astroray.Renderer()
-    r.set_integrator("path_tracer")
-    r.set_seed(1000 + sum(ord(c) for c in name))
-    _add_room(r, resolution, resolution)
     mat = r.create_material(material_type, color, params)
     caps = dict(r.get_material_backend_capabilities(mat))
     device_label, backend_reason = _select_device(r, device, caps)
-    r.add_sphere([0.0, 0.0, 0.0], 0.85, mat)
-    pixels = np.asarray(r.render(samples, max_depth, None, True), dtype=np.float32)
+    pixels = render_material_preview(r, mat, resolution, samples, max_depth)
     return pixels, device_label, backend_reason, caps
 
 
@@ -197,7 +166,7 @@ def main() -> int:
             args.resolution, args.samples,
             args.max_depth, args.device)
         seconds = time.perf_counter() - start
-        _save_png(pixels, args.output_dir / f"{name}.png")
+        save_preview_png(pixels, args.output_dir / f"{name}.png")
         renders.append((name, pixels))
         lum = 0.2126 * pixels[..., 0] + 0.7152 * pixels[..., 1] + 0.0722 * pixels[..., 2]
         stats.append({

--- a/tests/test_blender_material_preview.py
+++ b/tests/test_blender_material_preview.py
@@ -1,0 +1,182 @@
+"""pkg66: Blender live material preview operator tests."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+
+
+def _load_blender_addon(monkeypatch, renderer_cls):
+    bpy_module = types.ModuleType("bpy")
+    bpy_types_module = types.ModuleType("bpy.types")
+    bpy_props_module = types.ModuleType("bpy.props")
+
+    registered = []
+
+    class _Base:
+        def report(self, *_args):
+            pass
+
+    class _RenderEngineBase(_Base):
+        pass
+
+    class _Images:
+        def load(self, *_args, **_kwargs):
+            return None
+
+        def new(self, *_args, **_kwargs):
+            return types.SimpleNamespace(
+                pixels=types.SimpleNamespace(foreach_set=lambda *_a: None),
+                save=lambda: None,
+                filepath_raw="",
+                file_format="PNG",
+            )
+
+    bpy_types_module.Panel = _Base
+    bpy_types_module.Operator = _Base
+    bpy_types_module.AddonPreferences = _Base
+    bpy_types_module.PropertyGroup = _Base
+    bpy_types_module.RenderEngine = _RenderEngineBase
+    bpy_types_module.Scene = type("Scene", (), {})
+    bpy_types_module.Material = type("Material", (), {})
+    bpy_types_module.Object = type("Object", (), {})
+    bpy_module.types = bpy_types_module
+    bpy_module.data = types.SimpleNamespace(materials=[], images=_Images())
+    bpy_module.path = types.SimpleNamespace(abspath=lambda p: p)
+    bpy_module.utils = types.SimpleNamespace(
+        register_class=lambda cls: registered.append(cls),
+        unregister_class=lambda cls: None,
+    )
+    for name in [
+        "BoolProperty", "IntProperty", "FloatProperty", "StringProperty",
+        "PointerProperty", "FloatVectorProperty", "EnumProperty",
+    ]:
+        setattr(bpy_props_module, name, lambda **kwargs: kwargs.get("default"))
+    bpy_module.props = bpy_props_module
+
+    astroray_module = types.ModuleType("astroray")
+    astroray_module.__version__ = "test"
+    astroray_module.__features__ = {}
+    astroray_module.Renderer = renderer_cls
+    astroray_module.material_registry_names = lambda: ["lambertian", "disney", "light"]
+    astroray_module.integrator_registry_names = lambda: ["path_tracer"]
+    astroray_module.integrator_capabilities = lambda _name: {}
+
+    monkeypatch.setitem(sys.modules, "bpy", bpy_module)
+    monkeypatch.setitem(sys.modules, "bpy.types", bpy_types_module)
+    monkeypatch.setitem(sys.modules, "bpy.props", bpy_props_module)
+    monkeypatch.setitem(sys.modules, "astroray", astroray_module)
+    monkeypatch.setitem(sys.modules, "mathutils", types.ModuleType("mathutils"))
+
+    module_path = Path(__file__).parent.parent / "blender_addon" / "__init__.py"
+    spec = importlib.util.spec_from_file_location("astroray_blender_addon_preview_test", module_path)
+    addon = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = addon
+    spec.loader.exec_module(addon)
+    addon._registered_classes = registered
+    return addon
+
+
+class _PreviewRenderer:
+    instances = []
+
+    def __init__(self):
+        self.created_materials = []
+        self.render_calls = []
+        self.camera = None
+        _PreviewRenderer.instances.append(self)
+
+    def set_integrator(self, name):
+        self.integrator = name
+
+    def set_seed(self, seed):
+        self.seed = seed
+
+    def set_background_color(self, color):
+        self.background = color
+
+    def create_material(self, mat_type, color, params):
+        mat_id = len(self.created_materials) + 1
+        self.created_materials.append((mat_id, mat_type, list(color), dict(params)))
+        return mat_id
+
+    def add_sun_light(self, direction, angular_diameter, material_id):
+        self.sun = (list(direction), angular_diameter, material_id)
+
+    def add_sphere(self, center, radius, material_id):
+        self.sphere = (list(center), radius, material_id)
+
+    def setup_camera(self, *args, **kwargs):
+        self.camera = (args, kwargs)
+
+    def render(self, samples, max_depth, progress_callback=None, apply_gamma=True):
+        self.render_calls.append((samples, max_depth, progress_callback, apply_gamma))
+        return np.ones((4, 4, 3), dtype=np.float32) * 0.5
+
+
+class _Material(dict):
+    name = "Preview Mat"
+    use_nodes = False
+    node_tree = None
+    diffuse_color = [0.25, 0.5, 0.75, 1.0]
+
+    def __init__(self):
+        super().__init__()
+        self.custom_raytracer = types.SimpleNamespace(
+            live_preview_resolution="128",
+            live_preview_samples=13,
+            use_disney=True,
+            metallic=0.0,
+            roughness=0.5,
+            transmission=0.0,
+            ior=1.45,
+            clearcoat=0.0,
+            clearcoat_gloss=1.0,
+        )
+
+
+def test_live_preview_operator_is_registered(monkeypatch):
+    addon = _load_blender_addon(monkeypatch, _PreviewRenderer)
+    addon.register()
+
+    assert any(cls.__name__ == "MATERIAL_OT_astroray_live_preview"
+               for cls in addon._registered_classes)
+
+
+def test_live_preview_operator_generates_file(monkeypatch):
+    addon = _load_blender_addon(monkeypatch, _PreviewRenderer)
+    mat = _Material()
+    context = types.SimpleNamespace(
+        material=mat,
+        active_object=types.SimpleNamespace(active_material=mat),
+    )
+
+    result = addon.MATERIAL_OT_astroray_live_preview().execute(context)
+
+    assert result == {'FINISHED'}
+    path = Path(mat["astroray_preview_path"])
+    assert path.exists()
+    assert path.stat().st_size > 0
+
+
+def test_live_preview_honors_resolution_and_samples(monkeypatch):
+    _PreviewRenderer.instances.clear()
+    addon = _load_blender_addon(monkeypatch, _PreviewRenderer)
+    mat = _Material()
+    mat.custom_raytracer.live_preview_resolution = "256"
+    mat.custom_raytracer.live_preview_samples = 21
+    context = types.SimpleNamespace(
+        material=mat,
+        active_object=types.SimpleNamespace(active_material=mat),
+    )
+
+    addon.MATERIAL_OT_astroray_live_preview().execute(context)
+
+    renderer = _PreviewRenderer.instances[-1]
+    assert renderer.render_calls[-1] == (21, 4, None, True)
+    assert renderer.camera[1]["width"] == 256
+    assert renderer.camera[1]["height"] == 256


### PR DESCRIPTION
## Summary
- add a Material Properties live preview section with resolution/sample controls and a render operator
- render the active material on a one-sphere Astroray preview scene and save test_results/material_preview_<material>.png
- extract shared one-sphere preview helpers for material_contact_sheet.py and package the helper with the addon

## Verification
- pytest tests/test_blender_material_preview.py tests/test_blender_backend_policy.py tests/test_blender_principled_texture.py tests/test_blender_uv_plumbing.py tests/test_spectral_profile_ui.py -q --tb=short
- pytest tests/ -q --tb=short
- default helper timing: 64x64, 8 spp, 0.0175s local CPU