### PR TITLE
verify(pkg70): blocked — OptiX SDK not installed on this workstation

### DIFF
--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -391,6 +391,29 @@ Brief notes on notable events.
   `test_oidn_denoiser_persistence.py` shape; skips cleanly when SDK or
   CUDA absent. CPU pytest unaffected; OptiX timing vs OIDN-CUDA gate
   pending verifier session with the SDK installed.
+- **2026-05-10** — pkg70 verifier session **blocked**: OptiX SDK is not
+  installed on the RTX 5070 Ti workstation. `scripts\build\build_cuda.bat`
+  configure log: `OptiX SDK not found — OptiX denoiser disabled`; runtime
+  feature flags: `optix_denoiser=False, oidn_denoiser=True, cuda=True`.
+  All 4 tests in `tests/test_optix_denoiser.py` skip cleanly with reason
+  "OptiX denoiser not compiled in" — exactly as the spec intends. No
+  regression: `test_oidn_denoiser.py + test_oidn_denoiser_persistence.py
+  + test_aov_passes.py` still 13/13 green (incl.
+  `test_cuda_capable_build_reports_cuda_device`). pkg70 stays
+  **implemented (pending verification)**. To clear: install OptiX 8.x
+  SDK (manual, NVIDIA-account download from
+  https://developer.nvidia.com/designworks/optix/download), default path
+  `C:\ProgramData\NVIDIA Corporation\OptiX SDK 8.x.x\` is auto-detected,
+  or set `OPTIX_INSTALL_DIR` / pass `-DOPTIX_INSTALL_DIR=<path>`; clean
+  rebuild and re-run the §3.1 verifier prompt from `NEXT_STAGE_REPORT`.
+- **2026-05-10** — pkg57 verifier session: pytest portion green
+  (`tests/test_blender_native_nodes.py`, 7/7 passed) — covers all 5
+  manual GUI behaviors mechanically (engine-gated Add menu, engine
+  switch survival, AstrorayOutput precedence over BsdfPrincipled,
+  Cycles fallback when AstrorayOutput absent, register/unregister
+  cleanliness). Live Blender 5.1 GUI walkthrough (Add menu visual
+  inspection + prism dispersion render) deferred to user QA. Status
+  unchanged at **done** (already promoted in PR #204).
 - **2026-05-10** — pkg68 implemented (pending CUDA verification). OIDN
   device + filter hoisted to `OIDNDenoiser` class members and lazy-initialised
   on first `execute()`; init tries `oidn::DeviceType::CUDA` first and falls

--- a/.astroray_plan/packages/pkg57-native-shader-nodes.md
+++ b/.astroray_plan/packages/pkg57-native-shader-nodes.md
@@ -245,3 +245,13 @@ total; they are the main remaining unknowns.
   the stub `Material` raises `AttributeError` from it; live verification
   against Blender 5.1 is still pending (Open Question §1 in the research
   note).
+- **Live Blender 5.1 GUI verification deferred to user QA** (2026-05-10
+  verifier session). The 7-test pytest suite in
+  `tests/test_blender_native_nodes.py` mechanically covers every behavior
+  in the spec's manual GUI checklist (engine-gated Add-menu visibility,
+  engine-switch survival of `mat.astroray` PointerProperty,
+  AstrorayOutput-takes-precedence over BsdfPrincipled, Cycles fallback
+  when AstrorayOutput absent, register/unregister cleanliness), but a
+  visual walkthrough in a real Blender 5.1 instance — Add menu inspection
+  and a prism dispersion render against `tests/scenes/prism_reference.py`
+  — was not performed in the headless verifier environment.


### PR DESCRIPTION
Verifier session for pkg70 + pkg57 confirmation. Hardware: RTX 5070 Ti,
Windows MSVC `build_cuda`.

## pkg70 — BLOCKED on tooling

- CMake configure: `OptiX SDK not found — OptiX denoiser disabled`
- Module feature flags: `optix_denoiser=False, oidn_denoiser=True, cuda=True`
- All 4 tests in `tests/test_optix_denoiser.py` skip with `OptiX denoiser not compiled in` — exactly as the spec intends when the SDK is absent.
- **No regression:** `test_oidn_denoiser.py + test_oidn_denoiser_persistence.py + test_aov_passes.py` 13/13 green (incl. `test_cuda_capable_build_reports_cuda_device`).

**To unblock:** install NVIDIA OptiX 8.x SDK (manual, NVIDIA-account download from <https://developer.nvidia.com/designworks/optix/download>); default Windows path `C:\ProgramData\NVIDIA Corporation\OptiX SDK 8.x.x\` is auto-detected by `cmake/FindOptiX.cmake`, or set `OPTIX_INSTALL_DIR`. Clean rebuild + re-run the §3.1 verifier prompt from `NEXT_STAGE_REPORT`.

pkg70 spec status **unchanged** at `implemented (pending verification)`.

## pkg57 — confirmed `done`

- `tests/test_blender_native_nodes.py`: **7/7 passed**.
- The 7 tests mechanically cover all 5 manual-GUI behaviors in the spec checklist:
  - engine-gated Add-menu visibility (`test_draw_astroray_nodes_emits_only_for_astroray_engine`)
  - register/unregister cleanliness (`test_all_classes_register_without_error`, `test_property_group_registers_on_material`, `test_add_menu_appended_on_register`)
  - Cycles BsdfPrincipled path unchanged (`test_cycles_principled_path_unchanged`)
  - AstrorayOutput precedence + SellmeierGlass (`test_astroray_output_takes_precedence_with_sellmeier_glass`)
  - Cycles fallback when AstrorayOutput absent (`test_astroray_output_without_surface_falls_back`)
- Live Blender 5.1 GUI walkthrough (Add-menu visual inspection + prism dispersion render against `tests/scenes/prism_reference.py`) **deferred to user QA** — headless verifier environment.
- Status already promoted in PR #204; no spec change here, just a Lessons line documenting the deferral.

## Doc changes in this PR

- `.astroray_plan/docs/STATUS.md` — two changelog entries: pkg70 blocked + pkg57 verified-pytest-portion.
- `.astroray_plan/packages/pkg57-native-shader-nodes.md` — Lessons line on the GUI deferral.

No implementation code touched. No package status promoted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)