### PR TITLE
[codex] fix(pkg70): NOMINMAX guard and OptiX SDK glob

### DIFF
--- a/cmake/FindOptiX.cmake
+++ b/cmake/FindOptiX.cmake
@@ -30,8 +30,7 @@ endif()
 
 if(WIN32)
     file(GLOB _optix_default_windows
-        "C:/ProgramData/NVIDIA Corporation/OptiX SDK 8.*"
-        "C:/ProgramData/NVIDIA Corporation/OptiX SDK 7.*"
+        "C:/ProgramData/NVIDIA Corporation/OptiX SDK *"
     )
     list(APPEND _optix_search_paths ${_optix_default_windows})
 elseif(UNIX)

--- a/plugins/passes/optix_denoiser.cpp
+++ b/plugins/passes/optix_denoiser.cpp
@@ -1,3 +1,7 @@
+#ifdef _WIN32
+#  define NOMINMAX
+#endif
+
 // pkg70 — NVIDIA OptiX AI denoiser as a co-equal alternative to OIDN.
 //
 // Mirrors the pkg68 OIDN class shape (member-cached state, lazy init,


### PR DESCRIPTION
## Summary

- Define `NOMINMAX` before any includes in `plugins/passes/optix_denoiser.cpp` on Windows so OptiX 9.x transitive Windows headers do not break `std::max`.
- Broaden the Windows OptiX SDK auto-detection glob in `cmake/FindOptiX.cmake` so it finds 9.x, 10.x, and later SDK folders under `C:/ProgramData/NVIDIA Corporation/`.

## Root Cause

OptiX 9.x can transitively pull in Windows headers that define `min`/`max` macros unless `NOMINMAX` is defined first. The previous CMake glob also only checked `OptiX SDK 7.*` and `OptiX SDK 8.*`, so SDK 9.1 required manual `-DOPTIX_INSTALL_DIR` configuration.

## Validation

- `scripts\build\build_cuda.bat` passed on the CUDA + OptiX 9.1 workstation.
- Configure log confirms auto-detection: `OptiX found: 9.1.0 (C:/ProgramData/NVIDIA Corporation/OptiX SDK 9.1.0/include)`.
- No max/min macro warning or C2589/C2059 failure while compiling `plugins/passes/optix_denoiser.cpp`.
- `python scripts\dev\run_tests.py --build-dir build_cuda -- tests/test_optix_denoiser.py tests/test_oidn_denoiser.py tests/test_oidn_denoiser_persistence.py tests/test_aov_passes.py -v --tb=short` passed: 17 passed.