### PR TITLE
feat(pkg59): named UV layers (closes pkg59)

### DIFF
--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -22,7 +22,7 @@ personally should pick up.
   not CUDA kernels.
 - Pillar 5 is the active practical queue. The Cycles-parity/Blender package
   series is now the live near-term roadmap: pkg52/pkg53/pkg58/pkg60/pkg61/pkg62
-  are done, pkg59 is partial, and pkg54/pkg57 remain open.
+  are done, pkg59 is done, and pkg54/pkg57 remain open.
 - Fresh local collection on this branch: `pytest --collect-only -q` reports
   **435 tests collected** (2026-05-09). Focused pkg53/viewport checks pass.
 - Historical docs that are intentionally not current: `NEXT_STAGE_REPORT.md`
@@ -40,7 +40,7 @@ personally should pick up.
 | 2 | Spectral core | **Done** | 100% | — | — |
 | 3 | Light transport | **Validation** | 90% | NRC batched-inference speedup target | CUDA kernels for ReSTIR/NRC are not implemented |
 | 4 | Astrophysics platform | Preparation | 5% | Kerr metric extraction | Pillars 1, 2 complete; backend parity bridge recommended before GPU parity claims |
-| 5 | Production polish / Blender parity | Ongoing | — | finish pkg59 or start pkg54/pkg57 | — |
+| 5 | Production polish / Blender parity | Ongoing | — | start pkg54/pkg57 | — |
 
 **Pillar 1 package summary:**
 
@@ -119,7 +119,7 @@ is currently the weakest link.
 | pkg54 | GPU multi-wavelength path tracer (CPU/GPU parity) | open | A |
 | pkg57 | Native Astroray shader nodes (with Cycles compat) | open | A |
 | pkg58 | Spectral profile dropdown + IR/UV reference scenes | **done** | B |
-| pkg59 | Shader-graph vector / UV plumbing (texture routing, Mapping scale/offset/rotation, coord_mode, uv_debug_aov; named UV layers remain — separate package) | mostly done | A |
+| pkg59 | Shader-graph vector / UV plumbing (texture routing, Mapping scale/offset/rotation, coord_mode, uv_debug_aov, named UV layers) | **done** | A |
 | pkg60 | Disney v2 energy compensation (no-glow materials) | **done** | A/E |
 | pkg61 | GPU per-vertex normals (shade-smooth parity) | **done** | A/E |
 | pkg62 | Viewport pass selector + live OIDN preview | **done** | B |
@@ -181,7 +181,7 @@ forgotten):
   compensation tables are loaded from data files, the old additive roughness
   boost was removed, Disney spec/clearcoat eval was corrected, and the
   270-case Halton furnace grid measured worst-case reflectance **1.015891**.
-- Recommended next-up order: **finish pkg59 → pkg54 → pkg57**.
+- Recommended next-up order: **pkg54 → pkg57**.
   pkg64 and pkg67 require a research note signed off by
   the project owner before code starts; CLAUDE.md §6 covers the policy.
 
@@ -278,7 +278,7 @@ events are summarized in the changelog below.
 | pkg54 | A | open | GPU multi-wavelength CUDA kernel work |
 | pkg57 | A | open | native shader nodes / Cycles compatibility design |
 | pkg58 | B | **done** | — |
-| pkg59 | A | partial | broader vector/UV/Mapping plumbing and UV debug AOV |
+| pkg59 | A | done | broader vector/UV/Mapping plumbing, named UV layers, and UV debug AOV |
 | pkg61 | A/E | **done** | broader CPU/GPU spectral parity tracked separately |
 | pkg62 | B | **done** | — |
 | pkg64 | A | research blocked | caustics research note |
@@ -310,7 +310,7 @@ events are summarized in the changelog below.
   dispatch on the GPU all remain CPU-only follow-ups. pkg36 expands shared
   closure lowering.
 - The Blender addon backend UI/packaging refresh from pkg37 is complete.
-  Remaining Blender parity work is narrower: pkg57/pkg59 shader graph
+  Remaining Blender parity work is narrower: pkg57 shader graph
   fidelity and pkg54 multi-wavelength GPU parity. pkg52 persistent viewport
   sessions and pkg62 viewport pass/OIDN UX are complete on `origin/main` plus
   the current pkg52 branch.
@@ -331,6 +331,11 @@ events are summarized in the changelog below.
 ## Changelog
 
 Brief notes on notable events.
+
+- **2026-05-09** — pkg59 done. Named UV layers now upload through
+  `add_triangle_layers`, textures can select a layer via Texture
+  Coordinate/UV Map node names, and the same image used with different UV
+  layers gets distinct texture cache entries.
 
 - **2026-05-09** — pkg60 complete (PR #178, Codex). Disney v2 energy
   compensation: ported Cycles-derived GGX + sheen LUTs, replaced Disney's

--- a/.astroray_plan/packages/pkg59-shader-graph-uv-vector.md
+++ b/.astroray_plan/packages/pkg59-shader-graph-uv-vector.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 5
 **Track:** A
-**Status:** mostly done (named UV layers remain — separate package)
+**Status:** **done**
 **Estimated effort:** 1-2 sessions (~6 h)
 **Depends on:** none
 
@@ -32,7 +32,7 @@ This is the texture / PBR bug from your screenshot. The black face is a separate
 
 ## Prerequisites
 
-- [ ] Confirm what coordinate spaces the Astroray sampler supports today. Likely only "UV from active layer". This package adds: named UV layers, Generated, Object, plus Mapping transforms.
+- [x] Confirm what coordinate spaces the Astroray sampler supports today. The sampler now supports UV, Generated, Object, Mapping transforms, and named UV-layer selection.
 - [ ] Confirm whether the C++ side already supports per-texture UV transform (scale/offset/rotation). If not, add a `TextureTransform` struct or fold the transform into the sampler call site.
 
 ---
@@ -72,7 +72,7 @@ This is the texture / PBR bug from your screenshot. The black face is a separate
 - [x] A Mapping node with scale=2 between Texture Coordinate.UV and Image Texture doubles the texture frequency. (PR #173)
 - [x] A Mapping node with rotation rotates the sampled UVs.
 - [x] `uv_debug_aov` pass plugin writes a UV-as-color image (R=u, G=v).
-- [ ] A material that references a non-active UV layer by name renders correctly. **Deferred — separate package.**
+- [x] A material that references a non-active UV layer by name renders correctly.
 - [x] Tests pass (56 Blender addon tests).
 
 ---
@@ -88,11 +88,11 @@ This is the texture / PBR bug from your screenshot. The black face is a separate
 ## Progress
 
 - [x] Trace the screenshot's first failure: Image Texture → Principled Base Color was not reaching a textured material.
-- [ ] Add `_resolve_vector_input` and the named-UV upload path.
-- [ ] Add `TextureTransform` to the sampler call site.
-- [ ] Implement Generated and Object coord spaces.
-- [ ] Add the `uv_debug` AOV.
-- [ ] Tests.
+- [x] Add `_resolve_vector_input` and the named-UV upload path.
+- [x] Add `TextureTransform` to the sampler call site.
+- [x] Implement Generated and Object coord spaces.
+- [x] Add the `uv_debug` AOV.
+- [x] Tests.
 
 ---
 
@@ -101,5 +101,6 @@ This is the texture / PBR bug from your screenshot. The black face is a separate
 - PR #164 fixed the first production blocker by routing Image Texture →
   Principled Base Color into a textured Lambertian material and adding
   `tests/test_blender_principled_texture.py`.
-- The package is still partial: named UV layers, Mapping transforms,
-  Generated/Object coordinates, and the UV debug AOV remain open.
+- PRs #164, #173, #176, and the named-UV follow-up completed the original
+  texture routing, Mapping transform, Generated/Object coordinate, UV debug
+  AOV, and named UV-layer scope.

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -1654,7 +1654,7 @@ class CustomRaytracerRenderEngine(RenderEngine):
     @staticmethod
     def _resolve_vector_input(vector_socket, depth=0):
         """Walk the Vector input on a TEX_IMAGE / procedural texture node and
-        return ``(coord_mode, scale_xy, offset_xy, rotation_z)``:
+        return ``(coord_mode, scale_xy, offset_xy, rotation_z, uv_layer_name)``:
 
         - ``coord_mode``: one of "UV", "GENERATED", "OBJECT" — passed straight
           to ``renderer.set_texture_coord_mode``. Other Texture Coordinate
@@ -1673,14 +1673,15 @@ class CustomRaytracerRenderEngine(RenderEngine):
         scale = (1.0, 1.0)
         offset = (0.0, 0.0)
         rotation = 0.0
+        uv_layer_name = ""
         if depth > 4 or vector_socket is None or not getattr(vector_socket, 'is_linked', False):
-            return coord_mode, scale, offset, rotation
+            return coord_mode, scale, offset, rotation, uv_layer_name
         try:
             link = vector_socket.links[0]
             src = link.from_node
             src_socket_name = link.from_socket.name
         except (IndexError, AttributeError):
-            return coord_mode, scale, offset, rotation
+            return coord_mode, scale, offset, rotation, uv_layer_name
 
         ntype = getattr(src, 'type', None)
         if ntype == 'MAPPING':
@@ -1711,53 +1712,54 @@ class CustomRaytracerRenderEngine(RenderEngine):
                     pass
             # Recurse to find the upstream coord source.
             inner_socket = src.inputs.get('Vector') if hasattr(src, 'inputs') else None
-            inner_coord, _inner_scale, _inner_offset, _inner_rot = \
+            inner_coord, _inner_scale, _inner_offset, _inner_rot, inner_layer = \
                 CustomRaytracerRenderEngine._resolve_vector_input(inner_socket, depth + 1)
-            return inner_coord, scale, offset, rotation
+            return inner_coord, scale, offset, rotation, inner_layer
 
         if ntype == 'TEX_COORD':
             if src_socket_name == 'Generated':
-                return "GENERATED", scale, offset, rotation
+                return "GENERATED", scale, offset, rotation, uv_layer_name
             if src_socket_name == 'Object':
-                return "OBJECT", scale, offset, rotation
+                return "OBJECT", scale, offset, rotation, uv_layer_name
+            if src_socket_name == 'UV':
+                return "UV", scale, offset, rotation, getattr(src, 'uv_map', '') or ""
             # 'UV' (default), 'Camera', 'Window', 'Reflection', 'Normal' →
             # fall through to "UV". A future package can extend this.
-            return "UV", scale, offset, rotation
+            return "UV", scale, offset, rotation, uv_layer_name
 
-        # UV Map node (Blender's named-UV-layer source). The active UV layer
-        # is what we ship today; the layer name is recorded on the node but
-        # named UV layer routing is a separate package (structural change to
-        # the per-triangle UV upload).
         if ntype == 'UVMAP':
-            return "UV", scale, offset, rotation
+            return "UV", scale, offset, rotation, getattr(src, 'uv_map', '') or ""
 
-        return coord_mode, scale, offset, rotation
+        return coord_mode, scale, offset, rotation, uv_layer_name
 
     @staticmethod
-    def _is_default_uv_transform(coord_mode, scale, offset, rotation):
+    def _is_default_uv_transform(coord_mode, scale, offset, rotation, uv_layer_name=""):
         return (coord_mode == "UV"
                 and abs(scale[0] - 1.0) < 1e-6 and abs(scale[1] - 1.0) < 1e-6
                 and abs(offset[0]) < 1e-6 and abs(offset[1]) < 1e-6
-                and abs(rotation) < 1e-6)
+                and abs(rotation) < 1e-6
+                and not uv_layer_name)
 
     @staticmethod
-    def _texture_variant_key(base_name, coord_mode, scale, offset, rotation):
+    def _texture_variant_key(base_name, coord_mode, scale, offset, rotation, uv_layer_name=""):
         """Cache key that distinguishes the same image used with different
         Mapping or coord-mode wiring across materials."""
         if CustomRaytracerRenderEngine._is_default_uv_transform(
-                coord_mode, scale, offset, rotation):
+                coord_mode, scale, offset, rotation, uv_layer_name):
             return base_name
         return (f"{base_name}::{coord_mode}::"
                 f"{scale[0]:.4f},{scale[1]:.4f},"
                 f"{offset[0]:.4f},{offset[1]:.4f},"
-                f"{rotation:.4f}")
+                f"{rotation:.4f}::{uv_layer_name}")
 
     def _apply_texture_transform(self, renderer, tex_name, coord_mode,
-                                 scale, offset, rotation):
+                                 scale, offset, rotation, uv_layer_name=""):
         """Push coord_mode + UV transform to the C++ side (no-ops if default)."""
         try:
             if coord_mode != "UV":
                 renderer.set_texture_coord_mode(tex_name, coord_mode)
+            if uv_layer_name and hasattr(renderer, "set_texture_uv_layer"):
+                renderer.set_texture_uv_layer(tex_name, uv_layer_name)
             non_identity = (
                 abs(scale[0] - 1.0) >= 1e-6 or abs(scale[1] - 1.0) >= 1e-6
                 or abs(offset[0]) >= 1e-6 or abs(offset[1]) >= 1e-6
@@ -1790,8 +1792,8 @@ class CustomRaytracerRenderEngine(RenderEngine):
         """
         if bpy_image is None:
             return None
-        coord_mode, scale, offset, rotation = self._resolve_vector_input(vector_input)
-        cache_key = self._texture_variant_key(bpy_image.name, coord_mode, scale, offset, rotation)
+        coord_mode, uv_scale, offset, rotation, uv_layer_name = self._resolve_vector_input(vector_input)
+        cache_key = self._texture_variant_key(bpy_image.name, coord_mode, uv_scale, offset, rotation, uv_layer_name)
 
         # Deduplicate: a single (image, transform) pair is uploaded at most
         # once per conversion pass.
@@ -1825,7 +1827,7 @@ class CustomRaytracerRenderEngine(RenderEngine):
             rgb = pixels[:, :, :3].reshape(-1).tolist()
 
             renderer.load_texture(cache_key, rgb, width, height)
-            self._apply_texture_transform(renderer, cache_key, coord_mode, scale, offset, rotation)
+            self._apply_texture_transform(renderer, cache_key, coord_mode, uv_scale, offset, rotation, uv_layer_name)
             cache[cache_key] = cache_key
             return cache_key
         except Exception as e:
@@ -1851,8 +1853,8 @@ class CustomRaytracerRenderEngine(RenderEngine):
         # with different Mapping wiring gets distinct entries. A procedural
         # node only has one Vector input in practice, so the same id+vector
         # combination is always identical — the variant key is defensive.
-        coord_mode, scale, offset, rotation = self._resolve_vector_input(vector_input)
-        cache_key = self._texture_variant_key(f"_proc_{id(node)}", coord_mode, scale, offset, rotation)
+        coord_mode, uv_scale, offset, rotation, uv_layer_name = self._resolve_vector_input(vector_input)
+        cache_key = self._texture_variant_key(f"_proc_{id(node)}", coord_mode, uv_scale, offset, rotation, uv_layer_name)
         if cache_key in cache:
             return cache[cache_key]
         node_id = id(node)
@@ -1935,7 +1937,7 @@ class CustomRaytracerRenderEngine(RenderEngine):
             return None
 
         if tex_name:
-            self._apply_texture_transform(renderer, tex_name, coord_mode, scale, offset, rotation)
+            self._apply_texture_transform(renderer, tex_name, coord_mode, uv_scale, offset, rotation, uv_layer_name)
             cache[cache_key] = tex_name
         return tex_name
 
@@ -2471,7 +2473,15 @@ class CustomRaytracerRenderEngine(RenderEngine):
             # split_normals carries the correct per-corner normal for
             # smooth/flat/custom shading. Available since Blender 4.1; on
             # older versions we silently skip it (fall back to face normals).
-            uv_data = mesh.uv_layers.active.data if mesh.uv_layers.active else None
+            uv_layer_items = []
+            active_uv = mesh.uv_layers.active if mesh.uv_layers.active else None
+            if active_uv is not None:
+                uv_layer_items.append((getattr(active_uv, "name", "") or "UVMap", active_uv.data))
+            for layer in mesh.uv_layers:
+                if layer is active_uv:
+                    continue
+                uv_layer_items.append((getattr(layer, "name", "") or "UVMap", layer.data))
+            uv_data = uv_layer_items[0][1] if uv_layer_items else None
 
             for tri in mesh.loop_triangles:
                 v0 = matrix @ mesh.vertices[tri.vertices[0]].co
@@ -2487,6 +2497,14 @@ class CustomRaytracerRenderEngine(RenderEngine):
                     uv0 = list(uv_data[tri.loops[0]].uv)
                     uv1 = list(uv_data[tri.loops[1]].uv)
                     uv2 = list(uv_data[tri.loops[2]].uv)
+                uv_layers = {}
+                if len(uv_layer_items) > 1:
+                    for layer_name, layer_data in uv_layer_items:
+                        uv_layers[layer_name] = [
+                            list(layer_data[tri.loops[0]].uv),
+                            list(layer_data[tri.loops[1]].uv),
+                            list(layer_data[tri.loops[2]].uv),
+                        ]
 
                 # Per-corner normals (Blender 4.1+). Fall back gracefully.
                 n0 = n1 = n2 = []
@@ -2501,13 +2519,22 @@ class CustomRaytracerRenderEngine(RenderEngine):
                 except (AttributeError, IndexError):
                     n0 = n1 = n2 = []
 
-                renderer.add_triangle(
-                    list(v0), list(v1), list(v2), mat_id,
-                    uv0, uv1, uv2,
-                    n0, n1, n2,
-                    int(getattr(obj, "pass_index", 0)),
-                    int(tri.material_index),
-                )
+                if uv_layers and hasattr(renderer, "add_triangle_layers"):
+                    renderer.add_triangle_layers(
+                        list(v0), list(v1), list(v2), mat_id,
+                        uv_layers,
+                        n0, n1, n2,
+                        int(getattr(obj, "pass_index", 0)),
+                        int(tri.material_index),
+                    )
+                else:
+                    renderer.add_triangle(
+                        list(v0), list(v1), list(v2), mat_id,
+                        uv0, uv1, uv2,
+                        n0, n1, n2,
+                        int(getattr(obj, "pass_index", 0)),
+                        int(tri.material_index),
+                    )
                 tri_count += 1
 
         print(f"Astroray: converted {obj_count} meshes, {tri_count} triangles")

--- a/include/advanced_features.h
+++ b/include/advanced_features.h
@@ -27,6 +27,7 @@ private:
     Vec2 uvScale_{1.0f, 1.0f};
     Vec2 uvOffset_{0.0f, 0.0f};
     float uvRotation_ = 0.0f;  // radians, Z-axis only (2D)
+    std::string uvLayerName_;
 
 protected:
     Vec2 applyUVTransform(const Vec2& uv) const {
@@ -56,7 +57,19 @@ protected:
         return Vec2(u, v);
     }
 
+    Vec2 selectedUV(const HitRecord& rec) const {
+        if (!uvLayerName_.empty()) {
+            for (size_t i = 0; i < rec.uvLayerNames.size() && i < rec.uvLayers.size(); ++i) {
+                if (rec.uvLayerNames[i] == uvLayerName_) {
+                    return rec.uvLayers[i];
+                }
+            }
+        }
+        return rec.uv;
+    }
+
     std::pair<Vec2, Vec3> textureCoordinates(const HitRecord& rec, const Vec3& wo) const {
+        Vec2 uv = selectedUV(rec);
         switch (coordMode) {
             case CoordMode::Generated: {
                 if (rec.hitObject) {
@@ -75,7 +88,7 @@ protected:
                         return {Vec2(g.x, g.y), g};
                     }
                 }
-                return {rec.uv, rec.objectPoint};
+                return {uv, rec.objectPoint};
             }
             case CoordMode::Object:
                 return {Vec2(rec.objectPoint.x, rec.objectPoint.y), rec.objectPoint};
@@ -98,7 +111,7 @@ protected:
                 return {rec.windowUV, Vec3(rec.windowUV.u, rec.windowUV.v, 0.0f)};
             case CoordMode::UV:
             default:
-                return {rec.uv, rec.point};
+                return {uv, rec.point};
         }
     }
 
@@ -131,6 +144,8 @@ public:
     Vec2 getUVScale()  const { return uvScale_;  }
     Vec2 getUVOffset() const { return uvOffset_; }
     float getUVRotation() const { return uvRotation_; }
+    void setUVLayerName(const std::string& name) { uvLayerName_ = name; }
+    const std::string& getUVLayerName() const { return uvLayerName_; }
 
     // Spectral hook (pkg13). Default upsamples the RGB value per-call.
     virtual astroray::SampledSpectrum sampleSpectral(

--- a/include/astroray/shapes.h
+++ b/include/astroray/shapes.h
@@ -84,6 +84,8 @@ public:
 class Triangle : public Hittable {
     Vec3 v0, v1, v2, normal;
     Vec2 uv0, uv1, uv2;
+    std::vector<std::array<Vec2, 3>> uvLayers;
+    std::vector<std::string> uvLayerNames;
     std::shared_ptr<Material> material;
     bool emissive;
     Vec3 vn0, vn1, vn2;
@@ -100,6 +102,32 @@ public:
              std::shared_ptr<Material> m)
         : v0(a), v1(b), v2(c), uv0(t0), uv1(t1), uv2(t2), material(m),
           emissive(m->isEmissive()) {
+        uvLayerNames = {"UVMap"};
+        uvLayers = {{{uv0, uv1, uv2}}};
+        normal = (v1 - v0).cross(v2 - v0).normalized();
+    }
+
+    Triangle(const Vec3& a, const Vec3& b, const Vec3& c,
+             const std::vector<std::array<Vec2, 3>>& layers,
+             const std::vector<std::string>& layerNames,
+             std::shared_ptr<Material> m)
+        : v0(a), v1(b), v2(c), material(m), uvLayers(layers), uvLayerNames(layerNames),
+          emissive(m->isEmissive()) {
+        if (!uvLayers.empty()) {
+            uv0 = uvLayers[0][0];
+            uv1 = uvLayers[0][1];
+            uv2 = uvLayers[0][2];
+        } else {
+            uv0 = Vec2(0,0); uv1 = Vec2(1,0); uv2 = Vec2(0,1);
+        }
+        if (uvLayerNames.size() < uvLayers.size()) {
+            uvLayerNames.resize(uvLayers.size());
+        }
+        for (size_t i = 0; i < uvLayerNames.size(); ++i) {
+            if (uvLayerNames[i].empty()) {
+                uvLayerNames[i] = (i == 0) ? "UVMap" : ("UVMap" + std::to_string(i + 1));
+            }
+        }
         normal = (v1 - v0).cross(v2 - v0).normalized();
     }
 
@@ -136,6 +164,11 @@ public:
         rec.material = material;
         rec.hitObject = this;
         rec.uv = uv0 * w + uv1 * u + uv2 * v;
+        rec.uvLayers.clear();
+        rec.uvLayerNames = uvLayerNames;
+        for (const auto& layer : uvLayers) {
+            rec.uvLayers.push_back(layer[0] * w + layer[1] * u + layer[2] * v);
+        }
         return true;
     }
 

--- a/include/raytracer.h
+++ b/include/raytracer.h
@@ -408,6 +408,8 @@ struct HitRecord {
     bool frontFace;
     bool hasCameraFrame = false;
     Vec2 uv;
+    std::vector<Vec2> uvLayers;
+    std::vector<std::string> uvLayerNames;
     Vec2 windowUV;
     std::shared_ptr<Material> material;
     bool isDelta;

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -141,6 +141,9 @@ public:
                                float rotZRad = 0.0f) {
         if (auto tex = getTexture(name)) tex->setUVTransform(sx, sy, ox, oy, rotZRad);
     }
+    void setTextureUVLayerName(const std::string& name, const std::string& layerName) {
+        if (auto tex = getTexture(name)) tex->setUVLayerName(layerName);
+    }
     std::shared_ptr<Texture> getTexture(const std::string& name) {
         auto it1 = imageTextures.find(name);
         if (it1 != imageTextures.end()) return it1->second;
@@ -180,6 +183,9 @@ public:
                                float sx, float sy, float ox, float oy,
                                float rotZRad = 0.0f) {
         textureManager.setTextureUVTransform(name, sx, sy, ox, oy, rotZRad);
+    }
+    void setTextureUVLayerName(const std::string& name, const std::string& layerName) {
+        textureManager.setTextureUVLayerName(name, layerName);
     }
 
     std::vector<float> sampleTexture(const std::string& type, py::dict params, float u, float v) {
@@ -400,6 +406,42 @@ public:
         }
         // Optional per-vertex normals for smooth shading. All three must be
         // provided together; empty vectors trigger the face-normal fallback.
+        if (n0.size() == 3 && n1.size() == 3 && n2.size() == 3) {
+            tri->setVertexNormals(
+                Vec3(n0[0], n0[1], n0[2]),
+                Vec3(n1[0], n1[1], n1[2]),
+                Vec3(n2[0], n2[1], n2[2]));
+        }
+        tri->setObjectPassIndex(objectPassIndex);
+        tri->setMaterialPassIndex(materialPassIndex);
+        renderer.addObject(tri);
+    }
+
+    void addTriangleLayers(const std::vector<float>& v0, const std::vector<float>& v1, const std::vector<float>& v2,
+                           int materialId, py::dict uvLayers,
+                           const std::vector<float>& n0 = {}, const std::vector<float>& n1 = {},
+                           const std::vector<float>& n2 = {},
+                           int objectPassIndex = 0, int materialPassIndex = 0) {
+        Vec3 p0(v0[0], v0[1], v0[2]), p1(v1[0], v1[1], v1[2]), p2(v2[0], v2[1], v2[2]);
+        auto mat = materials.count(materialId) ? materials[materialId] : std::make_shared<Lambertian>(Vec3(0.5f));
+
+        std::vector<std::array<Vec2, 3>> layers;
+        std::vector<std::string> names;
+        for (auto item : uvLayers) {
+            std::string name = py::cast<std::string>(item.first);
+            std::vector<std::vector<float>> coords = py::cast<std::vector<std::vector<float>>>(item.second);
+            if (coords.size() != 3 || coords[0].size() < 2 || coords[1].size() < 2 || coords[2].size() < 2) {
+                throw std::runtime_error("uv_layers entries must contain three [u, v] pairs");
+            }
+            names.push_back(name.empty() ? (names.empty() ? "UVMap" : ("UVMap" + std::to_string(names.size() + 1))) : name);
+            layers.push_back({
+                Vec2(coords[0][0], coords[0][1]),
+                Vec2(coords[1][0], coords[1][1]),
+                Vec2(coords[2][0], coords[2][1]),
+            });
+        }
+
+        auto tri = std::make_shared<Triangle>(p0, p1, p2, layers, names, mat);
         if (n0.size() == 3 && n1.size() == 3 && n2.size() == 3) {
             tri->setVertexNormals(
                 Vec3(n0[0], n0[1], n0[2]),
@@ -1048,6 +1090,8 @@ PYBIND11_MODULE(astroray, m) {
              "Apply scale + Z-rotation + offset (UV-space) to a texture; "
              "baked from a Blender Mapping node. Order matches Blender Point "
              "mapping: scale → rotate → translate. Rotation is in radians.")
+        .def("set_texture_uv_layer", &PyRenderer::setTextureUVLayerName,
+             "name"_a, "layer_name"_a)
         .def("create_material", &PyRenderer::createMaterial, "type"_a, "base_color"_a, "params"_a)
         .def("eval_material", &PyRenderer::evalMaterial,
              "material_id"_a, "wo"_a, "wi"_a,
@@ -1069,6 +1113,10 @@ PYBIND11_MODULE(astroray, m) {
              "object_pass_index"_a = 0, "material_pass_index"_a = 0)
         .def("add_triangle", &PyRenderer::addTriangle, "v0"_a, "v1"_a, "v2"_a, "material_id"_a,
              "uv0"_a = std::vector<float>(), "uv1"_a = std::vector<float>(), "uv2"_a = std::vector<float>(),
+             "n0"_a = std::vector<float>(), "n1"_a = std::vector<float>(), "n2"_a = std::vector<float>(),
+             "object_pass_index"_a = 0, "material_pass_index"_a = 0)
+        .def("add_triangle_layers", &PyRenderer::addTriangleLayers,
+             "v0"_a, "v1"_a, "v2"_a, "material_id"_a, "uv_layers"_a,
              "n0"_a = std::vector<float>(), "n1"_a = std::vector<float>(), "n2"_a = std::vector<float>(),
              "object_pass_index"_a = 0, "material_pass_index"_a = 0)
         .def("add_mesh", &PyRenderer::addMesh, "filename"_a, "material_id"_a,

--- a/tests/test_blender_named_uv_layers.py
+++ b/tests/test_blender_named_uv_layers.py
@@ -1,0 +1,202 @@
+"""pkg59 named UV-layer plumbing tests."""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from test_blender_uv_plumbing import (
+    _FakeImage,
+    _load_blender_addon,
+    _Node,
+    _RecordingRenderer,
+    _Socket,
+)
+
+
+def test_resolve_vector_input_uvmap_node_returns_layer_name(monkeypatch):
+    addon = _load_blender_addon(monkeypatch)
+    cls = addon.CustomRaytracerRenderEngine
+    uvmap = _Node("UVMAP", uv_map="Highres")
+    socket = _Socket(linked_to=uvmap, output_name="UV")
+
+    coord, scale, offset, rotation, layer = cls._resolve_vector_input(socket)
+
+    assert coord == "UV"
+    assert scale == (1.0, 1.0)
+    assert offset == (0.0, 0.0)
+    assert rotation == 0.0
+    assert layer == "Highres"
+
+
+def test_resolve_vector_input_texture_coordinate_uv_map(monkeypatch):
+    addon = _load_blender_addon(monkeypatch)
+    cls = addon.CustomRaytracerRenderEngine
+    texcoord = _Node("TEX_COORD", uv_map="UVMap2")
+    socket = _Socket(linked_to=texcoord, output_name="UV")
+
+    coord, _scale, _offset, _rotation, layer = cls._resolve_vector_input(socket)
+
+    assert coord == "UV"
+    assert layer == "UVMap2"
+
+
+def test_texture_variant_key_includes_uv_layer(monkeypatch):
+    addon = _load_blender_addon(monkeypatch)
+    engine = addon.CustomRaytracerRenderEngine()
+    renderer = _RecordingRenderer()
+    image = _FakeImage(name="shared.png")
+
+    highres = _Socket(linked_to=_Node("UVMAP", uv_map="Highres"), output_name="UV")
+    lowres = _Socket(linked_to=_Node("UVMAP", uv_map="Lowres"), output_name="UV")
+
+    n1 = engine.load_blender_image(image, renderer, vector_input=highres)
+    n2 = engine.load_blender_image(image, renderer, vector_input=lowres)
+
+    assert n1 != n2
+    assert "Highres" in n1
+    assert "Lowres" in n2
+    assert renderer.uv_layer_calls == [(n1, "Highres"), (n2, "Lowres")]
+
+
+class _Matrix:
+    def __matmul__(self, other):
+        return other
+
+    def to_3x3(self):
+        return self
+
+    def inverted_safe(self):
+        return self
+
+    def transposed(self):
+        return self
+
+
+class _UVLayers(list):
+    def __init__(self, layers, active=None):
+        super().__init__(layers)
+        self.active = active if active is not None else (layers[0] if layers else None)
+
+
+class _Mesh:
+    def __init__(self, uv_layers):
+        self.vertices = [
+            types.SimpleNamespace(co=[0.0, 0.0, 0.0]),
+            types.SimpleNamespace(co=[1.0, 0.0, 0.0]),
+            types.SimpleNamespace(co=[0.0, 1.0, 0.0]),
+        ]
+        self.loop_triangles = [
+            types.SimpleNamespace(vertices=[0, 1, 2], loops=[0, 1, 2], material_index=0)
+        ]
+        self.uv_layers = uv_layers
+
+    def calc_loop_triangles(self):
+        pass
+
+
+class _Object:
+    type = "MESH"
+    name = "UV Object"
+    material_slots = [types.SimpleNamespace(material=types.SimpleNamespace(name="Mat"))]
+    pass_index = 3
+    matrix_world = _Matrix()
+
+    def __init__(self, mesh):
+        self._mesh = mesh
+        self.data = mesh
+
+    def evaluated_get(self, _depsgraph):
+        return self
+
+    def to_mesh(self):
+        return self._mesh
+
+    def to_mesh_clear(self):
+        pass
+
+
+class _MeshRenderer:
+    def __init__(self):
+        self.triangles = []
+        self.layer_triangles = []
+
+    def add_triangle(self, *args):
+        self.triangles.append(args)
+
+    def add_triangle_layers(self, *args):
+        self.layer_triangles.append(args)
+
+
+def _uv_layer(name, coords):
+    data = [types.SimpleNamespace(uv=uv) for uv in coords]
+    return types.SimpleNamespace(name=name, data=data)
+
+
+def test_mesh_with_two_uv_layers_uploads_both(monkeypatch):
+    addon = _load_blender_addon(monkeypatch)
+    engine = addon.CustomRaytracerRenderEngine()
+    uv1 = _uv_layer("UVMap", [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
+    uv2 = _uv_layer("UVMap2", [[0.2, 0.2], [0.8, 0.2], [0.2, 0.8]])
+    mesh = _Mesh(_UVLayers([uv1, uv2], active=uv1))
+    renderer = _MeshRenderer()
+
+    obj = _Object(mesh)
+    depsgraph = types.SimpleNamespace(object_instances=[
+        types.SimpleNamespace(object=obj, matrix_world=obj.matrix_world)
+    ])
+    engine.convert_objects(depsgraph, renderer, {"Mat": 7})
+
+    assert renderer.triangles == []
+    assert len(renderer.layer_triangles) == 1
+    uv_layers = renderer.layer_triangles[0][4]
+    assert uv_layers == {
+        "UVMap": [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]],
+        "UVMap2": [[0.2, 0.2], [0.8, 0.2], [0.2, 0.8]],
+    }
+
+
+def test_mesh_with_one_uv_layer_keeps_single_layer_path(monkeypatch):
+    addon = _load_blender_addon(monkeypatch)
+    engine = addon.CustomRaytracerRenderEngine()
+    uv = _uv_layer("UVMap", [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
+    mesh = _Mesh(_UVLayers([uv], active=uv))
+    renderer = _MeshRenderer()
+
+    obj = _Object(mesh)
+    depsgraph = types.SimpleNamespace(object_instances=[
+        types.SimpleNamespace(object=obj, matrix_world=obj.matrix_world)
+    ])
+    engine.convert_objects(depsgraph, renderer, {"Mat": 7})
+
+    assert renderer.layer_triangles == []
+    assert len(renderer.triangles) == 1
+    assert renderer.triangles[0][4:7] == (
+        [0.0, 0.0],
+        [1.0, 0.0],
+        [0.0, 1.0],
+    )
+
+
+def test_renderer_exposes_named_uv_layer_bindings():
+    try:
+        import astroray
+    except ImportError:
+        pytest.skip("astroray module not available")
+
+    renderer = astroray.Renderer()
+    assert hasattr(renderer, "add_triangle_layers")
+    assert hasattr(renderer, "set_texture_uv_layer")
+
+    mat = renderer.create_material("lambertian", [0.8, 0.8, 0.8], {})
+    renderer.add_triangle_layers(
+        [0.0, 0.0, -1.0],
+        [1.0, 0.0, -1.0],
+        [0.0, 1.0, -1.0],
+        mat,
+        {
+            "UVMap": [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]],
+            "UVMap2": [[0.2, 0.2], [0.8, 0.2], [0.2, 0.8]],
+        },
+    )

--- a/tests/test_blender_uv_plumbing.py
+++ b/tests/test_blender_uv_plumbing.py
@@ -10,8 +10,8 @@ TEX_IMAGE / procedural texture nodes so that:
 - ``Mapping(Location, Scale)`` is baked into a per-texture UV transform
   via ``renderer.set_texture_uv_transform``.
 
-Mapping rotation, named UV layers, and the UV-debug AOV are deferred —
-each is its own follow-up.
+Mapping rotation and the UV-debug AOV are covered by earlier follow-ups; named
+UV layer routing is tested separately.
 
 Tests use the same Blender API stub pattern as the other addon tests.
 """
@@ -120,6 +120,7 @@ class _RecordingRenderer:
         self.loaded_textures = []
         self.coord_mode_calls = []     # (name, mode)
         self.uv_transform_calls = []   # (name, sx, sy, ox, oy)
+        self.uv_layer_calls = []       # (name, layer)
         self.proc_texture_calls = []   # (name, type, params)
         self.created_materials = []
         self._next_id = 1
@@ -132,6 +133,9 @@ class _RecordingRenderer:
 
     def set_texture_uv_transform(self, name, sx, sy, ox, oy, rotation=0.0):
         self.uv_transform_calls.append((name, sx, sy, ox, oy, rotation))
+
+    def set_texture_uv_layer(self, name, layer):
+        self.uv_layer_calls.append((name, layer))
 
     def create_procedural_texture(self, name, ttype, params):
         self.proc_texture_calls.append((name, ttype, list(params)))
@@ -152,7 +156,7 @@ def test_resolve_vector_input_unlinked_returns_default(monkeypatch):
     addon = _load_blender_addon(monkeypatch)
     cls = addon.CustomRaytracerRenderEngine
     socket = _Socket()  # not linked
-    coord, scale, offset, rotation = cls._resolve_vector_input(socket)
+    coord, scale, offset, rotation, layer = cls._resolve_vector_input(socket)
     assert coord == "UV"
     assert scale == (1.0, 1.0)
     assert offset == (0.0, 0.0)
@@ -164,7 +168,7 @@ def test_resolve_vector_input_uv_default(monkeypatch):
     cls = addon.CustomRaytracerRenderEngine
     tc = _Node('TEX_COORD')
     socket = _Socket(linked_to=tc, output_name='UV')
-    coord, _scale, _offset, _rotation = cls._resolve_vector_input(socket)
+    coord, _scale, _offset, _rotation, layer = cls._resolve_vector_input(socket)
     assert coord == "UV"
 
 
@@ -174,7 +178,7 @@ def test_resolve_vector_input_generated(monkeypatch):
     cls = addon.CustomRaytracerRenderEngine
     tc = _Node('TEX_COORD')
     socket = _Socket(linked_to=tc, output_name='Generated')
-    coord, _scale, _offset, _rotation = cls._resolve_vector_input(socket)
+    coord, _scale, _offset, _rotation, layer = cls._resolve_vector_input(socket)
     assert coord == "GENERATED"
 
 
@@ -183,7 +187,7 @@ def test_resolve_vector_input_object(monkeypatch):
     cls = addon.CustomRaytracerRenderEngine
     tc = _Node('TEX_COORD')
     socket = _Socket(linked_to=tc, output_name='Object')
-    coord, _scale, _offset, _rotation = cls._resolve_vector_input(socket)
+    coord, _scale, _offset, _rotation, layer = cls._resolve_vector_input(socket)
     assert coord == "OBJECT"
 
 
@@ -198,7 +202,7 @@ def test_resolve_vector_input_mapping_scale_only(monkeypatch):
         'Scale': _Socket(default=(2.0, 3.0, 1.0)),
     })
     socket = _Socket(linked_to=mapping, output_name='Vector')
-    coord, scale, offset, rotation = cls._resolve_vector_input(socket)
+    coord, scale, offset, rotation, layer = cls._resolve_vector_input(socket)
     assert coord == "UV"
     assert scale == (2.0, 3.0)
     assert offset == (0.0, 0.0)
@@ -213,7 +217,7 @@ def test_resolve_vector_input_mapping_offset(monkeypatch):
         'Scale': _Socket(default=(1.0, 1.0, 1.0)),
     })
     socket = _Socket(linked_to=mapping, output_name='Vector')
-    _coord, scale, offset, _rotation = cls._resolve_vector_input(socket)
+    _coord, scale, offset, _rotation, layer = cls._resolve_vector_input(socket)
     assert scale == (1.0, 1.0)
     assert offset == (0.5, -0.25)
 
@@ -230,7 +234,7 @@ def test_resolve_vector_input_mapping_chained_with_generated(monkeypatch):
         'Scale':    _Socket(default=(2.0, 2.0, 1.0)),
     })
     socket = _Socket(linked_to=mapping, output_name='Vector')
-    coord, scale, _offset, _rotation = cls._resolve_vector_input(socket)
+    coord, scale, _offset, _rotation, layer = cls._resolve_vector_input(socket)
     assert coord == "GENERATED"
     assert scale == (2.0, 2.0)
 
@@ -250,7 +254,7 @@ def test_resolve_vector_input_depth_limit(monkeypatch):
             'Scale': _Socket(default=(1.0, 1.0, 1.0)),
         })
     socket = _Socket(linked_to=inner, output_name='Vector')
-    coord, scale, offset, rotation = cls._resolve_vector_input(socket)
+    coord, scale, offset, rotation, layer = cls._resolve_vector_input(socket)
     # The outer-most Mapping still applies its own Scale; deeper ones get
     # cut off, but the outer (depth=0) Scale should still be honored.
     assert coord == "UV"
@@ -365,7 +369,7 @@ def test_resolve_vector_input_mapping_rotation_z(monkeypatch):
         'Scale':    _Socket(default=(1.0, 1.0, 1.0)),
     })
     socket = _Socket(linked_to=mapping, output_name='Vector')
-    coord, scale, offset, rotation = cls._resolve_vector_input(socket)
+    coord, scale, offset, rotation, layer = cls._resolve_vector_input(socket)
     assert coord == "UV"
     assert scale == (1.0, 1.0)
     assert offset == (0.0, 0.0)
@@ -412,7 +416,7 @@ def test_resolve_vector_input_mapping_full_combo(monkeypatch):
         'Scale':    _Socket(default=(2.0, 3.0, 1.0)),
     })
     socket = _Socket(linked_to=mapping, output_name='Vector')
-    coord, scale, offset, rotation = cls._resolve_vector_input(socket)
+    coord, scale, offset, rotation, layer = cls._resolve_vector_input(socket)
     assert coord == "UV"
     assert scale == (2.0, 3.0)
     assert offset == (0.5, -0.25)


### PR DESCRIPTION
## Summary
- extend Triangle/HitRecord and texture sampling with named UV-layer storage and selection
- expose renderer.add_triangle_layers(...) and renderer.set_texture_uv_layer(...) through pybind while preserving add_triangle
- upload all Blender mesh UV layers and route Texture Coordinate/UV Map uv_map names into texture cache keys and C++ texture selection
- mark pkg59 done in STATUS.md and the package spec

## Verification
- cmake --build build --config Release --target astroray -j
- pytest tests/test_blender_named_uv_layers.py tests/test_blender_uv_plumbing.py -q --tb=short
- pytest tests/test_blender_named_uv_layers.py tests/test_blender_uv_plumbing.py tests/test_python_bindings.py -q --tb=short
- pytest tests/ -q --tb=short (ASTRORAY_BUILD_DIR=build; 715 passed, 14 skipped, 18 xfailed)