### PR TITLE
verify(pkg73, pkg64-3): hardware re-baseline

### DIFF
--- a/.astroray_plan/packages/pkg64-spectral-caustics.md
+++ b/.astroray_plan/packages/pkg64-spectral-caustics.md
@@ -298,3 +298,66 @@ inside the 25 % cross-machine tolerance. Both gates (`PSNR delta ≥
   returns `{}` from `debugStats()` when no caster is flagged so
   pre-pkg64-3 callers (`tests/test_integrator_plugin.py`) keep
   working. SMS counters appear only when the SMS hook actually runs.
+
+### Phase 3 hardware verification 2026-05-10 — RTX 5070 Ti, Windows MSVC `build_cuda`
+
+Run: `pytest tests/test_pkg64_phase3_default_integrator.py
+tests/test_pkg64_phase3_no_regression.py -v -s` against
+`build_cuda/astroray.cp313-win_amd64.pyd` (CUDA 12.6 toolkit, OptiX SDK
+9.1.0, CUDA + spectral GPU features confirmed via
+`astroray.__features__`). Total wall time 0.91 s for the 5-test
+combined collection.
+
+Result: **2 / 5 passed, 3 failed.** The two passes are the entire
+`test_pkg64_phase3_no_regression.py` file:
+
+| Test | Result | Notes |
+|---|---|---|
+| `test_no_caster_no_regression` | ✅ | Empty SMS hook is bit-equal to the pre-pkg64-3 path tracer on this hardware build. |
+| `test_no_caster_cost_gate` | ✅ | Per-bounce walltime overhead with the empty hook is **within the ≤ 5 % budget** on RTX 5070 Ti. The test passes its self-defined cost gate; it does not print the headline ratio, so a stricter "log the actual per-bounce overhead percentage" assertion is a good follow-up for the next re-baseline. |
+| `test_path_tracer_caustic_caster_toggle` | ❌ | `AttributeError: 'astroray.Renderer' object has no attribute 'scene_object_count'`. |
+| `test_pkg64_phase3_default_integrator_sms_fires` | ❌ | Same `AttributeError` — fails inside `_make_prism_scene()` at `r.scene_object_count() - 1`. |
+| `test_pkg64_phase3_default_integrator_psnr_gain` | ❌ | Same `AttributeError` from the same shared scene helper. |
+
+**SMS receiver-energy ratio (≥ 1.10× the no-caustics baseline):
+NOT CAPTURED on this run.** The `*_sms_fires` test is the one that
+would have produced the `stats` dict (and the receiver-energy delta
+recorded as a side effect), but it cannot reach the renderer call
+because the binding lookup fails at scene-construction time.
+
+**Per-bounce walltime overhead with empty hook (≤ 5 %): MET** —
+`test_no_caster_cost_gate` passes its in-test cost gate, which is the
+package spec's authoritative empty-hook overhead check.
+
+**PSNR floor non-regression (≥ −0.5 dB): NOT CAPTURED on this run** —
+the `_psnr_gain` test fails before reaching the dB measurement for the
+same `scene_object_count` AttributeError reason.
+
+Root cause is not a hardware regression; it is a **stale `build_cuda`
+.pyd** relative to the pkg64-3 binding surface. Source check confirms
+both `module/blender_module.cpp:1440` and `:1446` define
+`set_object_caustic_caster` and `scene_object_count` on the
+`PyRenderer` pybind11 class, but `dir(astroray.Renderer())` on the
+loaded .pyd shows only `set_use_reflective_caustics` /
+`set_use_refractive_caustics` (the pre-pkg64-3 global toggles) — the
+new per-object opt-in symbols are absent. The .pyd file mtime matches
+today, but the bindings it exposes pre-date PR #230
+(`feat(pkg64-3): fold SMS into default path_tracer with per-object
+caustic_caster opt-in + MIS combine`). A rebuild from `main` HEAD
+(currently `9834e58`) is the prerequisite for re-running the three
+failing tests; per the verifier brief's "Doc-only PR. No source
+touched." constraint, that rebuild and the resulting numeric capture
+are explicitly **deferred to a follow-up verifier session**, not done
+in this PR.
+
+Recommendation for the next verifier: invoke
+`cmake --build build_cuda --config Release --target astroray` (or
+the `windows-cuda-vs-release` preset) before re-running these two
+test files; confirm `hasattr(astroray.Renderer(), 'scene_object_count')`
+returns `True` as a smoke check, then capture the receiver-energy
+ratio (from `stats["sms_caustic_path_tracer"]` /
+`debugStats()["accepted_attempts"]`-style counters) and the PSNR-floor
+delta into a fresh "Phase 3 hardware verification YYYY-MM-DD" section
+appended below this one. Do not overwrite this entry — keeping the
+sequence of verifier observations is how Round 5's mid-refresh tracks
+build-currency drift on the CUDA branch.

--- a/.astroray_plan/packages/pkg73-optix-temporal-denoiser.md
+++ b/.astroray_plan/packages/pkg73-optix-temporal-denoiser.md
@@ -210,3 +210,76 @@ mode on a static-camera frame; observed disocclusion / trail-smear
 artefacts if any; whether the HtoD motion-buffer copy showed up in
 the per-frame profile, and whether moving motion to a device-resident
 buffer is worth a follow-up.)*
+
+### Hardware verification 2026-05-10 — RTX 5070 Ti, Windows MSVC `build_cuda`
+
+Run: `pytest tests/test_optix_denoiser_temporal.py -v -s` against
+`build_cuda/astroray.cp313-win_amd64.pyd` (CUDA 12.6 toolkit, OptiX SDK
+9.1.0 headers, OIDN runtime on `PATH` for the .pyd's transitive deps).
+`astroray.__features__["optix_denoiser"]` is `True`,
+`astroray.gpu_optix_available()` is `True`, `[OptiX] Using CUDA device 0
+(NVIDIA GeForce RTX 5070 Ti)` confirmed in stdout on every render that
+takes the OptiX path. Total wall time 0.93 s for the 5-test file.
+
+Result: **3 / 5 passed, 2 failed.** Honest table:
+
+| Test | Result | Notes |
+|---|---|---|
+| `test_optix_pass_registered_when_compiled_in` | ✅ | `optix_denoiser` is in `pass_registry_names()`. |
+| `test_temporal_mode_entered_when_motion_present` | ❌ | Captured stdout is exactly `[OptiX] Using CUDA device 0 (NVIDIA GeForce RTX 5070 Ti)\n`. The plugin's mode-transition log line does not contain the literal token `TEMPORAL_AOV` on this build, so the test's substring assertion fails even though OptiX initialised on the right device. |
+| `test_first_frame_finite_output` | ✅ | First-frame fallback (no `prev_valid_`) produces a finite, non-negative image — pkg73 acceptance "first-frame correctness" lower bound holds. |
+| `test_resize_does_not_crash` | ✅ | Mid-stream HDR-equivalent → AOV → resize cycle: handle and prev-output buffers are reallocated, next frame is finite. Covers the resize-invalidates-state acceptance bullet and is the closest in-suite proxy for the HDR → AOV → TEMPORAL_AOV kind-transition reset the verifier brief asks about (the plugin's `currentKind_` change path is the same in both directions). |
+| `test_inter_frame_variance_reduction` | ❌ | **`[pkg73] inter-frame RMS: temporal=0.011740 aov=0.011740 reduction=0.0%`** — the two sequences are bit-for-bit identical. **The acceptance gate (≥30 % reduction) is not met on this build.** |
+
+Inter-frame variance reduction pkg73 (TEMPORAL_AOV) vs pkg70 (AOV) on
+the 10-frame pan: **0.0 %** (target ≥ 30 %). RMS of frame-to-frame
+first differences over the kept central frames is `0.011740` for both
+the temporal and AOV-reference legs of the test, to all decimal places
+the test prints. Both legs use the same seed (42), the same scene, the
+same per-frame `samples_per_pixel=2` / `max_depth=3`, and the same
+camera poses; the AOV leg only differs in that each kept render is
+preceded by a discarded "snapshot" render that pins prev-pose to
+curr-pose, so the plugin's motion buffer is all-zero and the plugin
+should select AOV instead of TEMPORAL_AOV. Identical RMS to that
+precision is consistent with one of three hypotheses, in order of
+likelihood:
+
+1. The plugin is selecting the same kind (most likely AOV) on both
+   legs because the camera-pan motion produced by `_pan_camera` /
+   `setup_camera` is not surviving as non-zero entries in the motion
+   buffer the plugin reads, on this `build_cuda` revision.
+2. The plugin is selecting TEMPORAL_AOV on both legs (the reset-by-
+   discard trick from the test docstring is not actually pinning
+   `currentKind_` to AOV on this build).
+3. TEMPORAL_AOV is selected on the temporal leg but the previous-
+   output buffer is being re-seeded with the noisy beauty every frame
+   (`prev_valid_` not latching), so the inter-frame correlation
+   collapses to the AOV baseline.
+
+The test does not capture per-frame stdout from `_pan_sequence`, so
+which of (1)/(2)/(3) is the cause cannot be decided from the artefacts
+of this run alone. Recommended follow-up before the gate is reasserted:
+extend the test to capture stdout per frame and assert the kind line
+explicitly on each leg (matches the pattern `test_temporal_mode_*`
+already uses), so a future re-baseline can attribute the result to a
+pipeline issue rather than a metric one. **Do not silently relax the
+30 % gate — the spec is explicit about that.**
+
+First-frame fallback (no prev-output buffer): **passes.** Output is
+finite and non-negative.
+
+Kind-transition reset (HDR → AOV → TEMPORAL_AOV cycle): the explicit
+HDR-leg toggle is not exercised by the in-suite tests on this branch;
+the closest signal is `test_resize_does_not_crash`, which forces a
+`currentKind_` change between renders and a destroy-and-recreate of the
+denoiser handle. That passes — the destroy/recreate path is robust on
+hardware. A dedicated HDR ↔ AOV ↔ TEMPORAL_AOV cycle test is a
+worthwhile follow-up for a future package; out of scope for this
+doc-only re-baseline.
+
+Build-environment note. The .pyd's transitive `OpenImageDenoise.dll`
+dependency was not on the default `PATH`; the run only succeeded after
+prepending `C:\oidn\bin`. `tests/runtime_setup.py` already
+`os.add_dll_directory()`s the CUDA toolkit but not OIDN — fine while
+OIDN is on user PATH on the build machine, but worth noting when
+another verifier reproduces this run.


### PR DESCRIPTION
Doc-only PR. Appends "Hardware verification 2026-05-10" sections to
`pkg73-optix-temporal-denoiser.md` and "Phase 3 hardware verification
2026-05-10" to `pkg64-spectral-caustics.md`, recording observed
results from running the requested test files on RTX 5070 Ti /
Windows MSVC `build_cuda` (CUDA 12.6 toolkit, OptiX SDK 9.1.0
headers, OIDN runtime DLL on PATH).

## pkg73 — `tests/test_optix_denoiser_temporal.py`

**3 / 5 passed, 2 failed.** OptiX initialised on the right device
(`[OptiX] Using CUDA device 0 (NVIDIA GeForce RTX 5070 Ti)`).

| Test | Result |
|---|---|
| `test_optix_pass_registered_when_compiled_in` | ✅ |
| `test_first_frame_finite_output` | ✅ |
| `test_resize_does_not_crash` | ✅ |
| `test_temporal_mode_entered_when_motion_present` | ❌ — no `TEMPORAL_AOV` token in captured stdout |
| `test_inter_frame_variance_reduction` | ❌ — `rms_t = rms_a = 0.011740`, **0.0 %** reduction (target ≥ 30 %) |

- **Inter-frame variance reduction TEMPORAL_AOV vs AOV (10-frame
  pan):** 0.0 % — acceptance gate **not met** on this build.
- **First-frame fallback (no prev-output):** finite, non-negative
  output ✅.
- **Kind-transition reset:** explicit HDR → AOV → TEMPORAL_AOV cycle
  not in-suite; `test_resize_does_not_crash` exercises the
  destroy/recreate path and passes — closest available proxy.

Diagnostic hypotheses for the 0 % result (motion-buffer not
surviving into the plugin, plugin selecting the same kind on both
legs, or `prev_valid_` not latching) are recorded in the section
along with a recommended follow-up: extend the variance test to
capture per-frame stdout and assert the kind line on each leg
before reasserting the 30 % gate. Gate is **not** silently relaxed.

## pkg64-3 — `tests/test_pkg64_phase3_default_integrator.py` + `tests/test_pkg64_phase3_no_regression.py`

**2 / 5 passed, 3 failed.**

| Test | Result |
|---|---|
| `test_no_caster_no_regression` | ✅ |
| `test_no_caster_cost_gate` | ✅ — empty-hook overhead within ≤ 5 % budget |
| `test_path_tracer_caustic_caster_toggle` | ❌ — `AttributeError: scene_object_count` |
| `test_pkg64_phase3_default_integrator_sms_fires` | ❌ — same |
| `test_pkg64_phase3_default_integrator_psnr_gain` | ❌ — same |

- **Per-bounce overhead with empty hook (≤ 5 %): MET.**
- **SMS receiver-energy ratio (≥ 1.10×): NOT CAPTURED** — `_sms_fires`
  fails before reaching the renderer.
- **PSNR floor non-regression (≥ −0.5 dB): NOT CAPTURED** — `_psnr_gain`
  fails for the same reason.

Root cause is **not a hardware regression**; the `build_cuda` .pyd
on this machine predates PR #230 (`feat(pkg64-3): …`). Source has
the binding (`module/blender_module.cpp:1440,1446`); the loaded
.pyd does not. Per the doc-only constraint, the rebuild + numeric
re-capture is deferred to a follow-up verifier session. Section
documents the exact rebuild + smoke-check recommended for the next
run.

## Constraints

- Doc-only — `git diff --stat`: 2 files (`pkg73-…md`,
  `pkg64-…md`), 136 lines added, 0 removed, no source files
  touched.
- PR titled `verify(pkg73, pkg64-3): hardware re-baseline` per the
  brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)