### PR TITLE
docs(pkg47, pkg48, pkg49): Pillar 4 data I/O research + Codex-ready spec tightenings

### DIFF
--- a/.astroray_plan/docs/pillar4-data-io-research.md
+++ b/.astroray_plan/docs/pillar4-data-io-research.md
@@ -1,0 +1,491 @@
+# Pillar 4 Data I/O Research — FITS, HDF5/NumPy, SPH-to-Volume
+
+**Date:** 2026-05-10  
+**Covers:** pkg47 (FITS loader), pkg48 (HDF5/NumPy loader), pkg49 (SPH-to-volume)  
+**Status:** research complete; specs tightened; ready for Codex implementation pending
+dep verification on Windows
+
+---
+
+## 1. Pipeline Shape and Common Volume Representation
+
+All three loaders must produce the same internal representation so that the renderer
+and the Blender addon see a uniform interface regardless of source format.
+
+### Proposed common type: `DensityGrid`
+
+```cpp
+// include/astroray/density_grid.h
+struct DensityGrid {
+    std::vector<float> data;    // flat C-order (x varies slowest, z varies fastest)
+    int nx, ny, nz;             // grid dimensions
+    float bbox_min[3];          // world-space bounding box corners
+    float bbox_max[3];
+    std::string field_name;     // "density", "temperature", etc.
+};
+```
+
+This is a thin wrapper. It does not duplicate any existing volume machinery — it
+holds the raw grid and enough geometry to hand off to `SimulationVolume` (pkg48).
+`FITSVolume` (pkg47) and `SPHToGrid` (pkg49) both output `DensityGrid` values
+and pass them to `SimulationVolume` or write them to `.npy` files.
+
+**Why a wrapper, not a new class hierarchy:** `SimulationVolume` already handles
+rendering; the loaders only need to produce a well-defined grid. One struct,
+passed by value (small overhead) or returned via `std::unique_ptr<DensityGrid>`.
+
+### Load path diagram
+
+```
+FITS file ──────────────────────────────────────────────────────── pkg47
+                                                                       │
+HDF5 file ──── pkg48 (npy_reader.h or HighFive) ─── DensityGrid ──────┤
+                                                                       │
+.npy file ──── pkg48 (npy_reader.h)              ─── DensityGrid ──────┤
+                                                                       │
+SPH particles ─ pkg49 (sph_kernel.h + splatting) ─ DensityGrid ────────┤
+                                                                       │
+                                              SimulationVolume (pkg48) ─┘
+                                                          │
+                                                    volume plugin
+                                                  (render path unchanged)
+```
+
+---
+
+## 2. cfitsio Integration
+
+### Library
+
+**cfitsio** — NASA/HEASARC C library for reading and writing FITS files.  
+License: **public domain** (explicitly stated in `cfitsio.h`: "This software is  
+provided with no warranty whatsoever").  
+Canonical source: https://heasarc.gsfc.nasa.gov/fitsio/  
+Current version as of 2026: 4.x (4.6.4 documented April 2026).
+
+Do **not** vendor. Use as a system dependency.
+
+### Core C API functions
+
+```c
+/* Open/close */
+int fits_open_file(fitsfile **fptr, const char *filename,
+                   int iomode, int *status);
+int fits_close_file(fitsfile *fptr, int *status);
+
+/* Navigate HDUs */
+int fits_movabs_hdu(fitsfile *fptr, int hdunum,
+                    int *hdutype, int *status);   // 1-based
+
+/* Inspect image geometry */
+int fits_get_img_dim(fitsfile *fptr, int *naxis, int *status);
+int fits_get_img_size(fitsfile *fptr, int maxdim,
+                      long *naxes, int *status);
+int fits_get_img_type(fitsfile *fptr, int *bitpix, int *status);
+
+/* Read pixels into float array (BSCALE/BZERO applied automatically) */
+int fits_read_pix(fitsfile *fptr, int datatype, long *fpixel,
+                  LONGLONG nelements, void *nulval,
+                  void *array, int *anynul, int *status);
+// datatype = TFLOAT; fpixel = {1,1,...,1} (1-based first pixel)
+
+/* Header keyword */
+int fits_read_key(fitsfile *fptr, int datatype, const char *keyname,
+                  void *value, char *comment, int *status);
+```
+
+`fits_read_pix` applies `BSCALE`/`BZERO` when `datatype = TFLOAT` — no manual
+scaling needed. For a 2D image the call is `fits_read_pix(fptr, TFLOAT,
+fpixel={1,1}, nx*ny, NULL, data.data(), &anynul, &status)`.
+
+Compressed FITS (tile-compression and `.fits.gz`) is handled transparently by
+cfitsio; the application code sees a normal FITS file.
+
+### CMake recipe
+
+```cmake
+option(ASTRORAY_ENABLE_FITS "Enable FITS I/O (requires cfitsio)" OFF)
+
+if(ASTRORAY_ENABLE_FITS)
+  # vcpkg provides cfitsio::cfitsio; system installs may use FindCFITSIO
+  find_package(cfitsio CONFIG QUIET)
+  if(NOT cfitsio_FOUND)
+    find_package(PkgConfig QUIET)
+    if(PkgConfig_FOUND)
+      pkg_check_modules(cfitsio IMPORTED_TARGET cfitsio)
+      if(cfitsio_FOUND)
+        add_library(cfitsio::cfitsio ALIAS PkgConfig::cfitsio)
+      endif()
+    endif()
+  endif()
+
+  if(cfitsio_FOUND)
+    target_sources(astroray PRIVATE plugins/data/fits_loader.cpp)
+    target_link_libraries(astroray PRIVATE cfitsio::cfitsio)
+    target_compile_definitions(astroray PRIVATE ASTRORAY_FITS_ENABLED)
+    message(STATUS "FITS I/O enabled (cfitsio found)")
+  else()
+    message(WARNING "ASTRORAY_ENABLE_FITS=ON but cfitsio not found; FITS disabled")
+  endif()
+endif()
+```
+
+### Windows / vcpkg
+
+```
+vcpkg install cfitsio          # classic mode
+# or in vcpkg.json manifest:
+{ "name": "cfitsio", "version>=": "3.49" }
+```
+
+Pass `-DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%/scripts/buildsystems/vcpkg.cmake`
+to CMake. vcpkg installs a `cfitsio-config.cmake` that provides the
+`cfitsio::cfitsio` target, so `find_package(cfitsio CONFIG REQUIRED)` works
+immediately with no extra shims.
+
+**Codex-ready when:** `find_package(cfitsio CONFIG QUIET)` resolves on the
+Windows MinGW toolchain used in this repo.
+
+---
+
+## 3. HDF5 Integration
+
+### Library stack
+
+**HDF5 C library** — maintained by The HDF Group.  
+License: **BSD-style** (HDF5 Software License, 1.0; functionally permissive).  
+Canonical source: https://www.hdfgroup.org/solutions/hdf5/  
+Use as a system dependency; do not vendor.
+
+**HighFive** — header-only C++14 wrapper around the HDF5 C library.  
+License: **MIT** (BlueBrain Project / highfive-devs).  
+Repo: https://github.com/highfive-devs/highfive (note: project migrated from
+BlueBrain namespace in 2025; both URLs resolve).  
+We use HighFive to avoid calling the HDF5 C API directly in plugin code.
+
+### Core h5py API (Python, for test generation)
+
+```python
+import h5py, numpy as np
+
+# Write synthetic test file
+with h5py.File("test_density.hdf5", "w") as f:
+    f.create_dataset("density", data=np.ones((16, 16, 16), dtype=np.float32))
+    f["density"].attrs["units"] = "g/cm^3"
+
+# Read
+with h5py.File("test_density.hdf5", "r") as f:
+    data = f["density"][...]   # numpy array
+    keys = list(f.keys())
+```
+
+### HighFive C++ API
+
+```cpp
+#include <highfive/highfive.hpp>
+
+HighFive::File file(path, HighFive::File::ReadOnly);
+auto dataset = file.getDataSet("density");
+auto dims = dataset.getDimensions();  // std::vector<size_t>
+std::vector<float> buf(dims[0] * dims[1] * dims[2]);
+dataset.read(buf);
+```
+
+`find_package(HighFive)` automatically discovers the HDF5 C library.
+
+### Chunked-read pattern (yt-inspired)
+
+For large datasets (>1 GB), read in slabs to avoid peak-memory spikes:
+
+```cpp
+// Read z-slabs of size CHUNK_Z at a time
+const size_t CHUNK_Z = 64;
+for (size_t z0 = 0; z0 < nz; z0 += CHUNK_Z) {
+    size_t z1 = std::min(z0 + CHUNK_Z, nz);
+    dataset.select({0, 0, z0}, {nx, ny, z1 - z0}).read(slab);
+    process_slab(slab, z0);
+}
+```
+
+Reference: yt's HDF5 chunked-read pattern in
+`yt/frontends/enzo/data_structures.py`. License: BSD-3, attribution in
+code comment required.
+
+### CMake recipe
+
+```cmake
+option(ASTRORAY_ENABLE_HDF5 "Enable HDF5 I/O (requires HDF5 + HighFive)" OFF)
+
+if(ASTRORAY_ENABLE_HDF5)
+  find_package(HighFive CONFIG QUIET)   # finds HDF5 automatically
+  if(NOT HighFive_FOUND)
+    find_package(HDF5 REQUIRED COMPONENTS C)
+    # Fallback: raw HDF5 target without HighFive niceties
+  endif()
+
+  if(HighFive_FOUND OR HDF5_FOUND)
+    target_sources(astroray PRIVATE plugins/data/simulation_volume.cpp)
+    if(HighFive_FOUND)
+      target_link_libraries(astroray PRIVATE HighFive::HighFive)
+      target_compile_definitions(astroray PRIVATE ASTRORAY_HIGHFIVE_ENABLED)
+    else()
+      target_include_directories(astroray PRIVATE ${HDF5_INCLUDE_DIRS})
+      target_link_libraries(astroray PRIVATE ${HDF5_C_LIBRARIES})
+      target_compile_definitions(astroray PRIVATE ASTRORAY_HDF5_ENABLED)
+    endif()
+    message(STATUS "HDF5 I/O enabled")
+  else()
+    message(WARNING "ASTRORAY_ENABLE_HDF5=ON but HDF5/HighFive not found")
+  endif()
+endif()
+```
+
+### Windows / vcpkg
+
+```
+vcpkg install hdf5 highfive
+```
+
+On Windows with static builds, set `-DHDF5_USE_STATIC_LIBRARIES=ON` so
+`find_package(HDF5)` finds `hdf5.lib` rather than `libhdf5.lib`.
+
+**Codex-ready when:** `find_package(HighFive CONFIG QUIET)` resolves on this
+Windows MinGW toolchain.
+
+---
+
+## 4. NumPy .npy / .npz Format
+
+### Recommendation: in-house C++ parser (~80 lines)
+
+The `.npy` format is simple and stable enough to parse without pulling NumPy
+into the C++ build. A minimal parser handles everything pkg48 needs:
+
+```
+Offset  Size   Field
+------  ----   -----
+0       6      Magic:  \x93NUMPY
+6       1      Major version (1 or 2)
+7       1      Minor version (0)
+8       2/4    Header length (uint16 for v1, uint32 for v2), little-endian
+10/12   N      Header: Python dict literal, ASCII, padded with spaces to
+               align total (magic+version+len+header) to 64-byte boundary,
+               terminated with \n
+varies  M      Raw array data: product(shape) × itemsize bytes, C-order
+```
+
+Header dict keys (alphabetical):
+- `'descr'`: dtype string, e.g. `'<f4'` (little-endian float32)
+- `'fortran_order'`: boolean
+- `'shape'`: tuple of ints, e.g. `(32, 32, 32)`
+
+**Parser requirements for pkg48:**
+- Accept `'<f4'` (float32) and `'<f8'` (float64); reject others with clear error.
+- Accept `fortran_order: False` only; reject Fortran-order with clear error.
+- Accept 3D shape only; reject 2D or 4D with clear error.
+- No regex — parse the shape by finding `'shape': (` and reading the integers.
+
+Format spec: https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html
+
+### .npz files
+
+`.npz` is a ZIP archive containing `.npy` files. Handle at the Python level only:
+```python
+data = np.load("sim.npz")["density"]  # extract as ndarray
+data.astype(np.float32).tofile("density.npy")  # write raw .npy
+```
+No `.npz` support in C++ is needed.
+
+---
+
+## 5. SPH Kernel + Splatting Algorithm
+
+### Kernel choice: cubic B-spline (Monaghan 1992)
+
+The cubic B-spline is the most widely used SPH kernel in astrophysics codes
+(GADGET, PHANTOM, early FLASH). We use it as the primary kernel because:
+- it is the standard reference in Monaghan (1992) and Price (2012),
+- its compact support (2h) is well-characterised,
+- it is straightforward to implement and test.
+
+**Reference:** Monaghan, J.J. (1992). "Smoothed Particle Hydrodynamics."
+*Annual Review of Astronomy and Astrophysics* 30, 543–574.
+DOI: 10.1146/annurev.aa.30.090192.002551
+
+**Kernel formula (3D):**
+
+```
+W(r, h) = (1 / πh³) × w(q),    q = r/h
+
+         ⎧ 1 − (3/2)q² + (3/4)q³,   0 ≤ q < 1
+w(q) =  ⎨ (1/4)(2 − q)³,           1 ≤ q < 2
+         ⎩ 0,                        q ≥ 2
+```
+
+**Normalisation check:** ∫₀^{2h} W(r,h) 4πr² dr = 1 (verified analytically;
+the two-piece integral evaluates to 1/4 + 1/4 = 1/2... wait, computed above:
+19/120 + 11/120 = 30/120 = 1/4, then × 4 = 1 ✓).
+
+**Compact support radius:** `2h`. Particles touch only cells within `2h` of
+their centre.
+
+### Splatting algorithm (Westover 1990 footprint evaluation)
+
+**Reference:** Westover, L. (1990). "Footprint Evaluation for Volume
+Rendering." *SIGGRAPH '90 Proceedings*, pp. 367–376.
+DOI: 10.1145/97879.97919
+
+```
+Input:
+  particles[N]: (pos[3], h, value)      // positions, smoothing lengths, field
+  grid[nx,ny,nz], bbox_min[3], cell_size // output grid
+  V[i] = m[i] / rho[i]                  // particle volume (mass / density)
+
+Output:
+  grid[j]: field value at each cell
+
+Algorithm (scatter-gather / "shepard sum"):
+  field[...] = 0;  weight[...] = 0
+
+  for i in 0..N-1:
+    # AABB of particle's kernel support in grid index space
+    j_min[d] = floor((pos[i][d] - 2*h[i] - bbox_min[d]) / cell_size)
+    j_max[d] = ceil( (pos[i][d] + 2*h[i] - bbox_min[d]) / cell_size)
+    clamp j_min/j_max to [0, n{x,y,z})
+
+    for jx in j_min[0]..j_max[0]:
+      for jy in j_min[1]..j_max[1]:
+        for jz in j_min[2]..j_max[2]:
+          cell_pos = bbox_min + (jx+0.5, jy+0.5, jz+0.5) * cell_size
+          r = |cell_pos - pos[i]|
+          q = r / h[i]
+          w = cubic_spline_kernel(q)      # evaluates W as above
+          field[jx,jy,jz]  += value[i] * w * V[i]
+          weight[jx,jy,jz] += w * V[i]
+
+  for all j:
+    if weight[j] > 0:
+      field[j] /= weight[j]   # Shepard normalisation
+    else:
+      field[j] = 0.0           # vacuum cell
+```
+
+**Normalisation:** The Shepard (1968) sum (`field / weight`) ensures that a
+uniform particle distribution produces a uniform grid. Without it, boundary
+regions where fewer particles overlap produce artefacts.
+
+**Complexity:** O(N × (2h/Δx)³). For typical astrophysical SPH with h ≈ 2Δx,
+each particle touches ≈ 8³ = 512 cells. With N=10⁵ and 128³ grid: ~5×10⁷
+operations, well under the 10-second wall-clock target on a single core.
+
+**Note on Wendland kernels:** Wendland C2 (Dehnen & Aly 2012,
+DOI: 10.1111/j.1365-2966.2012.21439.x) and C4 are alternatives with better
+stability properties (no pairing instability, positive semi-definite). The
+splatting algorithm is kernel-agnostic — only `cubic_spline_kernel()` needs
+to be replaced. If downstream use requires rendering at the particle level
+(ray-marching through particles), Wendland C4 is preferred. For grid
+pre-processing as implemented in pkg49, cubic spline is sufficient.
+
+---
+
+## 6. Test Data Strategy
+
+**Rule:** No binary test data checked into the repository. Each test creates
+its own synthetic dataset at runtime using standard Python libraries, writes
+it to `tmp_path` (pytest fixture), and the file is deleted on test teardown.
+
+### Synthetic FITS (pkg47)
+
+```python
+import numpy as np
+from astropy.io import fits
+
+def make_fits_2d(tmp_path) -> Path:
+    data = np.arange(64*64, dtype=np.float32).reshape(64, 64)
+    hdu = fits.PrimaryHDU(data)
+    hdu.header['BSCALE'] = 1.0
+    hdu.header['BZERO'] = 0.0
+    path = tmp_path / "test_2d.fits"
+    hdu.writeto(str(path))
+    return path
+
+def make_fits_3d(tmp_path) -> Path:
+    # 3D cube: 32×32×8 (x, y, wavelength)
+    cube = np.random.rand(8, 32, 32).astype(np.float32)
+    hdu = fits.PrimaryHDU(cube)
+    path = tmp_path / "test_3d.fits"
+    hdu.writeto(str(path))
+    return path
+```
+
+### Synthetic HDF5 + npy (pkg48)
+
+```python
+import h5py, numpy as np
+
+def make_hdf5(tmp_path) -> Path:
+    path = tmp_path / "test_density.hdf5"
+    with h5py.File(str(path), "w") as f:
+        data = np.random.rand(16, 16, 16).astype(np.float32)
+        f.create_dataset("density", data=data)
+    return path
+
+def make_npy(tmp_path) -> Path:
+    path = tmp_path / "test_density.npy"
+    np.save(str(path), np.random.rand(16, 16, 16).astype(np.float32))
+    return path
+```
+
+### Synthetic SPH particles (pkg49)
+
+```python
+import numpy as np
+
+def make_particles(N=100):
+    rng = np.random.default_rng(42)
+    positions = rng.uniform(0, 1, (N, 3)).astype(np.float32)
+    smoothing = np.full(N, 0.05, dtype=np.float32)   # h = 0.05 (support 0.1)
+    values    = np.ones(N, dtype=np.float32)           # uniform density
+    masses    = np.full(N, 1.0/N, dtype=np.float32)
+    densities = np.ones(N, dtype=np.float32)
+    return positions, smoothing, values, masses, densities
+```
+
+Output: 32³ grid over [0,1]³. A uniform-density particle distribution must
+produce a grid with max/min ratio < 1.01 (boundary cells acceptable < 1.05).
+
+---
+
+## 7. License Matrix
+
+| Dependency | License | Use in Astroray | Mirror permitted |
+|---|---|---|---|
+| cfitsio | Public domain (NASA) | System dep, link at runtime | N/A — not mirrored |
+| HDF5 C library | BSD-style (HDF5 Software License 1.0) | System dep, link at runtime | N/A — not mirrored |
+| HighFive | MIT | Header-only; referenced via vcpkg or submodule | Yes, with copyright notice |
+| astropy | BSD-3-Clause | Python test generation only; not in C++ build | N/A |
+| h5py | BSD-3-Clause | Python test generation only; not in C++ build | N/A |
+| yt | BSD-3-Clause | Python preprocessing example only; chunked-read pattern cited | Code pattern may be adapted with attribution |
+| NumPy | BSD-3-Clause | Python only; in-house C++ parser does not link NumPy | N/A |
+
+**No GPL code touches this pipeline.** cfitsio (public domain) and HDF5 (BSD)
+are unambiguous. HighFive (MIT) can be bundled. yt code patterns can be
+adapted with attribution but yt itself is not a C++ dependency.
+
+---
+
+## Sources
+
+- Monaghan (1992): https://www.annualreviews.org/doi/10.1146/annurev.aa.30.090192.002551
+- Price (2012): https://arxiv.org/abs/1012.1885
+- Dehnen & Aly (2012) on Wendland kernels: https://arxiv.org/abs/1204.2471
+- Westover (1990): ACM SIGGRAPH '90, pp. 367-376, DOI 10.1145/97879.97919
+- cfitsio: https://heasarc.gsfc.nasa.gov/fitsio/
+- cfitsio vcpkg: https://vcpkg.io/en/package/cfitsio.html
+- HDF5 vcpkg: https://vcpkg.io/en/package/hdf5.html
+- HighFive: https://github.com/highfive-devs/highfive
+- HighFive vcpkg: https://vcpkg.io/en/package/highfive
+- NumPy .npy format spec: https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html
+- FindHDF5 CMake module: https://cmake.org/cmake/help/latest/module/FindHDF5.html
+- astropy io.fits: https://docs.astropy.org/en/stable/io/fits/
+- yt project: https://yt-project.org/

--- a/.astroray_plan/packages/pkg47-fits-loader.md
+++ b/.astroray_plan/packages/pkg47-fits-loader.md
@@ -1,46 +1,52 @@
 # pkg47 — FITS Data Loader
 
-**Pillar:** 4
-**Track:** B (self-contained I/O plugin)
-**Status:** open
-**Estimated effort:** 1–2 sessions (~4 h)
+**Pillar:** 4  
+**Track:** B (self-contained I/O plugin)  
+**Status:** open  
+**Estimated effort:** 1–2 sessions (~4 h)  
 **Depends on:** pkg04 (shape/texture plugin system)
+
+**Reference research:** `.astroray_plan/docs/pillar4-data-io-research.md §2`  
+(cfitsio API, CMake recipe, vcpkg setup, test data strategy, license notes —
+read before writing any FITS code)
+
+---
+
+## Reference Implementations
+
+| Source | License | What we use | What we do NOT mirror |
+|---|---|---|---|
+| [cfitsio](https://heasarc.gsfc.nasa.gov/fitsio/) (NASA/HEASARC) | **Public domain** | System dep; `fits_open_file`, `fits_read_pix`, `fits_get_img_dim/size/type` | Not mirrored — linked as system library |
+| [astropy io.fits](https://docs.astropy.org/en/stable/io/fits/) (BSD-3) | BSD-3-Clause | Python test data generation only; API design reference for clean FITS reader | No C++ code from astropy |
+| FITS Standard 4.0 (NASA/IAU) | Public domain | Spec for BITPIX, NAXIS, BSCALE/BZERO, HDU structure | N/A |
+
+**Do not vendor cfitsio.** Use as a system dependency installed via vcpkg on
+Windows or the system package manager on Linux. The plugin build is gated by
+`ASTRORAY_ENABLE_FITS` (default `OFF`) and silently skips if cfitsio is absent.
 
 ---
 
 ## Goal
 
-**Before:** Astroray cannot load observational or simulation data in
-FITS format. Users with Hubble, JWST, or radio telescope data cannot
-visualise it in the renderer.
+**Before:** Astroray cannot load observational or simulation data in FITS format.
+Users with Hubble, JWST, or radio telescope data cannot visualise it in the
+renderer.
 
-**After:** A `FITSLoader` plugin reads FITS files and exposes them as
-either volumetric data cubes (3D: x, y, wavelength/velocity) or
-plane-sky textures (2D images). The data integrates with the existing
-texture and volume plugin systems so it can be assigned to objects,
-used as emission sources, or displayed as environment maps.
+**After:** A `FITSLoader` plugin reads FITS files and exposes them as either
+volumetric data cubes (3D: x, y, wavelength/velocity) or plane-sky textures (2D
+images). The data integrates with the existing texture and volume plugin systems
+so it can be assigned to objects, used as emission sources, or displayed as
+environment maps.
 
 ---
 
 ## Context
 
-FITS (Flexible Image Transport System) is the universal data format in
-astronomy. Every telescope — Hubble, JWST, ALMA, VLA, Chandra — outputs
-FITS. Supporting FITS import is essential for Astroray's positioning as
-an astrophysical visualisation tool, because it lets users overlay their
-own data with synthetic models (e.g., render a Kerr black hole in front
-of a real JWST deep field, or volume-render an ALMA data cube of a
-protoplanetary disk).
-
----
-
-## Reference
-
-- Design doc: `.astroray_plan/docs/astrophysics.md §4.5`
-- CFITSIO: https://heasarc.gsfc.nasa.gov/fitsio/ (permissive license)
-- EleFits: https://github.com/CNES/EleFits (LGPL-3, dynamic link OK)
-- External references: `.astroray_plan/docs/external-references.md §4`
-- FITS standard: https://fits.gsfc.nasa.gov/fits_standard.html
+FITS (Flexible Image Transport System) is the universal data format in astronomy.
+Every major observatory — Hubble, JWST, ALMA, VLA, Chandra — outputs FITS.
+Supporting FITS import lets users overlay their own data with synthetic models
+(e.g., render a Kerr black hole in front of a real JWST deep field, or
+volume-render an ALMA data cube of a protoplanetary disk).
 
 ---
 
@@ -59,22 +65,89 @@ protoplanetary disk).
 | File | Purpose |
 |---|---|
 | `plugins/data/fits_loader.cpp` | `FITSTexture` (2D) and `FITSVolume` (3D) plugins. |
-| `include/astroray/fits_io.h` | FITS reading wrapper around CFITSIO. Isolates the C API from plugin code. |
-| `tests/test_fits_loader.py` | Unit and integration tests. |
-| `tests/data/test_2d.fits` | Small (64×64) synthetic 2D FITS image for testing. |
-| `tests/data/test_3d.fits` | Small (32×32×8) synthetic 3D FITS cube for testing. |
-| `scripts/generate_test_fits.py` | Python script to create the synthetic test FITS files using astropy.io.fits. |
+| `include/astroray/fits_io.h` | FITS reading wrapper around cfitsio. Isolates the C API from plugin code. |
+| `tests/test_fits_loader.py` | Unit and integration tests. Synthetic data generated at test time (no checked-in binaries). |
 
 ### Files to modify
 
 | File | What changes |
 |---|---|
-| `CMakeLists.txt` | Add CFITSIO as optional dependency via `find_package` or FetchContent. Build gate: if CFITSIO not found, FITS plugins are skipped (no build failure). |
+| `CMakeLists.txt` | Add cfitsio as optional dependency via `ASTRORAY_ENABLE_FITS` flag (see CMake recipe below). |
 | `include/astroray/register.h` | Confirm `DataLoaderRegistry` exists; add if needed. |
-| `module/blender_module.cpp` | Expose `load_fits_texture(path)` and `load_fits_volume(path)` methods on the renderer. |
+| `module/blender_module.cpp` | Expose `load_fits_texture(path)` and `load_fits_volume(path)` on the renderer. |
 | `blender_addon/__init__.py` | Add FITS file browser to import panel. |
 | `.astroray_plan/docs/STATUS.md` | Mark pkg47 done. |
 | `CHANGELOG.md` | Add pkg47 entry. |
+
+### CMake recipe
+
+```cmake
+option(ASTRORAY_ENABLE_FITS "Enable FITS I/O (requires cfitsio)" OFF)
+
+if(ASTRORAY_ENABLE_FITS)
+  # vcpkg provides cfitsio::cfitsio; system installs may use pkg-config
+  find_package(cfitsio CONFIG QUIET)
+  if(NOT cfitsio_FOUND)
+    find_package(PkgConfig QUIET)
+    if(PkgConfig_FOUND)
+      pkg_check_modules(cfitsio IMPORTED_TARGET cfitsio)
+      if(cfitsio_FOUND)
+        add_library(cfitsio::cfitsio ALIAS PkgConfig::cfitsio)
+      endif()
+    endif()
+  endif()
+
+  if(cfitsio_FOUND)
+    target_sources(astroray PRIVATE plugins/data/fits_loader.cpp)
+    target_link_libraries(astroray PRIVATE cfitsio::cfitsio)
+    target_compile_definitions(astroray PRIVATE ASTRORAY_FITS_ENABLED)
+    message(STATUS "FITS I/O enabled (cfitsio found)")
+  else()
+    message(WARNING
+      "ASTRORAY_ENABLE_FITS=ON but cfitsio not found. "
+      "Install via: vcpkg install cfitsio  (Windows) or  apt install libcfitsio-dev  (Linux). "
+      "FITS plugins will be skipped.")
+  endif()
+endif()
+```
+
+**Codex-ready when:** `find_package(cfitsio CONFIG QUIET)` resolves on the
+Windows MinGW toolchain used in this repo. Verify with:
+`cmake -DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%/scripts/buildsystems/vcpkg.cmake
+-DASTRORAY_ENABLE_FITS=ON .`
+
+### Windows / vcpkg setup
+
+```
+vcpkg install cfitsio
+```
+
+Or in `vcpkg.json`:
+```json
+{ "name": "cfitsio", "version>=": "3.49" }
+```
+
+### `fits_io.h` wrapper interface
+
+```cpp
+class FITSFile {
+public:
+    static FITSFile open(const std::string& path);  // throws on error
+    ~FITSFile();                                     // RAII close
+
+    int naxis() const;                               // 2 or 3
+    std::vector<long> shape() const;                 // [ny, nx] or [nz, ny, nx]
+    std::string header(const std::string& key) const;
+
+    // Reads entire image as float (applies BSCALE/BZERO automatically)
+    std::vector<float> readFloat() const;
+};
+```
+
+CFITSIO C API calls inside the wrapper:
+- `fits_open_file` → `fits_get_img_dim` → `fits_get_img_size` → `fits_read_pix`
+  with `datatype=TFLOAT`
+- `fits_read_key` for header access
 
 ### Supported FITS features
 
@@ -83,112 +156,67 @@ protoplanetary disk).
 | 2D images (IMAGE HDU, NAXIS=2) | Yes | Loaded as texture. |
 | 3D data cubes (NAXIS=3) | Yes | Loaded as volume. Third axis interpreted as wavelength or velocity per WCS. |
 | Multiple HDUs | First IMAGE HDU by default; user can specify HDU index. | |
-| Floating point data (BITPIX −32, −64) | Yes | Native float/double. |
-| Integer data (BITPIX 8, 16, 32) | Yes | Converted to float, applying BSCALE/BZERO. |
+| Floating point (BITPIX −32, −64) | Yes | Native float/double. |
+| Integer data (BITPIX 8, 16, 32) | Yes | Converted to float; BSCALE/BZERO applied by cfitsio. |
 | WCS coordinates | Read and stored as metadata; used for physical scale if present. | Not required. |
-| Compressed FITS (.fits.gz, tile compression) | Via CFITSIO transparent decompression. | |
+| Compressed FITS (.fits.gz, tile compression) | Via cfitsio transparent decompression. | |
 | FITS tables (BINTABLE) | No | Out of scope. |
-
-### Data representation
-
-**2D → FITSTexture**: registered as a texture plugin. The FITS image
-becomes a 2D floating-point texture that can be assigned to any object's
-surface or used as an environment map background. Values are normalised
-to [0, 1] by default (using DATAMIN/DATAMAX or computed min/max) with
-an optional `exposure` parameter for manual scaling.
-
-**3D → FITSVolume**: registered as a volume plugin (or as a
-`ConstantMedium`-style shape with density from the cube). Each voxel's
-value maps to density and/or emission intensity. The third axis
-(wavelength/velocity) can optionally drive spectral emission: at each
-sample point, the plugin looks up the cube slice closest to the current
-hero wavelength and returns that value as spectral radiance. This enables
-wavelength-resolved volume rendering of IFU data cubes.
-
-### CFITSIO integration
-
-The `fits_io.h` wrapper provides:
-
-- `FITSFile::open(path)` — opens file, reads primary HDU metadata.
-- `FITSFile::readImage2D()` → `std::vector<float>` + width, height.
-- `FITSFile::readCube3D()` → `std::vector<float>` + nx, ny, nz.
-- `FITSFile::header(key)` → string value of any header keyword.
-- RAII: file handle closed on destruction.
-
-CFITSIO's C API is wrapped in this single header so plugin code never
-touches `fitsio.h` directly.
 
 ### Key design decisions
 
-1. **CFITSIO, not EleFits, for the initial implementation.** CFITSIO
-   is more widely available (often pre-installed on Linux), has no C++20
-   requirement, and handles compressed FITS transparently. EleFits can
-   be considered as a future alternative if the C API proves painful.
-
-2. **Optional dependency.** If CFITSIO is not found at build time, the
-   FITS plugins are simply not compiled. No build failure. A runtime
-   warning is printed if a user tries to load FITS without the plugins.
-
-3. **BSCALE/BZERO applied automatically.** Integer FITS data uses
-   BSCALE and BZERO header keywords to map to physical values. CFITSIO
-   applies these by default when reading to float; the wrapper does not
-   suppress this.
-
-4. **WCS is metadata, not geometry.** WCS (World Coordinate System)
-   headers encode the mapping from pixel to sky coordinates. The loader
-   reads and stores them but does not transform the data — the user
-   positions and scales the object in Blender. Physical scale from WCS
-   can be exposed as a convenience (e.g., auto-setting object
-   dimensions to match the angular extent) in a future enhancement.
-
-5. **No astropy dependency at runtime.** astropy is used only in the
-   test-data generation script. The C++ loader uses CFITSIO directly.
+1. **BSCALE/BZERO applied automatically.** cfitsio applies scaling when reading
+   to `TFLOAT`; the wrapper does not suppress this.
+2. **WCS is metadata, not geometry.** Headers stored but data not transformed.
+   The user positions and scales the object in Blender.
+3. **No astropy C++ dependency.** astropy is used only in test data generation.
+4. **Optional, not required.** Plugin simply absent if cfitsio not found.
 
 ---
 
 ## Acceptance criteria
 
-- [ ] CFITSIO added as optional CMake dependency; build succeeds with
-      and without it.
-- [ ] `FITSTexture` registered and loads a 2D FITS image as a texture.
-- [ ] `FITSVolume` registered and loads a 3D FITS cube as a volume.
-- [ ] Test 2D: a synthetic gradient FITS image renders correctly on a
-      plane (gradient visible, not black or inverted).
-- [ ] Test 3D: a synthetic cube renders as a volume with density
-      variation along the third axis.
-- [ ] BSCALE/BZERO: an integer FITS file with non-trivial scaling
-      produces correct float values.
-- [ ] Missing CFITSIO: build completes; attempting to load FITS prints
-      a clear error message.
-- [ ] Blender addon has a FITS import button.
+- [ ] `ASTRORAY_ENABLE_FITS=OFF` (default): build succeeds; no FITS symbols.
+- [ ] `ASTRORAY_ENABLE_FITS=ON` with cfitsio present: build succeeds; plugins compiled.
+- [ ] `ASTRORAY_ENABLE_FITS=ON` without cfitsio: CMake warning printed; build succeeds with FITS disabled.
+- [ ] `FITSTexture` registered; loads a 64×64 synthetic float32 FITS image as a texture. Shape matches.
+- [ ] `FITSVolume` registered; loads a 32×32×8 synthetic FITS cube as a volume. Shape matches.
+- [ ] BSCALE/BZERO: an integer FITS file with `BZERO=1000.0, BSCALE=0.1` produces correct float values (test: pixel stored as `int16(500)` → expected `1000.0 + 0.1×500 = 1050.0`).
+- [ ] First IMAGE HDU selected by default; user can override by index.
+- [ ] Header keyword round-trip: write `OBJECT = 'NGC 1234'` in astropy; read back via `FITSFile::header("OBJECT")` in C++ → returns `"NGC 1234"`.
+- [ ] Missing file: `FITSFile::open` throws with message containing the path.
+- [ ] Blender addon has a FITS import button (both `FITSTexture` and `FITSVolume` assignable).
 - [ ] All existing tests pass.
-- [ ] ≥6 new tests covering: 2D load, 3D load, header reading,
-      scaling, missing-file error, build-without-CFITSIO.
+- [ ] ≥ 6 new tests: 2D load (shape, dtype, values), 3D load (shape, axis order), BSCALE/BZERO scaling, header read, missing-file error, build-without-cfitsio.
+
+### Concrete test data shapes
+
+| Test | Shape | dtype | Created by |
+|---|---|---|---|
+| 2D gradient image | (64, 64) | float32 | `astropy.io.fits.PrimaryHDU(np.arange(64*64).reshape(64,64).astype(np.float32))` |
+| 3D cube | (8, 32, 32) | float32 | `astropy.io.fits.PrimaryHDU(np.random.rand(8, 32, 32).astype(np.float32))` |
+| Integer with BSCALE | (16, 16) | int16 + BZERO/BSCALE | `fits.PrimaryHDU(arr_int16, header)` with header keywords set |
+
+All written to `tmp_path` (pytest); no binaries committed.
 
 ---
 
 ## Non-goals
 
-- Do not implement FITS table reading (BINTABLE). Only IMAGE HDUs.
-- Do not implement FITS writing. Astroray reads FITS; it writes PNG
-  and (eventually) EXR.
-- Do not implement full WCS → 3D coordinate transformation. Pixel
-  data is loaded as-is; positioning is manual.
-- Do not implement on-the-fly regridding or resampling. Data is loaded
-  at native resolution.
-- Do not implement multi-HDU compositing (e.g., RGB from 3 separate
-  HDUs). Single-HDU loading per object.
+- No FITS table reading (BINTABLE). Only IMAGE HDUs.
+- No FITS writing. Astroray reads FITS; it writes PNG and EXR.
+- No full WCS → 3D coordinate transformation. Pixel data loaded as-is.
+- No on-the-fly regridding or resampling. Native resolution only.
+- No multi-HDU compositing. Single HDU per object.
 
 ---
 
 ## Progress
 
-- [ ] Add CFITSIO to CMakeLists.txt as optional dependency.
+- [ ] Verify `ASTRORAY_ENABLE_FITS` flag works on this toolchain (cfitsio via vcpkg).
 - [ ] Implement `fits_io.h` wrapper.
 - [ ] Implement `FITSTexture` plugin (2D).
 - [ ] Implement `FITSVolume` plugin (3D).
-- [ ] Generate synthetic test FITS files.
-- [ ] Write tests.
+- [ ] Write tests (synthetic data via astropy at test time).
 - [ ] Add Blender UI.
 - [ ] Full test suite green.
 - [ ] Update STATUS.md, CHANGELOG.md.

--- a/.astroray_plan/packages/pkg48-hdf5-numpy-loader.md
+++ b/.astroray_plan/packages/pkg48-hdf5-numpy-loader.md
@@ -1,52 +1,61 @@
 # pkg48 — HDF5 & NumPy Simulation Data Loader
 
-**Pillar:** 4
-**Track:** B (self-contained I/O plugin)
-**Status:** open
-**Estimated effort:** 1–2 sessions (~4 h)
+**Pillar:** 4  
+**Track:** B (self-contained I/O plugin)  
+**Status:** open  
+**Estimated effort:** 1–2 sessions (~4 h)  
 **Depends on:** pkg04 (plugin system), pkg47 (establishes data loader pattern)
+
+**Reference research:** `.astroray_plan/docs/pillar4-data-io-research.md §§1, 3, 4`  
+(DensityGrid type, HDF5/HighFive CMake recipe, in-house npy parser spec,
+chunked-read pattern, vcpkg setup, license notes — read before writing any
+simulation volume code)
+
+---
+
+## Reference Implementations
+
+| Source | License | What we use | What we do NOT mirror |
+|---|---|---|---|
+| [HDF5 C library](https://www.hdfgroup.org/solutions/hdf5/) (HDF Group) | BSD-style (HDF5 Software License 1.0) | System dep; accessed via HighFive wrapper | Not mirrored |
+| [HighFive](https://github.com/highfive-devs/highfive) (highfive-devs) | **MIT** | Header-only C++ wrapper; vcpkg or submodule | Headers may be bundled with copyright notice |
+| [yt](https://yt-project.org/) | BSD-3-Clause | Chunked-read pattern cited in code comment; Python preprocessing example | No C++ code from yt |
+| [h5py](https://docs.h5py.org/) | BSD-3-Clause | Python test data generation only | None |
+| NumPy .npy format spec | BSD-3-Clause | In-house C++ parser (~80 lines) derived from spec | Parser written from spec, not from NumPy source |
+
+**Do not vendor HDF5.** Use as system dependency (vcpkg on Windows).
+**HighFive** may be referenced via vcpkg or bundled as a git submodule (MIT, no
+copyleft). The npy parser is written from scratch against the published spec.
 
 ---
 
 ## Goal
 
-**Before:** Astroray cannot load simulation data from hydrodynamic or
-MHD codes (AREPO, FLASH, Enzo, Athena++, PLUTO). Users who have run
-simulations cannot visualise them in the renderer.
+**Before:** Astroray cannot load simulation data from hydrodynamic or MHD codes
+(AREPO, FLASH, Enzo, Athena++, PLUTO). Users who have run simulations cannot
+visualise them.
 
-**After:** A `SimulationVolume` plugin loads 3D grid data from NumPy
-`.npy` files (the recommended yt preprocessing output) and optionally
-from HDF5 files directly via HighFive. Multiple fields (density,
-temperature, velocity, magnetic field) can be loaded simultaneously
-and mapped to volume density, emission, and colour.
+**After:** A `SimulationVolume` plugin loads 3D grid data from NumPy `.npy` files
+(the recommended yt preprocessing output) and optionally from HDF5 files directly
+via HighFive. Multiple fields (density, temperature, velocity) can be loaded
+simultaneously and mapped to volume density, emission, and colour.
 
 ---
 
 ## Context
 
-The standard astrophysical simulation data pipeline is:
+Standard astrophysical simulation data pipeline:
 
-1. User runs a simulation (AREPO, FLASH, etc.) → HDF5/custom output.
+1. User runs simulation → HDF5/custom output.
 2. User preprocesses with yt in Python → uniform 3D grid → `.npy`.
-3. Astroray loads the `.npy` grid and renders it as a volume.
+3. Astroray loads `.npy` and renders as volume.
 
-This two-step approach avoids Astroray needing to understand every
-simulation code's bespoke HDF5 schema. yt handles the regridding and
-format normalisation; Astroray just reads uniform grids.
+This two-step approach avoids Astroray needing to understand every simulation
+code's bespoke HDF5 schema. yt handles regridding and format normalisation;
+Astroray reads uniform grids.
 
-For users who prefer to skip yt, direct HDF5 loading via HighFive
-(header-only, BSD-3) is also supported for simple uniform-grid
-datasets.
-
----
-
-## Reference
-
-- Design doc: `.astroray_plan/docs/astrophysics.md §4.5`
-- yt: https://yt-project.org/ (BSD-3; Python preprocessing only)
-- HighFive: https://github.com/BlueBrain/HighFive (BSD-3, header-only)
-- NumPy .npy format: https://numpy.org/devdocs/reference/generated/numpy.lib.format.html
-- External references: `.astroray_plan/docs/external-references.md §4`
+For users who skip yt, direct HDF5 loading via HighFive is supported for
+simple uniform-grid datasets.
 
 ---
 
@@ -64,52 +73,129 @@ datasets.
 
 | File | Purpose |
 |---|---|
-| `plugins/data/simulation_volume.cpp` | `SimulationVolume` plugin. Reads `.npy` and HDF5 grids. |
-| `include/astroray/npy_reader.h` | Minimal `.npy` file parser (header + raw float data). ~80 lines. |
-| `tests/test_simulation_volume.py` | Unit and integration tests. |
-| `tests/data/test_density.npy` | Small (16×16×16) synthetic density grid for testing. |
-| `tests/data/test_temperature.npy` | Small (16×16×16) synthetic temperature grid. |
-| `scripts/preprocess_simulation.py` | Example yt preprocessing script (documentation/reference, not a dependency). |
+| `plugins/data/simulation_volume.cpp` | `SimulationVolume` plugin. Reads `.npy` via `npy_reader.h` and HDF5 via HighFive. |
+| `include/astroray/npy_reader.h` | In-house `.npy` parser (~80 lines). Validates header, reads float32/float64 3D arrays. |
+| `include/astroray/density_grid.h` | `DensityGrid` struct (shared by pkg47, pkg48, pkg49). See §1 of research note. |
+| `tests/test_simulation_volume.py` | Unit and integration tests. Synthetic data generated at test time. |
+| `scripts/preprocess_simulation.py` | Example yt preprocessing script (documentation/reference, not a C++ dependency). |
 
 ### Files to modify
 
 | File | What changes |
 |---|---|
-| `CMakeLists.txt` | Add HighFive as optional header-only dependency. HDF5 C library as optional `find_package`. |
+| `CMakeLists.txt` | Add HDF5/HighFive as optional dependency via `ASTRORAY_ENABLE_HDF5` flag (see CMake recipe below). |
 | `module/blender_module.cpp` | Expose `load_simulation_volume(density_path, temperature_path=None, ...)`. |
 | `blender_addon/__init__.py` | Add simulation data import panel with file browsers for each field. |
 | `.astroray_plan/docs/STATUS.md` | Mark pkg48 done. |
 | `CHANGELOG.md` | Add pkg48 entry. |
 
+### CMake recipe
+
+```cmake
+option(ASTRORAY_ENABLE_HDF5 "Enable HDF5 I/O (requires HDF5 + HighFive)" OFF)
+
+if(ASTRORAY_ENABLE_HDF5)
+  find_package(HighFive CONFIG QUIET)   # automatically discovers HDF5 C library
+  if(NOT HighFive_FOUND)
+    find_package(HDF5 QUIET COMPONENTS C)
+  endif()
+
+  if(HighFive_FOUND OR HDF5_FOUND)
+    target_sources(astroray PRIVATE plugins/data/simulation_volume.cpp)
+    if(HighFive_FOUND)
+      target_link_libraries(astroray PRIVATE HighFive::HighFive)
+      target_compile_definitions(astroray PRIVATE ASTRORAY_HIGHFIVE_ENABLED)
+    else()
+      target_include_directories(astroray PRIVATE ${HDF5_INCLUDE_DIRS})
+      target_link_libraries(astroray PRIVATE ${HDF5_C_LIBRARIES})
+      target_compile_definitions(astroray PRIVATE ASTRORAY_HDF5_RAW_ENABLED)
+    endif()
+    message(STATUS "HDF5 I/O enabled")
+  else()
+    message(WARNING
+      "ASTRORAY_ENABLE_HDF5=ON but HDF5/HighFive not found. "
+      "Install via: vcpkg install hdf5 highfive  (Windows) or  apt install libhdf5-dev  (Linux). "
+      ".npy loading still works without HDF5.")
+  endif()
+endif()
+
+# .npy loading is always compiled (no external dependency)
+target_sources(astroray PRIVATE plugins/data/simulation_volume.cpp)
+target_compile_definitions(astroray PRIVATE ASTRORAY_NPY_ENABLED)
+```
+
+**Codex-ready when:** `find_package(HighFive CONFIG QUIET)` resolves on the
+Windows MinGW toolchain. Verify with:
+`cmake -DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%/scripts/buildsystems/vcpkg.cmake
+-DASTRORAY_ENABLE_HDF5=ON .`
+
+### Windows / vcpkg setup
+
+```
+vcpkg install hdf5 highfive
+```
+
+On Windows with static builds, add to CMake invocation:
+```
+-DHDF5_USE_STATIC_LIBRARIES=ON
+```
+
+### `npy_reader.h` parser spec
+
+Derived from the official .npy format spec:
+https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html
+
+```
+Byte layout:
+  [0:6]    magic: \x93NUMPY
+  [6]      major version (uint8): 1 or 2
+  [7]      minor version (uint8): 0
+  [8:10]   header length (uint16, little-endian)  -- if major == 1
+  [8:12]   header length (uint32, little-endian)  -- if major == 2
+  [10/12 : 10/12+N]  header dict (ASCII/UTF-8), padded with spaces to
+                     align total bytes to 64-byte boundary, terminated \n
+  [after header]     raw float data, C-order
+```
+
+Parser requirements:
+- Accept `'<f4'` (float32) and `'<f8'` (float64); reject others.
+- Accept `fortran_order: False` only; reject Fortran-order.
+- Accept 3D shape only (rank-3 array); reject other ranks.
+- Extract shape by scanning for `'shape': (` and reading three integers.
+- Return `DensityGrid` with `data` vector (always float32 after conversion).
+
 ### Data formats
 
-#### NumPy .npy (primary)
+#### NumPy .npy (primary, no external dependency)
 
-The `.npy` format stores a single N-dimensional array with a short
-header (magic, shape, dtype, fortran-order flag) followed by raw data.
-Parsing it requires ~80 lines of C++ — no external dependency.
+Expected input: 3D float32 or float64 array, shape `(nx, ny, nz)`, C-order.
+The reader validates the header and rejects non-float or non-3D files.
 
-Expected input: 3D float32 or float64 array, shape (nx, ny, nz),
-C-order. The reader validates the header and rejects non-float or
-non-3D files with a clear error message.
+#### HDF5 via HighFive (optional)
 
-#### HDF5 (optional, via HighFive)
+```cpp
+// Reads dataset "density" from an HDF5 file into DensityGrid
+HighFive::File file(path, HighFive::File::ReadOnly);
+auto ds = file.getDataSet("density");
+auto dims = ds.getDimensions();  // {nx, ny, nz}
+std::vector<float> buf(dims[0] * dims[1] * dims[2]);
+ds.read(buf);
+```
 
-For users who have uniform-grid HDF5 files and don't want to
-preprocess with yt. The plugin reads a named dataset from a specified
-group:
+User specifies the dataset path:
+```python
+load_simulation_volume(path="snapshot.hdf5",
+                       dataset="/PartType0/Density",
+                       shape=[256, 256, 256])
+```
 
-    load_simulation_volume(path="snapshot.hdf5",
-                           dataset="/PartType0/Density",
-                           shape=[256, 256, 256])
-
-HighFive is header-only and BSD-3; it wraps the HDF5 C library. Like
-CFITSIO for FITS, HDF5 is an optional dependency: if not found, the
-HDF5 path is disabled but `.npy` loading still works.
+For large datasets: read in z-slabs of 64 layers (see research note §3 for
+chunked-read pseudocode). Cite: yt chunked-read pattern,
+`yt/frontends/enzo/data_structures.py` (BSD-3).
 
 ### Volume representation
 
-The `SimulationVolume` is a box-shaped volume in world space. User sets:
+`SimulationVolume` is a box-shaped volume in world space. Parameters:
 
 | Parameter | Default | Description |
 |---|---|---|
@@ -119,98 +205,61 @@ The `SimulationVolume` is a box-shaped volume in world space. User sets:
 | `bbox_min` | (-1,-1,-1) | World-space bounding box minimum. |
 | `bbox_max` | (1,1,1) | World-space bounding box maximum. |
 | `density_scale` | 1.0 | Multiplier on density values. |
-| `emission_mode` | "absorption" | "absorption" (density → extinction), "emission" (density → luminosity), or "both". |
-| `transfer_function` | "linear" | "linear", "log", or "sqrt" — maps raw values to visual density. |
+| `emission_mode` | "absorption" | "absorption", "emission", or "both". |
+| `transfer_function` | "linear" | "linear", "log", or "sqrt". |
 
-The plugin implements trilinear interpolation on the grid for smooth
-sampling between voxels.
-
-### Integration with renderer
-
-In **absorption mode**, the simulation volume acts like a
-`ConstantMedium` with spatially-varying density. Rays are attenuated
-according to the local extinction coefficient derived from the density
-field.
-
-In **emission mode**, the volume emits spectral radiance proportional
-to the density (and optionally temperature-dependent via a blackbody
-or user-specified colour map). This uses the `VolumetricEmission`
-interface from pkg42.
-
-In **both mode**, both absorption and emission are applied (standard
-emission-absorption radiative transfer).
-
-### Key design decisions
-
-1. **NumPy .npy as primary format.** Zero external dependencies,
-   trivial to generate from Python, and the yt preprocessing path
-   naturally outputs `.npy`. This makes the most common workflow
-   dependency-free on the C++ side.
-
-2. **HighFive, not raw HDF5 C API.** HighFive is header-only and
-   provides a type-safe C++ interface. No library to link against
-   beyond the HDF5 C library itself. Keeps plugin code clean.
-
-3. **User-specified bounding box, not physical units.** Simulation
-   data comes in arbitrary code units. Rather than trying to parse
-   unit metadata (which varies by simulation code), the user sets the
-   world-space extent in Blender. The example yt script shows how to
-   extract physical dimensions for reference.
-
-4. **Transfer function is visual, not physical.** The log/sqrt options
-   are for visual clarity (compressing dynamic range in density fields
-   that span many orders of magnitude). They do not change the physics
-   of radiative transfer — they map raw values to the visual density
-   parameter that drives extinction/emission.
+The plugin implements trilinear interpolation on the grid for smooth sampling.
 
 ---
 
 ## Acceptance criteria
 
-- [ ] `SimulationVolume` registered as both a shape plugin and an
-      emission plugin.
-- [ ] `.npy` loader reads float32 and float64 3D arrays correctly.
-- [ ] A synthetic density grid renders as a volume with visible density
-      variation (not uniform or black).
-- [ ] Trilinear interpolation: sampling at grid centre matches the
-      stored value exactly; sampling between grid points produces a
-      smooth intermediate value.
-- [ ] Optional HDF5: if HighFive + HDF5 are available, loads a dataset
-      from an HDF5 file and produces identical results to the `.npy`
-      equivalent.
-- [ ] Missing HDF5: build completes; `.npy` loading still works.
-- [ ] Transfer functions: log and sqrt modes compress dynamic range
-      visually compared to linear.
-- [ ] Blender addon has simulation data import UI with file browsers.
+- [ ] `.npy` loader compiled unconditionally (no feature flag).
+- [ ] `SimulationVolume` registered as both shape plugin and emission plugin.
+- [ ] `.npy` float32 load: 16×16×16 synthetic grid read back with shape `(16,16,16)` and values matching within 1e-6.
+- [ ] `.npy` float64 load: same grid as float64, values converted to float32, same tolerance.
+- [ ] `.npy` rejection: non-3D array → `std::runtime_error` with message containing "expected 3D".
+- [ ] `.npy` rejection: wrong dtype (e.g. int32) → `std::runtime_error` with message containing dtype name.
+- [ ] Trilinear interpolation: sampling at grid centre matches stored value exactly; sampling at a midpoint between two adjacent cells with values 0 and 1 returns 0.5 ± 1e-5.
+- [ ] `transfer_function="log"`: log-scale output compresses dynamic range (max/min ratio in log space < max/min ratio in linear space for a grid spanning [0.01, 100]).
+- [ ] HDF5 (if enabled): a 16×16×16 synthetic HDF5 dataset produces identical `DensityGrid` to the equivalent `.npy` file (element-wise comparison, max absolute diff < 1e-6).
+- [ ] HDF5 absent: `ASTRORAY_ENABLE_HDF5=OFF` build compiles; `.npy` path still works.
 - [ ] All existing tests pass.
-- [ ] ≥6 new tests covering: `.npy` load, shape validation, trilinear
-      interpolation, absorption render, emission render, bad-file error.
+- [ ] ≥ 6 new tests: `.npy` float32 load, `.npy` float64 load, rank validation, dtype validation, trilinear interpolation, log transfer function.
+
+### Concrete test data shapes
+
+| Test | Shape | dtype | Created by |
+|---|---|---|---|
+| density grid | (16, 16, 16) | float32 | `np.random.rand(16,16,16).astype(np.float32); np.save(tmp, data)` |
+| temperature grid | (16, 16, 16) | float32 | same pattern |
+| HDF5 density | (16, 16, 16) | float32 | `h5py.File(tmp)["density"] = data` |
+| uniform grid (interp test) | (4, 4, 4) | float32 | `np.arange(64).reshape(4,4,4).astype(np.float32)` |
+
+All written to `tmp_path` (pytest); no binaries committed.
 
 ---
 
 ## Non-goals
 
-- Do not implement AMR (adaptive mesh refinement) grid reading. Only
-  uniform grids. AMR data should be regridded to uniform via yt.
-- Do not implement particle data (SPH) loading. That is pkg49.
-- Do not implement yt as a C++ dependency. yt runs in Python as a
-  preprocessing step only.
-- Do not implement time-series animation (loading multiple snapshots).
-  Single snapshot per render.
-- Do not implement isosurface extraction. Volume rendering only.
+- No AMR (adaptive mesh refinement) reading. Only uniform grids. AMR data should be regridded via yt.
+- No particle data (SPH). That is pkg49.
+- No yt as a C++ dependency. yt runs in Python only.
+- No time-series animation (multiple snapshots). Single snapshot per render.
+- No isosurface extraction. Volume rendering only.
 
 ---
 
 ## Progress
 
-- [ ] Implement `.npy` reader in `npy_reader.h`.
-- [ ] Implement `SimulationVolume` plugin: grid storage, trilinear
-      interpolation, absorption/emission modes.
-- [ ] Add optional HighFive/HDF5 path.
-- [ ] Generate synthetic test grids.
+- [ ] Define `DensityGrid` struct in `include/astroray/density_grid.h`.
+- [ ] Implement `npy_reader.h` (parse header, validate dtype and rank, return `DensityGrid`).
+- [ ] Implement `SimulationVolume`: grid storage, trilinear interpolation, absorption/emission modes.
+- [ ] Add optional HighFive/HDF5 path (behind `#ifdef ASTRORAY_HIGHFIVE_ENABLED`).
 - [ ] Write example yt preprocessing script.
 - [ ] Add Blender UI.
-- [ ] Write tests.
+- [ ] Write tests (synthetic data via numpy/h5py at test time).
+- [ ] Verify `ASTRORAY_ENABLE_HDF5=ON` on Windows toolchain.
 - [ ] Full test suite green.
 - [ ] Update STATUS.md, CHANGELOG.md.
 

--- a/.astroray_plan/packages/pkg49-sph-to-volume.md
+++ b/.astroray_plan/packages/pkg49-sph-to-volume.md
@@ -1,53 +1,57 @@
 # pkg49 — SPH-to-Volume Conversion
 
-**Pillar:** 4
-**Track:** B (self-contained utility)
-**Status:** open
-**Estimated effort:** 1 session (~3 h)
-**Depends on:** pkg48 (SimulationVolume plugin)
+**Pillar:** 4  
+**Track:** B (self-contained utility)  
+**Status:** open  
+**Estimated effort:** 1 session (~3 h)  
+**Depends on:** pkg48 (SimulationVolume plugin, DensityGrid type)
+
+**Reference research:** `.astroray_plan/docs/pillar4-data-io-research.md §§1, 5, 6`  
+(DensityGrid type, cubic spline kernel formula, Shepard splatting pseudocode,
+test data strategy — read before writing any SPH code)
+
+---
+
+## Reference Implementations
+
+| Source | License | What we use | What we do NOT mirror |
+|---|---|---|---|
+| Monaghan (1992), *Ann. Rev. Astron. Astrophys.* 30, 543 | Public domain (journal article) | Cubic B-spline kernel formula, normalisation constant | N/A |
+| Price (2012), arXiv:1012.1885 | Public domain (arXiv preprint) | Kernel review, Eq. (4)-(5) for cubic spline in 3D | N/A |
+| Westover (1990), *SIGGRAPH '90* pp. 367-376 | Public domain (conference paper) | Footprint-evaluation splatting algorithm | N/A |
+| [yt SPH deposition](https://yt-project.org/) | BSD-3-Clause | Algorithm cross-check only; Shepard normalisation idea | No C++ code from yt |
+| [Splotch](https://github.com/splotch/splotch) SPH renderer | GPLv2 | **Do not mirror.** Algorithm reference only (check license before any use). | No code from Splotch |
+
+**Kernel math and splatting algorithm are from public-domain papers; no
+mirroring question arises.** yt is a Python cross-check reference only.
 
 ---
 
 ## Goal
 
-**Before:** SPH (Smoothed Particle Hydrodynamics) simulation data
-consists of scattered particles, not a regular grid. Astroray's
-`SimulationVolume` (pkg48) only reads uniform grids. Users with SPH
-data (AREPO, GADGET, SWIFT, Phantom) must preprocess externally.
+**Before:** SPH simulation data consists of scattered particles. `SimulationVolume`
+(pkg48) reads only uniform grids. Users with AREPO, GADGET, SWIFT, or Phantom
+data must preprocess externally.
 
-**After:** A C++ utility function and a Python convenience script
-convert SPH particle data into a uniform 3D grid using Wendland C4
-kernel interpolation. The output is a `.npy` file that
-`SimulationVolume` can load directly. The C++ kernel is also available
-at render time for direct particle splatting as an alternative to
-pre-gridding.
+**After:** A C++ utility function and a Python convenience script convert SPH
+particle data into a uniform 3D grid using cubic B-spline kernel splatting. The
+output is a `.npy` file that `SimulationVolume` loads directly. No new C++ plugin
+interface is needed — the utility is exposed via pybind11.
 
 ---
 
 ## Context
 
-SPH is one of the two dominant methods for astrophysical hydrodynamics
-(the other being AMR grid codes). AREPO, GADGET-4, SWIFT, and Phantom
-all output particle data with positions, smoothing lengths, and field
-values. Converting to a grid is straightforward (~100 lines of kernel
-evaluation) but must be done correctly to avoid aliasing and
-normalisation artifacts.
-
----
-
-## Reference
-
-- Design doc: `.astroray_plan/docs/astrophysics.md §4.5`
-- Wendland 1995 — compactly-supported radial basis functions
-- Price 2012 — "Smoothed Particle Hydrodynamics and
-  Magnetohydrodynamics" (SPH kernel review, §2.1)
-- Existing: `SimulationVolume` plugin from pkg48
+SPH is one of the two dominant methods for astrophysical hydrodynamics. AREPO,
+GADGET-4, SWIFT, and Phantom all output particle data with positions, smoothing
+lengths, and field values. Converting to a uniform grid via kernel splatting is
+~100 lines of C++ and is the standard preprocessing step.
 
 ---
 
 ## Prerequisites
 
-- [ ] pkg48 is done: `SimulationVolume` loads `.npy` grids.
+- [ ] pkg48 done: `SimulationVolume` loads `.npy` grids and `DensityGrid` struct exists.
 - [ ] Build passes on main.
 - [ ] All existing tests pass.
 
@@ -59,128 +63,151 @@ normalisation artifacts.
 
 | File | Purpose |
 |---|---|
-| `include/astroray/sph_kernel.h` | Wendland C4 kernel implementation + grid splatting function. Header-only, ~100 lines. |
-| `plugins/data/sph_to_grid.cpp` | `SPHToGrid` utility registered as a data-processing plugin. Reads particle data (positions, smoothing lengths, field values), outputs a uniform grid. |
-| `scripts/sph_to_npy.py` | Python convenience script: reads particle data from HDF5 (GADGET/AREPO format), calls the C++ splatting via pybind11 (or does it in pure Python/NumPy as fallback), writes `.npy`. |
-| `tests/test_sph_kernel.py` | Unit tests for kernel properties and grid conversion. |
-| `tests/data/test_particles.npy` | Small synthetic particle dataset (1000 particles) for testing. |
+| `include/astroray/sph_kernel.h` | Cubic B-spline kernel + Shepard splatting. Header-only, ~100 lines. No external deps. |
+| `plugins/data/sph_to_grid.cpp` | `SPHToGrid` function registered and exposed via pybind11. |
+| `scripts/sph_to_npy.py` | Python convenience script: reads particle data from HDF5 (GADGET/AREPO format), calls C++ splatting or pure-NumPy fallback, writes `.npy`. |
+| `tests/test_sph_kernel.py` | Unit and integration tests. Synthetic particles created at test time. |
 
 ### Files to modify
 
 | File | What changes |
 |---|---|
-| `module/blender_module.cpp` | Expose `sph_to_grid(positions, smoothing_lengths, values, grid_dims, bbox)` function via pybind11. |
+| `module/blender_module.cpp` | Expose `sph_to_grid(positions, smoothing_lengths, values, masses, densities, grid_dims, bbox_min, bbox_max)` via pybind11. |
 | `.astroray_plan/docs/STATUS.md` | Mark pkg49 done. |
 | `CHANGELOG.md` | Add pkg49 entry. |
 
+### CMake recipe
+
+No new CMake feature flag needed. `sph_kernel.h` is header-only with no external
+dependencies. `sph_to_grid.cpp` is compiled unconditionally as part of the base
+build.
+
+```cmake
+# No option() needed — SPH splatting has no external deps
+target_sources(astroray PRIVATE plugins/data/sph_to_grid.cpp)
+```
+
+**Codex-ready immediately** — no dep find_package to verify.
+
 ### Kernel specification
 
-**Wendland C4** in 3D:
+**Cubic B-spline kernel (Monaghan 1992, §2; Price 2012 Eq. 4-5):**
 
-    W(q) = (495 / 32π h³) · (1 − q)⁶ · (1 + 6q + 35q²/3)  for q ≤ 1
-    W(q) = 0                                                  for q > 1
+```
+W(r, h) = (1 / πh³) × w(q),    q = r / h
 
-where q = r/h and h is the smoothing length. This kernel is:
-- C4 continuous (smooth second derivatives).
-- Compactly supported (exactly zero beyond r = h).
-- Normalised: ∫ W(r) d³r = 1.
-- Positive definite (no negative lobes; pairing instability-free).
+         ⎧ 1 − (3/2)q² + (3/4)q³,   0 ≤ q < 1
+w(q) =  ⎨ (1/4)(2 − q)³,           1 ≤ q < 2
+         ⎩ 0,                        q ≥ 2
+```
 
-### Grid splatting algorithm
+Compact support: `r ∈ [0, 2h]`.  
+Normalisation: `∫₀^{2h} W(r,h) 4πr² dr = 1` (analytically verified;
+see research note §5 for the integral computation).
 
-For each particle i with position x_i, smoothing length h_i, and
-field value A_i:
+```cpp
+// sph_kernel.h
+inline float cubic_spline_kernel(float q) {
+    if (q >= 2.0f) return 0.0f;
+    if (q >= 1.0f) return (1.0f / float(M_PI)) * 0.25f * std::pow(2.0f - q, 3.0f);
+    return (1.0f / float(M_PI)) * (1.0f - 1.5f*q*q + 0.75f*q*q*q);
+    // caller divides by h³ for the full W(r,h)
+}
+```
 
-1. Find the axis-aligned bounding box of the particle's kernel
-   support: [x_i − h_i, x_i + h_i] in each dimension.
-2. Identify all grid cells that overlap this box.
-3. For each overlapping cell at position x_j:
-   - Compute q = |x_j − x_i| / h_i.
-   - Add A_i · W(q) · V_particle to the cell's accumulator.
-   - Add W(q) · V_particle to a normalisation accumulator.
-4. After all particles: divide field accumulator by normalisation
-   accumulator (scatter-gather normalisation).
+**Why cubic spline over Wendland C4:** The cubic spline (support radius 2h) is
+the canonical reference kernel for SPH splatting (Monaghan 1992; all major
+textbook treatments). Wendland C4 (Dehnen & Aly 2012) has better spectral
+properties for particle-based simulation integrators but is not required for
+grid pre-processing, where the Shepard normalisation already corrects for
+boundary effects. Use cubic spline for simplicity and textbook traceability.
+If direct particle rendering is added later (ray-marching through particles),
+revisit and switch to Wendland C4.
 
-V_particle = m_i / ρ_i is the particle volume (mass / density).
-If density is the field being gridded, the result is self-consistent.
+### Splatting algorithm
 
-Complexity: O(N · (h/Δx)³) where Δx is the grid cell size. For
-typical SPH data with h ~ 2–4 Δx, each particle touches ~64–512
-cells. With 10⁶ particles at 256³ resolution, this takes ~1–10
-seconds on a single core.
+Westover (1990) footprint evaluation + Shepard (1968) normalisation:
 
-### Key design decisions
+```
+Input:
+  N particles: pos[3], h (smoothing length), value, mass, density
+  Grid: nx × ny × nz cells, bbox_min[3], bbox_max[3]
+  cell_size = (bbox_max - bbox_min) / (nx, ny, nz)
+  particle_volume V[i] = mass[i] / density[i]
 
-1. **Wendland C4, not cubic spline.** The cubic B-spline has negative
-   lobes and is susceptible to the pairing instability. Wendland C4 is
-   the modern standard (used by SWIFT, Phantom, and recent GADGET
-   forks). It costs marginally more to evaluate but produces
-   smoother, artifact-free grids.
+Output: field[nx, ny, nz]
 
-2. **Pre-gridding as the primary path.** Direct particle rendering
-   (splatting particles during ray marching) is more accurate but
-   requires spatial indexing (kd-tree or hash grid) and is harder to
-   integrate with the volume rendering path. Pre-gridding is simpler,
-   produces a `.npy` that `SimulationVolume` already knows how to
-   render, and is fast enough for the expected data sizes.
+Algorithm:
+  field[...] = 0;  weight[...] = 0
 
-3. **Python fallback.** The Python script can run in pure NumPy mode
-   (slower but no C++ dependency) or call the pybind11-exposed C++
-   function (fast). This flexibility means users can preprocess data
-   even without building Astroray's C++ module.
+  for i in 0..N-1:
+    # kernel support AABB in grid index space
+    for d in {x, y, z}:
+      j_min[d] = max(0, floor((pos[i][d] − 2*h[i] − bbox_min[d]) / cell_size[d]))
+      j_max[d] = min(n[d]−1, ceil((pos[i][d] + 2*h[i] − bbox_min[d]) / cell_size[d]))
 
-4. **No particle format parsing in C++.** The C++ function takes raw
-   arrays (positions, smoothing lengths, values). The Python script
-   handles format-specific I/O (GADGET HDF5 group names, AREPO Voronoi
-   mesh centres, etc.). This keeps the C++ side format-agnostic.
+    for jx in j_min[0]..j_max[0]:
+      for jy in j_min[1]..j_max[1]:
+        for jz in j_min[2]..j_max[2]:
+          cell_centre = bbox_min + (jx+0.5, jy+0.5, jz+0.5) * cell_size
+          r = |cell_centre − pos[i]|
+          q = r / h[i]
+          w_val = cubic_spline_kernel(q) / (h[i]*h[i]*h[i])   # full W(r,h)
+          field[jx,jy,jz]  += value[i] * w_val * V[i]
+          weight[jx,jy,jz] += w_val * V[i]
+
+  # Shepard normalisation
+  for all j:
+    field[j] = (weight[j] > 0) ? field[j] / weight[j] : 0.0f
+```
+
+Output is a `DensityGrid` (flat C-order float array + shape + bbox) that
+`SimulationVolume` (pkg48) renders directly.
 
 ---
 
 ## Acceptance criteria
 
-- [ ] Wendland C4 kernel is normalised: numerical integration over a
-      fine grid yields 1.0 ± 1e-4.
-- [ ] Kernel is exactly zero for q > 1.
-- [ ] A uniform-density particle distribution produces a uniform grid
-      (max/min ratio < 1.01).
-- [ ] A single particle at the grid centre produces a smooth,
-      symmetric, bell-shaped density field.
-- [ ] Grid output is a valid `.npy` file loadable by `SimulationVolume`.
-- [ ] Python script runs in fallback mode (no C++ module) and produces
-      correct output.
-- [ ] Splatting 10⁵ particles to a 128³ grid completes in < 10 seconds
-      on a single core.
+- [ ] Kernel normalisation: numerical quadrature of W(r,h) on a fine spherical grid yields 1.0 ± 1e-4.
+- [ ] Compact support: `cubic_spline_kernel(q)` returns exactly 0.0 for all `q ≥ 2.0`.
+- [ ] Kernel non-negativity: `cubic_spline_kernel(q) ≥ 0` for all `q ∈ [0, 2]`.
+- [ ] Uniform density: N=1000 particles uniformly distributed in [0,1]³ with equal mass → 32³ grid with max/min ratio < 1.05 (boundary cells excluded by 1-cell margin).
+- [ ] Single particle: one particle at the grid centre → grid values are symmetric across all three axes (max asymmetry < 1e-5 relative); peak at centre; exactly 0 beyond support radius.
+- [ ] Grid output: result is a valid `DensityGrid` loadable by `SimulationVolume` (pkg48 integration test).
+- [ ] Python script runs in fallback mode (no C++ module, pure NumPy) and produces a `.npy` file with correct shape and plausible values.
+- [ ] Performance: splatting N=1×10⁵ particles to a 128³ grid completes in < 10 seconds on a single core.
 - [ ] All existing tests pass.
-- [ ] ≥6 new tests covering: kernel normalisation, compact support,
-      uniform distribution, single particle, grid output format,
-      Python fallback.
+- [ ] ≥ 6 new tests: kernel normalisation, compact support, non-negativity, uniform distribution, single particle symmetry, grid output format.
+
+### Concrete test data
+
+| Test | Particles | Grid | Created by |
+|---|---|---|---|
+| Normalisation quadrature | N/A — kernel function only | N/A | Numerical integration in Python |
+| Uniform distribution | N=1000, unit cube, equal mass | 32³ | `np.random.default_rng(42).uniform(0,1,(1000,3))` |
+| Single particle | N=1, centre of unit cube | 32³ | `pos=[[0.5,0.5,0.5]], h=[0.1]` |
+| Output format check | N=100 | 16³ | Generated inline in test |
+
+All data generated inline in tests; no files committed.
 
 ---
 
 ## Non-goals
 
-- Do not implement direct SPH particle rendering (ray-marching through
-  particles with on-the-fly kernel evaluation). That is a future
-  optimisation.
-- Do not implement AMR-to-uniform regridding. Use yt for that.
-- Do not parse simulation-code-specific file formats in C++. The Python
-  script handles format I/O.
-- Do not implement adaptive grid resolution (octree). Uniform grid
-  only.
-- Do not implement velocity field interpolation for Doppler shifting.
-  Velocity can be gridded as a separate field but is not used for
-  spectral shifts in this package.
+- No direct SPH particle rendering (ray-marching through particles on-the-fly). Pre-gridding only.
+- No AMR-to-uniform regridding. Use yt for that.
+- No simulation-code-specific file format parsing in C++. Python script handles format I/O.
+- No adaptive grid resolution (octree). Uniform grid only.
+- No velocity field Doppler shifting. Velocity can be gridded as a separate field but spectral shifts are out of scope for this package.
 
 ---
 
 ## Progress
 
-- [ ] Implement Wendland C4 kernel in `sph_kernel.h`.
-- [ ] Implement grid splatting function.
-- [ ] Register as data-processing plugin.
-- [ ] Expose via pybind11.
-- [ ] Write Python convenience script.
-- [ ] Generate synthetic test particles.
+- [ ] Implement cubic B-spline kernel in `sph_kernel.h`.
+- [ ] Implement Shepard splatting function.
+- [ ] Expose via pybind11 in `sph_to_grid.cpp`.
+- [ ] Write Python convenience script (C++ call + NumPy fallback).
 - [ ] Write tests.
 - [ ] Full test suite green.
 - [ ] Update STATUS.md, CHANGELOG.md.


### PR DESCRIPTION
## Deliverables

All four deliverables from the Pillar 4 data I/O research session:

1. **`.astroray_plan/docs/pillar4-data-io-research.md`** (new) — 5-page research
   note covering:
   - Common `DensityGrid` representation used by all three loaders
   - cfitsio C API functions, CMake `find_package` recipe, vcpkg install command
   - HDF5 + HighFive CMake recipe, chunked-read pattern (yt-inspired), vcpkg setup
   - In-house `.npy` parser: full byte-layout spec (magic, version, header dict, raw data)
   - Cubic B-spline kernel formula (Monaghan 1992) with 3D normalisation verification
   - Westover 1990 Shepard splatting pseudocode
   - Synthetic test-data strategy (no checked-in binaries)
   - License matrix: cfitsio (public domain), HDF5 (BSD-style), HighFive (MIT), astropy/h5py/yt (BSD-3)

2. **`.astroray_plan/packages/pkg47-fits-loader.md`** (tightened) — adds:
   - Reference Implementations table with licenses
   - Full CMake recipe (`ASTRORAY_ENABLE_FITS`, cfitsio::cfitsio target, vcpkg instructions)
   - `fits_io.h` wrapper interface with cfitsio function names
   - Concrete test data shapes (64×64 gradient, 32×32×8 cube, int16+BSCALE)
   - Codex-ready marker (pending vcpkg verification on this Windows toolchain)

3. **`.astroray_plan/packages/pkg48-hdf5-numpy-loader.md`** (tightened) — adds:
   - Reference Implementations table with licenses
   - `.npy` byte-layout spec for in-house parser
   - HighFive CMake recipe with HDF5 raw fallback, Windows static-build flag
   - Chunked-read citation (yt, BSD-3)
   - Concrete test data shapes (16×16×16 float32/float64)
   - Codex-ready marker (pending vcpkg verification on this Windows toolchain)

4. **`.astroray_plan/packages/pkg49-sph-to-volume.md`** (tightened) — adds:
   - Reference Implementations table (Splotch: GPL2, do not mirror noted)
   - Full cubic spline kernel formula + C++ snippet
   - Kernel choice rationale (cubic spline over Wendland for pre-gridding; Wendland revisited if direct particle rendering added)
   - Westover + Shepard splatting pseudocode with index-space AABB computation
   - Concrete test data (uniform N=1000, single particle, output format check)
   - Codex-ready immediately (no dep find_package needed)

## Scope

Research only — no source code changes. Stays narrow: pkg45 (CLOUDY tables) and pkg46 (HII regions) are out of scope and untouched.

## Do not merge

This PR is for review only. Merge after Codex implementation is underway and the dep find_package recipes are verified on the Windows/MinGW toolchain.