### PR TITLE
feat(pkg70): OptiX AI denoiser backend (HDR/AOV, persistent state, fallback to OIDN)

### DIFF
--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -131,6 +131,7 @@ is currently the weakest link.
 | pkg64 | Spectral caustics (prism-accurate, refractive + reflective) — SMS skeleton + spectral MNEE extension | research signed off; ready to implement | A |
 | pkg67 | Metric-aware path tracer (GR + spectral unification) — research-grade | open (research blocked) | A |
 | pkg69 | Albedo pass for Blender compositor denoise node | **done** | A |
+| pkg70 | OptiX AI denoiser backend (HDR/AOV, persistent state, OIDN fallback) | **implemented (pending verification)** | A |
 | pkg71 | Cycles parity benchmark framework | **implemented** | A |
 
 **Deferred / not-yet-spec'd from the 2026-05-08 triage** (mentioned in the
@@ -293,6 +294,7 @@ events are summarized in the changelog below.
 | pkg67 | A | research blocked | metric-aware tracer research note |
 | pkg68 | A | **done** | persistent OIDN device, CUDA-first init, member-cached filter; CUDA verifier session 2026-05-10 on RTX 5070 Ti: 13/13 pytest green (incl. `test_cuda_capable_build_reports_cuda_device`), `[OIDN] Using CUDA device` confirmed, single device init across N=4 renders verified; viewport timing 256×256 spp=2: OIDN-on 50.67 ms/frame vs OIDN-off baseline 23.81 ms/frame (Δ=26.86 ms persistent-device overhead) |
 | pkg69 | A | **done** | Blender compositor denoise Albedo/Normal data passes |
+| pkg70 | A | **implemented (pending verification)** | OptiX denoiser plugin co-equal with OIDN; persistent OptixDeviceContext + OptixDenoiser handle, lazy init, HDR vs AOV model selection by guide presence; `gpu_optix_available()` Python probe; addon `denoiser_backend` Auto/OptiX/OIDN with OptiX preferred when both present; OptiX SDK + CUDA hardware verification pending |
 | pkg71 | A | **implemented** | benchmark framework done; first full baseline CSV pending CUDA/Cycles hardware |
 
 ---
@@ -368,6 +370,22 @@ events are summarized in the changelog below.
 
 Brief notes on notable events.
 
+- **2026-05-10** — pkg70 implemented (pending OptiX SDK + CUDA hardware
+  verification). New `optix_denoiser` pass plugin co-equal with
+  `oidn_denoiser`: persistent `OptixDeviceContext` + `OptixDenoiser`
+  handle as class members, lazy init on first `execute()`, HDR model
+  when no guides / AOV model when albedo+normal present (Cycles
+  `OptiXDevice::denoise_buffer` shape, Apache-2.0). State + scratch
+  device buffers cached per-dimension. `cmake/FindOptiX.cmake` locates
+  the SDK via `OPTIX_INSTALL_DIR` or default Windows path; SDK headers
+  are NOT bundled (NVIDIA license forbids redistribution). New
+  `astroray.gpu_optix_available()` Python probe. Blender addon gains
+  `denoiser_backend` Auto/OptiX/OIDN dropdown — Auto prefers OptiX when
+  both backends are compiled in and a CUDA device is visible at
+  runtime. New `tests/test_optix_denoiser.py` mirrors
+  `test_oidn_denoiser_persistence.py` shape; skips cleanly when SDK or
+  CUDA absent. CPU pytest unaffected; OptiX timing vs OIDN-CUDA gate
+  pending verifier session with the SDK installed.
 - **2026-05-10** — pkg68 implemented (pending CUDA verification). OIDN
   device + filter hoisted to `OIDNDenoiser` class members and lazy-initialised
   on first `execute()`; init tries `oidn::DeviceType::CUDA` first and falls

--- a/.astroray_plan/packages/pkg70-optix-denoiser-backend.md
+++ b/.astroray_plan/packages/pkg70-optix-denoiser-backend.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 5
 **Track:** A
-**Status:** open
+**Status:** implemented (pending verification)
 **Estimated effort:** 3–5 days (~25 h)
 **Depends on:** pkg33 (OIDN integration — done), pkg68 (OIDN architectural fix — establishes the device-selection plumbing pattern this package mirrors)
 
@@ -241,16 +241,16 @@ either is fine — the user can choose.
 
 ## Progress
 
-- [ ] Write `cmake/FindOptiX.cmake` (or adapt NVIDIA SDK's).
-- [ ] Add `ASTRORAY_ENABLE_OPTIX` build flag with auto-detect default.
-- [ ] Implement `OptiXDenoiser` plugin with persistent state.
-- [ ] Implement model-kind selection (HDR vs AOV based on available
+- [x] Write `cmake/FindOptiX.cmake` (or adapt NVIDIA SDK's).
+- [x] Add `ASTRORAY_ENABLE_OPTIX` build flag with auto-detect default.
+- [x] Implement `OptiXDenoiser` plugin with persistent state.
+- [x] Implement model-kind selection (HDR vs AOV based on available
   guide buffers).
-- [ ] Add `gpu_optix_available()` Python binding.
-- [ ] Wire addon backend-selection logic with user override.
-- [ ] Add `tests/test_optix_denoiser.py`.
+- [x] Add `gpu_optix_available()` Python binding.
+- [x] Wire addon backend-selection logic with user override.
+- [x] Add `tests/test_optix_denoiser.py`.
 - [ ] Verify on RTX 5070 Ti: record OptiX vs OIDN-CUDA timing + SSIM
-  in Lessons.
+  in Lessons. *(pending — OptiX SDK + CUDA hardware verifier session)*
 
 ---
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,12 @@ option(USE_NATIVE_ARCH "Build with -march=native" ON)
 option(USE_FAST_MATH "Enable fast math optimizations" ON)
 option(ASTRORAY_ENABLE_CUDA "Enable CUDA GPU acceleration" ON)
 option(ASTRORAY_ENABLE_OIDN "Enable Intel Open Image Denoise integration when available" ON)
+# pkg70 — NVIDIA OptiX AI denoiser. AUTO = enable when SDK headers are
+# located by cmake/FindOptiX.cmake; ON = error when not found; OFF = skip.
+set(ASTRORAY_ENABLE_OPTIX "AUTO" CACHE STRING
+    "Enable NVIDIA OptiX AI denoiser pass (ON/OFF/AUTO). AUTO requires CUDA + the OptiX SDK headers")
+set_property(CACHE ASTRORAY_ENABLE_OPTIX PROPERTY STRINGS "AUTO" "ON" "OFF")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 option(ASTRORAY_ENABLE_PYTEST_TARGET "Add an astroray_pytest convenience target" ON)
 # Disable OpenMP entirely. Needed when building the Python module (.pyd) for
 # distribution as a Blender addon: MinGW's libgomp deadlocks during module
@@ -145,6 +151,36 @@ if(ASTRORAY_ENABLE_OIDN)
     endif()
 endif()
 
+# ---------------------------------------------------------------------------
+# pkg70 — Optional NVIDIA OptiX AI denoiser
+# Headers are NOT bundled (NVIDIA SDK license forbids redistribution).
+# We locate optix.h via cmake/FindOptiX.cmake (OPTIX_INSTALL_DIR env or
+# default Windows path C:\ProgramData\NVIDIA Corporation\OptiX SDK 8.x).
+# OptiX needs CUDA: with no CUDA toolkit the option is silently disabled.
+# ---------------------------------------------------------------------------
+set(ASTRORAY_OPTIX_FOUND FALSE)
+if(NOT ASTRORAY_ENABLE_OPTIX STREQUAL "OFF")
+    if(ASTRORAY_CUDA_FOUND)
+        find_package(OptiX QUIET)
+        if(OptiX_FOUND)
+            set(ASTRORAY_OPTIX_FOUND TRUE)
+            message(STATUS "OptiX found: ${OptiX_VERSION} (${OptiX_INCLUDE_DIR})")
+        elseif(ASTRORAY_ENABLE_OPTIX STREQUAL "ON")
+            message(FATAL_ERROR
+                "ASTRORAY_ENABLE_OPTIX=ON but OptiX SDK was not found. "
+                "Install the OptiX 8.x SDK and set OPTIX_INSTALL_DIR.")
+        else()
+            message(STATUS "OptiX SDK not found — OptiX denoiser disabled")
+        endif()
+    elseif(ASTRORAY_ENABLE_OPTIX STREQUAL "ON")
+        message(FATAL_ERROR
+            "ASTRORAY_ENABLE_OPTIX=ON but CUDA was not found. "
+            "OptiX requires CUDA.")
+    else()
+        message(STATUS "CUDA disabled/missing — OptiX denoiser disabled")
+    endif()
+endif()
+
 # Compiler flags for optimization
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     # Base optimization flags
@@ -228,6 +264,20 @@ if(ASTRORAY_PLUGIN_SOURCES)
     if(ASTRORAY_OIDN_FOUND)
         target_link_libraries(astroray_plugins PUBLIC ${ASTRORAY_OIDN_TARGET})
         target_compile_definitions(astroray_plugins PUBLIC ASTRORAY_OIDN_ENABLED)
+    endif()
+    if(ASTRORAY_OPTIX_FOUND)
+        # OptiX is a header-only host API at compile time; the function
+        # table is loaded at runtime via optixInit() from optix_stubs.h.
+        # We do still need the CUDA runtime headers + CUDA::cudart to call
+        # cudaMalloc/cudaMemcpy from the plugin.
+        target_include_directories(astroray_plugins PUBLIC
+            ${OptiX_INCLUDE_DIRS}
+            ${CUDAToolkit_INCLUDE_DIRS}
+        )
+        target_compile_definitions(astroray_plugins PUBLIC ASTRORAY_OPTIX_ENABLED)
+        if(TARGET CUDA::cudart)
+            target_link_libraries(astroray_plugins PUBLIC CUDA::cudart)
+        endif()
     endif()
 endif()
 
@@ -354,6 +404,9 @@ if(ASTRORAY_CUDA_FOUND)
     target_link_libraries(raytracer_standalone PRIVATE astroray_cuda)
     target_compile_definitions(raytracer_standalone PRIVATE ASTRORAY_CUDA_ENABLED)
 endif()
+if(ASTRORAY_OPTIX_FOUND)
+    target_compile_definitions(raytracer_standalone PRIVATE ASTRORAY_OPTIX_ENABLED)
+endif()
 
 # Set output name and configuration-specific properties
 set_target_properties(raytracer_standalone PROPERTIES
@@ -444,6 +497,10 @@ if(BUILD_PYTHON_MODULE)
         target_compile_definitions(astroray PRIVATE ASTRORAY_CUDA_ENABLED)
     endif()
 
+    if(ASTRORAY_OPTIX_FOUND)
+        target_compile_definitions(astroray PRIVATE ASTRORAY_OPTIX_ENABLED)
+    endif()
+
     # Set output directory to CMAKE_BINARY_DIR for both Windows and Linux
     # pybind11_add_module automatically handles .pyd on Windows and .so on Linux
     set_target_properties(astroray PROPERTIES
@@ -500,6 +557,10 @@ if(BUILD_BLENDER_MODULE)
     if(ASTRORAY_OIDN_FOUND)
         target_link_libraries(raytracer_blender PRIVATE ${ASTRORAY_OIDN_TARGET})
         target_compile_definitions(raytracer_blender PRIVATE ASTRORAY_OIDN_ENABLED)
+    endif()
+
+    if(ASTRORAY_OPTIX_FOUND)
+        target_compile_definitions(raytracer_blender PRIVATE ASTRORAY_OPTIX_ENABLED)
     endif()
 
     # Set properties for Python module
@@ -737,6 +798,7 @@ message(STATUS "Native arch: ${USE_NATIVE_ARCH}")
 message(STATUS "Fast math: ${USE_FAST_MATH}")
 message(STATUS "CUDA GPU backend: ${ASTRORAY_CUDA_FOUND}")
 message(STATUS "OIDN denoiser: ${ASTRORAY_OIDN_FOUND}")
+message(STATUS "OptiX denoiser: ${ASTRORAY_OPTIX_FOUND}")
 message(STATUS "Python module: ${BUILD_PYTHON_MODULE}")
 if(BUILD_PYTHON_MODULE)
     message(STATUS "  Python: ${Python3_VERSION}")

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -137,9 +137,24 @@ class CustomRaytracerRenderSettings(PropertyGroup):
         default="combined",
     )
     viewport_oidn: BoolProperty(
-        name="Viewport OIDN",
+        name="Viewport Denoise",
         default=False,
-        description="Apply OIDN denoiser to the viewport buffer (visible wavelengths only)",
+        description="Apply AI denoiser to the viewport buffer (visible wavelengths only). "
+                    "Backend selected by 'Denoiser' setting below.",
+    )
+    # pkg70 — denoiser backend chooser. AUTO prefers OptiX when both OptiX
+    # and OIDN are compiled in AND a CUDA device is visible at runtime;
+    # falls back to OIDN otherwise. Used for both viewport_oidn and
+    # use_denoising final-render denoise.
+    denoiser_backend: EnumProperty(
+        name="Denoiser",
+        description="Which AI denoiser to use when denoising is enabled",
+        items=[
+            ('auto',  'Auto',  'OptiX when available on NVIDIA GPUs, OIDN otherwise'),
+            ('optix', 'OptiX', 'NVIDIA OptiX (NVIDIA GPU + OptiX SDK build only)'),
+            ('oidn',  'OIDN',  'Intel Open Image Denoise (CPU and CUDA)'),
+        ],
+        default='auto',
     )
     max_bounces: IntProperty(name="Max Bounces", min=0, max=1024, default=10,
         description="Maximum path-trace depth — caps how many times a ray can scatter")
@@ -218,6 +233,48 @@ class CustomRaytracerRenderSettings(PropertyGroup):
         options={'HIDDEN'},
         description="Integrator stats from the most recent render (auto-populated)",
     )
+
+
+# pkg70 — backend availability cache. Probing OptiX init constructs a
+# CUDARenderer to check device visibility, which we don't want to do per
+# frame. Cache first answer.
+_DENOISER_BACKEND_CACHE = {}
+
+
+def _optix_runtime_available() -> bool:
+    if "optix" in _DENOISER_BACKEND_CACHE:
+        return _DENOISER_BACKEND_CACHE["optix"]
+    available = False
+    if RAYTRACER_AVAILABLE and astroray.__features__.get("optix_denoiser", False):
+        try:
+            available = bool(astroray.gpu_optix_available())
+        except Exception:
+            available = False
+    _DENOISER_BACKEND_CACHE["optix"] = available
+    return available
+
+
+def _oidn_compiled_in() -> bool:
+    return RAYTRACER_AVAILABLE and bool(astroray.__features__.get("oidn_denoiser", False))
+
+
+def _resolve_denoiser_pass(settings) -> str | None:
+    """Pick the denoiser pass name to register, or None if neither backend
+    is available. Mirrors Cycles' "OptiX preferred when both present" choice.
+    """
+    choice = getattr(settings, "denoiser_backend", "auto")
+    optix_ok = _optix_runtime_available()
+    oidn_ok  = _oidn_compiled_in()
+    if choice == "optix":
+        return "optix_denoiser" if optix_ok else None
+    if choice == "oidn":
+        return "oidn_denoiser" if oidn_ok else None
+    # auto — OptiX preferred on NVIDIA, OIDN fallback.
+    if optix_ok:
+        return "optix_denoiser"
+    if oidn_ok:
+        return "oidn_denoiser"
+    return None
 
 
 def _report_backend(reporter, level, message):
@@ -697,7 +754,9 @@ class CustomRaytracerRenderEngine(RenderEngine):
                 renderer.set_output_mode("luminance")
             renderer.set_integrator(integrator_name)
             if settings.use_denoising and not is_outside_visible:
-                renderer.add_pass("oidn_denoiser")
+                denoise_pass = _resolve_denoiser_pass(settings)
+                if denoise_pass is not None:
+                    renderer.add_pass(denoise_pass)
             if is_outside_visible and settings.colourmap != 'grayscale':
                 renderer.add_pass("colourmap_output")
             pixels = renderer.render(
@@ -770,6 +829,7 @@ class CustomRaytracerRenderEngine(RenderEngine):
             self._camera_state_hash(context, region),
             getattr(settings, "viewport_display_pass", "combined"),
             bool(getattr(settings, "viewport_oidn", False)),
+            getattr(settings, "denoiser_backend", "auto"),
             round(float(lmin), 3), round(float(lmax), 3),
             getattr(settings, "colourmap", "grayscale"),
             _effective_integrator_name(settings),
@@ -908,7 +968,9 @@ class CustomRaytracerRenderEngine(RenderEngine):
         elif viewport_display_pass == "depth":
             renderer.add_pass("depth_aov")
         if getattr(settings, "viewport_oidn", False) and not is_outside_visible:
-            renderer.add_pass("oidn_denoiser")
+            denoise_pass = _resolve_denoiser_pass(settings)
+            if denoise_pass is not None:
+                renderer.add_pass(denoise_pass)
 
         samples = self._viewport_chunk_samples(settings, self._viewport_current_spp)
         if samples <= 0:
@@ -3087,7 +3149,10 @@ class RENDER_PT_custom_raytracer_sampling(AstrorayPanelBase, Panel):
         layout.separator()
         col = layout.column(align=True)
         col.prop(settings, "viewport_display_pass", text="Render Pass")
-        col.prop(settings, "viewport_oidn", text="Viewport OIDN")
+        col.prop(settings, "viewport_oidn", text="Viewport Denoise")
+        sub = col.column()
+        sub.active = bool(getattr(settings, "viewport_oidn", False))
+        sub.prop(settings, "denoiser_backend", text="Denoiser")
 
         layout.separator()
         layout.prop(settings, "use_adaptive_sampling")

--- a/cmake/FindOptiX.cmake
+++ b/cmake/FindOptiX.cmake
@@ -1,0 +1,75 @@
+# FindOptiX.cmake — locate the NVIDIA OptiX SDK headers.
+#
+# We do NOT bundle the SDK (NVIDIA license forbids redistribution). Users
+# install OptiX 8.0+ themselves and we just locate the include directory.
+#
+# Search order:
+#   1. -DOPTIX_INSTALL_DIR=<path>
+#   2. $ENV{OPTIX_INSTALL_DIR}
+#   3. Default platform install paths.
+#
+# OptiX is a header-only API at compile time — the device functions are
+# loaded at runtime through the optix function table (optixInit) so there
+# is nothing to link. We expose:
+#   OptiX_FOUND        — TRUE if optix.h was located.
+#   OptiX_INCLUDE_DIRS — directory containing optix.h.
+#   OptiX_VERSION      — string parsed from optix_function_table.h
+#                        (best-effort; empty when not parseable).
+#
+# Adapted from NVIDIA's SDK/CMake/FindOptiX.cmake (NVIDIA OptiX SDK
+# License — re-implemented from the public interface, no source mirrored).
+
+set(_optix_search_paths "")
+
+if(OPTIX_INSTALL_DIR)
+    list(APPEND _optix_search_paths "${OPTIX_INSTALL_DIR}")
+endif()
+if(DEFINED ENV{OPTIX_INSTALL_DIR})
+    list(APPEND _optix_search_paths "$ENV{OPTIX_INSTALL_DIR}")
+endif()
+
+if(WIN32)
+    file(GLOB _optix_default_windows
+        "C:/ProgramData/NVIDIA Corporation/OptiX SDK 8.*"
+        "C:/ProgramData/NVIDIA Corporation/OptiX SDK 7.*"
+    )
+    list(APPEND _optix_search_paths ${_optix_default_windows})
+elseif(UNIX)
+    file(GLOB _optix_default_unix
+        "/opt/optix"
+        "/opt/NVIDIA-OptiX-SDK-*"
+        "$ENV{HOME}/NVIDIA-OptiX-SDK-*"
+    )
+    list(APPEND _optix_search_paths ${_optix_default_unix})
+endif()
+
+find_path(OptiX_INCLUDE_DIR
+    NAMES optix.h
+    PATHS ${_optix_search_paths}
+    PATH_SUFFIXES include
+    DOC "Directory containing optix.h from the NVIDIA OptiX SDK"
+)
+
+if(OptiX_INCLUDE_DIR AND EXISTS "${OptiX_INCLUDE_DIR}/optix.h")
+    file(STRINGS "${OptiX_INCLUDE_DIR}/optix.h" _optix_version_line
+         REGEX "^#define[ \t]+OPTIX_VERSION[ \t]+[0-9]+")
+    if(_optix_version_line)
+        string(REGEX REPLACE "^#define[ \t]+OPTIX_VERSION[ \t]+([0-9]+).*" "\\1"
+               _optix_version_int "${_optix_version_line}")
+        # OPTIX_VERSION = major*10000 + minor*100 + micro
+        math(EXPR _optix_major "${_optix_version_int} / 10000")
+        math(EXPR _optix_minor "(${_optix_version_int} % 10000) / 100")
+        math(EXPR _optix_micro "${_optix_version_int} % 100")
+        set(OptiX_VERSION "${_optix_major}.${_optix_minor}.${_optix_micro}")
+    endif()
+endif()
+
+set(OptiX_INCLUDE_DIRS "${OptiX_INCLUDE_DIR}")
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(OptiX
+    REQUIRED_VARS OptiX_INCLUDE_DIR
+    VERSION_VAR   OptiX_VERSION
+)
+
+mark_as_advanced(OptiX_INCLUDE_DIR)

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -1316,6 +1316,33 @@ PYBIND11_MODULE(astroray, m) {
         return astroray::PassRegistry::instance().names();
     });
 
+    // pkg70 — runtime probe for the OptiX denoiser. The Blender addon uses
+    // this to decide whether to default to OptiX or OIDN on viewport.
+    // Returns true only when (a) the build was compiled with OptiX support,
+    // (b) the optix_denoiser pass is registered, and (c) a CUDA device is
+    // visible at runtime. We don't actually create a denoiser here — that
+    // would force a CUDA context init just to answer a Python query.
+    m.def("gpu_optix_available", []() {
+#if defined(ASTRORAY_OPTIX_ENABLED) && defined(ASTRORAY_CUDA_ENABLED)
+        const auto names = astroray::PassRegistry::instance().names();
+        bool registered = false;
+        for (const auto& n : names) {
+            if (n == "optix_denoiser") { registered = true; break; }
+        }
+        if (!registered) return false;
+        // Cheap CUDA-visibility check — same probe getGPUAvailable() uses.
+        try {
+            CUDARenderer test;
+            return test.isAvailable();
+        } catch (...) {
+            return false;
+        }
+#else
+        return false;
+#endif
+    }, "Return True when the OptiX denoiser plugin is built in and a CUDA "
+       "device is visible at runtime.");
+
     // pkg39: spectral profile database
     m.def("load_spectral_profiles", [](const std::string& path) {
         astroray::SpectralProfileDatabase::instance().load(path);
@@ -1594,6 +1621,11 @@ PYBIND11_MODULE(astroray, m) {
         "oidn_denoiser"_a=true,
 #else
         "oidn_denoiser"_a=false,
+#endif
+#ifdef ASTRORAY_OPTIX_ENABLED
+        "optix_denoiser"_a=true,
+#else
+        "optix_denoiser"_a=false,
 #endif
 #ifdef ASTRORAY_CUDA_ENABLED
         "cuda"_a=true

--- a/plugins/passes/optix_denoiser.cpp
+++ b/plugins/passes/optix_denoiser.cpp
@@ -1,0 +1,340 @@
+// pkg70 — NVIDIA OptiX AI denoiser as a co-equal alternative to OIDN.
+//
+// Mirrors the pkg68 OIDN class shape (member-cached state, lazy init,
+// dimension-cached buffers). Where OIDN owns its own device, here we
+// piggyback on the CUDA driver context that the runtime already opens
+// for the path tracer (cuda_renderer.cu) — OptiX accepts a
+// CUcontext/CUstream pair via optixDeviceContextCreate.
+//
+// References:
+//   - OptiX 8 Programming Guide, "AI-Accelerated Denoiser":
+//     https://raytracing-docs.nvidia.com/optix8/guide/index.html#ai_denoiser
+//   - OptiX 8 host API:
+//     https://raytracing-docs.nvidia.com/optix8/api/optix__host_8h.html
+//   - Cycles `intern/cycles/device/optix/device_impl.cpp`
+//     (Apache-2.0) — `OptiXDevice::denoise_buffer()` for the
+//     setup/invoke shape, model-kind selection.
+//
+// Constraints (per pkg70 spec):
+//   - HDR model when no guides; AOV model when albedo+normal both present.
+//   - No temporal mode (motion vectors not yet emitted by integrator).
+//   - No SDK headers redistributed: build only when find_package(OptiX)
+//     succeeds and ASTRORAY_OPTIX_ENABLED is defined.
+
+#include "astroray/pass.h"
+#include "astroray/register.h"
+
+#include <cstdio>
+#include <cmath>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#ifdef ASTRORAY_OPTIX_ENABLED
+#  include <cuda_runtime.h>
+#  include <optix.h>
+#  include <optix_function_table_definition.h>
+#  include <optix_stubs.h>
+
+namespace {
+
+// One-shot OptiX function table init. Returns true on success.
+bool ensureOptixInit_() {
+    static bool tried = false;
+    static bool ok    = false;
+    if (tried) return ok;
+    tried = true;
+    OptixResult r = optixInit();
+    ok = (r == OPTIX_SUCCESS);
+    if (!ok) {
+        std::fprintf(stderr, "[OptiX] optixInit failed (%d)\n", static_cast<int>(r));
+    }
+    return ok;
+}
+
+void optixLogCallback_(unsigned int level, const char* tag,
+                       const char* message, void*) {
+    // Levels: 1 fatal, 2 error, 3 warning, 4 print. Surface fatals/errors
+    // unconditionally; everything else only at >= warning to avoid spam.
+    if (level <= 3) {
+        std::fprintf(stderr, "[OptiX %s] %s\n", tag ? tag : "?", message ? message : "");
+    }
+}
+
+#define ASTRORAY_OPTIX_CHECK(expr) do {                                        \
+        OptixResult _r = (expr);                                               \
+        if (_r != OPTIX_SUCCESS) {                                             \
+            throw std::runtime_error(std::string("OptiX call failed: " #expr " -> ") \
+                                     + std::to_string(static_cast<int>(_r)));  \
+        }                                                                      \
+    } while (0)
+
+#define ASTRORAY_CUDA_CHECK(expr) do {                                         \
+        cudaError_t _e = (expr);                                               \
+        if (_e != cudaSuccess) {                                               \
+            throw std::runtime_error(std::string("CUDA call failed: " #expr " -> ") \
+                                     + cudaGetErrorString(_e));                \
+        }                                                                      \
+    } while (0)
+
+} // namespace
+#endif // ASTRORAY_OPTIX_ENABLED
+
+
+class OptiXDenoiser : public Pass {
+public:
+    explicit OptiXDenoiser(const astroray::ParamDict&) {}
+
+    ~OptiXDenoiser() override {
+#ifdef ASTRORAY_OPTIX_ENABLED
+        try { destroy_(); } catch (...) {}
+#endif
+    }
+
+    std::string name() const override { return "OptiX Denoiser"; }
+
+    void execute(Framebuffer& fb) override {
+#ifdef ASTRORAY_OPTIX_ENABLED
+        const int w = fb.width();
+        const int h = fb.height();
+        const size_t pixels = static_cast<size_t>(w) * static_cast<size_t>(h);
+        if (pixels == 0) return;
+
+        const float* srcColor  = fb.buffer("color");
+        const float* srcAlbedo = fb.hasBuffer("albedo") ? fb.buffer("albedo") : nullptr;
+        const float* srcNormal = fb.hasBuffer("normal") ? fb.buffer("normal") : nullptr;
+        const bool   hasGuides = (srcAlbedo != nullptr) && (srcNormal != nullptr);
+
+        if (!initialised_) {
+            initContext_();
+            // Cycles selects HDR vs AOV per-invocation based on guide
+            // availability and locks it for the denoiser's lifetime —
+            // mirror that. Switching modes requires recreating the handle.
+            modelKind_ = hasGuides ? OPTIX_DENOISER_MODEL_KIND_AOV
+                                   : OPTIX_DENOISER_MODEL_KIND_HDR;
+            createDenoiser_();
+            initialised_ = true;
+        }
+
+        if (w != cachedWidth_ || h != cachedHeight_) {
+            allocateBuffers_(w, h);
+            cachedWidth_  = w;
+            cachedHeight_ = h;
+        }
+
+        // Sanitize NaNs/Infs in the host buffers (path tracer can produce
+        // them from very-rare divide edge cases) before HtoD copy. Mirrors
+        // the OIDN plugin's safeF lambda.
+        const size_t rgbBytes = pixels * 3 * sizeof(float);
+        sanitised_.resize(pixels * 3);
+        auto sanitiseInto = [&](const float* src) {
+            for (size_t i = 0; i < pixels * 3; ++i) {
+                const float v = src[i];
+                sanitised_[i] = std::isfinite(v) ? v : 0.0f;
+            }
+        };
+
+        sanitiseInto(srcColor);
+        ASTRORAY_CUDA_CHECK(cudaMemcpy(reinterpret_cast<void*>(colorDev_),
+                                       sanitised_.data(), rgbBytes,
+                                       cudaMemcpyHostToDevice));
+        if (modelKind_ == OPTIX_DENOISER_MODEL_KIND_AOV) {
+            sanitiseInto(srcAlbedo);
+            ASTRORAY_CUDA_CHECK(cudaMemcpy(reinterpret_cast<void*>(albedoDev_),
+                                           sanitised_.data(), rgbBytes,
+                                           cudaMemcpyHostToDevice));
+            // Normalise normals before upload (OIDN plugin does the same;
+            // OptiX expects unit-length world-space normals).
+            for (size_t i = 0; i < pixels; ++i) {
+                float nx = std::isfinite(srcNormal[i*3+0]) ? srcNormal[i*3+0] : 0.0f;
+                float ny = std::isfinite(srcNormal[i*3+1]) ? srcNormal[i*3+1] : 0.0f;
+                float nz = std::isfinite(srcNormal[i*3+2]) ? srcNormal[i*3+2] : 0.0f;
+                const float len = std::sqrt(nx*nx + ny*ny + nz*nz);
+                if (len > 0.0f) { nx /= len; ny /= len; nz /= len; }
+                sanitised_[i*3+0] = nx;
+                sanitised_[i*3+1] = ny;
+                sanitised_[i*3+2] = nz;
+            }
+            ASTRORAY_CUDA_CHECK(cudaMemcpy(reinterpret_cast<void*>(normalDev_),
+                                           sanitised_.data(), rgbBytes,
+                                           cudaMemcpyHostToDevice));
+        }
+
+        // Build per-frame layer/guide descriptors.
+        OptixImage2D colorImg = makeImage_(colorDev_, w, h);
+        OptixImage2D outputImg = makeImage_(outputDev_, w, h);
+
+        OptixDenoiserLayer layer = {};
+        layer.input         = colorImg;
+        layer.output        = outputImg;
+        // previousOutput left null — temporal mode is out of scope (#4).
+
+        OptixDenoiserGuideLayer guide = {};
+        if (modelKind_ == OPTIX_DENOISER_MODEL_KIND_AOV) {
+            guide.albedo = makeImage_(albedoDev_, w, h);
+            guide.normal = makeImage_(normalDev_, w, h);
+        }
+
+        // Compute intensity (HDR exposure normalisation). OptiX provides a
+        // helper kernel for this; passing a non-zero intensity yields better
+        // results on HDR inputs than the default 1.0.
+        ASTRORAY_OPTIX_CHECK(optixDenoiserComputeIntensity(
+            denoiser_, /*stream*/ 0,
+            &colorImg, intensityDev_,
+            scratchDev_, scratchSize_));
+
+        OptixDenoiserParams params = {};
+        params.hdrIntensity      = intensityDev_;
+        params.blendFactor       = 0.0f;
+        params.hdrAverageColor   = 0; // not used in HDR/AOV models
+        // Older OptiX 7.x SDKs had `denoiseAlpha` as a bool field; OptiX 8
+        // moved it to an enum (OPTIX_DENOISER_ALPHA_MODE_*). We render
+        // 3-channel float (no alpha), so the default zero-init is correct
+        // for both ABIs.
+
+        ASTRORAY_OPTIX_CHECK(optixDenoiserInvoke(
+            denoiser_, /*stream*/ 0, &params,
+            stateDev_, stateSize_,
+            &guide, &layer, /*numLayers*/ 1,
+            /*offsetX*/ 0, /*offsetY*/ 0,
+            scratchDev_, scratchSize_));
+
+        ASTRORAY_CUDA_CHECK(cudaDeviceSynchronize());
+
+        // DtoH copy back into the framebuffer's color buffer, clamping
+        // any residual non-finite or negative values.
+        ASTRORAY_CUDA_CHECK(cudaMemcpy(sanitised_.data(),
+                                       reinterpret_cast<void*>(outputDev_),
+                                       rgbBytes, cudaMemcpyDeviceToHost));
+        float* dst = fb.buffer("color");
+        for (size_t i = 0; i < pixels * 3; ++i) {
+            const float v = sanitised_[i];
+            dst[i] = std::isfinite(v) ? std::max(v, 0.0f) : 0.0f;
+        }
+#else
+        (void)fb;
+#endif
+    }
+
+private:
+#ifdef ASTRORAY_OPTIX_ENABLED
+    void initContext_() {
+        if (!ensureOptixInit_()) {
+            throw std::runtime_error("OptiX function table init failed (no NVIDIA driver?)");
+        }
+
+        // Force a CUDA primary context to exist on the current device. We
+        // share whatever the runtime already opened in cuda_renderer.cu;
+        // calling cudaFree(0) is the documented way to lazily create the
+        // primary context without taking a runtime API dependency.
+        ASTRORAY_CUDA_CHECK(cudaFree(0));
+
+        OptixDeviceContextOptions ctxOpts = {};
+        ctxOpts.logCallbackFunction = &optixLogCallback_;
+        ctxOpts.logCallbackLevel    = 3; // warnings + errors
+        // CUcontext = nullptr → use the current thread's primary context.
+        ASTRORAY_OPTIX_CHECK(optixDeviceContextCreate(/*ctx*/ 0, &ctxOpts, &context_));
+
+        int dev = 0;
+        cudaGetDevice(&dev);
+        cudaDeviceProp props{};
+        if (cudaGetDeviceProperties(&props, dev) == cudaSuccess) {
+            std::printf("[OptiX] Using CUDA device %d (%s)\n", dev, props.name);
+        } else {
+            std::printf("[OptiX] Using CUDA device %d\n", dev);
+        }
+        std::fflush(stdout);
+    }
+
+    void createDenoiser_() {
+        OptixDenoiserOptions opts = {};
+        if (modelKind_ == OPTIX_DENOISER_MODEL_KIND_AOV) {
+            opts.guideAlbedo = 1;
+            opts.guideNormal = 1;
+        }
+        ASTRORAY_OPTIX_CHECK(optixDenoiserCreate(context_, modelKind_, &opts, &denoiser_));
+    }
+
+    void allocateBuffers_(int w, int h) {
+        // Free anything previously allocated.
+        freeDeviceBuffers_();
+
+        OptixDenoiserSizes sizes = {};
+        ASTRORAY_OPTIX_CHECK(optixDenoiserComputeMemoryResources(
+            denoiser_, static_cast<unsigned int>(w),
+            static_cast<unsigned int>(h), &sizes));
+
+        stateSize_   = sizes.stateSizeInBytes;
+        scratchSize_ = sizes.withoutOverlapScratchSizeInBytes;
+
+        ASTRORAY_CUDA_CHECK(cudaMalloc(reinterpret_cast<void**>(&stateDev_),   stateSize_));
+        ASTRORAY_CUDA_CHECK(cudaMalloc(reinterpret_cast<void**>(&scratchDev_), scratchSize_));
+
+        const size_t rgbBytes = static_cast<size_t>(w) * h * 3 * sizeof(float);
+        ASTRORAY_CUDA_CHECK(cudaMalloc(reinterpret_cast<void**>(&colorDev_),  rgbBytes));
+        ASTRORAY_CUDA_CHECK(cudaMalloc(reinterpret_cast<void**>(&outputDev_), rgbBytes));
+        if (modelKind_ == OPTIX_DENOISER_MODEL_KIND_AOV) {
+            ASTRORAY_CUDA_CHECK(cudaMalloc(reinterpret_cast<void**>(&albedoDev_), rgbBytes));
+            ASTRORAY_CUDA_CHECK(cudaMalloc(reinterpret_cast<void**>(&normalDev_), rgbBytes));
+        }
+        ASTRORAY_CUDA_CHECK(cudaMalloc(reinterpret_cast<void**>(&intensityDev_), sizeof(float)));
+
+        ASTRORAY_OPTIX_CHECK(optixDenoiserSetup(
+            denoiser_, /*stream*/ 0,
+            static_cast<unsigned int>(w), static_cast<unsigned int>(h),
+            stateDev_, stateSize_,
+            scratchDev_, scratchSize_));
+    }
+
+    OptixImage2D makeImage_(CUdeviceptr ptr, int w, int h) const {
+        OptixImage2D img = {};
+        img.data               = ptr;
+        img.width              = static_cast<unsigned int>(w);
+        img.height             = static_cast<unsigned int>(h);
+        img.rowStrideInBytes   = static_cast<unsigned int>(w) * 3 * sizeof(float);
+        img.pixelStrideInBytes = 3 * sizeof(float);
+        img.format             = OPTIX_PIXEL_FORMAT_FLOAT3;
+        return img;
+    }
+
+    void freeDeviceBuffers_() {
+        auto freeIf = [](CUdeviceptr& p) {
+            if (p) { cudaFree(reinterpret_cast<void*>(p)); p = 0; }
+        };
+        freeIf(stateDev_);
+        freeIf(scratchDev_);
+        freeIf(colorDev_);
+        freeIf(albedoDev_);
+        freeIf(normalDev_);
+        freeIf(outputDev_);
+        freeIf(intensityDev_);
+        stateSize_   = 0;
+        scratchSize_ = 0;
+    }
+
+    void destroy_() {
+        freeDeviceBuffers_();
+        if (denoiser_) { optixDenoiserDestroy(denoiser_); denoiser_ = nullptr; }
+        if (context_)  { optixDeviceContextDestroy(context_); context_ = nullptr; }
+    }
+
+    OptixDeviceContext      context_      = nullptr;
+    OptixDenoiser           denoiser_     = nullptr;
+    OptixDenoiserModelKind  modelKind_    = OPTIX_DENOISER_MODEL_KIND_HDR;
+    CUdeviceptr             stateDev_     = 0;
+    CUdeviceptr             scratchDev_   = 0;
+    CUdeviceptr             colorDev_     = 0;
+    CUdeviceptr             albedoDev_    = 0;
+    CUdeviceptr             normalDev_    = 0;
+    CUdeviceptr             outputDev_    = 0;
+    CUdeviceptr             intensityDev_ = 0;
+    size_t                  stateSize_    = 0;
+    size_t                  scratchSize_  = 0;
+    int                     cachedWidth_  = 0;
+    int                     cachedHeight_ = 0;
+    bool                    initialised_  = false;
+    std::vector<float>      sanitised_;
+#endif
+};
+
+ASTRORAY_REGISTER_PASS("optix_denoiser", OptiXDenoiser)

--- a/tests/test_blender_viewport_passes.py
+++ b/tests/test_blender_viewport_passes.py
@@ -60,7 +60,13 @@ def _load_blender_addon(monkeypatch, renderer_cls):
 
     astroray_module = types.ModuleType("astroray")
     astroray_module.__version__ = "test"
-    astroray_module.__features__ = {"cuda": False, "spectral": True}
+    astroray_module.__features__ = {
+        "cuda": False, "spectral": True,
+        "oidn_denoiser": True, "optix_denoiser": False,
+    }
+    # pkg70: addon probes astroray.gpu_optix_available() to decide whether
+    # to default to OptiX. The CPU mock has no NVIDIA GPU, so always False.
+    astroray_module.gpu_optix_available = lambda: False
     astroray_module.__file__ = "/fake/astroray.pyd"
     astroray_module.Renderer = renderer_cls
     astroray_module.integrator_registry_names = lambda: ["path_tracer"]

--- a/tests/test_optix_denoiser.py
+++ b/tests/test_optix_denoiser.py
@@ -1,0 +1,141 @@
+"""Tests for pkg70: NVIDIA OptiX AI denoiser backend.
+
+Skips cleanly when the build was compiled without OptiX (the most common
+case in CI — OptiX SDK is not bundled), or when no CUDA device is visible
+at runtime. When the backend IS available, mirrors the shape of
+test_oidn_denoiser_persistence.py: persistent context across N renders,
+"[OptiX] Using ..." log line printed exactly once, OptiX denoiser
+actually reduces noise on a synthetic noisy image.
+
+OptiX SDK + CUDA hardware verification of these tests is pending — they
+are written so a verifier session can run them as-is once the SDK is
+installed and CUDA is enabled.
+"""
+import math
+import numpy as np
+import pytest
+
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+
+try:
+    import astroray
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray module not available")
+
+OPTIX_BUILD = AVAILABLE and bool(
+    astroray.__features__.get("optix_denoiser", False) if AVAILABLE else False
+)
+
+
+def _optix_runtime_available() -> bool:
+    if not OPTIX_BUILD:
+        return False
+    try:
+        return bool(astroray.gpu_optix_available())
+    except Exception:
+        return False
+
+
+OPTIX_AVAILABLE = _optix_runtime_available()
+
+
+def _tiny_renderer(width: int = 64, height: int = 64) -> "astroray.Renderer":
+    """Minimal Cornell-style scene; small for fast multi-render tests.
+    Mirrors test_oidn_denoiser_persistence._tiny_renderer.
+    """
+    r = astroray.Renderer()
+    r.setup_camera(
+        look_from=[0, 0, 5.5], look_at=[0, 0, 0], vup=[0, 1, 0],
+        vfov=40, aspect_ratio=width / height, aperture=0.0, focus_dist=5.5,
+        width=width, height=height,
+    )
+    r.set_background_color([0.0, 0.0, 0.0])
+    white = r.create_material("lambertian", [0.73, 0.73, 0.73], {})
+    red   = r.create_material("lambertian", [0.65, 0.05, 0.05], {})
+    light = r.create_material("light",      [1.0, 0.9, 0.8],    {"intensity": 15.0})
+    r.add_triangle([-2, -2, -2], [ 2, -2, -2], [ 2, -2,  2], white)
+    r.add_triangle([-2, -2, -2], [ 2, -2,  2], [-2, -2,  2], white)
+    r.add_triangle([-2, -2, -2], [-2, -2,  2], [-2,  2,  2], red)
+    r.add_triangle([-2, -2, -2], [-2,  2,  2], [-2,  2, -2], red)
+    r.add_triangle([-0.5, 1.98, -0.5], [0.5, 1.98, -0.5], [0.5, 1.98,  0.5], light)
+    r.add_triangle([-0.5, 1.98, -0.5], [0.5, 1.98,  0.5], [-0.5, 1.98, 0.5], light)
+    r.add_sphere([0, -1.0, 0], 1.0, white)
+    return r
+
+
+@pytest.mark.skipif(not OPTIX_BUILD, reason="OptiX denoiser not compiled in")
+def test_optix_pass_registered_when_compiled_in():
+    """The plugin must register itself under 'optix_denoiser'."""
+    assert "optix_denoiser" in astroray.pass_registry_names()
+
+
+@pytest.mark.skipif(not OPTIX_BUILD, reason="OptiX denoiser not compiled in")
+def test_gpu_optix_available_returns_bool():
+    """gpu_optix_available is a cheap probe — must always return a bool,
+    never raise, regardless of whether a CUDA device is present.
+    """
+    assert isinstance(astroray.gpu_optix_available(), bool)
+
+
+@pytest.mark.skipif(not OPTIX_AVAILABLE, reason="OptiX denoiser unavailable at runtime (SDK or CUDA missing)")
+def test_optix_context_initialised_once_across_n_frames(capfd):
+    """Persistent context: '[OptiX] Using ...' should print exactly once
+    across N renders on the same Renderer (mirrors pkg68 OIDN test)."""
+    r = _tiny_renderer()
+    r.set_seed(1)
+    r.add_pass("optix_denoiser")
+
+    N = 4
+    capfd.readouterr()
+    for _ in range(N):
+        r.render(samples_per_pixel=2, max_depth=3)
+    captured = capfd.readouterr()
+    combined = captured.out + captured.err
+
+    init_lines = [ln for ln in combined.splitlines() if "[OptiX] Using" in ln]
+    assert len(init_lines) == 1, (
+        f"Expected exactly one OptiX init line across {N} renders, got "
+        f"{len(init_lines)}: {init_lines!r}"
+    )
+
+
+@pytest.mark.skipif(not OPTIX_AVAILABLE, reason="OptiX denoiser unavailable at runtime (SDK or CUDA missing)")
+def test_optix_denoise_reduces_noise_on_synthetic_input():
+    """End-to-end: render a small Cornell scene at low spp to introduce
+    noticeable noise, then assert the OptiX-denoised output has lower
+    per-pixel variance than an undenoised reference at the same spp.
+    """
+    r_ref   = _tiny_renderer()
+    r_ref.set_seed(7)
+    ref     = np.array(r_ref.render(samples_per_pixel=2, max_depth=3),
+                       dtype=np.float32)
+
+    r_dnz = _tiny_renderer()
+    r_dnz.set_seed(7)
+    r_dnz.add_pass("optix_denoiser")
+    dnz   = np.array(r_dnz.render(samples_per_pixel=2, max_depth=3),
+                     dtype=np.float32)
+
+    assert np.all(np.isfinite(dnz)), "OptiX output contains non-finite pixels"
+
+    # Local 3x3 variance is the standard noise-floor proxy.
+    def local_var(img):
+        from numpy.lib.stride_tricks import sliding_window_view
+        # Treat each channel independently, then average.
+        v_total = 0.0
+        for c in range(img.shape[2]):
+            w = sliding_window_view(img[..., c], (3, 3))
+            v_total += w.var(axis=(-1, -2)).mean()
+        return v_total / img.shape[2]
+
+    v_ref = local_var(ref)
+    v_dnz = local_var(dnz)
+    assert v_dnz < v_ref * 0.5, (
+        f"OptiX-denoised noise floor not meaningfully lower than reference: "
+        f"ref={v_ref:.6f}, denoised={v_dnz:.6f}"
+    )


### PR DESCRIPTION
## Summary

pkg70 — NVIDIA OptiX AI denoiser as a co-equal alternative to OIDN.
Implements [.astroray_plan/packages/pkg70-optix-denoiser-backend.md](.astroray_plan/packages/pkg70-optix-denoiser-backend.md)
end-to-end. Mirrors the pkg68 OIDN class shape: persistent device
context, lazy init on first execute(), member-cached state + scratch
buffers reallocated only when the framebuffer geometry changes.

## Changes

- **[cmake/FindOptiX.cmake](cmake/FindOptiX.cmake)** — locates `optix.h`
  via `-DOPTIX_INSTALL_DIR=...`, `$OPTIX_INSTALL_DIR`, or the default
  Windows path `C:\ProgramData\NVIDIA Corporation\OptiX SDK 8.x\`.
  SDK headers are **not** bundled (NVIDIA license forbids redistribution).
- **[CMakeLists.txt](CMakeLists.txt)** — new `ASTRORAY_ENABLE_OPTIX`
  cache string (`AUTO`/`ON`/`OFF`, default `AUTO`). Defines
  `ASTRORAY_OPTIX_ENABLED` for the plugin object library and the
  standalone/Python/Blender modules. Pulls in `${OptiX_INCLUDE_DIRS}`
  + `CUDA::cudart` only on the plugin target.
- **[plugins/passes/optix_denoiser.cpp](plugins/passes/optix_denoiser.cpp)** —
  `OptiXDenoiser` class:
  - `OptixDeviceContext` + `OptixDenoiser` handle as members.
  - HDR model when no guides; AOV model when both `albedo` + `normal`
    framebuffers are present (Cycles `OptiXDevice::denoise_buffer`
    selection, Apache-2.0).
  - State + scratch device buffers (`cudaMalloc`-backed) cached and
    reallocated only on dimension change.
  - `[OptiX] Using <device>` log line on first invocation.
- **[module/blender_module.cpp](module/blender_module.cpp)** —
  `astroray.gpu_optix_available()` Python probe and a new
  `optix_denoiser` entry in `astroray.__features__`.
- **[blender_addon/__init__.py](blender_addon/__init__.py)** —
  `denoiser_backend` Auto/OptiX/OIDN `EnumProperty` + UI dropdown next
  to the existing Viewport Denoise toggle. Auto prefers OptiX when both
  backends are compiled in and a CUDA device is visible at runtime;
  falls back to OIDN otherwise. Used by both viewport preview and
  final-render denoise paths.
- **[tests/test_optix_denoiser.py](tests/test_optix_denoiser.py)** —
  mirrors `test_oidn_denoiser_persistence.py` shape; skips cleanly when
  OptiX is not compiled in or no CUDA device is visible at runtime.

## Out of scope (per spec)

- **Temporal mode** (decision #4) — needs motion vectors which the
  integrator does not currently emit. Follow-up package.
- No changes to `path_trace_kernel.cu` or `multiwavelength_kernel.cu`.

## Verification

- CPU pytest: unaffected (OptiX tests skip cleanly without the SDK).
- **OptiX SDK + CUDA hardware verification pending** — requires a
  workstation with the OptiX 8.x SDK installed and an NVIDIA GPU. The
  test suite will run end-to-end on such a machine; the OptiX-vs-OIDN
  timing + SSIM gates from the spec land as a follow-up Lessons entry.

DO NOT MERGE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)