### PR TITLE
docs: file pkg82 (gate variance) after pkg78 §1 refusal of the bisect

### DIFF
--- a/.astroray_plan/docs/NEXT_STAGE_REPORT.md
+++ b/.astroray_plan/docs/NEXT_STAGE_REPORT.md
@@ -61,6 +61,16 @@ fixes a daily-workflow blocker. Round 6 priorities:
   re-baseline precondition did **not** hold (CPU/GPU output bit-
   identical pre/post pkg75), so the gate floor was **not** lowered
   and the drift was filed as defect [#237](https://github.com/HendrikGC02/Astroray/issues/237).
+- **pkg78 bisect** session refused the 20-commit hardware bisect
+  on §1 grounds (static enumeration of `5aba401..fcbbbf2` showed
+  zero commits touching the multiwavelength integrator path —
+  bisect would have been theatre). Diagnosis posted on issue #237:
+  the gate is too tight relative to NVCC build-time non-
+  determinism in the SSIM saturation regime (0.999263 sat 6.3e-4
+  above a 0.999 floor; cross-build FMA reordering moves it by
+  O(1e-4)). **pkg78 closes as diagnosed**; the variance
+  characterisation that justifies the actual gate decision is
+  filed as **pkg82** *(new)*.
 
 **Pillar-5 reality check (filed 2026-05-10):**
 
@@ -93,7 +103,7 @@ viewport "is a slog vs Cycles". Two new packages capture the gap:
 | pkg55 Phase B | Per-material shade kernels | 4–6 weeks | After A.1; possible pkg81 dependency |
 | pkg55 Phase C | Megakernel removal | 2–4 weeks | After B |
 | pkg76 CSV | Classroom / Junkshop / BMW27 baseline rows | ~½ day on RTX | After pkg73 fix (so denoiser path is healthy for parity numbers) |
-| pkg78 bisect | Find the commit that drifted SSIM 0.999263 → 0.998629 | ~½ day on RTX | Tracking issue [#237](https://github.com/HendrikGC02/Astroray/issues/237) |
+| **pkg82** *(new)* | pkg54c gate variance characterisation (intra-binary + cross-build SSIM distribution; data-driven gate decision) | ~1 day on RTX | Replaces pkg78 bisect after the diagnosis ruled out a code regression; [#237](https://github.com/HendrikGC02/Astroray/issues/237) closes when this lands |
 | pkg79 (tiny) | ReSTIR `test_spatial_reduces_mse` flake (margin 0.000004) | ~½ day | Surfaced by PR #236 CI |
 | pkg47 / 48 / 49 | FITS / HDF5 / SPH loaders (Pillar 4 data import) | weeks each | Codex-paste-ready specs queued; deferred behind pkg42–44 |
 | pkg67 | Metric-aware path tracer | ~1 month | Unblocks once pkg40 + pkg55 maturity in place |
@@ -112,7 +122,7 @@ Eight sessions, parallel-safe (pkg80 + pkg81 added this round):
 | 4 | Claude tech | `pkg81-viewport-parity` (new) | **pkg81 Phase 1 + Phase 2** — viewport-interactivity benchmark harness + Cycles A/B + diagnosis note | ~1 week |
 | 5 | Claude tech | `pkg55-phase-a1` (new) | pkg55 Phase A.1 — SoA infra + intersect queue | ~1–2 weeks |
 | 6 | Codex (after #1) | main directory | **pkg42 synchrotron emission** (Pillar 4) | ~2 weeks |
-| 7 | Codex (after #6) | main directory | pkg78 bisect (#237) — find the SSIM-drift commit + report | ~½ day |
+| 7 | Codex (after #6) | main directory + RTX | **pkg82** — pkg54c gate variance characterisation (replaces the pkg78 bisect, which closed as "diagnosed: not a code regression") | ~1 day on RTX |
 | 8 | Codex (after #7) | main directory | pkg76 CSV — populate Classroom / Junkshop / BMW27 rows on RTX | ~½ day |
 
 Sessions 1, 2, 4, 5 spawn at once. Session 3 starts the moment #2
@@ -346,52 +356,69 @@ When done:
   - PR titled "feat(pkg42): synchrotron emission".
 ```
 
-### 3.5 Codex (main directory, after #4) — pkg78 bisect for #237
+### 3.5 Codex (main directory + RTX, after #4) — pkg82 pkg54c gate variance characterisation
 
 ```
-You are Codex investigating issue #237: the pkg54c visible-band
-SSIM drifted from 0.999263 (originally measured in pkg54c) to
-0.998629 (current HEAD). The pkg78 verifier (pre-Round-6) proved
-bit-identical CPU+GPU output between pre-pkg75 (fcbbbf2) and
-HEAD, so the drift PRE-DATES pkg75.
+You are Codex on the RTX 5070 Ti box. The pkg78 bisect session
+correctly refused the hardware bisect on §1 grounds — static
+enumeration of 5aba401..fcbbbf2 (the 20-commit range) showed zero
+commits touching the multiwavelength integrator path, so the
+bisect would have been theatre. The diagnosis (posted on #237)
+points at NVCC build-time non-determinism: the original 0.999263
+sat 6.3e-4 above the 0.999 floor in the SSIM saturation regime,
+and FMA reordering across rebuilds (pkg68/pkg70 added OptiX
+detection in CMakeLists, which can flip the CUDA build context)
+moves saturated SSIM by O(1e-4) without touching kernel logic.
+
+pkg82 measures the variance and re-sets the gate (or bumps spp)
+based on data. NO opinion-based gate changes.
 
 Read first:
+  - .astroray_plan/packages/pkg82-pkg54c-gate-variance.md (the
+    full spec; Phase 1 + Phase 2 + Phase 3 procedures)
   - https://github.com/HendrikGC02/Astroray/issues/237 (the
-    defect filing)
-  - .astroray_plan/packages/pkg54c-spectral-rgb-jakob-hanika.md
-    — find the commit hash that originally reported 0.999263
-    (this is the GOOD anchor)
+    defect filing + pkg78 diagnosis comment)
   - tests/test_gpu_multiwavelength.py::test_visible_band_cpu_gpu_ssim
+  - .astroray_plan/packages/pkg54c-gpu-jakob-hanika-upsampling.md
+    (gate definition; will append Lessons section here)
 
-Procedure:
-  1. From the pkg54c spec, find the GOOD commit (where
-     0.999263 was first measured).
-  2. Use `fcbbbf2` (pre-pkg75) as the BAD end — already
-     proven to drift below 0.999.
-  3. git bisect start fcbbbf2 <good>
-  4. At each probe: rebuild CUDA module, run the visible-band
-     test in isolation, mark good (≥0.999) or bad (<0.999).
-  5. Report the first-bad commit + its diff.
+Procedure (per spec):
+  Phase 1 — intra-binary repeatability:
+    Run the test 20× against the SAME .pyd. Record SSIM each
+    run. Compute mean / stddev / min / max / unique-values.
+    If stddev > 1e-6, you can stop early — gate floor decision
+    falls out of Phase 1 alone (see spec).
 
-  If the first-bad commit is a deliberate integrator change with
-  a justified reason: comment on #237 with the diagnosis +
-  open a follow-up issue to discuss whether to re-baseline the
-  gate or revert. Do NOT touch the gate in this PR.
+  Phase 2 — cross-build variance (only if Phase 1 stddev ≈ 0):
+    Five clean rebuilds with the variations specified in
+    pkg82 spec §"Phase 2" (control × 2, OptiX-disabled,
+    --fmad=false, RelWithDebInfo). One run each, record SSIM.
 
-  If unintended regression: comment on #237 with the finding
-  and STOP — fix is a separate PR.
+  Phase 3 — gate decision (Option A re-baseline OR Option B
+  spp bump). Choose based on data, NOT preference.
+
+Output:
+  1. Phase 1 + Phase 2 measured tables in
+     pkg54c-gpu-jakob-hanika-upsampling.md "Cross-build variance
+     characterisation 2026-05-XX" Lessons section.
+  2. ONE-LINE change in tests/test_gpu_multiwavelength.py —
+     EITHER the gate floor OR the spp constant, never both.
+  3. Closing comment on issue #237 with the table and the
+     chosen resolution.
+  4. PR titled "verify(pkg82): pkg54c gate variance + data-driven
+     {gate floor | spp bump}".
 
 Constraints:
-  - CLAUDE.md sections 1, 4.
-  - Do NOT change the gate value.
-  - If the bisect range is large (>30 commits), narrow with a
-    midpoint probe at a pkg54-related commit first.
-
-When done:
-  - Comment on #237 with first-bad commit hash + one-line
-    diagnosis.
-  - No PR (or doc-only PR if the bisect log is long enough to
-    warrant a Lessons append).
+  - CLAUDE.md sections 1, 4. This is THE template for every
+    future numerical-gate decision in the project — get the
+    methodology right.
+  - NO kernel changes. Measurement only.
+  - NO pytest.approx fudging. The gate is a number; we change
+    the number based on data.
+  - If Phase 2 shows variance > 1e-3 (large enough to hide a
+    real regression), STOP and file a follow-up package on
+    reducing CUDA build non-determinism — don't try to fix it
+    here.
 ```
 
 ### 3.6 Codex (main directory) — pkg80 Blender `'auto'` integrator resolution (ship FIRST)
@@ -595,7 +622,7 @@ Constraints:
 | pkg81 Phase 1+2 | new `benchmarks/viewport_parity/*`, new fixture `.blend`s, new test, new `.astroray_plan/docs/pkg81-diagnosis.md`, pkg81 spec, STATUS.md |
 | pkg55 Phase A.1 | new `src/gpu/wavefront/*.cu` + headers, `src/gpu/path_trace_kernel.cu` (alt launcher behind flag), CMake guard, new test, `benchmarks/wavefront/baseline.json` (extra column), pkg55 spec, STATUS.md |
 | pkg42 synchrotron | new `plugins/emitters/synchrotron.cpp` (or volumes), maybe Kerr-side accessors, new tests, pkg42 spec, STATUS.md |
-| pkg78 bisect | comment on #237; possibly doc-only PR with bisect log |
+| pkg82 (variance) | `tests/test_gpu_multiwavelength.py` (one-line gate or spp change), pkg54c spec Lessons append, issue #237 close comment |
 | pkg76 CSV | `benchmarks/cycles-parity/results.csv` only |
 
 **Conflict points:**
@@ -637,7 +664,7 @@ When Round 6 closes:
 - **pkg76 CSV** populated; the 5-scene parity baseline is finally
   4 rows wide (Cornell + Classroom + Junkshop + BMW27; Monster
   correctly dropped).
-- **#237** diagnosed.
+- **#237** diagnosed (pkg78) and resolved (pkg82) — gate either re-set with measured headroom or spp bumped, both options data-driven.
 
 Then **Round 7**:
 

--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -68,8 +68,13 @@ personally should pick up.
 - Tracking issue [#237](https://github.com/HendrikGC02/Astroray/issues/237):
   pkg54c visible-band SSIM gate currently fails at 0.998629 (floor
   0.999). pkg78 verifier proved bit-identical CPU+GPU output pre/post
-  pkg75, so the drift PRE-DATES pkg75; bisect for the actual breaking
-  commit is queued as a Round 6 Codex pickup.
+  pkg75; the bisect session then refused the 20-commit hardware
+  bisect on §1 grounds (static enumeration showed zero commits in
+  range touching the multiwavelength integrator path) and posted a
+  diagnosis on the issue: most plausible cause is NVCC build-time
+  non-determinism in the SSIM saturation regime. **pkg82** picks up
+  the variance characterisation that turns the diagnosis into a
+  data-driven gate decision. Round 6 Codex pickup on RTX.
 - `NEXT_STAGE_REPORT.md` is the live action queue (Round 6 prompts);
   this file is the source of truth for completion state. `production.md`
   remains historical (pkg50+ placeholder names that conflict with live

--- a/.astroray_plan/packages/pkg82-pkg54c-gate-variance.md
+++ b/.astroray_plan/packages/pkg82-pkg54c-gate-variance.md
@@ -1,0 +1,177 @@
+# pkg82 — pkg54c visible-band SSIM gate variance characterisation
+
+**Pillar:** 5
+**Track:** A (CUDA verifier on RTX 5070 Ti)
+**Status:** open
+**Estimated effort:** ~1 day on hardware (~6 h)
+**Depends on:** pkg54c (the gate definition); pkg78 (the bisect that ruled out a code regression)
+
+---
+
+## Goal
+
+**Before:** `tests/test_gpu_multiwavelength.py::test_visible_band_cpu_gpu_ssim`
+fails on `main` at SSIM `0.998629` against a `0.999` floor (issue
+[#237](https://github.com/HendrikGC02/Astroray/issues/237)). pkg78
+proved bit-identical CPU+GPU output between pre-pkg75 (`fcbbbf2`)
+and HEAD, so the drift is **not** a kernel-logic change. pkg78
+narrowed to a 20-commit range (`5aba401..fcbbbf2`) and static-
+enumerated every changed file: zero touch the multiwavelength
+integrator path. Most plausible cause is **build-time numerical
+non-determinism** (NVCC FMA reordering, warp-reduction order)
+shifting SSIM in the saturation regime by O(10⁻⁴) — well below any
+correctness threshold but enough to push 0.999263 below the 0.999
+gate.
+
+The gate was set without measuring cross-build variance. We don't
+yet know how much room is needed.
+
+**After:** Measured intra-binary repeatability + cross-build SSIM
+distribution for the visible-band test on the project's hardware.
+A data-driven gate floor with documented headroom. Gate either
+re-set against measured variance, or kept at 0.999 with the test
+spp bumped (pulling the measured value back above noise). One PR,
+gate decision based on numbers.
+
+---
+
+## Context
+
+ROADMAP.md's **correctness wins over both** principle plus the
+project's "no silent gate relaxation" precedent (pkg78 + pkg64-3
+verifier audit trail) means we can't lower the floor on a hunch.
+The gate has been failing CI since 2026-05-10. Every PR since
+carries that red mark in its build report. The longer it stays,
+the more likely a real future regression hides behind the noise.
+
+This package settles it with measurement, not opinion.
+
+---
+
+## Reference
+
+### Internal
+
+- [`tests/test_gpu_multiwavelength.py`](../tests/test_gpu_multiwavelength.py) — `test_visible_band_cpu_gpu_ssim` (the gate test).
+- [`.astroray_plan/packages/pkg54c-gpu-jakob-hanika-upsampling.md`](pkg54c-gpu-jakob-hanika-upsampling.md) — gate definition; original 0.999263 measurement at line ~126.
+- [Issue #237](https://github.com/HendrikGC02/Astroray/issues/237) — the defect filing + pkg78 diagnosis comment.
+- pkg78 (the bisect that justified this package).
+
+### External (read for understanding only — no code mirrored)
+
+- NVIDIA CUDA C++ Programming Guide §F (Floating-Point Considerations) — how `--fmad`, `--prec-div`, and reduction ordering produce reproducible vs reproducibility-trading results.
+- Whitehead & Fit-Florea, "Precision & Performance: Floating Point and IEEE 754 Compliance for NVIDIA GPUs" (2011) — the standard reference on cross-build NVCC determinism. Cite in the Lessons section.
+
+---
+
+## Specification
+
+### Phase 1 — intra-binary repeatability (~1 h on RTX)
+
+Run the visible-band test **N=20 times against the SAME built `.pyd`**
+without rebuilding between runs. Record SSIM each run. Report:
+- mean, stddev, min, max, p50, p99
+- The set of unique SSIM values observed (often k <= 3 due to
+  reduction ordering caching warm-up)
+
+If stddev > 1e-6 across runs of the same binary, that's already
+the gate-margin lower bound; no further work needed to set the
+floor (gate := mean − 3·stddev, rounded down to next 1e-3).
+
+If stddev ≈ 0 (same SSIM every run), proceed to Phase 2.
+
+### Phase 2 — cross-build variance (~3-4 h on RTX)
+
+Run **N=5 clean rebuilds** of `astroray.pyd` against `main`. For
+each rebuild, record the SSIM from one run. Hypothesis: SSIM will
+be deterministic within a binary but vary by O(10⁻⁴) across
+rebuilds, exactly what pkg78 predicted.
+
+Variation procedure for the 5 rebuilds:
+1. `cmake --build --preset windows-tcnn-vs-release --clean-first`
+2. `cmake --build --preset windows-tcnn-vs-release --clean-first` (again, same flags — control)
+3. Same as #2 but with `-DASTRORAY_DISABLE_OPTIX=ON` (the change pkg68/pkg70 introduced)
+4. Same as #2 but with `-DCMAKE_CUDA_FLAGS="--fmad=false"` (FMA-disabled — should bound the upper noise envelope)
+5. Same as #2 but with `-DCMAKE_BUILD_TYPE=RelWithDebInfo` (different optimisation profile)
+
+Record each SSIM. Report the cross-build distribution.
+
+### Phase 3 — gate decision (~½ h)
+
+Two acceptable outcomes, **chosen by data**:
+
+**Option A — re-baseline the gate** with measured headroom:
+- New floor = `min(observed SSIM across all builds) − 5·max(stddev)`
+- Round down to next 1e-3 (so 0.998629 → 0.998 floor, with a clear
+  Lessons note explaining the cross-build provenance).
+- The test still fails on real regressions because real
+  regressions move SSIM by O(10⁻²) or more (the original pkg54
+  bug was a misordered renormalize step worth 0.014 SSIM).
+
+**Option B — bump test spp** to pull measured SSIM out of the
+saturation regime:
+- Re-render at spp=16384 or spp=32768 on a fixed seed.
+- If the new measurement is > 0.99975 across all five builds,
+  keep the 0.999 gate and note the spp bump in the test.
+- Acceptable if the spp bump still runs under 60 s on RTX 5070 Ti
+  (it should — pkg54c originally took ~5 s at spp=8192).
+
+Whichever option the data supports, the PR commits **only**:
+- The gate floor change OR the spp bump (one line each)
+- A "Cross-build variance characterisation 2026-05-XX" section
+  appended to `pkg54c-gpu-jakob-hanika-upsampling.md` Lessons,
+  containing the measured table from Phase 1 + Phase 2
+- A close-out comment on issue #237 with the data + the chosen
+  resolution
+
+### Files to modify
+
+| File | Change |
+|---|---|
+| `tests/test_gpu_multiwavelength.py` | Either gate floor (one line) or spp constant (one line) — never both. |
+| `.astroray_plan/packages/pkg54c-gpu-jakob-hanika-upsampling.md` | Append "Cross-build variance characterisation" section under Lessons. |
+| Issue #237 (GitHub) | Closing comment with the measured table and the chosen resolution. |
+
+### Acceptance criteria
+
+- [ ] Phase 1 measured table committed in the spec Lessons section.
+- [ ] Phase 2 measured table (5 builds × 1 run each) committed.
+- [ ] Either gate floor or spp constant updated, with the change
+      directly traceable to the measured table.
+- [ ] CI on `main` is green (gate passes after the change).
+- [ ] Issue #237 closed with the resolution comment.
+- [ ] If Phase 1 already shows stddev > 1e-6 (intra-binary
+      non-determinism), Phase 2 is OPTIONAL — the spec lets you
+      stop early and re-set the gate from Phase 1 alone.
+
+### Hard non-goals
+
+- **No kernel changes.** This package is a measurement package,
+  not a fix. If Phase 2 shows variance > 1e-3 (large enough that
+  it WOULD hide a real regression), STOP and file a follow-up
+  package on reducing CUDA build non-determinism — don't try to
+  fix it here.
+- **No moving the test to a deterministic-but-irrelevant scene.**
+  The visible-band parity scene exercises the multiwavelength
+  integrator's actual hot path; replacing it would lose coverage.
+- **No `pytest.approx`-style fudging on the assertion.** The gate
+  is a number, not an approximate comparison. We change the
+  number based on data, not the assertion shape.
+
+---
+
+## Why this matters
+
+This is the project's first measurement-based gate-tightening
+exercise. The precedent it sets — *"we re-set numerical gates
+based on cross-build measurement, not opinion or convenience"* —
+applies to every spectral / SSIM / energy-conservation gate the
+project will accumulate as Pillar 4 lights up (synchrotron PSNR,
+slim-disk centroid spread, ADAF emission-line wavelengths, etc.).
+The methodology this package commits is the template for those.
+
+---
+
+## Lessons (filled in on completion)
+
+*(empty until done)*


### PR DESCRIPTION
The pkg78 bisect session [posted a clean §1 refusal](https://github.com/HendrikGC02/Astroray/issues/237#issuecomment-4415440573) of the 20-commit hardware bisect — static enumeration showed zero commits in the range touch the multiwavelength integrator path, so the bisect would have been theatre.

That diagnosis (NVCC build-time non-determinism in the SSIM saturation regime) is the right hypothesis but it's still a hypothesis. **pkg82** turns it into a measurement:

- **Phase 1** — 20× same-binary repeatability → intra-binary stddev
- **Phase 2** — 5 clean rebuilds (control ×2, OptiX off, `--fmad=false`, RelWithDebInfo) → cross-build SSIM distribution
- **Phase 3** — data-driven gate decision: Option A re-baseline floor with measured headroom OR Option B bump test spp out of the saturation regime

**Hard non-goals:** no kernel changes, no opinion-based gate fudging, no `pytest.approx` fudging.

This is the project's **first measurement-based numerical-gate template**. The methodology applies to every future spectral / SSIM / energy-conservation gate as Pillar 4 emission models light up (synchrotron PSNR, slim-disk centroid spread, ADAF emission lines, etc.).

## Round 6 set

pkg82 replaces pkg78 in slot #7 (Codex on RTX, ~1 day). STATUS.md updated with the diagnosis trail; `NEXT_STAGE_REPORT.md` §3.5 prompt rewritten with the pkg82 procedure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)