### PR TITLE
feat(pkg73): OptiX TEMPORAL_AOV denoiser mode (motion-aware viewport stability)

### DIFF
--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -162,6 +162,7 @@ is currently the weakest link.
 | pkg74 | Engine benchmark + visual showcase framework (material zoo, convergence grid, stats CSV, HTML index) | **Phase 1 implemented**; Phase 2/3 open | A |
 | pkg75 | First-hit normal buffer population for denoiser AOV guides — surfaced during pkg70 verification | **done** (CPU integrator fix landed; OIDN-CUDA / OptiX re-baseline pending verifier session) | A |
 | pkg72 | Per-pixel motion vector AOV (camera-only screen-space flow; OptiX prev→curr convention; `Renderer.get_motion_buffer()` zero-copy NumPy view; `motion_vector_aov` visualisation pass) — unblocks pkg73 OptiX temporal denoiser | **done** | A |
+| pkg73 | OptiX TEMPORAL_AOV denoiser mode (auto-upgrade from pkg70 AOV when pkg72 motion buffer is non-zero; destroy + recreate on model-kind transition; ping-pong internal-guide-layer pair; previous-output cache + first-frame fallback; clean fallback to AOV on static cameras and on resolution change). Mirrors Cycles `intern/cycles/device/optix/device_impl.cpp` (Apache-2.0). | **implemented** (CUDA + OptiX SDK verification + ≥30% inter-frame variance gate pending verifier session) | A |
 
 **Deferred / not-yet-spec'd from the 2026-05-08 triage** (mentioned in the
 original roadmap but no full spec written; capture intent before they're

--- a/.astroray_plan/packages/pkg72-motion-vectors.md
+++ b/.astroray_plan/packages/pkg72-motion-vectors.md
@@ -228,7 +228,6 @@ External URLs:
   every pixel (motion or zero) on every render call, so no
   `std::fill` clear is needed. The buffer is sized once in the
   Camera constructor and lives for the camera's lifetime.
-
 ### Hardware verification 2026-05-10 — RTX 5070 Ti, Windows MSVC `build_cuda`
 
 `tests/test_motion_vector_aov.py`: **6/6 passed in 0.19s** (the test
@@ -248,3 +247,10 @@ The 2b numbers confirm the OptiX flow convention end-to-end on
 hardware: positive motion.x for a +x camera translation, zero
 motion on sky pixels, zero motion on the very first frame. pkg73
 (OptiX temporal denoiser) can take the buffer verbatim.
+
+- **Consumed by pkg73 OptiX temporal denoiser as designed.** The
+  pixel-unit `prev - curr` flow + zero-fill on static / first-frame /
+  sky pixels were taken verbatim by pkg73's
+  `OptixDenoiserGuideLayer::flow` binding with no remap; the pkg73
+  plugin uses the all-zero state as its "stay in AOV mode" signal,
+  which is precisely the contract pkg72 advertised.

--- a/.astroray_plan/packages/pkg73-optix-temporal-denoiser.md
+++ b/.astroray_plan/packages/pkg73-optix-temporal-denoiser.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 5
 **Track:** A
-**Status:** open
+**Status:** implemented (pending CUDA + OptiX verification)
 **Estimated effort:** ~3–4 days (~14 h)
 **Depends on:** pkg70 (OptiX denoiser backend — done), pkg72 (motion-vector AOV — open)
 

--- a/plugins/passes/optix_denoiser.cpp
+++ b/plugins/passes/optix_denoiser.cpp
@@ -3,6 +3,10 @@
 #endif
 
 // pkg70 — NVIDIA OptiX AI denoiser as a co-equal alternative to OIDN.
+// pkg73 — Extended with TEMPORAL_AOV mode when pkg72's motion buffer is
+//         present and non-zero. Mode is selected per execute(); model-kind
+//         transitions destroy + recreate the OptiX denoiser handle (the
+//         model kind is locked at optixDenoiserCreate time).
 //
 // Mirrors the pkg68 OIDN class shape (member-cached state, lazy init,
 // dimension-cached buffers). Where OIDN owns its own device, here we
@@ -17,11 +21,16 @@
 //     https://raytracing-docs.nvidia.com/optix8/api/optix__host_8h.html
 //   - Cycles `intern/cycles/device/optix/device_impl.cpp`
 //     (Apache-2.0) — `OptiXDevice::denoise_buffer()` for the
-//     setup/invoke shape, model-kind selection.
+//     setup/invoke shape, model-kind selection, and the
+//     destroy-and-recreate transition pattern used in pkg73.
+//   - Cycles `intern/cycles/integrator/denoiser_gpu.cpp` (Apache-2.0)
+//     — temporal previous-output lifecycle + resize invalidation.
 //
-// Constraints (per pkg70 spec):
-//   - HDR model when no guides; AOV model when albedo+normal both present.
-//   - No temporal mode (motion vectors not yet emitted by integrator).
+// Constraints (per pkg70/pkg73 spec):
+//   - HDR model when no guides; AOV model when albedo+normal both present;
+//     TEMPORAL_AOV when motion+albedo+normal are all present and motion
+//     is non-zero (static cameras stay on AOV — no point paying the
+//     prev-output buffer cost).
 //   - No SDK headers redistributed: build only when find_package(OptiX)
 //     succeeds and ASTRORAY_OPTIX_ENABLED is defined.
 
@@ -107,24 +116,66 @@ public:
         const float* srcColor  = fb.buffer("color");
         const float* srcAlbedo = fb.hasBuffer("albedo") ? fb.buffer("albedo") : nullptr;
         const float* srcNormal = fb.hasBuffer("normal") ? fb.buffer("normal") : nullptr;
+        const float* srcMotion = fb.hasBuffer("motion") ? fb.buffer("motion") : nullptr;
         const bool   hasGuides = (srcAlbedo != nullptr) && (srcNormal != nullptr);
+
+        // pkg73: only upgrade to TEMPORAL_AOV when motion is actually moving.
+        // pkg72 zero-fills the motion buffer for static cameras, sky pixels,
+        // and the first frame after setup_camera; in those cases the prev-
+        // output buffer + ping-pong internal-guide pair is wasted memory.
+        bool hasNonzeroMotion = false;
+        if (srcMotion) {
+            const size_t n2 = pixels * 2;
+            for (size_t i = 0; i < n2; ++i) {
+                if (srcMotion[i] != 0.0f) { hasNonzeroMotion = true; break; }
+            }
+        }
+
+        OptixDenoiserModelKind desiredKind;
+        if (hasGuides && hasNonzeroMotion) {
+            desiredKind = OPTIX_DENOISER_MODEL_KIND_TEMPORAL_AOV;
+        } else if (hasGuides) {
+            desiredKind = OPTIX_DENOISER_MODEL_KIND_AOV;
+        } else {
+            desiredKind = OPTIX_DENOISER_MODEL_KIND_HDR;
+        }
 
         if (!initialised_) {
             initContext_();
-            // Cycles selects HDR vs AOV per-invocation based on guide
-            // availability and locks it for the denoiser's lifetime —
-            // mirror that. Switching modes requires recreating the handle.
-            modelKind_ = hasGuides ? OPTIX_DENOISER_MODEL_KIND_AOV
-                                   : OPTIX_DENOISER_MODEL_KIND_HDR;
+            modelKind_ = desiredKind;
             createDenoiser_();
             initialised_ = true;
+        } else if (desiredKind != modelKind_) {
+            // Mirror Cycles `device_impl.cpp`: model kind is locked at
+            // optixDenoiserCreate time, so transitioning means destroy +
+            // recreate. Buffers tied to the handle (state + scratch +
+            // internal-guide pair + prev-output) are also freed and will
+            // be reallocated below.
+            std::printf("[OptiX] denoiser model kind transition %d -> %d\n",
+                        static_cast<int>(modelKind_), static_cast<int>(desiredKind));
+            std::fflush(stdout);
+            freeDeviceBuffers_();
+            if (denoiser_) { optixDenoiserDestroy(denoiser_); denoiser_ = nullptr; }
+            modelKind_    = desiredKind;
+            cachedWidth_  = 0;  // force allocateBuffers_ on next branch
+            cachedHeight_ = 0;
+            prev_valid_   = false;
+            frame_index_  = 0;
+            createDenoiser_();
         }
 
         if (w != cachedWidth_ || h != cachedHeight_) {
+            // pkg73: prev-output is sized for the old resolution; drop it
+            // (allocateBuffers_ recreates) and treat next frame as first.
             allocateBuffers_(w, h);
             cachedWidth_  = w;
             cachedHeight_ = h;
+            prev_valid_   = false;
+            frame_index_  = 0;
         }
+
+        const bool isTemporal = (modelKind_ == OPTIX_DENOISER_MODEL_KIND_TEMPORAL_AOV);
+        const bool isAOV      = (modelKind_ == OPTIX_DENOISER_MODEL_KIND_AOV) || isTemporal;
 
         // Sanitize NaNs/Infs in the host buffers (path tracer can produce
         // them from very-rare divide edge cases) before HtoD copy. Mirrors
@@ -142,13 +193,15 @@ public:
         ASTRORAY_CUDA_CHECK(cudaMemcpy(reinterpret_cast<void*>(colorDev_),
                                        sanitised_.data(), rgbBytes,
                                        cudaMemcpyHostToDevice));
-        if (modelKind_ == OPTIX_DENOISER_MODEL_KIND_AOV) {
+        if (isAOV) {
             sanitiseInto(srcAlbedo);
             ASTRORAY_CUDA_CHECK(cudaMemcpy(reinterpret_cast<void*>(albedoDev_),
                                            sanitised_.data(), rgbBytes,
                                            cudaMemcpyHostToDevice));
             // Normalise normals before upload (OIDN plugin does the same;
-            // OptiX expects unit-length world-space normals).
+            // OptiX expects unit-length normals). pkg70 §6 confirms our
+            // normal buffer is camera-space-3-channel, which is what
+            // TEMPORAL_AOV's normal-guide rule also requires.
             for (size_t i = 0; i < pixels; ++i) {
                 float nx = std::isfinite(srcNormal[i*3+0]) ? srcNormal[i*3+0] : 0.0f;
                 float ny = std::isfinite(srcNormal[i*3+1]) ? srcNormal[i*3+1] : 0.0f;
@@ -163,25 +216,55 @@ public:
                                            sanitised_.data(), rgbBytes,
                                            cudaMemcpyHostToDevice));
         }
+        if (isTemporal) {
+            // pkg72 writes motion as `prev_pixel - curr_pixel` in pixel units
+            // (see pkg72 Lessons "Sign convention"), which is exactly the
+            // OptixDenoiserGuideLayer::flow contract — no remap here.
+            const size_t flowBytes = pixels * 2 * sizeof(float);
+            sanitisedFlow_.resize(pixels * 2);
+            for (size_t i = 0; i < pixels * 2; ++i) {
+                const float v = srcMotion[i];
+                sanitisedFlow_[i] = std::isfinite(v) ? v : 0.0f;
+            }
+            ASTRORAY_CUDA_CHECK(cudaMemcpy(reinterpret_cast<void*>(motionDev_),
+                                           sanitisedFlow_.data(), flowBytes,
+                                           cudaMemcpyHostToDevice));
+        }
 
         // Build per-frame layer/guide descriptors.
-        OptixImage2D colorImg = makeImage_(colorDev_, w, h);
+        OptixImage2D colorImg  = makeImage_(colorDev_,  w, h);
         OptixImage2D outputImg = makeImage_(outputDev_, w, h);
 
         OptixDenoiserLayer layer = {};
-        layer.input         = colorImg;
-        layer.output        = outputImg;
-        // previousOutput left null — temporal mode is out of scope (#4).
+        layer.input  = colorImg;
+        layer.output = outputImg;
+        if (isTemporal) {
+            // First-frame fallback per the OptiX programming guide: when no
+            // valid prev-output exists yet, feed the noisy current beauty as
+            // previousOutput and rely on pkg72's zero-fill flow.
+            CUdeviceptr prev = prev_valid_ ? prevOutputDev_ : colorDev_;
+            layer.previousOutput = makeImage_(prev, w, h);
+        }
 
         OptixDenoiserGuideLayer guide = {};
-        if (modelKind_ == OPTIX_DENOISER_MODEL_KIND_AOV) {
+        if (isAOV) {
             guide.albedo = makeImage_(albedoDev_, w, h);
             guide.normal = makeImage_(normalDev_, w, h);
         }
+        if (isTemporal) {
+            guide.flow = makeFlowImage_(motionDev_, w, h);
+            // Internal-guide-layer ping-pong: this frame's `output` becomes
+            // next frame's `previous`. Mirror Cycles `device_impl.cpp`.
+            const int prevSlot = (frame_index_ & 1);
+            const int currSlot = 1 - prevSlot;
+            guide.previousOutputInternalGuideLayer =
+                makeInternalGuideImage_(internalGuideDev_[prevSlot], w, h);
+            guide.outputInternalGuideLayer =
+                makeInternalGuideImage_(internalGuideDev_[currSlot], w, h);
+        }
 
-        // Compute intensity (HDR exposure normalisation). OptiX provides a
-        // helper kernel for this; passing a non-zero intensity yields better
-        // results on HDR inputs than the default 1.0.
+        // Compute intensity (HDR exposure normalisation). Documented to
+        // work for HDR, AOV and TEMPORAL_AOV models.
         ASTRORAY_OPTIX_CHECK(optixDenoiserComputeIntensity(
             denoiser_, /*stream*/ 0,
             &colorImg, intensityDev_,
@@ -190,11 +273,13 @@ public:
         OptixDenoiserParams params = {};
         params.hdrIntensity      = intensityDev_;
         params.blendFactor       = 0.0f;
-        params.hdrAverageColor   = 0; // not used in HDR/AOV models
+        params.hdrAverageColor   = 0;
         // Older OptiX 7.x SDKs had `denoiseAlpha` as a bool field; OptiX 8
-        // moved it to an enum (OPTIX_DENOISER_ALPHA_MODE_*). We render
-        // 3-channel float (no alpha), so the default zero-init is correct
-        // for both ABIs.
+        // moved it to an enum (OPTIX_DENOISER_ALPHA_MODE_*). 3-channel
+        // float means the default zero-init is correct for both ABIs.
+        // pkg73: `temporalModeUsePreviousLayers` defaults to 0 — we use
+        // the noisy-input fallback on the very first frame (prev_valid_
+        // == false), which matches the OptiX guide's recommendation.
 
         ASTRORAY_OPTIX_CHECK(optixDenoiserInvoke(
             denoiser_, /*stream*/ 0, &params,
@@ -204,6 +289,15 @@ public:
             scratchDev_, scratchSize_));
 
         ASTRORAY_CUDA_CHECK(cudaDeviceSynchronize());
+
+        if (isTemporal) {
+            // Cache denoised output for next frame's previousOutput binding.
+            ASTRORAY_CUDA_CHECK(cudaMemcpy(reinterpret_cast<void*>(prevOutputDev_),
+                                           reinterpret_cast<void*>(outputDev_),
+                                           rgbBytes, cudaMemcpyDeviceToDevice));
+            prev_valid_ = true;
+            ++frame_index_;
+        }
 
         // DtoH copy back into the framebuffer's color buffer, clamping
         // any residual non-finite or negative values.
@@ -252,11 +346,17 @@ private:
 
     void createDenoiser_() {
         OptixDenoiserOptions opts = {};
-        if (modelKind_ == OPTIX_DENOISER_MODEL_KIND_AOV) {
+        if (modelKind_ == OPTIX_DENOISER_MODEL_KIND_AOV ||
+            modelKind_ == OPTIX_DENOISER_MODEL_KIND_TEMPORAL_AOV) {
             opts.guideAlbedo = 1;
             opts.guideNormal = 1;
         }
         ASTRORAY_OPTIX_CHECK(optixDenoiserCreate(context_, modelKind_, &opts, &denoiser_));
+        std::printf("[OptiX] denoiser created (kind=%d%s)\n",
+                    static_cast<int>(modelKind_),
+                    modelKind_ == OPTIX_DENOISER_MODEL_KIND_TEMPORAL_AOV
+                        ? " TEMPORAL_AOV" : "");
+        std::fflush(stdout);
     }
 
     void allocateBuffers_(int w, int h) {
@@ -277,11 +377,29 @@ private:
         const size_t rgbBytes = static_cast<size_t>(w) * h * 3 * sizeof(float);
         ASTRORAY_CUDA_CHECK(cudaMalloc(reinterpret_cast<void**>(&colorDev_),  rgbBytes));
         ASTRORAY_CUDA_CHECK(cudaMalloc(reinterpret_cast<void**>(&outputDev_), rgbBytes));
-        if (modelKind_ == OPTIX_DENOISER_MODEL_KIND_AOV) {
+        if (modelKind_ == OPTIX_DENOISER_MODEL_KIND_AOV ||
+            modelKind_ == OPTIX_DENOISER_MODEL_KIND_TEMPORAL_AOV) {
             ASTRORAY_CUDA_CHECK(cudaMalloc(reinterpret_cast<void**>(&albedoDev_), rgbBytes));
             ASTRORAY_CUDA_CHECK(cudaMalloc(reinterpret_cast<void**>(&normalDev_), rgbBytes));
         }
         ASTRORAY_CUDA_CHECK(cudaMalloc(reinterpret_cast<void**>(&intensityDev_), sizeof(float)));
+
+        if (modelKind_ == OPTIX_DENOISER_MODEL_KIND_TEMPORAL_AOV) {
+            const size_t flowBytes = static_cast<size_t>(w) * h * 2 * sizeof(float);
+            ASTRORAY_CUDA_CHECK(cudaMalloc(reinterpret_cast<void**>(&motionDev_),     flowBytes));
+            ASTRORAY_CUDA_CHECK(cudaMalloc(reinterpret_cast<void**>(&prevOutputDev_), rgbBytes));
+
+            // Internal-guide-layer pair (ping-pong). Size in bytes per pixel
+            // is reported by optixDenoiserComputeMemoryResources (OptiX 7.5+
+            // OptixDenoiserSizes::internalGuideLayerPixelSizeInBytes).
+            const size_t igBytes = static_cast<size_t>(w) * h *
+                sizes.internalGuideLayerPixelSizeInBytes;
+            ASTRORAY_CUDA_CHECK(cudaMalloc(reinterpret_cast<void**>(&internalGuideDev_[0]), igBytes));
+            ASTRORAY_CUDA_CHECK(cudaMalloc(reinterpret_cast<void**>(&internalGuideDev_[1]), igBytes));
+            ASTRORAY_CUDA_CHECK(cudaMemset(reinterpret_cast<void*>(internalGuideDev_[0]), 0, igBytes));
+            ASTRORAY_CUDA_CHECK(cudaMemset(reinterpret_cast<void*>(internalGuideDev_[1]), 0, igBytes));
+            internalGuidePixelSize_ = sizes.internalGuideLayerPixelSizeInBytes;
+        }
 
         ASTRORAY_OPTIX_CHECK(optixDenoiserSetup(
             denoiser_, /*stream*/ 0,
@@ -301,6 +419,29 @@ private:
         return img;
     }
 
+    OptixImage2D makeFlowImage_(CUdeviceptr ptr, int w, int h) const {
+        OptixImage2D img = {};
+        img.data               = ptr;
+        img.width              = static_cast<unsigned int>(w);
+        img.height             = static_cast<unsigned int>(h);
+        img.rowStrideInBytes   = static_cast<unsigned int>(w) * 2 * sizeof(float);
+        img.pixelStrideInBytes = 2 * sizeof(float);
+        img.format             = OPTIX_PIXEL_FORMAT_FLOAT2;
+        return img;
+    }
+
+    OptixImage2D makeInternalGuideImage_(CUdeviceptr ptr, int w, int h) const {
+        OptixImage2D img = {};
+        img.data               = ptr;
+        img.width              = static_cast<unsigned int>(w);
+        img.height             = static_cast<unsigned int>(h);
+        img.rowStrideInBytes   = static_cast<unsigned int>(w) *
+            static_cast<unsigned int>(internalGuidePixelSize_);
+        img.pixelStrideInBytes = static_cast<unsigned int>(internalGuidePixelSize_);
+        img.format             = OPTIX_PIXEL_FORMAT_INTERNAL_GUIDE_LAYER;
+        return img;
+    }
+
     void freeDeviceBuffers_() {
         auto freeIf = [](CUdeviceptr& p) {
             if (p) { cudaFree(reinterpret_cast<void*>(p)); p = 0; }
@@ -312,8 +453,13 @@ private:
         freeIf(normalDev_);
         freeIf(outputDev_);
         freeIf(intensityDev_);
-        stateSize_   = 0;
-        scratchSize_ = 0;
+        freeIf(motionDev_);
+        freeIf(prevOutputDev_);
+        freeIf(internalGuideDev_[0]);
+        freeIf(internalGuideDev_[1]);
+        stateSize_              = 0;
+        scratchSize_            = 0;
+        internalGuidePixelSize_ = 0;
     }
 
     void destroy_() {
@@ -332,12 +478,20 @@ private:
     CUdeviceptr             normalDev_    = 0;
     CUdeviceptr             outputDev_    = 0;
     CUdeviceptr             intensityDev_ = 0;
+    // pkg73 TEMPORAL_AOV state.
+    CUdeviceptr             motionDev_           = 0;
+    CUdeviceptr             prevOutputDev_       = 0;
+    CUdeviceptr             internalGuideDev_[2] = {0, 0};
+    size_t                  internalGuidePixelSize_ = 0;
+    int                     frame_index_  = 0;
+    bool                    prev_valid_   = false;
     size_t                  stateSize_    = 0;
     size_t                  scratchSize_  = 0;
     int                     cachedWidth_  = 0;
     int                     cachedHeight_ = 0;
     bool                    initialised_  = false;
     std::vector<float>      sanitised_;
+    std::vector<float>      sanitisedFlow_;
 #endif
 };
 

--- a/tests/test_optix_denoiser_temporal.py
+++ b/tests/test_optix_denoiser_temporal.py
@@ -1,0 +1,244 @@
+"""Tests for pkg73: OptiX TEMPORAL_AOV denoiser mode.
+
+Skips cleanly when OptiX is not compiled in or no CUDA device is visible
+at runtime — most CI machines. When OptiX IS available, exercises the
+four acceptance scenarios from
+.astroray_plan/packages/pkg73-optix-temporal-denoiser.md:
+
+  1. Mode-selection log line: TEMPORAL_AOV is entered on the first frame
+     with non-zero motion (verified via captured stdout, mirroring pkg68's
+     `[OptiX] Using ...` capture pattern).
+  2. Inter-frame variance gate: a camera-pan sequence with the temporal
+     mode shows ≥ 30 % less inter-frame pixel variance than a matched
+     pkg70 AOV-mode run.
+  3. First-frame correctness: with `prev_valid_ == False`, the denoiser
+     produces finite output.
+  4. Resize invalidates state: changing resolution between frames does
+     not crash and the next frame is treated as a first frame.
+
+OptiX SDK + CUDA hardware verification of these tests is pending — they
+are written so a verifier session can run them as-is.
+"""
+import numpy as np
+import pytest
+
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+
+try:
+    import astroray
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray module not available")
+
+OPTIX_BUILD = AVAILABLE and bool(
+    astroray.__features__.get("optix_denoiser", False) if AVAILABLE else False
+)
+
+
+def _optix_runtime_available() -> bool:
+    if not OPTIX_BUILD:
+        return False
+    try:
+        return bool(astroray.gpu_optix_available())
+    except Exception:
+        return False
+
+
+OPTIX_AVAILABLE = _optix_runtime_available()
+
+
+# --- Scene helpers ---------------------------------------------------------
+
+W, H = 96, 96
+SAMPLES = 2
+DEPTH = 3
+
+
+def _scene(width: int = W, height: int = H, look_from=(0.0, 0.0, 5.5)):
+    """Small Cornell-style scene matching pkg70 tests, but parameterised on
+    camera position so we can drive a pan."""
+    r = astroray.Renderer()
+    r.setup_camera(
+        look_from=list(look_from), look_at=[0.0, 0.0, 0.0], vup=[0.0, 1.0, 0.0],
+        vfov=40.0, aspect_ratio=width / height, aperture=0.0, focus_dist=5.5,
+        width=width, height=height,
+    )
+    r.set_background_color([0.0, 0.0, 0.0])
+    white = r.create_material("lambertian", [0.73, 0.73, 0.73], {})
+    red   = r.create_material("lambertian", [0.65, 0.05, 0.05], {})
+    light = r.create_material("light",      [1.0, 0.9, 0.8],    {"intensity": 15.0})
+    r.add_triangle([-2, -2, -2], [ 2, -2, -2], [ 2, -2,  2], white)
+    r.add_triangle([-2, -2, -2], [ 2, -2,  2], [-2, -2,  2], white)
+    r.add_triangle([-2, -2, -2], [-2, -2,  2], [-2,  2,  2], red)
+    r.add_triangle([-2, -2, -2], [-2,  2,  2], [-2,  2, -2], red)
+    r.add_triangle([-0.5, 1.98, -0.5], [0.5, 1.98, -0.5], [0.5, 1.98,  0.5], light)
+    r.add_triangle([-0.5, 1.98, -0.5], [0.5, 1.98,  0.5], [-0.5, 1.98, 0.5], light)
+    r.add_sphere([0, -1.0, 0], 1.0, white)
+    return r
+
+
+def _pan_camera(r, x: float):
+    r.setup_camera(
+        look_from=[x, 0.0, 5.5], look_at=[0.0, 0.0, 0.0], vup=[0.0, 1.0, 0.0],
+        vfov=40.0, aspect_ratio=W / H, aperture=0.0, focus_dist=5.5,
+        width=W, height=H,
+    )
+
+
+# --- Tests -----------------------------------------------------------------
+
+
+@pytest.mark.skipif(not OPTIX_BUILD, reason="OptiX denoiser not compiled in")
+def test_optix_pass_registered_when_compiled_in():
+    assert "optix_denoiser" in astroray.pass_registry_names()
+
+
+@pytest.mark.skipif(not OPTIX_AVAILABLE,
+                    reason="OptiX denoiser unavailable at runtime (SDK or CUDA missing)")
+def test_temporal_mode_entered_when_motion_present(capfd):
+    """Frame 1 has zero motion (no prev camera) -> AOV. Frame 2 after a
+    pan has non-zero motion -> denoiser should transition to TEMPORAL_AOV.
+    The plugin prints a 'kind=2' (== TEMPORAL_AOV) line on transition."""
+    r = _scene()
+    r.set_seed(1)
+    r.add_pass("optix_denoiser")
+
+    capfd.readouterr()
+    r.render(samples_per_pixel=SAMPLES, max_depth=DEPTH)  # frame 1: zero motion -> AOV
+    _pan_camera(r, 0.4)
+    r.render(samples_per_pixel=SAMPLES, max_depth=DEPTH)  # frame 2: motion -> TEMPORAL_AOV
+    captured = capfd.readouterr()
+    out = captured.out + captured.err
+
+    assert "TEMPORAL_AOV" in out, (
+        f"Expected TEMPORAL_AOV transition log line. Captured:\n{out}"
+    )
+
+
+@pytest.mark.skipif(not OPTIX_AVAILABLE,
+                    reason="OptiX denoiser unavailable at runtime (SDK or CUDA missing)")
+def test_first_frame_finite_output():
+    """First frame after add_pass: prev_valid_ is False, denoiser falls back
+    to feeding the noisy beauty as previousOutput. Output must be finite."""
+    r = _scene()
+    r.set_seed(2)
+    r.add_pass("optix_denoiser")
+    img = np.array(r.render(samples_per_pixel=SAMPLES, max_depth=DEPTH),
+                   dtype=np.float32)
+    assert img.shape == (H, W, 3)
+    assert np.all(np.isfinite(img))
+    assert np.all(img >= 0.0)
+
+
+@pytest.mark.skipif(not OPTIX_AVAILABLE,
+                    reason="OptiX denoiser unavailable at runtime (SDK or CUDA missing)")
+def test_resize_does_not_crash():
+    """Mid-stream resolution change must invalidate prev-output and produce
+    finite output (pkg73 acceptance: 'no crash; the denoiser handle and
+    previous-output buffers are reallocated')."""
+    r = _scene(width=64, height=64)
+    r.set_seed(3)
+    r.add_pass("optix_denoiser")
+    r.render(samples_per_pixel=SAMPLES, max_depth=DEPTH)
+    _pan_camera(r, 0.3)  # introduce motion
+    r.render(samples_per_pixel=SAMPLES, max_depth=DEPTH)
+
+    # Now resize.
+    r.setup_camera(
+        look_from=[0.0, 0.0, 5.5], look_at=[0.0, 0.0, 0.0], vup=[0.0, 1.0, 0.0],
+        vfov=40.0, aspect_ratio=1.0, aperture=0.0, focus_dist=5.5,
+        width=128, height=128,
+    )
+    img = np.array(r.render(samples_per_pixel=SAMPLES, max_depth=DEPTH),
+                   dtype=np.float32)
+    assert img.shape == (128, 128, 3)
+    assert np.all(np.isfinite(img))
+
+
+def _pan_sequence(r, n_frames=10, dx_per_frame=0.05):
+    """Render n_frames with the camera panning right by `dx_per_frame` each
+    frame. Returns a (n, H, W, 3) float32 array."""
+    frames = []
+    # Frame 0: no pan applied yet, so motion is zero (matches pkg72 first-frame).
+    img0 = np.array(r.render(samples_per_pixel=SAMPLES, max_depth=DEPTH),
+                    dtype=np.float32)
+    frames.append(img0)
+    for i in range(1, n_frames):
+        _pan_camera(r, dx_per_frame * i)
+        frames.append(np.array(r.render(samples_per_pixel=SAMPLES, max_depth=DEPTH),
+                               dtype=np.float32))
+    return np.stack(frames, axis=0)
+
+
+@pytest.mark.skipif(not OPTIX_AVAILABLE,
+                    reason="OptiX denoiser unavailable at runtime (SDK or CUDA missing)")
+def test_inter_frame_variance_reduction():
+    """pkg73 acceptance gate: TEMPORAL_AOV reduces inter-frame pixel variance
+    by ≥ 30 % vs pkg70 AOV mode on the same camera-pan sequence.
+
+    The plugin always picks TEMPORAL_AOV when motion is non-zero, so to
+    isolate the two modes we construct two passes: the temporal run does
+    the full pan; the AOV-mode reference holds the camera static between
+    frames so motion stays zero (which keeps the plugin in AOV mode).
+    Both runs use the same RNG seed and the same per-frame integrator
+    samples, so any variance delta is the temporal accumulation, not
+    sampling noise.
+    """
+    n_frames = 10
+    dx = 0.04
+
+    # Temporal run.
+    r_t = _scene()
+    r_t.set_seed(42)
+    r_t.add_pass("optix_denoiser")
+    seq_t = _pan_sequence(r_t, n_frames=n_frames, dx_per_frame=dx)
+
+    # AOV reference: same camera positions, but force the plugin to stay
+    # in AOV mode by ensuring motion is zero on every render we keep.
+    # Trick: at each pose, render twice and discard the first. After the
+    # discarded render, `snapshotForMotion()` records the current pose, so
+    # the next render at the same pose has prev == curr -> motion is
+    # all-zero -> the plugin picks AOV (not TEMPORAL_AOV). Same camera
+    # poses + same scene as the temporal run; only the denoiser mode
+    # differs.
+    r_a = _scene()
+    r_a.set_seed(42)
+    r_a.add_pass("optix_denoiser")
+    seq_a = []
+    for i in range(n_frames):
+        pose_x = dx * i
+        r_a.setup_camera(
+            look_from=[pose_x, 0.0, 5.5], look_at=[0.0, 0.0, 0.0],
+            vup=[0.0, 1.0, 0.0], vfov=40.0, aspect_ratio=1.0, aperture=0.0,
+            focus_dist=5.5, width=W, height=H,
+        )
+        # Discarded render: advances the prev-pose snapshot to pose_x.
+        r_a.render(samples_per_pixel=SAMPLES, max_depth=DEPTH)
+        # Kept render: motion buffer is now all zero -> AOV mode.
+        seq_a.append(np.array(r_a.render(samples_per_pixel=SAMPLES, max_depth=DEPTH),
+                              dtype=np.float32))
+    seq_a = np.stack(seq_a, axis=0)
+
+    # Inter-frame variance over the central frames (skip frame 0 = no prev).
+    # For a panning sequence the per-pixel time-series is non-stationary,
+    # so we measure first-difference RMS rather than raw variance — this is
+    # the standard "boiling" / shimmer proxy and is what pkg73 §Acceptance
+    # calls "inter-frame pixel variance".
+    def inter_frame_rms(seq):
+        diffs = np.diff(seq[1:], axis=0)  # central N-2 differences
+        return float(np.sqrt(np.mean(diffs ** 2)))
+
+    rms_t = inter_frame_rms(seq_t)
+    rms_a = inter_frame_rms(seq_a)
+    print(f"[pkg73] inter-frame RMS: temporal={rms_t:.6f} aov={rms_a:.6f} "
+          f"reduction={(1.0 - rms_t / rms_a) * 100.0:.1f}%")
+
+    assert rms_t < rms_a * 0.70, (
+        f"pkg73 acceptance gate: TEMPORAL_AOV must reduce inter-frame RMS by "
+        f"≥30%, got rms_t={rms_t:.6f} vs rms_a={rms_a:.6f} "
+        f"(reduction {(1.0 - rms_t / rms_a) * 100.0:.1f}%)"
+    )


### PR DESCRIPTION
## pkg73 — OptiX Temporal Denoiser

Extends [`plugins/passes/optix_denoiser.cpp`](plugins/passes/optix_denoiser.cpp) to upgrade to `OPTIX_DENOISER_MODEL_KIND_TEMPORAL_AOV` when pkg72's motion buffer is non-zero and both AOV guides are present. Static-camera / first-frame / sky cases keep motion all-zero per pkg72's contract, so the plugin stays on the existing AOV/HDR paths and pays no prev-output or internal-guide-pair memory cost.

Spec: [.astroray_plan/packages/pkg73-optix-temporal-denoiser.md](.astroray_plan/packages/pkg73-optix-temporal-denoiser.md).

### What changed

- **Mode selection per `execute()`**: scan `fb.buffer("motion")` for any non-zero entry; pick `TEMPORAL_AOV` when motion + albedo + normal all present, else fall back to existing AOV / HDR.
- **Destroy + recreate on kind transition**: OptiX locks the model kind at `optixDenoiserCreate` time. Mirror Cycles' `intern/cycles/device/optix/device_impl.cpp` (Apache-2.0) by freeing per-handle buffers, calling `optixDenoiserDestroy`, then recreating with the new kind. Logs a `[OptiX] denoiser model kind transition X -> Y` line.
- **Temporal state**: `motionDev_` (FLOAT2), `prevOutputDev_` (FLOAT3, updated DtoD post-invoke), `internalGuideDev_[2]` (ping-pong using `frame_index_ & 1`, `OPTIX_PIXEL_FORMAT_INTERNAL_GUIDE_LAYER`, sized via `OptixDenoiserSizes::internalGuideLayerPixelSizeInBytes`).
- **First-frame fallback**: with `prev_valid_ == false`, bind the noisy beauty as `previousOutput`, per OptiX guide. Combined with pkg72's zero motion on frame 1, this is a clean cold start.
- **Resize**: drops prev-output + internal-guide pair, sets `prev_valid_ = false`, treats next frame as first.
- **Sign convention**: pkg72 already writes `prev_pixel - curr_pixel` in pixel units, which is exactly the `OptixDenoiserGuideLayer::flow` contract — no remap.

### Tests

[tests/test_optix_denoiser_temporal.py](tests/test_optix_denoiser_temporal.py) covers the four pkg73 acceptance scenarios:

1. `test_temporal_mode_entered_when_motion_present` — pan after frame 1, assert `TEMPORAL_AOV` log line in captured stdout.
2. `test_first_frame_finite_output` — first frame with `prev_valid_ == False`, assert finite output.
3. `test_resize_does_not_crash` — change resolution mid-stream, assert finite output.
4. `test_inter_frame_variance_reduction` — 10-frame camera-pan, ≥30% inter-frame RMS reduction vs an AOV-mode reference (forced by rendering twice per pose and discarding the first, so motion is zero on the kept render).

All tests skip cleanly when OptiX SDK or CUDA hardware is unavailable.

### Bookkeeping

- pkg73 spec status → `implemented (pending CUDA + OptiX verification)`.
- [.astroray_plan/docs/STATUS.md](.astroray_plan/docs/STATUS.md) pkg73 row added.
- pkg72 Lessons appended: "Consumed by pkg73 OptiX temporal denoiser as designed."

### Verification

OptiX SDK + CUDA verification pending verifier session — this branch was developed without an OptiX SDK installed locally. The verifier should run the four tests on RTX hardware and record the measured inter-frame variance reduction in the pkg73 spec's Lessons section.

### Constraints respected

- Does not redistribute OptiX SDK headers (gated on `ASTRORAY_OPTIX_ENABLED`).
- Does not modify pkg70's OIDN denoiser.
- Static-camera scenes pay no prev-output / internal-guide cost.
- Cited references in code: Cycles `device_impl.cpp` (Apache-2.0), OptiX 8/9 programming guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)