### PR TITLE
diag(pkg73): instrument motion buffer + snapshotForMotion + renderFrame entry to localise TEMPORAL_AOV defect

### DIFF
--- a/include/raytracer.h
+++ b/include/raytracer.h
@@ -1727,6 +1727,13 @@ public:
         prevVw = vw_; prevVh = vh_; prevFocusDist = focusDist_;
         prevShiftX = shiftX_; prevShiftY = shiftY_;
         hasPrevCamera = true;
+        // pkg73 defect-2026-05-10 — temporary diagnostic; remove after fix.
+        std::fprintf(stderr,
+            "[pkg73-diag] snapshot cam=%p origin=(%.4f,%.4f,%.4f) "
+            "hasPrevCamera->true\n",
+            (const void*)this,
+            (double)origin.x, (double)origin.y, (double)origin.z);
+        std::fflush(stderr);
     }
 
     // pkg72: project a world-space point P through the *previous* frame's
@@ -2452,6 +2459,17 @@ inline void Renderer::render(Camera& cam, int maxSamples, int maxDepth,
         ensureDefaultIntegrator();
         buildAcceleration();
         if (integrator_) integrator_->beginFrame(*this, cam);
+        // pkg73 defect-2026-05-10 — temporary diagnostic; remove after fix.
+        std::fprintf(stderr,
+            "[pkg73-diag] renderFrame entry cam=%p origin=(%.4f,%.4f,%.4f) "
+            "hasPrevCamera=%d prevOrigin=(%.4f,%.4f,%.4f)\n",
+            (const void*)&cam,
+            (double)cam.getOrigin().x, (double)cam.getOrigin().y,
+            (double)cam.getOrigin().z,
+            (int)cam.hasPrevCamera,
+            (double)cam.prevOrigin.x, (double)cam.prevOrigin.y,
+            (double)cam.prevOrigin.z);
+        std::fflush(stderr);
         std::atomic<int> tilesCompleted{0};
         const int tileSize = 16;
         int tilesX = (cam.width + tileSize - 1) / tileSize;

--- a/plugins/passes/optix_denoiser.cpp
+++ b/plugins/passes/optix_denoiser.cpp
@@ -124,12 +124,31 @@ public:
         // and the first frame after setup_camera; in those cases the prev-
         // output buffer + ping-pong internal-guide pair is wasted memory.
         bool hasNonzeroMotion = false;
+        size_t motionNonzeroCount = 0;
+        float motionAbsMax = 0.0f;
         if (srcMotion) {
             const size_t n2 = pixels * 2;
             for (size_t i = 0; i < n2; ++i) {
-                if (srcMotion[i] != 0.0f) { hasNonzeroMotion = true; break; }
+                if (srcMotion[i] != 0.0f) {
+                    hasNonzeroMotion = true;
+                    ++motionNonzeroCount;
+                    const float a = std::fabs(srcMotion[i]);
+                    if (a > motionAbsMax) motionAbsMax = a;
+                }
             }
         }
+        // pkg73 defect-2026-05-10 — temporary diagnostic. The hardware
+        // verifier saw rms_t == rms_a == 0.011740 on seq_t and the
+        // TEMPORAL_AOV substring missing from stdout, indicating
+        // desiredKind never became TEMPORAL_AOV. Print enough state to
+        // distinguish (a) motion buffer pointer mismatch, (b) buffer
+        // populated with zeros, (c) buffer populated but check skipped.
+        std::fprintf(stderr,
+            "[pkg73-diag] execute w=%d h=%d hasGuides=%d hasMotion=%d "
+            "motion_buf=%p motion_nonzero_count=%zu motion_abs_max=%.6g\n",
+            w, h, (int)hasGuides, (int)hasNonzeroMotion,
+            (const void*)srcMotion, motionNonzeroCount, motionAbsMax);
+        std::fflush(stderr);
 
         OptixDenoiserModelKind desiredKind;
         if (hasGuides && hasNonzeroMotion) {


### PR DESCRIPTION
## Context

Verifier report on PR #228 (pkg73 OptiX TEMPORAL_AOV) on RTX 5070 Ti
recorded in [`.astroray_plan/packages/pkg73-optix-temporal-denoiser.md`](.astroray_plan/packages/pkg73-optix-temporal-denoiser.md)
under *Hardware verification 2026-05-10*:

- `test_inter_frame_variance_reduction`: **`temporal=0.011740 aov=0.011740 reduction=0.0%`** (gate ≥ 30 %).
- `test_temporal_mode_entered_when_motion_present`: stdout contains
  `[OptiX] Using CUDA device 0 (NVIDIA GeForce RTX 5070 Ti)` only —
  no `TEMPORAL_AOV` substring → `desiredKind` never became
  `OPTIX_DENOISER_MODEL_KIND_TEMPORAL_AOV`.

Pass-registers / first-frame-finite / resize-no-crash all green —
the OptiX context, handle, scratch/state, and resize/destroy paths
are working. The defect is upstream of the denoiser invoke: either
the motion buffer is all-zero when `OptiXDenoiser::execute()` reads
it, or the `!= 0.0f` gate is slipping through.

## Why this PR is diagnostics-only

Per the verifier brief: **"Step 1 — DIAGNOSE before changing code …
Report which signal is wrong before fixing."** I cannot run on the
RTX 5070 Ti from this worktree (no astroray module available
locally; the test skips cleanly without OptiX). Static analysis of
[`plugins/passes/optix_denoiser.cpp`](plugins/passes/optix_denoiser.cpp:126),
[`include/raytracer.h:2616-2628`](include/raytracer.h:2616) (motion-
write block), [`module/blender_module.cpp:525-551`](module/blender_module.cpp:525)
(setup_camera bridge), and [`tests/test_optix_denoiser_temporal.py`](tests/test_optix_denoiser_temporal.py)
did not surface a logic bug — every code path I traced should
produce non-zero motion on the temporal leg's frames 1+. So
shipping a blind fix now would be exactly the kind of guess the
verifier brief warns against ("do not silently relax the gate").

This commit instead adds three `[pkg73-diag]` stderr lines that
pin down which hypothesis is the real cause, and ships nothing
else. **No production behaviour changes; the gate is not relaxed;
the plugin's `hasNonzeroMotion` check is bit-identical (only the
loop now tallies a count + abs-max for the print).**

## Diagnostics added

1. **`plugins/passes/optix_denoiser.cpp` `execute()`** — `w`, `h`,
   `hasGuides`, `hasMotion`, motion buffer pointer, count of
   strictly-non-zero motion entries, abs-max motion magnitude.
2. **`include/raytracer.h` `Camera::snapshotForMotion()`** —
   Camera pointer + current origin each time it fires.
3. **`include/raytracer.h` `Renderer::render()` entry** — cam
   pointer, current origin, `hasPrevCamera`, `prevOrigin`.

## How to read the output

Run:
```
pytest tests/test_optix_denoiser_temporal.py::test_inter_frame_variance_reduction -v -s 2>&1 | grep pkg73-diag
```

Decision tree:

| Observation | Root cause |
|---|---|
| `motion_nonzero_count == 0` on temporal leg's frames 1+ AND `prevOrigin == origin` at the same `renderFrame` entry | `setup_camera` bridge / snapshot timing — fix in `module/blender_module.cpp` setupCamera or `Renderer::render` snapshot site. (Hypothesis 2.) |
| `motion_nonzero_count == 0` AND `prevOrigin != origin` AND `hasPrevCamera == 1` | Motion-write path in `Renderer::render` (line 2616 conditional or `projectToPrevPixel`) is skipping every pixel — investigate `firstRayCaptured`, `depth > 0`, or `projectToPrevPixel` returning false. |
| `motion_nonzero_count > 0` AND `hasMotion == 0` | Plugin gate logic bug (impossible from the source, but the diag will catch it if I missed something). |
| Two distinct `motion_buf=` pointers in the same render | `Framebuffer::buffer("motion")` returns a different pointer than the renderer writes to. (Hypothesis 1.) |

## Next step

After the verifier runs the diagnostic against the RTX 5070 Ti `build_cuda` `.pyd` and reports the `[pkg73-diag]` lines, the follow-up PR will:
- Land the actual fix at the identified root cause (renderer / bridge / test, per the decision tree).
- Strip these diagnostic lines.
- Append a *Defect fix 2026-05-XX* section to the pkg73 spec with measured numbers, including the ≥30 % variance reduction gate cleared.
- Carry the title format from the verifier brief: `fix(pkg73): TEMPORAL_AOV upgrade branch never fired on hardware (root cause: <one-line>)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)