### PR TITLE
docs(pkg76): Astroray .blend importer (parity scope) spec

### DIFF
--- a/.astroray_plan/docs/blend-importer-research.md
+++ b/.astroray_plan/docs/blend-importer-research.md
@@ -1,0 +1,245 @@
+# Blender `.blend` Importer Research — Astroray pkg76
+
+**Date:** 2026-05-10
+**Scope:** External (non-`bpy`) reader for `.blend` files, sufficient
+to drive the pkg71 Cycles-parity benchmark on Classroom, Junkshop,
+BMW27 (and any future demo scene that ships only as `.blend`).
+This is **parity scope** — not a general Blender compatibility layer.
+
+---
+
+## 1. Problem Statement (from pkg71 baseline)
+
+The first pkg71 baseline run
+(`benchmarks/cycles-parity/2026-05-10-hendrik-desktop-amd64-family-25-model-97-stepping-2-authenticamd-4fa95be.md`)
+emitted clean Cycles rows for all five scenes but skipped
+Astroray-CPU and Astroray-GPU on every `.blend` source with:
+
+```
+skip: astroray_blend_import_not_implemented
+```
+
+Cornell parity landed (Astroray-CPU SSIM 0.9536, Astroray-GPU SSIM
+0.9548 vs Cycles-CPU EXR) because Cornell is built natively by both
+engines from a Python scene description. Astroray today has no
+external `.blend` reader; the in-Blender addon path translates
+through the live `bpy` data API at viewport time, which is not
+reachable from a CLI process. To fill the four missing rows the
+benchmark needs an offline `.blend` → Astroray-scene importer.
+
+Monster (`UDIM_monster/udim-monster.blend`) failed differently —
+Cycles itself errored with `RuntimeError: Error: Cannot render, no
+camera` for both CPU and CUDA rows. The file ships as a
+texture-paint UDIM rig without a camera object. pkg76 must decide
+whether to fix or drop it (see §5).
+
+---
+
+## 2. The `.blend` File Format — Summary
+
+The file format is self-describing through a Structure DNA (SDNA)
+block, which means a parser that reads the SDNA can walk every
+typed block in the file without any hardcoded struct layouts. This
+is the property that makes a parity-scope reader feasible in a few
+hundred lines of Python rather than tens of thousands of lines of
+C++.
+
+**Canonical references (fetched 2026-05-10):**
+
+| Source | Fetch result | Notes |
+|---|---|---|
+| `https://wiki.blender.org/wiki/Source/File_Format` | **HTTP 403** at fetch time | Implementer must retry or use an authenticated browser. Format described below from prior published descriptions. |
+| `https://www.atmind.nl/blender/mystery_ot_blend.html` | **Reachable but body trimmed**; only title returned by harness | Implementer should re-fetch in a browser. Useful as a beginner walkthrough of block addressing and pointer resolution. |
+| `https://github.com/blender/blender` (`source/blender/blenkernel/intern/`) | n/a (no fetch needed; license-fenced) | **GPL-2.0-or-later. Read for understanding, do NOT mirror code.** Authoritative reference for SDNA semantics. |
+| `https://github.com/JTraversa/Blender-File-Reader` | License could not be auto-fetched (404 on raw paths tried) | Repo exists; the implementer **MUST visually confirm the LICENSE file at port time**. The brief instructed "BSD-3" — verify before mirroring. If no LICENSE is present, do not mirror. |
+| `https://pypi.org/project/blend2json/` | Could not auto-confirm license | Same as above — **verify LICENSE at port time**. |
+
+> **License-fence rule for pkg76:** No code is copied into Astroray
+> until the implementer has the LICENSE file open in front of them
+> and has confirmed it is one of: MIT, BSD-2/3, Apache-2.0, MPL-2.0,
+> public-domain, or unlicense (CC0). Anything else — including
+> "no LICENSE file present" — is treated as "all rights reserved"
+> and the algorithm is re-implemented from the published format
+> description, citing the format spec rather than the third-party
+> code.
+
+### 2.1 File header (12 bytes)
+
+| Offset | Bytes | Field | Values |
+|---|---|---|---|
+| 0  | 7 | Magic | ASCII `BLENDER` |
+| 7  | 1 | Pointer size | `_` = 4-byte pointers, `-` = 8-byte pointers |
+| 8  | 1 | Endianness | `v` = little-endian, `V` = big-endian |
+| 9  | 3 | Version | ASCII digits, e.g. `403` for Blender 4.3 |
+
+Modern `.blend` files (Blender 3.0+) are wrapped in a Zstandard
+stream; pre-3.0 files used gzip. The first 4 bytes of the raw file
+distinguish them: `0x28 0xB5 0x2F 0xFD` for zstd, `0x1F 0x8B` for
+gzip, otherwise treat as uncompressed. The reader must transparently
+decompress before applying the table above.
+
+### 2.2 File-block header
+
+Every block after the file header begins with a fixed-layout
+header, then `size` bytes of payload:
+
+| Field | Type | Notes |
+|---|---|---|
+| `code` | char[4] | Block code, see §2.4 |
+| `size` | uint32 | Payload size |
+| `old`  | pointer | Original in-memory address, used as the pointer key |
+| `SDNAnr` | uint32 | Index into the SDNA struct table |
+| `count` | uint32 | Number of struct instances in payload |
+
+`old` is the lookup key: every pointer in the file is the address
+the data had when Blender wrote it, so resolving a pointer means
+finding the block whose `old == ptr`. Build an `old → block` dict
+during the first pass and the rest of parsing is straight
+struct-decode.
+
+### 2.3 SDNA1 block
+
+Exactly one block has code `DNA1`. Its payload is a fixed sequence
+of sub-records:
+
+| Magic | Contents |
+|---|---|
+| `SDNA` | header magic |
+| `NAME` | field-name list. Names embed type modifiers: `*foo`, `**bar`, `verts[3]`, `(*func)()`. Parse them — they are how arrays and pointer levels are recovered. |
+| `TYPE` | type-name list (e.g. `Camera`, `Mesh`, `MPoly`, `float`). |
+| `TLEN` | uint16 size of each type. |
+| `STRC` | struct descriptors: `(type_index, n_fields, [(type_index, name_index)] * n_fields)`. |
+
+`SDNAnr` from a block header indexes `STRC`. Combined with `TLEN`
+and `NAME` parsing, every typed block is fully decodable without
+hardcoding any C struct definitions. **This is the key invariant
+that keeps the parser version-portable.**
+
+### 2.4 Block codes touched by parity scope
+
+| Code | Struct (typical) | Why pkg76 cares |
+|---|---|---|
+| `GLOB` | FileGlobal | points to the active scene |
+| `SC`   | Scene | points to camera, world, master collection |
+| `OB`   | Object | transform + pointer to data block (mesh / camera / lamp) |
+| `ME`   | Mesh | vertices, faces, per-face material index |
+| `CA`   | Camera | focal length, sensor size |
+| `LA`   | Lamp / Light | type, color, energy |
+| `MA`   | Material | (legacy r,g,b OR pointer to nodetree) |
+| `WO`   | World | (legacy horr,horg,horb OR pointer to nodetree) |
+| `NT`   | bNodeTree | shader graph; only walked far enough to find Principled/Diffuse base color and Background color/strength |
+| `DATA` | inline child arrays (MVert, MPoly, MLoop, position attribute, corner_verts, custom-data layers) — addressed via parent pointers |
+| `ENDB` | (none) | end-of-file sentinel |
+
+### 2.5 Mesh-storage compatibility note
+
+Mesh storage rewrote in Blender 3.6+: the legacy `MVert.co` /
+`MPoly` / `MLoop` arrays were deprecated in favour of
+attribute-based storage on a generic `CustomData` layer system
+(`position` attribute for verts, `face_offset_indices` +
+`corner_verts` for faces, `material_index` as a face-domain
+attribute). pkg71's target scenes (Classroom 2017, Junkshop 2020,
+BMW27 2014) were authored against the legacy layout and re-saved
+with current Blender. The importer must read **both layouts**, but
+should prefer the attribute-based one when both are present (the
+legacy fields are no longer updated on save in 4.x).
+
+### 2.6 Camera, Light, Material fields
+
+- **Camera** (`bCamera`): `lens` (mm focal length, only when
+  `type == CAM_PERSP`), `sensor_x`, `sensor_y`, `sensor_fit`,
+  `clipsta`, `clipend`, `type` (`CAM_PERSP`=0, `CAM_ORTHO`=1,
+  `CAM_PANO`=2). Panoramic is out of scope; reject and skip.
+- **Light** (`Light` / `Lamp`): `type` (`LA_LOCAL`=0 point,
+  `LA_SUN`=1, `LA_SPOT`=2, `LA_AREA`=4 — area lights are out of
+  parity scope unless the harness already supports them; check
+  before importing), `r`, `g`, `b`, `energy`.
+- **Material** (`Material`): `use_nodes` flag — if false, fall back
+  to legacy `r`/`g`/`b`/`metallic`/`roughness`. If true, walk
+  `nodetree` for the active output's surface input, expect
+  `ShaderNodeBsdfPrincipled` (read `Base Color` socket default) or
+  `ShaderNodeBsdfDiffuse` (read `Color` socket default). Anything
+  else: emit a warning, fall back to mid-grey, **continue** (parity
+  scope, not perfection).
+- **World** (`World`): same pattern — `use_nodes` false →
+  `horr`/`horg`/`horb`; true → walk for `ShaderNodeBackground`'s
+  Color and Strength defaults. HDRI image textures are out of
+  scope (see §5 of the spec).
+
+---
+
+## 3. Reference Implementations Survey
+
+| Repo | License (verify at port time) | Mirror? | Use |
+|---|---|---|---|
+| `blender/blender` `source/blender/blenkernel/intern/` | GPL-2.0-or-later | **No** | Authoritative for SDNA + struct semantics; read for understanding. |
+| `JTraversa/Blender-File-Reader` | brief said BSD-3 — **unverified at fetch time** | If LICENSE confirmed BSD-3 at port time: yes, with attribution in source headers | Reference Python reader; mine for SDNA-walk pattern. |
+| `blend2json` (PyPI) | brief said BSD-3 — **unverified at fetch time** | If LICENSE confirmed BSD-3 at port time: yes, with attribution | Reference for which fields matter for an offline render-spec dump. |
+| `mont29/blendfile` (older Python reader, sometimes vendored elsewhere) | check at port time | maybe | Backup if the two above are unsuitable. |
+
+If neither mirrorable reader is available, the parser is small
+enough — header + block walk + SDNA decoder + a handful of typed
+field reads — to be re-implemented from the format spec alone in
+under ~600 LOC. Cite the format spec URL in the source header.
+
+---
+
+## 4. Validation Strategy
+
+The reader is data-driven; the test that proves it works is a
+roundtrip on a synthetic `.blend` we author with `bpy` at
+test-collection time:
+
+1. With `bpy` available (`pytest.importorskip("bpy")`), build a
+   trivial scene: one Cube mesh, one Sun light, one Camera, a
+   Principled BSDF with a known base colour, and a known World
+   background colour.
+2. Save to a temp `.blend`.
+3. Run the new importer on that file.
+4. Assert: vert count, face count, material count, light count,
+   camera focal length, base colour RGB, world colour RGB all
+   match the values used to author the scene.
+
+This is the only acceptance test that does not depend on the full
+pkg71 harness. The integration test is "the next pkg71 baseline
+emits non-skip Astroray rows for the four `.blend` scenes."
+
+---
+
+## 5. Monster Scene Decision
+
+The pkg71 baseline shows `udim-monster.blend` failing inside
+**Cycles itself** with "no camera." This is a property of the
+asset, not a bug in our harness. Three options:
+
+1. **Drop Monster from pkg71's manifest.** Smallest change.
+   Justification: Monster as shipped is a paint/texturing rig, not
+   a render scene. Replacement coverage (many materials, hero
+   render) is already provided by Junkshop.
+2. Find a different "Monster"-class CC-0 scene (e.g. one of the
+   Blender Studio short-film stills). Adds work to pkg76 and
+   delays the parity baseline.
+3. Inject a camera into the file at fetch time. Brittle and breaks
+   the SHA-256 manifest gate.
+
+**pkg76 chooses option 1.** Per CLAUDE.md §2 ("Simplicity First")
+the four-scene set (Cornell + Classroom + Junkshop + BMW27)
+already covers indoor-lighting, dense-prop, and HDRI cases.
+Replacement Monster is a future package if anyone asks for it.
+
+---
+
+## 6. What this Document Does NOT Cover
+
+- Animation (`Action`, `FCurve`), modifiers (`Modifier`), particle
+  systems, hair, volumes, fluid sims. All out of pkg76 scope.
+- Image textures and HDRIs (`Image`, `ImBuf`, packed pixel data).
+  The `.blend` may embed images; the parity-scope importer reads
+  the path string only and emits a warning if a node references
+  one.
+- The full shader graph. pkg57 already gives Astroray a node-based
+  shader stack on the engine side; that is the place to extend
+  shader fidelity, not in `.blend` import.
+- Library linking (`Library` blocks pointing at other `.blend`s).
+  The four target scenes are self-contained; the importer can fail
+  loudly on a non-empty `LI` block.

--- a/.astroray_plan/packages/pkg76-blend-importer-parity-scope.md
+++ b/.astroray_plan/packages/pkg76-blend-importer-parity-scope.md
@@ -1,0 +1,330 @@
+# pkg76 — Astroray `.blend` Importer (Parity Scope)
+
+**Pillar:** 5
+**Track:** A
+**Status:** open
+**Estimated effort:** 1–2 weeks (~30–45 h, multi-session)
+**Depends on:** pkg71 (the harness consumer; landed in PR #218)
+
+---
+
+## Goal
+
+**Before:** pkg71's first canonical baseline (PR #218) lands clean
+Cornell parity numbers — Astroray-CPU SSIM 0.9536, Astroray-GPU
+SSIM 0.9548 vs Cycles-CPU EXR — but every non-Cornell row in
+`benchmarks/cycles-parity/2026-05-10-hendrik-desktop-amd64-family-25-model-97-stepping-2-authenticamd-4fa95be.md`
+reads `skip: astroray_blend_import_not_implemented`. Astroray has
+no offline `.blend` reader, so the harness can only compare on
+scenes both engines build natively from a Python scene-spec.
+"Astroray matches Cycles" is therefore an unfounded claim outside
+Cornell.
+
+**After:** A small Python `.blend` reader that walks the SDNA
+self-description, extracts a parity-scope subset (camera, mesh,
+material base colour, light, world colour) and emits an Astroray
+scene via the existing Renderer Python API. The pkg71 harness
+calls it for every Astroray-engine row whose source is a `.blend`,
+and the next baseline run produces real, non-skip Astroray-CPU and
+Astroray-GPU rows for **Classroom, Junkshop, and BMW27**, with
+SSIM ≥ 0.85 vs the Cycles-CPU EXR reference. (See §4 for the
+Monster decision.)
+
+The scope is *parity for pkg71*, not a Blender compatibility
+layer. Future packages can extend.
+
+---
+
+## Context
+
+pkg71 is the only thing standing between Astroray and a publishable
+parity number on more than a single Cornell box. Without offline
+`.blend` import, every CC-0/CC-BY demo scene in the manifest
+remains a one-engine row. The blocker is small, well-bounded, and
+solvable by reading a self-describing format — no rendering
+research, no GPU work. This package belongs in track A only because
+it unblocks the parity story; the work itself is unglamorous file
+parsing.
+
+The Blender source (`source/blender/blenkernel/intern/`) is the
+authoritative reference but is GPL-2.0-or-later and cannot be
+mirrored into MIT-licensed Astroray. The `.blend` format is
+self-describing through its embedded SDNA (Structure DNA), which
+means a parser written from the published format spec — not from
+Blender source — stays small (a few hundred lines) and license-clean.
+
+---
+
+## Reference
+
+- Research notes: [`.astroray_plan/docs/blend-importer-research.md`](.astroray_plan/docs/blend-importer-research.md)
+  (created in this commit, contains format-summary tables, license
+  verdicts, and the Monster decision rationale).
+- Format spec (re-fetch in browser if 403 from `WebFetch`):
+  - `https://wiki.blender.org/wiki/Source/File_Format` — official.
+  - `https://www.atmind.nl/blender/mystery_ot_blend.html` —
+    community walkthrough of block addressing.
+- Authoritative reader (read-only, GPL-2.0-or-later, **do not
+  mirror**): `blender/blender` `source/blender/blenkernel/intern/`,
+  in particular `readfile.c` for the SDNA + block-walk semantics.
+- Candidate mirrorable readers (license **must be confirmed at
+  port time**, brief described both as BSD-3 but auto-fetch failed):
+  - `https://github.com/JTraversa/Blender-File-Reader`
+  - `https://pypi.org/project/blend2json/`
+- pkg71 baseline that motivates this package:
+  `benchmarks/cycles-parity/2026-05-10-hendrik-desktop-amd64-family-25-model-97-stepping-2-authenticamd-4fa95be.md`.
+- pkg71 manifest: `benchmarks/cycles-parity/scenes/manifest.toml`.
+
+---
+
+## Reference Implementations
+
+Per CLAUDE.md §6 and the pkg71 precedent ("Cite, Borrow, Verify"),
+the table below records what we may and may not draw from. License
+fields are the authors' claims as of 2026-05-10; **the implementer
+re-confirms each LICENSE file before pasting any line of code**.
+
+| Repo | Commit/version | License | Mirror? | Files to study | What to mirror | What NOT to mirror |
+|---|---|---|---|---|---|---|
+| `blender/blender` (`source/blender/blenkernel/intern/readfile.c`, `dna_genfile.c`) | record SHA in source header at port time | **GPL-2.0-or-later** | **No** | SDNA decoder, block-walk loop, pointer-resolve dictionary | nothing (algorithm understanding only) | any code lines, comments, struct names that came from the file verbatim |
+| `JTraversa/Blender-File-Reader` | record SHA at port time | brief: BSD-3 — **VERIFY before mirroring** | conditional: yes if BSD-3 confirmed, with attribution | overall reader entry point, SDNA struct table walk | small helpers (header decode, name parser, block iterator) cited per-function | engine-specific render code if present (none expected; this is a reader-only repo) |
+| `blend2json` (PyPI) | record version at port time | brief: BSD-3 — **VERIFY before mirroring** | conditional: yes if BSD-3 confirmed, with attribution | which fields it surfaces for camera/mesh/material/light/world | the field-selection list (use as a checklist for our parity subset) | any code we cannot license-clear |
+| Blender format spec (wiki + atmind) | URL + fetch date | docs (no code license) | n/a | header layout, block header, SDNA1 sub-records | our parser is written *from* this spec | n/a |
+| `BlendLuxCore` `export/` (Python) | n/a | **GPL-3.0** — incompatible with MIT | **No** | how a third-party engine consumes `bpy` data structurally | nothing | anything |
+
+If both candidate Python readers turn out to be unsuitable (no
+LICENSE, GPL, or otherwise restrictive), the parser is written
+from the format spec alone in ~600 LOC. The format spec is the
+canonical reference and is licence-neutral as documentation.
+
+Cite the source in the file header of every adapted module:
+```python
+# Adapted from JTraversa/Blender-File-Reader@<SHA> — BSD-3, see THIRD_PARTY/Blender-File-Reader-LICENSE
+# .blend format reference: https://wiki.blender.org/wiki/Source/File_Format
+```
+
+---
+
+## Specification
+
+### Strategy — Python, not C++
+
+The reader is **Python**, not C++. Cycles uses C++ because it lives
+inside the Blender process and needs to consume `bpy` struct
+pointers in-memory. Astroray reads the file offline; there is
+nothing about the parsing work that benefits from being native, and
+the existing addon-shaped Python scene builder is already the path
+that constructs Astroray scenes from a `.blend` (via `bpy`). pkg76
+mirrors that builder's output API, but driven from raw file bytes.
+
+This avoids: ABI churn against `bpy`, MinGW C++ struct-by-value
+issues (per `mingw_large_struct_byval` memory), and the need for a
+new build target.
+
+### File parser
+
+A four-pass design:
+
+1. **Decompress** if needed (Zstd for Blender 3.0+, gzip for
+   pre-3.0). Detect by magic bytes; fall through to raw if
+   neither.
+2. **Header decode** — read the 12-byte header, latch
+   pointer-size and endianness for the rest of the read.
+3. **First block-pass** — scan every block header (code, size,
+   `old`, SDNA index, count), build a dict `old → (offset, code,
+   sdna_index, count)`. When we hit `DNA1`, decode SDNA into
+   `(name_table, type_table, type_size_table, struct_table)`.
+   Stop at `ENDB`.
+4. **Typed read pass** — starting from `GLOB`, follow pointers
+   through `Scene → camera`, `Scene → master_collection →
+   children → objects` (or legacy `Scene → base → object` chain
+   on older files), and per-`Object` follow `Object.data` to
+   `Mesh` / `Camera` / `Light`. Each typed read is driven by the
+   SDNA struct descriptor — there are **zero hardcoded C struct
+   layouts** in our code.
+
+### Minimum field set (parity scope only)
+
+| Datablock | Field | Purpose | Out of scope |
+|---|---|---|---|
+| `bCamera` | `lens`, `sensor_x`, `sensor_y`, `sensor_fit`, `clipsta`, `clipend`, `type` | perspective camera | `CAM_PANO` (skip with warning), DOF, shift |
+| `Object` | `loc[3]`, `rot[3]` (or `obmat[4][4]` if present), `size[3]`, `data` ptr, `type` | transform + datablock dispatch | constraints, parents, drivers, modifiers |
+| `Mesh` (legacy ≤3.5) | `mvert[].co`, `mpoly[].loopstart`+`totloop`+`mat_nr`, `mloop[].v` | tris/quads + per-face material index | UVs (pkg59 territory), normals (pkg61) |
+| `Mesh` (≥3.6 attribute layout) | `position` attribute, `face_offset_indices`, `corner_verts`, `material_index` attribute | same as above on the new layout | same |
+| `Material` | `use_nodes`; if false: `r,g,b,metallic,roughness`; if true: walk `nodetree` for active output → `ShaderNodeBsdfPrincipled.Base Color` (default value only) **or** `ShaderNodeBsdfDiffuse.Color` | base colour for parity SSIM | full shader graph (use pkg57 nodes manually for full fidelity) |
+| `Light` (Lamp) | `type` (LA_LOCAL/LA_SUN/LA_SPOT — area lights conditional on Astroray support), `r,g,b`, `energy` | point/sun/spot lights | LA_AREA shape parameters, IES files, light linking |
+| `World` | `use_nodes`; if false: `horr,horg,horb`; if true: walk `nodetree` for `ShaderNodeBackground` Color + Strength defaults | background colour | HDRI / image-texture-driven worlds (out of scope; document) |
+
+Anything else encountered emits a one-line warning to the import
+log and is silently skipped — the reader **never aborts** an
+import on an unrecognised feature; it degrades to "rendered with
+parity-scope fidelity."
+
+### Output — Python builder script
+
+`tools/blend_import/blend_to_astroray.py` (or wherever the existing
+Astroray Python API conventionally lives — confirm at implement
+time). Public surface:
+
+```python
+def import_blend(path: pathlib.Path,
+                 *,
+                 strict: bool = False) -> astroray.Scene:
+    """Build an Astroray scene from a .blend file at *path*.
+
+    Parameters
+    ----------
+    path
+        Path to a .blend file (compressed or uncompressed).
+    strict
+        If True, raise on any parity-scope-unsupported feature
+        instead of warning. The pkg71 harness passes False.
+    """
+```
+
+The output is the same `astroray.Scene` object the Cornell scenes
+already construct, so the renderer pipeline downstream is unchanged.
+
+### Wiring into pkg71
+
+The harness gains one branch in its scene-prep step: if
+`scene.source.endswith(".blend")` and `engine.startswith("astroray")`,
+call `import_blend(path)` and feed the result to the existing
+Astroray run path. The `astroray_blend_import_not_implemented`
+skip reason is removed; replaced (where parity-scope import does
+emit warnings) with a per-row warning count column in the CSV.
+
+The harness change is intentionally tiny — 5–10 lines, no
+restructuring of pkg71's runner.
+
+### Files to create / modify
+
+| File | What |
+|---|---|
+| `tools/blend_import/__init__.py` | package marker |
+| `tools/blend_import/sdna.py` | SDNA decoder (header, type/name/struct tables) |
+| `tools/blend_import/reader.py` | block walk + pointer resolution |
+| `tools/blend_import/scene_builder.py` | typed reads → `astroray.Scene` |
+| `tools/blend_import/blend_to_astroray.py` | public `import_blend()` entry point |
+| `tests/test_blend_import_roundtrip.py` | bpy-authored synthetic `.blend` roundtrip (skip-if-no-bpy) |
+| `tests/test_blend_import_format.py` | unit tests for SDNA decode + header decode against a tiny checked-in `.blend` blob |
+| `tests/fixtures/synthetic_min.blend` | 1 cube + 1 sun + 1 camera + 1 Principled BSDF, authored by `bpy` once and committed (≪10 KB) |
+| `THIRD_PARTY/Blender-File-Reader-LICENSE` | iff we mirror from JTraversa repo and confirm BSD-3 |
+| `THIRD_PARTY/blend2json-LICENSE` | iff we mirror from blend2json and confirm BSD-3 |
+| `benchmarks/cycles-parity/runner.py` (or harness equivalent) | replace skip stub with `import_blend()` call for `astroray-*` engines on `.blend` sources |
+| `benchmarks/cycles-parity/scenes/manifest.toml` | drop `[[scene]] id="monster"` entry (see §4) |
+| `.astroray_plan/docs/blend-importer-research.md` | already created in this PR; updated as port-time discoveries land |
+
+Test note: `tests/fixtures/synthetic_min.blend` is generated by a
+small `bpy` script (`tests/fixtures/build_synthetic_min.py`) that
+the test author runs once outside CI. The script is committed; the
+output `.blend` is committed (binary, but ≪10 KB and stable across
+re-runs because we set deterministic IDs). CI does not require
+`bpy`.
+
+---
+
+## Acceptance
+
+- [ ] Unit tests in `tests/test_blend_import_format.py` decode the
+      header, SDNA, and three known struct fields from
+      `synthetic_min.blend` with no `bpy` dependency. Green on
+      all three platforms in CI.
+- [ ] `tests/test_blend_import_roundtrip.py`
+      (`pytest.importorskip("bpy")`) builds a fresh scene
+      programmatically, saves it to a temp `.blend`, imports it
+      with `import_blend()`, and asserts: vert count, face count,
+      material count == 1, light count == 1, camera focal length
+      within 1e-3, base colour RGB within 1e-3, world colour RGB
+      within 1e-3.
+- [ ] `pytest -q tests/test_blend_import_*` passes locally on
+      Windows MinGW + Linux GCC. (Per `mingw_large_struct_byval`
+      memory the parser is pure Python so the toolchain risk is
+      nil; this row is a sanity check.)
+- [ ] The next pkg71 baseline run on Hendrik's reference machine
+      emits **non-skip** Astroray-CPU and Astroray-GPU rows for
+      Classroom, Junkshop, and BMW27 (Monster row absent — see §4).
+      Each Astroray row records timing, peak RSS, peak VRAM, and
+      SSIM ≥ 0.85 vs the Cycles-CPU EXR reference at the manifest
+      `reference_spp`. The 0.85 threshold (relaxed from Cornell's
+      0.95 gate) accounts for shader-graph and procedural-texture
+      fidelity loss in parity-scope import.
+- [ ] The pkg71 baseline `.md` summary now contains attribution
+      lines for any scene we successfully imported under CC-BY
+      (Junkshop, BMW27).
+- [ ] Every adapted file has a header citation pointing to either
+      the format spec or the third-party repo + commit + license,
+      per CLAUDE.md §6.
+- [ ] No GPL-licensed code from `blender/blender` or
+      `BlendLuxCore` appears anywhere in the diff. Verified by
+      visual diff review.
+
+---
+
+## Non-goals
+
+- **Full shader graph import.** Parity scope reads only the Base
+  Color of a Principled or Diffuse BSDF, plus the World
+  Background colour. Anything else (Mix shaders, ColorRamp,
+  procedural textures, Voronoi, Musgrave) is silently degraded to
+  the base colour with a warning. Astroray-side complexity is
+  pkg57 territory; manual shader authoring on the engine side
+  remains the path for full fidelity.
+- **Image textures and HDRIs.** Parity scope is procedural only.
+  Image paths are read but not loaded; HDRI worlds degrade to the
+  Background node's colour default. Future package: `pkgNN-blend-image-import`.
+- **Animation, modifiers, particles, hair, volumes.** All out of
+  parity scope. The reader does not even visit these blocks.
+- **Library-linked `.blend`s.** A non-empty `LI` block fails
+  loudly. The four target scenes are self-contained.
+- **Round-trip writing.** This is a one-way reader; we never
+  write `.blend` files.
+- **Camera panoramic / fisheye / equirectangular projections.**
+  `CAM_PANO` is skipped with a warning.
+- **Area lights** unless Astroray's existing light infrastructure
+  already supports them at parity-scope geometry; the importer
+  decides at port time and documents the choice.
+
+---
+
+## Monster Scene Decision
+
+Per the pkg71 baseline, `udim-monster.blend` fails inside Cycles
+itself with `RuntimeError: Error: Cannot render, no camera`. The
+file ships as a paint/UDIM rig, not a render scene.
+
+**pkg76 drops `[[scene]] id = "monster"` from
+`benchmarks/cycles-parity/scenes/manifest.toml`.** Justification
+(per CLAUDE.md §2 "Simplicity First"): the four-scene set
+(Cornell + Classroom + Junkshop + BMW27) already covers
+sanity-light-transport, indoor-mixed-lighting, dense-prop, and
+HDRI-studio. A "many-materials hero render" replacement scene is
+not on the critical path; if anyone wants one, it's a future
+package, not a pkg76 sub-task. The pkg71 README is updated in this
+PR with a one-line note explaining the drop.
+
+---
+
+## Progress
+
+- [ ] Re-fetch the format spec in a browser; commit a fresh
+      revision of `blend-importer-research.md` if any details
+      contradict §2 of the research doc.
+- [ ] Visit each candidate reader's LICENSE file in a browser;
+      commit the verdict to the research doc.
+- [ ] Author `tests/fixtures/build_synthetic_min.py`, generate
+      `synthetic_min.blend`, commit both.
+- [ ] Implement `sdna.py` + `reader.py`; pass
+      `test_blend_import_format.py`.
+- [ ] Implement `scene_builder.py` + `blend_to_astroray.py`;
+      pass `test_blend_import_roundtrip.py`.
+- [ ] Wire into pkg71 runner; drop monster from manifest; rerun
+      baseline on reference machine; commit the new baseline `.md`.
+- [ ] Verify SSIM ≥ 0.85 for all three Astroray-CPU and
+      Astroray-GPU rows.
+
+---
+
+## Lessons
+
+*(Fill in after the package is done.)*


### PR DESCRIPTION
## Summary

Spec + research notes for **pkg76 — Astroray `.blend` Importer (parity scope)**, the package that unblocks real Astroray rows in the pkg71 Cycles-parity baseline. **No source code changes — spec only.**

## Why

The first pkg71 canonical baseline (PR #218) landed Cornell parity (Astroray-CPU SSIM 0.9536, Astroray-GPU SSIM 0.9548) but skipped every other Astroray row with \`skip: astroray_blend_import_not_implemented\`. Astroray has no offline \`.blend\` reader; the in-Blender addon path needs \`bpy\` and is unreachable from a CLI process.

## Approach

- Small **Python** parser (not C++) driven by the \`.blend\` SDNA self-description — a few hundred lines is enough because SDNA describes every typed block and there are no hardcoded struct layouts in our code.
- Parity-scope minimum field set only: camera (lens/sensor), mesh (verts + faces + per-face material index, both legacy MVert/MPoly and post-3.6 attribute layout), Principled/Diffuse base color, point/sun/spot light, world background color.
- Wired into pkg71 with a 5–10-line branch in the harness; replaces the skip stub with \`import_blend()\`.
- **Monster dropped from manifest** — Cycles itself errors \"no camera\" on \`udim-monster.blend\`; CLAUDE.md §2 \"Simplicity First\" → drop rather than scavenge a replacement (justification in spec §4).
- Acceptance: next baseline emits non-skip Astroray-CPU + Astroray-GPU rows for Classroom + Junkshop + BMW27 with **SSIM ≥ 0.85** (relaxed from Cornell's 0.95 because shader-graph fidelity is out of scope; pkg57 handles Astroray-side shader complexity).

## License fencing (CLAUDE.md §6)

- \`blender/blender\` is **GPL-2.0+**, read-only — algorithm understanding, no code mirroring.
- \`JTraversa/Blender-File-Reader\` and \`blend2json\` are described as BSD-3 but the auto-fetch returned 404/blocked; the spec **mandates a visual LICENSE re-confirmation at port time** before any line is mirrored.
- BlendLuxCore is GPL-3.0 — never mirrored.
- If neither candidate is mirrorable, the parser is written from the published format spec alone (~600 LOC).

## Files

- [.astroray_plan/packages/pkg76-blend-importer-parity-scope.md](.astroray_plan/packages/pkg76-blend-importer-parity-scope.md) — the spec (~5 pages, 7 H2 sections per the brief).
- [.astroray_plan/docs/blend-importer-research.md](.astroray_plan/docs/blend-importer-research.md) — SDNA / format summary, license verdicts, Monster decision.

## Notes / honesty

- \`https://wiki.blender.org/wiki/Source/File_Format\` returned 403 to my fetcher; \`atmind.nl\` returned only the title. Format details in §2 of the research doc are from the well-published format description and **must be re-verified by the implementer in a browser** before they paste any field offsets into code. The spec acceptance row makes this explicit.
- This branch must **NOT be merged** per the request; left for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)