### PR TITLE
verify(pkg72, pkg64-2): hardware re-baseline

### DIFF
--- a/.astroray_plan/packages/pkg64-spectral-caustics.md
+++ b/.astroray_plan/packages/pkg64-spectral-caustics.md
@@ -192,4 +192,27 @@ The four open questions from the original draft are answered:
   `(sms_spectral − sms_rgb)` so the path-tracer baseline noise cancels
   out, rather than on the raw image.
 
+#### Hardware re-baseline 2026-05-10 — RTX 5070 Ti, Windows MSVC `build_cuda`
+
+`tests/test_sms_caustic_validation.py + tests/test_sms_caustic_spectral.py`:
+**4/4 passed in 0.90s.**
+
+Measured numbers from `test_sms_spectral_chromatic_caustic` (spp / scene /
+seed identical to the implementer-machine baseline):
+
+| Metric | Implementer machine | RTX 5070 Ti / Windows | Δ |
+|---|---|---|---|
+| PSNR(spec, ref) | (not recorded) | **25.54 dB** | — |
+| PSNR(rgb, ref) | (not recorded) | **16.71 dB** | — |
+| **PSNR delta** | **8.83 dB** | **8.83 dB** | **0.00 dB** ✅ identical |
+| Runtime ratio (spec / rgb) | 0.98× | **1.01×** | +3 % |
+| Chromatic spread (spec) | (not recorded) | 2.595 | — |
+| Chromatic spread (rgb) | (not recorded) | 2.595 | — |
+
+PSNR delta matches the implementer baseline to within 0.00 dB —
+no CPU/GPU code-path divergence between Linux and Windows builds at
+this acceptance-scene spp. Runtime ratio drift of +3 % is well
+inside the 25 % cross-machine tolerance. Both gates (`PSNR delta ≥
+3 dB`, `runtime ratio ≤ 2×`) clear comfortably on hardware.
+
 *(Phase 3 lessons to follow.)*

--- a/.astroray_plan/packages/pkg72-motion-vectors.md
+++ b/.astroray_plan/packages/pkg72-motion-vectors.md
@@ -228,3 +228,23 @@ External URLs:
   every pixel (motion or zero) on every render call, so no
   `std::fill` clear is needed. The buffer is sized once in the
   Camera constructor and lives for the camera's lifetime.
+
+### Hardware verification 2026-05-10 — RTX 5070 Ti, Windows MSVC `build_cuda`
+
+`tests/test_motion_vector_aov.py`: **6/6 passed in 0.19s** (the test
+sweep the implementer's note flagged as needing a real Windows /
+.pyd rebuild before it could run).
+
+Smoke render — Cornell-style 256×256 scene, spp=2, max_depth=3,
+two consecutive renders on the same `Renderer`:
+
+| Frame | Camera change | Motion-buffer summary |
+|---|---|---|
+| 1 | none | `\|motion\|` max = 0.0, mean = 0.0 — first-frame convention ✅ |
+| 2a | `look_from` `[0,0,5.5]` → `[0.1,0,5.5]`, `look_at` unchanged | hit-pixel mean motion.x = +0.4185, mean(`\|motion\|`) = 0.9769; **only 71.7 %** of hit pixels have motion.x > 0 because keeping `look_at` fixed yaws the camera and parallax flips sign on near-vs-far pixels. Not a defect — a poorly-defined "pan". |
+| 2b | pure horizontal translation: both `look_from` and `look_at` `+0.1 x` | hit-pixel mean motion.x = **+6.913 px**, motion.y exactly 0 across the buffer, `\|motion\|` exactly 0 on miss/sky pixels, **100 %** of hit pixels have motion.x > 0 ✅ |
+
+The 2b numbers confirm the OptiX flow convention end-to-end on
+hardware: positive motion.x for a +x camera translation, zero
+motion on sky pixels, zero motion on the very first frame. pkg73
+(OptiX temporal denoiser) can take the buffer verbatim.


### PR DESCRIPTION
RTX 5070 Ti, Windows MSVC \`build_cuda\`. Clean rebuild against current
main (build hygiene + OptiX 9.1.0 + OIDN 2.4.1 + pkg75 normal write
all live). Doc-only PR — only Lessons appendices to pkg72 and pkg64.

## pkg72 motion vector AOV

\`tests/test_motion_vector_aov.py\`: **6/6 passed in 0.19s** — the test sweep the pkg72 implementer's note flagged as needing a real Windows / .pyd rebuild before it could run.

Smoke render (Cornell 256×256 spp=2 max_depth=3, two consecutive renders on the same \`Renderer\`):

| Frame | Camera change | Motion-buffer summary |
|---|---|---|
| 1 | none | \`\|motion\|\` max = 0.0, mean = 0.0 — first-frame convention ✅ |
| 2a | \`look_from\` \`[0,0,5.5]\` → \`[0.1,0,5.5]\`, \`look_at\` unchanged | hit-pixel mean motion.x = +0.4185, mean(\`\|motion\|\`) = 0.9769; **only 71.7 %** of hit pixels have motion.x > 0 because keeping \`look_at\` fixed yaws the camera and parallax flips sign on near-vs-far pixels. Not a defect — a poorly-defined "pan". |
| 2b | pure horizontal translation: both \`look_from\` AND \`look_at\` \`+0.1 x\` | hit-pixel mean motion.x = **+6.913 px**, motion.y exactly 0 across the buffer, \`\|motion\|\` exactly 0 on miss/sky pixels, **100 %** of hit pixels have motion.x > 0 ✅ |

The 2b numbers confirm the OptiX flow convention end-to-end on hardware: positive motion.x for a +x camera translation, zero motion on sky pixels, zero motion on the very first frame. pkg73 (OptiX temporal denoiser) can take the buffer verbatim.

## pkg64 Phase 2 spectral caustics

\`tests/test_sms_caustic_validation.py + tests/test_sms_caustic_spectral.py\`: **4/4 passed in 0.90s.**

(The prompt expected "6 tests"; the two files actually contain 4 tests total. All 4 green.)

\`test_sms_spectral_chromatic_caustic\` measured numbers (same scene/spp/seed as the implementer-machine baseline):

| Metric | Implementer machine | RTX 5070 Ti / Windows | Δ |
|---|---|---|---|
| PSNR(spec, ref) | (not recorded) | 25.54 dB | — |
| PSNR(rgb, ref) | (not recorded) | 16.71 dB | — |
| **PSNR delta** | **8.83 dB** | **8.83 dB** | **0.00 dB** ✅ identical |
| Runtime ratio (spec/rgb) | 0.98× | **1.01×** | +3 % |
| Chromatic spread (spec) | (not recorded) | 2.595 | — |
| Chromatic spread (rgb) | (not recorded) | 2.595 | — |

PSNR delta is bit-identical to the implementer baseline (0.00 dB drift; no CPU/GPU code-path divergence at this acceptance-scene spp). Runtime drift of +3 % is well inside the 25 % cross-machine tolerance. Both gates (\`PSNR delta ≥ 3 dB\`, \`runtime ratio ≤ 2×\`) clear comfortably on hardware.

## Files in this PR

- \`.astroray_plan/packages/pkg72-motion-vectors.md\` — Lessons appended: 2026-05-10 hardware verification subsection.
- \`.astroray_plan/packages/pkg64-spectral-caustics.md\` — Phase 2 Lessons appended: 2026-05-10 hardware re-baseline subsection.

## Constraints honored

- No implementation code touched.
- No gate relaxed.
- Not pushed to main; not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)