### PR TITLE
docs: pkg81 measurement-complete; file pkg83/pkg84; pkg55 B absorbs viewport gate

### DIFF
--- a/.astroray_plan/docs/NEXT_STAGE_REPORT.md
+++ b/.astroray_plan/docs/NEXT_STAGE_REPORT.md
@@ -95,12 +95,14 @@ viewport "is a slog vs Cycles". Two new packages capture the gap:
 |---|---|---|---|
 | **pkg80** *(new)* | Blender addon `'auto'` integrator resolution | ~½ day | Daily-workflow blocker; small Codex pickup |
 | ~~pkg73 fix~~ | ~~TEMPORAL_AOV upgrade branch never fires on RTX~~ | — | **DONE 2026-05-11** (PR #249): two compounding bugs fixed (plugin: `temporalModeUsePreviousLayers` was 0; test: AOV ref silently upgraded). Hardware: 53.1 % reduction vs ≥30 % gate. Denoiser story closes end-to-end. |
-| **pkg81** *(new)* | Viewport interactivity parity with Cycles (Phase 1 harness + Phase 2 diagnosis + Phase 3 fix) | ~1–2 weeks | The real Pillar-5 closing work; partially overlaps pkg55 if H4 register-pressure dominates |
+| ~~pkg81~~ | ~~Viewport interactivity parity with Cycles (Phase 1 + 2 + 3)~~ | — | **Phase 1+2 DONE 2026-05-11** (PR #248). H4 megakernel-register-pressure dominates: **CUDA 104 ms vs CPU 58 ms on 100k tris** — the pkg55-A 158 regs/thread cliff measured at viewport scale. **Phase 3 routes to pkg55 Phase B** per the spec's escape clause; Phase B's acceptance now includes the viewport-parity gate. Smaller H2/H5 follow-ups split out as **pkg83** + **pkg84**. |
+| **pkg83** *(new)* | Progressive accumulation continuation across camera changes (H2 from pkg81) | ~½ day | Addon-only; user-facing UX win independent of pkg55 Phase B |
+| **pkg84** *(new)* | CUDA kernel pre-warm at viewport start (H5 from pkg81) | ~½ day | Addon-only; moves the 12 s first-frame freeze to a moment the user expects |
 | **pkg42** | Synchrotron emission (Pillar 4) | ~2 weeks | Codex-paste-ready spec |
 | **pkg43** | Slim disk model (Pillar 4) | ~2 weeks | Codex-paste-ready spec |
 | **pkg44** | ADAF model (Pillar 4) | ~2 weeks | Codex-paste-ready spec |
 | **pkg55** Phase A.1 | SoA infra + intersect queue | ~1–2 weeks | Renamed in spec by PR #238; first real refactor before Phase B; pkg81 may surface this as a viewport bottleneck too |
-| pkg55 Phase B | Per-material shade kernels | 4–6 weeks | After A.1; possible pkg81 dependency |
+| pkg55 Phase B | Per-material shade kernels | 4–6 weeks | After A.1; **now owns the viewport-parity gate** (pkg81 Phase 3) — Phase B isn't done until the wavefront `path_tracer` clears CUDA pan-frame p99 ≤ 1.2× Cycles-CUDA on the pkg81 harness scene |
 | pkg55 Phase C | Megakernel removal | 2–4 weeks | After B |
 | pkg76 CSV | Classroom / Junkshop / BMW27 baseline rows | ~½ day on RTX | After pkg73 fix (so denoiser path is healthy for parity numbers) |
 | **pkg82** *(new)* | pkg54c gate variance characterisation (intra-binary + cross-build SSIM distribution; data-driven gate decision) | ~1 day on RTX | Replaces pkg78 bisect after the diagnosis ruled out a code regression; [#237](https://github.com/HendrikGC02/Astroray/issues/237) closes when this lands |

--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -190,7 +190,9 @@ is currently the weakest link.
 | pkg73 | OptiX TEMPORAL_AOV denoiser mode (auto-upgrade from pkg70 AOV when pkg72 motion buffer is non-zero; destroy + recreate on model-kind transition; ping-pong internal-guide-layer pair; previous-output cache + first-frame fallback; clean fallback to AOV on static cameras). Mirrors Cycles `intern/cycles/integrator/path_trace_work_gpu.cpp` (Apache-2.0). | **done** — defect fixed in PR #249 (2026-05-11). Two compounding root causes: (1) plugin: `OptixDenoiserParams::temporalModeUsePreviousLayers` was zero-init and never set → OptiX silently treated every frame as a new sequence start and dropped temporal accumulation, (2) test: AOV reference was silently upgraded to TEMPORAL_AOV by sub-pixel float dust (~2e-5) in `projectToPrevPixel` even when prev-pose == curr-pose → `rms_t == rms_a` by construction, masking root cause 1. Hardware-verified on RTX 5070 Ti / OptiX 9.1 / CUDA 12.8: **53.1% inter-frame variance reduction (gate ≥30%), 5/5 tests pass**. Diagnostic prints from PR #241 removed. **Denoiser story closes here** (pkg33 → pkg68 → pkg69 → pkg70 → pkg72 → pkg73). | A |
 | pkg76 | Astroray `.blend` importer (parity scope) — offline SDNA-walking Python reader, no `bpy` runtime dependency; supports Blender 5.1's 17-byte file header + 32-byte block header + new `attribute_storage`; returns `astroray.Scene`. `tools/blend_import/{sdna,reader,scene_builder,blend_to_astroray}.py`. | **done** (PR #240; CSV row population on Classroom/Junkshop/BMW27 deferred to a Round 6 RTX session — needs healthy denoiser path post-pkg73 fix) | A |
 | pkg80 | Blender addon: resolve `'auto'` integrator dropdown to a registered plugin before C++ calls — daily-workflow blocker surfaced 2026-05-10 by owner (`RuntimeError: Astroray: integrator 'auto' does not support GPU` on viewport rendered-view + GPU device mode). | **open** (Round 6 Codex pickup) | A |
-| pkg81 | Viewport interactivity parity with Cycles — Phase 1 harness + Phase 2 diagnosis + Phase 3 fix. The actual Pillar-5-closing package per ROADMAP.md's "rival Cycles" promise. Surfaced 2026-05-10 by owner ("rendered view is a slog vs Cycles"). pkg52/56/68/73/74 all closed against internal gates but never against Cycles-CUDA on the same scene during pan/zoom. | **open** (Round 6 Phase 1+2 Claude tech pickup; Phase 3 → Round 7 or routes through pkg55 Phase B) | A |
+| pkg81 | Viewport interactivity parity with Cycles — Phase 1 harness + Phase 2 diagnosis + Phase 3 fix. | **Phase 1+2 done 2026-05-11** (PR #248); harness + 16-config sweep + pkg81-diagnosis.md committed. Headline: **CUDA 104 ms vs CPU 58 ms on 100k tris** — H4 (megakernel register pressure, the pkg55-A 158 regs/thread cliff) dominates. **Phase 3 routes to pkg55 Phase B** per spec escape clause; Phase B now owns the viewport-parity acceptance gate. H2 + H5 follow-ups split out as pkg83 + pkg84. | A |
+| pkg83 | Progressive accumulation continuation — addon-only fix for H2 from pkg81. Today: addon resets accumulator on every `camera_changed` notification; pkg81 confirmed `spp_trace=[1]` per pan-frame. Cycles' `BlenderSession::reset` only invalidates on substantive scene-graph mutations. | **open** (Round 6 Codex pickup; ~½ day) | A |
+| pkg84 | CUDA kernel pre-warm at viewport start — addon-only fix for H5 from pkg81. Today: first CUDA frame in a session = 12,079 ms (kernel JIT + context init); subsequent ~14 ms. Pre-warm a 1-pixel render of a trivial scene during viewport-start to move the spinner to a moment the user expects. | **open** (Round 6 Codex pickup; ~½ day) | A |
 | pkg55 | Wavefront SoA GPU refactor — Phase A (`ASTRORAY_PROFILE=1`-gated CUDA events + NVTX + baseline.json; **measured 158 regs/thread + 1 active block/SM** at the 256-thread launch — Laine 2013 occupancy cliff documented for Phase B to attack) | **Phase A done; Phase A.1 (SoA infra + intersect queue) + Phase B (per-material shade kernels) + Phase C (megakernel removal) open** | A |
 
 **Deferred / not-yet-spec'd from the 2026-05-08 triage** (mentioned in the
@@ -433,6 +435,20 @@ events are summarized in the changelog below.
 ## Changelog
 
 Brief notes on notable events.
+
+- **2026-05-11 (pkg81 measurement-complete)** — first honest
+  Astroray-vs-Cycles viewport numbers exist. Harness + 16-config
+  sweep + diagnosis note shipped (PR #248). Headline: **CUDA 104 ms
+  vs CPU 58 ms on identical 100k-tri load** — pkg55 Phase A's
+  158 regs/thread + 1 active block/SM cliff is now measurably
+  costing the user, not just a documented number. **H4 (megakernel
+  register pressure) dominates;** H5 (12 s cold-start), H2
+  (accumulator-reset-per-pan), H3 (OIDN blocking on CPU) all
+  confirmed at smaller magnitudes. H1 ruled out. **Phase 3 routes
+  to pkg55 Phase B** per spec escape; Phase B now owns the
+  viewport-parity acceptance gate (CUDA pan-frame p99 ≤ 1.2×
+  Cycles-CUDA). H2 + H5 split out as **pkg83** + **pkg84** for
+  immediate addon-side wins.
 
 - **2026-05-11 (pkg73 closeout)** — pkg73 OptiX TEMPORAL_AOV defect
   fixed in PR #249. Hardware-verified on RTX 5070 Ti / OptiX 9.1 /

--- a/.astroray_plan/packages/pkg55-wavefront-soa-refactor.md
+++ b/.astroray_plan/packages/pkg55-wavefront-soa-refactor.md
@@ -180,6 +180,7 @@ queue) is renamed to **Phase A.1** below and remains open.
 - [ ] Wavefront vs CPU `path_tracer` SSIM ≥ 0.97 at 64 spp on the NIR band parity scene.
 - [ ] Megakernel render output unchanged (all pkg54b SSIM gates still pass).
 - [ ] **Performance gate:** Wavefront `path_tracer` is ≥ 1.5× faster than the megakernel `path_tracer` on a mixed-material scene (Disney contact sheet: 7 material types, 512 SPP, measured as end-to-end frame time on RTX 5070 Ti).
+- [ ] **Viewport-parity gate (absorbed from pkg81 Phase 3 — H4 dominant per [`pkg81-diagnosis.md`](../docs/pkg81-diagnosis.md), 2026-05-11):** the wavefront `path_tracer`, run through the persistent viewport on the pkg81 harness's 99k-tri reference scene, achieves CUDA pan-frame p99 **≤ 1.2× Cycles-CUDA** on RTX 5070 Ti at the same denoiser + spp settings. Re-run `benchmarks/viewport_parity/run.py` post-Phase-B; the existing megakernel column (104 ms @ 100k) stays for reference; the new wavefront column must close the gap to Cycles. **This is the goal that the user-facing "viewport feels like a slog" complaint resolves into; pkg55 Phase B now owns it.**
 - [ ] `restir_di` and `neural-cache` integrators produce visually correct output via wavefront (no numerical acceptance gate for ReSTIR in Phase B — visual inspection only; full gate in Phase C).
 
 ---

--- a/.astroray_plan/packages/pkg83-progressive-accumulation-continuation.md
+++ b/.astroray_plan/packages/pkg83-progressive-accumulation-continuation.md
@@ -1,0 +1,108 @@
+# pkg83 — Progressive accumulation continuation across camera changes
+
+**Pillar:** 5
+**Track:** A
+**Status:** open
+**Estimated effort:** ~½ day (~3 h)
+**Depends on:** pkg52 (persistent viewport), pkg56 Phase C (depsgraph dispatch), pkg81 diagnosis
+
+---
+
+## Goal
+
+**Before:** The Astroray Blender addon resets the progressive sample
+accumulator on every `camera_changed` depsgraph notification.
+pkg81's harness recorded `spp_trace = [1]` per frame across a
+deterministic camera pan — every frame starts from sample 1, even
+when the camera nudge is sub-pixel and the accumulator could
+correctly continue. This is **H2 from the pkg81 hypothesis tree,
+confirmed at the code level.**
+
+Cycles' `BlenderSession::reset` only invalidates the framebuffer
+on **scene-graph mutations** — not on every camera tick. A pure
+pan therefore keeps progressive samples accumulating, and the
+denoiser's input quality improves frame-over-frame instead of
+restarting from 1 spp every tick.
+
+**After:** The addon distinguishes "camera transform changed" from
+"camera transform changed *and* prior samples are no longer
+representative" (the latter is the only case that needs a reset).
+Pure-pan ticks keep accumulating; substantive scene mutations
+still reset. Measured `spp_trace` rises monotonically across a
+pan in the pkg81 harness.
+
+---
+
+## Context — why this matters now
+
+H2 isn't the dominant viewport bottleneck — pkg81 confirmed that's
+H4 (megakernel register pressure, routed to pkg55 Phase B). But H2
+is small, mechanical, addon-only, and has an immediate user-facing
+benefit: the viewport image stops "boiling" with each camera nudge,
+instead refining smoothly as the user holds steady. It's
+independently worth shipping while pkg55 Phase B (the multi-week
+register-pressure fix) is in flight.
+
+This package is **not** the viewport-interactivity-parity fix.
+pkg55 Phase B is. This is a small UX polish that the pkg81
+measurement made findable.
+
+---
+
+## Reference
+
+- `intern/cycles/blender/session.cpp::BlenderSession::reset` —
+  Apache-2.0 — when Cycles invalidates the framebuffer. Read for
+  the test of "what counts as 'sample 1 prior is still valid?'".
+- `blender_addon/__init__.py` — current camera_changed reset path
+  (the call site pkg81 traced). Around the persistent viewport
+  invalidation hooks.
+- `.astroray_plan/docs/pkg81-diagnosis.md` — the measurement that
+  surfaced this.
+- pkg52 spec — persistent viewport session; the accumulator state
+  this package preserves across more events.
+
+---
+
+## Specification
+
+### Files to modify
+
+| File | Change |
+|---|---|
+| `blender_addon/__init__.py` | In the depsgraph handler that currently fires the accumulator reset on `camera_changed`, only reset when the camera change is "substantive" — i.e., the mutation crosses a threshold that invalidates prior samples (focal length / sensor size / lens shift / aperture). Pure transform changes (pan / orbit / dolly) keep accumulating. |
+| `tests/test_blender_progressive_accumulation.py` *(new)* | Synthetic depsgraph events: pure-pan, focal-length change, mesh edit. Assert: pure-pan does NOT trigger the reset; focal-length does; mesh edit does. Mock the renderer's accumulator-reset method. |
+| `benchmarks/viewport_parity/2026-05-XX.json` | After re-running the pkg81 harness post-fix: `spp_trace` for `camera_only` should rise monotonically (1, 2, 3, …) across the 8-frame pan instead of staying flat at `[1]`. |
+
+### Acceptance criteria
+
+- [ ] `camera_only` scenario in the pkg81 harness shows
+      `spp_trace[-1] >= 8` (one accumulated sample per frame
+      across the 8-frame pan).
+- [ ] `transform_edit` scenario still resets correctly when a
+      mesh transform changes (sub-tree of geometry mutated).
+- [ ] Synthetic addon-test green (no Blender required).
+- [ ] No regression in offline F12 render path — that path
+      doesn't go through this code, but a sanity check that
+      `pytest tests/test_blender*.py` stays green.
+- [ ] No measurable per-frame cost added (the check itself is a
+      handful of attribute compares).
+
+### Hard non-goals
+
+- **Not a fix for the viewport-Cycles-parity gap.** That's pkg55
+  Phase B (H4 / register pressure). This package only fixes the
+  H2 sub-issue.
+- **No camera-state hashing or fancy invalidation policy.** Just
+  a small allow-list of "fields that genuinely require a reset"
+  (focal length, lens shift, sensor size, dof toggle, aperture
+  fstop). Anything not on the list is a transform-only change.
+- **No back-port to final-render F12.** F12 doesn't accumulate
+  across separate render calls anyway; this is a viewport-only
+  feature.
+
+---
+
+## Lessons (filled in on completion)
+
+*(empty until done)*

--- a/.astroray_plan/packages/pkg84-cuda-kernel-prewarm.md
+++ b/.astroray_plan/packages/pkg84-cuda-kernel-prewarm.md
@@ -1,0 +1,109 @@
+# pkg84 — CUDA kernel pre-warm at viewport start
+
+**Pillar:** 5
+**Track:** A
+**Status:** open
+**Estimated effort:** ~½ day (~3 h)
+**Depends on:** pkg52 (persistent viewport), pkg81 diagnosis
+
+---
+
+## Goal
+
+**Before:** First CUDA frame in a viewport session takes
+**12,079 ms** on RTX 5070 Ti (kernel JIT + CUDA context init +
+first cudaMalloc), measured by pkg81's harness. Subsequent frames
+are ~14 ms. This is **H5 from the pkg81 hypothesis tree, confirmed
+one-shot.**
+
+User experience: the first time the user clicks "Rendered" in the
+viewport with `device_mode='cuda'`, the viewport freezes for ~12
+seconds. The 14 ms steady state that follows is acceptable; the
+12-second cold-start is not.
+
+**After:** CUDA context + kernel cache is pre-warmed when the
+persistent viewport session starts (i.e., before the user
+explicitly clicks "Rendered"). The user-perceived first-frame
+latency drops from ~12 s to whatever the steady-state is (~14 ms
+on the harness scene). Idle CPU/GPU cost during warm-up is
+acceptable: a single launch of an empty / 1-pixel render against a
+zero-triangle scene is enough to JIT all of `pathTraceKernel` and
+populate `nvJitLink`'s cache.
+
+---
+
+## Context
+
+H5 is one-shot per session — once the kernel cache is populated,
+subsequent viewport-engine switches reuse it. So this isn't a
+recurring cost; it's a one-time onboarding tax. But it's the first
+thing a Cycles user notices when comparing the two engines.
+
+Cycles avoids this by precompiling kernels at install time
+(Cycles' shipped `.cubin` / OptiX PTX cache) and by initialising
+its CUDA context at addon-startup, not at first-render. We can't
+ship precompiled kernels for arbitrary GPU architectures (the
+project supports sm_120 Blackwell + older), but we can move the
+JIT cost to a moment the user expects to wait — addon load, or
+viewport "Rendered" mode entry.
+
+---
+
+## Reference
+
+- `intern/cycles/blender/blender_python.cpp::list_render_devices`
+  + addon-load CUDA query — Apache-2.0 — Cycles initialises the
+  CUDA context at addon load.
+- `intern/cycles/device/cuda/device.cpp::CUDADevice::compile_kernel`
+  — Cycles' kernel-precompile path; we can't mirror this directly
+  (no PTX shipping) but we can ape the "compile early" intent.
+- `.astroray_plan/docs/pkg81-diagnosis.md` — the H5 measurement.
+- pkg52 spec — persistent viewport lifecycle this hooks into.
+
+---
+
+## Specification
+
+### Files to modify
+
+| File | Change |
+|---|---|
+| `blender_addon/__init__.py` | Add a `_prewarm_cuda(renderer)` helper that runs once when the persistent viewport renderer is first instantiated **and** the device mode is `'cuda'`. The helper triggers the CUDA path through a 1-pixel render of a single-triangle scene, swallowing the result. This pulls all megakernel JIT into the warm-up phase. |
+| `module/blender_module.cpp` | If a public Python-side hook doesn't already exist, expose `Renderer.prewarm_cuda()` that performs the equivalent of "render 1 pixel of a trivial scene, discard, return". Otherwise the addon can drive it through the existing render path. |
+| `tests/test_cuda_prewarm.py` *(new)* | Synthetic test: instantiate a Renderer in CPU mode (so test stays fast and cross-platform), call `prewarm_cuda()`, assert it returns a sensible "no CUDA available" instead of crashing. CUDA-only assertion lives behind the existing `cuda_available` skip. |
+
+### Acceptance criteria
+
+- [ ] First "real" viewport frame after pre-warm shows
+      ≤ 100 ms initialisation cost (vs the measured 12,079 ms
+      pre-fix). Re-run the pkg81 harness's first-frame number;
+      it must drop by an order of magnitude.
+- [ ] Pre-warm runs at most once per Blender session
+      (idempotent).
+- [ ] Pre-warm time is itself in the ~12-second range — that
+      cost moved, not eliminated. The package's job is to move
+      the spinner to a moment the user expects (clicking
+      Rendered the first time during *setup*) instead of mid-
+      navigation.
+- [ ] CPU device mode is unchanged (no pre-warm needed).
+- [ ] No effect on offline F12 path.
+- [ ] If the user changes `device_mode` mid-session (CPU → CUDA
+      via the Astroray panel), the pre-warm fires again.
+
+### Hard non-goals
+
+- **No persistent kernel cache to disk.** That's a much larger
+  package (sm-arch-keyed PTX cache + load-time validation).
+  H5 is one-shot per session; on-disk caching would amortise
+  across sessions but is multi-week scope.
+- **No PTX shipping.** Same reason — multi-arch-targeted PTX
+  shipping is its own package.
+- **No background pre-warm.** Run synchronously when the user
+  hits Rendered with CUDA selected. Background pre-warm risks
+  fighting the user's own first-render call.
+
+---
+
+## Lessons (filled in on completion)
+
+*(empty until done)*


### PR DESCRIPTION
PR #248 (2026-05-11) closed pkg81 Phase 1+2 with the headline number that turns pkg55 Phase A's documented register-pressure cliff into a user-facing measurement: **CUDA 104 ms vs CPU 58 ms on identical 100k-tri load**.

## Diagnosis from pkg81-diagnosis.md

| H | Verdict | Owns |
|---|---|---|
| H4 megakernel register pressure | **dominant** | CUDA pan slowness (pkg55-A's 158 regs/thread cliff at viewport scale) |
| H5 cold CUDA | confirmed, one-shot | 12,079 ms first frame, ~14 ms after |
| H2 accumulator reset per pan | confirmed code-level | spp_trace flat at [1] every camera tick |
| H3 OIDN blocking | confirmed CPU only | +90 ms CPU, ~0 ms CUDA |
| H1 uploaders during pan | RULED OUT | 0 calls/frame in camera_only |

## Outcome

- **pkg81 closes** as measurement-complete; Phase 3 routes to pkg55 Phase B per spec escape.
- **pkg55 Phase B spec amended** — viewport-parity acceptance gate added: wavefront pan-frame p99 ≤ 1.2× Cycles-CUDA on the pkg81 harness scene. Phase B now owns the user-facing 'viewport feels like a slog' claim.
- **pkg83** *(new)* — progressive accumulation continuation (H2; addon-only, ~½ day Codex)
- **pkg84** *(new)* — CUDA kernel pre-warm at viewport start (H5; addon-only, ~½ day Codex)

🤖 Generated with [Claude Code](https://claude.com/claude-code)