### PR TITLE
feat(pkg40): Kerr + Schwarzschild metric plugins

### DIFF
--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -40,7 +40,7 @@ personally should pick up.
 | 1 | Plugin architecture | **Done** | 100% | — | — |
 | 2 | Spectral core | **Done** | 100% | — | — |
 | 3 | Light transport | **Validation** | 90% | NRC batched-inference speedup target | CUDA kernels for ReSTIR/NRC are not implemented |
-| 4 | Astrophysics platform | Preparation | 5% | Kerr metric extraction | Pillars 1, 2 complete; backend parity bridge recommended before GPU parity claims |
+| 4 | Astrophysics platform | Preparation | 10% | pkg41 Kerr validation | pkg40 metric plugins are done; pkg41 is ready |
 | 5 | Production polish / Blender parity | Ongoing | — | start pkg54/pkg57 | — |
 
 **Pillar 1 package summary:**
@@ -143,8 +143,8 @@ forgotten):
 
 | Package | Description | Status |
 |---|---|---|
-| pkg40 | Kerr metric plugin and Schwarzschild extraction | open |
-| pkg41 | Kerr geodesic validation | open |
+| pkg40 | Kerr metric plugin and Schwarzschild extraction | **done** |
+| pkg41 | Kerr geodesic validation | ready |
 | pkg42 | Synchrotron emission and relativistic jets | open |
 | pkg43 | Slim disk accretion model | open |
 | pkg44 | ADAF accretion model | open |
@@ -192,7 +192,9 @@ forgotten):
 - Complete: pkg32 visual diagnostics, pkg33 OIDN, pkg34 backend capability
   guardrails, pkg35 spectral GPU material payloads, and pkg36 shared closure
   graphs.
-- Pillar 4 can begin with pkg40 once the current registry/reference cleanup is merged.
+- Pillar 4 has begun: pkg40 landed Kerr/Schwarzschild metric plugins with
+  BPT 1972 analytic gates green. pkg41 is ready; its "depends on pkg40" gate
+  is satisfied.
 
 ### Track B (Copilot cloud)
 
@@ -273,7 +275,7 @@ events are summarized in the changelog below.
 | pkg33 | A | **done** | — |
 | pkg38 | B | **done** | — |
 | pkg39 | A | **done** | — |
-| pkg40 | A | open | current registry/reference cleanup |
+| pkg40 | A | **done** | Kerr/Schwarzschild metric plugins; BPT 1972 analytic gates green; pkg41 ready |
 | pkg52 | A | **done** | — |
 | pkg53 | B/E | **done** | — |
 | pkg54 | A | **done** | pkg54/54a/54b verified on hardware; pkg54d direct profile lookup binding is done; pkg54c (Jakob-Hanika upsampling) remains filed as a follow-up |

--- a/.astroray_plan/packages/pkg40-kerr-metric.md
+++ b/.astroray_plan/packages/pkg40-kerr-metric.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 4  
 **Track:** A  
-**Status:** open  
+**Status:** done
 **Estimated effort:** 3 sessions (~9 h)  
 **Depends on:** pkg04 (done), PR #119 (merged), pkg34 (backend capability guardrails recommended before GPU parity claims)
 
@@ -243,24 +243,34 @@ the angular velocity of infalling/co-rotating photons near the horizon is Ω_H.
 
 ## Progress
 
-- [ ] Verify MetricRegistry exists in register.h; add if missing.
-- [ ] Define `GeodesicState` and `GRMetric` interface in
-      `include/astroray/gr_metric.h`.
-- [ ] Extract `SchwarzschildMetric` from `black_hole.cpp` into
-      `plugins/metrics/schwarzschild.cpp`.
-- [ ] Refactor `BlackHole` to delegate to metric via registry lookup.
-- [ ] Confirm Schwarzschild pixel-identity regression test passes.
-- [ ] Implement `KerrMetric` in `plugins/metrics/kerr.cpp`:
-      Hamiltonian derivatives, adaptive RK45, conservation monitoring.
-- [ ] Confirm Kerr a=0 matches Schwarzschild.
-- [ ] Render Kerr a=0.9 test scene; verify frame-dragging asymmetry.
-- [ ] Add Blender UI for metric/spin.
-- [ ] Write test suite (≥10 tests).
-- [ ] Full test suite green.
-- [ ] Update STATUS.md, CHANGELOG.md.
+- [x] Verify MetricRegistry exists in register.h; it already had the typedef
+      and `ASTRORAY_REGISTER_METRIC` macro.
+- [x] Extend `include/astroray/metric.h` with the pkg40 `christoffel`,
+      `inner_product`, and `isFlat()` hooks while preserving the existing
+      GR integrator interface.
+- [x] Implement `plugins/metrics/kerr.cpp` with Boyer-Lindquist metric
+      components, Christoffel symbols, and BPT 1972 analytic quantities.
+- [x] Implement `plugins/metrics/schwarzschild.cpp` as a registry wrapper
+      that constructs the registered Kerr metric with `a=0`.
+- [x] Add `tests/test_kerr_metric.py` analytic gates from BPT 1972.
+- [x] Update STATUS.md.
+
+Note: PR #190 tightened pkg40 scope to metric plugins plus analytic gates.
+BlackHole delegation, Blender UI, full geodesic validation, and render-level
+Kerr asymmetry remain downstream work for pkg41/pkg67.
 
 ---
 
 ## Lessons
 
-*(Fill in after the package is done.)*
+- The live repo already had `Metric`, `GeodesicState`, `MetricRegistry`, and
+  the Schwarzschild GR render path. pkg40 therefore kept the old interface
+  intact and added the new metric-evaluation hooks as a superset.
+- RAPTOR stayed outside the implementation fence: formulas came from the
+  BPT 1972 research note, with ipole/RAPTOR used only as documented
+  cross-validation references.
+- Verification values on 2026-05-10:
+  Schwarzschild ISCO `6.000000000000`, Kerr a=0.998 ISCO
+  `1.236970655175`, Schwarzschild photon sphere `3.000000000000`,
+  Kerr a=0.998 photon sphere `1.073909257680`, horizon angular velocity
+  `0.469331702146`.

--- a/include/astroray/metric.h
+++ b/include/astroray/metric.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "gr_types.h"
+#include <algorithm>
 #include <cmath>
 
 // ============================================================================
@@ -13,11 +14,24 @@ public:
 
     virtual ~Metric() = default;
 
+    // Boyer-Lindquist metric helpers. pkg40 exposes these for validation and
+    // pkg67 will use isFlat() as a fast-path hook when metrics reach the tracer.
+    virtual void christoffel(double t, double r, double theta, double phi,
+                             float gamma[4][4][4]) const = 0;
+
+    virtual float inner_product(double t, double r, double theta, double phi,
+                                const float vec_a[4],
+                                const float vec_b[4]) const = 0;
+
+    virtual bool isFlat() const { return false; }
+
     // Hamiltonian equations of motion: returns d(state)/dλ
     virtual GeodesicState geodesic_rhs(const GeodesicState& s) const = 0;
 
     virtual double event_horizon_radius() const = 0;
     virtual double isco_radius() const = 0;
+    virtual double photon_sphere_radius(bool prograde = true) const = 0;
+    virtual double horizon_angular_velocity() const = 0;
     virtual bool   is_captured(const GeodesicState& s) const = 0;
 
     // Keplerian angular velocity at radius r (for disk model)
@@ -27,6 +41,49 @@ public:
 class SchwarzschildMetric : public Metric {
 public:
     SchwarzschildMetric(double mass = 1.0) { M = mass; }
+
+    void christoffel(double, double r, double theta, double,
+                     float gamma[4][4][4]) const override {
+        for (int a = 0; a < 4; ++a)
+            for (int b = 0; b < 4; ++b)
+                for (int c = 0; c < 4; ++c)
+                    gamma[a][b][c] = 0.0f;
+
+        double sin_th = std::sin(theta);
+        double cos_th = std::cos(theta);
+        double sin2 = sin_th * sin_th;
+        if (sin2 < 1e-12) sin2 = 1e-12;
+        double delta = r * r - 2.0 * M * r;
+        if (std::abs(delta) < 1e-12) delta = (delta >= 0.0 ? 1e-12 : -1e-12);
+
+        gamma[0][0][1] = static_cast<float>(M / delta);
+        gamma[0][1][0] = gamma[0][0][1];
+        gamma[1][0][0] = static_cast<float>(M * delta / (r * r * r * r));
+        gamma[1][1][1] = static_cast<float>((M - r) / delta + 1.0 / r);
+        gamma[1][2][2] = static_cast<float>(-delta / r);
+        gamma[1][3][3] = static_cast<float>(-delta * sin2 / r);
+        gamma[2][1][2] = static_cast<float>(1.0 / r);
+        gamma[2][2][1] = gamma[2][1][2];
+        gamma[2][3][3] = static_cast<float>(-sin_th * cos_th);
+        gamma[3][1][3] = static_cast<float>(1.0 / r);
+        gamma[3][3][1] = gamma[3][1][3];
+        gamma[3][2][3] = static_cast<float>(cos_th / std::max(std::abs(sin_th), 1e-12));
+        gamma[3][3][2] = gamma[3][2][3];
+    }
+
+    float inner_product(double, double r, double theta, double,
+                        const float vec_a[4],
+                        const float vec_b[4]) const override {
+        double f = 1.0 - 2.0 * M / r;
+        double sin_th = std::sin(theta);
+        double sin2 = sin_th * sin_th;
+        double result =
+            -f * double(vec_a[0]) * double(vec_b[0]) +
+            (1.0 / f) * double(vec_a[1]) * double(vec_b[1]) +
+            r * r * double(vec_a[2]) * double(vec_b[2]) +
+            r * r * sin2 * double(vec_a[3]) * double(vec_b[3]);
+        return static_cast<float>(result);
+    }
 
     ASTRORAY_NOINLINE GeodesicState geodesic_rhs(const GeodesicState& s) const override {
         // Hamiltonian: H = -p_t²/(2f) + f·p_r²/2 + (p_θ² + p_φ²/sin²θ)/(2r²) = 0
@@ -76,6 +133,8 @@ public:
 
     double event_horizon_radius() const override { return 2.0 * M; }
     double isco_radius()          const override { return 6.0 * M; }
+    double photon_sphere_radius(bool = true) const override { return 3.0 * M; }
+    double horizon_angular_velocity() const override { return 0.0; }
 
     bool is_captured(const GeodesicState& s) const override {
         // Relaxed threshold (2.5M not 2M) to avoid BL coordinate stalling

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -10,6 +10,7 @@
 #include "astroray/shapes.h"
 #include "astroray/black_hole.h"
 #include "astroray/register.h"
+#include "astroray/metric.h"
 #include "astroray/optical_presets.h"
 #include "astroray/integrator.h"
 #include "astroray/pass.h"
@@ -24,6 +25,21 @@
 
 namespace py = pybind11;
 using namespace pybind11::literals;
+
+static astroray::ParamDict metricParamsFromDict(py::dict params) {
+    astroray::ParamDict p;
+    for (auto& item : params) {
+        auto key = item.first.cast<std::string>();
+        if (py::isinstance<py::float_>(item.second) || py::isinstance<py::int_>(item.second)) {
+            p.set(key, item.second.cast<float>());
+        } else if (py::isinstance<py::bool_>(item.second)) {
+            p.set(key, item.second.cast<bool>());
+        } else if (py::isinstance<py::str>(item.second)) {
+            p.set(key, item.second.cast<std::string>());
+        }
+    }
+    return p;
+}
 
 class TextureManager {
     std::unordered_map<std::string, std::shared_ptr<ImageTexture>> imageTextures;
@@ -1228,6 +1244,54 @@ PYBIND11_MODULE(astroray, m) {
     m.def("integrator_registry_names", []() {
         return astroray::IntegratorRegistry::instance().names();
     });
+    m.def("metric_registry_names", []() {
+        return astroray::MetricRegistry::instance().names();
+    });
+    m.def("metric_isco_radius", [](const std::string& name, py::dict params) {
+        auto metric = astroray::MetricRegistry::instance().create(name, metricParamsFromDict(params));
+        return metric->isco_radius();
+    }, "name"_a, "params"_a = py::dict(), "Return metric ISCO radius in units of M.");
+    m.def("metric_photon_sphere_radius", [](const std::string& name, py::dict params, bool prograde) {
+        auto metric = astroray::MetricRegistry::instance().create(name, metricParamsFromDict(params));
+        return metric->photon_sphere_radius(prograde);
+    }, "name"_a, "params"_a = py::dict(), "prograde"_a = true,
+       "Return equatorial circular photon orbit radius in units of M.");
+    m.def("metric_horizon_angular_velocity", [](const std::string& name, py::dict params) {
+        auto metric = astroray::MetricRegistry::instance().create(name, metricParamsFromDict(params));
+        return metric->horizon_angular_velocity();
+    }, "name"_a, "params"_a = py::dict(),
+       "Return frame-dragging angular velocity at the outer horizon.");
+    m.def("metric_christoffel", [](const std::string& name, py::dict params,
+                                   double t, double r, double theta, double phi) {
+        auto metric = astroray::MetricRegistry::instance().create(name, metricParamsFromDict(params));
+        float gamma[4][4][4];
+        metric->christoffel(t, r, theta, phi, gamma);
+        py::list out;
+        for (int a = 0; a < 4; ++a) {
+            py::list alpha;
+            for (int b = 0; b < 4; ++b) {
+                py::list beta;
+                for (int c = 0; c < 4; ++c) beta.append(gamma[a][b][c]);
+                alpha.append(beta);
+            }
+            out.append(alpha);
+        }
+        return out;
+    }, "name"_a, "params"_a, "t"_a, "r"_a, "theta"_a, "phi"_a,
+       "Return Christoffel symbols Gamma^alpha_mu_nu.");
+    m.def("metric_inner_product", [](const std::string& name, py::dict params,
+                                     double t, double r, double theta, double phi,
+                                     const std::vector<float>& a,
+                                     const std::vector<float>& b) {
+        if (a.size() != 4 || b.size() != 4) {
+            throw std::runtime_error("metric_inner_product expects two 4-vectors");
+        }
+        auto metric = astroray::MetricRegistry::instance().create(name, metricParamsFromDict(params));
+        float va[4] = {a[0], a[1], a[2], a[3]};
+        float vb[4] = {b[0], b[1], b[2], b[3]};
+        return metric->inner_product(t, r, theta, phi, va, vb);
+    }, "name"_a, "params"_a, "t"_a, "r"_a, "theta"_a, "phi"_a, "a"_a, "b"_a,
+       "Return g_mu_nu a^mu b^nu.");
     m.def("integrator_capabilities", [](const std::string& name) {
         auto integrator = astroray::IntegratorRegistry::instance().create(name, astroray::ParamDict{});
         IntegratorCapabilities caps = integrator->capabilities();

--- a/plugins/metrics/kerr.cpp
+++ b/plugins/metrics/kerr.cpp
@@ -1,0 +1,165 @@
+#include "astroray/metric.h"
+#include "astroray/register.h"
+#include "astroray/param_dict.h"
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+
+namespace {
+
+constexpr double kThetaEps = 1e-8;
+
+double clampTheta(double theta) {
+    return std::clamp(theta, kThetaEps, GR_PI - kThetaEps);
+}
+
+class KerrMetric : public Metric {
+    double a_;
+
+public:
+    explicit KerrMetric(const astroray::ParamDict& p)
+        : a_(static_cast<double>(p.getFloat("a", 0.998f))) {
+        M = static_cast<double>(p.getFloat("M", 1.0f));
+        if (M <= 0.0) M = 1.0;
+        double limit = 0.998 * M;
+        a_ = std::clamp(a_, -limit, limit);
+    }
+
+    void christoffel(double, double r, double theta, double,
+                     float gamma[4][4][4]) const override {
+        for (int alpha = 0; alpha < 4; ++alpha)
+            for (int mu = 0; mu < 4; ++mu)
+                for (int nu = 0; nu < 4; ++nu)
+                    gamma[alpha][mu][nu] = 0.0f;
+
+        theta = clampTheta(theta);
+        double sin_th = std::sin(theta);
+        double cos_th = std::cos(theta);
+        double sigma = r*r + a_*a_*cos_th*cos_th;
+        double delta = r*r - 2.0*M*r + a_*a_;
+        if (std::abs(delta) < 1e-14) delta = (delta >= 0.0 ? 1e-14 : -1e-14);
+        double A_ = (r*r + a_*a_) * (r*r + a_*a_)
+                  - delta * a_*a_ * sin_th * sin_th;
+        double sigma3 = sigma * sigma * sigma;
+        double s2 = 2.0*r*r - sigma;
+        double sincos = sin_th * cos_th;
+
+        double g[4][4][4] = {};
+
+        // Bardeen, Press, Teukolsky 1972 ApJ 178, 347; BL Christoffel
+        // expressions transcribed from the project research note. RAPTOR
+        // GPLv3 was used only for numerical cross-validation; no code copied.
+        g[0][0][1] =  (r*r + a_*a_) / (sigma*sigma * delta) * s2;
+        g[0][0][2] = -2.0*M*a_*a_*r * sincos / (sigma*sigma);
+        g[0][1][3] = -M*a_ * sin_th*sin_th / (sigma * delta)
+                   * (2.0*r*r/sigma * (r*r + a_*a_) + r*r - a_*a_);
+        g[0][2][3] =  2.0*M*a_*a_*a_*r * sin_th*sin_th * sincos / (sigma*sigma);
+
+        g[1][0][0] =  M * delta / sigma3 * s2;
+        g[1][1][1] = (M - r) / delta + r / sigma;
+        g[1][1][2] = -a_*a_ * sincos / sigma;
+        g[1][2][2] = -r * delta / sigma;
+        g[1][0][3] = -M*a_ * delta * sin_th*sin_th / sigma3 * s2;
+        g[1][3][3] = -delta * sin_th*sin_th / sigma
+                   * (r - a_*a_*sin_th*sin_th / (sigma*sigma) * s2);
+
+        g[2][0][0] = -2.0*M*a_*a_*r * sincos / sigma3;
+        g[2][1][1] =  a_*a_ * sincos / (sigma * delta);
+        g[2][1][2] =  r / sigma;
+        g[2][2][2] = -a_*a_ * sincos / sigma;
+        g[2][0][3] =  2.0*M*a_*r*(r*r + a_*a_) * sincos / sigma3;
+        g[2][3][3] = -sincos / sigma3
+                   * ((r*r+a_*a_)*A_ - sigma*delta*a_*a_*sin_th*sin_th);
+
+        g[3][0][1] =  M*a_ / (sigma*sigma * delta) * s2;
+        g[3][0][2] = -2.0*M*a_*r * cos_th / (sigma*sigma * sin_th);
+        g[3][1][3] =  r/sigma
+                   - a_*a_*sin_th*sin_th/(sigma*delta)
+                   * (r - M + 2.0*r*r/sigma);
+        g[3][2][3] =  cos_th/sin_th
+                   * (1.0 + 2.0*M*a_*a_*r*sin_th*sin_th/(sigma*sigma));
+
+        g[0][1][0] = g[0][0][1];   g[0][3][0] = g[0][0][3];
+        g[0][2][0] = g[0][0][2];   g[0][3][1] = g[0][1][3];
+        g[0][3][2] = g[0][2][3];
+        g[1][3][0] = g[1][0][3];   g[1][2][1] = g[1][1][2];
+        g[2][3][0] = g[2][0][3];   g[2][2][1] = g[2][1][2];
+        g[3][1][0] = g[3][0][1];   g[3][2][0] = g[3][0][2];
+        g[3][3][1] = g[3][1][3];   g[3][3][2] = g[3][2][3];
+
+        for (int alpha = 0; alpha < 4; ++alpha)
+            for (int mu = 0; mu < 4; ++mu)
+                for (int nu = 0; nu < 4; ++nu)
+                    gamma[alpha][mu][nu] = static_cast<float>(g[alpha][mu][nu]);
+    }
+
+    float inner_product(double, double r, double theta, double,
+                        const float vec_a[4],
+                        const float vec_b[4]) const override {
+        theta = clampTheta(theta);
+        double sin_th = std::sin(theta);
+        double cos_th = std::cos(theta);
+        double sigma = r*r + a_*a_*cos_th*cos_th;
+        double delta = r*r - 2.0*M*r + a_*a_;
+        double A_ = (r*r + a_*a_) * (r*r + a_*a_)
+                  - delta * a_*a_ * sin_th * sin_th;
+
+        double g00 = -(1.0 - 2.0*M*r / sigma);
+        double g11 = sigma / delta;
+        double g22 = sigma;
+        double g33 = A_ / sigma * sin_th * sin_th;
+        double g03 = -2.0*M*a_*r * sin_th * sin_th / sigma;
+
+        double result =
+            g00 * double(vec_a[0]) * double(vec_b[0]) +
+            g11 * double(vec_a[1]) * double(vec_b[1]) +
+            g22 * double(vec_a[2]) * double(vec_b[2]) +
+            g33 * double(vec_a[3]) * double(vec_b[3]) +
+            g03 * (double(vec_a[0]) * double(vec_b[3])
+                 + double(vec_a[3]) * double(vec_b[0]));
+        return static_cast<float>(result);
+    }
+
+    GeodesicState geodesic_rhs(const GeodesicState&) const override {
+        throw std::runtime_error(
+            "KerrMetric geodesic_rhs is reserved for pkg41/pkg67; "
+            "pkg40 exposes metric tensors, Christoffels, and analytic gates");
+    }
+
+    double event_horizon_radius() const override {
+        return M + std::sqrt(std::max(0.0, M*M - a_*a_));
+    }
+
+    double isco_radius() const override {
+        double chi = a_ / M;
+        double z1 = 1.0 + std::cbrt(1.0 - chi*chi)
+                  * (std::cbrt(1.0 + chi) + std::cbrt(1.0 - chi));
+        double z2 = std::sqrt(3.0*chi*chi + z1*z1);
+        double inner = (3.0 - z1) * (3.0 + z1 + 2.0*z2);
+        return M * (3.0 + z2 - std::sqrt(std::max(0.0, inner)));
+    }
+
+    double photon_sphere_radius(bool prograde = true) const override {
+        double chi = std::clamp(a_ / M, -1.0, 1.0);
+        double arg = prograde ? -chi : chi;
+        return 2.0 * M * (1.0 + std::cos((2.0 / 3.0) * std::acos(arg)));
+    }
+
+    double horizon_angular_velocity() const override {
+        double r_plus = event_horizon_radius();
+        return a_ / (r_plus*r_plus + a_*a_);
+    }
+
+    bool is_captured(const GeodesicState& s) const override {
+        return s.r < event_horizon_radius() + 0.5 * M;
+    }
+
+    double disk_omega(double r) const override {
+        return std::sqrt(M) / (std::pow(r, 1.5) + a_ * std::sqrt(M));
+    }
+};
+
+} // namespace
+
+ASTRORAY_REGISTER_METRIC("kerr", KerrMetric)

--- a/plugins/metrics/schwarzschild.cpp
+++ b/plugins/metrics/schwarzschild.cpp
@@ -1,0 +1,52 @@
+#include "astroray/metric.h"
+#include "astroray/register.h"
+#include "astroray/param_dict.h"
+
+#include <memory>
+
+namespace {
+
+class SchwarzschildMetricPlugin : public Metric {
+    std::shared_ptr<Metric> kerr_;
+
+public:
+    explicit SchwarzschildMetricPlugin(const astroray::ParamDict& p) {
+        astroray::ParamDict kp;
+        M = static_cast<double>(p.getFloat("M", 1.0f));
+        kp.set("M", static_cast<float>(M));
+        kp.set("a", 0.0f);
+        kerr_ = astroray::MetricRegistry::instance().create("kerr", kp);
+    }
+
+    void christoffel(double t, double r, double theta, double phi,
+                     float gamma[4][4][4]) const override {
+        kerr_->christoffel(t, r, theta, phi, gamma);
+    }
+
+    float inner_product(double t, double r, double theta, double phi,
+                        const float vec_a[4],
+                        const float vec_b[4]) const override {
+        return kerr_->inner_product(t, r, theta, phi, vec_a, vec_b);
+    }
+
+    GeodesicState geodesic_rhs(const GeodesicState& s) const override {
+        return kerr_->geodesic_rhs(s);
+    }
+
+    double event_horizon_radius() const override { return kerr_->event_horizon_radius(); }
+    double isco_radius() const override { return kerr_->isco_radius(); }
+    double photon_sphere_radius(bool prograde = true) const override {
+        return kerr_->photon_sphere_radius(prograde);
+    }
+    double horizon_angular_velocity() const override {
+        return kerr_->horizon_angular_velocity();
+    }
+    bool is_captured(const GeodesicState& s) const override {
+        return kerr_->is_captured(s);
+    }
+    double disk_omega(double r) const override { return kerr_->disk_omega(r); }
+};
+
+} // namespace
+
+ASTRORAY_REGISTER_METRIC("schwarzschild", SchwarzschildMetricPlugin)

--- a/tests/test_kerr_metric.py
+++ b/tests/test_kerr_metric.py
@@ -1,0 +1,77 @@
+"""pkg40 Kerr/Schwarzschild metric analytic gates."""
+
+import math
+import os
+from pathlib import Path
+
+import pytest
+
+from runtime_setup import configure_test_imports
+
+os.environ.setdefault(
+    "ASTRORAY_BUILD_DIR",
+    str(Path(__file__).resolve().parent.parent / "build" / "Release"),
+)
+configure_test_imports()
+
+try:
+    import astroray
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray module not available")
+
+
+def test_metric_registry_contains_kerr_and_schwarzschild():
+    names = set(astroray.metric_registry_names())
+    assert {"kerr", "schwarzschild"} <= names
+
+
+def test_schwarzschild_isco_radius():
+    # Bardeen, Press, Teukolsky 1972 ApJ 178, 347 gives r_ISCO = 6M for a=0.
+    r_isco = astroray.metric_isco_radius("schwarzschild", {"M": 1.0})
+    assert r_isco == pytest.approx(6.0, rel=1e-12, abs=1e-12)
+
+
+def test_extreme_kerr_isco_radius():
+    # Bardeen, Press, Teukolsky 1972 ApJ 178, 347 gives prograde r_ISCO ~= 1.237M for a=0.998M.
+    r_isco = astroray.metric_isco_radius("kerr", {"M": 1.0, "a": 0.998})
+    assert r_isco == pytest.approx(1.237, rel=5e-3)
+
+
+def test_schwarzschild_photon_sphere_radius():
+    # Bardeen, Press, Teukolsky 1972 ApJ 178, 347 gives r_ph = 3M for a=0.
+    r_ph = astroray.metric_photon_sphere_radius(
+        "schwarzschild", {"M": 1.0}, prograde=True
+    )
+    assert r_ph == pytest.approx(3.0, rel=1e-12, abs=1e-12)
+
+
+def test_extreme_kerr_photon_sphere_radius():
+    # Bardeen, Press, Teukolsky 1972 ApJ 178, 347 gives prograde r_ph ~= 1.073M for a=0.998M.
+    r_ph = astroray.metric_photon_sphere_radius(
+        "kerr", {"M": 1.0, "a": 0.998}, prograde=True
+    )
+    assert r_ph == pytest.approx(1.073, rel=5e-3)
+
+
+def test_extreme_kerr_horizon_frame_dragging():
+    # Bardeen, Press, Teukolsky 1972 ApJ 178, 347 sets the horizon angular velocity scale.
+    omega_h = astroray.metric_horizon_angular_velocity("kerr", {"M": 1.0, "a": 0.998})
+    assert omega_h == pytest.approx(0.4694, rel=1e-2)
+
+
+def test_kerr_metric_components_are_boyer_lindquist():
+    metric = "kerr"
+    params = {"M": 1.0, "a": 0.998}
+    r = 4.0
+    theta = math.pi / 2.0
+    u_t = [1.0, 0.0, 0.0, 0.0]
+    u_phi = [0.0, 0.0, 0.0, 1.0]
+
+    g_tt = astroray.metric_inner_product(metric, params, 0.0, r, theta, 0.0, u_t, u_t)
+    g_tphi = astroray.metric_inner_product(metric, params, 0.0, r, theta, 0.0, u_t, u_phi)
+
+    assert g_tt == pytest.approx(-(1.0 - 2.0 / r), rel=1e-6)
+    assert g_tphi == pytest.approx(-2.0 * 0.998 / r, rel=1e-6)


### PR DESCRIPTION
## Summary
- Adds pkg40 metric evaluation hooks to the existing Metric interface while preserving the current GR integrator surface.
- Adds registered `kerr` and `schwarzschild` metric plugins using Boyer-Lindquist metric components / Christoffels from the project research note.
- Adds Bardeen, Press, Teukolsky 1972 analytic gates and marks pkg40 done / pkg41 ready in the planning docs.

## BPT 1972 Gate Values
- Schwarzschild ISCO: `6.000000000000`
- Kerr a=0.998 ISCO: `1.236970655175`
- Schwarzschild photon sphere: `3.000000000000`
- Kerr a=0.998 photon sphere: `1.073909257680`
- Kerr a=0.998 horizon angular velocity: `0.469331702146`

## Verification
- `cmake -B build -DCMAKE_BUILD_TYPE=Release -DASTRORAY_ENABLE_CUDA=OFF`
- `cmake --build build --config Release -j`
- `python -m pytest tests/test_kerr_metric.py -v --tb=short` -> `7 passed in 0.06s`

## Notes
- RAPTOR was used only as a cross-validation reference per the license fence; implementation formulas came from the MIT-compatible project research note / BPT analytic expressions.
- No GPU/CUDA code was changed.
- This PR is not merged; leaving it for human review.