### PR TITLE
feat(pkg68): OIDN persistent device + CUDA backend selection

### DIFF
--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -105,6 +105,7 @@ personally should pick up.
 |---|---|---|
 | pkg32 | Visual diagnostics & benchmark renders | **done** |
 | pkg33 | OIDN FetchContent integration | **done** |
+| pkg68 | OIDN persistent device + CUDA backend selection | **implemented (pending CUDA verification)** |
 | pkg38 | Spectral material profile database | **done** |
 | pkg39 | Multi-wavelength rendering (IR/UV) | **done** |
 
@@ -287,6 +288,7 @@ events are summarized in the changelog below.
 | pkg62 | B | **done** | — |
 | pkg64 | A | research blocked | caustics research note |
 | pkg67 | A | research blocked | metric-aware tracer research note |
+| pkg68 | A | **implemented (pending CUDA verification)** | persistent OIDN device, CUDA-first init, member-cached filter; CPU pytest green (12+1 skip); CUDA SSIM/timing gates pending verifier session |
 
 ---
 
@@ -360,6 +362,18 @@ events are summarized in the changelog below.
 ## Changelog
 
 Brief notes on notable events.
+
+- **2026-05-10** — pkg68 implemented (pending CUDA verification). OIDN
+  device + filter hoisted to `OIDNDenoiser` class members and lazy-initialised
+  on first `execute()`; init tries `oidn::DeviceType::CUDA` first and falls
+  back to `oidn::DeviceType::CPU` (Cycles `denoiser_oidn_gpu.cpp::create_device`
+  shape, Apache-2.0). Filter is rebound only when the framebuffer geometry
+  or source pointers change. CMakeLists FetchContent fallback bumped from
+  oidn-2.3.3 to oidn-2.4.1 (latest with CUDA backend). New
+  `tests/test_oidn_denoiser_persistence.py` pins: device init runs once
+  across N renders, CUDA selected on CUDA-capable builds, albedo/normal
+  guides present without explicit AOV pass. CPU pytest run: 12 passed,
+  1 CUDA-only test skipped. CUDA SSIM/timing verification pending.
 
 - **2026-05-09** — pkg59 done. Named UV layers now upload through
   `add_triangle_layers`, textures can select a layer via Texture

--- a/.astroray_plan/packages/pkg68-oidn-architectural-fix.md
+++ b/.astroray_plan/packages/pkg68-oidn-architectural-fix.md
@@ -1,0 +1,133 @@
+# pkg68 — OIDN persistent device + CUDA backend selection
+
+**Pillar:** 5
+**Track:** A
+**Status:** implemented (pending CUDA verification)
+**Estimated effort:** 1 session (~3 h)
+**Depends on:** pkg33 (OIDN FetchContent integration)
+
+---
+
+## Goal
+
+Before: every viewport frame the OIDN pass tore down and rebuilt the
+`oidn::DeviceRef`, four `oidn::BufferRef`s, and the `RT` filter. Device
+creation alone is the dominant per-frame cost at viewport SPP, and the
+device was always CPU because we never asked OIDN for the CUDA backend.
+
+After: device + filter live as `OIDNDenoiser` members, are lazy-initialised
+on first `execute()`, prefer `oidn::DeviceType::CUDA` and fall back to
+`oidn::DeviceType::CPU`, and the `setImage` + `commit()` filter rebind only
+fires when the framebuffer geometry or source pointers change. The
+prebuilt OIDN fallback bumps to v2.4.1 (latest with CUDA backend).
+
+---
+
+## Context
+
+pkg33 wired OIDN in with the simplest possible path: build everything
+locally inside `execute()`. That works for one-shot renders but is the
+wrong shape for the persistent viewport session (pkg52). The fact-finding
+pass also showed that the `fb.hasBuffer("albedo")` guard is a soft trap:
+albedo/normal are written unconditionally by the integrator, so the guard
+is harmless today, but if anyone ever made the buffers conditional we'd
+silently degrade to color-only denoising. This package locks the contract
+in tests.
+
+---
+
+## Reference
+
+- Cycles denoiser (Apache-2.0): `intern/cycles/integrator/denoiser_oidn.cpp`,
+  `intern/cycles/integrator/denoiser_oidn_gpu.cpp` — the `create_device()`
+  helper and member-cached device + filter shape we mirror.
+- OIDN C++ API: <https://www.openimagedenoise.org/documentation.html>,
+  `include/OpenImageDenoise/oidn.hpp` (RenderKit/oidn).
+- Astroray pkg33: `.astroray_plan/packages/pkg33-oidn-fetchcontent.md`.
+
+---
+
+## Prerequisites
+
+- [x] pkg33 is done and `tests/test_oidn_denoiser.py` is green.
+- [x] Integrator audit: `Camera::albedoBuffer` / `normalBuffer` are sized
+      unconditionally (raytracer.h:1653-1654) and written every pixel by
+      the render loop (raytracer.h:2451-2452). No fix needed in step 4.
+
+---
+
+## Specification
+
+### Files to create
+
+| File | Purpose |
+|---|---|
+| `tests/test_oidn_denoiser_persistence.py` | Pin one-time device init, CUDA selection on capable builds, and unconditional albedo/normal guides. |
+
+### Files to modify
+
+| File | What changes |
+|---|---|
+| `plugins/passes/oidn_denoiser.cpp` | Hoist `oidn::DeviceRef` + `oidn::FilterRef` + 4 buffers to class members; lazy-init device with CUDA→CPU fallback; cache last-bound source pointers + dims. |
+| `CMakeLists.txt` | Bump FetchContent fallback URL from `oidn-2.3.3.x64.windows.zip` to `oidn-2.4.1.x64.windows.zip`. |
+
+### Key design decisions
+
+1. **Member-cached device, lazy-init** — mirrors Cycles
+   `denoiser_oidn_gpu.cpp::create_device()`. Constructor does no work, so a
+   no-op build (OIDN disabled) costs nothing.
+2. **CUDA-first, CPU fallback** — `oidn::newDevice(DeviceType::CUDA)`
+   followed by `getError()`. The C wrapper returns a NULL handle when the
+   backend is unsupported; the C++ wrapper exposes that as a non-`None`
+   error before commit.
+3. **No temporal mode** — out of scope. OIDN does not have a `color1`
+   previous-frame input; temporal denoising is a separate filter family
+   (e.g. OptiX `Temporal_AOV`), tracked under pkg70.
+4. **Filter rebind on pointer change** — Camera buffers are reallocated
+   on resolution change, so a pointer-equality check on `fb.buffer("color"
+   /"albedo"/"normal")` is sufficient to detect resize without storing a
+   resolution flag separately.
+
+---
+
+## Acceptance criteria
+
+- [x] `pytest tests/test_oidn_denoiser_persistence.py
+      tests/test_oidn_denoiser.py tests/test_aov_passes.py` is all green
+      (12 passed + 1 CUDA-only test skipped on a CPU-only build).
+- [x] `[OIDN] Using <type> device` prints exactly once across N≥4
+      consecutive renders on the same `Renderer`.
+- [ ] On a CUDA-capable build the printed type is "CUDA". *(verifier
+      session, hardware-gated.)*
+- [x] Albedo / normal AOV passes return non-zero output without
+      pre-registration.
+
+---
+
+## Non-goals
+
+- Do not add OptiX (pkg70).
+- Do not add temporal mode.
+- Do not change OIDN behaviour for the standalone CLI build path beyond
+  the persistence refactor.
+
+---
+
+## Progress
+
+- [x] Audit integrator: albedo / normal are populated unconditionally.
+- [x] Refactor `OIDNDenoiser` to member-cached device + filter.
+- [x] CMakeLists FetchContent URL bumped to 2.4.1.
+- [x] Persistence tests added; full pytest run green on CPU build.
+- [ ] CUDA verifier session: confirm `[OIDN] Using CUDA device` and
+      that the CUDA path produces SSIM-equivalent output to CPU.
+
+---
+
+## Lessons
+
+The ostensibly-conditional `fb.hasBuffer("albedo")` guard turned out to
+be a no-op in practice — `Framebuffer::buffer()` returns a pointer into
+`Camera::albedoBuffer`, which is always allocated. Worth keeping the
+guard for forward-compat, but the test suite should pin the contract so
+nobody flips it accidentally.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,14 +95,15 @@ if(ASTRORAY_ENABLE_OIDN)
 
     find_package(OpenImageDenoise CONFIG QUIET)
 
-    # 3. FetchContent fallback — download the OIDN 2.3.3 Windows x64 prebuilt
+    # 3. FetchContent fallback — download the OIDN 2.4.1 Windows x64 prebuilt
     #    zip when the library is not installed locally.  Only attempted on
     #    Windows because the prebuilt packages are platform-specific.
+    #    pkg68: bumped 2.3.3 → 2.4.1 (latest release with CUDA backend support).
     if(NOT OpenImageDenoise_FOUND AND WIN32)
-        message(STATUS "OIDN not found locally — fetching prebuilt binary (v2.3.3)…")
+        message(STATUS "OIDN not found locally — fetching prebuilt binary (v2.4.1)…")
         include(FetchContent)
         FetchContent_Declare(oidn_prebuilt
-            URL      "https://github.com/RenderKit/oidn/releases/download/v2.3.3/oidn-2.3.3.x64.windows.zip"
+            URL      "https://github.com/RenderKit/oidn/releases/download/v2.4.1/oidn-2.4.1.x64.windows.zip"
             DOWNLOAD_EXTRACT_TIMESTAMP TRUE
         )
         # The prebuilt zip contains no CMakeLists.txt, so FetchContent_MakeAvailable

--- a/plugins/passes/oidn_denoiser.cpp
+++ b/plugins/passes/oidn_denoiser.cpp
@@ -6,9 +6,22 @@
 #  endif
 #endif
 
+#include <cstdio>
+
 #include "astroray/pass.h"
 #include "astroray/register.h"
 
+// pkg68: Persistent OIDN device + filter, lazy-initialised on first execute().
+// The previous implementation rebuilt the device, allocated four buffers, and
+// rebuilt the "RT" filter on every frame, which is the dominant per-frame cost
+// for OIDN at viewport SPP. The Cycles denoiser caches the device and filter
+// as members of the denoiser class — see
+// intern/cycles/integrator/denoiser_oidn.cpp / denoiser_oidn_gpu.cpp in the
+// Blender repository (Apache-2.0). We mirror that pattern here:
+//   * device + filter live as class members
+//   * device init tries CUDA first, falls back to CPU (Cycles' create_device shape)
+//   * buffers are reallocated only when the framebuffer dimensions change
+//   * filter is rebuilt only when the source pointers/dims change
 class OIDNDenoiser : public Pass {
 public:
     explicit OIDNDenoiser(const astroray::ParamDict&) {}
@@ -19,26 +32,38 @@ public:
 #ifdef ASTRORAY_OIDN_ENABLED
         const int w = fb.width();
         const int h = fb.height();
-        const size_t pixelCount = static_cast<size_t>(w * h);
+        const size_t pixelCount = static_cast<size_t>(w) * static_cast<size_t>(h);
         if (pixelCount == 0) return;
 
         const size_t byteSize = pixelCount * 3 * sizeof(float);
 
-        oidn::DeviceRef device = oidn::newDevice();
-        device.commit();
-
-        oidn::BufferRef colorBuf  = device.newBuffer(byteSize);
-        oidn::BufferRef albedoBuf = device.newBuffer(byteSize);
-        oidn::BufferRef normalBuf = device.newBuffer(byteSize);
-        oidn::BufferRef outputBuf = device.newBuffer(byteSize);
-
-        float* colorData  = static_cast<float*>(colorBuf.getData());
-        float* albedoData = static_cast<float*>(albedoBuf.getData());
-        float* normalData = static_cast<float*>(normalBuf.getData());
+        if (!deviceInitialised_) {
+            initDevice_();
+            deviceInitialised_ = true;
+        }
 
         const float* srcColor  = fb.buffer("color");
         const float* srcAlbedo = fb.hasBuffer("albedo") ? fb.buffer("albedo") : nullptr;
         const float* srcNormal = fb.hasBuffer("normal") ? fb.buffer("normal") : nullptr;
+
+        // (Re)allocate buffers when the framebuffer geometry changes.
+        if (w != cachedWidth_ || h != cachedHeight_) {
+            colorBuf_  = device_.newBuffer(byteSize);
+            albedoBuf_ = device_.newBuffer(byteSize);
+            normalBuf_ = device_.newBuffer(byteSize);
+            outputBuf_ = device_.newBuffer(byteSize);
+            cachedWidth_  = w;
+            cachedHeight_ = h;
+            // Force filter rebind on next bind check.
+            lastBoundColor_  = nullptr;
+            lastBoundAlbedo_ = nullptr;
+            lastBoundNormal_ = nullptr;
+            filterReady_ = false;
+        }
+
+        float* colorData  = static_cast<float*>(colorBuf_.getData());
+        float* albedoData = static_cast<float*>(albedoBuf_.getData());
+        float* normalData = static_cast<float*>(normalBuf_.getData());
 
         auto safeF = [](float v) { return std::isfinite(v) ? v : 0.0f; };
         for (size_t i = 0; i < pixelCount; ++i) {
@@ -64,23 +89,38 @@ public:
             }
         }
 
-        oidn::FilterRef filter = device.newFilter("RT");
-        filter.setImage("color",  colorBuf,  oidn::Format::Float3, w, h);
-        if (srcAlbedo) filter.setImage("albedo", albedoBuf, oidn::Format::Float3, w, h);
-        if (srcNormal) filter.setImage("normal", normalBuf, oidn::Format::Float3, w, h);
-        filter.setImage("output", outputBuf, oidn::Format::Float3, w, h);
-        filter.set("hdr", true);
-        filter.commit();
-        filter.execute();
+        // Rebind the filter only when the source pointers (or dims, handled
+        // above) change. setImage + commit is the expensive part we want to
+        // avoid on every frame.
+        const bool needRebind = !filterReady_ ||
+            srcColor  != lastBoundColor_  ||
+            srcAlbedo != lastBoundAlbedo_ ||
+            srcNormal != lastBoundNormal_;
+
+        if (needRebind) {
+            filter_ = device_.newFilter("RT");
+            filter_.setImage("color",  colorBuf_,  oidn::Format::Float3, w, h);
+            if (srcAlbedo) filter_.setImage("albedo", albedoBuf_, oidn::Format::Float3, w, h);
+            if (srcNormal) filter_.setImage("normal", normalBuf_, oidn::Format::Float3, w, h);
+            filter_.setImage("output", outputBuf_, oidn::Format::Float3, w, h);
+            filter_.set("hdr", true);
+            filter_.commit();
+            lastBoundColor_  = srcColor;
+            lastBoundAlbedo_ = srcAlbedo;
+            lastBoundNormal_ = srcNormal;
+            filterReady_ = true;
+        }
+
+        filter_.execute();
 
         const char* errorMessage = nullptr;
-        if (device.getError(errorMessage) != oidn::Error::None) {
+        if (device_.getError(errorMessage) != oidn::Error::None) {
             throw std::runtime_error(std::string("OIDN denoiser failed: ") +
                                      (errorMessage ? errorMessage : "unknown error"));
         }
 
         float* dst = fb.buffer("color");
-        const float* outputData = static_cast<const float*>(outputBuf.getData());
+        const float* outputData = static_cast<const float*>(outputBuf_.getData());
         for (size_t i = 0; i < pixelCount; ++i) {
             const float r = outputData[i*3];
             const float g = outputData[i*3+1];
@@ -89,8 +129,57 @@ public:
             dst[i*3+1] = std::isfinite(g) ? std::max(g, 0.0f) : 0.0f;
             dst[i*3+2] = std::isfinite(b) ? std::max(b, 0.0f) : 0.0f;
         }
+#else
+        (void)fb;
 #endif
     }
+
+private:
+#ifdef ASTRORAY_OIDN_ENABLED
+    // Cycles' create_device() shape: try the GPU type the build was compiled
+    // for, fall back to CPU. OIDN's C API returns a NULL handle if the
+    // requested DeviceType is unsupported; the C++ wrapper exposes that as a
+    // non-None error from getError() before commit().
+    void initDevice_() {
+        oidn::DeviceRef dev = oidn::newDevice(oidn::DeviceType::CUDA);
+        const char* perr = nullptr;
+        bool cudaOk = (dev.getError(perr) == oidn::Error::None);
+        if (cudaOk) {
+            dev.commit();
+            const char* perr2 = nullptr;
+            cudaOk = (dev.getError(perr2) == oidn::Error::None);
+        }
+
+        if (!cudaOk) {
+            dev = oidn::newDevice(oidn::DeviceType::CPU);
+            dev.commit();
+            const char* perr3 = nullptr;
+            if (dev.getError(perr3) != oidn::Error::None) {
+                throw std::runtime_error(std::string("OIDN CPU device init failed: ") +
+                                         (perr3 ? perr3 : "unknown error"));
+            }
+            std::printf("[OIDN] Using CPU device\n");
+        } else {
+            std::printf("[OIDN] Using CUDA device\n");
+        }
+        std::fflush(stdout);
+        device_ = dev;
+    }
+
+    oidn::DeviceRef device_;
+    oidn::FilterRef filter_;
+    oidn::BufferRef colorBuf_;
+    oidn::BufferRef albedoBuf_;
+    oidn::BufferRef normalBuf_;
+    oidn::BufferRef outputBuf_;
+    bool deviceInitialised_ = false;
+    bool filterReady_       = false;
+    int  cachedWidth_       = 0;
+    int  cachedHeight_      = 0;
+    const float* lastBoundColor_  = nullptr;
+    const float* lastBoundAlbedo_ = nullptr;
+    const float* lastBoundNormal_ = nullptr;
+#endif
 };
 
 ASTRORAY_REGISTER_PASS("oidn_denoiser", OIDNDenoiser)

--- a/tests/test_oidn_denoiser_persistence.py
+++ b/tests/test_oidn_denoiser_persistence.py
@@ -1,0 +1,139 @@
+"""Tests for pkg68: persistent OIDN device + CUDA backend selection.
+
+The pkg33 implementation rebuilt the OIDN device, four buffers, and the "RT"
+filter on every execute() call. pkg68 hoists device + filter to class members
+and lazy-initialises them on first execute. These tests pin that behaviour:
+
+  1. Across N consecutive renders on the same Renderer the device is
+     initialised exactly once (the "[OIDN] Using <type> device" line is
+     printed once).
+  2. On a CUDA-capable build, the device that gets selected is CUDA, not CPU.
+     On CPU-only builds (no CUDA toolkit / no NVIDIA GPU) the test skips the
+     CUDA assertion but still runs the persistence/CPU path.
+  3. Albedo/normal guides are fed to OIDN even when the user has not
+     explicitly registered an `albedo_aov`/`normal_aov` pass. The renderer's
+     albedo/normal buffers are populated unconditionally by the integrator
+     (raytracer.h::Camera + render loop), so a single-pass `albedo_aov` run
+     after a vanilla render produces non-zero output.
+"""
+import numpy as np
+import pytest
+
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+
+try:
+    import astroray
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray module not available")
+
+OIDN_ENABLED = AVAILABLE and bool(
+    astroray.__features__.get("oidn_denoiser", False) if AVAILABLE else False
+)
+CUDA_BUILD = AVAILABLE and bool(
+    astroray.__features__.get("cuda", False) if AVAILABLE else False
+)
+
+
+def _tiny_renderer(width: int = 64, height: int = 64) -> "astroray.Renderer":
+    """Minimal Cornell-style scene; small for fast multi-render tests."""
+    r = astroray.Renderer()
+    r.setup_camera(
+        look_from=[0, 0, 5.5], look_at=[0, 0, 0], vup=[0, 1, 0],
+        vfov=40, aspect_ratio=width / height, aperture=0.0, focus_dist=5.5,
+        width=width, height=height,
+    )
+    r.set_background_color([0.0, 0.0, 0.0])
+    white = r.create_material("lambertian", [0.73, 0.73, 0.73], {})
+    red   = r.create_material("lambertian", [0.65, 0.05, 0.05], {})
+    light = r.create_material("light",      [1.0, 0.9, 0.8],    {"intensity": 15.0})
+    # Floor + back wall + left red wall
+    r.add_triangle([-2, -2, -2], [ 2, -2, -2], [ 2, -2,  2], white)
+    r.add_triangle([-2, -2, -2], [ 2, -2,  2], [-2, -2,  2], white)
+    r.add_triangle([-2, -2, -2], [-2, -2,  2], [-2,  2,  2], red)
+    r.add_triangle([-2, -2, -2], [-2,  2,  2], [-2,  2, -2], red)
+    # Ceiling light
+    r.add_triangle([-0.5, 1.98, -0.5], [0.5, 1.98, -0.5], [0.5, 1.98,  0.5], light)
+    r.add_triangle([-0.5, 1.98, -0.5], [0.5, 1.98,  0.5], [-0.5, 1.98, 0.5], light)
+    r.add_sphere([0, -1.0, 0], 1.0, white)
+    return r
+
+
+@pytest.mark.skipif(not OIDN_ENABLED, reason="OIDN not compiled in")
+def test_device_initialised_once_across_n_frames(capfd):
+    """The '[OIDN] Using ... device' init line must print exactly once for N renders."""
+    r = _tiny_renderer()
+    r.set_seed(1)
+    r.add_pass("oidn_denoiser")
+
+    N = 4
+    capfd.readouterr()  # drop any prior output
+    for _ in range(N):
+        r.render(samples_per_pixel=2, max_depth=3)
+    captured = capfd.readouterr()
+    combined = captured.out + captured.err
+
+    init_lines = [ln for ln in combined.splitlines() if "[OIDN] Using" in ln]
+    assert len(init_lines) == 1, (
+        f"Expected exactly one OIDN device-init line across {N} renders, got "
+        f"{len(init_lines)}: {init_lines!r}"
+    )
+
+
+@pytest.mark.skipif(not OIDN_ENABLED, reason="OIDN not compiled in")
+@pytest.mark.skipif(not CUDA_BUILD, reason="CUDA backend not compiled / no GPU")
+def test_cuda_capable_build_reports_cuda_device(capfd):
+    """On a CUDA-enabled build with a working GPU, OIDN should pick CUDA, not CPU."""
+    r = _tiny_renderer()
+    r.set_seed(2)
+    r.add_pass("oidn_denoiser")
+    capfd.readouterr()
+    r.render(samples_per_pixel=2, max_depth=3)
+    captured = capfd.readouterr()
+    combined = captured.out + captured.err
+
+    assert "[OIDN] Using CUDA device" in combined, (
+        "CUDA-capable build did not select OIDN CUDA backend. Output was:\n"
+        + combined
+    )
+
+
+@pytest.mark.skipif(not OIDN_ENABLED, reason="OIDN not compiled in")
+def test_albedo_normal_guides_fed_without_explicit_aov_pass():
+    """Camera's albedo + normal buffers are populated unconditionally.
+
+    The renderer writes per-pixel albedo / normal in the inner loop regardless
+    of whether the user registered an `albedo_aov` / `normal_aov` pass, and
+    `Framebuffer::hasBuffer("albedo"/"normal")` always returns true. As a
+    result, the OIDN denoiser receives meaningful albedo + normal guides
+    without the user having to opt in.
+
+    Verify by running a render whose only post-pass is `albedo_aov` (which
+    copies the albedo buffer over color). If the buffer were populated only
+    when the AOV pass was pre-requested, this output would be all zeros.
+    """
+    r = _tiny_renderer()
+    r.set_seed(3)
+    r.add_pass("albedo_aov")  # exposes the buffer; does not request its population
+    img = np.array(r.render(samples_per_pixel=2, max_depth=3), dtype=np.float32)
+
+    # The Cornell-style scene has a non-black floor + walls + sphere; albedo
+    # must be non-zero somewhere if the integrator actually wrote it.
+    assert np.any(img > 0.01), (
+        "Albedo AOV produced all-zero output — albedo buffer was not populated. "
+        "Confirms a regression: OIDN cannot rely on albedo/normal guides being "
+        "present without an explicit AOV pass."
+    )
+
+    # And the same holds for the normal buffer.
+    r2 = _tiny_renderer()
+    r2.set_seed(3)
+    r2.add_pass("normal_aov")
+    nimg = np.array(r2.render(samples_per_pixel=2, max_depth=3), dtype=np.float32)
+    assert np.any(np.abs(nimg) > 0.01), (
+        "Normal AOV produced all-zero output — normal buffer was not populated."
+    )


### PR DESCRIPTION
## Summary

pkg68: refactor `OIDNDenoiser` from "build everything per frame" to a Cycles-style member-cached device + filter, and ask OIDN for the CUDA backend before falling back to CPU.

**Note:** the prompt referenced `pkg68-oidn-architectural-fix.md` and an `oidn-fact-finding-report-2026-05-10.md`; neither existed in the repo when this branch was started. The implementation outline in the user prompt was self-contained, so I implemented from that and added the pkg68 spec doc as part of this PR (`.astroray_plan/packages/pkg68-oidn-architectural-fix.md`).

## Changes

- `plugins/passes/oidn_denoiser.cpp` — `oidn::DeviceRef` + `oidn::FilterRef` + 4 buffers hoisted to class members. Device lazy-inits on first `execute()`, tries `oidn::DeviceType::CUDA` first, falls back to CPU. Logs `[OIDN] Using CUDA device` / `[OIDN] Using CPU device` on init. Filter is rebound only when `fb.buffer(...)` pointers or dims change; setImage + commit no longer fire every frame.
- `CMakeLists.txt` — FetchContent fallback URL bumped `oidn-2.3.3.x64.windows.zip` → `oidn-2.4.1.x64.windows.zip` (latest release with CUDA backend).
- `tests/test_oidn_denoiser_persistence.py` — three pins:
  1. `[OIDN] Using ...` prints exactly once across N=4 renders on the same `Renderer`.
  2. CUDA-capable build selects CUDA (skipped on CPU-only builds).
  3. Albedo / normal AOVs return non-zero without pre-registration — locks in the unconditional integrator population so the existing `fb.hasBuffer("albedo")` guard cannot silently degrade to color-only denoising.
- `.astroray_plan/packages/pkg68-oidn-architectural-fix.md` (new) and `STATUS.md` updated.

## Integrator audit

Per the prompt's step 4: confirmed `Camera::albedoBuffer` / `normalBuffer` are resized unconditionally in the constructor (`include/raytracer.h:1653-1654`) and written every pixel by the render loop (`include/raytracer.h:2451-2452`). `Framebuffer::hasBuffer("albedo")` is therefore always true today. **No code fix needed in step 4** — but the new test pins the contract so it cannot regress.

## Reference

- Cycles `intern/cycles/integrator/denoiser_oidn_gpu.cpp::create_device()` (Apache-2.0) — the CUDA-then-CPU member-cached pattern this mirrors.
- OIDN C++ wrapper: `include/OpenImageDenoise/oidn.hpp` (RenderKit/oidn).

## Verification

CPU build (MinGW, `--backend cpu --DASTRORAY_DISABLE_OPENMP=ON`):

```
pytest tests/test_oidn_denoiser_persistence.py
       tests/test_oidn_denoiser.py
       tests/test_aov_passes.py -v
12 passed, 1 skipped (CUDA-only test) in 2.24s
```

**CUDA verification pending** — the CUDA-path SSIM/timing gates skip cleanly on this CPU-only build site; the verifier session will run them on hardware.

## Out of scope (per prompt design decisions)

- No OptiX (pkg70).
- No temporal mode (OIDN has no `color1` previous-frame input).

## Status

`pkg68` → **implemented (pending CUDA verification)**. **Do not merge** until CUDA verification clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)