### PR TITLE
[codex] feat(pkg54d): GPU profile lookup binding

### DIFF
--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -22,8 +22,8 @@ personally should pick up.
   not CUDA kernels.
 - Pillar 5 is the active practical queue. The Cycles-parity/Blender package
   series is now the live near-term roadmap: pkg52/pkg53/pkg58/pkg60/pkg61/pkg62
-  are done, pkg59 is done, pkg54/54a/54b are done (with pkg54c/54d as
-  scoped follow-ups), and pkg57 remains open.
+  are done, pkg59 is done, pkg54/54a/54b/54d are done (with pkg54c as a
+  scoped follow-up), and pkg57 remains open.
 - Fresh local collection on this branch: `pytest --collect-only -q` reports
   **435 tests collected** (2026-05-09). Focused pkg53/viewport checks pass.
 - Historical docs that are intentionally not current: `NEXT_STAGE_REPORT.md`
@@ -276,7 +276,7 @@ events are summarized in the changelog below.
 | pkg40 | A | open | current registry/reference cleanup |
 | pkg52 | A | **done** | — |
 | pkg53 | B/E | **done** | — |
-| pkg54 | A | **done** | pkg54/54a/54b verified on hardware; pkg54c (Jakob-Hanika upsampling) and pkg54d (profile lookup binding) filed as follow-ups |
+| pkg54 | A | **done** | pkg54/54a/54b verified on hardware; pkg54d direct profile lookup binding is done; pkg54c (Jakob-Hanika upsampling) remains filed as a follow-up |
 | pkg57 | A | open | native shader nodes / Cycles compatibility design |
 | pkg58 | B | **done** | — |
 | pkg59 | A | done | broader vector/UV/Mapping plumbing, named UV layers, and UV debug AOV |
@@ -310,9 +310,10 @@ events are summarized in the changelog below.
   dispatch on the GPU; pkg54b replaced the Wyman 2013 1931 2° CMF fit with
   the same baked CIE 1964 10° table the CPU uses, and a D65-SPD parity bug
   (Gaussian stand-in for the true SPD) was fixed during hardware
-  verification. pkg54c (Jakob-Hanika spectral upsampling on GPU, SSIM
-  ceiling 0.985→0.999) and pkg54d (direct gpu_profile_reflectance binding
-  for unconfounded liveness gating) remain as scoped follow-ups.
+  verification. pkg54d added a direct `gpu_profile_reflectance` binding for
+  unconfounded liveness gating, with CPU/GPU lookup max delta `0` across all
+  loaded profiles on the 300-1000 nm grid. pkg54c (Jakob-Hanika spectral
+  upsampling on GPU, SSIM ceiling 0.985→0.999) remains as a scoped follow-up.
   Sellmeier direction-splitting and true spectral emitter parameter
   upload also remain CPU-only follow-ups. pkg36 expands shared closure
   lowering.

--- a/.astroray_plan/packages/pkg54a-gpu-spectral-profile-dispatch.md
+++ b/.astroray_plan/packages/pkg54a-gpu-spectral-profile-dispatch.md
@@ -148,5 +148,7 @@ the MW kernel.
   dilution by low-UV-reflectance floor (vegetation/water).
   Cross-backend ratio agreement within 25% (measured: CPU 1.73 vs
   GPU 1.64, 5% divergence) is the meaningful parity signal here.
-  True dispatch liveness — independent of scene physics — is filed
-  as pkg54d (direct gpu_profile_reflectance lookup binding).
+  True dispatch liveness — independent of scene physics — is now gated
+  by pkg54d's direct `gpu_profile_reflectance` lookup binding. Hardware
+  verification on 2026-05-10 measured CPU/GPU max delta `0` across all
+  loaded profiles and all 141 grid points.

--- a/.astroray_plan/packages/pkg54d-gpu-profile-lookup-binding.md
+++ b/.astroray_plan/packages/pkg54d-gpu-profile-lookup-binding.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 5
 **Track:** A
-**Status:** open
+**Status:** done
 **Estimated effort:** ~half a day
 **Depends on:** pkg54a
 
@@ -28,9 +28,9 @@ in `data/spectra/illuminant_d65.inc` is zero past 780 nm, so
 profiles get no light to reflect, and CPU/GPU agree on the dim 700-780 nm
 overlap whether profile dispatch is live or dead.
 
-**After:** A `astroray._gpu_profile_lookup(name, lambda)` Python binding
+**After:** A `Renderer._gpu_profile_lookup(profile_index, lambda)` Python binding
 launches a one-thread CUDA kernel that returns the device-side
-`gpu_profile_reflectance()` value for the named profile at `lambda`.
+`gpu_profile_reflectance()` value for the uploaded profile slot at `lambda`.
 This gives a true unit-test gate for pkg54a that does not depend on
 light-source spectrum, scene geometry, or Monte Carlo noise.
 
@@ -70,8 +70,8 @@ with a direct, scene-free unit gate.
 | File | What changes |
 |---|---|
 | `src/gpu/multiwavelength_kernel.cu` | Add `__global__ void gpu_profile_lookup_kernel(int idx, float lambda, float* d_out)` plus a host-callable `float launchProfileLookup(int profileIndex, float lambda)` wrapper. |
-| `src/gpu/cuda_renderer.cu` | Expose `CUDARenderer::profileLookup(int idx, float lam)` that calls into the launcher. |
-| `module/blender_module.cpp` | Add `_gpu_profile_lookup(name, lambda)` Python binding: resolve `name → profileIndex` via the existing `SpectralProfileDatabase`, ensure `uploadProfileTable()` has run with that index slotted, then call into the renderer hook. |
+| `src/gpu/cuda_renderer.cu` | Expose `CUDARenderer::lookupProfileReflectance(int idx, float lam)` that calls into the launcher. |
+| `module/blender_module.cpp` | Add `Renderer._gpu_profile_lookup(profile_index, lambda)` Python binding. The index is the profile slot assigned by the most recent `uploadScene()`. |
 | `tests/test_gpu_profile_lookup.py` | New test: for each loaded profile, sweep the GPU grid (`G_PROFILE_LAMBDA_MIN` step `G_PROFILE_LAMBDA_STEP`) and assert equality with `astroray.spectral_profile_reflectance` within 1e-6. |
 
 ### Key design decisions
@@ -82,8 +82,7 @@ with a direct, scene-free unit gate.
    `cudaMemcpyFromSymbol` would skip that path.
 2. **Reuse the existing upload pipeline** — do not introduce a
    second profile-table store. The binding requires that a scene with
-   the queried profile has been uploaded (or it triggers a minimal
-   upload of just that profile slot for testing).
+   the queried profile has been uploaded.
 3. **Underscore-prefixed name** (`_gpu_profile_lookup`) to flag it as an
    internal/test-only binding, not a public API.
 
@@ -91,13 +90,14 @@ with a direct, scene-free unit gate.
 
 ## Acceptance criteria
 
-- [ ] `astroray._gpu_profile_lookup(name, lambda)` returns the same
+- [x] `Renderer._gpu_profile_lookup(profile_index, lambda)` returns the same
   value as `astroray.spectral_profile_reflectance(name, lambda)` at
   every grid point (`G_PROFILE_LAMBDA_MIN`, `+ step`, …,
   `G_PROFILE_LAMBDA_MIN + (G_PROFILE_SAMPLES-1)*step`) for every
   loaded profile, within ε = 1e-6.
-- [ ] Test runs in <1 s on a CUDA-capable box.
-- [ ] Skipped (not failed) when no CUDA GPU is available.
+- [x] Test is focused and passed on CUDA hardware; measured 0.69 s on this
+  Windows CUDA build while uploading one profile scene per profile.
+- [x] Skipped (not failed) when no CUDA GPU is available.
 
 ---
 
@@ -112,14 +112,19 @@ with a direct, scene-free unit gate.
 
 ## Progress
 
-- [ ] Add `gpu_profile_lookup_kernel` + `launchProfileLookup`.
-- [ ] Wire `CUDARenderer::profileLookup` and Python binding.
-- [ ] Add `tests/test_gpu_profile_lookup.py`.
-- [ ] Document the binding in pkg54a Lessons (replace the UV-band
+- [x] Add `gpu_profile_lookup_kernel` + `launchProfileLookup`.
+- [x] Wire `CUDARenderer::lookupProfileReflectance` and Python binding.
+- [x] Add `tests/test_gpu_profile_lookup.py`.
+- [x] Document the binding in pkg54a Lessons (replace the UV-band
   workaround note once the unit gate is live).
 
 ---
 
 ## Lessons
 
-*(Fill in after the package is done.)*
+- Implemented as an integer profile-slot lookup, matching the current
+  NEXT_STAGE_REPORT outline. The slot is whatever `scene_upload.cu` assigned
+  during the latest CUDA scene upload; tests upload a one-profile scene so the
+  target profile is always slot 0.
+- Hardware verification on 2026-05-10: direct CPU/GPU profile lookup max
+  delta was `0` over every loaded profile and all 141 grid points.

--- a/include/astroray/gpu_renderer.h
+++ b/include/astroray/gpu_renderer.h
@@ -51,6 +51,10 @@ public:
                                float lambdaMin, float lambdaMax,
                                bool useLuminanceOutput);
 
+    // pkg54d: test hook for the profile table uploaded by the latest
+    // uploadScene() call.
+    float lookupProfileReflectance(int profileIndex, float lambda) const;
+
     // [0, 1] progress estimate (reserved for async use in Phase 3).
     float getProgress() const;
 

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -596,6 +596,20 @@ public:
 #endif
     }
 
+    float gpuProfileLookup(int profileIndex, float lambda) {
+#ifdef ASTRORAY_CUDA_ENABLED
+        if (!cudaRenderer) cudaRenderer = std::make_unique<CUDARenderer>();
+        if (!cudaRenderer->isAvailable()) {
+            throw std::runtime_error("No CUDA GPU available");
+        }
+        return cudaRenderer->lookupProfileReflectance(profileIndex, lambda);
+#else
+        (void)profileIndex;
+        (void)lambda;
+        throw std::runtime_error("CUDA support not compiled");
+#endif
+    }
+
     bool loadEnvironmentMap(const std::string& path, float strength = 1.0f, float rotation = 0.0f, bool blender_x_rotation = false) {
         envMap = std::make_shared<EnvironmentMap>();
         if (envMap->load(path, strength, rotation, blender_x_rotation)) {
@@ -1170,6 +1184,9 @@ PYBIND11_MODULE(astroray, m) {
         .def("get_width", &PyRenderer::getWidth)
         .def("get_height", &PyRenderer::getHeight)
         .def("set_use_gpu", &PyRenderer::setUseGPU, "enable"_a)
+        .def("_gpu_profile_lookup", &PyRenderer::gpuProfileLookup,
+             "profile_index"_a, "lambda_nm"_a,
+             "Return device-side reflectance for an uploaded spectral profile slot.")
         .def("get_material_backend_capabilities",
              &PyRenderer::getMaterialBackendCapabilities, "material_id"_a)
         .def("get_material_closure_graph",

--- a/src/gpu/cuda_renderer.cu
+++ b/src/gpu/cuda_renderer.cu
@@ -46,6 +46,7 @@ void launchPathTraceKernel(
 void uploadProfileTable(const float* host, int count);
 // pkg54b — one-time copy of CIE 1964 10° CMF tables into MW kernel constant memory.
 void uploadCmfTables();
+float launchProfileLookup(int profileIndex, float lambda);
 
 void launchMultiwavelengthKernel(
     float* d_framebuffer, int width, int height,
@@ -104,6 +105,7 @@ struct CUDARenderer::Impl {
     float*       d_framebuffer = nullptr;
     curandState* d_rngStates   = nullptr;
     int          fbWidth = 0, fbHeight = 0;
+    int          profileCount = 0;
 
     // Device info
     bool        available = false;
@@ -182,6 +184,7 @@ void CUDARenderer::uploadScene(const Renderer& cpuRenderer, const Camera& cam) {
     impl->numLights       = (int)r.lights.size();
     impl->totalLightPower = r.totalLightPower;
     impl->camera          = r.camera;
+    impl->profileCount    = r.profileCount;
 
     // Film exposure
     impl->filmExposure = cpuRenderer.getFilmExposure();
@@ -225,6 +228,14 @@ void CUDARenderer::uploadScene(const Renderer& cpuRenderer, const Camera& cam) {
     printf("[CUDA] Scene uploaded: %zu nodes, %zu prims, %zu mats, %d lights, %d profiles\n",
            r.nodes.size(), r.prims.size(), r.materials.size(), impl->numLights,
            r.profileCount);
+}
+
+float CUDARenderer::lookupProfileReflectance(int profileIndex, float lambda) const {
+    if (!impl->available) throw std::runtime_error("No CUDA GPU available");
+    if (profileIndex < 0 || profileIndex >= impl->profileCount) {
+        throw std::runtime_error("Profile index was not uploaded in the current CUDA scene");
+    }
+    return launchProfileLookup(profileIndex, lambda);
 }
 
 void CUDARenderer::uploadEnvironmentMap(const EnvironmentMap& envMap) {

--- a/src/gpu/multiwavelength_kernel.cu
+++ b/src/gpu/multiwavelength_kernel.cu
@@ -55,6 +55,41 @@ __device__ inline float gpu_profile_reflectance(int profileIndex, float lambda_n
     return row[i] * (1.f - f) + row[i + 1] * f;
 }
 
+__global__ void gpu_profile_lookup_kernel(int profileIndex, float lambda, float* out) {
+    if (blockIdx.x == 0 && threadIdx.x == 0 && out) {
+        *out = gpu_profile_reflectance(profileIndex, lambda);
+    }
+}
+
+float launchProfileLookup(int profileIndex, float lambda) {
+    float* d_out = nullptr;
+    float out = 0.0f;
+
+    cudaError_t err = cudaMalloc(reinterpret_cast<void**>(&d_out), sizeof(float));
+    if (err != cudaSuccess) {
+        fprintf(stderr, "profile lookup allocation failed: %s\n", cudaGetErrorString(err));
+        throw std::runtime_error(cudaGetErrorString(err));
+    }
+
+    gpu_profile_lookup_kernel<<<1, 1>>>(profileIndex, lambda, d_out);
+    err = cudaGetLastError();
+    if (err == cudaSuccess) err = cudaDeviceSynchronize();
+    if (err == cudaSuccess) {
+        err = cudaMemcpy(&out, d_out, sizeof(float), cudaMemcpyDeviceToHost);
+    }
+
+    cudaError_t freeErr = cudaFree(d_out);
+    if (err != cudaSuccess) {
+        fprintf(stderr, "profile lookup failed: %s\n", cudaGetErrorString(err));
+        throw std::runtime_error(cudaGetErrorString(err));
+    }
+    if (freeErr != cudaSuccess) {
+        fprintf(stderr, "profile lookup free failed: %s\n", cudaGetErrorString(freeErr));
+        throw std::runtime_error(cudaGetErrorString(freeErr));
+    }
+    return out;
+}
+
 // Host-callable upload entry; copies up to G_MAX_PROFILES profiles into
 // constant memory. Called from cuda_renderer.cu after buildSceneArrays().
 void uploadProfileTable(const float* host, int count) {

--- a/tests/test_gpu_profile_lookup.py
+++ b/tests/test_gpu_profile_lookup.py
@@ -1,0 +1,80 @@
+"""pkg54d direct GPU spectral profile lookup gate."""
+
+import os
+
+import pytest
+
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+
+try:
+    import astroray
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray module not available")
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PROFILES_BIN = os.path.join(REPO_ROOT, "data", "spectral_profiles", "profiles.bin")
+HAS_PROFILES = os.path.exists(PROFILES_BIN)
+
+
+def _has_cuda_gpu(renderer):
+    return (
+        bool(astroray.__features__.get("cuda", False))
+        and bool(getattr(renderer, "gpu_available", False))
+    )
+
+
+def _upload_single_profile_scene(profile_name):
+    renderer = astroray.Renderer()
+    renderer.setup_camera(
+        look_from=[0, 0, 3],
+        look_at=[0, 0, 0],
+        vup=[0, 1, 0],
+        vfov=40,
+        aspect_ratio=1.0,
+        aperture=0.0,
+        focus_dist=3.0,
+        width=2,
+        height=2,
+    )
+    mat = renderer.create_material("lambertian", [0.5, 0.5, 0.5], {})
+    renderer.set_material_spectral_profile(mat, profile_name)
+    renderer.add_sphere([0, 0, 0], 1.0, mat)
+    renderer.set_use_gpu(True)
+    renderer.render(samples_per_pixel=1, max_depth=1, apply_gamma=False)
+    return renderer
+
+
+@pytest.mark.skipif(not HAS_PROFILES, reason="profiles.bin not found")
+def test_gpu_profile_lookup_matches_cpu_grid():
+    probe = astroray.Renderer()
+    if not _has_cuda_gpu(probe):
+        pytest.skip("CUDA GPU not available")
+
+    astroray.load_spectral_profiles(PROFILES_BIN)
+    names = astroray.spectral_profile_names()
+    assert names
+
+    max_delta = 0.0
+    max_case = None
+    wavelengths = [300.0 + 5.0 * k for k in range(141)]
+
+    for name in names:
+        renderer = _upload_single_profile_scene(name)
+        for wavelength in wavelengths:
+            cpu = astroray.spectral_profile_reflectance(name, wavelength)
+            gpu = renderer._gpu_profile_lookup(0, wavelength)
+            delta = abs(cpu - gpu)
+            if delta > max_delta:
+                max_delta = delta
+                max_case = (name, wavelength, cpu, gpu)
+            assert delta < 1e-6, (
+                f"{name} R({wavelength:.1f}) CPU {cpu:.9f} vs GPU {gpu:.9f} "
+                f"delta {delta:.9g}"
+            )
+
+    print(f"pkg54d max profile lookup delta={max_delta:.9g} at {max_case}")


### PR DESCRIPTION
## Summary

Implements pkg54d end to end against current main:

- Adds a one-thread CUDA `gpu_profile_lookup_kernel` and `launchProfileLookup()` host wrapper that exercise `gpu_profile_reflectance()` through constant memory.
- Adds `CUDARenderer::lookupProfileReflectance(int profileIndex, float lambda)` and exposes it on `Renderer._gpu_profile_lookup(profile_index, lambda_nm)`.
- Adds `tests/test_gpu_profile_lookup.py`, which uploads a one-profile CUDA scene for each loaded spectral profile and compares every 300-1000 nm grid point against `astroray.spectral_profile_reflectance()` with `abs(cpu - gpu) < 1e-6`.
- Marks pkg54d done and updates pkg54/pkg54a status notes.

## Verification

- `scripts\build_cuda.bat`: requested path is not present on current main. Actual checked-in script used: `scripts\build\build_cuda.bat` — passed.
- `python scripts\dev\run_tests.py --build-dir build_cuda -- tests/test_gpu_profile_lookup.py -v` — `1 passed in 0.69s`.
- `python scripts\dev\run_tests.py --build-dir build_cuda -- tests/test_gpu_multiwavelength.py -v` — `5 passed in 0.35s`.

## Equality / SSIM Numbers

Direct pkg54d lookup gate:

- `pkg54d max profile lookup delta=0` across every loaded profile and all 141 grid points.

Existing pkg54a/b parity measurements from the same build:

- `visible_ssim=0.987982641`
- `nir_profile_ssim=0.999997175`
- `nir_fallback_ssim=0.999997274`
- `uv_profile_ssim=0.999995447`
- `uv_cpu_ratio=1.739261031`
- `uv_gpu_ratio=1.631194353`