### PR TITLE
feat(pkg69): Albedo pass for Blender compositor denoise node

### DIFF
--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -129,6 +129,7 @@ is currently the weakest link.
 | pkg63 | World / HDRI parity (Mapping XYZ rotation, color tint, MIS env-map) | **done** | A |
 | pkg64 | Spectral caustics (prism-accurate, refractive + reflective) — SMS skeleton + spectral MNEE extension | research signed off; ready to implement | A |
 | pkg67 | Metric-aware path tracer (GR + spectral unification) — research-grade | open (research blocked) | A |
+| pkg69 | Albedo pass for Blender compositor denoise node | **done** | A |
 
 **Deferred / not-yet-spec'd from the 2026-05-08 triage** (mentioned in the
 original roadmap but no full spec written; capture intent before they're
@@ -289,6 +290,7 @@ events are summarized in the changelog below.
 | pkg64 | A | research blocked | caustics research note |
 | pkg67 | A | research blocked | metric-aware tracer research note |
 | pkg68 | A | **implemented (pending CUDA verification)** | persistent OIDN device, CUDA-first init, member-cached filter; CPU pytest green (12+1 skip); CUDA SSIM/timing gates pending verifier session |
+| pkg69 | A | **done** | Blender compositor denoise Albedo/Normal data passes |
 
 ---
 

--- a/.astroray_plan/packages/pkg69-albedo-pass-blender-compositor.md
+++ b/.astroray_plan/packages/pkg69-albedo-pass-blender-compositor.md
@@ -1,0 +1,24 @@
+# pkg69 - Albedo Pass for Blender Compositor Denoise Node
+
+**Pillar:** 5
+**Track:** A
+**Status:** done
+
+## Goal
+
+Expose Astroray's first-hit albedo buffer as Blender's compositor Albedo
+denoising guide pass when `use_pass_denoising_data` is enabled, matching the
+Cycles compositor denoise workflow alongside the existing Normal guide buffer.
+
+## Scope
+
+- Register Albedo and Normal as 3-channel denoising data passes in the Blender
+  addon.
+- Write the renderer albedo buffer to the Albedo pass in `write_pixels`.
+- Reuse the existing `Renderer.get_albedo_buffer()` binding.
+- Add pure-Python Blender-addon tests for pass registration and pixel emission.
+
+## Verification
+
+- `python scripts\dev\run_tests.py -- tests/test_blender_compositor_denoise_passes.py tests/test_blender_view_layers.py -v --tb=short`
+  - 6 passed in 0.18s

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -554,13 +554,19 @@ class CustomRaytracerRenderEngine(RenderEngine):
         ("Shadow", "shadow", "use_pass_shadow"),
     ]
     _DATA_PASS_SPECS = [
-        ("Depth", "depth", "use_pass_z"),
-        ("Mist", "mist", "use_pass_mist"),
-        ("Position", "position", "use_pass_position"),
-        ("Normal", "normal", "use_pass_normal"),
-        ("UV", "uv", "use_pass_uv"),
-        ("IndexOB", "object_index", "use_pass_object_index"),
-        ("IndexMA", "material_index", "use_pass_material_index"),
+        # Cycles registers its DENOISING_PASS_* / PASS_DENOISING_* guide
+        # passes together in intern/cycles/blender/sync.cpp lines 740-745
+        # (Apache-2.0): Albedo and Normal are the compositor Denoise node's
+        # RGB guide inputs when Denoising Data is enabled.
+        ("Albedo", "albedo", 3, "RGB", "use_pass_denoising_data"),
+        ("Normal", "normal", 3, "RGB", "use_pass_denoising_data"),
+        ("Depth", "depth", 4, "RGBA", "use_pass_z"),
+        ("Mist", "mist", 4, "RGBA", "use_pass_mist"),
+        ("Position", "position", 4, "RGBA", "use_pass_position"),
+        ("Normal", "normal", 4, "RGBA", "use_pass_normal"),
+        ("UV", "uv", 4, "RGBA", "use_pass_uv"),
+        ("IndexOB", "object_index", 4, "RGBA", "use_pass_object_index"),
+        ("IndexMA", "material_index", 4, "RGBA", "use_pass_material_index"),
     ]
     _CRYPTOMATTE_PASS_SPECS = [
         ("CryptoObject00", "cryptomatte_object", "use_pass_cryptomatte_object"),
@@ -571,9 +577,13 @@ class CustomRaytracerRenderEngine(RenderEngine):
         for display_name, _, toggle_name in self._PASS_SPECS:
             if getattr(renderlayer, toggle_name, False):
                 self.register_pass(scene, renderlayer, display_name, 4, "RGBA", "COLOR")
-        for display_name, _, toggle_name in self._DATA_PASS_SPECS:
+        registered_data_passes = set()
+        for display_name, _, channels, channel_id, toggle_name in self._DATA_PASS_SPECS:
             if getattr(renderlayer, toggle_name, False):
-                self.register_pass(scene, renderlayer, display_name, 4, "RGBA", "COLOR")
+                if display_name in registered_data_passes:
+                    continue
+                registered_data_passes.add(display_name)
+                self.register_pass(scene, renderlayer, display_name, channels, channel_id, "COLOR")
         for display_name, _, toggle_name in self._CRYPTOMATTE_PASS_SPECS:
             if getattr(renderlayer, toggle_name, False):
                 self.register_pass(scene, renderlayer, display_name, 4, "RGBA", "COLOR")
@@ -589,8 +599,12 @@ class CustomRaytracerRenderEngine(RenderEngine):
     @classmethod
     def _enabled_data_pass_specs(cls, view_layer):
         enabled = []
-        for display_name, key, toggle_name in cls._DATA_PASS_SPECS:
+        seen = set()
+        for display_name, key, _, _, toggle_name in cls._DATA_PASS_SPECS:
             if getattr(view_layer, toggle_name, False):
+                if display_name in seen:
+                    continue
+                seen.add(display_name)
                 enabled.append((display_name, key))
         return enabled
 
@@ -2770,7 +2784,11 @@ class CustomRaytracerRenderEngine(RenderEngine):
                 if target_pass is None:
                     continue
                 try:
-                    if key == "normal":
+                    if key == "albedo":
+                        data_pixels = np.asarray(renderer.get_albedo_buffer(), dtype=np.float32)
+                        pass_rgba = np.ones((height, width, 4), dtype=np.float32)
+                        pass_rgba[:, :, :3] = data_pixels
+                    elif key == "normal":
                         data_pixels = np.asarray(renderer.get_normal_buffer(), dtype=np.float32)
                         pass_rgba = np.ones((height, width, 4), dtype=np.float32)
                         pass_rgba[:, :, :3] = data_pixels

--- a/tests/test_blender_compositor_denoise_passes.py
+++ b/tests/test_blender_compositor_denoise_passes.py
@@ -1,0 +1,84 @@
+import types
+
+import numpy as np
+
+from test_blender_view_layers import _load_blender_addon
+
+
+def test_denoising_data_registers_albedo_and_normal_rgb_passes(monkeypatch):
+    class RendererStub:
+        pass
+
+    addon = _load_blender_addon(monkeypatch, RendererStub)
+    engine = addon.CustomRaytracerRenderEngine()
+
+    registered = []
+    engine.register_pass = lambda scene, layer, name, channels, channel_id, kind: registered.append(
+        (name, channels, channel_id, kind)
+    )
+
+    view_layer = types.SimpleNamespace(
+        use_pass_denoising_data=True,
+        use_pass_z=False,
+        use_pass_mist=False,
+        use_pass_position=False,
+        use_pass_normal=False,
+        use_pass_uv=False,
+        use_pass_object_index=False,
+        use_pass_material_index=False,
+        use_pass_cryptomatte_object=False,
+        use_pass_cryptomatte_material=False,
+    )
+
+    engine.update_render_passes(types.SimpleNamespace(), view_layer)
+
+    pass_specs = {name: (channels, channel_id) for name, channels, channel_id, _ in registered}
+    assert pass_specs["Albedo"] == (3, "RGB")
+    assert pass_specs["Normal"] == (3, "RGB")
+
+
+def test_write_pixels_emits_denoising_albedo_and_normal(monkeypatch):
+    class RendererStub:
+        def get_albedo_buffer(self):
+            return np.full((2, 2, 3), 0.25, dtype=np.float32)
+
+        def get_normal_buffer(self):
+            return np.full((2, 2, 3), 0.75, dtype=np.float32)
+
+    addon = _load_blender_addon(monkeypatch, RendererStub)
+    engine = addon.CustomRaytracerRenderEngine()
+
+    class RectStub:
+        def __init__(self):
+            self.values = None
+
+        def foreach_set(self, flat):
+            self.values = np.asarray(flat, dtype=np.float32)
+
+    class PassStub:
+        def __init__(self):
+            self.rect = RectStub()
+
+    passes = {
+        "Combined": PassStub(),
+        "Albedo": PassStub(),
+        "Normal": PassStub(),
+    }
+    layer = types.SimpleNamespace(passes=passes)
+    result = types.SimpleNamespace(layers=[layer])
+    engine.begin_result = lambda *_args, **_kwargs: result
+    engine.end_result = lambda _result: None
+
+    view_layer = types.SimpleNamespace(use_pass_denoising_data=True)
+    pixels = np.zeros((2, 2, 3), dtype=np.float32)
+    engine.write_pixels(
+        pixels,
+        2,
+        2,
+        renderer=RendererStub(),
+        view_layer=view_layer,
+        scene=types.SimpleNamespace(),
+    )
+
+    assert passes["Albedo"].rect.values.reshape(2, 2, 4)[0, 0, :3].tolist() == [0.25, 0.25, 0.25]
+    assert passes["Normal"].rect.values.reshape(2, 2, 4)[0, 0, :3].tolist() == [0.75, 0.75, 0.75]


### PR DESCRIPTION
## Summary
- Registers Blender denoising data Albedo + Normal passes as RGB guide buffers behind `use_pass_denoising_data`.
- Emits `Renderer.get_albedo_buffer()` into the compositor Albedo pass in `write_pixels()`.
- Adds pure-Python addon coverage for pass registration and albedo/normal pixel emission.
- Marks pkg69 done in the package/status docs.

## Verification
- `python scripts\dev\run_tests.py -- tests/test_blender_compositor_denoise_passes.py tests/test_blender_view_layers.py -v --tb=short` -> `6 passed in 0.16s`

## Notes
- `Renderer.get_albedo_buffer()` already existed and was already bound, so no `module/blender_module.cpp` change was needed.
- No OIDN, OptiX, or CUDA changes.
- Cycles reference comment cites `intern/cycles/blender/sync.cpp` lines 740-745 for the denoising guide pass pattern.