### PR TITLE
docs: Round 4 NEXT_STAGE_REPORT + STATUS/ROADMAP audit

### DIFF
--- a/.astroray_plan/docs/NEXT_STAGE_REPORT.md
+++ b/.astroray_plan/docs/NEXT_STAGE_REPORT.md
@@ -1,549 +1,631 @@
 # Astroray Next Stage Report
 
-**Date:** 2026-05-10 (post-Round-2 — pkg64-1, pkg56-A, pkg74-1, pkg70 verify, pkg72/73/75 specs all landed)
+**Date:** 2026-05-10 (post-Round-3 — pkg72 + pkg64-2 + pkg74-2 + pkg75 + pkg75-rebaseline all landed)
 **Prepared by:** Claude (Anthropic Code, Sonnet 4.5 in Max 5x)
-**Scope:** prompts for Round 3, to be launched once the in-flight Codex
-pkg71-canonical-baseline PR lands. Round 3 focuses on closing the
-denoiser story (pkg75 normal-guide fix, then pkg72 motion vectors
-unlocking pkg73 OptiX temporal mode), keeping pkg64 + pkg74 + pkg56
-moving through their phases, and re-baselining pkg68/pkg70 once
-pkg75 corrects the AOV-mode floor.
+**Scope:** Round 4 prompts. Round 4 closes the OIDN/OptiX denoiser story
+end-to-end (pkg73 OptiX temporal mode), drives pkg56 incremental scene
+sync into Phase B (uploadScene split), folds pkg64 SMS into the default
+path tracer (Phase 3), polishes pkg74 into a CI-running showcase
+(Phase 3), formally specs the Astroray .blend importer (pkg76) so non-
+Cornell pkg71 rows can produce parity numbers, and re-baselines pkg72
+on hardware.
 
 > Strategic gate (unchanged): Pillar 4 (astrophysics) remains parked.
 > Focus is locking in Blender integration + measured parity + perf.
 > Strategy in [`ROADMAP.md`](ROADMAP.md), status in [`STATUS.md`](STATUS.md).
+>
+> The gate's release condition is now visible: pkg56 Phases B+C and
+> pkg64 Phase 3 are the last big Pillar 5 implementations. Once those
+> land, Pillar 4 thaws.
 
 ---
 
 ## 1. Current state (one screen)
 
-**Done since the previous report:**
+**Done since the previous report (Round 3):**
 
-- pkg70 OptiX denoiser verified on RTX 5070 Ti + OptiX 9.1.0 — 5.31×
-  synthetic-noise reduction at 256×256, 1.86× faster than OIDN-CUDA
-  at 1080p, SSIM 0.9987 vs OIDN. PR #216.
-- pkg64 Phase 1 (SMS skeleton) shipped — Mitsuba 2 BSD-3 reference
-  ported as opt-in `sms_caustic_path_tracer` integrator. Phase 2
-  (spectral wavelength-Newton from Hanika 2015) and Phase 3 (default-
-  integrator fold) are queued. PR #212.
-- pkg56 Phase A (viewport sync instrumentation) shipped — measured
-  baseline 129.92 ms/frame on a 100k-tri scene (geometry 77.68 ms,
-  render 51.73 ms). Phase B and C will optimize against these
-  numbers. PR #210.
-- pkg74 Phase 1 (engine showcase framework) shipped — material zoo
-  + convergence grid + RMSE-vs-spp curve + HTML index. Phase 2
-  (full stat coverage) and Phase 3 (CI integration) queued. PR #214.
-- pkg72 (motion vector AOV) + pkg73 (OptiX temporal denoiser) specs
-  filed — implementation pickups ready. PR #209.
-- pkg75 (first-hit normal-buffer population for AOV guides) spec
-  filed during pkg70 verification. **The defect is real and is the
-  priority pickup of Round 3** — both pkg68 (OIDN AOV) and pkg70
-  (OptiX AOV) silently degrade to HDR+albedo without it.
-- Build hygiene fixes: pkg70 NOMINMAX guard + FindOptiX glob for
-  OptiX 9.x via PR #215. README + QUICKSTART + CMake configure log
-  all now document OptiX as an optional GPU prerequisite (PR #213).
+- **pkg75** AOV normal-guide defect fixed and verified — root cause was
+  one-line missing `r.normal = rec.normal` in
+  `plugins/integrators/spectral_path_tracer.cpp::sampleFull`. Visual diff
+  confirmed detail preservation (the OIDN noise-ratio metric drop was
+  edge-detail picked up by the variance estimator, not real degradation).
+  PR #219 + #223 (re-baseline). **Headline pkg68 win up 2.57× → 2.77×**;
+  OIDN-pass-only delta **−23%**.
+- **pkg72** per-pixel motion vector AOV landed — camera-only screen-space
+  flow, OptiX prev→curr convention, `Renderer.get_motion_buffer()`
+  zero-copy NumPy view, `motion_vector_aov` visualisation pass. **Unblocks
+  pkg73**. PR #220.
+- **pkg64 Phase 2** spectral wavelength-Newton — Hanika 2015 §4 math
+  (Cycles MNEE GPL fence held). PSNR delta **+8.83 dB** at equal sample
+  count vs Phase 1 RGB-only; runtime **0.98×** (faster, not slower).
+  Behind `spectral_newton` opt-in param so Phase 1 regression baseline
+  is bit-identical. PR #221.
+- **pkg74 Phase 2** full stat coverage — 8 categories per research
+  catalog (geometry, memory, timing, sampling, quality, spectral, GPU,
+  integrator-specific). Convergence rate slope **−0.453** (vs MC target
+  −0.5). New `integrator_compare` scene + bar-chart timing artefact.
+  PR #222.
+- **pkg71 first canonical Cornell baseline** — Astroray-CPU SSIM
+  **0.9536**, Astroray-GPU SSIM **0.9548** vs Cycles-CPU EXR reference;
+  Astroray-GPU **5.2× faster than Cycles-CUDA** at the same Cornell
+  sample budget; Astroray uses **3-4× less memory** than Cycles. **First
+  measured Astroray vs Cycles parity datapoint we have ever shipped.**
+  PR #218.
+- Build hygiene: pkg70 Windows OptiX build (NOMINMAX + FindOptiX glob),
+  OIDN DLL bootstrap (`sitecustomize.py` + addon DLL handle keep-alive +
+  test runtime expansion + harness subprocess env), and Cornell harness
+  parity (matching tri-scene on both engines, EXR-vs-EXR SSIM with
+  99.9th percentile clipping). PRs #213 + #215 + #218.
 
-**In flight (do NOT spawn Round 3 sessions until this lands):**
-
-- **Codex pkg71-canonical-baseline** — running on
-  `codex/pkg71-first-canonical-baseline`. The big multi-fix PR per
-  the previous direction: NOMINMAX (already separately landed via
-  #215), OIDN DLL bootstrap on Windows, harness parity (Cycles EXR
-  reference vs Astroray EXR output, not gamma'd PNG vs HDR EXR), and
-  the canonical first-baseline CSV across all 5 scenes. Slow because
-  it's actually rendering a 5-scene × 4-engine × 3-runs matrix. May
-  take hours. Will land as a single PR.
-
-**Open Pillar 5 (the Round 3 + Round 4 pickup pool):**
+**Open Pillar 5 (the Round 4 + Round 5 pickup pool):**
 
 | Pkg | Title | Effort | Status |
 |---|---|---|---|
-| **pkg75** | First-hit normal buffer for AOV guides | 2–3 days | Spec filed; **highest priority of Round 3** |
-| **pkg72** | Motion vector AOV | ~3 days | Spec filed; standalone; unblocks pkg73 |
-| **pkg73** | OptiX temporal denoiser (AOV+motion) | ~3–4 days | Spec filed; depends on pkg72 |
-| **pkg64** Phase 2 | Spectral wavelength-Newton (Hanika 2015) | ~1.5 weeks | Phase 1 landed |
-| **pkg64** Phase 3 | Fold SMS into default path_tracer | ~½ week | Phase 2 first |
-| **pkg56** Phase B | uploadScene split into incremental uploaders | ~2 weeks | Phase A baseline measured |
-| **pkg56** Phase C | depsgraph-driven dispatch | ~2–3 weeks | Phase B first |
-| **pkg74** Phase 2 | Full stat coverage (BVH, GPU, integrator-specific) | ~1 week | Phase 1 framework in place |
-| **pkg74** Phase 3 | Interactive HTML dashboard + weekly CI | ~3 days | Phase 2 first |
-| pkg55 | Wavefront SoA GPU refactor | 8–12 weeks (3 phases) | Deferred until pkg56 + pkg64 land for measured baselines |
+| **pkg73** | OptiX temporal denoiser (AOV + motion mode) | 3–4 days | Spec filed, **unblocked** by pkg72 |
+| **pkg56** Phase B | uploadScene split into incremental uploaders | ~2 weeks | Phase A baseline measured (129.92 ms) |
+| **pkg56** Phase C | depsgraph-driven dispatch | ~2–3 weeks | After Phase B |
+| **pkg64** Phase 3 | Fold SMS into default path_tracer | ~½ week | Phases 1 + 2 done |
+| **pkg74** Phase 3 | Interactive HTML dashboard + weekly CI | ~3 days | Phases 1 + 2 done |
+| **pkg76** (new) | Astroray .blend importer (parity scope) | spec → ~1–2 weeks impl | Surfaced by pkg71 baseline run; specs need filing |
+| pkg77 (new, tiny) | Replace UDIM monster source / drop from set | ½ day | Surfaced by pkg71 baseline run |
+| pkg55 | Wavefront SoA GPU refactor | 8–12 weeks (3 phases) | Deferred until pkg56 + pkg64 land |
+| pkg67 | Metric-aware path tracer | ~1 month | Research-blocked (Pillar-4-coupled; revisit when astrophysics thaws) |
+
+**Pillar 4 (still parked):** pkg40 Kerr metric done; pkg41 Kerr
+validation ready; pkg42–51 Codex-paste-ready specs waiting. **Do NOT
+spawn Pillar 4 sessions in Round 4.** The gate releases when pkg56 +
+pkg64 fully land.
 
 ---
 
-## 2. Recommended next deployable set (Round 3, post-Codex-pkg71)
+## 2. Recommended next deployable set (Round 4)
 
-Five sessions, all parallel-safe:
+Six sessions, all parallel-safe:
 
 | # | Agent | Worktree / location | Package | Effort |
 |---|---|---|---|---|
-| 1 | Claude tech | `pkg75-normal-buffer` (new) | pkg75 — fix the AOV normal-guide defect that silently degrades pkg68 + pkg70 | 2–3 days |
-| 2 | Codex | main directory | pkg72 motion vector AOV | ~3 days |
-| 3 | Claude tech | `pkg64-phase-2` (new) | pkg64 Phase 2 — spectral wavelength-Newton (Hanika 2015) on top of Phase 1 SMS skeleton | ~1.5 weeks |
-| 4 | Claude tech | `pkg74-phase-2` (new) | pkg74 Phase 2 — full stat coverage (BVH stats, GPU rows, integrator-specific stats) on top of Phase 1 framework | ~1 week |
-| 5 | CUDA verifier | hardware (after #1 lands) | re-run pkg68 + pkg70 baselines to capture the AOV-mode improvement that pkg75 unlocks | ~½ day |
+| 1 | Claude tech | `pkg73-optix-temporal` (new) | pkg73 OptiX temporal denoiser (depends on landed pkg72) | 3–4 days |
+| 2 | Claude tech | `pkg56-phase-b` (new) | pkg56 Phase B — split `uploadScene` into per-domain incremental uploaders | ~2 weeks |
+| 3 | Codex | main directory | pkg64 Phase 3 — fold SMS into default `path_tracer` as an MIS strategy gated by `use_refractive_caustics` / `use_reflective_caustics` | ~½ week |
+| 4 | Codex (after #3 lands) | main directory | pkg74 Phase 3 — interactive HTML dashboard + weekly self-hosted CI workflow | ~3 days |
+| 5 | CUDA verifier | hardware | re-baseline pkg72 motion-vector tests + pkg64 Phase 2 spectral SMS PSNR on RTX | ~1 hour |
+| 6 | Claude research | `research-pkg76` (new) | spec **pkg76 Astroray .blend importer (parity-scope only)** — unblocks Classroom / Junkshop / BMW27 / Monster pkg71 rows | ~½ day |
 
-Session 5 only spawns AFTER session 1 lands (pkg75 is its prerequisite).
-Sessions 1–4 all spawn at once. Session 5 may be batched with the next
-round's verifier work; not a blocker.
+Sessions 1, 2, 5, 6 spawn at once. Session 3 starts immediately;
+session 4 follows 3 because Codex serializes in the main directory.
 
-After Round 3 lands:
+Round 4 closes when:
+- pkg73 verified (eliminates viewport boiling on temporal mode)
+- pkg56 Phase B merged (uploadScene split shipped)
+- pkg64 Phase 3 merged (caustics on by default through MIS)
+- pkg74 Phase 3 merged (showcase has interactive HTML + weekly CI run)
+- pkg76 spec written (next round can implement)
 
-- **Round 4** can pick up pkg73 (depends on pkg72), pkg56 Phase B,
-  pkg64 Phase 3, pkg74 Phase 3 — at which point Pillar 5 is mostly
-  done.
-- Then pkg55 wavefront refactor (the big architectural pivot) and
-  Pillar 4 thaws.
+Then **Round 5** picks up: pkg56 Phase C (depsgraph dispatch), pkg76
+implementation, and pkg55 Phase A (wavefront refactor instrumentation —
+the big architectural pivot starts).
 
 ---
 
 ## 3. Drop-in prompts per agent
 
-### 3.1 Claude tech (worktree `pkg75-normal-buffer`) — fix the AOV normal-guide defect
+### 3.1 Claude tech (worktree `pkg73-optix-temporal`) — OptiX temporal denoiser
 
 ```
-You are Claude Code in worktree .claude/worktrees/pkg75-normal-buffer,
-branched from current main. Implement pkg75 end to end.
+You are Claude Code in worktree .claude/worktrees/pkg73-optix-temporal,
+branched from current main. Implement pkg73 end to end. pkg72 motion
+vectors landed in PR #220 — `Camera::motionBuffer` is populated for
+every primary ray and accessible via `Renderer.get_motion_buffer()`.
 
 Read first:
-  - .astroray_plan/packages/pkg75-integrator-normal-guide-aov.md
-    (the spec)
-  - include/raytracer.h — search for `Camera::albedoBuffer` (the
-    correct precedent). normalBuffer is allocated alongside it
-    around line 1653-1654 but never written by the default render
-    loop. The one in-tree write site is around line 2451-2452 in
-    a spectral integrator branch that the canonical color path
-    doesn't reach.
-  - plugins/passes/normal_aov.cpp — confirm what shape it expects
-    in the buffer (world-space vs shading vs camera-space normals)
-  - plugins/passes/oidn_denoiser.cpp — confirm how OIDN AOV mode
-    binds the normal guide buffer. Same for plugins/passes/optix_denoiser.cpp.
+  - .astroray_plan/packages/pkg73-optix-temporal-denoiser.md (the spec)
+  - plugins/passes/optix_denoiser.cpp (the pkg70 OptiX denoiser this
+    extends — same shape: persistent OptixDeviceContext + handle,
+    lazy init, model-kind selection by guide presence)
+  - include/raytracer.h — `Camera::motionBuffer` (float2/pixel,
+    OptiX prev→curr convention) and `Camera::snapshotForMotion()`
+  - tests/test_motion_vector_aov.py — the contract pkg72 established
 
-Why this matters: pkg70 verification 2026-05-10 found that
-fb.hasBuffer("normal") returns true so both OIDN AOV mode and OptiX
-AOV mode bind the buffer as a guide image — but the data they
-upload is all-zeros. AOV mode is silently degrading to HDR+albedo
-on every scene at every resolution. Fixing this lifts the floor on
-pkg68 (measured 2.57× speedup is conservative) and pkg70 (5.31×
-synthetic-noise reduction is conservative).
+Phase 73 goal: extend OptiXDenoiser to upgrade to
+OPTIX_DENOISER_MODEL_KIND_TEMPORAL_AOV when both motion + albedo +
+normal guides are present. Falls back cleanly to AOV (pkg70) when
+motion is absent.
 
-Implementation:
+Reference (Apache-2.0, mirrorable):
+  - intern/cycles/device/optix/device_impl.cpp in the Blender
+    repository — Cycles' OptiX temporal denoiser. Search for
+    "Temporal" + the previous-output-buffer caching pattern.
+  - https://raytracing-docs.nvidia.com/optix9/guide/index.html#ai_denoiser
+    Section on TEMPORAL_AOV model kind. Read fully — temporal mode
+    needs previous-output buffer + motion vectors + careful model-
+    kind transition (destroy-and-recreate denoiser handle when
+    flipping modes).
 
-  1. Find the canonical write site for albedoBuffer in the default
-     render loop — probably around the same point where the
-     primary-ray hit record produces albedo (raytracer.h render
-     dispatch). The write should happen for every primary ray
-     that hits geometry.
+Implementation outline:
 
-  2. Add the matching normalBuffer write at the same point. Use
-     the SHADING normal (world-space) by default — that's what
-     OIDN's docs recommend and what Cycles uses for its
-     PASS_NORMAL output. Cite Cycles' intern/cycles/integrator/pass.cpp
-     PASS_NORMAL semantics in a code comment per CLAUDE.md §6.
-
-     For pixels that miss all geometry (env hit), write Vec3(0)
-     or the env-direction as the normal? Check what OIDN expects
-     for misses. If it expects 0, that matches today's behavior;
-     if it expects something else, document the choice.
-
-  3. Verify the normal_aov pass plugin still produces correct
-     output (no regression — the pass just exposes the buffer
-     to Blender). If normal_aov was the existing populator in
-     a different code path, refactor so the population happens
-     in one place and normal_aov reads it.
-
-Tests:
-
-  - tests/test_normal_buffer_populated.py — new test:
-    render a Cornell scene, assert get_normal_buffer() at every
-    geometry-hit pixel has |normal| ≈ 1.0 within 0.01. At
-    background pixels assert the documented choice (0 or
-    env-direction).
-
-  - tests/test_oidn_denoiser_aov_uses_guides.py — new test (or
-    extend test_oidn_denoiser_persistence.py): render the
-    same scene WITHOUT pkg75 normals (use a synthetic zero
-    buffer override if exposed via test hook, otherwise
-    compare to previous-baseline numbers) and WITH pkg75
-    normals. The OIDN-with-real-normals output should have
-    visibly tighter noise reduction than OIDN-with-zero-normals.
-
-  - Re-run tests/test_optix_denoiser.py at 256×256 — confirm
-    the synthetic noise reduction ratio improves from the
-    pkg70-verified 5.31× to something measurably higher.
-    Record both numbers in pkg75 Lessons.
-
-  - tests/test_aov_passes.py — make sure the existing normal
-    AOV pass still exposes the correct values to Blender.
-    No regression.
+  1. plugins/passes/optix_denoiser.cpp — extend OptiXDenoiser:
+     - Detect motion buffer at execute() time:
+       hasMotion = fb.hasBuffer("motion") &&
+                   anyNonzeroMotion(fb.buffer("motion"))
+       (Don't upgrade to temporal mode for static cameras —
+       previous-output buffer adds memory/latency for no win.)
+     - When hasMotion + hasAlbedo + hasNormal: select model kind
+       OPTIX_DENOISER_MODEL_KIND_TEMPORAL_AOV.
+     - Cache previous-frame OUTPUT (denoised color) in a CUDA
+       device buffer. First frame: zero buffer (or skip the
+       temporal blend; OptiX docs cover this).
+     - Model-kind transitions (HDR ↔ AOV ↔ TEMPORAL_AOV) require
+       optixDenoiserDestroy + recreate. Implement clean handle
+       lifecycle.
+  2. tests/test_optix_temporal_denoiser.py — new:
+     - Skip if OptiX SDK or CUDA unavailable.
+     - Render scene at frame 1 with camera at A; render frame 2
+       with camera panned; verify motion buffer non-zero, OptiX
+       denoiser entered TEMPORAL_AOV mode (printf check via
+       captured stdout, mirroring pkg68 pattern).
+     - Inter-frame pixel variance: render a 10-frame camera-pan,
+       compare pkg73 (TEMPORAL_AOV) vs pkg70 (AOV) on the same
+       sequence. Acceptance: ≥30% reduction in inter-frame pixel
+       variance per pkg73 spec.
 
 Constraints:
   - CLAUDE.md sections 2, 3, 6.
-  - Surgical: ONLY the canonical render loop's normal-buffer
-    write + tests. Do NOT touch denoiser plugins, do NOT
-    refactor the Camera buffer ABI.
-  - Cite Cycles PASS_NORMAL semantics in the new code site.
-  - You probably will not have CUDA at the implementation
-    site; the OptiX/OIDN-CUDA improvement gates will skip
-    cleanly. Mark in PR body: "CUDA + OptiX improvement
-    re-baselines pending verifier session 3.5."
+  - DO NOT consult Cycles MNEE source — wrong concern; OptiX
+    temporal denoiser code in intern/cycles/device/optix/ is the
+    relevant reference and is Apache-2.0 (mirrorable with
+    citation).
+  - DO NOT modify pkg70's OIDN denoiser — OIDN has no analog of
+    OptiX TEMPORAL_AOV (OIDN's color1 prev-frame input was an
+    earlier confusion; pkg68 design decision #4 resolved it).
+  - Static-camera scenes must NOT pay the memory cost of a
+    previous-output buffer — fall back to AOV mode cleanly.
+  - Without OptiX SDK: implementer's tests skip, mark in PR body
+    "OptiX SDK + CUDA verification pending verifier session."
 
 When done:
-  - pkg75 spec status -> done.
-  - STATUS.md: pkg75 row updated.
-  - Add brief note to pkg68 Lessons: "AOV normals now live
-    courtesy of pkg75; the 2.57× speedup baseline can be
-    re-measured."
-  - Add brief note to pkg70 Lessons: same shape, plus the
-    new synthetic-noise reduction number once the test gives
-    it.
+  - pkg73 spec status -> "implemented (pending CUDA + OptiX
+    verification)".
+  - STATUS.md: pkg73 row updated.
+  - Append note to pkg72 Lessons: "Consumed by pkg73 OptiX
+    temporal denoiser as designed."
   - Commit on this branch:
-      feat(pkg75): populate first-hit normal buffer for AOV
-      denoiser guides — restores AOV mode for OIDN + OptiX
+      feat(pkg73): OptiX TEMPORAL_AOV denoiser mode
+      (motion-aware viewport stability)
   - PR. DO NOT merge.
 ```
 
-### 3.2 Codex (main directory) — pkg72 motion vector AOV
+### 3.2 Claude tech (worktree `pkg56-phase-b`) — uploadScene split
 
 ```
-The Codex pkg71-canonical-baseline session must be done before
-spawning this. Implement pkg72 motion vectors end to end.
+You are Claude Code in worktree .claude/worktrees/pkg56-phase-b,
+branched from current main. Implement pkg56 Phase B only. Phase A
+(viewport sync instrumentation) landed PR #210 with measured
+baseline 129.92 ms/frame on a 100k-tri scene. Phase C (depsgraph-
+driven dispatch) is a separate package.
 
 Read first:
-  - .astroray_plan/packages/pkg72-motion-vectors.md (the spec)
-  - .astroray_plan/docs/motion-vectors-research.md (the research
-    note that backs the spec)
-  - include/raytracer.h — find the Camera class and the render
-    loop. You will add a Camera::motionBuffer alongside
-    albedoBuffer + normalBuffer (which after pkg75 will both
-    be populated correctly).
-  - plugins/passes/normal_aov.cpp — the AOV plugin pattern
-    you mirror for motion_vector_aov.
+  - .astroray_plan/packages/pkg56-incremental-scene-sync.md
+    (the spec — Phase B section)
+  - .astroray_plan/docs/blender-depsgraph-sync-research.md
+    (signed-off research, especially BlenderSync's per-domain
+    upload pattern)
+  - module/blender_module.cpp — find uploadScene + the per-domain
+    helpers it calls (geometry, materials, lights, environment).
+    Currently they all run together as a unit even when only one
+    has changed.
+  - blender_addon/__init__.py _sync_viewport_scene — the call
+    site that always invokes the full upload.
+  - The pkg56-A ring buffer in module/blender_module.cpp shows
+    the per-stage cost breakdown — that's exactly what Phase B
+    optimizes.
 
-Why this matters: pkg73 OptiX temporal denoiser depends on per-
-pixel motion vectors. Without them, the denoiser cannot upgrade
-to OPTIX_DENOISER_MODEL_KIND_TEMPORAL_AOV mode and viewport
-animation continues to suffer from frame-to-frame boiling.
-pkg72 unblocks pkg73.
+Phase B goal: refactor uploadScene from a monolithic call into
+per-domain incremental uploaders, WITHOUT yet wiring depsgraph
+dispatch (Phase C). Behavior unchanged for callers that invoke
+all uploaders sequentially; new fine-grained API for Phase C
+to use.
 
-Reference (Apache-2.0, mirrorable patterns):
-  - Cycles PASS_MOTION + PASS_MOTION_WEIGHT in
-    intern/cycles/integrator/pass.cpp — the per-pixel motion
-    vector layout (float2: previous→current screen-space
-    pixel offset).
-  - PBRT v4 motion vectors in src/pbrt/film.cpp.
+Implementation:
 
-The math: given a hit point P (world space) and the previous-
-frame camera transform C_prev, compute
-  P_prev_screen = projectToScreen(P, C_prev)
-  P_curr_screen = projectToScreen(P, C_curr)
-  motion = P_prev_screen - P_curr_screen   # float2 per pixel
+  1. Split uploadScene() in cuda_renderer.cu / module/blender_module.cpp
+     into:
+       uploadGeometry()    — BVH build + transforms + vertex normals
+       uploadMaterials()   — material plugin uploads + GMaterial flat array
+       uploadLights()      — light buffer + power CDF
+       uploadEnvironment() — env map data + sampling tables
+     Plus update_object_transform(obj_id, transform) for the cheap
+     transform-only case (BVH refit instead of rebuild — see
+     research note §4 for refit vs rebuild policy).
 
-For pixels that miss all geometry (env hit), motion = (0, 0).
-For the first frame of a render (no previous camera), motion
-= (0, 0).
+  2. uploadScene() becomes a thin wrapper that calls all four +
+     full BVH rebuild — preserves backward-compat. Existing
+     test_blender_*.py tests still pass without modification.
 
-Implementation outline (subject to spec):
-  1. Camera::motionBuffer added alongside albedoBuffer/normalBuffer
-     (raytracer.h:1653-1654). Sized unconditionally (matches
-     pkg68's audit pattern).
-  2. Renderer holds a copy of the previous frame's camera
-     transform. Update on every render call. First call uses
-     identity (returns zero motion).
-  3. Render loop populates motionBuffer for every primary ray
-     hit using the math above. One additional matrix-multiply
-     per pixel; cheap.
-  4. plugins/passes/motion_vector_aov.cpp — new plugin
-     mirroring normal_aov.cpp's shape; exposes the buffer
-     to Blender.
-  5. module/blender_module.cpp — Renderer.get_motion_buffer()
-     binding returning a numpy float32[H, W, 2].
-  6. tests/test_motion_vector_aov.py — synthetic camera-pan
-     test produces non-zero motion on every static-geometry
-     pixel; static-camera test produces zero motion within
-     float epsilon; first-frame produces zero motion.
+  3. Python bindings:
+       Renderer.upload_geometry()
+       Renderer.upload_materials()
+       Renderer.upload_lights()
+       Renderer.upload_environment()
+       Renderer.update_object_transform(obj_id, transform_matrix)
+
+  4. Tests/test_pkg56_phase_b_uploaders.py — new:
+       - upload_geometry() alone produces same BVH state as
+         uploadScene() (identical render output on a fixed scene).
+       - upload_materials() preserves geometry buffers (no rebuild).
+       - update_object_transform() refits BVH (orders-of-magnitude
+         faster than rebuild on a 100k-tri scene); render output
+         identical to a rebuild.
+       - All four uploaders called sequentially produces identical
+         render to uploadScene() on the same scene.
+
+  5. Document Phase C (depsgraph dispatch) as an explicit non-goal
+     of this PR; the new fine-grained API is the prerequisite, and
+     Phase C wires the addon-side depsgraph.updates iteration to
+     pick the right uploader.
+
+Acceptance gates:
+  - All 5 fine-grained uploaders accessible from Python, each with
+    a unit test confirming it produces correct partial state.
+  - update_object_transform() measurably faster than full rebuild
+    on the pkg56-A reference scene (record numbers in pkg56
+    Lessons "Phase B" subsection).
+  - tests/test_blender_viewport_session.py + the existing
+    pkg56-A tests pass unmodified.
+  - No behavior change in the addon's _sync_viewport_scene path
+    (still calls uploadScene = all four). That re-wiring is Phase C.
+
+Constraints:
+  - CLAUDE.md sections 2, 3.
+  - Multi-session work — Phase B alone is ~2 weeks of focused
+    Claude time across the C++ refactor, Python bindings, and
+    test coverage.
+  - Cite Cycles BlenderSync per-domain upload pattern in code
+    comments at the new uploader sites (Apache-2.0,
+    intern/cycles/blender/sync.cpp).
+
+When done:
+  - pkg56 Phase B checklist items checked; Phase C remains open.
+  - STATUS.md: pkg56 noted as "Phases A + B done; C open".
+  - Commit on this branch (squash later):
+      feat(pkg56-B): split uploadScene into per-domain
+      incremental uploaders + transform-refit fast path
+  - PR. DO NOT merge.
+```
+
+### 3.3 Codex — pkg64 Phase 3 default-integrator fold
+
+```
+Implement pkg64 Phase 3 end to end. Phases 1 (RGB SMS skeleton) and
+2 (spectral wavelength-Newton) are merged. Phase 3 folds SMS into
+the default `path_tracer` as an MIS strategy gated by per-object
+caustic-caster opt-in.
+
+Read first:
+  - .astroray_plan/packages/pkg64-spectral-caustics.md (Phase 3 section)
+  - .astroray_plan/docs/caustics-research.md (the per-object
+    caustic-caster opt-in UX section answers the "which objects
+    contribute SMS connections" question)
+  - plugins/integrators/sms_caustic_path_tracer.cpp (the Phase 1+2
+    opt-in integrator — Phase 3 makes its strategy available
+    through default `path_tracer` via MIS combination)
+  - plugins/integrators/spectral_path_tracer.cpp (the default
+    `path_tracer` registration — that's the integrator Phase 3
+    augments)
+  - include/raytracer.h — find where `use_refractive_caustics` /
+    `use_reflective_caustics` are wired into the existing
+    caustic_path_tracer; Phase 3 makes the same toggles work
+    inside spectral_path_tracer through MIS.
+
+Phase 3 goal: when `use_refractive_caustics=True` (already a
+Renderer-level toggle from pkg29a), the default `path_tracer`
+attempts an SMS connection per non-delta hit through any object
+flagged `is_caustic_caster`. The contribution is MIS-combined with
+the existing NEE direct-light estimate using the balance heuristic.
+
+Implementation:
+
+  1. Add per-object property `is_caustic_caster` (bool, default
+     False). Plumb through:
+       - Material/Object-level setter on Renderer
+       - Python binding Renderer.set_object_caustic_caster(obj_id, bool)
+       - Blender addon UI checkbox in object properties (a small
+         "Astroray" panel under object data — pkg57 established
+         the pattern)
+  2. In spectral_path_tracer's per-bounce loop: when
+     `use_refractive_caustics=True` AND the surface BSDF is non-delta
+     AND any caustic-caster object exists: invoke the SMS connection
+     attempt from sms_caustic_path_tracer (factor that out into a
+     shared helper if not already done).
+  3. MIS-combine the SMS contribution with NEE direct-light using
+     balance heuristic. For static caustic-free scenes the SMS
+     attempt's PDF is zero and MIS reduces to plain NEE — no
+     regression risk.
+  4. Update sms_caustic_path_tracer.cpp to share the MIS helper
+     (avoid code duplication; both integrators call the same SMS
+     attempt + MIS combine code).
+  5. Tests:
+       - tests/test_pkg64_phase3_default_integrator.py — render the
+         pkg64 prism scene through default `path_tracer` with
+         `use_refractive_caustics=True`. PSNR(spectral pkg64-3,
+         hi-spp ground truth) − PSNR(no-caustics path_tracer,
+         ground truth) ≥ 4 dB at equal sample count.
+       - tests/test_pkg64_phase3_no_regression.py — render the
+         standard Cornell box scene (no caustic casters). Output
+         must be bit-identical (or within float-precision noise)
+         to pre-pkg64-3 path_tracer output.
+       - All existing tests/test_caustic_validation.py pass.
 
 Constraints:
   - CLAUDE.md sections 2, 3, 6.
-  - Camera-only motion. Animated geometry (moving objects)
-    is OUT of scope per spec — that needs per-vertex previous
-    transforms which we don't have. Document this in pkg72
-    Lessons.
-  - Surgical: stay in raytracer.h render dispatch, new plugin
-    file, blender_module binding, new test, pkg72 spec, STATUS.
-  - Cite Cycles file + line in code comments.
+  - Cycles MNEE GPL fence: do NOT consult intern/cycles/integrator/
+    mnee.cpp or related. The math is Hanika 2015 + Zeltner 2020
+    SMS, both already cited in caustics-research.md.
+  - Default behavior unchanged: until the user sets
+    `use_refractive_caustics=True` AND marks at least one object
+    as caustic_caster, path_tracer is the same as today.
+  - Cost gate: on the standard Cornell box (no caustic casters),
+    per-bounce cost ≤ +5% vs pre-pkg64-3 (the SMS attempt is
+    short-circuited when no casters exist).
 
 When done:
-  - pkg72 spec status -> done.
-  - STATUS.md updated.
+  - pkg64 Phase 3 checklist items checked; pkg64 status -> "fully
+    done" (Phases 1 + 2 + 3 complete; GPU port is a future
+    package outside Pillar 5 scope).
+  - STATUS.md: pkg64 row updated to "Phases 1 + 2 + 3 done".
   - Commit on a fresh branch:
-      feat(pkg72): per-pixel motion vector AOV (camera-only)
+      feat(pkg64-3): fold SMS into default path_tracer with
+      per-object caustic_caster opt-in + MIS combine
   - PR. DO NOT merge.
 ```
 
-### 3.3 Claude tech (worktree `pkg64-phase-2`) — spectral wavelength-Newton
+### 3.4 Codex (after #3 lands) — pkg74 Phase 3 interactive HTML + weekly CI
 
 ```
-You are Claude Code in worktree .claude/worktrees/pkg64-phase-2,
-branched from current main. Implement pkg64 Phase 2 only.
-Phase 1 (RGB SMS skeleton) just landed (PR #212); Phase 3
-(default-integrator fold) is a separate package on its own
-branch.
+Implement pkg74 Phase 3 end to end. Phases 1 + 2 are merged. Phase 3
+turns the showcase framework into a browsable interactive dashboard
+and wires it to a weekly self-hosted CI run.
 
 Read first:
-  - .astroray_plan/packages/pkg64-spectral-caustics.md (the spec —
-    look for the Phase 2 section)
-  - .astroray_plan/docs/caustics-research.md (the signed-off
-    research, especially the Hanika 2015 MNEE wavelength-Newton
-    section)
-  - plugins/integrators/sms_caustic_path_tracer.cpp (the Phase 1
-    RGB SMS skeleton — Phase 2 extends this)
-  - include/astroray/manifold/half_vector_constraint.h +
-    newton_iterate.h (Phase 1 helpers)
-  - plugins/integrators/spectral_path_tracer.cpp +
-    plugins/integrators/spectral_dielectric_*.cpp — search for
-    Sellmeier dispersion (this is what produces wavelength-
-    dependent IOR which the Hanika 2015 wavelength-Newton needs)
+  - .astroray_plan/packages/pkg74-engine-benchmark-showcase.md (Phase 3 section)
+  - benchmarks/showcase/html_index.py (Phase 1 + 2 static HTML — Phase 3
+    extends with vanilla-JS sortable table + collapsible category sections)
+  - benchmarks/showcase/runner.py (the CLI driver — Phase 3 keeps
+    invocation unchanged; just adds artefact polish)
+  - .github/workflows/cycles-parity.yml (the existing pkg71 self-hosted
+    CI workflow — Phase 3 adds a sibling weekly workflow for pkg74)
 
-Phase 2 goal: extend the Phase 1 RGB SMS implementation to do
-per-wavelength Newton iteration on the half-vector constraint,
-producing prism-accurate spectral caustics.
-
-Reference (paper):
-  - Hanika, Droske, Manakov, "Manifold Next Event Estimation",
-    EGSR 2015 (DOI 10.1111/cgf.12681). The paper is the math
-    source — the spectral residual derivation is in §4.
-  - Mitsuba 2 SMS reference (BSD-3, mirrored via citation in
-    Phase 1) does NOT include spectral extension; we do this
-    ourselves from the paper.
-  - Cycles' MNEE source is GPL-2.0+ — DO NOT consult it for
-    code patterns (license fence per caustics-research.md).
-
-Implementation outline (subject to spec):
-
-  1. Convert the Newton residual + Jacobian in
-     sms_caustic_path_tracer.cpp from "use the material's
-     scalar IOR" to "evaluate IOR at the hero wavelength
-     λ_hero". Use the existing Sellmeier dispersion path
-     (via SpectralDielectric::iorAt(λ)).
-
-  2. For each spectral chain bounce, evaluate the constraint
-     residual at the hero wavelength only (the math from
-     Hanika 2015 §4 — the residual decouples per-wavelength
-     because the half-vector constraint is linear in cosθ).
-
-  3. Acceptance:
-     - Existing tests/test_sms_caustic_validation.py still passes
-       (RGB SMS regression baseline unchanged for monochromatic
-       light).
-     - New tests/test_sms_caustic_spectral.py: Cornell with
-       refractive sphere under broad-spectrum light produces a
-       visible chromatic spread in the caustic (red focuses
-       differently from blue). Acceptance: PSNR(spectral SMS,
-       hi-spp ground truth) − PSNR(RGB-only SMS, ground truth)
-       ≥ 3 dB at equal sample count on the prism scene.
-     - Performance: per-bounce cost increase ≤ 2× vs Phase 1
-       (one Newton solve per spectral sample, not per RGB
-       channel). Document the actual ratio in Lessons.
-
-NOT in Phase 2:
-  - Folding into the default path_tracer (Phase 3).
-  - GPU port (separate package after Phase 2).
-  - Triangle-mesh refraction (still spheres only — Phase 1
-    constraint).
-
-Constraints:
-  - CLAUDE.md sections 2, 3, 6.
-  - Cite Hanika 2015 §4 in code comments at the spectral
-    residual implementation site.
-  - DO NOT consult Cycles MNEE source.
-  - Multi-session work — Max 5x makes Phase 2 doable in one
-    focused push (~1.5 weeks of Claude time across the
-    Newton math, validation scene, and spectral test).
-
-When done:
-  - pkg64 Phase 2 checklist items checked; Phase 3 (default-
-    integrator fold) remains open.
-  - STATUS.md: pkg64 noted as "Phases 1+2 done (RGB + spectral
-    SMS); Phase 3 open".
-  - Commit on this branch:
-      feat(pkg64-2): spectral wavelength-Newton on top of
-      Phase 1 SMS — prism-accurate caustics
-  - PR. DO NOT merge.
-```
-
-### 3.4 Claude tech (worktree `pkg74-phase-2`) — full stat coverage
-
-```
-You are Claude Code in worktree .claude/worktrees/pkg74-phase-2,
-branched from current main. Implement pkg74 Phase 2 only.
-Phase 1 framework just landed (PR #214); Phase 3 (interactive
-HTML + weekly CI) is a separate package.
-
-Read first:
-  - .astroray_plan/packages/pkg74-engine-benchmark-showcase.md
-    (the spec — Phase 2 section)
-  - .astroray_plan/docs/engine-benchmark-research.md (the
-    research note's §2 stats catalog — that's the gold list
-    to implement against)
-  - benchmarks/showcase/ — the Phase 1 framework. Phase 2
-    extends, doesn't replace.
-
-Phase 2 goal: expand the stats catalog from Phase 1's basic
-set (image stats + render time + peak RSS + integrator-stats
-round-trip) to the full stats catalog from the research note:
-
-  - Geometry: BVH stats (tris, nodes, max depth), prim counts,
-    leaf utilization
-  - Sampling: rays/pixel (camera, shadow, scattered),
-    samples/light (NEE), Russian-roulette termination rate
-  - Memory: peak per-allocator (CUDA pool, OIDN buffers,
-    Framebuffer, BVH)
-  - Timing: per-bounce cost, per-material-type cost, per-
-    pass cost
-  - Quality: pixel variance histogram, firefly count,
-    convergence rate
-  - Spectral: hero-wavelength selection histogram, sampled-
-    wavelength coverage
-  - Integrator-specific: NRC training loss curve, ReSTIR
-    reservoir-reuse rate (when active)
-  - GPU rows: same scenes rendered with set_use_gpu(True),
-    appended to the same CSV
-
-This is a lot. Bite it off as:
-
-  Phase 2a (~3 days): Geometry + Memory + Timing categories
-  Phase 2b (~2 days): Sampling + Quality categories
-  Phase 2c (~2 days): Spectral + Integrator-specific + GPU rows
-
-Land all three sub-phases on the same PR if they fit in one
-focused push, or split into 2a+2b+2c on the same branch
-with clear commits.
+Phase 3 goal: interactive HTML dashboard + weekly CI workflow.
 
 Implementation:
 
-  1. Most stats already exist somewhere — they're just not
-     all surfaced through Renderer.get_integrator_stats()
-     or equivalent. Inventory: search for `printf` / log
-     lines in src/, plugins/, include/. Many will already
-     be measured but not exposed. Add Python bindings to
-     pull them out.
+  1. benchmarks/showcase/html_index.py — replace the current static
+     <details> sections with:
+     - Inline vanilla-JS sortable table (no external CDN deps;
+       the table sort code is ~30 lines of JS; embed in <script>
+       block, no source-map). Sort by any column on click.
+     - Collapsible category sections preserved.
+     - Inline-render the convergence curve, integrator-compare
+       contact sheet, and timing bar chart (already saved as PNG
+       by Phase 2).
+     - Footer with git SHA + Astroray version + machine ID +
+       runtime metadata (OIDN version, OptiX version, CUDA
+       version) — the moment-in-time provenance.
 
-  2. Some stats need a small bit of integrator instrumentation
-     (e.g. ray-counters per type). Mirror the pkg56-A
-     ring-buffer pattern from blender_module.cpp.
+  2. .github/workflows/showcase.yml — new sibling to
+     cycles-parity.yml:
+     - Weekly cron (Sundays 02:00 UTC, off-peak)
+     - Manual trigger via workflow_dispatch
+     - Self-hosted CUDA runner (same one pkg71 uses)
+     - Runs `python -m benchmarks.showcase.runner --quick`
+     - Commits the resulting CSV + HTML + PNG artefacts to a
+       dated branch under `benchmarks/showcase/output/<date>/`,
+       opens a PR with the Markdown summary in the body.
+     - Old artefacts: keep last 12 weekly runs in the branch;
+       rotate older ones to a separate archive branch.
 
-  3. Update benchmarks/showcase/runner.py to call into
-     each new stat source per (scene, integrator) row.
-     The CSV gets wider, not deeper.
+  3. tests/test_benchmark_showcase_phase3.py — new:
+     - Verify generated index.html contains the sortable-table
+       JS + valid HTML structure
+     - Verify the runner produces all expected PNG artefacts
+       and one CSV
+     - Skip the CI workflow validation (workflow file syntax)
+       since GitHub Actions yaml linting is the wrong place
 
-  4. Add a "stats categories" section to the HTML index
-     so viewers can collapse/expand each category.
-
-  5. tests/test_benchmark_showcase_phase2.py — confirm
-     each new category produces non-zero output on the
-     Cornell scene.
+Acceptance:
+  - python -m benchmarks.showcase.runner --quick produces the
+    interactive HTML in <60s on a CPU build.
+  - tests/test_benchmark_showcase_phase3.py green.
+  - .github/workflows/showcase.yml passes a `gh workflow view`
+    sanity check.
+  - First weekly run lands on a self-hosted runner (validation
+    happens once the runner picks up the cron).
 
 Constraints:
-  - CLAUDE.md sections 2, 3, 6.
-  - DO NOT add new integrators or denoisers; this is
-    measurement only.
-  - Phase 3 (interactive HTML + CI) is OUT of scope for
-    this PR.
-  - Multi-session work — expect 1 week of Claude time.
+  - CLAUDE.md sections 2, 3.
+  - DO NOT add npm dependencies, CDN dependencies, or any
+    runtime that requires network access. Inline JS/CSS only.
+  - DO NOT modify Phase 1 + 2 outputs — Phase 3 wraps them
+    with a richer index, doesn't replace.
+  - CI workflow: same self-hosted runner as pkg71. Don't
+    spawn a parallel runner.
 
 When done:
-  - pkg74 Phase 2 checklist items checked; Phase 3 still open.
-  - STATUS.md: pkg74 noted as "Phases 1+2 done; Phase 3 open".
-  - Commit on this branch:
-      feat(pkg74-2): full stat coverage (geometry, sampling,
-      memory, timing, quality, spectral, integrator-specific,
-      GPU rows)
+  - pkg74 Phase 3 checklist items checked; pkg74 -> fully done.
+  - STATUS.md: pkg74 row updated to "Phases 1 + 2 + 3 done".
+  - Commit on a fresh branch:
+      feat(pkg74-3): interactive HTML showcase + weekly CI
   - PR. DO NOT merge.
 ```
 
-### 3.5 CUDA verifier — re-baseline pkg68 + pkg70 after pkg75 lands
+### 3.5 CUDA verifier — pkg72 + pkg64 Phase 2 hardware verification
 
 ```
 You are a CUDA verification session on the user's RTX 5070 Ti
-Windows workstation. Spawn this AFTER pkg75 (PR from §3.1) is
-merged to main. Goal: capture the AOV-mode improvement that
-pkg75 unlocks for both pkg68 (OIDN) and pkg70 (OptiX).
+Windows workstation. Two tiny verifications, both ~30 minutes.
 
-Step 1: pull main, confirm pkg75 is present.
+Step 1: pull main, confirm pkg72 + pkg64-2 present.
   git fetch origin && git checkout main && git pull --ff-only
-  grep "pkg75" .astroray_plan/docs/STATUS.md   # confirm "done"
 
-Step 2: clean build + run all denoiser tests.
-  Remove build_cuda dir entirely (don't trust cached object
-  files after a buffer-population change).
+Step 2: pkg72 motion vector hardware verification.
   scripts\build\build_cuda.bat
   python scripts\dev\run_tests.py --build-dir build_cuda --
-    tests/test_oidn_denoiser_persistence.py
-    tests/test_oidn_denoiser.py
-    tests/test_optix_denoiser.py
-    tests/test_aov_passes.py
-    tests/test_normal_buffer_populated.py     # new from pkg75
-    tests/test_oidn_denoiser_aov_uses_guides.py  # new from pkg75
+    tests/test_motion_vector_aov.py
   -v --tb=short
 
-  All green expected.
+  Expected: all 6 tests pass. The pkg72 implementer noted
+  "full Windows VS / pyd rebuild was not run from this worktree
+  (existing build_cuda is configured against the main worktree);
+  please run tests/test_motion_vector_aov.py after the next
+  addon build." This is that step.
 
-Step 3: re-measure pkg68 OIDN A/B baseline.
-  Same harness as the 2026-05-10 baseline (Cornell, 256×256,
-  spp=2, max_depth=3, N=100, warmup=3, persistent Renderer):
+  Smoke-render a test scene:
+    Scene: Cornell with the camera panning +0.1 in x between
+           frame 1 and frame 2.
+    Frame 1: render, snapshot motion buffer (should be all-zero
+             — first-frame convention).
+    Frame 2: render, snapshot motion buffer (should show
+             non-zero positive x-component on every pixel hit
+             by static geometry).
+  Append the actual measured numbers (mean motion magnitude
+  on hit pixels) to pkg72 Lessons.
 
-  Build at the pkg75-merged main HEAD: time 100 frames OIDN-on,
-  100 frames OIDN-off. Record post-pkg75 OIDN-on ms/frame.
+Step 3: pkg64 Phase 2 hardware re-baseline.
+  python scripts\dev\run_tests.py --build-dir build_cuda --
+    tests/test_sms_caustic_validation.py
+    tests/test_sms_caustic_spectral.py
+  -v --tb=short
 
-  Compare against the recorded post-pkg68 numbers in pkg68
-  Lessons (50.67 ms/frame OIDN-on). The expected delta is
-  EITHER lower per-frame cost (OIDN converges faster with real
-  normal guides) OR same ms/frame with cleaner output (OIDN
-  uses the saved budget for tighter denoising). Either is a win.
+  Expected: 6 tests green. PSNR delta from
+  test_sms_caustic_spectral was 8.83 dB on the implementer's
+  machine (Linux build). Confirm the same number ±2 dB on RTX
+  5070 Ti — material differences would suggest a CPU/GPU code-
+  path divergence we want to know about.
 
-  Append to pkg68 Lessons:
-    "Post-pkg75 OIDN A/B baseline (RTX 5070 Ti, same harness
-    as 2026-05-10): OIDN-on X ms/frame, OIDN-off Y ms/frame.
-    Comparison with the 2026-05-10 baseline shows
-    [LOWER PER-FRAME COST | CLEANER OUTPUT AT SAME COST | both]."
+  Append actual measured PSNR delta + runtime ratio to pkg64
+  Lessons (Phase 2 subsection).
 
-Step 4: re-measure pkg70 OptiX synthetic-noise gate.
-  Re-run tests/test_optix_denoiser.py at 256×256 (the post-
-  fixture-bump size). Record the new noise-reduction ratio.
-
-  Compare against the recorded pkg70-verification number
-  (5.31× OptiX, 5.58× OIDN). Expected: BOTH numbers improve
-  measurably, since both denoisers were running degraded-AOV
-  before pkg75.
-
-  Append to pkg70 Lessons:
-    "Post-pkg75 synthetic noise gate re-measurement:
-    OptiX X.XX× (was 5.31× pre-pkg75), OIDN Y.YY× (was 5.58×).
-    Confirms the floor-not-ceiling reading of the original
-    verification."
-
-Step 5: re-measure pkg70 OptiX vs OIDN-CUDA timing.
-  1080p parity scene, spp=2, max_depth=3, N=10, warmup=2.
-  Compare against pre-pkg75 numbers (OptiX 728.94 ms,
-  OIDN-CUDA 1356.09 ms, ratio 1.86×). Document any change.
-
-Step 6: commit on a verify branch.
-  Title: verify(pkg75): post-pkg75 pkg68/pkg70 re-baseline
-  Body: include all four numbers with before/after table.
-
+Step 4: commit on a verify branch.
+  Title: verify(pkg72, pkg64-2): hardware re-baseline
+  Body: include the measured numbers from steps 2 + 3 verbatim.
   Push, open PR, do NOT merge.
 
 Constraints:
-  - Do NOT modify implementation code (test fixture stays at
-    256×256; pkg70 test docstring may be updated to reflect
-    the post-pkg75 numbers).
-  - Do NOT promote pkg75 yourself — this verifier session
-    only re-baselines pkg68/pkg70 numbers in their Lessons;
-    pkg75's own promotion happened at its merge.
-  - If any number REGRESSES (gets worse than pre-pkg75),
-    stop and ask. Regression would mean pkg75 broke
-    something rather than improving the floor.
+  - Do NOT modify implementation code.
+  - Do NOT relax any gate.
+  - If any number REGRESSES vs the implementer-machine baseline,
+    stop and ask. Cross-machine variation is expected (different
+    OS, compiler, CUDA toolkit), but a >25% delta is suspicious.
+```
+
+### 3.6 Claude research (worktree `research-pkg76`) — Astroray .blend importer (parity scope)
+
+```
+You are Claude Code in worktree .claude/worktrees/research-pkg76,
+branched from current main. RESEARCH + SPEC session — no
+implementation code. One deliverable.
+
+Why this matters: pkg71's first canonical baseline (PR #218)
+landed Cornell parity numbers cleanly (Astroray-CPU SSIM 0.9536,
+Astroray-GPU SSIM 0.9548 vs Cycles-CPU EXR), but Classroom,
+Junkshop, BMW27, and Monster all skipped Astroray rows with
+`astroray_blend_import_not_implemented`. Astroray has no .blend
+importer — the harness can only compare on scenes both engines
+can build natively. To land a real 5-scene parity baseline,
+Astroray needs at minimum a parity-scope .blend reader.
+
+Deliverable: create
+.astroray_plan/packages/pkg76-blend-importer-parity-scope.md.
+
+Required reading (use WebFetch):
+
+Blender .blend file format:
+  - https://wiki.blender.org/wiki/Source/File_Format
+    Official documentation on the SDNA format. SDNA self-describes
+    the binary structures, so a .blend reader at parity scope
+    can be quite small — read the SDNA, then walk the typed blocks.
+  - https://www.atmind.nl/blender/mystery_ot_blend.html
+    Shorter community walkthrough. Useful for understanding
+    block indexing.
+
+Existing third-party readers (license-fenced):
+  - https://github.com/blender/blender — official .blend reader is in
+    source/blender/blenkernel/intern/. License GPL-2.0+, so we cannot
+    mirror code. Read for understanding only.
+  - https://github.com/JTraversa/Blender-File-Reader — Python .blend
+    reader, BSD-3 licensed, mirroring permitted with citation. Check
+    the license tag at fetch time to confirm.
+  - https://pypi.org/project/blend2json/ — Python .blend → JSON tool.
+    BSD-3. Useful as a reference for which struct fields matter for
+    parity-scope rendering (camera, materials, geometry).
+
+Required H2 sections in pkg76 spec:
+
+  1. Goal / Before / After (parity-scope only — NOT a full Blender
+     compatibility layer. Only what pkg71 needs.)
+  2. Reference Implementations (URL, license, what to mirror, what NOT)
+  3. Specification:
+     - File parser strategy: probably a small Python parser using
+       the SDNA self-description, NOT a C++ reader. (Cycles uses C++
+       because it's IN Blender; we're external and can read the file
+       offline.)
+     - Minimum field set for parity scope:
+       - Camera: position, rotation, focal length, sensor size
+       - Mesh: vertices + faces + per-face material index
+       - Material: base color (Diffuse BSDF or Principled BSDF
+         basecolor only — full shader graph is OUT of scope; pkg57
+         shader nodes handle Astroray-side complexity, not
+         Blender-side import)
+       - Light: position + color + intensity (Point/Sun/Spot)
+       - World background color (HDRI import is OUT of scope —
+         document as future)
+     - Output: a Python builder script that takes a .blend path
+       and constructs the equivalent Astroray scene via the
+       Renderer Python API.
+     - Wiring into pkg71 harness: pkg71 invokes the importer for
+       every Astroray-engine row when the source is a .blend file.
+  4. Acceptance:
+     - Classroom + Junkshop + BMW27 produce non-skip Astroray
+       rows in the next pkg71 baseline run. SSIM target ≥ 0.85
+       (relaxed from the 0.95 Cornell gate because parity-scope
+       import will lose shader-graph and procedural-texture
+       fidelity).
+     - Test fixture: tiny synthetic .blend (created at test-write
+       time via bpy in a pytest skip-if-no-bpy guard), verify
+       roundtrip Astroray scene matches expected geometry and
+       material counts.
+     - Monster scene fix (the UDIM monster lacks a camera per the
+     pkg71 baseline output): either find a different monster source
+     OR drop monster from the pkg71 set. Whichever pkg76 chooses,
+     update the pkg71 manifest.toml.
+  5. Non-goals:
+     - Full shader graph import (use pkg57 shader nodes manually
+       on the Astroray side; this is parity scope only)
+     - HDRI / image-texture import (parity scope = procedural only)
+     - Animation, modifiers, particles, hair, volumes (out of
+     parity scope)
+  6. Front-matter:
+     - Pillar 5
+     - Track A
+     - Estimated effort: 1-2 weeks
+     - Depends on pkg71 (the harness consumer)
+  7. Reference matrix per CLAUDE.md §6
+
+Length: 4-6 pages.
+
+When done:
+  - Commit on this branch:
+      docs(pkg76): Astroray .blend importer (parity scope) spec
+  - PR. DO NOT merge.
+
+Constraints:
+  - CLAUDE.md section 6 (cite, borrow, verify).
+  - No source code changes.
+  - License-fence: Blender's own .blend reader is GPL-2.0+ and
+    NOT mirrorable. Cite for understanding. Permissive readers
+    (BSD-3 like Blender-File-Reader, blend2json) are mirrorable
+    with attribution.
+  - Be honest about scope: this is parity for pkg71, not a full
+    .blend compatibility layer. Future packages can extend.
 ```
 
 ---
@@ -554,70 +636,89 @@ Constraints:
 
 | Session | Files |
 |---|---|
-| pkg75 normal-buffer | `include/raytracer.h` (render loop normal-buffer write), maybe `plugins/passes/normal_aov.cpp` (refactor), new tests, pkg75 spec, STATUS.md, brief Lessons appends to pkg68/pkg70 specs |
-| Codex pkg72 motion vectors | `include/raytracer.h` (Camera::motionBuffer + render loop motion-vector population), new `plugins/passes/motion_vector_aov.cpp`, `module/blender_module.cpp` (binding), new test, pkg72 spec, STATUS.md |
-| pkg64 Phase 2 | `plugins/integrators/sms_caustic_path_tracer.cpp`, `include/astroray/manifold/` headers, new test, pkg64 spec, STATUS.md |
-| pkg74 Phase 2 | `benchmarks/showcase/runner.py`, possibly new `benchmarks/showcase/stats/` dir, `module/blender_module.cpp` (new stat bindings), new test, pkg74 spec, STATUS.md |
-| Verifier (post-pkg75) | only verify-branch commits + pkg68/pkg70 Lessons appends |
+| pkg73 OptiX temporal | `plugins/passes/optix_denoiser.cpp` (extend OptiXDenoiser class), new test, pkg73 spec, STATUS.md, brief Lessons append to pkg72 spec |
+| pkg56 Phase B | `module/blender_module.cpp` (split + new bindings), `src/gpu/cuda_renderer.cu` (per-domain uploaders), new test, pkg56 spec Phase B subsection, STATUS.md |
+| pkg64 Phase 3 | `plugins/integrators/spectral_path_tracer.cpp` (MIS-combine SMS), `plugins/integrators/sms_caustic_path_tracer.cpp` (extract shared helper), `include/raytracer.h` (per-object caustic_caster property), `module/blender_module.cpp` (binding), `blender_addon/__init__.py` (UI checkbox), 2 new tests, pkg64 spec, STATUS.md |
+| pkg74 Phase 3 | `benchmarks/showcase/html_index.py` (rewrite), new `.github/workflows/showcase.yml`, new test, pkg74 spec, STATUS.md |
+| Verifier (pkg72 + pkg64-2) | only verify-branch commits + pkg72/pkg64 Lessons appends |
+| pkg76 spec | only `.astroray_plan/packages/pkg76-*.md` (new) |
 
 **Two real conflict points to watch:**
 
-1. **`include/raytracer.h`** — pkg75 writes normalBuffer in the render
-   loop; pkg72 writes motionBuffer in the same loop. Different lines
-   but same file. **Mitigation:** pkg75 lands first (Round 3 priority
-   ordering). pkg72 rebases over it; the write-site is a 3-line
-   addition next to pkg75's normal-write — trivial three-way merge.
+1. **`module/blender_module.cpp`** — pkg56-B (split into per-domain
+   uploaders + new bindings) and pkg64-3 (per-object caustic_caster
+   binding) both touch this. Different sections; trivial three-way
+   merge.
 
-2. **`module/blender_module.cpp`** — pkg72 + pkg74 Phase 2 both add
-   new bindings. Different binding sets, same file. Trivial merge.
+2. **`plugins/integrators/spectral_path_tracer.cpp`** — pkg64-3 adds
+   an MIS-combined SMS branch in the per-bounce loop. No other Round 4
+   session touches this file. Should be conflict-free.
 
-**Recommended merge order** (when PRs land): verifier (smallest) →
-pkg72 (depends on pkg75 only via shared raytracer.h, can land second
-once the rebase is clean) → pkg64 Phase 2 → pkg74 Phase 2 → pkg75 first
-(actually pkg75 should land FIRST so others can rebase off it; revise
-order to: pkg75 → pkg72 → pkg64 Phase 2 → pkg74 Phase 2 → verifier).
+3. **STATUS.md** — five sessions all touch it. Same three-way merge
+   race we've been hitting. Mitigation as before: post-round sweep PR
+   to restore lost rows if the squash-merge collapse drops them.
 
-STATUS.md squash-merge race protection: same as last round — if rows
-go missing after the merges, file a small docs PR to restore.
+**Recommended merge order:** verifier (smallest) → pkg76 spec
+(docs only) → pkg64 Phase 3 (Codex, ½ week, ships first per Codex
+ordering) → pkg74 Phase 3 (Codex, after pkg64-3) → pkg73 OptiX
+temporal (Claude tech) → pkg56 Phase B (largest delta, last).
 
 ---
 
-## 5. After Round 3 lands
+## 5. After Round 4 lands
 
 When this round lands:
 
-- pkg75 → AOV mode actually works for both denoisers; pkg68 + pkg70
-  numbers are no longer floors.
-- pkg72 → motion vectors available; unblocks pkg73.
-- pkg64 → Phase 2 (spectral SMS) done; only Phase 3 (default-integrator
-  fold) and GPU port remain for caustics.
-- pkg74 → Phase 2 (full stat coverage) done; only Phase 3 (interactive
-  HTML + CI) remains for the showcase framework.
-- Verifier session → pkg68 and pkg70 Lessons document the post-pkg75
-  numbers, confirming the original measurements were conservative
-  floors.
+- **pkg73** → OptiX temporal denoiser ships; viewport animation has
+  hardware-accelerated temporal stability via motion vectors.
+  Together with pkg68 + pkg70 + pkg75, the entire denoiser story
+  closes.
+- **pkg64 Phase 3** → caustics opt-in via per-object property; the
+  flagship visual-fidelity package fully done end-to-end.
+- **pkg74 Phase 3** → showcase runs weekly in CI and produces an
+  interactive HTML report; the engine has self-publishing benchmark
+  artefacts.
+- **pkg56 Phase B** → fine-grained uploaders shipped; Phase C wires
+  depsgraph dispatch on top.
+- **pkg76 spec** → ready for Round 5 implementation; non-Cornell
+  pkg71 baseline rows become possible.
 
-Then **Round 4** picks up:
+Then **Round 5** picks up:
 
-- pkg73 OptiX temporal denoiser (now unblocked by pkg72) — ~3-4 days,
-  Claude tech.
-- pkg56 Phase B uploadScene split — ~2 weeks, Claude tech.
-- pkg64 Phase 3 default-integrator fold — ~½ week, Claude tech.
-- pkg74 Phase 3 HTML + CI — ~3 days, Codex.
-- Re-baseline pkg54a/b parity scene through the showcase framework
-  to show the cumulative pkg54+pkg68+pkg70+pkg75 visual quality story.
+- **pkg56 Phase C** (depsgraph-driven dispatch) — ~2-3 weeks, Claude tech.
+  Uses the fine-grained uploaders from Phase B; viewport idle frames
+  drop to the ≤5 ms gate.
+- **pkg76 implementation** (Astroray .blend importer) — ~1-2 weeks,
+  Claude tech. Unblocks 4 of 5 pkg71 baseline scenes.
+- **pkg77** (monster scene fix) — ½ day, Codex. Whichever resolution
+  pkg76 picks (replace source vs drop scene).
+- **pkg55 Phase A** (wavefront refactor instrumentation) — ~1 week,
+  Claude tech. The big architectural pivot begins. Measured baselines
+  from pkg56 + pkg64 + pkg71 + pkg74 are now in place to compare
+  against.
+- **CUDA verifier follow-ups** as needed for pkg73 + pkg64-3.
 
-Then **Round 5**:
+After Round 5:
 
-- pkg56 Phase C depsgraph-driven dispatch — ~2-3 weeks, Claude tech.
-- pkg55 wavefront SoA refactor Phase A (instrument current megakernel
-  perf) — ~1 week, Claude tech. The 3-phase wavefront work begins.
-- pkg74 Phase 3 if not already landed.
+- pkg56 fully done (Phases A + B + C).
+- pkg64 fully done (Phases 1 + 2 + 3).
+- pkg74 fully done (Phases 1 + 2 + 3).
+- pkg76 implementation done.
+- pkg55 Phase A done; Phases B + C ahead (long).
 
-When pkg56 Phases B+C land AND pkg64 Phase 3 lands, **Pillar 5 is
-essentially feature-complete**. At that point Pillar 4 thaws; the
-Codex-paste-ready specs for pkg41/pkg42/pkg43/pkg44/pkg47/pkg48/pkg49
-are waiting; pkg40 Kerr metric already landed.
+When pkg56 + pkg64 + pkg76 are all done, **Pillar 5 is essentially
+feature-complete** for the Cycles-parity / Blender integration push.
+At that point:
 
-Bump this report when pkg75 lands or when Round 3 verification
-returns numbers — that's the next major queue movement.
+- **Pillar 4 thaws.** Codex picks up pkg41 Kerr validation first
+  (already ready, gated only by the strategic freeze). Then the
+  Codex-paste-ready specs for pkg42 / 43 / 44 / 47 / 48 / 49 in
+  parallel as Codex bandwidth allows.
+- **pkg55 Phases B + C** (the wavefront SoA migration proper) become
+  the major Pillar 5 architectural work. Multi-month, but unlocks
+  measurable GPU parity claims with Cycles X for the eventual paper.
+- **pkg67 metric-aware path tracer** (research-blocked currently)
+  becomes unblocked by pkg40 + pkg55 maturity.
+
+Bump this report when pkg56 Phase B or pkg64 Phase 3 lands — those
+are the next major queue movements.

--- a/.astroray_plan/docs/ROADMAP.md
+++ b/.astroray_plan/docs/ROADMAP.md
@@ -103,18 +103,49 @@ GPU-default rendering and before Pillar 4 adds more spectral phenomena,
 material plugins should declare backend capabilities and either lower
 to a shared CPU/GPU closure representation or clearly fall back to CPU.
 
-**Status as of 2026-05-10:** the pkg34-pkg37 bridge is complete. The newer
-Cycles-parity queue extends the same honesty principle to integrators and
-Blender UX: pkg52/pkg53/pkg58/pkg59/pkg60/pkg61/pkg62/pkg65/pkg66 are
-done, and pkg54 (CPU/GPU multi-wavelength parity) landed in three
-verified pieces — pkg54 (megakernel + dispatch wiring), pkg54a (GPU
-spectral profile dispatch), pkg54b (CIE 1964 10° CMF table parity).
-Two scoped follow-ups carry the residual: pkg54c (Jakob-Hanika spectral
-upsampling on GPU, lifting visible SSIM 0.985 → 0.999) and pkg54d
-(direct `gpu_profile_reflectance` Python binding for unconfounded
-dispatch-liveness gating). pkg57 (native Astroray shader nodes), pkg63
-(world/HDRI parity), pkg64 (spectral caustics — research signed off),
-and pkg67 (metric-aware path tracer — research blocked) remain open.
+**Status as of 2026-05-10 (Round 3 close):** the pkg34-pkg37 backend
+bridge is complete. The Cycles-parity / Blender integration / denoiser
+push is **approaching feature-complete** for Pillar 5:
+
+- **Cycles parity wave done:** pkg52/53/57/58/59/60/61/62/63/65/66.
+- **GPU multi-wavelength parity done end-to-end:** pkg54/54a/54b/54c/54d
+  (all hardware-verified on RTX 5070 Ti; visible-band SSIM 0.999263 at
+  spp=8192).
+- **Denoiser story (mostly) closed:** pkg33 (OIDN integration, done),
+  pkg68 (OIDN persistent device + CUDA backend, **measured 2.77×
+  viewport speedup** post-pkg75), pkg69 (compositor Albedo pass, done),
+  pkg70 (OptiX denoiser, **1.86× faster than OIDN-CUDA, SSIM 0.9987 vs
+  OIDN**), pkg72 (motion vector AOV, done), pkg75 (AOV normal-guide
+  defect fixed and verified). pkg73 OptiX temporal denoiser is
+  unblocked and queued for Round 4.
+- **Caustics flagship:** pkg64 Phases 1+2 done (RGB SMS skeleton +
+  spectral wavelength-Newton, **+8.83 dB PSNR delta**); Phase 3
+  (default-integrator MIS fold) is a Round 4 Codex pickup.
+- **Cycles parity benchmark:** pkg71 framework + first canonical
+  Cornell baseline shipped — **Astroray-CPU SSIM 0.9536 vs
+  Cycles-CPU EXR; Astroray-GPU SSIM 0.9548 and 5.2× faster than
+  Cycles-CUDA on Cornell**. pkg76 (Astroray .blend importer for
+  parity scope) is the next pickup so non-Cornell scenes can produce
+  rows.
+- **Showcase framework:** pkg74 Phases 1+2 done (material zoo,
+  convergence grid, RMSE plot, full stat coverage); Phase 3
+  (interactive HTML + weekly CI) is a Round 4 Codex pickup.
+- **Viewport sync:** pkg52 (persistent viewport) + pkg56 Phase A
+  (instrumentation, baseline 129.92 ms) done. Phase B (uploadScene
+  split) is a Round 4 Claude tech pickup; Phase C (depsgraph dispatch)
+  follows in Round 5.
+
+Open Pillar 5: **pkg73 + pkg56-B + pkg64-3 + pkg74-3 + pkg76 spec**
+(Round 4); **pkg56 Phase C + pkg76 implementation + pkg55 Phase A**
+(Round 5). pkg67 (metric-aware path tracer) stays research-blocked
+until Pillar 4 thaws. pkg55 (wavefront SoA refactor) starts after
+pkg56+pkg64 land for measured baselines to compare against.
+
+**When pkg56 Phases B+C and pkg64 Phase 3 all land, Pillar 4 thaws.**
+The Codex-paste-ready specs for pkg41 (Kerr validation), pkg42-49
+(synchrotron, slim disk, ADAF, FITS, HDF5, SPH, etc.) are queued and
+waiting; pkg40 (Kerr metric) already landed during the pre-strategic-
+shift round.
 
 - `pkg34-material-backend-capabilities.md` — capability metadata,
   no silent grey-Lambertian GPU fallback, CPU/GPU contact-sheet diffs.

--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Astroray Status
 
-**Last updated:** 2026-05-09 (pkg60 Disney energy compensation)
+**Last updated:** 2026-05-10 (Round 3 closed — pkg72/73/74-2/75/64-2 + pkg71 first canonical Cornell baseline)
 
 This is the source-of-truth for "where are we?" Updated by the overseer
 at the start of each week, and by the project owner when a significant
@@ -20,24 +20,43 @@ personally should pick up.
   it remains in validation because NRC has not yet proven the 30% batched
   inference speedup/quality target and ReSTIR/NRC are CPU-integrator plugins,
   not CUDA kernels.
-- Pillar 5 is the active practical queue. The Cycles-parity/Blender package
-  series is now the live near-term roadmap: pkg52/pkg53/pkg58/pkg60/pkg61/pkg62
-  are done, pkg59 is done, pkg54/54a/54b/54c/54d are all done (CUDA
-  hardware verified 2026-05-10), pkg63 (World/HDRI parity) is done
-  pending CUDA-host SSIM verification, pkg57 native shader nodes is done,
-  pkg68 OIDN architectural fix is done with measured 2.57× speedup,
-  pkg69 Blender compositor Albedo pass is done, pkg70 OptiX denoiser is
-  done (verified on RTX 5070 Ti + OptiX 9.1.0; surfaced pkg75
-  empty-normal-buffer defect during verification), and pkg71 Cycles parity
-  benchmark framework is implemented with first baseline pending the
-  self-hosted CUDA + Cycles 4.x runner. Open Pillar 5: pkg56 incremental
-  scene sync (3 phases), pkg64 spectral caustics flagship.
-- Fresh local collection on this branch: `pytest --collect-only -q` reports
-  **435 tests collected** (2026-05-09). Focused pkg53/viewport checks pass.
-- Historical docs that are intentionally not current: `NEXT_STAGE_REPORT.md`
-  is a 2026-04-29 snapshot, and `production.md` had old pkg50+ placeholder
-  names that have now been marked obsolete where they conflict with live
-  package numbers.
+- Pillar 5 (Cycles parity / Blender integration / denoiser story) is
+  approaching feature-complete. Done as of 2026-05-10:
+  pkg52/53/57/58/59/60/61/62/63/65/66 (the original Cycles-parity wave);
+  pkg54/54a/54b/54c/54d (full GPU multi-wavelength parity, hardware
+  verified); pkg68 (OIDN persistent device, **measured 2.77× speedup**
+  post-pkg75); pkg69 (compositor Albedo pass); pkg70 (OptiX denoiser,
+  **1.86× faster than OIDN-CUDA, SSIM 0.9987 vs OIDN**); pkg72 (motion
+  vector AOV); pkg75 (first-hit normal buffer for AOV guides — fixed
+  silent AOV-mode degradation); pkg64 Phases 1+2 (RGB SMS skeleton +
+  spectral wavelength-Newton, **+8.83 dB PSNR delta** at 0.98× runtime);
+  pkg56 Phase A (viewport sync instrumentation, baseline 129.92 ms
+  on a 100k-tri scene); pkg74 Phases 1+2 (showcase framework + full
+  stat coverage, convergence rate slope −0.453); pkg71 framework + first
+  canonical Cornell baseline (**Astroray-CPU SSIM 0.9536, Astroray-GPU
+  SSIM 0.9548 vs Cycles-CPU EXR; Astroray-GPU 5.2× faster than
+  Cycles-CUDA at the same Cornell sample budget**). Open Pillar 5
+  for Round 4: pkg73 OptiX temporal denoiser (unblocked by pkg72),
+  pkg56 Phase B/C (uploadScene split + depsgraph dispatch), pkg64
+  Phase 3 (default-integrator MIS fold), pkg74 Phase 3 (interactive
+  HTML + weekly CI), pkg76 (Astroray .blend importer for non-Cornell
+  parity rows).
+- Pillar 4 (astrophysics) explicitly parked per 2026-05-10 strategic
+  gate. pkg40 Kerr metric is done; pkg41 Kerr validation is ready
+  (waiting for the gate). pkg42–51 specs are Codex-paste-ready and
+  waiting. The gate releases when pkg56 Phases B+C and pkg64 Phase 3
+  all land.
+- Fresh local collection: `pytest --collect-only -q` reports **460+
+  tests collected** as of Round 3 close (was 435 at 2026-05-09). New
+  tests added by Rounds 2+3: pkg54c JH GPU, pkg54d profile lookup,
+  pkg57 native nodes, pkg63 world parity, pkg64-1 SMS validation,
+  pkg64-2 spectral SMS, pkg68 persistence, pkg69 compositor passes,
+  pkg70 OptiX, pkg72 motion vectors, pkg74-1 + pkg74-2 showcase,
+  pkg75 normal buffer.
+- `NEXT_STAGE_REPORT.md` is the live action queue (Round 4 prompts);
+  this file is the source of truth for completion state. `production.md`
+  remains historical (pkg50+ placeholder names that conflict with live
+  package numbers are marked obsolete in-place).
 
 ---
 
@@ -48,8 +67,8 @@ personally should pick up.
 | 1 | Plugin architecture | **Done** | 100% | — | — |
 | 2 | Spectral core | **Done** | 100% | — | — |
 | 3 | Light transport | **Validation** | 90% | NRC batched-inference speedup target | CUDA kernels for ReSTIR/NRC are not implemented |
-| 4 | Astrophysics platform | Preparation | 10% | pkg41 Kerr validation | pkg40 metric plugins are done; pkg41 is ready |
-| 5 | Production polish / Blender parity | Ongoing | — | start pkg54/pkg57 | — |
+| 4 | Astrophysics platform | Preparation | 10% | pkg41 Kerr validation | parked per 2026-05-10 strategic gate; releases when pkg56 B+C and pkg64-3 land |
+| 5 | Production polish / Blender parity | **Approaching feature-complete** | ~85% | Round 4: pkg73 + pkg56-B + pkg64-3 + pkg74-3 + pkg76 spec | — |
 
 **Pillar 1 package summary:**
 
@@ -176,31 +195,30 @@ forgotten):
 
 ## This week
 
-**Week of:** 2026-05-08 (Cycles parity / Blender integration push)
+**Week of:** 2026-05-10 (Round 4 — denoiser story closeout, pkg56 Phase B,
+pkg64 final fold, pkg74 CI)
 
 ### Track A (Claude Code)
 
-- pkg37 Blender addon backend refresh is complete.
-- pkg52 is complete: the addon keeps a persistent viewport renderer,
-  `view_draw` re-renders on camera/region/zoom/pan changes, CAMERA-view
-  offset is applied to projection, and the preview progressively accumulates
-  chunked samples until `preview_samples` is reached.
-- pkg53 GPU integrator capability diagnostics and pkg61 GPU per-vertex normals
-  are complete. pkg53 adds C++ integrator capability metadata, Python
-  `integrator_capabilities()`, Blender forced-GPU refusal for unsupported
-  integrators, Auto CPU fallback INFO reports, and Diagnostics panel support
-  rows. pkg61 fixed CUDA per-vertex normal upload; broader CPU/GPU spectral
-  parity remains tracked separately.
-- New roadmap added: pkg52, pkg53, pkg54, pkg57, pkg58, pkg59, pkg61,
-  pkg62, pkg64 (research-blocked), pkg67 (research-blocked). See the
-  "Cycles parity & Blender integration" table above.
-- pkg60 is complete on `codex/pkg60-disney-energy-compensation`: Disney GGX
-  compensation tables are loaded from data files, the old additive roughness
-  boost was removed, Disney spec/clearcoat eval was corrected, and the
-  270-case Halton furnace grid measured worst-case reflectance **1.015891**.
-- Recommended next-up order: **pkg54 → pkg57**.
-  pkg64 and pkg67 require a research note signed off by
-  the project owner before code starts; CLAUDE.md §6 covers the policy.
+- Round 3 closed cleanly. pkg64 Phase 2 spectral SMS landed (+8.83 dB
+  PSNR delta, 0.98× runtime — faster, not slower). pkg72 motion vectors
+  landed (camera-only screen-space flow, OptiX prev→curr convention).
+  pkg74 Phase 2 full stat coverage landed (8 categories, convergence
+  rate slope −0.453). pkg75 normal-buffer fix landed and verified;
+  visual diff confirmed detail preservation; pkg68 headline win up to
+  **2.77×**.
+- Round 4 deployable set per [`NEXT_STAGE_REPORT.md`](NEXT_STAGE_REPORT.md):
+  - **pkg73** OptiX temporal denoiser (3-4 days) — unblocked by pkg72
+  - **pkg56 Phase B** uploadScene split (~2 weeks) — uses pkg56-A
+    instrumentation as before/after baseline
+  - **pkg64 Phase 3** fold SMS into default `path_tracer` via MIS
+    (~½ week) — completes the caustics flagship
+  - **pkg74 Phase 3** interactive HTML + weekly CI (~3 days)
+  - **pkg76 spec** Astroray .blend importer (parity scope) — unblocks
+    Classroom/Junkshop/BMW27/Monster pkg71 rows
+- After Round 4: pkg56 Phase C, pkg76 implementation, pkg55 Phase A
+  (wavefront refactor instrumentation begins). When pkg56 + pkg64 +
+  pkg76 all done, **Pillar 4 thaws**.
 
 ### Track A (Claude Code) — previous
 
@@ -214,13 +232,12 @@ forgotten):
 
 ### Track B (Copilot cloud)
 
-- Complete since the old queue note: albedo/normal/depth AOVs, bounce/sample
-  heatmap passes, `scripts/diagnostics/convergence_tracker.py`, and
-  `scripts/benchmarks/benchmark_showcase.py` are present in-tree.
-- Recent Track B fits pkg58 (spectral profile UX/reference scenes) and pkg62
-  (viewport pass selector + live OIDN preview) are complete; refresh the Track
-  B queue before launching more cloud work.
-- Queue depth: refresh needed
+- Currently inactive. Most Track B-friendly work has been folded into
+  Codex sessions (Track E) since they now have the comprehensive
+  package specs and license-fence research notes that Copilot couldn't
+  produce reliably from cold context. Track B can resume on pattern-
+  matching follow-ups (e.g., Pillar 4 plugins after the strategic gate
+  releases) once pkg42-49 specs prove themselves Codex-paste-ready.
 
 ### Track C (Cline prototype)
 
@@ -234,8 +251,15 @@ forgotten):
 
 ### Track E (Codex)
 
-- Recently merged: PR #116 (`codex/render-test-triage`), PR #117 (`codex/gr-spectral-dispatch`), and PR #119 (`codex/native-gr-spectrum`) — native sampled-spectrum GR disk emission.
-- Complete: pkg29 implementation; local triage work recorded convergence tracker repair, GGX/rough-metal sampling cleanup, and Disney rough-glass transmission.
+- 2026-05-10 round haul: pkg40 Kerr metric (#195), pkg54d profile lookup
+  binding (#187), pkg69 Albedo pass for compositor (#201), pkg71 framework
+  + first canonical Cornell baseline (#205 + #218), pkg70 build hygiene
+  (#215), pkg59 named UV (#184), pkg60 Disney v2 energy compensation (#178),
+  pkg65 scripts cleanup, pkg66 material iteration UX. **The Pillar 4 specs
+  (pkg41-pkg49) are Codex-paste-ready and waiting** for the strategic
+  gate to release.
+- Round 4 Codex queue: pkg64 Phase 3 (default-integrator MIS fold, ~½ week),
+  then pkg74 Phase 3 (interactive HTML + weekly CI, ~3 days).
 - Recent: pkg53 GPU integrator diagnostics and pkg61 shade-smooth GPU parity
   diagnostics/fix work; this docs reconciliation pass corrected stale package
   headers and package-number collisions in planning docs.
@@ -382,6 +406,22 @@ events are summarized in the changelog below.
 ## Changelog
 
 Brief notes on notable events.
+
+- **2026-05-10 (Round 3 close)** — Five packages landed in one round:
+  pkg72 motion vectors, pkg64 Phase 2 spectral SMS (+8.83 dB PSNR delta,
+  0.98× runtime), pkg74 Phase 2 full stat coverage (8 categories,
+  convergence rate slope −0.453), pkg75 normal-buffer fix (verified
+  via visual diff: detail preservation, not regression), and pkg71
+  first canonical Cornell baseline (**Astroray-CPU SSIM 0.9536,
+  Astroray-GPU SSIM 0.9548 vs Cycles-CPU EXR; Astroray-GPU 5.2× faster
+  than Cycles-CUDA at the same Cornell sample budget; Astroray uses
+  3-4× less memory than Cycles**). pkg68 headline OIDN-on speedup vs
+  pre-pkg68 strengthened from 2.57× to **2.77×** post-pkg75. Build
+  hygiene fixed (Windows OptiX, OIDN DLL bootstrap, harness EXR-vs-EXR
+  parity). Round 4 (pkg73 OptiX temporal denoiser, pkg56 Phase B
+  uploadScene split, pkg64 Phase 3 default-integrator fold, pkg74
+  Phase 3 interactive HTML+CI, pkg76 .blend importer spec) queued in
+  NEXT_STAGE_REPORT.md.
 
 - **2026-05-10** — pkg70 **verified and promoted to done** on RTX 5070 Ti +
   OptiX 9.1.0 (Windows MSVC `build_cuda`). 17/17 pytest green


### PR DESCRIPTION
Round 3 closed cleanly. This PR:

1. **Rewrites NEXT_STAGE_REPORT** for Round 4 — six paste-ready prompts (pkg73 OptiX temporal, pkg56 Phase B uploadScene split, pkg64 Phase 3 default-integrator MIS fold, pkg74 Phase 3 interactive HTML + weekly CI, CUDA verifier for pkg72/pkg64-2, pkg76 .blend-importer spec).

2. **Audits STATUS.md** — bumps Last updated, rewrites the current snapshot with all 2026-05-10 measured numbers (pkg68 2.77×, pkg70 1.86×, pkg64-2 +8.83 dB, pkg71 Cornell SSIM 0.95+, pkg74 slope −0.453), refreshes Pillar status (Pillar 5 → ~85% feature-complete, Pillar 4 parked with explicit release condition), refreshes 'This week' for Round 4, refreshes Track E queue, adds Round 3 close changelog entry.

3. **Audits ROADMAP.md** — expands the 'Status as of 2026-05-10' block into a properly categorized post-Round-3 picture (Cycles parity wave done, GPU multi-wavelength done, denoiser story closed except pkg73, caustics Phases 1+2 done, parity benchmark shipped with first measured datapoint, showcase Phases 1+2 done, viewport sync Phase A done). Open Round 4 + Round 5 work enumerated. **Pillar 4 thaw condition stated explicitly: when pkg56 Phases B+C and pkg64 Phase 3 land.**

No code touched. The audit reconciles the project's three planning docs with the post-Round-3 state so Round 4 starts from a true picture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)