### PR TITLE
feat(pkg54c): Jakob-Hanika spectral upsampling on GPU

### DIFF
--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -276,7 +276,7 @@ events are summarized in the changelog below.
 | pkg40 | A | open | current registry/reference cleanup |
 | pkg52 | A | **done** | — |
 | pkg53 | B/E | **done** | — |
-| pkg54 | A | **done** | pkg54/54a/54b verified on hardware; pkg54d direct profile lookup binding is done; pkg54c (Jakob-Hanika upsampling) remains filed as a follow-up |
+| pkg54 | A | **done** | pkg54/54a/54b verified on hardware; pkg54d direct profile lookup binding is done; pkg54c (Jakob-Hanika upsampling) is **implemented, pending CUDA verification** — promote-to-done held until the visible-band SSIM 0.999 gate runs on hardware |
 | pkg57 | A | open | native shader nodes / Cycles compatibility design |
 | pkg58 | B | **done** | — |
 | pkg59 | A | done | broader vector/UV/Mapping plumbing, named UV layers, and UV debug AOV |
@@ -313,7 +313,15 @@ events are summarized in the changelog below.
   verification. pkg54d added a direct `gpu_profile_reflectance` binding for
   unconfounded liveness gating, with CPU/GPU lookup max delta `0` across all
   loaded profiles on the 300-1000 nm grid. pkg54c (Jakob-Hanika spectral
-  upsampling on GPU, SSIM ceiling 0.985→0.999) remains as a scoped follow-up.
+  upsampling on GPU, SSIM ceiling 0.985→0.999) is now implemented:
+  `gpu_jhEvalSpectrum` mirrors `RGBAlbedoSpectrum::sample` via the same
+  shared `jhEvalSpectrumF` evaluator, the sRGB sigmoid LUT is uploaded to
+  device global memory once per process via `uploadJakobHanikaLut`
+  (cudaMalloc + cudaMemcpyToSymbol of pointers, 9 MB — overflows the
+  64 KB constant cap), and `gpu_rgbSpectrumAt` upsamples through it for
+  both `GSPEC_RGB_ALBEDO` and `GSPEC_RGB_ILLUMINANT`. Promote-to-done
+  is held until the verifier session runs `scripts/build/build_cuda.bat`
+  and confirms the visible-band SSIM 0.999 gate on CUDA hardware.
   Sellmeier direction-splitting and true spectral emitter parameter
   upload also remain CPU-only follow-ups. pkg36 expands shared closure
   lowering.

--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -22,8 +22,8 @@ personally should pick up.
   not CUDA kernels.
 - Pillar 5 is the active practical queue. The Cycles-parity/Blender package
   series is now the live near-term roadmap: pkg52/pkg53/pkg58/pkg60/pkg61/pkg62
-  are done, pkg59 is done, pkg54/54a/54b/54d are done (with pkg54c as a
-  scoped follow-up), and pkg57 remains open.
+  are done, pkg59 is done, pkg54/54a/54b/54c/54d are all done (CUDA
+  hardware verified 2026-05-10), and pkg57 remains open.
 - Fresh local collection on this branch: `pytest --collect-only -q` reports
   **435 tests collected** (2026-05-09). Focused pkg53/viewport checks pass.
 - Historical docs that are intentionally not current: `NEXT_STAGE_REPORT.md`
@@ -276,7 +276,7 @@ events are summarized in the changelog below.
 | pkg40 | A | open | current registry/reference cleanup |
 | pkg52 | A | **done** | — |
 | pkg53 | B/E | **done** | — |
-| pkg54 | A | **done** | pkg54/54a/54b verified on hardware; pkg54d direct profile lookup binding is done; pkg54c (Jakob-Hanika upsampling) is **implemented, pending CUDA verification** — promote-to-done held until the visible-band SSIM 0.999 gate runs on hardware |
+| pkg54 | A | **done** | pkg54/54a/54b/54c/54d all verified on hardware; pkg54c visible-band SSIM 0.999 gate clears at 0.999263 (spp=8192); GPU `gpu_rgbSpectrumAt` ILLUMINANT renormalization bug found and fixed during verification; frame-time regression +0.45 % (pkg54e not needed) |
 | pkg57 | A | open | native shader nodes / Cycles compatibility design |
 | pkg58 | B | **done** | — |
 | pkg59 | A | done | broader vector/UV/Mapping plumbing, named UV layers, and UV debug AOV |
@@ -319,9 +319,19 @@ events are summarized in the changelog below.
   device global memory once per process via `uploadJakobHanikaLut`
   (cudaMalloc + cudaMemcpyToSymbol of pointers, 9 MB — overflows the
   64 KB constant cap), and `gpu_rgbSpectrumAt` upsamples through it for
-  both `GSPEC_RGB_ALBEDO` and `GSPEC_RGB_ILLUMINANT`. Promote-to-done
-  is held until the verifier session runs `scripts/build/build_cuda.bat`
-  and confirms the visible-band SSIM 0.999 gate on CUDA hardware.
+  both `GSPEC_RGB_ALBEDO` and `GSPEC_RGB_ILLUMINANT`. Verified on CUDA
+  hardware 2026-05-10: visible-band CPU↔GPU SSIM = 0.999263 at spp=8192
+  on the parity scene (gate ≥ 0.999), per-channel mean ratios within
+  0.4 %, frame-time regression +0.45 % at 1080p / 64 spp / depth 4.
+  A real GPU bug — `gpu_rgbSpectrumAt` ILLUMINANT mode missed the
+  CPU's `2·max(rgb)` renormalize-then-rescale step, causing wrong
+  absolute spectra for any HDR emitter — was found and fixed during
+  verification (see pkg54c Lessons). The 0.999 SSIM gate is unreachable
+  at the original 64 spp regardless of evaluator correctness because
+  CPU OpenMP and GPU warp-parallel integrators place MC samples on
+  different per-pixel sub-streams; the test now runs at spp=8192
+  (~5 s on RTX-class hardware) where the noise floor drops below
+  the gate by ~26 %.
   Sellmeier direction-splitting and true spectral emitter parameter
   upload also remain CPU-only follow-ups. pkg36 expands shared closure
   lowering.

--- a/.astroray_plan/packages/pkg54c-gpu-jakob-hanika-upsampling.md
+++ b/.astroray_plan/packages/pkg54c-gpu-jakob-hanika-upsampling.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 5
 **Track:** A
-**Status:** open
+**Status:** implemented (pending CUDA verification)
 **Estimated effort:** 3–5 days
 **Depends on:** pkg54b
 
@@ -110,11 +110,11 @@ up as a chromaticity shift the integration never averages out.
 
 ## Progress
 
-- [ ] Bake / load `data/spectra/rgb_to_spectrum_srgb.coeff` to GPU texture memory.
-- [ ] Add `gpu_evalSigmoidCoeffs` device function.
-- [ ] Pre-bake JH coefficients on `GMaterial` in `scene_upload.cu`.
-- [ ] Replace the Gaussian mix in `gpu_rgbSpectrumAt`.
-- [ ] Tighten visible-band gate to 0.999.
+- [x] Bake / load `data/spectra/rgb_to_spectrum_srgb.coeff` to GPU global memory (Option A — `cudaMalloc` + `cudaMemcpyToSymbol` for pointers, behind a static-bool guard analogous to `uploadCmfTables`). The 9 MB sRGB LUT overflows the 64 KB `__constant__` cap; if the visible-band frame-time regresses past 10 % of the pkg54b baseline on hardware verification, the verifier session should switch to `cudaTextureObject_t` (Option B in the implementation note) and re-measure.
+- [x] Add `gpu_jhEvalSpectrum` / `gpu_jhLookupCoeffs` device functions in `src/gpu/multiwavelength_kernel.cu`; both call the shared `astroray::jhEvalSpectrumF` declared in `include/astroray/spectrum.h` so CPU and GPU evaluate the sigmoid through one source-of-truth function.
+- [x] Per-`GMaterial` pre-baking deferred — the LUT lookup is cheap enough to run at the per-wavelength call site for now (simplicity-first; pkg54c spec note 2 was only a perf hedge). Revisit if the hardware run shows >10 % MW frame-time regression.
+- [x] Replace the Gaussian mix in `gpu_rgbSpectrumAt`. `GSPEC_RGB_ALBEDO` and `GSPEC_RGB_ILLUMINANT` both upsample via `gpu_jhEvalSpectrum`; ILLUMINANT additionally multiplies by `gpu_sampleD65(λ)` (pkg54a/b fix preserved). `gpu_spectralChannelWeight` is removed — it was the only caller.
+- [x] Tighten visible-band gate to 0.999 in `tests/test_gpu_multiwavelength.py`. Added `test_visible_band_no_regression` (GPU mean within 2 % of CPU reference at fixed seed, so the JH switch cannot silently darken the render).
 
 ---
 

--- a/.astroray_plan/packages/pkg54c-gpu-jakob-hanika-upsampling.md
+++ b/.astroray_plan/packages/pkg54c-gpu-jakob-hanika-upsampling.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 5
 **Track:** A
-**Status:** implemented (pending CUDA verification)
+**Status:** done
 **Estimated effort:** 3–5 days
 **Depends on:** pkg54b
 
@@ -120,4 +120,80 @@ up as a chromaticity shift the integration never averages out.
 
 ## Lessons
 
-*(Fill in after the package is done.)*
+Hardware verification on RTX-class CUDA workstation (Windows 11, CUDA 12.6,
+sm_89), 2026-05-10:
+
+- **Visible-band SSIM gate (≥ 0.999):** measured **0.999263** at spp=8192
+  on the parity scene (48×48). Per-channel mean ratio gpu/cpu =
+  R 0.9998 / G 0.9965 / B 1.0033 (energy parity ~0.3 %). The headline
+  pkg54c gate clears with ~26 % margin.
+- **Visible-band no-regression (gpu mean within 2 % of cpu mean):**
+  passes at spp=64 and spp=8192 (mean ratios ≤ 0.4 %).
+- **NIR / UV with profiles:** no regression — both still pass at the
+  pre-existing 0.97 SSIM gate, untouched by the JH path.
+- **GPU shade-smooth (pkg61 hard gate):** residual_std/patch_mean =
+  **0.07231** (gate < 0.18). No regression.
+- **Frame-time delta** at 1080p / 64 spp / depth 4 on the parity scene,
+  median of 5 runs:
+  - origin/main (e292285, pre-pkg54c): 0.224 s
+  - HEAD with fix: 0.225 s
+  - **regression: +0.45 %** — well under the 10 % pkg54e trigger; pkg54e
+    is NOT needed.
+- **CPU spectral suite:** 309 / 309 passed. CPU bit-equivalence preserved
+  (the fix is GPU-only).
+
+### Two issues found during verification
+
+1. **Real bug — `gpu_rgbSpectrumAt` ILLUMINANT mode missed renormalization.**
+   The CPU `RGBIlluminantSpectrum::sample`
+   ([src/spectrum.cpp:464-491](src/spectrum.cpp:464)) computes
+   `scale = 2·max(rgb)`, normalizes the RGB into the LUT-valid [0, 0.5]
+   range, calls JH, then multiplies the result by `scale · D65(λ)`.
+   The first pkg54c GPU port did neither — it called JH on the raw
+   (unnormalized, then internally clamped to [0, 1]) RGB and multiplied
+   only by `D65(λ)`. For the test scene's emissive light with
+   `em = [8, 8, 8]`, GPU was effectively computing
+   `jh([1, 1, 1], λ)·D65` instead of `16·jh([0.5, 0.5, 0.5], λ)·D65` —
+   wildly different absolute spectra. The bug was masked in the SSIM
+   test because pixel clipping at 1.0 hides oversaturated emitters, but
+   it would have shown up in any HDR-output downstream (denoiser, AOVs,
+   EXR). Fix lives in
+   [include/astroray/gpu_materials.h:68-87](include/astroray/gpu_materials.h:68).
+
+2. **Gate-honesty issue — 0.999 SSIM unreachable at spp=64 for any
+   integrator-correct GPU path.** Even with a bit-perfect JH evaluator
+   (confirmed: `jhEvalSpectrumF` is `__host__ __device__` shared, and
+   `gpu_jhLookupCoeffs` mirrors `JakobHanikaLut::lookup` line-for-line),
+   the CPU OpenMP integrator and the GPU warp-parallel integrator place
+   Monte-Carlo samples on different per-pixel sub-streams. The resulting
+   per-pixel noise is energy-conserving but spatially de-correlated,
+   producing a noise floor that scales as 1 / √spp:
+
+   | spp  | SSIM    | mean_diff | gpu_mean / cpu_mean |
+   |------|---------|-----------|---------------------|
+   | 64   | 0.9902  | 0.00244   | 1.00015             |
+   | 256  | 0.9970  | 0.00130   | 1.00037             |
+   | 1024 | 0.9988  | 0.00072   | 0.99998             |
+   | 2048 | 0.9990  | 0.00058   | 1.00009             |
+   | 8192 | 0.99926 | 0.00039   | 1.00106             |
+
+   Convergence slows below ideal 1/√n past 1024 spp because the SSIM
+   formula approaches saturation. spp=8192 is the smallest power-of-two
+   that comfortably clears 0.999. Test now uses spp=8192 for the
+   `test_visible_band_cpu_gpu_ssim` gate (~5 s on RTX-class hardware);
+   the rest of the suite is unchanged.
+
+### Things that are NOT bugs (but were investigated)
+
+- **FMA contraction:** ruled out by rebuilding `multiwavelength_kernel.cu`
+  with `-fmad=false --ftz=false --prec-div=true --prec-sqrt=true`. SSIM
+  delta < 4×10⁻⁹. Production build keeps default FMA on.
+- **JH LUT layout / lookup divergence:** GPU `gpu_jhLookupCoeffs` mirrors
+  CPU `JakobHanikaLut::lookup` line-for-line, including the
+  `while (k + 1 < resM1 && scale[k+1] < z)` z-bracketing scan and the
+  `(((c·res + z)·res + y)·res + x)·3` flat layout.
+- **`cudaMemcpyToSymbol` of device pointers:** the prompt flagged this
+  as a candidate failure mode. The current implementation uses
+  `__device__ const float*` pointer symbols populated via
+  `cudaMemcpyToSymbol(symbol, &dev_ptr, sizeof(float*))`, which is the
+  correct idiom — verified to compile and run.

--- a/include/astroray/gpu_materials.h
+++ b/include/astroray/gpu_materials.h
@@ -68,11 +68,22 @@ __device__ float gpu_jhEvalSpectrum(const GVec3& rgb, float lambda);
 __device__ inline float gpu_rgbSpectrumAt(const GVec3& rgb, float lambda, GSpectralMode mode) {
     if (mode == GSPEC_NONE) return luminance(rgb);
     // pkg54c: JH 2019 sigmoid upsampling replaces the earlier 3-Gaussian
-    // RGB-basis stand-in. ILLUMINANT mode continues to multiply by the
-    // normalized D65 SPD (pkg54a/b fix preserved).
-    float v = gpu_jhEvalSpectrum(rgb, lambda);
-    if (mode == GSPEC_RGB_ILLUMINANT) v *= gpu_sampleD65(lambda);
-    return fmaxf(v, 0.f);
+    // RGB-basis stand-in. ILLUMINANT mode mirrors CPU
+    // RGBIlluminantSpectrum (src/spectrum.cpp:464-491): renormalize by
+    // 2*max(rgb) before the JH lookup, then scale-back and multiply by
+    // the normalized D65 SPD (pkg54a/b fix preserved). Without the
+    // renormalization the LUT is queried at the wrong location and the
+    // visible-band CPU<->GPU SSIM gate (>=0.999) cannot be hit.
+    if (mode == GSPEC_RGB_ILLUMINANT) {
+        float m = fmaxf(fmaxf(rgb.x, rgb.y), rgb.z);
+        if (m <= 0.f) return 0.f;
+        float scale = 2.f * m;
+        GVec3 normalized{ rgb.x / scale, rgb.y / scale, rgb.z / scale };
+        return fmaxf(scale * gpu_jhEvalSpectrum(normalized, lambda)
+                           * gpu_sampleD65(lambda), 0.f);
+    }
+    // ALBEDO: gpu_jhLookupCoeffs already clamps rgb to [0,1].
+    return fmaxf(gpu_jhEvalSpectrum(rgb, lambda), 0.f);
 }
 
 __device__ inline GSampledSpectrum gpu_rgbToSampledSpectrum(

--- a/include/astroray/gpu_materials.h
+++ b/include/astroray/gpu_materials.h
@@ -54,34 +54,24 @@ __device__ inline GSampledWavelengths gpu_sampleUniformWavelengths(curandState* 
     return wl;
 }
 
-__device__ inline float gpu_spectralChannelWeight(float lambda, int channel) {
-    float center = channel == 0 ? 610.f : (channel == 1 ? 540.f : 460.f);
-    float sigma = channel == 0 ? 52.f : (channel == 1 ? 46.f : 42.f);
-    float x = (lambda - center) / sigma;
-    return expf(-0.5f * x * x);
-}
-
 // Forward declaration — defined in src/gpu/multiwavelength_kernel.cu.
 // Mirrors astroray::sampleD65 (src/spectrum.cpp) via the same baked SPD
 // table, normalized so unit white emission integrates to Y = 1.
 __device__ float gpu_sampleD65(float lambda);
 
+// Forward declaration — defined in src/gpu/multiwavelength_kernel.cu (pkg54c).
+// Jakob & Hanika 2019 sigmoid-coefficient lookup; mirrors CPU
+// RGBAlbedoSpectrum::sample() at single wavelength so visible-band SSIM
+// reaches parity with the CPU integrator. Requires uploadJakobHanikaLut().
+__device__ float gpu_jhEvalSpectrum(const GVec3& rgb, float lambda);
+
 __device__ inline float gpu_rgbSpectrumAt(const GVec3& rgb, float lambda, GSpectralMode mode) {
     if (mode == GSPEC_NONE) return luminance(rgb);
-    float r = gpu_spectralChannelWeight(lambda, 0);
-    float g = gpu_spectralChannelWeight(lambda, 1);
-    float b = gpu_spectralChannelWeight(lambda, 2);
-    float denom = fmaxf(r + g + b, 1e-4f);
-    float v = (rgb.x * r + rgb.y * g + rgb.z * b) / denom;
-    if (mode == GSPEC_RGB_ILLUMINANT) {
-        // Mirror CPU RGBIlluminantSpectrum::sample(): multiply the
-        // RGB-derived spectrum by the true D65 SPD normalised by
-        // ∫D65·cmfY dλ. Earlier the GPU used a 0.85+0.15·gauss(λ,540)
-        // analytic stand-in for D65, which produced ~5× brighter
-        // values per wavelength than the CPU and broke visible-band
-        // SSIM parity (~0.21 instead of ≥0.99).
-        v *= gpu_sampleD65(lambda);
-    }
+    // pkg54c: JH 2019 sigmoid upsampling replaces the earlier 3-Gaussian
+    // RGB-basis stand-in. ILLUMINANT mode continues to multiply by the
+    // normalized D65 SPD (pkg54a/b fix preserved).
+    float v = gpu_jhEvalSpectrum(rgb, lambda);
+    if (mode == GSPEC_RGB_ILLUMINANT) v *= gpu_sampleD65(lambda);
     return fmaxf(v, 0.f);
 }
 

--- a/include/astroray/spectrum.h
+++ b/include/astroray/spectrum.h
@@ -16,6 +16,7 @@
 //     data/spectra/rgb_to_spectrum_srgb.coeff.
 
 #include <array>
+#include <cmath>
 #include <cstdint>
 #include <string>
 
@@ -39,6 +40,56 @@ float sampleD65(float lambda);
 // Filesystem path of the shipped Jakob-Hanika sRGB LUT. Resolved lazily on
 // first call; see src/spectrum.cpp for the search order.
 std::string spectrumLutPath();
+
+// --------------------------------------------------------------------------
+// Jakob-Hanika 2019 sigmoid evaluator — shared between CPU and CUDA paths.
+//
+// Reference: Jakob & Hanika, "A Low-Dimensional Function Space for Efficient
+// Spectral Upsampling", Eurographics 2019 (DOI: 10.1111/cgf.13626).
+//
+// This is the single source of truth for the per-wavelength sigmoid. The CPU
+// integrator (RGBAlbedoSpectrum::sample) and the GPU multiwavelength kernel
+// (gpu_jhEvalSpectrum) both call jhEvalSpectrumF; bit-exact parity matters
+// for visible-band SSIM ≥ 0.999 (pkg54c).
+// --------------------------------------------------------------------------
+#if defined(__CUDACC__)
+#  define ASTRORAY_HD __host__ __device__
+#else
+#  define ASTRORAY_HD
+#endif
+
+ASTRORAY_HD inline float jhEvalSpectrumF(float c0, float c1, float c2, float lambda) {
+    // Mirrors src/spectrum.cpp::sigmoidJH + evalSigmoidCoeffs; the c2 = -1e20
+    // sentinel for "effectively black" relies on the inf-handling branches.
+    float x;
+#if defined(__CUDACC__) && defined(__CUDA_ARCH__)
+    x = fmaf(fmaf(c0, lambda, c1), lambda, c2);
+#else
+    x = std::fma(std::fma(c0, lambda, c1), lambda, c2);
+#endif
+#if defined(__CUDACC__) && defined(__CUDA_ARCH__)
+    if (isinf(x)) return x > 0.0f ? 1.0f : 0.0f;
+    float xx = x * x;
+    if (isinf(xx)) return x > 0.0f ? 1.0f : 0.0f;
+    return 0.5f + x / (2.0f * sqrtf(1.0f + xx));
+#else
+    if (std::isinf(x)) return x > 0.0f ? 1.0f : 0.0f;
+    float xx = x * x;
+    if (std::isinf(xx)) return x > 0.0f ? 1.0f : 0.0f;
+    return 0.5f + x / (2.0f * std::sqrt(1.0f + xx));
+#endif
+}
+
+// Read-only accessors for the lazily-loaded sRGB LUT. Used by the CUDA
+// uploader (src/gpu/multiwavelength_kernel.cu::uploadJakobHanikaLut) to
+// cudaMemcpy the table into device global memory exactly once. Loading is
+// triggered on first call; throws on file errors.
+//
+// Coefficient grid layout (flat float buffer):
+//     coeffs[channel][z][y][x][coeff]   — 3 * res^3 * 3 floats total.
+int          jakobHanikaLutRes();
+const float* jakobHanikaLutScale();
+const float* jakobHanikaLutCoeffs();
 
 // --------------------------------------------------------------------------
 // SampledWavelengths — a bundle of `kSpectrumSamples` wavelengths with

--- a/src/gpu/cuda_renderer.cu
+++ b/src/gpu/cuda_renderer.cu
@@ -46,6 +46,9 @@ void launchPathTraceKernel(
 void uploadProfileTable(const float* host, int count);
 // pkg54b — one-time copy of CIE 1964 10° CMF tables into MW kernel constant memory.
 void uploadCmfTables();
+// pkg54c — one-time copy of the Jakob-Hanika sRGB sigmoid LUT into MW kernel
+// global memory; required by gpu_jhEvalSpectrum (the new upsampling path).
+void uploadJakobHanikaLut();
 float launchProfileLookup(int profileIndex, float lambda);
 
 void launchMultiwavelengthKernel(
@@ -281,8 +284,11 @@ void CUDARenderer::render(
     // path_trace_kernel.cu uses gpu_rgbToSampledSpectrum(...) with
     // GSPEC_RGB_ILLUMINANT for environment colour, which now reads the
     // D65 SPD baked into MW kernel constant memory — make sure it's
-    // uploaded before the kernel runs.
+    // uploaded before the kernel runs. pkg54c additionally requires the
+    // Jakob-Hanika sigmoid LUT in device global memory because
+    // gpu_rgbSpectrumAt now upsamples via gpu_jhEvalSpectrum.
     uploadCmfTables();
+    uploadJakobHanikaLut();
 
     unsigned long long rngSeed = (seed == 0)
         ? (unsigned long long)time(nullptr)
@@ -327,6 +333,9 @@ void CUDARenderer::renderMultiwavelength(
 
     // pkg54b: ensure CMF tables are present in MW kernel constant memory.
     uploadCmfTables();
+    // pkg54c: ensure the Jakob-Hanika sRGB sigmoid LUT is in device global
+    // memory before any gpu_jhEvalSpectrum call.
+    uploadJakobHanikaLut();
 
     unsigned long long rngSeed = (seed == 0)
         ? (unsigned long long)time(nullptr)

--- a/src/gpu/multiwavelength_kernel.cu
+++ b/src/gpu/multiwavelength_kernel.cu
@@ -21,6 +21,7 @@
 #include "astroray/gpu_types.h"
 #include "astroray/gpu_materials.h"
 #include "astroray/gpu_bvh.h"
+#include "astroray/spectrum.h"  // jhEvalSpectrumF + JH LUT accessors (pkg54c)
 
 #include <cuda_runtime.h>
 #include <curand_kernel.h>
@@ -200,6 +201,154 @@ void uploadCmfTables() {
         throw std::runtime_error("D65 norm upload failed");
     }
     uploaded = true;
+}
+
+// ---------------------------------------------------------------------------
+// pkg54c: Jakob-Hanika 2019 RGB→spectrum sigmoid coefficient LUT on the GPU.
+//
+// Reference: Jakob & Hanika, "A Low-Dimensional Function Space for Efficient
+// Spectral Upsampling", Eurographics 2019 (DOI: 10.1111/cgf.13626);
+// reference implementation https://github.com/mitsuba-renderer/rgb2spec
+// (BSD-3-Clause). The sRGB LUT shipped at data/spectra/rgb_to_spectrum_srgb
+// .coeff is 64³ × 3 channels × 3 coefficients ≈ 9 MB — too large for the
+// 64 KB __constant__ cap, so we keep it in device global memory and read
+// via __device__ pointers populated once at first render.
+//
+// gpu_jhLookupCoeffs / gpu_jhEvalSpectrum mirror JakobHanikaLut::lookup +
+// evalSigmoidCoeffs in src/spectrum.cpp; bit-exact parity is the pkg54c
+// SSIM ≥ 0.999 visible-band gate.
+// ---------------------------------------------------------------------------
+__device__ const float* g_jhLutScale  = nullptr;  // [res]
+__device__ const float* g_jhLutCoeffs = nullptr;  // flat [3][res][res][res][3]
+__device__ int          g_jhLutRes    = 0;
+
+// Host-side ownership of the device allocation; freed only on process exit
+// because the LUT is read-only and re-uploads would be wasteful.
+static float* s_jhLutScaleDev  = nullptr;
+static float* s_jhLutCoeffsDev = nullptr;
+
+void uploadJakobHanikaLut() {
+    static bool uploaded = false;
+    if (uploaded) return;
+
+    int          res    = astroray::jakobHanikaLutRes();
+    const float* hScale = astroray::jakobHanikaLutScale();
+    const float* hCoeff = astroray::jakobHanikaLutCoeffs();
+    if (res <= 0 || !hScale || !hCoeff) {
+        throw std::runtime_error("Jakob-Hanika LUT host data unavailable");
+    }
+
+    size_t scaleBytes  = size_t(res) * sizeof(float);
+    size_t coeffsBytes = size_t(3) * size_t(res) * res * res * 3 * sizeof(float);
+
+    cudaError_t e = cudaMalloc(reinterpret_cast<void**>(&s_jhLutScaleDev),
+                               scaleBytes);
+    if (e == cudaSuccess) {
+        e = cudaMalloc(reinterpret_cast<void**>(&s_jhLutCoeffsDev), coeffsBytes);
+    }
+    if (e == cudaSuccess) {
+        e = cudaMemcpy(s_jhLutScaleDev, hScale, scaleBytes,
+                       cudaMemcpyHostToDevice);
+    }
+    if (e == cudaSuccess) {
+        e = cudaMemcpy(s_jhLutCoeffsDev, hCoeff, coeffsBytes,
+                       cudaMemcpyHostToDevice);
+    }
+    if (e == cudaSuccess) {
+        e = cudaMemcpyToSymbol(g_jhLutScale,  &s_jhLutScaleDev,
+                               sizeof(float*));
+    }
+    if (e == cudaSuccess) {
+        e = cudaMemcpyToSymbol(g_jhLutCoeffs, &s_jhLutCoeffsDev,
+                               sizeof(float*));
+    }
+    if (e == cudaSuccess) {
+        e = cudaMemcpyToSymbol(g_jhLutRes, &res, sizeof(int));
+    }
+    if (e != cudaSuccess) {
+        fprintf(stderr, "uploadJakobHanikaLut failed: %s\n",
+                cudaGetErrorString(e));
+        throw std::runtime_error(cudaGetErrorString(e));
+    }
+    uploaded = true;
+}
+
+// Trilinear interpolation in the JH coefficient cube. Mirrors
+// JakobHanikaLut::lookup() in src/spectrum.cpp exactly.
+__device__ inline void gpu_jhLookupCoeffs(
+    float r, float g, float b, float& c0, float& c1, float& c2)
+{
+    int res = g_jhLutRes;
+    if (res <= 0) { c0 = 0.f; c1 = 0.f; c2 = -1e20f; return; }
+
+    // Clamp to [0, 1] (CPU RGBAlbedoSpectrum constructor does the same).
+    r = fminf(fmaxf(r, 0.f), 1.f);
+    g = fminf(fmaxf(g, 0.f), 1.f);
+    b = fminf(fmaxf(b, 0.f), 1.f);
+
+    int   i    = 0;
+    float vMax = r;
+    if (g > vMax) { i = 1; vMax = g; }
+    if (b > vMax) { i = 2; vMax = b; }
+    if (vMax <= 1e-8f) { c0 = 0.f; c1 = 0.f; c2 = -1e20f; return; }
+
+    float comp[3] = { r, g, b };
+    int   o0 = (i + 1) % 3;
+    int   o1 = (i + 2) % 3;
+    float x  = comp[o0] / vMax;
+    float y  = comp[o1] / vMax;
+    float z  = vMax;
+
+    int   resM1 = res - 1;
+    const float* scale = g_jhLutScale;
+
+    // Locate k such that scale[k] <= z <= scale[k+1].
+    int k = 0;
+    while (k + 1 < resM1 && scale[k + 1] < z) ++k;
+    float denomZ = scale[k + 1] - scale[k];
+    float tz = (denomZ > 0.f) ? (z - scale[k]) / denomZ : 0.f;
+    tz = fminf(fmaxf(tz, 0.f), 1.f);
+
+    float fx = x * float(resM1);
+    float fy = y * float(resM1);
+    int   x0 = (int)fx;  if (x0 < 0) x0 = 0;  if (x0 > resM1 - 1) x0 = resM1 - 1;
+    int   y0 = (int)fy;  if (y0 < 0) y0 = 0;  if (y0 > resM1 - 1) y0 = resM1 - 1;
+    float tx = fminf(fmaxf(fx - float(x0), 0.f), 1.f);
+    float ty = fminf(fmaxf(fy - float(y0), 0.f), 1.f);
+
+    // Flat layout: coeffs[i][z][y][x][comp]
+    const float* coeffs = g_jhLutCoeffs;
+    auto entry = [&] __device__ (int zi, int yi, int xi) -> const float* {
+        size_t idx = (((size_t(i) * res + zi) * res + yi) * res + xi) * 3;
+        return coeffs + idx;
+    };
+    const float* p000 = entry(k,     y0,     x0    );
+    const float* p100 = entry(k,     y0,     x0 + 1);
+    const float* p010 = entry(k,     y0 + 1, x0    );
+    const float* p110 = entry(k,     y0 + 1, x0 + 1);
+    const float* p001 = entry(k + 1, y0,     x0    );
+    const float* p101 = entry(k + 1, y0,     x0 + 1);
+    const float* p011 = entry(k + 1, y0 + 1, x0    );
+    const float* p111 = entry(k + 1, y0 + 1, x0 + 1);
+
+    float out[3];
+    #pragma unroll
+    for (int comp_i = 0; comp_i < 3; ++comp_i) {
+        float cLow  = (p000[comp_i] * (1.f - tx) + p100[comp_i] * tx) * (1.f - ty)
+                    + (p010[comp_i] * (1.f - tx) + p110[comp_i] * tx) * ty;
+        float cHigh = (p001[comp_i] * (1.f - tx) + p101[comp_i] * tx) * (1.f - ty)
+                    + (p011[comp_i] * (1.f - tx) + p111[comp_i] * tx) * ty;
+        out[comp_i] = cLow * (1.f - tz) + cHigh * tz;
+    }
+    c0 = out[0];  c1 = out[1];  c2 = out[2];
+}
+
+// Per-wavelength upsampled reflectance, mirroring CPU
+// RGBAlbedoSpectrum::sample → evalSigmoidCoeffs.
+__device__ float gpu_jhEvalSpectrum(const GVec3& rgb, float lambda) {
+    float c0, c1, c2;
+    gpu_jhLookupCoeffs(rgb.x, rgb.y, rgb.z, c0, c1, c2);
+    return astroray::jhEvalSpectrumF(c0, c1, c2, lambda);
 }
 
 // Mirror of astroray::sampleD65 in src/spectrum.cpp — linear lookup into

--- a/src/spectrum.cpp
+++ b/src/spectrum.cpp
@@ -226,21 +226,15 @@ XYZ SampledSpectrum::toXYZ(const SampledWavelengths& wl) const {
 }
 
 // ---------------------------------------------------------------------------
-// Jakob-Hanika sigmoid evaluator.
+// Jakob-Hanika sigmoid evaluator. The math now lives in include/astroray/
+// spectrum.h::jhEvalSpectrumF as a single source of truth shared with the
+// CUDA path (gpu_jhEvalSpectrum); this thin wrapper preserves the existing
+// std::array call sites unchanged.
 // ---------------------------------------------------------------------------
 namespace {
 
-inline float sigmoidJH(float x) {
-    if (std::isinf(x)) return x > 0.0f ? 1.0f : 0.0f;
-    float xx = x * x;
-    // x*x can overflow float (e.g. x=-1e20 used as "black" sentinel → xx=+inf → wrong 0.5)
-    if (std::isinf(xx)) return x > 0.0f ? 1.0f : 0.0f;
-    return 0.5f + x / (2.0f * std::sqrt(1.0f + xx));
-}
-
 inline float evalSigmoidCoeffs(const std::array<float, 3>& c, float lambda) {
-    float x = std::fma(std::fma(c[0], lambda, c[1]), lambda, c[2]);
-    return sigmoidJH(x);
+    return jhEvalSpectrumF(c[0], c[1], c[2], lambda);
 }
 
 }  // namespace
@@ -258,6 +252,11 @@ public:
 
     // res_ is the edge length of each 3D table (typically 64 for sRGB).
     int res() const { return res_; }
+
+    // Raw table pointers — used by the GPU uploader to cudaMemcpy the
+    // tables verbatim into device global memory.
+    const float* scaleData()  const { return scale_.data(); }
+    const float* coeffsData() const { return coeffs_.data(); }
 
     std::array<float, 3> lookup(const std::array<float, 3>& rgb) const;
 
@@ -341,6 +340,17 @@ const JakobHanikaLut& JakobHanikaLut::get() {
         instance.load(resolveLutPath());
     });
     return instance;
+}
+
+// Read-only accessors for the GPU uploader; trigger lazy load on first use.
+int jakobHanikaLutRes() {
+    return JakobHanikaLut::get().res();
+}
+const float* jakobHanikaLutScale() {
+    return JakobHanikaLut::get().scaleData();
+}
+const float* jakobHanikaLutCoeffs() {
+    return JakobHanikaLut::get().coeffsData();
 }
 
 std::array<float, 3> JakobHanikaLut::lookup(const std::array<float, 3>& rgb) const {

--- a/tests/test_gpu_multiwavelength.py
+++ b/tests/test_gpu_multiwavelength.py
@@ -100,9 +100,8 @@ def _render_pair(lmin, lmax, mode, *,
 # ---------------------------------------------------------------------------
 
 def test_visible_band_cpu_gpu_ssim():
-    """pkg54b parity gate. Ceiling is ~0.996 because GPU upsamples
-    RGB→spectrum via a 3-Gaussian basis while CPU uses Jakob-Hanika
-    2019 sigmoid coefficients; closing that residual is pkg54c."""
+    """pkg54c: shared JH sigmoid coefficient table on both backends;
+    visible-band parity is now exact within float precision."""
     cpu, gpu = _render_pair(380.0, 780.0, "", spp=64)
     assert np.all(np.isfinite(cpu))
     assert np.all(np.isfinite(gpu))
@@ -110,7 +109,25 @@ def test_visible_band_cpu_gpu_ssim():
     cpu_t = np.clip(cpu, 0.0, 1.0)
     gpu_t = np.clip(gpu, 0.0, 1.0)
     ssim = _ssim(cpu_t, gpu_t)
-    assert ssim >= 0.985, f"visible-band SSIM {ssim:.4f} < 0.985 (pkg54b gate)"
+    assert ssim >= 0.999, f"visible-band SSIM {ssim:.4f} < 0.999 (pkg54c gate)"
+
+
+def test_visible_band_no_regression():
+    """pkg54c sanity gate: replacing the GPU 3-Gaussian basis with the
+    Jakob-Hanika LUT must not silently darken or brighten the render.
+    The CPU integrator is unchanged across pkg54c, so its mean serves
+    as the pre-pkg54c reference; GPU mean is required within 2 %."""
+    cpu, gpu = _render_pair(380.0, 780.0, "", spp=64)
+    assert np.all(np.isfinite(cpu))
+    assert np.all(np.isfinite(gpu))
+    cpu_mean = float(cpu.mean())
+    gpu_mean = float(gpu.mean())
+    assert cpu_mean > 1e-6, f"CPU reference mean too small: {cpu_mean}"
+    rel = abs(gpu_mean - cpu_mean) / cpu_mean
+    assert rel < 0.02, (
+        f"GPU mean {gpu_mean:.4f} drifted {rel*100:.2f}% from CPU "
+        f"reference mean {cpu_mean:.4f}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_gpu_multiwavelength.py
+++ b/tests/test_gpu_multiwavelength.py
@@ -101,8 +101,24 @@ def _render_pair(lmin, lmax, mode, *,
 
 def test_visible_band_cpu_gpu_ssim():
     """pkg54c: shared JH sigmoid coefficient table on both backends;
-    visible-band parity is now exact within float precision."""
-    cpu, gpu = _render_pair(380.0, 780.0, "", spp=64)
+    visible-band parity is now exact within float precision per evaluator
+    (jhEvalSpectrumF + JH LUT lookup are bit-identical between CPU and GPU,
+    confirmed by diag_pkg54c.py — albedo/illuminant means agree to ~0.04%).
+
+    Integrator-level CPU<->GPU MC sample-stream divergence (OpenMP vs warp
+    parallel) leaves a per-pixel noise floor that scales as 1/sqrt(spp);
+    on this scene it tops out at SSIM ~0.99 at 64 spp, ~0.998 at 1024 spp.
+    Measured SSIM convergence on RTX-class hardware (48x48, this scene):
+        spp=64    -> 0.9902 (gate fails)
+        spp=256   -> 0.9970 (gate fails)
+        spp=1024  -> 0.9988 (gate fails)
+        spp=2048  -> 0.9990 (gate fails by ~3e-6)
+        spp=8192  -> 0.99926 (clears with ~26 % margin)
+    Convergence slows below the ideal 1/sqrt(n) past ~1024 spp because the
+    SSIM formula approaches saturation. spp=8192 is the smallest
+    power-of-two that comfortably clears 0.999. Do NOT lower this spp
+    without re-running the convergence sweep — see pkg54c Lessons."""
+    cpu, gpu = _render_pair(380.0, 780.0, "", spp=8192)
     assert np.all(np.isfinite(cpu))
     assert np.all(np.isfinite(gpu))
     # Tone-map to [0, 1] so SSIM is well-behaved.


### PR DESCRIPTION
Closes the visible-band SSIM gap left by pkg54b: the GPU multi-wavelength
path tracer now upsamples RGB to spectra via the same Jakob & Hanika 2019
sigmoid coefficient LUT (`data/spectra/rgb_to_spectrum_srgb.coeff`) the CPU
integrator uses, instead of a 3-Gaussian RGB-basis stand-in.

Reference: Jakob & Hanika, *"A Low-Dimensional Function Space for Efficient
Spectral Upsampling"*, Eurographics 2019 (DOI [10.1111/cgf.13626](https://doi.org/10.1111/cgf.13626)); reference
implementation [mitsuba-renderer/rgb2spec](https://github.com/mitsuba-renderer/rgb2spec) (BSD-3-Clause).

## What changed

- **`include/astroray/spectrum.h`**: shared `jhEvalSpectrumF` evaluator
  (`__host__ __device__` inline) — single source of truth for the sigmoid
  on both backends. New `jakobHanikaLutRes/Scale/Coeffs` accessors expose
  the lazily-loaded LUT to the GPU uploader.
- **`src/spectrum.cpp`**: CPU `evalSigmoidCoeffs` delegates to
  `jhEvalSpectrumF`; `JakobHanikaLut` exposes raw scale/coeff pointers.
- **`src/gpu/multiwavelength_kernel.cu`**:
    - `uploadJakobHanikaLut` (host) — `cudaMalloc` + `cudaMemcpyToSymbol`
      of device pointers, behind a static-bool guard analogous to
      `uploadCmfTables`. The 9 MB sRGB LUT overflows the 64 KB
      `__constant__` cap, so it lives in device global memory (Option A
      in the package note).
    - `gpu_jhLookupCoeffs` — trilinear interpolation mirroring
      `JakobHanikaLut::lookup` exactly.
    - `gpu_jhEvalSpectrum` — calls the shared `jhEvalSpectrumF`.
- **`include/astroray/gpu_materials.h`**: `gpu_rgbSpectrumAt` upsamples
  via `gpu_jhEvalSpectrum` for both `GSPEC_RGB_ALBEDO` and
  `GSPEC_RGB_ILLUMINANT`; ILLUMINANT continues to multiply by
  `gpu_sampleD65(λ)` (pkg54a/b fix preserved). The orphaned
  `gpu_spectralChannelWeight` is removed.
- **`src/gpu/cuda_renderer.cu`**: `uploadJakobHanikaLut` is invoked next
  to `uploadCmfTables` in both `render` (the standard path tracer also
  routes RGB env colour through `gpu_rgbSpectrumAt`) and
  `renderMultiwavelength`.
- **`tests/test_gpu_multiwavelength.py`**: visible-band SSIM gate raised
  **0.985 → 0.999**, docstring rewritten. New `test_visible_band_no_regression`
  guards GPU mean within 2 % of the CPU reference at fixed seed so the
  JH switch cannot silently darken the render.

## Acceptance — pending CUDA hardware verification

This worktree has no CUDA toolchain, so the SSIM gates skip locally. The
verifier session must run `scripts\build\build_cuda.bat` and pytest, then
promote pkg54c to *done*.

Expected on CUDA hardware:
- `test_visible_band_cpu_gpu_ssim` (0.999 gate) passes.
- `test_visible_band_no_regression` passes.
- `test_nir_band_*` and `test_uv_band_*` still ≥ 0.97 (no regression).
- Visible-band MW frame-time within 10 % of pkg54b baseline; if it
  regresses past 10 %, switch the LUT to a `cudaTextureObject_t` (Option B
  in `pkg54c-gpu-jakob-hanika-upsampling.md`) and re-measure. Record the
  numbers in the package's *Lessons* section.
- `tests/test_gpu_profile_lookup.py` (pkg54d) still green.

## Out of scope

- No CPU upsampling change (CPU path is the reference and stays bit-equal).
- No `cudaTextureObject_t` plumbing — only added if Option A regresses.
- No per-`GMaterial` coefficient pre-baking (simplicity-first; revisit if
  per-wavelength LUT lookups dominate the MW kernel hot path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)