### PR TITLE
verify(pkg54c): CUDA gates green — fix GPU illuminant renormalization, raise SSIM-test spp

### DIFF
--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -22,8 +22,8 @@ personally should pick up.
   not CUDA kernels.
 - Pillar 5 is the active practical queue. The Cycles-parity/Blender package
   series is now the live near-term roadmap: pkg52/pkg53/pkg58/pkg60/pkg61/pkg62
-  are done, pkg59 is done, pkg54/54a/54b/54d are done (with pkg54c as a
-  scoped follow-up), and pkg57 remains open.
+  are done, pkg59 is done, pkg54/54a/54b/54c/54d are all done (CUDA
+  hardware verified 2026-05-10), and pkg57 remains open.
 - Fresh local collection on this branch: `pytest --collect-only -q` reports
   **435 tests collected** (2026-05-09). Focused pkg53/viewport checks pass.
 - Historical docs that are intentionally not current: `NEXT_STAGE_REPORT.md`
@@ -276,7 +276,7 @@ events are summarized in the changelog below.
 | pkg40 | A | open | current registry/reference cleanup |
 | pkg52 | A | **done** | — |
 | pkg53 | B/E | **done** | — |
-| pkg54 | A | **done** | pkg54/54a/54b verified on hardware; pkg54d direct profile lookup binding is done; pkg54c (Jakob-Hanika upsampling) is **implemented, pending CUDA verification** — promote-to-done held until the visible-band SSIM 0.999 gate runs on hardware |
+| pkg54 | A | **done** | pkg54/54a/54b/54c/54d all verified on hardware; pkg54c visible-band SSIM 0.999 gate clears at 0.999263 (spp=8192); GPU `gpu_rgbSpectrumAt` ILLUMINANT renormalization bug found and fixed during verification; frame-time regression +0.45 % (pkg54e not needed) |
 | pkg57 | A | open | native shader nodes / Cycles compatibility design |
 | pkg58 | B | **done** | — |
 | pkg59 | A | done | broader vector/UV/Mapping plumbing, named UV layers, and UV debug AOV |
@@ -319,9 +319,19 @@ events are summarized in the changelog below.
   device global memory once per process via `uploadJakobHanikaLut`
   (cudaMalloc + cudaMemcpyToSymbol of pointers, 9 MB — overflows the
   64 KB constant cap), and `gpu_rgbSpectrumAt` upsamples through it for
-  both `GSPEC_RGB_ALBEDO` and `GSPEC_RGB_ILLUMINANT`. Promote-to-done
-  is held until the verifier session runs `scripts/build/build_cuda.bat`
-  and confirms the visible-band SSIM 0.999 gate on CUDA hardware.
+  both `GSPEC_RGB_ALBEDO` and `GSPEC_RGB_ILLUMINANT`. Verified on CUDA
+  hardware 2026-05-10: visible-band CPU↔GPU SSIM = 0.999263 at spp=8192
+  on the parity scene (gate ≥ 0.999), per-channel mean ratios within
+  0.4 %, frame-time regression +0.45 % at 1080p / 64 spp / depth 4.
+  A real GPU bug — `gpu_rgbSpectrumAt` ILLUMINANT mode missed the
+  CPU's `2·max(rgb)` renormalize-then-rescale step, causing wrong
+  absolute spectra for any HDR emitter — was found and fixed during
+  verification (see pkg54c Lessons). The 0.999 SSIM gate is unreachable
+  at the original 64 spp regardless of evaluator correctness because
+  CPU OpenMP and GPU warp-parallel integrators place MC samples on
+  different per-pixel sub-streams; the test now runs at spp=8192
+  (~5 s on RTX-class hardware) where the noise floor drops below
+  the gate by ~26 %.
   Sellmeier direction-splitting and true spectral emitter parameter
   upload also remain CPU-only follow-ups. pkg36 expands shared closure
   lowering.

--- a/.astroray_plan/packages/pkg54c-gpu-jakob-hanika-upsampling.md
+++ b/.astroray_plan/packages/pkg54c-gpu-jakob-hanika-upsampling.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 5
 **Track:** A
-**Status:** implemented (pending CUDA verification)
+**Status:** done
 **Estimated effort:** 3–5 days
 **Depends on:** pkg54b
 
@@ -120,4 +120,80 @@ up as a chromaticity shift the integration never averages out.
 
 ## Lessons
 
-*(Fill in after the package is done.)*
+Hardware verification on RTX-class CUDA workstation (Windows 11, CUDA 12.6,
+sm_89), 2026-05-10:
+
+- **Visible-band SSIM gate (≥ 0.999):** measured **0.999263** at spp=8192
+  on the parity scene (48×48). Per-channel mean ratio gpu/cpu =
+  R 0.9998 / G 0.9965 / B 1.0033 (energy parity ~0.3 %). The headline
+  pkg54c gate clears with ~26 % margin.
+- **Visible-band no-regression (gpu mean within 2 % of cpu mean):**
+  passes at spp=64 and spp=8192 (mean ratios ≤ 0.4 %).
+- **NIR / UV with profiles:** no regression — both still pass at the
+  pre-existing 0.97 SSIM gate, untouched by the JH path.
+- **GPU shade-smooth (pkg61 hard gate):** residual_std/patch_mean =
+  **0.07231** (gate < 0.18). No regression.
+- **Frame-time delta** at 1080p / 64 spp / depth 4 on the parity scene,
+  median of 5 runs:
+  - origin/main (e292285, pre-pkg54c): 0.224 s
+  - HEAD with fix: 0.225 s
+  - **regression: +0.45 %** — well under the 10 % pkg54e trigger; pkg54e
+    is NOT needed.
+- **CPU spectral suite:** 309 / 309 passed. CPU bit-equivalence preserved
+  (the fix is GPU-only).
+
+### Two issues found during verification
+
+1. **Real bug — `gpu_rgbSpectrumAt` ILLUMINANT mode missed renormalization.**
+   The CPU `RGBIlluminantSpectrum::sample`
+   ([src/spectrum.cpp:464-491](src/spectrum.cpp:464)) computes
+   `scale = 2·max(rgb)`, normalizes the RGB into the LUT-valid [0, 0.5]
+   range, calls JH, then multiplies the result by `scale · D65(λ)`.
+   The first pkg54c GPU port did neither — it called JH on the raw
+   (unnormalized, then internally clamped to [0, 1]) RGB and multiplied
+   only by `D65(λ)`. For the test scene's emissive light with
+   `em = [8, 8, 8]`, GPU was effectively computing
+   `jh([1, 1, 1], λ)·D65` instead of `16·jh([0.5, 0.5, 0.5], λ)·D65` —
+   wildly different absolute spectra. The bug was masked in the SSIM
+   test because pixel clipping at 1.0 hides oversaturated emitters, but
+   it would have shown up in any HDR-output downstream (denoiser, AOVs,
+   EXR). Fix lives in
+   [include/astroray/gpu_materials.h:68-87](include/astroray/gpu_materials.h:68).
+
+2. **Gate-honesty issue — 0.999 SSIM unreachable at spp=64 for any
+   integrator-correct GPU path.** Even with a bit-perfect JH evaluator
+   (confirmed: `jhEvalSpectrumF` is `__host__ __device__` shared, and
+   `gpu_jhLookupCoeffs` mirrors `JakobHanikaLut::lookup` line-for-line),
+   the CPU OpenMP integrator and the GPU warp-parallel integrator place
+   Monte-Carlo samples on different per-pixel sub-streams. The resulting
+   per-pixel noise is energy-conserving but spatially de-correlated,
+   producing a noise floor that scales as 1 / √spp:
+
+   | spp  | SSIM    | mean_diff | gpu_mean / cpu_mean |
+   |------|---------|-----------|---------------------|
+   | 64   | 0.9902  | 0.00244   | 1.00015             |
+   | 256  | 0.9970  | 0.00130   | 1.00037             |
+   | 1024 | 0.9988  | 0.00072   | 0.99998             |
+   | 2048 | 0.9990  | 0.00058   | 1.00009             |
+   | 8192 | 0.99926 | 0.00039   | 1.00106             |
+
+   Convergence slows below ideal 1/√n past 1024 spp because the SSIM
+   formula approaches saturation. spp=8192 is the smallest power-of-two
+   that comfortably clears 0.999. Test now uses spp=8192 for the
+   `test_visible_band_cpu_gpu_ssim` gate (~5 s on RTX-class hardware);
+   the rest of the suite is unchanged.
+
+### Things that are NOT bugs (but were investigated)
+
+- **FMA contraction:** ruled out by rebuilding `multiwavelength_kernel.cu`
+  with `-fmad=false --ftz=false --prec-div=true --prec-sqrt=true`. SSIM
+  delta < 4×10⁻⁹. Production build keeps default FMA on.
+- **JH LUT layout / lookup divergence:** GPU `gpu_jhLookupCoeffs` mirrors
+  CPU `JakobHanikaLut::lookup` line-for-line, including the
+  `while (k + 1 < resM1 && scale[k+1] < z)` z-bracketing scan and the
+  `(((c·res + z)·res + y)·res + x)·3` flat layout.
+- **`cudaMemcpyToSymbol` of device pointers:** the prompt flagged this
+  as a candidate failure mode. The current implementation uses
+  `__device__ const float*` pointer symbols populated via
+  `cudaMemcpyToSymbol(symbol, &dev_ptr, sizeof(float*))`, which is the
+  correct idiom — verified to compile and run.

--- a/include/astroray/gpu_materials.h
+++ b/include/astroray/gpu_materials.h
@@ -68,11 +68,22 @@ __device__ float gpu_jhEvalSpectrum(const GVec3& rgb, float lambda);
 __device__ inline float gpu_rgbSpectrumAt(const GVec3& rgb, float lambda, GSpectralMode mode) {
     if (mode == GSPEC_NONE) return luminance(rgb);
     // pkg54c: JH 2019 sigmoid upsampling replaces the earlier 3-Gaussian
-    // RGB-basis stand-in. ILLUMINANT mode continues to multiply by the
-    // normalized D65 SPD (pkg54a/b fix preserved).
-    float v = gpu_jhEvalSpectrum(rgb, lambda);
-    if (mode == GSPEC_RGB_ILLUMINANT) v *= gpu_sampleD65(lambda);
-    return fmaxf(v, 0.f);
+    // RGB-basis stand-in. ILLUMINANT mode mirrors CPU
+    // RGBIlluminantSpectrum (src/spectrum.cpp:464-491): renormalize by
+    // 2*max(rgb) before the JH lookup, then scale-back and multiply by
+    // the normalized D65 SPD (pkg54a/b fix preserved). Without the
+    // renormalization the LUT is queried at the wrong location and the
+    // visible-band CPU<->GPU SSIM gate (>=0.999) cannot be hit.
+    if (mode == GSPEC_RGB_ILLUMINANT) {
+        float m = fmaxf(fmaxf(rgb.x, rgb.y), rgb.z);
+        if (m <= 0.f) return 0.f;
+        float scale = 2.f * m;
+        GVec3 normalized{ rgb.x / scale, rgb.y / scale, rgb.z / scale };
+        return fmaxf(scale * gpu_jhEvalSpectrum(normalized, lambda)
+                           * gpu_sampleD65(lambda), 0.f);
+    }
+    // ALBEDO: gpu_jhLookupCoeffs already clamps rgb to [0,1].
+    return fmaxf(gpu_jhEvalSpectrum(rgb, lambda), 0.f);
 }
 
 __device__ inline GSampledSpectrum gpu_rgbToSampledSpectrum(

--- a/tests/test_gpu_multiwavelength.py
+++ b/tests/test_gpu_multiwavelength.py
@@ -113,7 +113,7 @@ def test_visible_band_cpu_gpu_ssim():
         spp=256   -> 0.9970 (gate fails)
         spp=1024  -> 0.9988 (gate fails)
         spp=2048  -> 0.9990 (gate fails by ~3e-6)
-        spp=8192  -> ~0.9994 (clears with ~40 % margin)
+        spp=8192  -> 0.99926 (clears with ~26 % margin)
     Convergence slows below the ideal 1/sqrt(n) past ~1024 spp because the
     SSIM formula approaches saturation. spp=8192 is the smallest
     power-of-two that comfortably clears 0.999. Do NOT lower this spp

--- a/tests/test_gpu_multiwavelength.py
+++ b/tests/test_gpu_multiwavelength.py
@@ -101,8 +101,24 @@ def _render_pair(lmin, lmax, mode, *,
 
 def test_visible_band_cpu_gpu_ssim():
     """pkg54c: shared JH sigmoid coefficient table on both backends;
-    visible-band parity is now exact within float precision."""
-    cpu, gpu = _render_pair(380.0, 780.0, "", spp=64)
+    visible-band parity is now exact within float precision per evaluator
+    (jhEvalSpectrumF + JH LUT lookup are bit-identical between CPU and GPU,
+    confirmed by diag_pkg54c.py — albedo/illuminant means agree to ~0.04%).
+
+    Integrator-level CPU<->GPU MC sample-stream divergence (OpenMP vs warp
+    parallel) leaves a per-pixel noise floor that scales as 1/sqrt(spp);
+    on this scene it tops out at SSIM ~0.99 at 64 spp, ~0.998 at 1024 spp.
+    Measured SSIM convergence on RTX-class hardware (48x48, this scene):
+        spp=64    -> 0.9902 (gate fails)
+        spp=256   -> 0.9970 (gate fails)
+        spp=1024  -> 0.9988 (gate fails)
+        spp=2048  -> 0.9990 (gate fails by ~3e-6)
+        spp=8192  -> ~0.9994 (clears with ~40 % margin)
+    Convergence slows below the ideal 1/sqrt(n) past ~1024 spp because the
+    SSIM formula approaches saturation. spp=8192 is the smallest
+    power-of-two that comfortably clears 0.999. Do NOT lower this spp
+    without re-running the convergence sweep — see pkg54c Lessons."""
+    cpu, gpu = _render_pair(380.0, 780.0, "", spp=8192)
     assert np.all(np.isfinite(cpu))
     assert np.all(np.isfinite(gpu))
     # Tone-map to [0, 1] so SSIM is well-behaved.


### PR DESCRIPTION
Hardware verification of #194 on RTX-class CUDA workstation (Windows 11, CUDA 12.6, sm_89).

**Two changes:**
1. **Fix:** `gpu_rgbSpectrumAt` ILLUMINANT mode now mirrors the CPU's `2·max(rgb)` renormalize-and-rescale step that `RGBIlluminantSpectrum::sample` does. Without it, HDR emitters produced wrong absolute spectra on GPU (masked in the SSIM test by pixel clamping at 1.0, but visible in any HDR-output downstream — denoiser, AOVs, EXR).
2. **Test:** raised `test_visible_band_cpu_gpu_ssim` spp 64→8192. The 0.999 gate is unreachable at 64 spp regardless of evaluator correctness because CPU OpenMP and GPU warp-parallel integrators use different per-pixel MC sub-streams; SSIM scales as 1/√spp.

**Headline numbers:**
- visible-band SSIM **0.999263** (gate ≥ 0.999, ~26 % margin)
- frame-time regression **+0.45 %** at 1080p / 64 spp / depth 4 (pkg54e not needed)
- CPU spectral suite 309/309 PASS (CPU bit-equivalence preserved)
- GPU full suite 18 passed / 1 xfail (xfail pre-existing)

Full convergence table, ruled-out hypotheses (FMA contraction, layout drift), and per-test recorded numbers in the commit message and pkg54c Lessons.

Targets `claude/brave-knuth-dad22c` so the fix folds into #194 before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)