### PR TITLE
fix(pkg80): resolve 'auto' integrator in addon before C++ calls

### DIFF
--- a/.astroray_plan/packages/pkg80-blender-auto-integrator-fix.md
+++ b/.astroray_plan/packages/pkg80-blender-auto-integrator-fix.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 5
 **Track:** A
-**Status:** open
+**Status:** done
 **Estimated effort:** ~½ day (~3 h)
 **Depends on:** pkg37 (Blender addon backend refresh), pkg53 (integrator capability diagnostics)
 
@@ -129,4 +129,20 @@ No code is copied; the file is read for pattern only.
 
 ## Lessons (filled in on completion)
 
-*(empty until done)*
+- Resolved 2026-05-10. `blender_addon/__init__.py` now defines
+  `_resolve_auto_integrator(settings)` which queries
+  `astroray.integrator_registry_names()` and walks a hardcoded preference
+  list (`path_tracer` → `multiwavelength_path_tracer` → registry order),
+  filtering by `integrator_capabilities(name)["gpuSupported"]` when
+  `device_mode='gpu'`. `_effective_integrator_name(settings)` calls it
+  only when `settings.integrator_type == 'auto'`; the existing wavelength
+  override (`multiwavelength_path_tracer` for non-visible ranges) is
+  preserved untouched.
+- `RuntimeError` raised with a clear "set the dropdown to a specific
+  integrator" hint when no registered plugin reports GPU support and
+  `device_mode='gpu'`.
+- Tests: `tests/test_blender_auto_integrator.py` covers the four
+  acceptance cases (cpu/auto resolves, gpu CUDA-build resolves,
+  gpu CPU-only-build raises, non-auto returns unchanged without touching
+  the registry). 19/19 pass alongside `test_blender_backend_policy.py`.
+- C++ side untouched per spec non-goal: `'auto'` stays a UI-only sentinel.

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -334,11 +334,66 @@ def _wavelength_range_from_settings(settings):
     return 380.0, 780.0
 
 
+# Hardcoded preference order for the 'auto' integrator dropdown. The addon
+# owns this UX policy so the engine doesn't need to know about it; the actual
+# names must come from astroray.integrator_registry_names() at runtime
+# (registry is the source of truth). Pattern mirrored from Cycles'
+# intern/cycles/blender/properties.py device-type auto-resolution.
+_AUTO_INTEGRATOR_PREFERENCE = ("path_tracer", "multiwavelength_path_tracer")
+
+
+def _resolve_auto_integrator(settings):
+    """Resolve the UI sentinel 'auto' to a concrete registered plugin.
+
+    Policy (pkg80):
+      - Query astroray.integrator_registry_names().
+      - Walk a hardcoded preference list first, then any remaining names in
+        registry order.
+      - When device_mode='gpu', skip plugins whose capabilities report
+        gpu_supported=False.
+      - Raise RuntimeError if no registered plugin satisfies the request.
+    """
+    try:
+        names = list(astroray.integrator_registry_names())
+    except Exception as exc:
+        raise RuntimeError(
+            f"Astroray: integrator 'auto' could not be resolved — "
+            f"registry query failed ({exc})"
+        ) from exc
+
+    require_gpu = getattr(settings, "device_mode", "auto") == "gpu"
+
+    ordered = [n for n in _AUTO_INTEGRATOR_PREFERENCE if n in names]
+    ordered.extend(n for n in names if n not in ordered)
+
+    for name in ordered:
+        if not require_gpu:
+            return name
+        caps = _integrator_capabilities(name)
+        if bool(caps.get("gpuSupported", False)):
+            return name
+
+    if require_gpu:
+        raise RuntimeError(
+            "Astroray: integrator 'auto' could not be resolved to a "
+            "registered plugin for device_mode='gpu' — no registered "
+            "integrator reports GPU support. Set the integrator dropdown "
+            "to a specific integrator."
+        )
+    raise RuntimeError(
+        "Astroray: integrator 'auto' could not be resolved — no "
+        "integrators are registered."
+    )
+
+
 def _effective_integrator_name(settings):
     lmin, lmax = _wavelength_range_from_settings(settings)
     if lmax > 780.0 or lmin < 380.0:
         return "multiwavelength_path_tracer"
-    return getattr(settings, "integrator_type", "path_tracer")
+    name = getattr(settings, "integrator_type", "path_tracer")
+    if name != "auto":
+        return name
+    return _resolve_auto_integrator(settings)
 
 
 def _integrator_capabilities(name):

--- a/tests/test_blender_auto_integrator.py
+++ b/tests/test_blender_auto_integrator.py
@@ -1,0 +1,88 @@
+"""pkg80 — Blender addon must resolve the 'auto' integrator dropdown to a
+concrete registered plugin before any C++ call.
+
+Reuses the loader helper from test_blender_backend_policy.py.
+"""
+
+import pytest
+
+from test_blender_backend_policy import _load_blender_addon, _make_settings
+
+
+class _NullRenderer:
+    gpu_available = False
+
+
+def _registry(*, names, gpu_supported_set):
+    return {
+        "integrator_registry_names": lambda: list(names),
+        "integrator_capabilities": lambda n: {
+            "gpuSupported": n in gpu_supported_set,
+            "gpuFallbackReason": "" if n in gpu_supported_set else "no GPU kernel",
+        },
+    }
+
+
+def test_auto_integrator_cpu_returns_registered_name(monkeypatch):
+    """integrator='auto' + device_mode='cpu' → first preferred registered name."""
+    addon = _load_blender_addon(
+        monkeypatch, _NullRenderer,
+        extra_astroray_attrs=_registry(
+            names=["multiwavelength_path_tracer", "path_tracer", "ambient_occlusion"],
+            gpu_supported_set={"path_tracer"},
+        ),
+    )
+    settings = _make_settings(device_mode="cpu", integrator_type="auto")
+    assert addon._effective_integrator_name(settings) == "path_tracer"
+
+
+def test_auto_integrator_gpu_picks_gpu_capable_plugin(monkeypatch):
+    """integrator='auto' + device_mode='gpu' (CUDA build) → GPU-capable name."""
+    addon = _load_blender_addon(
+        monkeypatch, _NullRenderer,
+        extra_astroray_attrs=_registry(
+            # path_tracer first in preference but lacks GPU here; ambient_occlusion has GPU.
+            names=["path_tracer", "ambient_occlusion"],
+            gpu_supported_set={"ambient_occlusion"},
+        ),
+    )
+    settings = _make_settings(device_mode="gpu", integrator_type="auto")
+    name = addon._effective_integrator_name(settings)
+    assert name == "ambient_occlusion"
+
+
+def test_auto_integrator_gpu_raises_when_no_plugin_supports_gpu(monkeypatch):
+    """integrator='auto' + device_mode='gpu' (CPU-only build) → clear RuntimeError."""
+    addon = _load_blender_addon(
+        monkeypatch, _NullRenderer,
+        extra_astroray_attrs=_registry(
+            names=["path_tracer", "multiwavelength_path_tracer"],
+            gpu_supported_set=set(),
+        ),
+    )
+    settings = _make_settings(device_mode="gpu", integrator_type="auto")
+    with pytest.raises(RuntimeError) as exc_info:
+        addon._effective_integrator_name(settings)
+    msg = str(exc_info.value)
+    assert "auto" in msg
+    assert "gpu" in msg.lower()
+
+
+def test_non_auto_integrator_returned_unchanged(monkeypatch):
+    """integrator='path_tracer' (any non-auto) → returned verbatim, no registry lookup."""
+    calls = {"registry": 0}
+
+    def _registry_names():
+        calls["registry"] += 1
+        return ["path_tracer"]
+
+    addon = _load_blender_addon(
+        monkeypatch, _NullRenderer,
+        extra_astroray_attrs={
+            "integrator_registry_names": _registry_names,
+            "integrator_capabilities": lambda n: {"gpuSupported": True, "gpuFallbackReason": ""},
+        },
+    )
+    settings = _make_settings(device_mode="cpu", integrator_type="path_tracer")
+    assert addon._effective_integrator_name(settings) == "path_tracer"
+    assert calls["registry"] == 0, "non-auto must not query the registry"


### PR DESCRIPTION
## pkg80 — Blender addon: resolve `'auto'` integrator before C++ calls

**Bug (2026-05-10).** Viewport rendered-view crashed on the first frame
with `device_mode='gpu'` + integrator dropdown `Auto (Best Available)`:

```
RuntimeError: Astroray: integrator 'auto' does not support GPU
(capability query failed: astroray: unknown plugin 'auto')
```

`_effective_integrator_name(settings)` returned the literal `'auto'`
verbatim, and the addon then passed it to
`astroray.integrator_capabilities('auto')` / `set_integrator('auto')` —
but no plugin is registered under that name. `'auto'` is a UI-only
sentinel that pkg27b's design always intended to resolve addon-side.

## Fix

`blender_addon/__init__.py`:

- Add `_resolve_auto_integrator(settings)`. Queries
  `astroray.integrator_registry_names()` at runtime (registry is the
  source of truth), then walks a hardcoded preference list
  (`path_tracer` → `multiwavelength_path_tracer` → registry order).
  When `device_mode='gpu'`, skips plugins whose capabilities report
  `gpuSupported=False`. Raises `RuntimeError` with a clear "set the
  dropdown to a specific integrator" hint when no registered plugin
  satisfies a forced GPU request.
- `_effective_integrator_name(settings)` calls the resolver only when
  `settings.integrator_type == 'auto'`. The existing wavelength
  override (`multiwavelength_path_tracer` for non-visible ranges) is
  preserved untouched per CLAUDE.md §3.
- Pattern mirrored from Cycles' `intern/cycles/blender/properties.py`
  (Apache-2.0) — read-only reference, no code copied.

C++ side untouched per spec non-goal.

## Tests

`tests/test_blender_auto_integrator.py` covers the four acceptance
cases from the spec:

- `integrator='auto'` + `device_mode='cpu'` → first preferred name.
- `integrator='auto'` + `device_mode='gpu'` (CUDA build) →
  GPU-capable name (skips preferred entries that lack GPU).
- `integrator='auto'` + `device_mode='gpu'` (CPU-only build) →
  clear `RuntimeError` mentioning `auto` + `gpu`.
- `integrator='path_tracer'` (any non-auto) → returned unchanged
  without querying the registry.

19/19 tests pass alongside `tests/test_blender_backend_policy.py`.

## Spec status

`.astroray_plan/packages/pkg80-blender-auto-integrator-fix.md` →
**done**, with measured fix in the Lessons section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)