### PR TITLE
verify(pkg75): post-pkg75 pkg68/pkg70 re-baseline

### DIFF
--- a/.astroray_plan/packages/pkg68-oidn-architectural-fix.md
+++ b/.astroray_plan/packages/pkg68-oidn-architectural-fix.md
@@ -179,3 +179,27 @@ write). The 2.57× speedup baseline can be re-measured against the
 true HDR+albedo+normal AOV path; the previous number was bound to
 HDR+albedo only because the normal guide was a zero buffer.
 Re-baseline pending the next verifier session with CUDA online.
+
+### Post-pkg75 OIDN A/B baseline (2026-05-10, RTX 5070 Ti, same harness)
+
+Cornell-style 256×256, spp=2, max_depth=3, N=100, warmup=3, persistent
+`Renderer`, on a clean rebuild at `c96dad8` (pkg75 landed) with
+OptiX 9.1.0 + OIDN 2.4.1:
+
+| Build | OIDN-on | OIDN-off | OIDN delta | vs pre-pkg68 |
+|---|---|---|---|---|
+| pre-pkg68 (`c934bdf`) | 130.01 ms/frame | 23.52 ms/frame | 106.49 ms | 1.00× |
+| post-pkg68 (`1253894`) | 50.67 ms/frame | 23.81 ms/frame | 26.86 ms | **2.57×** |
+| post-pkg68 + pkg75 (`c96dad8`) | **46.98 ms/frame** | 26.21 ms/frame | **20.77 ms** | **2.77×** |
+
+Comparison vs the 2026-05-10 baseline shows **lower per-frame OIDN
+cost** (50.67 → 46.98 ms, **−7.3 %**) AND a smaller OIDN-pass-only
+delta (26.86 → 20.77 ms, **−23 %**). The pkg68 win-vs-pre-pkg68
+strengthens from 2.57× to **2.77×**.
+
+The OIDN-off baseline grew from 23.81 → 26.21 ms (+10 %) — that is
+the inner-loop cost of pkg75's first-hit shading-normal write per
+primary ray hit. Net effect on the user-facing OIDN-on path is
+favorable (the denoiser saves more than the integrator spends);
+on the no-denoiser path, pkg75 adds a small fixed cost in exchange
+for correct AOV semantics everywhere.

--- a/.astroray_plan/packages/pkg70-optix-denoiser-backend.md
+++ b/.astroray_plan/packages/pkg70-optix-denoiser-backend.md
@@ -300,4 +300,37 @@ against an all-zero normal guide — OptiX AOV mode was effectively
 running HDR+albedo only. With real unit-length world-space normals
 now feeding both `OptixDenoiserGuideLayer::normal` and OIDN's normal
 input, the 5.31× / 5.58× ratios are a conservative floor.
-Re-baseline pending verifier session 3.5 (CUDA + OptiX online).
+
+### Post-pkg75 re-baseline (2026-05-10, RTX 5070 Ti, OptiX 9.1.0)
+
+Clean rebuild at `c96dad8`; same fixtures, same harness:
+
+| Measurement | pre-pkg75 | post-pkg75 | Δ |
+|---|---|---|---|
+| **Synthetic noise reduction @ 256×256, spp=2** | | | |
+| OptiX ratio | 5.31× | **5.55×** | **+4.5 %** ✅ |
+| OIDN ratio | 5.58× | **5.45×** | −2.3 % (metric artifact, see below) |
+| **1080p parity-scene timing (spp=2, max_depth=3, N=10, warmup=2)** | | | |
+| OptiX | 728.94 ms/frame | **792.18 ms/frame** | +8.6 % slower |
+| OIDN-CUDA | 1356.09 ms/frame | **1403.74 ms/frame** | +3.5 % slower |
+| OIDN/OptiX speedup | 1.86× | **1.77×** | still well above ≥1.5× gate |
+| **SSIM(OptiX, OIDN) @ 1080p spp=16** | 0.9987 | **0.9987** | unchanged ✅ |
+
+Visual diff confirms detail preservation: an amplified-4× absolute
+difference between the pre-pkg75 and post-pkg75 OIDN-denoised
+outputs of `tests/test_oidn_denoiser.py::test_oidn_reduces_variance`
+(saved to `test_results/oidn_before_after.png` on each run) is
+**black everywhere except along geometry edges** — sphere silhouette,
+wall corners, ceiling-light boundary, floor/wall meet line. Mean
+abs-diff in the denoised half = 0.39/255; max = 15/255 (~6 %). The
+noise-ratio metric drops because the 3×3 sliding-window local-variance
+estimator reads preserved edge detail as "unreduced noise"; SSIM
+unchanged supports the detail-preservation reading.
+
+The 1080p timing regressions (and the OIDN-off Cornell baseline going
+23.81 → 26.21 ms, +10 %) are the inner-loop cost of pkg75's per-primary-hit
+shading-normal write. The OIDN-on path still nets a win
+(see pkg68 Lessons: 50.67 → 46.98 ms, −7.3 %) because the denoiser
+saves more than the integrator spends. OptiX gate margins are now
+1.77× (target 1.5×), 5.55× (target 5×), 0.9987 (target 0.95) —
+all comfortably green.


### PR DESCRIPTION
Re-baseline of the pkg68 OIDN A/B speedup and the pkg70 OptiX gates
on a clean rebuild at \`c96dad8\` (pkg75 merged), RTX 5070 Ti +
OptiX 9.1.0, Windows MSVC \`build_cuda\`. Doc-only PR — only updates
to the Lessons sections of pkg68 and pkg70 specs.

## Test sweep — 19/19 green

\`tests/test_oidn_denoiser_persistence.py + test_oidn_denoiser.py + test_optix_denoiser.py + test_aov_passes.py + test_normal_buffer_populated.py\` (the last is new from pkg75).

Sanity: \`r.get_normal_buffer()\` at 256×256 reports **18684/65536 nonzero pixels with mean ‖n‖ = 1.0000** across hits — pkg75's first-hit shading-normal write is live on the default \`Renderer\` path.

## pkg68 OIDN A/B re-baseline (Cornell 256×256, spp=2 max_depth=3, N=100, warmup=3)

| Build | OIDN-on | OIDN-off | OIDN delta | vs pre-pkg68 |
|---|---|---|---|---|
| pre-pkg68 (\`c934bdf\`) | 130.01 ms/frame | 23.52 ms/frame | 106.49 ms | 1.00× |
| post-pkg68 (\`1253894\`) | 50.67 ms/frame | 23.81 ms/frame | 26.86 ms | 2.57× |
| **post-pkg68 + pkg75 (\`c96dad8\`)** | **46.98 ms/frame** | 26.21 ms/frame | **20.77 ms** | **2.77×** |

OIDN-on **−7.3 %** (50.67 → 46.98 ms); OIDN-pass-only delta **−23 %** (26.86 → 20.77 ms); OIDN-off baseline **+10 %** (23.81 → 26.21 ms — the inner-loop cost of pkg75's per-primary-hit shading-normal write). **Net OIDN-on win: pkg68 vs pre-pkg68 strengthens 2.57× → 2.77×.**

## pkg70 synthetic-noise gate re-measurement at 256×256

| | pre-pkg75 | post-pkg75 | Δ |
|---|---|---|---|
| OptiX | 5.31× | **5.55×** | **+4.5 %** ✅ (gate ≥5×) |
| OIDN | 5.58× | **5.45×** | −2.3 % (metric artifact, see visual diff) |

## pkg70 OptiX vs OIDN-CUDA at 1080p (parity scene, spp=2 max_depth=3, N=10 warmup=2)

| | pre-pkg75 | post-pkg75 |
|---|---|---|
| OptiX | 728.94 ms/frame | **792.18 ms/frame** (+8.6 % slower) |
| OIDN-CUDA | 1356.09 ms/frame | **1403.74 ms/frame** (+3.5 % slower) |
| OIDN/OptiX speedup | 1.86× | **1.77×** (still well above ≥1.5× gate) |
| SSIM(OptiX, OIDN) @ spp=16 | 0.9987 | **0.9987** (unchanged) |

Both 1080p denoiser timings regressed 3–9 % — same inner-loop pkg75 cost, just measured at higher resolution. **All gates still pass comfortably**: 1.77× (≥1.5×), 5.55× (≥5×), 0.9987 (≥0.95).

## Visual diff: option (i) confirmed — detail preservation, not degradation

Comparison generated by re-running \`test_oidn_reduces_variance\` against a throwaway worktree at \`c96dad8^\` (pre-pkg75, fast-forward of \`fcbbbf2\`) and stacking the resulting \`test_results/oidn_before_after.png\` files.

**The amplified-4× absolute difference is the smoking gun:** it's BLACK EVERYWHERE except along geometry edges — sphere silhouette, wall corners, ceiling-light boundary, floor/wall meet line. The integrator's color output (left half of each PNG) is bit-identical pre/post pkg75 (pkg75 only added a buffer write, no color path change). Differences live exclusively in the OIDN-denoised half, exclusively at edges.

Mean abs-diff in the denoised half = **0.39/255**; max = **15/255 (~6 %)**. Eye-level: the two side-by-side denoised images are essentially indistinguishable.

The 3×3 sliding-window local-variance estimator reads preserved edge detail as "unreduced noise" — that's why the OIDN ratio metric drops 5.58× → 5.45× while perceptual quality is at-least-as-good. SSIM(OptiX, OIDN) unchanged at 0.9987 supports the detail-preservation reading: both denoisers improved comparably, so their agreement is identical.

## What this PR contains

- \`.astroray_plan/packages/pkg68-oidn-architectural-fix.md\` — Lessons appended: full post-pkg75 OIDN A/B baseline table; explains the OIDN-off cost and why the OIDN-on path nets a win.
- \`.astroray_plan/packages/pkg70-optix-denoiser-backend.md\` — Lessons appended: full post-pkg75 re-baseline table for synthetic-noise + 1080p timing + SSIM; visual-diff finding.

## Constraints honored

- No implementation code touched.
- No spec edits beyond the two Lessons sections.
- pkg75 is **not** promoted here (its merge already did that).
- No gate relaxed.
- Not pushed to main; not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)