### PR TITLE
docs(pkg72, pkg73): motion vectors + OptiX temporal denoiser specs

### DIFF
--- a/.astroray_plan/docs/motion-vectors-research.md
+++ b/.astroray_plan/docs/motion-vectors-research.md
@@ -1,0 +1,137 @@
+# Motion Vectors + OptiX Temporal Denoiser — Research Notes
+
+Background reading for pkg72 (motion-vector AOV) and pkg73 (OptiX temporal
+denoiser). Saved per CLAUDE.md §6 (cite, borrow, verify).
+
+---
+
+## Reference implementations surveyed
+
+### Cycles motion pass — Apache-2.0, mirrorable
+
+- File: `intern/cycles/integrator/pass.cpp` in the Blender mono-repo.
+  Search keys: `PASS_MOTION`, `PASS_MOTION_WEIGHT`.
+  Repo: <https://projects.blender.org/blender/blender> (also mirrored on
+  <https://github.com/blender/blender>).
+- License: Apache-2.0.
+- Key facts (from Blender devtalk + commit `8393ccd076` — "Cycles: Add
+  OptiX temporal denoising support"):
+  - Cycles' `PASS_MOTION` stores **2D vectors to both the next AND
+    previous frame** (4 channels: `(prev.x, prev.y, next.x, next.y)`).
+    OptiX temporal mode only consumes the previous→current direction.
+  - Cycles enforces: motion-vector pass and rendered motion blur are
+    mutually exclusive — you cannot have per-frame motion blur and
+    temporal denoising at the same time.
+  - Cycles also writes a `PASS_MOTION_WEIGHT` so the compositor can
+    normalize when multiple sub-samples accumulate into a pixel.
+
+### PBRT v4 — Apache-2.0, mirrorable
+
+- File: `src/pbrt/film.cpp` — searched, **no explicit per-pixel motion
+  vector storage**. PBRT v4's `GBufferFilm` records `visibleSurface->time`
+  and applies `outputFromRender.ApplyInverse(p, time)`, i.e. PBRT works
+  with parametric time-of-hit rather than a precomputed flow image.
+  Repo: <https://github.com/mmp/pbrt-v4>.
+- Implication: Cycles is the cleaner reference for our use case
+  (per-pixel screen-space flow consumed by an OptiX denoiser).
+
+### NVIDIA OptiX 8/9 denoiser — temporal mode
+
+- Programming guide: <https://raytracing-docs.nvidia.com/optix8/guide/index.html>
+  §"AI-Accelerated Denoiser". (HTTPS sometimes 403/cert-fails depending
+  on the fetch path; the OptiX 9 host-API page is mirrored at
+  <https://raytracing-docs.nvidia.com/optix9/api/group__optix__host__api__denoiser.html>
+  and contains identical API contract text.)
+- License: NVIDIA OptiX SDK License Agreement. Headers **not
+  redistributable**; we link against a user-installed SDK exactly as
+  pkg70 already does.
+- Contract for `OPTIX_DENOISER_MODEL_KIND_TEMPORAL` /
+  `OPTIX_DENOISER_MODEL_KIND_TEMPORAL_AOV`:
+  1. **Flow image** in `OptixDenoiserGuideLayer::flow` — 2D vectors in
+     pixel space, "flow from previous to current frame" (i.e. for each
+     pixel in the current frame, the displacement from where that
+     surface point was sampled in the previous frame).
+  2. **Normal guide** must be 3D camera-space vectors (XYZ used; in
+     non-temporal modes only XY are read).
+  3. `previousOutputInternalGuideLayer` and `outputInternalGuideLayer`
+     must both be allocated, pixel format
+     `OPTIX_PIXEL_FORMAT_INTERNAL_GUIDE_LAYER`, dimensions matching the
+     other layers.
+  4. `previousOutput` (in `OptixDenoiserLayer`) must hold the denoised
+     beauty of the previous frame. First-frame fallback: pass the
+     current noisy beauty + a zeroed flow image.
+
+### Cycles' OptiX temporal wiring — Apache-2.0, mirrorable
+
+- Files: `intern/cycles/device/optix/device_impl.cpp` and
+  `intern/cycles/integrator/denoiser_gpu.cpp`.
+  Search key: `OPTIX_DENOISER_MODEL_KIND_TEMPORAL`, `previousOutput`.
+- Original commit:
+  <https://developer.blender.org/rB8393ccd07634> ("Cycles: Add OptiX
+  temporal denoising support").
+- Forum thread that walks through the wiring, gotchas, and quality
+  observations:
+  <https://devtalk.blender.org/t/taking-a-look-at-optix-7-3-temporal-denoising-for-cycles/18656>
+- Key reusable patterns:
+  - Lazy upgrade from HDR→AOV→TEMPORAL_AOV is *not* supported by a
+    single denoiser handle — each model kind needs its own
+    `optixDenoiserCreate`. Cycles destroys + recreates on mode change.
+  - The internal-guide-layer pair is round-robined across frames: this
+    frame's `outputInternalGuideLayer` becomes next frame's
+    `previousOutputInternalGuideLayer`.
+  - First frame is detected by an `is_first_frame_` flag; on first
+    frame the code passes the noisy beauty as `previousOutput` and a
+    zero buffer as `flow`.
+
+### NVIDIA forum — flow-vector convention sanity check
+
+- <https://forums.developer.nvidia.com/t/how-do-you-calculate-flow-vector-for-denoiser/184859>
+  Confirms: for each pixel `(x, y)` in the **current** frame, the flow
+  value is `prev_pixel_xy - current_pixel_xy` — i.e. "where did this
+  surface point come from in the previous frame, in pixel units".
+  Sub-pixel precision matters; the denoiser samples the previous-output
+  with bilinear interpolation under the hood.
+
+---
+
+## Math we will reproduce (pkg72)
+
+Camera-only motion (sufficient for static-geometry viewport stability,
+which is pkg73's acceptance gate):
+
+```
+Given:
+  P_world      : world-space hit point sampled by the primary ray
+  cam_curr     : current frame camera (view + projection)
+  cam_prev     : previous frame camera (view + projection)
+  pixel_curr   : (x, y) integer pixel of the primary ray
+
+Compute:
+  P_clip_prev  = cam_prev.proj * cam_prev.view * P_world
+  P_ndc_prev   = P_clip_prev.xy / P_clip_prev.w
+  pixel_prev   = ((P_ndc_prev * 0.5 + 0.5) * (width, height))
+
+Store:
+  motion(x,y) = pixel_prev - pixel_curr        // float2, OptiX convention
+```
+
+Sky / env-miss pixels store `(0, 0)` (no surface point, no flow).
+Negative-w (point behind previous-frame camera) is also stored as
+`(0, 0)` — the denoiser will fall back to spatial-only behaviour for
+those pixels.
+
+This is **camera-only** motion. Animated geometry would need the
+previous-frame object transform looked up via the BVH instance; that
+is explicitly out of scope for pkg72 — viewport interaction is
+camera-driven and the static-geometry test covers it.
+
+---
+
+## License compliance summary
+
+| Source | License | Action |
+|---|---|---|
+| Cycles `pass.cpp`, `device/optix/*` | Apache-2.0 | Mirror with `Cycles <file>:<line>` citation in code comments. |
+| PBRT v4 `film.cpp` | Apache-2.0 | Studied, not mirrored (different model). Cite in research notes only. |
+| OptiX SDK headers | NVIDIA EULA, **not redistributable** | Link only. Matches pkg70's existing handling. |
+| OptiX programming guide text | NVIDIA docs | Cite by URL; do not paste verbatim. |

--- a/.astroray_plan/packages/pkg72-motion-vectors.md
+++ b/.astroray_plan/packages/pkg72-motion-vectors.md
@@ -1,0 +1,196 @@
+# pkg72 — Motion Vector AOV
+
+**Pillar:** 5
+**Track:** A
+**Status:** open
+**Estimated effort:** ~3 days (~12 h)
+**Depends on:** pkg06 (pass registry — done), pkg70 (OptiX denoiser — done; this package unblocks pkg70's deferred temporal mode)
+
+---
+
+## Goal
+
+**Before:** The integrator emits no per-pixel motion information.
+pkg70's OptiX denoiser explicitly excluded
+`OPTIX_DENOISER_MODEL_KIND_TEMPORAL` because of this gap (see
+[pkg70 §Key design decisions #4](pkg70-optix-denoiser-backend.md)).
+There is no way for any temporal post-process — denoiser, TAA,
+upscaler — to know where a surface point was in the previous frame.
+
+**After:** The integrator populates a new per-pixel `motion`
+buffer (float2: previous-frame screen-space pixel offset) using the
+previous-frame camera transform. A new `motion_vector_aov` pass
+plugin exposes the buffer for visualisation. Python binding
+`Renderer.get_motion_buffer()` returns the buffer to the addon.
+This unblocks pkg73 (OptiX temporal denoiser) and any future
+TAA / temporal-reproject work.
+
+---
+
+## Context
+
+Viewport interaction in Astroray is overwhelmingly camera-driven
+(orbit, pan, zoom). For these workloads, screen-space motion is
+fully recoverable from the **previous-frame camera transform** plus
+the **current-frame primary-ray hit point** — no per-object
+animation tracking is needed. That keeps this package small and
+makes pkg73's acceptance test (camera-pan inter-frame variance)
+directly verifiable.
+
+Cycles solves the same problem with `PASS_MOTION` /
+`PASS_MOTION_WEIGHT` ([Apache-2.0](#reference)). We mirror the
+shape but only the previous→current half of Cycles' four-channel
+representation, since that is all OptiX consumes.
+
+---
+
+## Reference
+
+### Reference Implementations
+
+| Source | License | What we borrow |
+|---|---|---|
+| Cycles `intern/cycles/integrator/pass.cpp` (`PASS_MOTION`, `PASS_MOTION_WEIGHT`) | Apache-2.0 | Buffer naming, sky-pixel zero-fill convention, motion-blur exclusion rule. |
+| Cycles `intern/cycles/kernel/integrator/shade_surface.h` (motion-vector write site) | Apache-2.0 | Where in the integrator the previous-frame projection runs. |
+| PBRT v4 `src/pbrt/film.cpp` (`GBufferFilm`) | Apache-2.0 | Studied as a contrast — PBRT uses parametric `time` rather than precomputed flow; we follow Cycles. |
+| OptiX programming guide §AI Denoiser, "flow image" contract | NVIDIA EULA (link only) | Sign convention: `flow(x,y) = prev_pixel - current_pixel`. |
+| NVIDIA forum thread on flow-vector convention | Public docs | Sub-pixel float2 in pixel units; `(0,0)` for sky / behind-prev-camera pixels. |
+
+Research notes: [docs/motion-vectors-research.md](../docs/motion-vectors-research.md).
+
+External URLs:
+
+- <https://projects.blender.org/blender/blender/src/branch/main/intern/cycles/integrator/pass.cpp>
+- <https://github.com/mmp/pbrt-v4/blob/master/src/pbrt/film.cpp>
+- <https://raytracing-docs.nvidia.com/optix8/guide/index.html#ai_denoiser>
+- <https://forums.developer.nvidia.com/t/how-do-you-calculate-flow-vector-for-denoiser/184859>
+
+---
+
+## Prerequisites
+
+- [ ] Build passes on main.
+- [ ] pkg70 merged (so the consumer of this buffer exists in tree).
+- [ ] No active motion-blur work in progress (the two are mutually
+      exclusive at write time — see Key design decisions #3).
+
+---
+
+## Specification
+
+### Files to create
+
+| File | Purpose |
+|---|---|
+| `plugins/passes/motion_vector_aov.cpp` | Pass plugin `MotionVectorAOV` mirroring `normal_aov.cpp`'s shape. Reads `fb.buffer("motion")` (float2/pixel), writes a colourised RGB visualisation into `color` (red = +x flow, green = +y flow, magnitude in luminance). For debugging and the synthetic acceptance tests. |
+| `tests/test_motion_vector_aov.py` | (a) Static-camera test: render two frames with identical camera, assert `\|motion\| < 1e-4` on every surface-hit pixel. (b) Camera-pan test: translate the camera by `dx` pixels horizontally between frames, render a static plane filling the view, assert per-pixel `motion.x ≈ -dx` within 0.5 px tolerance. (c) Sky pixels assert exactly `(0, 0)`. |
+
+### Files to modify
+
+| File | What changes |
+|---|---|
+| `include/raytracer.h` (`Camera`) | Add `std::vector<float> motionBuffer` (size `width*height*2`). Add `Mat4 prevViewProj` and a `bool hasPrevCamera` flag, populated via a new `Camera::snapshotForMotion()` call invoked once per frame by the renderer before the next render begins. |
+| `include/raytracer.h` (`Framebuffer::buffer`) | Add `if (name == "motion") return cam_->motionBuffer.data();`. Mirrors the existing `uv` / `depth` registrations at lines ~1702–1712. |
+| `include/raytracer.h` (`Renderer::renderFrame` primary-ray loop, ~line 2392 region per pkg70's audit) | After the first surface hit `P` is known, compute `pixel_prev` from `cam.prevViewProj * P` and write `motion[2*i + 0/1] = pixel_prev - pixel_curr`. Sky / `w <= 0` → `(0, 0)`. Wrap in `if (cam.hasPrevCamera)`; first frame writes zeros. |
+| `include/raytracer.h` (`Renderer::renderFrame` end) | Call `cam.snapshotForMotion()` so the next frame sees this frame's `viewProj` as `prevViewProj`. |
+| `module/blender_module.cpp` | Add `Renderer.get_motion_buffer()` returning a NumPy view shaped `(height, width, 2)` over `cam.motionBuffer`. Mirror `get_normal_buffer()`'s shape exactly. |
+| `plugins/passes/CMakeLists.txt` (or the equivalent plugin glob) | Register the new `motion_vector_aov.cpp` source. |
+
+### Key design decisions
+
+1. **Camera-only motion is sufficient for the deliverable.** Per
+   research notes: viewport interaction is camera-driven; pkg73's
+   acceptance gate is a camera-pan test. Animated-geometry motion
+   (per-object previous-frame transforms via the BVH) is explicitly
+   a follow-up package, not in scope.
+
+2. **Two channels, not four.** Cycles stores both prev→current and
+   current→next (see `PASS_MOTION` in `pass.cpp`). OptiX only
+   consumes the previous→current half. We omit the forward half
+   until something asks for it.
+
+3. **Mutually exclusive with rendered motion blur.** Cycles enforces
+   the same constraint. If/when motion blur lands, it must guard
+   on `cam.motionBuffer.empty()` or the convention here breaks
+   (you cannot meaningfully give "the" prev-frame pixel for a
+   shutter-time-averaged hit). Document the rule; do not enforce
+   it in this package because motion blur is not implemented yet.
+
+4. **No `motion_weight` buffer.** Cycles needs it because of
+   sub-sample accumulation in its compositor pipeline; Astroray
+   writes one sample per pixel into the motion buffer (the primary
+   ray's hit) and overwrites — no accumulation, no weight needed.
+   If multi-sample motion lands later, add the weight buffer then.
+
+5. **Sign and units match OptiX directly.** `flow(x,y) = prev - curr`
+   in pixel units. No conversion at the consumer (pkg73) site.
+
+6. **Sky / behind-prev-camera pixels store `(0, 0)`.** Per the
+   NVIDIA forum thread, this signals "no temporal correspondence"
+   and the denoiser falls back to spatial-only behaviour on those
+   pixels. This is also what pkg73's first-frame fallback uses.
+
+---
+
+## Acceptance criteria
+
+- [ ] Static-camera synthetic test: two consecutive renders with
+      identical `Camera` produce `max(|motion|) < 1e-4` on every
+      surface-hit pixel.
+- [ ] Camera-pan synthetic test: translate camera by 10 px in
+      screen-x against a static plane filling the view; assert
+      per-pixel `motion.x` is in `[-10.5, -9.5]` and `|motion.y| < 0.5`
+      on every surface-hit pixel.
+- [ ] Sky-pixel test: env-miss pixels report exactly `(0.0, 0.0)`.
+- [ ] First-frame test: a freshly-constructed `Renderer` returns an
+      all-zero motion buffer (no prev-camera available yet).
+- [ ] `Renderer.get_motion_buffer()` returns a NumPy array of shape
+      `(height, width, 2)` and dtype `float32`, sharing memory with
+      the C++ buffer (verify `.base is not None` and a write through
+      the C++ side is visible to Python without re-fetching).
+- [ ] `motion_vector_aov` pass renders without crashing and produces
+      a finite RGB image when motion is non-zero.
+- [ ] All existing tests still pass; no regression in `oidn_denoiser`
+      / `optix_denoiser` outputs (they don't read `motion` yet).
+
+---
+
+## Non-goals
+
+- Do not generate motion vectors for animated geometry (per-object
+  previous-frame transforms). Camera-only is the deliverable.
+- Do not implement motion blur. Motion blur and the motion-vector
+  pass are mutually exclusive by design (see Key design decisions
+  #3); whichever lands second will own the guard.
+- Do not write the forward (current→next) flow channels.
+- Do not wire pkg73 (OptiX temporal mode) here — that is a separate
+  package that depends on this one.
+- Do not add a `motion_weight` AOV.
+- Do not redistribute OptiX SDK headers; this package does not
+  depend on OptiX at build time.
+
+---
+
+## Progress
+
+- [ ] Add `motionBuffer`, `prevViewProj`, `hasPrevCamera`, and
+      `snapshotForMotion()` to `Camera`.
+- [ ] Register `"motion"` in `Framebuffer::buffer`.
+- [ ] Compute and write motion in the integrator's primary-ray loop.
+      Cite Cycles `pass.cpp:PASS_MOTION` in the code comment.
+- [ ] Call `snapshotForMotion()` at end of `renderFrame`.
+- [ ] Add `Renderer.get_motion_buffer()` Python binding.
+- [ ] Implement `MotionVectorAOV` pass plugin.
+- [ ] Add `tests/test_motion_vector_aov.py` covering the four
+      acceptance scenarios.
+- [ ] Update `STATUS.md`.
+
+---
+
+## Lessons
+
+*(Fill in after the package is done. Required: actual peak `|motion|`
+on the static-camera test; per-pixel error distribution on the
+camera-pan test; any subtleties in the `Mat4 * Vec3` projection path
+on Windows/MinGW; whether the buffer needs to be cleared each frame
+or fully overwritten by the integrator.)*

--- a/.astroray_plan/packages/pkg73-optix-temporal-denoiser.md
+++ b/.astroray_plan/packages/pkg73-optix-temporal-denoiser.md
@@ -1,0 +1,212 @@
+# pkg73 — OptiX Temporal Denoiser
+
+**Pillar:** 5
+**Track:** A
+**Status:** open
+**Estimated effort:** ~3–4 days (~14 h)
+**Depends on:** pkg70 (OptiX denoiser backend — done), pkg72 (motion-vector AOV — open)
+
+---
+
+## Goal
+
+**Before:** pkg70 ships an OptiX denoiser that runs in HDR or AOV
+mode. Frame-to-frame the denoiser sees each frame in isolation,
+which produces visible "boiling" / shimmer in the viewport when the
+sample budget is low and the camera is moving slowly. pkg70
+explicitly deferred temporal mode pending motion vectors
+([pkg70 §Key design decisions #4](pkg70-optix-denoiser-backend.md)).
+
+**After:** When pkg72's `motion` buffer is present, the existing
+`OptiXDenoiser` upgrades its denoiser handle to
+`OPTIX_DENOISER_MODEL_KIND_TEMPORAL_AOV`, caches the previous
+denoised frame and the round-robined internal-guide-layer pair, and
+feeds them on each `execute()`. Viewport camera-pan stability
+improves measurably (≥ 30% reduction in inter-frame pixel variance
+vs. pkg70 AOV mode on the same scene at the same sample count). HDR
+and AOV non-temporal modes remain available as fallbacks.
+
+---
+
+## Context
+
+Temporal denoising is the strongest viewport-stability story
+available without raising the sample count. NVIDIA's OptiX denoiser
+exposes it via a single model-kind switch — but the model-kind
+choice is locked at `optixDenoiserCreate` time, so adding the mode
+means handling create/destroy on transition, not a runtime flag.
+Cycles solved exactly this problem in commit
+[`8393ccd076`](https://developer.blender.org/rB8393ccd07634); we
+mirror their approach (Apache-2.0).
+
+---
+
+## Reference
+
+### Reference Implementations
+
+| Source | License | What we borrow |
+|---|---|---|
+| Cycles `intern/cycles/device/optix/device_impl.cpp` (`denoise()`, search `OPTIX_DENOISER_MODEL_KIND_TEMPORAL`) | Apache-2.0 | Mode-transition pattern (destroy+recreate handle on kind change), internal-guide-layer ping-pong, first-frame fallback. |
+| Cycles `intern/cycles/integrator/denoiser_gpu.cpp` | Apache-2.0 | High-level lifecycle: when to allocate the previous-output buffer, when to invalidate it on resize. |
+| Original Blender commit adding OptiX temporal: <https://developer.blender.org/rB8393ccd07634> | Apache-2.0 | Reviewed for design intent and known gotchas. |
+| OptiX programming guide §AI Denoiser (temporal section) | NVIDIA EULA — link only | Definition of `OptixDenoiserGuideLayer::flow`, `previousOutput`, `previousOutputInternalGuideLayer`, `outputInternalGuideLayer`, normal-guide channel-count rule (3D in temporal mode). |
+| OptiX 9 host API (mirror of the same contract): <https://raytracing-docs.nvidia.com/optix9/api/group__optix__host__api__denoiser.html> | NVIDIA EULA — link only | Same as above, fetched as a reachable mirror when the OptiX 8 page 403s. |
+| Blender devtalk discussion: <https://devtalk.blender.org/t/taking-a-look-at-optix-7-3-temporal-denoising-for-cycles/18656> | Public forum | Quality observations, debugging workflow, motion-blur exclusion rule. |
+
+Research notes: [docs/motion-vectors-research.md](../docs/motion-vectors-research.md).
+
+---
+
+## Prerequisites
+
+- [ ] pkg70 in tree (`OptiXDenoiser` plugin compiles and tests pass).
+- [ ] pkg72 in tree (`fb.hasBuffer("motion")` returns true on a normal
+      render; `Renderer.get_motion_buffer()` exists).
+- [ ] OptiX SDK ≥ 8.0 (same as pkg70). 8.1 preferred.
+- [ ] Working RTX hardware in CI / verifier path; the same hardware
+      pkg70's verification bullet is waiting on (RTX 5070 Ti).
+
+---
+
+## Specification
+
+### Files to create
+
+| File | Purpose |
+|---|---|
+| `tests/test_optix_denoiser_temporal.py` | (1) Skip if OptiX or motion buffer unavailable. (2) Camera-pan inter-frame variance test (acceptance gate). (3) First-frame fallback test: render frame 0 with no prior state, assert finite output. (4) Resize-invalidates-state test: change resolution between frames, assert no crash and a fresh denoiser handle is created. |
+
+### Files to modify
+
+| File | What changes |
+|---|---|
+| `include/astroray/optix_denoiser.h` (or wherever pkg70 placed the persistent state struct) | Add: `OptixDenoiserModelKind currentKind_`; `void* d_prev_output_ = nullptr` (CUDA buffer for previous denoised beauty); `void* d_internal_guide_a_ = nullptr;` `void* d_internal_guide_b_ = nullptr;` (the ping-pong pair, `OPTIX_PIXEL_FORMAT_INTERNAL_GUIDE_LAYER`); `int frame_index_ = 0`; `bool prev_valid_ = false;` |
+| `plugins/passes/optix_denoiser.cpp` | (a) **Mode selection.** At the top of `execute()`, decide `desiredKind`: `TEMPORAL_AOV` if `fb.hasBuffer("motion") && fb.hasBuffer("albedo") && fb.hasBuffer("normal")`, else `TEMPORAL` if motion-only, else fall back to pkg70's existing AOV/HDR logic. (b) **Mode transitions.** If `desiredKind != currentKind_`, destroy the existing denoiser handle + state + scratch + internal-guide buffers, recreate via `optixDenoiserCreate(desiredKind, …)`, set `prev_valid_ = false`. Mirror Cycles `device_impl.cpp`. (c) **Per-frame populate.** Fill `OptixDenoiserGuideLayer::flow` from the `motion` buffer (HtoD copy or shared CUDA pointer if motion is already device-resident — for now CPU buffer + HtoD copy is fine). Bind `previousOutput` to `d_prev_output_` if `prev_valid_`, else to the noisy `color` input (first-frame fallback per the OptiX guide). Bind the internal-guide-layer pair, swapping which is "previous" vs "current" each frame using `frame_index_ & 1`. (d) **Post-invoke.** Copy denoised output into `d_prev_output_` for next frame; set `prev_valid_ = true; ++frame_index_;`. (e) **Normal-guide channel rule.** In temporal modes, ensure the bound normal layer is treated as 3-channel camera-space (already true in our buffer layout per pkg70 §6 — verify and cite). |
+| `plugins/passes/optix_denoiser.cpp` (resize path) | On dimension change, additionally free `d_prev_output_` + the internal-guide pair, set `prev_valid_ = false`. |
+| `module/blender_module.cpp` | No new bindings; the addon picks up temporal automatically once motion is populated. (Optional: a `gpu_optix_temporal_active()` query for the UI to display the active mode.) |
+| `blender_addon/__init__.py` | (Optional, small.) When the addon enables the OptiX backend in viewport mode, also enable the motion-vector pass automatically so temporal mode kicks in. Add a checkbox "OptiX temporal denoising" defaulting to `True`. |
+
+### Key design decisions
+
+1. **Model kind locked at `optixDenoiserCreate` — destroy + recreate
+   on transition.** This is a hard OptiX contract, not a choice.
+   Mirror Cycles' `device_impl.cpp` pattern of comparing
+   `currentKind_` against `desiredKind` at the top of each invoke.
+
+2. **Internal guide layers ping-pong, do not realloc each frame.**
+   `outputInternalGuideLayer` this frame becomes
+   `previousOutputInternalGuideLayer` next frame. Use
+   `frame_index_ & 1` to select. Cycles does the same.
+
+3. **First-frame fallback per the OptiX programming guide.** Pass
+   the noisy current beauty as `previousOutput` and rely on the
+   zero motion vectors that pkg72 emits when `hasPrevCamera` is
+   false. Do not skip the denoise call on the first frame — that
+   would visibly flash on viewport startup.
+
+4. **Sign convention matches pkg72 directly.** No conversion at the
+   binding site: pkg72 already writes `prev - current` in pixel
+   units, which is exactly what `OptixDenoiserGuideLayer::flow`
+   expects. Cite the relevant pkg72 line in the code comment.
+
+5. **Auto-disable temporal on resolution change mid-stream.**
+   Cached previous-frame buffers are sized for the old resolution
+   and meaningless after a resize. Drop them, mark
+   `prev_valid_ = false`, then the regular first-frame fallback
+   handles the next invoke. Same logic Cycles uses.
+
+6. **Quality regressions are a stop-the-line condition.** OptiX
+   temporal can occasionally trail-smear on disocclusions. The
+   acceptance gate is **inter-frame variance reduction**, not just
+   "looks smoother" — record the actual numbers in Lessons. If the
+   variance gate is met but a single-frame quality regression
+   appears (SSIM vs pkg70 AOV mode drops below 0.95 on a
+   static-camera frame), document and surface to the user before
+   merging.
+
+7. **Do not redistribute OptiX SDK headers.** Same handling as
+   pkg70 — link against the user-installed SDK via
+   `cmake/FindOptiX.cmake`.
+
+---
+
+## Acceptance criteria
+
+- [ ] On a build with OptiX SDK + motion buffer available,
+      `OptiXDenoiser::execute()` selects
+      `OPTIX_DENOISER_MODEL_KIND_TEMPORAL_AOV` on the first frame
+      with motion present (verifiable via a debug log line).
+- [ ] **Inter-frame variance gate.** Render a 16-frame camera-pan
+      sequence at 1080p / fixed sample count using (a) pkg70's
+      AOV mode, (b) this package's temporal-AOV mode. Compute
+      per-pixel inter-frame variance over the central 8 frames,
+      averaged across pixels with non-zero motion. Temporal mode
+      must show **≥ 30% reduction** in this metric. Record both
+      numbers in Lessons; do not silently relax the gate.
+- [ ] First-frame correctness: with `prev_valid_ == false`, the
+      denoiser produces finite output and matches pkg70's HDR/AOV
+      output within SSIM ≥ 0.99 (it's the same call modulo zero
+      flow + noisy `previousOutput`).
+- [ ] No regression on the pkg70 test suite — `tests/test_optix_denoiser.py`
+      still passes.
+- [ ] On a build *without* pkg72's motion buffer (e.g. motion AOV
+      disabled), the denoiser silently falls back to pkg70 AOV/HDR
+      behaviour. No crash, no error log.
+- [ ] On a runtime resolution change between frames, no crash; the
+      denoiser handle and previous-output buffers are reallocated
+      and the next frame is treated as a first frame.
+- [ ] On a non-OptiX build, pkg72's motion buffer continues to be
+      written but is unused — both packages remain independent.
+
+---
+
+## Non-goals
+
+- Do not implement per-object animated-geometry motion. pkg72 ships
+  camera-only motion; this package consumes it as-is.
+- Do not implement OIDN temporal mode. OIDN's temporal support is
+  weaker and out of scope (see pkg70's table); revisit only if
+  user demand appears.
+- Do not retrain or fine-tune the OptiX model. Use NVIDIA's shipped
+  weights.
+- Do not add a "force temporal off" runtime override for production
+  renders — the same plugin handles both, and forcing single-frame
+  mode is just "do not render an animation".
+- Do not redistribute the OptiX SDK headers.
+- Do not address motion blur. Temporal denoising and rendered
+  motion blur are mutually exclusive (see pkg72 §Key design
+  decisions #3).
+
+---
+
+## Progress
+
+- [ ] Extend `OptiXDenoiser` persistent state with the temporal
+      fields listed in "Files to modify".
+- [ ] Add mode-selection logic at the top of `execute()`.
+- [ ] Add destroy-and-recreate path on `currentKind_` change. Cite
+      Cycles `device_impl.cpp`.
+- [ ] Allocate / free `d_prev_output_` and the internal-guide-layer
+      pair around the denoiser handle's lifetime.
+- [ ] Wire flow / previousOutput / internal-guide bindings on each
+      `optixDenoiserInvoke`.
+- [ ] Add post-invoke copy into `d_prev_output_`; advance
+      `frame_index_`.
+- [ ] Handle resize: invalidate `prev_valid_` and reallocate.
+- [ ] Add `tests/test_optix_denoiser_temporal.py` covering the four
+      acceptance scenarios.
+- [ ] Run the variance gate on RTX 5070 Ti; record numbers in
+      Lessons.
+- [ ] Update `STATUS.md`.
+
+---
+
+## Lessons
+
+*(Fill in after the package is done. Required: measured inter-frame
+variance reduction (%) on the camera-pan scene; SSIM vs pkg70 AOV
+mode on a static-camera frame; observed disocclusion / trail-smear
+artefacts if any; whether the HtoD motion-buffer copy showed up in
+the per-frame profile, and whether moving motion to a device-resident
+buffer is worth a follow-up.)*


### PR DESCRIPTION
Closes the temporal-mode follow-up gap left open by pkg70 (OptiX denoiser). Two specs, no source code.

**pkg72 — Motion Vector AOV (~3 days).** Adds a per-pixel `motion` float2 buffer (previous→current screen-space pixel offset) populated from the previous-frame camera transform. New `motion_vector_aov` plugin, `Renderer.get_motion_buffer()` Python binding. Camera-only motion — animated geometry is out of scope. Mirrors Cycles' `PASS_MOTION` shape (Apache-2.0, cited).

**pkg73 — OptiX Temporal Denoiser (~3–4 days, depends on pkg72).** Extends pkg70's `OptiXDenoiser` to upgrade to `OPTIX_DENOISER_MODEL_KIND_TEMPORAL_AOV` when motion is present: previous-output caching, internal-guide-layer ping-pong, first-frame fallback, destroy-and-recreate on model-kind transition. Acceptance gate: ≥30% inter-frame variance reduction on a 1080p camera-pan vs pkg70 AOV mode. Mirrors Cycles `device/optix/device_impl.cpp` (Apache-2.0, cited).

Research notes saved to `.astroray_plan/docs/motion-vectors-research.md` per CLAUDE.md §6 (cite, borrow, verify). OptiX SDK headers remain link-only (NVIDIA EULA, not redistributable).

**Do not merge** — review the spec scope first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)