### PR TITLE
fix(pkg70, pkg71): Windows OptiX build + OIDN DLL bootstrap + Cornell parity harness

### DIFF
--- a/benchmarks/cycles-parity/2026-05-10-hendrik-desktop-amd64-family-25-model-97-stepping-2-authenticamd-4fa95be.csv
+++ b/benchmarks/cycles-parity/2026-05-10-hendrik-desktop-amd64-family-25-model-97-stepping-2-authenticamd-4fa95be.csv
@@ -1,0 +1,21 @@
+scene,engine,samples,time_ms,peak_mem_mb,ssim_to_cycles,skip_reason
+cornell,cycles-cpu,64,10648.201,595.3,1.000000,
+cornell,cycles-cuda,64,4182.948,673.8,0.999963,
+cornell,astroray-cpu,64,15389.610,134.9,0.953596,
+cornell,astroray-gpu,64,800.741,244.5,0.954770,
+classroom,cycles-cpu,300,486451.691,1506.2,1.000000,
+classroom,cycles-cuda,300,31167.653,1587.0,0.998390,
+classroom,astroray-cpu,300,,,,astroray_blend_import_not_implemented
+classroom,astroray-gpu,300,,,,astroray_blend_import_not_implemented
+monster,cycles-cpu,256,,,,"exit:1 00:01.594  blend            | Read blend: ""C:\Users\hgcom\OneDrive\Astroray\Astroray_repo\Astroray\benchmarks\cycles-parity\scenes\cache\monster\UDIM_monster\udim-monster.blend"" Traceback (most recent call last):   File ""C:\Users\hgcom\OneDrive\Astroray\Astroray_repo\Astroray\benchmarks\cycles-parity\results\monster-cycles-cpu-tryop9cg\warmup.py"", line 19, in <module>     bpy.ops.render.render(write_still=True)     ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^ RuntimeError: Error: Cannot render, no camera  Custom Raytracer 3.0.0 loaded Astroray renderer addon registered Error: Cannot render, no camera Astroray renderer addon unregistered Blender 5.1.0 (hash adfe2921d5f3 built 2026-03-17 01:37:32)  Blender quit"
+monster,cycles-cuda,256,,,,"exit:1 00:01.625  blend            | Read blend: ""C:\Users\hgcom\OneDrive\Astroray\Astroray_repo\Astroray\benchmarks\cycles-parity\scenes\cache\monster\UDIM_monster\udim-monster.blend"" Traceback (most recent call last):   File ""C:\Users\hgcom\OneDrive\Astroray\Astroray_repo\Astroray\benchmarks\cycles-parity\results\monster-cycles-cuda-gdcuxj3n\warmup.py"", line 19, in <module>     bpy.ops.render.render(write_still=True)     ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^ RuntimeError: Error: Cannot render, no camera  Custom Raytracer 3.0.0 loaded Astroray renderer addon registered Error: Cannot render, no camera Astroray renderer addon unregistered Blender 5.1.0 (hash adfe2921d5f3 built 2026-03-17 01:37:32)  Blender quit"
+monster,astroray-cpu,256,,,,astroray_blend_import_not_implemented
+monster,astroray-gpu,256,,,,astroray_blend_import_not_implemented
+junkshop,cycles-cpu,240,225573.385,7096.2,1.000000,
+junkshop,cycles-cuda,240,30576.592,8514.3,0.999686,
+junkshop,astroray-cpu,240,,,,astroray_blend_import_not_implemented
+junkshop,astroray-gpu,240,,,,astroray_blend_import_not_implemented
+bmw27,cycles-cpu,1024,138051.651,582.5,1.000000,
+bmw27,cycles-cuda,1024,13444.425,704.9,0.999570,
+bmw27,astroray-cpu,1024,,,,astroray_blend_import_not_implemented
+bmw27,astroray-gpu,1024,,,,astroray_blend_import_not_implemented

--- a/benchmarks/cycles-parity/2026-05-10-hendrik-desktop-amd64-family-25-model-97-stepping-2-authenticamd-4fa95be.md
+++ b/benchmarks/cycles-parity/2026-05-10-hendrik-desktop-amd64-family-25-model-97-stepping-2-authenticamd-4fa95be.md
@@ -1,0 +1,36 @@
+# Cycles Parity Summary: `2026-05-10-hendrik-desktop-amd64-family-25-model-97-stepping-2-authenticamd-4fa95be.csv`
+
+## Time to Samples (ms)
+
+| Scene | cycles-cpu | cycles-cuda | astroray-cpu | astroray-gpu |
+|---|---|---|---|---|
+| bmw27 | 138051.651 | 13444.425 | skip: astroray_blend_import_not_implemented | skip: astroray_blend_import_not_implemented |
+| classroom | 486451.691 | 31167.653 | skip: astroray_blend_import_not_implemented | skip: astroray_blend_import_not_implemented |
+| cornell | 10648.201 | 4182.948 | 15389.610 | 800.741 |
+| junkshop | 225573.385 | 30576.592 | skip: astroray_blend_import_not_implemented | skip: astroray_blend_import_not_implemented |
+| monster | skip: exit:1 00:01.594  blend            | Read blend: "C:\Users\hgcom\OneDrive\Astroray\Astroray_repo\Astroray\benchmarks\cycles-parity\scenes\cache\monster\UDIM_monster\udim-monster.blend" Traceback (most recent call last):   File "C:\Users\hgcom\OneDrive\Astroray\Astroray_repo\Astroray\benchmarks\cycles-parity\results\monster-cycles-cpu-tryop9cg\warmup.py", line 19, in <module>     bpy.ops.render.render(write_still=True)     ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^ RuntimeError: Error: Cannot render, no camera  Custom Raytracer 3.0.0 loaded Astroray renderer addon registered Error: Cannot render, no camera Astroray renderer addon unregistered Blender 5.1.0 (hash adfe2921d5f3 built 2026-03-17 01:37:32)  Blender quit | skip: exit:1 00:01.625  blend            | Read blend: "C:\Users\hgcom\OneDrive\Astroray\Astroray_repo\Astroray\benchmarks\cycles-parity\scenes\cache\monster\UDIM_monster\udim-monster.blend" Traceback (most recent call last):   File "C:\Users\hgcom\OneDrive\Astroray\Astroray_repo\Astroray\benchmarks\cycles-parity\results\monster-cycles-cuda-gdcuxj3n\warmup.py", line 19, in <module>     bpy.ops.render.render(write_still=True)     ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^ RuntimeError: Error: Cannot render, no camera  Custom Raytracer 3.0.0 loaded Astroray renderer addon registered Error: Cannot render, no camera Astroray renderer addon unregistered Blender 5.1.0 (hash adfe2921d5f3 built 2026-03-17 01:37:32)  Blender quit | skip: astroray_blend_import_not_implemented | skip: astroray_blend_import_not_implemented |
+
+## Peak Resident Memory (MB)
+
+| Scene | cycles-cpu | cycles-cuda | astroray-cpu | astroray-gpu |
+|---|---|---|---|---|
+| bmw27 | 582.5 | 704.9 | skip: astroray_blend_import_not_implemented | skip: astroray_blend_import_not_implemented |
+| classroom | 1506.2 | 1587.0 | skip: astroray_blend_import_not_implemented | skip: astroray_blend_import_not_implemented |
+| cornell | 595.3 | 673.8 | 134.9 | 244.5 |
+| junkshop | 7096.2 | 8514.3 | skip: astroray_blend_import_not_implemented | skip: astroray_blend_import_not_implemented |
+| monster | skip: exit:1 00:01.594  blend            | Read blend: "C:\Users\hgcom\OneDrive\Astroray\Astroray_repo\Astroray\benchmarks\cycles-parity\scenes\cache\monster\UDIM_monster\udim-monster.blend" Traceback (most recent call last):   File "C:\Users\hgcom\OneDrive\Astroray\Astroray_repo\Astroray\benchmarks\cycles-parity\results\monster-cycles-cpu-tryop9cg\warmup.py", line 19, in <module>     bpy.ops.render.render(write_still=True)     ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^ RuntimeError: Error: Cannot render, no camera  Custom Raytracer 3.0.0 loaded Astroray renderer addon registered Error: Cannot render, no camera Astroray renderer addon unregistered Blender 5.1.0 (hash adfe2921d5f3 built 2026-03-17 01:37:32)  Blender quit | skip: exit:1 00:01.625  blend            | Read blend: "C:\Users\hgcom\OneDrive\Astroray\Astroray_repo\Astroray\benchmarks\cycles-parity\scenes\cache\monster\UDIM_monster\udim-monster.blend" Traceback (most recent call last):   File "C:\Users\hgcom\OneDrive\Astroray\Astroray_repo\Astroray\benchmarks\cycles-parity\results\monster-cycles-cuda-gdcuxj3n\warmup.py", line 19, in <module>     bpy.ops.render.render(write_still=True)     ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^ RuntimeError: Error: Cannot render, no camera  Custom Raytracer 3.0.0 loaded Astroray renderer addon registered Error: Cannot render, no camera Astroray renderer addon unregistered Blender 5.1.0 (hash adfe2921d5f3 built 2026-03-17 01:37:32)  Blender quit | skip: astroray_blend_import_not_implemented | skip: astroray_blend_import_not_implemented |
+
+## SSIM to Cycles CPU Reference
+
+| Scene | cycles-cpu | cycles-cuda | astroray-cpu | astroray-gpu |
+|---|---|---|---|---|
+| bmw27 | 1.000000 | 0.999570 | skip: astroray_blend_import_not_implemented | skip: astroray_blend_import_not_implemented |
+| classroom | 1.000000 | 0.998390 | skip: astroray_blend_import_not_implemented | skip: astroray_blend_import_not_implemented |
+| cornell | 1.000000 | 0.999963 | 0.953596 | 0.954770 |
+| junkshop | 1.000000 | 0.999686 | skip: astroray_blend_import_not_implemented | skip: astroray_blend_import_not_implemented |
+| monster | skip: exit:1 00:01.594  blend            | Read blend: "C:\Users\hgcom\OneDrive\Astroray\Astroray_repo\Astroray\benchmarks\cycles-parity\scenes\cache\monster\UDIM_monster\udim-monster.blend" Traceback (most recent call last):   File "C:\Users\hgcom\OneDrive\Astroray\Astroray_repo\Astroray\benchmarks\cycles-parity\results\monster-cycles-cpu-tryop9cg\warmup.py", line 19, in <module>     bpy.ops.render.render(write_still=True)     ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^ RuntimeError: Error: Cannot render, no camera  Custom Raytracer 3.0.0 loaded Astroray renderer addon registered Error: Cannot render, no camera Astroray renderer addon unregistered Blender 5.1.0 (hash adfe2921d5f3 built 2026-03-17 01:37:32)  Blender quit | skip: exit:1 00:01.625  blend            | Read blend: "C:\Users\hgcom\OneDrive\Astroray\Astroray_repo\Astroray\benchmarks\cycles-parity\scenes\cache\monster\UDIM_monster\udim-monster.blend" Traceback (most recent call last):   File "C:\Users\hgcom\OneDrive\Astroray\Astroray_repo\Astroray\benchmarks\cycles-parity\results\monster-cycles-cuda-gdcuxj3n\warmup.py", line 19, in <module>     bpy.ops.render.render(write_still=True)     ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^ RuntimeError: Error: Cannot render, no camera  Custom Raytracer 3.0.0 loaded Astroray renderer addon registered Error: Cannot render, no camera Astroray renderer addon unregistered Blender 5.1.0 (hash adfe2921d5f3 built 2026-03-17 01:37:32)  Blender quit | skip: astroray_blend_import_not_implemented | skip: astroray_blend_import_not_implemented |
+
+## Scene Attribution
+
+- Junkshop by Alex Trevino, CC-BY-4.0, Blender Foundation demo files
+- BMW27 by Mike Pan, CC-BY-3.0, https://download.blender.org/demo/test/BMW27.blend.zip

--- a/benchmarks/cycles-parity/README.md
+++ b/benchmarks/cycles-parity/README.md
@@ -5,11 +5,15 @@ against Cycles CPU/CUDA on a small Blender demo scene matrix. It records
 quality as SSIM against a Cycles-CPU EXR reference and records timing/memory
 for trend tracking. SSIM is the only correctness gate in this package;
 performance is recorded but not gated until the later wavefront/sync work.
+SSIM is computed on linear EXR values with both images clipped to their shared
+99.9th percentile, which keeps isolated firefly outliers from dominating the
+structural comparison.
 
 ## Layout
 
 - `scenes/cornell/` contains the repo-shipped MIT Cornell control scene
-  descriptor. Astroray renders this through the standalone built-in scene 1.
+  descriptor. The harness builds the same triangle scene for Cycles and
+  Astroray so Cornell compares matching camera, geometry, materials, and light.
 - `scenes/cache/` is gitignored and holds downloaded Blender Foundation scene
   archives.
 - `scenes/scripts/fetch_scenes.py` downloads Classroom, Monster, Junkshop, and

--- a/benchmarks/cycles-parity/scenes/cache/ATTRIBUTION.md
+++ b/benchmarks/cycles-parity/scenes/cache/ATTRIBUTION.md
@@ -1,0 +1,6 @@
+# Benchmark Scene Attribution
+
+Generated for the pkg71 canonical baseline. Keep these lines with any published CSV/Markdown bundle that includes CC-BY scenes.
+
+- Junkshop by Alex Trevino, CC-BY-4.0, Blender Benchmark scene archive https://download.blender.org/release/BlenderBenchmark2.0/scenes/junkshop.tar.bz2
+- BMW27 by Mike Pan, CC-BY-3.0, https://download.blender.org/demo/test/BMW27.blend.zip

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -61,17 +61,23 @@ _ASTRORAY_NODES_AVAILABLE = astroray_nodes is not None
 # dependencies, so we have to explicitly add the addon directory to the
 # DLL search list before importing.
 if sys.platform == "win32" and hasattr(os, "add_dll_directory"):
+    _ASTRORAY_DLL_DIRECTORY_HANDLES = []
     _dll_dirs = [
         addon_dir,
         # OIDN DLLs bundled alongside the addon (placed here by build_blender_addon.py)
         os.path.join(addon_dir, "oidn"),
-        # OIDN installed system-wide at the RenderKit default location
+        # OIDN installed system-wide at common locations.
         r"C:\oidn\bin",
+        r"C:\Program Files\Intel\oidn\bin",
+        r"C:\Program Files\Intel\OpenImageDenoise\bin",
     ]
+    for _env_var in ("OIDN_ROOT", "ASTRORAY_OIDN_DIR"):
+        if _env_var in os.environ:
+            _dll_dirs.append(os.path.join(os.environ[_env_var], "bin"))
     for _d in _dll_dirs:
         if os.path.isdir(_d):
             try:
-                os.add_dll_directory(_d)
+                _ASTRORAY_DLL_DIRECTORY_HANDLES.append(os.add_dll_directory(_d))
             except (FileNotFoundError, OSError):
                 pass
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -22,19 +22,21 @@ found.
 
 - **CUDA Toolkit 12.x** — GPU path tracer + OIDN-CUDA denoiser backend.
   Standard NVIDIA installer.
-- **NVIDIA OptiX 8.x SDK** — OptiX AI denoiser backend, ~2× faster than
+- **NVIDIA OptiX SDK 8.x+** — OptiX AI denoiser backend, ~2× faster than
   OIDN-CUDA on Tensor Core GPUs (Turing+) and a prerequisite for the
   upcoming temporal denoiser. Manual download from
   <https://developer.nvidia.com/designworks/optix/download> (free
   NVIDIA developer account required; the OptiX SDK License forbids
   redistribution, so we cannot bundle it). The default install path
   on Windows
-  (`C:\ProgramData\NVIDIA Corporation\OptiX SDK 8.x.x\`) is
+  (`C:\ProgramData\NVIDIA Corporation\OptiX SDK x.y.z\`) is
   auto-detected; for a custom path, set `OPTIX_INSTALL_DIR` env var
   or pass `-DOPTIX_INSTALL_DIR=<path>` to CMake. Without OptiX,
   the denoiser falls back to OIDN.
 - **Intel OIDN 2.4+** — usually fetched automatically by
-  CMake when not installed locally. No manual step required.
+  CMake when not installed locally. OIDN install paths are auto-detected at
+  standard locations; for non-standard installs, set `OIDN_ROOT` or
+  `ASTRORAY_OIDN_DIR`.
 
 ---
 

--- a/scripts/run_parity.py
+++ b/scripts/run_parity.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import os
 import platform
 import shutil
 import statistics
@@ -41,6 +42,42 @@ CSV_COLUMNS = [
     "skip_reason",
 ]
 ENGINES = ("cycles-cpu", "cycles-cuda", "astroray-cpu", "astroray-gpu")
+
+
+def _oidn_bin_dirs() -> list[Path]:
+    candidates: list[Path] = []
+    for env_var in ("OIDN_ROOT", "ASTRORAY_OIDN_DIR"):
+        root = os.environ.get(env_var)
+        if root:
+            candidates.append(Path(root) / "bin")
+    candidates.extend([
+        Path(r"C:\oidn\bin"),
+        Path(r"C:\Program Files\Intel\oidn\bin"),
+        Path(r"C:\Program Files\Intel\OpenImageDenoise\bin"),
+        Path(r"C:\Program Files\OpenImageDenoise\bin"),
+    ])
+    return [path for path in candidates if path.is_dir()]
+
+
+def _subprocess_env() -> dict[str, str]:
+    env = os.environ.copy()
+    python_paths = [
+        str(ROOT),
+        str(ROOT / "build_cuda"),
+        str(ROOT / "build_cuda" / "Release"),
+        str(ROOT / "build"),
+        str(ROOT / "build" / "Release"),
+    ]
+    existing_pythonpath = env.get("PYTHONPATH", "")
+    if existing_pythonpath:
+        python_paths.append(existing_pythonpath)
+    env["PYTHONPATH"] = os.pathsep.join(python_paths)
+    if platform.system() == "Windows":
+        oidn_bins = [str(path) for path in _oidn_bin_dirs()]
+        if oidn_bins:
+            env["PATH"] = os.pathsep.join(oidn_bins + [env.get("PATH", "")])
+        env.setdefault("OPENCV_IO_ENABLE_OPENEXR", "1")
+    return env
 
 
 @dataclass(frozen=True)
@@ -154,6 +191,7 @@ def _run_command(command: list[str], cwd: Path, timeout: int) -> tuple[float, fl
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
+        env=_subprocess_env(),
     )
     done, mem_samples = _monitor_process(proc)
     try:
@@ -176,39 +214,49 @@ def _cycles_script(scene: Scene, output: Path, device: str) -> str:
 import bpy
 bpy.ops.object.delete()
 scene = bpy.context.scene
+scene.world.color = (0.0, 0.0, 0.0)
 def mat(name, color, emit=0.0):
     m = bpy.data.materials.new(name)
     m.use_nodes = True
-    bsdf = m.node_tree.nodes.get('Principled BSDF')
-    bsdf.inputs['Base Color'].default_value = color
-    bsdf.inputs['Emission Strength'].default_value = emit
+    nodes = m.node_tree.nodes
+    nodes.clear()
+    out = nodes.new(type='ShaderNodeOutputMaterial')
     if emit:
-        bsdf.inputs['Emission Color'].default_value = color
+        shader = nodes.new(type='ShaderNodeEmission')
+        shader.inputs['Color'].default_value = color
+        shader.inputs['Strength'].default_value = emit
+        m.node_tree.links.new(shader.outputs['Emission'], out.inputs['Surface'])
+    else:
+        shader = nodes.new(type='ShaderNodeBsdfDiffuse')
+        shader.inputs['Color'].default_value = color
+        shader.inputs['Roughness'].default_value = 1.0
+        m.node_tree.links.new(shader.outputs['BSDF'], out.inputs['Surface'])
     return m
 white = mat('white', (0.73, 0.73, 0.73, 1))
 red = mat('red', (0.65, 0.05, 0.05, 1))
 green = mat('green', (0.12, 0.45, 0.15, 1))
 light_mat = mat('light', (1.0, 0.9, 0.8, 1), 15.0)
-def plane(name, loc, scale, rot, material):
-    bpy.ops.mesh.primitive_cube_add(size=1, location=loc, rotation=rot)
-    obj = bpy.context.object
+def tri(name, vertices, material):
+    mesh = bpy.data.meshes.new(name + 'Mesh')
+    mesh.from_pydata(vertices, [], [(0, 1, 2)])
+    mesh.update()
+    obj = bpy.data.objects.new(name, mesh)
+    bpy.context.collection.objects.link(obj)
     obj.name = name
-    obj.dimensions = scale
     obj.data.materials.append(material)
     return obj
-plane('floor', (0, -2, 0), (4, 0.02, 4), (0, 0, 0), white)
-plane('ceiling', (0, 2, 0), (4, 0.02, 4), (0, 0, 0), white)
-plane('back', (0, 0, -2), (4, 4, 0.02), (0, 0, 0), white)
-plane('left', (-2, 0, 0), (0.02, 4, 4), (0, 0, 0), red)
-plane('right', (2, 0, 0), (0.02, 4, 4), (0, 0, 0), green)
-plane('light', (0, 1.98, 0), (1, 0.02, 1), (0, 0, 0), light_mat)
-bpy.ops.mesh.primitive_uv_sphere_add(segments=48, ring_count=24, radius=0.7, location=(-0.7, -1.3, -0.5))
-bpy.context.object.data.materials.append(white)
-bpy.ops.mesh.primitive_uv_sphere_add(segments=48, ring_count=24, radius=0.5, location=(0.8, -1.5, 0.3))
-bpy.context.object.data.materials.append(white)
-bpy.ops.object.light_add(type='AREA', location=(0, 1.8, 0))
-bpy.context.object.data.energy = 350
-bpy.context.object.data.size = 1
+tri('floor_0', [(-2, -2, -2), (2, -2, -2), (2, -2, 2)], white)
+tri('floor_1', [(-2, -2, -2), (2, -2, 2), (-2, -2, 2)], white)
+tri('ceiling_0', [(-2, 2, -2), (-2, 2, 2), (2, 2, 2)], white)
+tri('ceiling_1', [(-2, 2, -2), (2, 2, 2), (2, 2, -2)], white)
+tri('back_0', [(-2, -2, -2), (-2, 2, -2), (2, 2, -2)], white)
+tri('back_1', [(-2, -2, -2), (2, 2, -2), (2, -2, -2)], white)
+tri('left_0', [(-2, -2, -2), (-2, -2, 2), (-2, 2, 2)], red)
+tri('left_1', [(-2, -2, -2), (-2, 2, 2), (-2, 2, -2)], red)
+tri('right_0', [(2, -2, -2), (2, 2, -2), (2, 2, 2)], green)
+tri('right_1', [(2, -2, -2), (2, 2, 2), (2, -2, 2)], green)
+tri('light_0', [(-0.5, 1.98, -0.5), (0.5, 1.98, -0.5), (0.5, 1.98, 0.5)], light_mat)
+tri('light_1', [(-0.5, 1.98, -0.5), (0.5, 1.98, 0.5), (-0.5, 1.98, 0.5)], light_mat)
 bpy.ops.object.camera_add(location=(0, 0, 5.5), rotation=(0, 0, 0))
 scene.camera = bpy.context.object
 """
@@ -236,6 +284,45 @@ bpy.ops.render.render(write_still=True)
 """
 
 
+def _astroray_script(scene: Scene, output: Path, device: str) -> str:
+    if scene.scene_id != "cornell":
+        raise ValueError("Astroray scene import is only implemented for cornell")
+    return f"""
+import os
+os.environ.setdefault('OPENCV_IO_ENABLE_OPENEXR', '1')
+import imageio.v3 as iio
+import numpy as np
+import astroray
+
+r = astroray.Renderer()
+if {device == 'gpu'!r}:
+    r.set_use_gpu(True)
+r.set_seed(1)
+red = r.create_material('lambertian', [0.65, 0.05, 0.05], {{}})
+green = r.create_material('lambertian', [0.12, 0.45, 0.15], {{}})
+white = r.create_material('lambertian', [0.73, 0.73, 0.73], {{}})
+light = r.create_material('light', [1.0, 0.9, 0.8], {{'intensity': 15.0}})
+for v0, v1, v2, mat in [
+    ([-2, -2, -2], [2, -2, -2], [2, -2, 2], white),
+    ([-2, -2, -2], [2, -2, 2], [-2, -2, 2], white),
+    ([-2, 2, -2], [-2, 2, 2], [2, 2, 2], white),
+    ([-2, 2, -2], [2, 2, 2], [2, 2, -2], white),
+    ([-2, -2, -2], [-2, 2, -2], [2, 2, -2], white),
+    ([-2, -2, -2], [2, 2, -2], [2, -2, -2], white),
+    ([-2, -2, -2], [-2, -2, 2], [-2, 2, 2], red),
+    ([-2, -2, -2], [-2, 2, 2], [-2, 2, -2], red),
+    ([2, -2, -2], [2, 2, -2], [2, 2, 2], green),
+    ([2, -2, -2], [2, 2, 2], [2, -2, 2], green),
+    ([-0.5, 1.98, -0.5], [0.5, 1.98, -0.5], [0.5, 1.98, 0.5], light),
+    ([-0.5, 1.98, -0.5], [0.5, 1.98, 0.5], [-0.5, 1.98, 0.5], light),
+]:
+    r.add_triangle(v0, v1, v2, mat)
+r.setup_camera([0, 0, 5.5], [0, 0, 0], [0, 1, 0], 38.0, {scene.width / scene.height!r}, 0.01, 5.5, {scene.width}, {scene.height})
+pixels = np.asarray(r.render({scene.samples}, 8, None, False), dtype=np.float32)
+iio.imwrite({str(output)!r}, pixels)
+"""
+
+
 def _render_once(
     scene: Scene,
     engine: str,
@@ -253,6 +340,12 @@ def _render_once(
         script = output.with_suffix(".py")
         script.write_text(_cycles_script(scene, output, device), encoding="utf-8")
         return _run_command([blender, "--background", "--python", str(script)], ROOT, timeout)
+
+    if scene.scene_id == "cornell":
+        device = "gpu" if engine == "astroray-gpu" else "cpu"
+        script = output.with_suffix(".py")
+        script.write_text(_astroray_script(scene, output, device), encoding="utf-8")
+        return _run_command([sys.executable, str(script)], ROOT, timeout)
 
     if astroray is None or not astroray.exists():
         return 0.0, 0.0, "astroray_binary_not_found"
@@ -286,15 +379,22 @@ def _ssim(output: Path, reference: Path) -> str:
         import imageio.v3 as iio  # type: ignore
         from skimage.metrics import structural_similarity  # type: ignore
 
-        a = iio.imread(output).astype("float32")
-        b = iio.imread(reference).astype("float32")
+        import numpy as np  # type: ignore
+
+        a = iio.imread(output).astype("float32")[..., :3]
+        b = iio.imread(reference).astype("float32")[..., :3]
         if a.shape != b.shape:
             return ""
-        if a.max() > 2.0:
-            a /= 255.0
-        if b.max() > 2.0:
-            b /= 255.0
-        value = structural_similarity(a[..., :3], b[..., :3], channel_axis=-1, data_range=1.0)
+        finite = np.concatenate([a[np.isfinite(a)], b[np.isfinite(b)]])
+        if finite.size == 0:
+            return ""
+        lo = 0.0
+        hi = float(np.percentile(finite, 99.9))
+        if hi <= lo:
+            return ""
+        a = np.clip(np.nan_to_num(a, nan=0.0, posinf=hi, neginf=lo), lo, hi)
+        b = np.clip(np.nan_to_num(b, nan=0.0, posinf=hi, neginf=lo), lo, hi)
+        value = structural_similarity(a, b, channel_axis=-1, data_range=hi - lo)
         return f"{value:.6f}"
     except Exception:
         return ""
@@ -309,7 +409,7 @@ def _run_tuple(
     timeout: int,
 ) -> dict[str, str]:
     RESULTS.mkdir(parents=True, exist_ok=True)
-    suffix = ".exr" if engine.startswith("cycles") else ".png"
+    suffix = ".exr"
     with tempfile.TemporaryDirectory(prefix=f"{scene.scene_id}-{engine}-", dir=RESULTS) as tmp:
         tmpdir = Path(tmp)
         warm_output = tmpdir / f"warmup{suffix}"
@@ -334,7 +434,9 @@ def _run_tuple(
             return _row(scene, engine, skip_reason=final_skip)
 
         ref = REFS / f"{scene.scene_id}-{scene.samples}.exr"
-        if engine == "cycles-cpu" and not ref.exists():
+        if engine == "cycles-cpu":
+            ref.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(final_output, ref)
             ssim = "1.000000"
         else:
             ssim = _ssim(final_output, ref)

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,58 @@
+"""Process-wide Astroray runtime bootstrap.
+
+Python imports ``sitecustomize`` automatically during interpreter startup when
+this repository or a copied build directory is on ``sys.path``. On Windows this
+lets the compiled ``astroray`` extension find optional runtime DLLs before the
+extension loader resolves transitive dependencies.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+_DLL_DIRECTORY_HANDLES = []
+
+
+def _candidate_oidn_bins() -> list[str]:
+    candidates: list[str] = []
+    for env_var in ("OIDN_ROOT", "ASTRORAY_OIDN_DIR"):
+        root = os.environ.get(env_var)
+        if root:
+            candidates.append(os.path.join(root, "bin"))
+
+    candidates.extend([
+        r"C:\oidn\bin",
+        r"C:\Program Files\Intel\oidn\bin",
+        r"C:\Program Files\Intel\OpenImageDenoise\bin",
+        r"C:\Program Files\OpenImageDenoise\bin",
+    ])
+    return candidates
+
+
+def _candidate_cuda_bins() -> list[str]:
+    candidates: list[str] = []
+    cuda_path = os.environ.get("CUDA_PATH")
+    if cuda_path:
+        candidates.append(os.path.join(cuda_path, "bin"))
+    candidates.extend([
+        r"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.2\bin",
+        r"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.9\bin",
+        r"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.8\bin",
+        r"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.6\bin",
+    ])
+    return candidates
+
+
+if sys.platform == "win32" and hasattr(os, "add_dll_directory"):
+    _path_additions: list[str] = []
+    for _dll_dir in _candidate_oidn_bins() + _candidate_cuda_bins():
+        if os.path.isdir(_dll_dir):
+            try:
+                _DLL_DIRECTORY_HANDLES.append(os.add_dll_directory(_dll_dir))
+                _path_additions.append(_dll_dir)
+            except (FileNotFoundError, OSError):
+                pass
+    if _path_additions:
+        _current_path = os.environ.get("PATH", "")
+        os.environ["PATH"] = os.pathsep.join(_path_additions + [_current_path])

--- a/tests/runtime_setup.py
+++ b/tests/runtime_setup.py
@@ -15,6 +15,7 @@ DEFAULT_CUDA_BUILD_DIR = PROJECT_ROOT / "build_cuda"
 DEFAULT_TCNN_BUILD_DIR = PROJECT_ROOT / "build_tcnn"
 TEST_RESULTS_DIR = PROJECT_ROOT / "test_results"
 DEFAULT_TEMP_DIR = TEST_RESULTS_DIR / "tmp"
+_DLL_DIRECTORY_HANDLES = []
 
 
 def _unique_existing(paths: list[Path]) -> list[str]:
@@ -157,9 +158,10 @@ def candidate_oidn_dirs(build_dirs: list[str]) -> list[str]:
     env_dir = os.environ.get("OIDN_BIN_DIR")
     if env_dir:
         candidates.append(Path(env_dir))
-    oidn_root = os.environ.get("OIDN_DIR")
-    if oidn_root:
-        candidates.append(Path(oidn_root) / "bin")
+    for env_var in ("OIDN_DIR", "OIDN_ROOT", "ASTRORAY_OIDN_DIR"):
+        oidn_root = os.environ.get(env_var)
+        if oidn_root:
+            candidates.append(Path(oidn_root) / "bin")
 
     for build_dir in build_dirs:
         root = Path(build_dir)
@@ -180,6 +182,7 @@ def candidate_oidn_dirs(build_dirs: list[str]) -> list[str]:
 
     candidates.extend([
         Path(r"C:\oidn\bin"),
+        Path(r"C:\Program Files\Intel\oidn\bin"),
         Path(r"C:\Program Files\Intel\OpenImageDenoise\bin"),
         Path(r"C:\Program Files\OpenImageDenoise\bin"),
     ])
@@ -247,7 +250,7 @@ def configure_test_imports(include_blender_addon: bool = False) -> str:
             + candidate_oidn_dirs(build_dirs)
         )
         for dll_dir in runtime_dirs:
-            os.add_dll_directory(dll_dir)
+            _DLL_DIRECTORY_HANDLES.append(os.add_dll_directory(dll_dir))
         _prepend_path(runtime_dirs)
 
     return build_dirs[0] if build_dirs else str(DEFAULT_BUILD_DIR)


### PR DESCRIPTION
## Summary

Fixes the Windows/CUDA and pkg71 parity blockers found while attempting the first canonical baseline on this Windows + RTX 5070 Ti workstation.

- Fix 1, Windows OptiX build hygiene: current main already carries the canonical `NOMINMAX` guard in `plugins/passes/optix_denoiser.cpp:2` and the future-proof OptiX SDK glob in `cmake/FindOptiX.cmake:33`; this PR verifies both with a clean CUDA build against OptiX 9.1.0.
- Fix 2, OIDN DLL bootstrap: added process-wide Windows bootstrap in `sitecustomize.py:19`, kept DLL directory handles alive in `blender_addon/__init__.py:61`, expanded test/runtime OIDN discovery in `tests/runtime_setup.py:158`, and documented `OIDN_ROOT` / `ASTRORAY_OIDN_DIR` in `docs/QUICKSTART.md:38`.
- Fix 3, pkg71 parity harness: `scripts/run_parity.py:62` now gives subprocesses deterministic Python/DLL env, Cornell now builds matching Diffuse/Emission triangle scenes for Cycles and Astroray via `scripts/run_parity.py:230` and `scripts/run_parity.py:287`, and SSIM is computed on linear EXR data with documented 99.9th-percentile clipping at `scripts/run_parity.py:392` / `benchmarks/cycles-parity/README.md:8`.

## Before / After

Before:
- Astroray rows in the previous smoke CSV skipped with `exit:3221225781` (`0xC0000142`) because `OpenImageDenoise.dll` was not in Python's DLL search path.
- Cornell parity compared Cycles HDR EXR against Astroray gamma/LDR standalone PNG and measured `astroray-cpu = 0.019031` SSIM.
- Clean CUDA configure/build could hit the Windows `max` macro collision in OptiX 9 include paths before the current-main NOMINMAX/glob fix.

After:
- `python -c "import astroray"` succeeds with OIDN removed from `PATH` when `PYTHONPATH=.;build_cuda`.
- Clean `scripts\build\build_cuda.bat` is green and CMake reports `OptiX found: 9.1.0 (C:/ProgramData/NVIDIA Corporation/OptiX SDK 9.1.0/include)` without `-DOPTIX_INSTALL_DIR`.
- Cornell smoke on the clean CUDA build:
  - `cycles-cpu`: `1.000000`
  - `cycles-cuda`: `0.999963`
  - `astroray-cpu`: `0.953596`
  - `astroray-gpu`: `0.954770`

## Validation

- `python -m py_compile sitecustomize.py scripts\run_parity.py scripts\summarize_parity.py tests\runtime_setup.py`
- `scripts\build\build_cuda.bat`
- `PYTHONPATH=.;build_cuda` with OIDN removed from `PATH`: `python -c "import astroray; print(astroray.__features__)"`
- `python scripts\run_parity.py --runs 1 --timeout 900 --scene cornell --output test_results\tmp\pkg71-cornell-final-branch.csv`
- `python scripts\run_parity.py --timeout 3600`

## Baseline Caveats

The full baseline CSV is committed because all Astroray rows that produced output passed the SSIM gate. It is not yet a complete 5-scene Astroray-vs-Cycles baseline:

- Classroom, Junkshop, and BMW27 Cycles rows render, but Astroray rows skip with `astroray_blend_import_not_implemented`.
- Monster fails on the Cycles side with `Cannot render, no camera` for the downloaded `udim-monster.blend`.
- This confirms the next needed sub-task: build/import the parity scene set in Astroray before non-Cornell SSIM can be meaningful.

# Cycles Parity Summary: `2026-05-10-hendrik-desktop-amd64-family-25-model-97-stepping-2-authenticamd-4fa95be.csv`

## Time to Samples (ms)

| Scene | cycles-cpu | cycles-cuda | astroray-cpu | astroray-gpu |
|---|---|---|---|---|
| bmw27 | 138051.651 | 13444.425 | skip: astroray_blend_import_not_implemented | skip: astroray_blend_import_not_implemented |
| classroom | 486451.691 | 31167.653 | skip: astroray_blend_import_not_implemented | skip: astroray_blend_import_not_implemented |
| cornell | 10648.201 | 4182.948 | 15389.610 | 800.741 |
| junkshop | 225573.385 | 30576.592 | skip: astroray_blend_import_not_implemented | skip: astroray_blend_import_not_implemented |
| monster | skip: exit:1 00:01.594  blend            | Read blend: "C:\Users\hgcom\OneDrive\Astroray\Astroray_repo\Astroray\benchmarks\cycles-parity\scenes\cache\monster\UDIM_monster\udim-monster.blend" Traceback (most recent call last):   File "C:\Users\hgcom\OneDrive\Astroray\Astroray_repo\Astroray\benchmarks\cycles-parity\results\monster-cycles-cpu-tryop9cg\warmup.py", line 19, in <module>     bpy.ops.render.render(write_still=True)     ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^ RuntimeError: Error: Cannot render, no camera  Custom Raytracer 3.0.0 loaded Astroray renderer addon registered Error: Cannot render, no camera Astroray renderer addon unregistered Blender 5.1.0 (hash adfe2921d5f3 built 2026-03-17 01:37:32)  Blender quit | skip: exit:1 00:01.625  blend            | Read blend: "C:\Users\hgcom\OneDrive\Astroray\Astroray_repo\Astroray\benchmarks\cycles-parity\scenes\cache\monster\UDIM_monster\udim-monster.blend" Traceback (most recent call last):   File "C:\Users\hgcom\OneDrive\Astroray\Astroray_repo\Astroray\benchmarks\cycles-parity\results\monster-cycles-cuda-gdcuxj3n\warmup.py", line 19, in <module>     bpy.ops.render.render(write_still=True)     ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^ RuntimeError: Error: Cannot render, no camera  Custom Raytracer 3.0.0 loaded Astroray renderer addon registered Error: Cannot render, no camera Astroray renderer addon unregistered Blender 5.1.0 (hash adfe2921d5f3 built 2026-03-17 01:37:32)  Blender quit | skip: astroray_blend_import_not_implemented | skip: astroray_blend_import_not_implemented |

## Peak Resident Memory (MB)

| Scene | cycles-cpu | cycles-cuda | astroray-cpu | astroray-gpu |
|---|---|---|---|---|
| bmw27 | 582.5 | 704.9 | skip: astroray_blend_import_not_implemented | skip: astroray_blend_import_not_implemented |
| classroom | 1506.2 | 1587.0 | skip: astroray_blend_import_not_implemented | skip: astroray_blend_import_not_implemented |
| cornell | 595.3 | 673.8 | 134.9 | 244.5 |
| junkshop | 7096.2 | 8514.3 | skip: astroray_blend_import_not_implemented | skip: astroray_blend_import_not_implemented |
| monster | skip: exit:1 00:01.594  blend            | Read blend: "C:\Users\hgcom\OneDrive\Astroray\Astroray_repo\Astroray\benchmarks\cycles-parity\scenes\cache\monster\UDIM_monster\udim-monster.blend" Traceback (most recent call last):   File "C:\Users\hgcom\OneDrive\Astroray\Astroray_repo\Astroray\benchmarks\cycles-parity\results\monster-cycles-cpu-tryop9cg\warmup.py", line 19, in <module>     bpy.ops.render.render(write_still=True)     ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^ RuntimeError: Error: Cannot render, no camera  Custom Raytracer 3.0.0 loaded Astroray renderer addon registered Error: Cannot render, no camera Astroray renderer addon unregistered Blender 5.1.0 (hash adfe2921d5f3 built 2026-03-17 01:37:32)  Blender quit | skip: exit:1 00:01.625  blend            | Read blend: "C:\Users\hgcom\OneDrive\Astroray\Astroray_repo\Astroray\benchmarks\cycles-parity\scenes\cache\monster\UDIM_monster\udim-monster.blend" Traceback (most recent call last):   File "C:\Users\hgcom\OneDrive\Astroray\Astroray_repo\Astroray\benchmarks\cycles-parity\results\monster-cycles-cuda-gdcuxj3n\warmup.py", line 19, in <module>     bpy.ops.render.render(write_still=True)     ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^ RuntimeError: Error: Cannot render, no camera  Custom Raytracer 3.0.0 loaded Astroray renderer addon registered Error: Cannot render, no camera Astroray renderer addon unregistered Blender 5.1.0 (hash adfe2921d5f3 built 2026-03-17 01:37:32)  Blender quit | skip: astroray_blend_import_not_implemented | skip: astroray_blend_import_not_implemented |

## SSIM to Cycles CPU Reference

| Scene | cycles-cpu | cycles-cuda | astroray-cpu | astroray-gpu |
|---|---|---|---|---|
| bmw27 | 1.000000 | 0.999570 | skip: astroray_blend_import_not_implemented | skip: astroray_blend_import_not_implemented |
| classroom | 1.000000 | 0.998390 | skip: astroray_blend_import_not_implemented | skip: astroray_blend_import_not_implemented |
| cornell | 1.000000 | 0.999963 | 0.953596 | 0.954770 |
| junkshop | 1.000000 | 0.999686 | skip: astroray_blend_import_not_implemented | skip: astroray_blend_import_not_implemented |
| monster | skip: exit:1 00:01.594  blend            | Read blend: "C:\Users\hgcom\OneDrive\Astroray\Astroray_repo\Astroray\benchmarks\cycles-parity\scenes\cache\monster\UDIM_monster\udim-monster.blend" Traceback (most recent call last):   File "C:\Users\hgcom\OneDrive\Astroray\Astroray_repo\Astroray\benchmarks\cycles-parity\results\monster-cycles-cpu-tryop9cg\warmup.py", line 19, in <module>     bpy.ops.render.render(write_still=True)     ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^ RuntimeError: Error: Cannot render, no camera  Custom Raytracer 3.0.0 loaded Astroray renderer addon registered Error: Cannot render, no camera Astroray renderer addon unregistered Blender 5.1.0 (hash adfe2921d5f3 built 2026-03-17 01:37:32)  Blender quit | skip: exit:1 00:01.625  blend            | Read blend: "C:\Users\hgcom\OneDrive\Astroray\Astroray_repo\Astroray\benchmarks\cycles-parity\scenes\cache\monster\UDIM_monster\udim-monster.blend" Traceback (most recent call last):   File "C:\Users\hgcom\OneDrive\Astroray\Astroray_repo\Astroray\benchmarks\cycles-parity\results\monster-cycles-cuda-gdcuxj3n\warmup.py", line 19, in <module>     bpy.ops.render.render(write_still=True)     ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^ RuntimeError: Error: Cannot render, no camera  Custom Raytracer 3.0.0 loaded Astroray renderer addon registered Error: Cannot render, no camera Astroray renderer addon unregistered Blender 5.1.0 (hash adfe2921d5f3 built 2026-03-17 01:37:32)  Blender quit | skip: astroray_blend_import_not_implemented | skip: astroray_blend_import_not_implemented |

## Scene Attribution

- Junkshop by Alex Trevino, CC-BY-4.0, Blender Foundation demo files
- BMW27 by Mike Pan, CC-BY-3.0, https://download.blender.org/demo/test/BMW27.blend.zip
