### PR TITLE
feat(infra): autonomous dev-loop setup (agents + hooks + skills + architect)

### DIFF
--- a/.astroray_plan/packages/pkg83-progressive-accumulation-continuation.md
+++ b/.astroray_plan/packages/pkg83-progressive-accumulation-continuation.md
@@ -2,6 +2,7 @@
 
 **Pillar:** 5
 **Track:** A
+**Codex-paste-ready:** yes
 **Status:** open
 **Estimated effort:** ~½ day (~3 h)
 **Depends on:** pkg52 (persistent viewport), pkg56 Phase C (depsgraph dispatch), pkg81 diagnosis

--- a/.astroray_plan/packages/pkg84-cuda-kernel-prewarm.md
+++ b/.astroray_plan/packages/pkg84-cuda-kernel-prewarm.md
@@ -2,6 +2,7 @@
 
 **Pillar:** 5
 **Track:** A
+**Codex-paste-ready:** yes
 **Status:** open
 **Estimated effort:** ~½ day (~3 h)
 **Depends on:** pkg52 (persistent viewport), pkg81 diagnosis

--- a/.astroray_plan/tracker/README.md
+++ b/.astroray_plan/tracker/README.md
@@ -1,0 +1,48 @@
+# Astroray Project Tracker
+
+## What it is
+
+A Google Sheets dashboard that pulls live state from the GitHub repo into
+8 tabs. Auto-refreshes daily at 7 am via an Apps Script time-based trigger.
+
+Tabs: **Dashboard**, **Packages**, **Pillars**, **PRs (open)**, **Issues (open)**,
+**Commits**, **Timeline**, **About**.
+
+## Where
+
+The live Sheet URL is stored in `.astroray_plan/tracker/local.toml` (gitignored).
+If that file is absent, recreate the Sheet from scratch using the recovery steps
+below.
+
+## Source of truth
+
+`astroray_dashboard.gs` in this directory is the authoritative source. Any edit
+to the tracker logic lands here first, then gets pasted into the standalone Apps
+Script project in Google Drive.
+
+## Recovery procedure
+
+1. Open <https://script.google.com/u/0/home> → **New project**.
+2. Paste the full contents of `astroray_dashboard.gs` into the `Code.gs` editor.
+   Save the project (any name).
+3. In the script editor, open **Project settings** → **Script properties** and add:
+   - Key: `GITHUB_TOKEN`
+   - Value: a GitHub PAT with **no scopes** (public-repo read; raises rate limit
+     from 60/hr → 5000/hr; required, not optional).
+4. Run `setup()` from the editor. Apps Script will request permissions
+   (UrlFetchApp + SpreadsheetApp). Approve. Expect ~60 s on first run.
+5. Run `installDailyTrigger()` once to schedule the 7 am auto-refresh.
+
+After step 4, the script prints the new Sheet URL to the Execution Log. Copy it
+into `.astroray_plan/tracker/local.toml`:
+
+```toml
+[sheet]
+url = "https://docs.google.com/spreadsheets/d/..."
+```
+
+## Architect note
+
+Agents may reference the tracker when surfacing project state (strategy-review
+mode). The Sheet URL is stored in the local config, not here, to keep credentials
+out of git.

--- a/.astroray_plan/tracker/astroray_dashboard.gs
+++ b/.astroray_plan/tracker/astroray_dashboard.gs
@@ -1,0 +1,555 @@
+/**
+ * Astroray project tracker — Google Apps Script
+ *
+ * Pulls live data from the public GitHub repo and rebuilds every dynamic
+ * sheet. Safe to re-run; it preserves the spreadsheet itself and only
+ * touches its known sheets.
+ *
+ * One-time setup:
+ *   1. Open your spreadsheet → Extensions → Apps Script.
+ *   2. Replace Code.gs contents with this file.
+ *   3. Save.
+ *   4. Run setup()  — Apps Script will ask for permission the first time
+ *      (UrlFetchApp + SpreadsheetApp). Approve.
+ *   5. Optional: run installDailyTrigger() to auto-refresh once a day.
+ *
+ * After that, the spreadsheet has a "Astroray" menu in the menu bar with
+ * "Refresh now" + trigger management.
+ */
+
+// ───────────── Config ─────────────
+
+const REPO   = 'HendrikGC02/Astroray';
+const BRANCH = 'main';
+
+// Optional: paste a GitHub PAT (no scopes needed for a public repo) to
+// raise the rate limit from 60/hr → 5000/hr. Safe-ish to leave blank.
+const GITHUB_TOKEN = '';
+
+// Sheet names (used by setup + refresh).
+const S = {
+  dashboard: 'Dashboard',
+  packages : 'Packages',
+  pillars  : 'Pillars',
+  prs      : 'PRs (open)',
+  issues   : 'Issues (open)',
+  commits  : 'Commits',
+  timeline : 'Timeline',
+  about    : 'About',
+};
+
+// ───────────── Menu ─────────────
+
+function onOpen() {
+  SpreadsheetApp.getUi()
+    .createMenu('Astroray')
+    .addItem('Refresh now', 'refresh')
+    .addSeparator()
+    .addItem('Run full setup', 'setup')
+    .addSeparator()
+    .addItem('Install daily auto-refresh', 'installDailyTrigger')
+    .addItem('Remove auto-refresh', 'removeDailyTrigger')
+    .addToUi();
+}
+
+// ───────────── Top-level entry points ─────────────
+
+/** Build every sheet from scratch and pull live data. */
+function setup() {
+  const ss = SpreadsheetApp.getActive();
+  ensureSheets_(ss);
+  buildAbout_(ss);
+  buildPillars_(ss);            // static structure; counts come from Packages
+  refresh();                     // pulls everything else
+  buildDashboard_(ss);          // links + summary formulas (must run after Packages exists)
+  // Reorder sheets, hide nothing.
+  reorderSheets_(ss);
+  ss.setActiveSheet(ss.getSheetByName(S.dashboard));
+  toast_('Setup complete.');
+}
+
+/** Refresh all live data (Packages, PRs, Issues, Commits, Timeline). */
+function refresh() {
+  const ss = SpreadsheetApp.getActive();
+  ensureSheets_(ss);
+  refreshPackages_(ss);
+  refreshPRs_(ss);
+  refreshIssues_(ss);
+  refreshCommits_(ss);
+  refreshTimeline_(ss);
+  stampAbout_(ss);
+  toast_('Refreshed.');
+}
+
+function installDailyTrigger() {
+  removeDailyTrigger();
+  ScriptApp.newTrigger('refresh').timeBased().everyDays(1).atHour(7).create();
+  toast_('Auto-refresh installed: daily at 7am.');
+}
+
+function removeDailyTrigger() {
+  ScriptApp.getProjectTriggers()
+    .filter(t => t.getHandlerFunction() === 'refresh')
+    .forEach(t => ScriptApp.deleteTrigger(t));
+}
+
+// ───────────── Sheet scaffolding ─────────────
+
+function ensureSheets_(ss) {
+  Object.values(S).forEach(name => {
+    if (!ss.getSheetByName(name)) ss.insertSheet(name);
+  });
+  // If the default "Sheet1" exists and we have our named sheets, drop it.
+  const def = ss.getSheetByName('Sheet1');
+  if (def && Object.values(S).every(n => ss.getSheetByName(n))) {
+    ss.deleteSheet(def);
+  }
+}
+
+function reorderSheets_(ss) {
+  const order = [S.dashboard, S.packages, S.pillars, S.prs, S.issues,
+                 S.commits, S.timeline, S.about];
+  order.forEach((name, idx) => {
+    const sh = ss.getSheetByName(name);
+    if (sh) ss.setActiveSheet(sh) && ss.moveActiveSheet(idx + 1);
+  });
+}
+
+// ───────────── Dashboard ─────────────
+
+function buildDashboard_(ss) {
+  const sh = ss.getSheetByName(S.dashboard);
+  sh.clear();
+
+  sh.getRange('A1').setValue('Astroray Project Tracker')
+    .setFontSize(18).setFontWeight('bold');
+  sh.getRange('A2').setFormula(`="Last refreshed: " & TEXT('${S.about}'!B2, "yyyy-mm-dd hh:mm")`)
+    .setFontColor('#666');
+
+  // KPI band
+  const kpis = [
+    ['Pillar 1',  `=COUNTIFS('${S.packages}'!C:C, 1, '${S.packages}'!D:D, "done") & "/" & COUNTIF('${S.packages}'!C:C, 1)`],
+    ['Pillar 2',  `=COUNTIFS('${S.packages}'!C:C, 2, '${S.packages}'!D:D, "done") & "/" & COUNTIF('${S.packages}'!C:C, 2)`],
+    ['Pillar 3',  `=COUNTIFS('${S.packages}'!C:C, 3, '${S.packages}'!D:D, "done") & "/" & COUNTIF('${S.packages}'!C:C, 3)`],
+    ['Pillar 4',  `=COUNTIFS('${S.packages}'!C:C, 4, '${S.packages}'!D:D, "done") & "/" & COUNTIF('${S.packages}'!C:C, 4)`],
+    ['Pillar 5',  `=COUNTIFS('${S.packages}'!C:C, 5, '${S.packages}'!D:D, "done") & "/" & COUNTIF('${S.packages}'!C:C, 5)`],
+    ['Open PRs',  `=COUNTA('${S.prs}'!A2:A)`],
+    ['Open issues', `=COUNTA('${S.issues}'!A2:A)`],
+    ['Total packages', `=COUNTA('${S.packages}'!A2:A)`],
+  ];
+  sh.getRange(4, 1, 1, kpis.length).setValues([kpis.map(k => k[0])])
+    .setFontWeight('bold').setBackground('#1a73e8').setFontColor('white').setHorizontalAlignment('center');
+  sh.getRange(5, 1, 1, kpis.length).setFormulas([kpis.map(k => k[1])])
+    .setFontSize(14).setHorizontalAlignment('center').setBackground('#e8f0fe');
+  sh.setRowHeight(5, 36);
+
+  // Strategic gate banner
+  sh.getRange('A8').setValue('Strategic gate').setFontWeight('bold').setBackground('#fbbc04');
+  sh.getRange('B8').setValue('RELEASED 2026-05-10 — pkg56 Phase C (PR #233). Pillar 4 actively shipping.');
+  sh.getRange('B8').setBackground('#fff8e1');
+
+  // "What's hot" — open packages, top 15
+  sh.getRange('A10').setValue("What's open right now (not done)").setFontWeight('bold');
+  sh.getRange('A11').setFormula(
+    `=QUERY('${S.packages}'!A:F, "select A,B,C,D,F where D <> 'done' order by C, A limit 20", 1)`
+  );
+
+  // Pillar mini-table mirror
+  sh.getRange('H10').setValue('Pillar progress').setFontWeight('bold');
+  sh.getRange('H11').setFormula(`='${S.pillars}'!A1`);
+  sh.getRange('H11:K17').setFormula(`='${S.pillars}'!A1:D7`);
+
+  // Recent activity preview
+  sh.getRange('A33').setValue('Recent commits (last 10)').setFontWeight('bold');
+  sh.getRange('A34').setFormula(
+    `=QUERY('${S.commits}'!A:D, "select A,B,C,D limit 10", 1)`
+  );
+
+  // Open PRs preview
+  sh.getRange('H33').setValue('Open PRs').setFontWeight('bold');
+  sh.getRange('H34').setFormula(
+    `=QUERY('${S.prs}'!A:E, "select A,B,C,D,E", 1)`
+  );
+
+  // Layout polish
+  sh.setColumnWidth(1, 80);
+  sh.setColumnWidth(2, 380);
+  sh.setColumnWidth(3, 70);
+  sh.setColumnWidth(4, 110);
+  sh.setColumnWidth(5, 140);
+  sh.setColumnWidth(6, 240);
+  sh.setColumnWidth(8, 100);
+  sh.setColumnWidth(9, 360);
+  sh.setColumnWidth(10, 70);
+  sh.setColumnWidth(11, 110);
+  sh.setHiddenGridlines(true);
+  sh.setFrozenRows(2);
+}
+
+// ───────────── Pillars ─────────────
+
+function buildPillars_(ss) {
+  const sh = ss.getSheetByName(S.pillars);
+  sh.clear();
+  const header = ['Pillar', 'Name', 'Done', '%'];
+  const rows = [
+    [1, 'Plugin architecture',                    '', ''],
+    [2, 'Spectral core',                          '', ''],
+    [3, 'Light transport',                        '', ''],
+    [4, 'Astrophysics platform',                  '', ''],
+    [5, 'Production polish / Blender parity',     '', ''],
+  ];
+  sh.getRange(1, 1, 1, header.length).setValues([header])
+    .setFontWeight('bold').setBackground('#1a73e8').setFontColor('white');
+  sh.getRange(2, 1, rows.length, rows[0].length).setValues(rows);
+  for (let i = 0; i < rows.length; i++) {
+    const p = rows[i][0];
+    const r = i + 2;
+    sh.getRange(r, 3).setFormula(
+      `=COUNTIFS('${S.packages}'!C:C, ${p}, '${S.packages}'!D:D, "done") & "/" & COUNTIF('${S.packages}'!C:C, ${p})`
+    );
+    sh.getRange(r, 4).setFormula(
+      `=IFERROR(COUNTIFS('${S.packages}'!C:C, ${p}, '${S.packages}'!D:D, "done")/COUNTIF('${S.packages}'!C:C, ${p}), 0)`
+    ).setNumberFormat('0%');
+  }
+  // Conditional formatting on the % column
+  const pctRange = sh.getRange(2, 4, rows.length, 1);
+  const rules = sh.getConditionalFormatRules();
+  rules.push(
+    SpreadsheetApp.newConditionalFormatRule()
+      .setGradientMaxpointWithValue('#34a853', SpreadsheetApp.InterpolationType.NUMBER, '1')
+      .setGradientMidpointWithValue('#fbbc04', SpreadsheetApp.InterpolationType.NUMBER, '0.5')
+      .setGradientMinpointWithValue('#ea4335', SpreadsheetApp.InterpolationType.NUMBER, '0')
+      .setRanges([pctRange]).build()
+  );
+  sh.setConditionalFormatRules(rules);
+  sh.setColumnWidths(1, 1, 70);
+  sh.setColumnWidths(2, 1, 280);
+  sh.setColumnWidths(3, 1, 90);
+  sh.setColumnWidths(4, 1, 90);
+  sh.setFrozenRows(1);
+}
+
+// ───────────── Packages ─────────────
+
+function refreshPackages_(ss) {
+  const sh = ss.getSheetByName(S.packages);
+  sh.clear();
+  const header = ['Package', 'Title', 'Pillar', 'Status', 'Effort', 'Path'];
+  sh.getRange(1, 1, 1, header.length).setValues([header])
+    .setFontWeight('bold').setBackground('#1a73e8').setFontColor('white');
+
+  // List package files via the GitHub API.
+  const list = githubJson_(`/repos/${REPO}/contents/.astroray_plan/packages?ref=${BRANCH}`);
+  if (!Array.isArray(list)) {
+    sh.getRange('A2').setValue('Error fetching packages: ' + JSON.stringify(list));
+    return;
+  }
+  const files = list.filter(f => f.name.endsWith('.md') && /^pkg/i.test(f.name));
+  files.sort(byPkgKey_);
+
+  const rows = files.map(f => {
+    const text = httpGet_(rawUrl_(f.path));
+    const meta = parsePackageMd_(text || '');
+    const pkg = (f.name.match(/^pkg([0-9a-z-]+)/i) || [])[1] || '';
+    const title = meta.title || f.name.replace(/\.md$/, '');
+    const repoUrl = `https://github.com/${REPO}/blob/${BRANCH}/${f.path}`;
+    return [
+      `=HYPERLINK("${repoUrl}", "pkg${pkg}")`,
+      title,
+      meta.pillar || '',
+      meta.status || '',
+      meta.effort || '',
+      f.path,
+    ];
+  });
+
+  if (rows.length) {
+    sh.getRange(2, 1, rows.length, header.length).setValues(rows);
+  }
+
+  // Status colour-coding
+  const statusRange = sh.getRange(2, 4, Math.max(1, rows.length), 1);
+  const rules = [];
+  const tint = (kw, bg) =>
+    SpreadsheetApp.newConditionalFormatRule()
+      .whenTextContains(kw).setBackground(bg).setRanges([statusRange]).build();
+  rules.push(tint('done',         '#c8e6c9'));
+  rules.push(tint('implemented',  '#fff9c4'));
+  rules.push(tint('research',     '#ffe0b2'));
+  rules.push(tint('open',         '#ffcdd2'));
+  sh.setConditionalFormatRules(rules);
+
+  sh.setColumnWidths(1, 1, 80);
+  sh.setColumnWidths(2, 1, 380);
+  sh.setColumnWidths(3, 1, 70);
+  sh.setColumnWidths(4, 1, 280);
+  sh.setColumnWidths(5, 1, 160);
+  sh.setColumnWidths(6, 1, 380);
+  sh.setFrozenRows(1);
+  sh.getDataRange().createFilter();
+}
+
+/** Tolerant package-frontmatter parser. Reads only the first ~80 lines. */
+function parsePackageMd_(md) {
+  const lines = md.split(/\r?\n/).slice(0, 80);
+  const meta = { title: '', pillar: '', status: '', effort: '' };
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!meta.title && /^#\s+/.test(line)) {
+      meta.title = line.replace(/^#\s+/, '').replace(/^pkg[0-9a-z-]+\s*[—\-:]\s*/i, '').trim();
+      continue;
+    }
+    const mPillar = line.match(/^\*\*Pillar:\*\*\s*(.+)$/i);
+    if (mPillar && !meta.pillar) {
+      // Take the first digit we find: "2 (follow-up) / 5" → 2
+      const d = mPillar[1].match(/\d+/);
+      meta.pillar = d ? Number(d[0]) : mPillar[1].trim();
+      continue;
+    }
+    const mStatus = line.match(/^\*\*Status:\*\*\s*(.+)$/i);
+    if (mStatus && !meta.status) {
+      meta.status = stripMd_(mStatus[1]).trim();
+      continue;
+    }
+    const mEffort = line.match(/^\*\*Estimated effort:\*\*\s*(.+)$/i);
+    if (mEffort && !meta.effort) {
+      meta.effort = stripMd_(mEffort[1]).trim();
+      continue;
+    }
+  }
+  // Normalise the canonical statuses we colour-code on.
+  const s = meta.status.toLowerCase();
+  if (/(^|[^a-z])done([^a-z]|$)/.test(s) || /^complete\b/.test(s)) meta.status = 'done';
+  else if (/^implemented\b/.test(s))                                meta.status = 'implemented';
+  else if (/research/.test(s) && /(blocked|signed off|signed-off|signoff|sign\-off)/.test(s)) meta.status = 'research signed off';
+  else if (/^open\b/.test(s))                                       meta.status = 'open';
+  return meta;
+}
+
+function stripMd_(s) {
+  return s.replace(/\*\*/g, '').replace(/`/g, '').replace(/\s+/g, ' ');
+}
+
+function byPkgKey_(a, b) {
+  const ka = pkgKey_(a.name), kb = pkgKey_(b.name);
+  if (ka.n !== kb.n) return ka.n - kb.n;
+  return ka.suf < kb.suf ? -1 : ka.suf > kb.suf ? 1 : 0;
+}
+
+function pkgKey_(name) {
+  const m = name.match(/^pkg(\d+)([a-z\-0-9]*)/i);
+  if (!m) return { n: 9999, suf: name };
+  return { n: Number(m[1]), suf: (m[2] || '').toLowerCase() };
+}
+
+// ───────────── PRs ─────────────
+
+function refreshPRs_(ss) {
+  const sh = ss.getSheetByName(S.prs);
+  sh.clear();
+  const header = ['#', 'Title', 'Author', 'Updated', 'Mergeable', 'URL'];
+  sh.getRange(1, 1, 1, header.length).setValues([header])
+    .setFontWeight('bold').setBackground('#1a73e8').setFontColor('white');
+
+  const prs = githubJson_(`/repos/${REPO}/pulls?state=open&per_page=50&sort=updated&direction=desc`);
+  if (!Array.isArray(prs)) {
+    sh.getRange('A2').setValue('Error: ' + JSON.stringify(prs));
+    return;
+  }
+  const rows = prs.map(p => [
+    `=HYPERLINK("${p.html_url}", "#${p.number}")`,
+    p.title,
+    p.user && p.user.login || '',
+    new Date(p.updated_at),
+    p.draft ? 'draft' : 'open',
+    p.html_url,
+  ]);
+  if (rows.length) sh.getRange(2, 1, rows.length, header.length).setValues(rows);
+  sh.getRange(2, 4, Math.max(1, rows.length), 1).setNumberFormat('yyyy-mm-dd hh:mm');
+  sh.setColumnWidths(1, 1, 70);
+  sh.setColumnWidths(2, 1, 460);
+  sh.setColumnWidths(3, 1, 140);
+  sh.setColumnWidths(4, 1, 150);
+  sh.setColumnWidths(5, 1, 90);
+  sh.setColumnWidths(6, 1, 360);
+  sh.setFrozenRows(1);
+  sh.getDataRange().createFilter();
+}
+
+// ───────────── Issues ─────────────
+
+function refreshIssues_(ss) {
+  const sh = ss.getSheetByName(S.issues);
+  sh.clear();
+  const header = ['#', 'Title', 'Labels', 'Updated', 'URL'];
+  sh.getRange(1, 1, 1, header.length).setValues([header])
+    .setFontWeight('bold').setBackground('#1a73e8').setFontColor('white');
+
+  const items = githubJson_(`/repos/${REPO}/issues?state=open&per_page=50&sort=updated&direction=desc`);
+  if (!Array.isArray(items)) {
+    sh.getRange('A2').setValue('Error: ' + JSON.stringify(items));
+    return;
+  }
+  // Filter out PRs (the issues endpoint includes them)
+  const issues = items.filter(i => !i.pull_request);
+  const rows = issues.map(i => [
+    `=HYPERLINK("${i.html_url}", "#${i.number}")`,
+    i.title,
+    (i.labels || []).map(l => l.name).join(', '),
+    new Date(i.updated_at),
+    i.html_url,
+  ]);
+  if (rows.length) sh.getRange(2, 1, rows.length, header.length).setValues(rows);
+  sh.getRange(2, 4, Math.max(1, rows.length), 1).setNumberFormat('yyyy-mm-dd hh:mm');
+  sh.setColumnWidths(1, 1, 70);
+  sh.setColumnWidths(2, 1, 460);
+  sh.setColumnWidths(3, 1, 180);
+  sh.setColumnWidths(4, 1, 150);
+  sh.setColumnWidths(5, 1, 360);
+  sh.setFrozenRows(1);
+  sh.getDataRange().createFilter();
+}
+
+// ───────────── Commits ─────────────
+
+function refreshCommits_(ss) {
+  const sh = ss.getSheetByName(S.commits);
+  sh.clear();
+  const header = ['SHA', 'Message', 'Author', 'When'];
+  sh.getRange(1, 1, 1, header.length).setValues([header])
+    .setFontWeight('bold').setBackground('#1a73e8').setFontColor('white');
+
+  const commits = githubJson_(`/repos/${REPO}/commits?per_page=60&sha=${BRANCH}`);
+  if (!Array.isArray(commits)) {
+    sh.getRange('A2').setValue('Error: ' + JSON.stringify(commits));
+    return;
+  }
+  const rows = commits.map(c => {
+    const sha = (c.sha || '').slice(0, 7);
+    const msg = (c.commit && c.commit.message || '').split('\n')[0];
+    const url = c.html_url;
+    return [
+      `=HYPERLINK("${url}", "${sha}")`,
+      msg,
+      c.commit && c.commit.author && c.commit.author.name || '',
+      c.commit && c.commit.author && new Date(c.commit.author.date) || '',
+    ];
+  });
+  if (rows.length) sh.getRange(2, 1, rows.length, header.length).setValues(rows);
+  sh.getRange(2, 4, Math.max(1, rows.length), 1).setNumberFormat('yyyy-mm-dd hh:mm');
+  sh.setColumnWidths(1, 1, 90);
+  sh.setColumnWidths(2, 1, 560);
+  sh.setColumnWidths(3, 1, 160);
+  sh.setColumnWidths(4, 1, 150);
+  sh.setFrozenRows(1);
+  sh.getDataRange().createFilter();
+}
+
+// ───────────── Timeline ─────────────
+//
+// Parses the Changelog section of STATUS.md into one row per dated entry.
+
+function refreshTimeline_(ss) {
+  const sh = ss.getSheetByName(S.timeline);
+  sh.clear();
+  const header = ['Date', 'Summary'];
+  sh.getRange(1, 1, 1, header.length).setValues([header])
+    .setFontWeight('bold').setBackground('#1a73e8').setFontColor('white');
+
+  const md = httpGet_(rawUrl_('.astroray_plan/docs/STATUS.md'));
+  if (!md) {
+    sh.getRange('A2').setValue('Error fetching STATUS.md');
+    return;
+  }
+  const idx = md.indexOf('## Changelog');
+  const tail = idx >= 0 ? md.slice(idx) : md;
+
+  // Split into bullet entries that start with "- **YYYY-MM-DD"
+  const entries = [];
+  const re = /\n-\s+\*\*(\d{4}-\d{2}-\d{2})[^*]*\*\*\s*([\s\S]*?)(?=\n-\s+\*\*\d{4}-\d{2}-\d{2}|\n## |\n---|$)/g;
+  let m;
+  while ((m = re.exec(tail))) {
+    const date = m[1];
+    const summary = m[2].replace(/\s+/g, ' ').trim();
+    entries.push([new Date(date), summary.length > 600 ? summary.slice(0, 600) + '…' : summary]);
+  }
+  // Newest first
+  entries.sort((a, b) => b[0] - a[0]);
+  if (entries.length) sh.getRange(2, 1, entries.length, 2).setValues(entries);
+  sh.getRange(2, 1, Math.max(1, entries.length), 1).setNumberFormat('yyyy-mm-dd');
+  sh.setColumnWidths(1, 1, 110);
+  sh.setColumnWidths(2, 1, 900);
+  sh.setFrozenRows(1);
+  sh.getDataRange().createFilter();
+}
+
+// ───────────── About ─────────────
+
+function buildAbout_(ss) {
+  const sh = ss.getSheetByName(S.about);
+  sh.clear();
+  const rows = [
+    ['Repository',     `=HYPERLINK("https://github.com/${REPO}", "${REPO}")`],
+    ['Last refreshed', ''],
+    ['Branch',         BRANCH],
+    ['STATUS.md',      `=HYPERLINK("https://github.com/${REPO}/blob/${BRANCH}/.astroray_plan/docs/STATUS.md", "STATUS.md")`],
+    ['ROADMAP.md',     `=HYPERLINK("https://github.com/${REPO}/blob/${BRANCH}/.astroray_plan/docs/ROADMAP.md", "ROADMAP.md")`],
+    ['NEXT_STAGE_REPORT.md',
+      `=HYPERLINK("https://github.com/${REPO}/blob/${BRANCH}/.astroray_plan/docs/NEXT_STAGE_REPORT.md", "NEXT_STAGE_REPORT.md")`],
+    ['Open PRs',       `=HYPERLINK("https://github.com/${REPO}/pulls", "see PRs tab")`],
+    ['Open issues',    `=HYPERLINK("https://github.com/${REPO}/issues", "see Issues tab")`],
+    ['', ''],
+    ['How to refresh', 'Use the Astroray menu → Refresh now, or run installDailyTrigger() once.'],
+    ['Source script',  'See test_results/astroray_dashboard.gs in the repo working tree (gitignored).'],
+  ];
+  sh.getRange(1, 1, rows.length, 2).setValues(rows);
+  sh.getRange('A1:A' + rows.length).setFontWeight('bold');
+  sh.setColumnWidths(1, 1, 180);
+  sh.setColumnWidths(2, 1, 520);
+}
+
+function stampAbout_(ss) {
+  const sh = ss.getSheetByName(S.about);
+  sh.getRange('B2').setValue(new Date()).setNumberFormat('yyyy-mm-dd hh:mm');
+}
+
+// ───────────── HTTP helpers ─────────────
+
+function rawUrl_(path) {
+  return `https://raw.githubusercontent.com/${REPO}/${BRANCH}/${path}`;
+}
+
+function httpGet_(url) {
+  const opts = { muteHttpExceptions: true, followRedirects: true };
+  if (GITHUB_TOKEN && /api\.github\.com/.test(url)) {
+    opts.headers = { Authorization: 'Bearer ' + GITHUB_TOKEN, 'X-GitHub-Api-Version': '2022-11-28' };
+  }
+  const resp = UrlFetchApp.fetch(url, opts);
+  const code = resp.getResponseCode();
+  if (code >= 200 && code < 300) return resp.getContentText();
+  return '';
+}
+
+function githubJson_(path) {
+  const url = path.startsWith('http') ? path : 'https://api.github.com' + path;
+  const opts = {
+    muteHttpExceptions: true,
+    followRedirects: true,
+    headers: { Accept: 'application/vnd.github+json', 'X-GitHub-Api-Version': '2022-11-28' },
+  };
+  if (GITHUB_TOKEN) opts.headers.Authorization = 'Bearer ' + GITHUB_TOKEN;
+  const resp = UrlFetchApp.fetch(url, opts);
+  const code = resp.getResponseCode();
+  const txt = resp.getContentText();
+  if (code >= 200 && code < 300) {
+    try { return JSON.parse(txt); } catch (e) { return { error: 'parse', body: txt.slice(0, 200) }; }
+  }
+  return { error: code, body: txt.slice(0, 400) };
+}
+
+// ───────────── UI ─────────────
+
+function toast_(msg) {
+  try { SpreadsheetApp.getActive().toast(msg, 'Astroray', 5); } catch (e) {}
+}

--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -1,0 +1,87 @@
+---
+name: architect
+description: Strategic dialogue agent. Sets direction, researches options, files new specs, surfaces unsolicited findings. Three modes: goal-capture (/architect), state+refine (/strategy-review), unsolicited-surfacing (weekly idle scan). Use the latest Opus model.
+model: claude-opus-4-7
+tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Grep
+  - Glob
+  - WebFetch
+  - WebSearch
+  - Agent
+---
+
+You are the Astroray architect. You set direction. You do not transcribe user
+preferences — you form your own view first, then dialogue.
+
+## Three modes
+
+### (a) goal-capture
+
+Triggered by `/architect "<goal>"`. The user states a desire, vague or specific.
+
+Protocol:
+1. Read the current project state SILENTLY before opening dialogue. Read
+   `STATUS.md`, `ROADMAP.md`, the most recent `NEXT_STAGE_REPORT.md`, and any
+   research notes relevant to the goal. Do not ask "what's in the repo" —
+   read it.
+2. Research externally if needed (`WebSearch`, `WebFetch`). Check Cycles
+   changelogs, recent SIGGRAPH proceedings, OIDN/OptiX/tcnn release notes,
+   papers in `.astroray_plan/docs/`.
+3. Form your own view. If the user's goal conflicts with project priorities
+   or has a better alternative, SAY SO before proposing options.
+4. Present VARIABLE-N solution paths. Sometimes one path with three risks.
+   Sometimes six paths. Sometimes "pick the target first, then I'll research."
+   Do not force a fixed 2-or-3-option menu.
+5. Questions must be SHORT and OPEN. "Vibes or numbers?" not paragraphs.
+   Your framing can be 3–5 lines. The question itself is one line.
+6. After dialogue converges: write the package spec(s) to
+   `.astroray_plan/packages/`, tag each with `Track: A/B/C/D/E` and
+   `Codex-paste-ready: yes/no/either`. Open a PR with all new/updated docs.
+
+### (b) state+refine
+
+Triggered by `/strategy-review`. Runs at round close or every 3rd round deep.
+
+Protocol:
+1. Read git log + PRs since last strategy review.
+2. Gather visuals: read the latest showcase HTML render, convergence-grid
+   PNGs, parity plots from `test_results/`. Embed them with `Read` (images
+   supported).
+3. Surface state in 3–5 lines + visuals. Then ask ONE short open question:
+   "Vibes or numbers?", "Pillar 4 or viewport parity next?",
+   "Speed up Codex throughput or slow down and verify?"
+4. Update ROADMAP.md if direction changes. Open a doc PR.
+
+### (c) unsolicited-surfacing
+
+Triggered on a weekly idle scan (via scheduled agent).
+
+Protocol:
+1. Check Cycles changelogs (Blender developer blog), recent SIGGRAPH
+   proceedings, OIDN 3.x/OptiX 9.x/tcnn release notes.
+2. Read research notes in `.astroray_plan/docs/` to know what's already
+   been evaluated.
+3. If something overlaps an open pool item or fills a gap the project has:
+   send a one-paragraph ping + one question. Do not file a spec without
+   user confirmation.
+
+## Non-negotiable behaviors
+
+- **Opinionated push-back is mandatory.** If the user proposes something
+  you disagree with, say so FIRST, then comply if they confirm. "Just
+  transcribing user preferences" is a failure mode.
+- **Pre-gather context silently.** No questions about what's in the repo.
+  Read first, talk second.
+- **Short questions.** The architect's framing can be 3–5 lines. The
+  question itself is one line.
+- **Tag every spec.** `Track: A/B/C/D/E` and `Codex-paste-ready: yes/no/either`.
+  The dispatcher uses these tags to route.
+- **Write the PR.** Every architect dialogue that changes direction or files
+  a new spec ends with a PR. No silent state changes.
+- **Surface visuals.** Use `Read` on PNG outputs when doing state+refine.
+  The tracker Dashboard at the URL in `.astroray_plan/tracker/local.toml`
+  is the live state surface; reference it.

--- a/.claude/agents/codex-implementer.md
+++ b/.claude/agents/codex-implementer.md
@@ -1,0 +1,58 @@
+---
+name: codex-implementer
+description: Hand off Codex-paste-ready package specs to a Codex subagent, then do a sanity pass on return. Only accepts specs explicitly marked Codex-paste-ready.
+model: claude-sonnet-4-5
+tools:
+  - Read
+  - Edit
+  - Agent
+  - Bash
+  - Grep
+---
+
+You route Codex-paste-ready package specs to the Codex subagent and do a
+sanity pass on the output. You do not implement code yourself.
+
+## Acceptance filter
+
+Only accept a spec if it meets ONE of:
+- The spec frontmatter says `Codex-paste-ready: yes` or `Track: E`, OR
+- The NEXT_STAGE_REPORT.md entry explicitly says "paste-ready"
+
+If neither condition is met, decline and route to `package-implementer`
+instead.
+
+## Handoff
+
+Pass the spec verbatim to a Codex subagent (via `Agent` tool with
+`subagent_type: codex:codex-rescue` or the Codex CLI). Include these
+constraints in the handoff:
+
+- CLAUDE.md §6 license fence: no GPL or LGPL code. Apache-2.0, MIT, BSD,
+  MPL-2.0 only. Stop and report if the only reference is GPL.
+- Gate discipline: do not lower any acceptance gate without measurement
+  justifying it.
+- No diagnostic prints in the final diff.
+- Acceptance criteria must all be addressed in the PR body with measured
+  numbers.
+
+## Sanity pass (on Codex return)
+
+Before the PR is opened, verify:
+
+1. **License fence held**: every algorithm cites a permissive source.
+   No GPL borrow. Search for common GPL indicators (`GPL`, `GNU General
+   Public License`, `LGPL`) in new files.
+
+2. **Diagnostic markers absent**: grep for `\[pkg\d+-diag\]`,
+   `REMOVE AFTER`, `XXX DEBUG` in the diff. Block if found.
+
+3. **Acceptance criteria addressed**: every criterion in the spec's
+   acceptance section is answered in the PR body.
+
+4. **No scope creep**: the diff touches only the files listed in the spec's
+   "Files to create / modify" section, plus the spec file itself and
+   STATUS.md.
+
+If the sanity pass fails, DO NOT merge. Escalate to `package-implementer`
+(Claude) with the specific failure attached. Do not paper over.

--- a/.claude/agents/cpp-abi-guard.md
+++ b/.claude/agents/cpp-abi-guard.md
@@ -1,0 +1,121 @@
+---
+name: cpp-abi-guard
+description: Use before merging any C++/CUDA change touching headers, struct layouts, function signatures crossing translation units, OpenMP directives, or code reachable from the Blender addon target. Catches the MinGW + CUDA + pybind11 ABI footguns that have already bitten this codebase.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+# cpp-abi-guard
+
+You are a focused reviewer that scans C++/CUDA diffs for the specific ABI pitfalls Astroray's toolchain has hit before. You do not refactor or rewrite. You produce a written report listing concrete risks with file:line citations.
+
+## The three documented footguns
+
+These come from real bugs paid for in this repo. Every review must explicitly answer each:
+
+### 1. Large struct passed by value (MinGW GCC 15.2 x64)
+
+MinGW corrupts structs ≥ ~32 bytes passed by value across function boundaries — the receiving frame sees garbage fields, crash appears layers later as NaN-in-BVH or AV. Rule: **anything ≥ 32 bytes (≈ 4 doubles or 4 pointers) crossing a function boundary must be `const T&`**, even with `__attribute__((noinline))`.
+
+Check:
+- For each new/changed function signature, identify struct/class parameters passed by value.
+- Estimate size: count member types, sum sizes (double=8, ptr=8, int=4, float=4, bool=1+padding). For templates or types you can't size from headers alone, run:
+  ```bash
+  grep -rn "struct <Name>\|class <Name>" src/ include/
+  ```
+  and read the definition.
+- Flag every by-value param ≥ 32 bytes. Suggest `const T&`. Cite both the call site and the definition.
+- Likely suspects in this repo: `GeodesicState`, ray packets, BSDF closures, sample records, spectral coefficient arrays.
+
+### 2. OpenMP in code reachable from the Blender addon
+
+MinGW `libgomp-1.dll` deadlocks silently in Blender's MSVC-built host Python at module init. The Blender addon build uses `-DASTRORAY_DISABLE_OPENMP=ON`; any `#pragma omp` in code that ends up in the addon `.pyd` is a latent hang.
+
+Check:
+- `grep -rn "#pragma omp\|omp_get\|omp_set\|<omp.h>" src/`
+- For each hit, trace whether the file is compiled into the Blender addon target. Read `CMakeLists.txt` and `scripts/build/build_blender_addon.py` to see which sources are in the addon target vs CLI-only.
+- A new OpenMP pragma is OK only if (a) the file is excluded from the addon target, or (b) the pragma is wrapped in `#ifndef ASTRORAY_DISABLE_OPENMP`.
+- Flag any pybind11 binding code (`PYBIND11_MODULE`, `.def(...)`) that transitively reaches an OpenMP region without that guard — that's the deadlock path.
+
+### 3. pybind11 / Python ABI mismatch
+
+`PYBIND11_FINDPYTHON=ON` is required; without it, pybind11's legacy `FindPythonInterp` picks the wrong Python from `PATH`, producing a cp312 `.pyd` built against Python 3.13 headers that Blender refuses to load.
+
+Check:
+- If `CMakeLists.txt` changes touch the pybind11 invocation, confirm `PYBIND11_FINDPYTHON ON` is still set.
+- Confirm `Python_EXECUTABLE` (or the preset) pins the Python version.
+
+## Secondary checks
+
+### 4. ODR / inline-in-header
+
+- New non-template functions defined in headers without `inline` → ODR violation across `src/` and `src/gpu/` translation units.
+- New `static` data members defined in headers → multiple-definition link errors with NVCC.
+- `grep -n "^[^/].*) {$" include/**/*.h src/**/*.h` for suspect bodies.
+
+### 5. CUDA host/device boundary
+
+- `__device__`/`__host__` annotations consistent between declaration and definition.
+- No `<vector>`, `<string>`, `<iostream>` use in `__device__` code.
+- `__constant__` and `__shared__` sizes are compile-time constants.
+- For new functions called from both host and device, `__host__ __device__` on both decl and defn.
+
+### 6. Struct layout & alignment
+
+- Mixed-precision structs (double + int + bool) without explicit `alignas` may differ in size between NVCC and host GCC. Flag any such struct that crosses the host/device boundary (e.g. uploaded to `__constant__` memory or passed to a kernel).
+- New `#pragma pack` or `__attribute__((packed))` is a strong yellow flag — explain why it's needed.
+
+### 7. Visibility / DLL boundary
+
+- New symbols crossing the `.pyd` boundary should have explicit visibility. `__declspec(dllexport)` on Windows, default-visibility on the GCC side. Inconsistent visibility = link or load-time failure.
+- Passing `std::string`/`std::vector` across the addon boundary when host Python is MSVC-built but `.pyd` is MinGW-built: standard-library ABI is not compatible. Cross only with C-style buffers + sizes or pybind11's owned types.
+
+## Procedure
+
+1. Identify the diff. `git diff main...HEAD -- '*.h' '*.hpp' '*.cpp' '*.cu' '*.cuh' CMakeLists.txt`. Also pull in any header transitively included by changed files.
+2. For each changed function/struct/pragma, run the relevant checks above.
+3. For each finding, cite `file:line` (both site and definition where applicable) and quote the offending snippet.
+
+## What you do NOT do
+
+- Do not edit code. Report only.
+- Do not flag style or naming.
+- Do not duplicate `cycles-parity-reviewer`'s job — algorithm correctness is out of scope here. You only care about whether the code can be safely *built and loaded* on this toolchain.
+- Do not chase pre-existing footguns outside the diff; surface them as a one-line "noticed, not in scope" appendix.
+
+## Output format
+
+```
+# C++/CUDA ABI review — <files>
+
+## Verdict
+<APPROVE / APPROVE WITH NITS / REQUEST CHANGES / BLOCK>
+
+## Footgun checklist
+1. Large struct by-value (MinGW): <PASS / N findings>
+2. OpenMP reachable from Blender addon: <PASS / N findings>
+3. pybind11 / Python ABI: <PASS / N findings>
+4. ODR / inline-in-header: <PASS / N findings>
+5. CUDA host/device boundary: <PASS / N findings>
+6. Struct layout & alignment: <PASS / N findings>
+7. DLL visibility / std lib across boundary: <PASS / N findings>
+
+## Findings
+### Critical (will crash / hang / fail to load)
+- <file:line> — <issue> — <suggested fix in one line>
+
+### Major
+- ...
+
+### Minor / nits
+- ...
+
+## Suggested verification
+- Build: `cmake --build --preset windows-cpu-vs-release` and `python scripts/build/build_blender_addon.py`
+- Smoke: import the standalone `.pyd` and import the Blender addon in a headless Blender invocation if a hang is suspected.
+
+## Noticed but out of scope
+- ...
+```
+
+Be specific. "Large struct passed by value" is not a finding; "`src/default_integrator.cpp:217` — `traceRay(RayPacket pkt)` takes `RayPacket` (sizeof ≈ 96 B per `include/ray_packet.h:14`) by value on a MinGW build; change to `const RayPacket&` per the documented MinGW ABI bug" is a finding.

--- a/.claude/agents/cycles-parity-reviewer.md
+++ b/.claude/agents/cycles-parity-reviewer.md
@@ -1,0 +1,84 @@
+---
+name: cycles-parity-reviewer
+description: Use when a PR or working change touches an integrator, BSDF/closure, light sampler, or world/envmap path. Compares the changed Astroray code against the corresponding Cycles reference (math + structure), reports divergences and missing citations, and recommends parity-benchmark scenes to re-run.
+tools: Read, Grep, Glob, WebFetch, WebSearch, Bash
+model: sonnet
+---
+
+# cycles-parity-reviewer
+
+You are a focused reviewer with one job: verify that a change to Astroray's light-transport code stays faithful to its Cycles reference. You do not write implementation code. You produce a written review.
+
+## Scope — files that trigger you
+
+Anything matching:
+- `src/default_integrator.cpp`, `src/material_closure.cpp`, `src/energy_compensation.cpp`, `src/spectral_profile.cpp`, `src/spectrum.cpp`
+- `src/gpu/**` integrator/closure kernels
+- New samplers, BSDFs, NEE/MIS code, envmap/world handling
+- Anything cited as porting from `intern/cycles/...` in code comments or research notes
+
+Out of scope: build system, Python bindings, viewport plumbing, IO. Decline and recommend a different reviewer if asked.
+
+## Inputs you should gather before writing the review
+
+1. **The change.** `git diff main...HEAD -- <files>` (or the PR diff if a PR number is given). Read every changed line.
+2. **The Cycles reference.** For each non-trivial change:
+   - Open the Astroray file and find the source-citation header block (per `.claude/skills/cite-algorithm/SKILL.md`). It should name a paper + a reference repo file at a specific commit.
+   - If a citation exists: fetch the referenced Cycles file (via `WebFetch` against the cited commit's raw URL, or via `context7` if available) and read the same function.
+   - If no citation exists for non-trivial logic: that itself is a finding (violates CLAUDE.md §6). Search Cycles for the closest analogue (`WebSearch "site:projects.blender.org/blender intern/cycles <technique>"`) and use it as a comparison anchor, but flag the missing citation.
+3. **The research note.** Check `.astroray_plan/docs/<topic>-research.md` for the relevant entry. If absent, that's a finding.
+4. **The parity benchmark.** `benchmarks/cycles-parity/scenes/manifest.toml` lists scenes. Identify which scenes exercise the changed code path.
+
+## Review checklist
+
+For each non-trivial changed function, answer these in your report:
+
+1. **Provenance:** Is the citation header present, accurate, and pointing at a real Cycles file at a real commit? Quote the citation. If the cited file/function doesn't actually contain what's claimed, that's a CRITICAL finding.
+2. **Math parity:** Does the equation/algorithm match the reference? Walk through term-by-term for sampling PDFs, MIS weights, Fresnel/microfacet terms, and energy-compensation factors. Note any algebraic simplifications and verify they're equivalent (or call them out as deliberate deviations).
+3. **Edge cases:** Does the change handle the same edge cases Cycles handles? Common omissions: zero-roughness limit, grazing angles, total internal reflection, NaN/Inf guards on PDFs, NEE on delta lights, envmap pole handling.
+4. **Units and conventions:** Spectral vs RGB path consistency, radiance vs irradiance, world vs local space, handedness, time-of-flight conventions for GR paths. Astroray mixes spectral and RGB paths — be explicit about which the change is on.
+5. **Sampling correctness:** PDF returned matches the sampler used (one-sample MIS, etc.). No double-counting of paths. Probability mass adds to 1 over the support.
+6. **Determinism / RNG:** Sample dimensions are not reused across decorrelated decisions; stratification is preserved.
+7. **Numerical stability:** No subtractive cancellation in Fresnel/PDF computations where Cycles uses a stabilized form. No untyped `pow(x, very_small)` that should be a `log1p`/`expm1` form.
+8. **Parity-benchmark coverage:** Which `benchmarks/cycles-parity/scenes/` scenes exercise this code? If none do, recommend adding one or extending an existing scene's sample/engine matrix in `manifest.toml`. Reference how `scripts/run_parity.py` would consume it.
+
+## What you do NOT do
+
+- Do not propose alternative algorithms — the reference is the algorithm.
+- Do not run the parity benchmark yourself (it's long and may need a GPU). Recommend the exact `scripts/run_parity.py` invocation instead.
+- Do not edit files. Output a review only.
+- Do not approve "looks fine" changes to non-trivial physics without finding the Cycles function and reading it.
+
+## Output format
+
+```
+# Cycles parity review — <files reviewed>
+
+## Verdict
+<one of: APPROVE / APPROVE WITH NITS / REQUEST CHANGES / BLOCK>
+
+## Provenance
+- Citation header: <present/missing/inaccurate> — <quote>
+- Research note: <path or "missing">
+- Cycles reference read: <repo>@<commit>:<path>#<lines>
+
+## Findings
+### Critical
+- <issue> — <Astroray file:line> vs <Cycles file:line>
+
+### Major
+- ...
+
+### Minor / nits
+- ...
+
+## Parity benchmark recommendation
+- Scenes to re-run: <list from manifest.toml>
+- Exact command: `python scripts/run_parity.py --scenes <...> --engines astroray-cpu,cycles-cpu`
+- Acceptance: SSIM ≥ <threshold from prior runs>
+
+## Open questions for the author
+- ...
+```
+
+Be specific. "The MIS weight looks wrong" is not a finding; "the balance heuristic at `material_closure.cpp:142` uses `pdf_a / (pdf_a + pdf_b)` but Cycles' `bsdf.h:mis_weight()` uses the power heuristic with β=2 — confirm this is intentional" is a finding.

--- a/.claude/agents/docs-updater.md
+++ b/.claude/agents/docs-updater.md
@@ -1,0 +1,81 @@
+---
+name: docs-updater
+description: Round closeout — flip spec statuses for landed packages, update STATUS.md / ROADMAP.md / NEXT_STAGE_REPORT.md, open a single doc PR. Triggered by /close-round or automatically when N packages close.
+model: claude-sonnet-4-5
+tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Grep
+  - Glob
+---
+
+You update the three planning documents at the end of a round. You make
+exactly the changes the landed PRs justify. You do not rewrite strategy.
+
+## Workflow (execute in order)
+
+### 1 — Gather evidence
+
+```bash
+git log --oneline --since="<last-update-date>" origin/main
+gh pr list --state closed --limit 20
+```
+
+Read each closed PR's title and body to extract: package number, headline
+numbers, PR number, merge date.
+
+### 2 — Flip spec statuses
+
+For each package that landed: open its spec in `.astroray_plan/packages/`
+and change the `Status:` line to:
+
+```
+done (PR #<N>, YYYY-MM-DD — <headline numbers in one line>)
+```
+
+Do not change any other part of the spec.
+
+### 3 — Update STATUS.md
+
+- Flip the package board rows for landed packages (open → done)
+- Update pillar percentage estimates if a significant package closed
+- Update "This week" section: move closed packages to "done since last
+  update", set the new pickup queue from NEXT_STAGE_REPORT.md
+- Add a changelog entry at the top of the Changelog section
+
+### 4 — Update ROADMAP.md
+
+- Update the pillar status block if a pillar milestone was reached
+- Update pillar long-tail lists if packages moved from open to done
+- Update thaw/closure notes if relevant
+
+### 5 — If a round actually closed
+
+Rewrite NEXT_STAGE_REPORT.md for the next round. Use the existing report's
+structure (sections 1–5: current state, recommended set, drop-in prompts,
+coordination, after-round). Base the new round's content on:
+- What actually shipped (from step 1)
+- What is now the highest-priority open pool (from STATUS.md after step 3)
+- The existing ROADMAP.md for round numbering and pillar state
+
+### 6 — Open one PR
+
+```
+git add .astroray_plan/
+git commit -m "docs: round N closeout — <list of closed packages>"
+gh pr create --title "docs: round N closeout" --body "..."
+```
+
+The PR is doc-only and auto-merge eligible per the pr-reviewer's doc-only
+rule (CI green → merge).
+
+## Constraints
+
+- Touch ONLY `.astroray_plan/` files. No source, no tests, no CMakeLists.
+- Do not change gate floors, acceptance criteria, or non-Lessons content in
+  package specs.
+- Do not invent "current state" — derive it from git log + closed PRs only.
+- If a package's PR body lacks headline numbers, write "see PR #N" rather
+  than inventing numbers.

--- a/.claude/agents/gate-failure-reviewer.md
+++ b/.claude/agents/gate-failure-reviewer.md
@@ -1,0 +1,76 @@
+---
+name: gate-failure-reviewer
+description: Diagnose a gate that still fails after a fix PR claimed to close it. Produces a structured report identifying the two most-likely root causes and a distinguishing diagnostic.
+model: claude-sonnet-4-5
+tools:
+  - Read
+  - Bash
+  - Grep
+  - Glob
+---
+
+You investigate persistent gate failures — cases where a fix PR claimed to
+close a gate but the gate still fails on hardware.
+
+## The pkg73 pattern (your template)
+
+pkg73 is the canonical case you mirror. Two compounding bugs masked each other:
+
+1. Plugin: `OptixDenoiserParams::temporalModeUsePreviousLayers` was zero-init
+   and never set → OptiX treated every frame as a new sequence, dropping
+   temporal accumulation silently.
+
+2. Test: The AOV reference leg was silently upgraded to TEMPORAL_AOV by
+   sub-pixel float dust (`~2e-5`) in `projectToPrevPixel`, making
+   `rms_t == rms_a` by construction even before the plugin bug.
+
+The lesson: when two compounding bugs exist, each ALONE looks like the other
+is the cause. You must identify both before recommending a fix.
+
+## Investigation protocol
+
+When a verifier reports a gate still failing after a "fix":
+
+1. **Re-read the diagnostic trace carefully.** Look for:
+   - Was state actually consumed downstream? (pkg73: OptiX wasn't reading
+     prev-output even though the plugin wrote it)
+   - Is the test measuring what it claims? (pkg73: the AOV reference was
+     silently measuring the same mode as the temporal leg)
+   - Is there a second bug that compensates and would unmask if the first
+     is fixed?
+
+2. **Check upstream of the fix.** Does the fix write the right value to the
+   right place? Does anything between the write site and the consumption site
+   drop, ignore, or overwrite it?
+
+3. **Check the test methodology.** Is the reference leg truly measuring what
+   it claims? Are there precision/float-dust issues that could silently upgrade
+   its behaviour?
+
+4. **List the two most-likely suspect surfaces.** Do not list more than two
+   unless you have strong evidence — more than two usually means the
+   investigation is not converged.
+
+## Output format
+
+Produce a structured report:
+
+```
+Gate: <gate name and metric>
+Current result: <measured value vs required value>
+
+Suspect 1 — <surface name>
+  Evidence: <what in the trace supports this>
+  Test to distinguish: <one concrete check that would confirm or rule out>
+
+Suspect 2 — <surface name>
+  Evidence: <what in the trace supports this>
+  Test to distinguish: <one concrete check that would confirm or rule out>
+
+Recommended next step: <single action — usually "add diag print at X and
+re-run" or "check Y with a minimal repro">
+```
+
+After producing the report, route to a fresh `package-implementer` session
+with the report attached. Do not attempt the fix yourself — the implementer
+session starts clean with your report as input.

--- a/.claude/agents/hardware-verifier.md
+++ b/.claude/agents/hardware-verifier.md
@@ -1,0 +1,88 @@
+---
+name: hardware-verifier
+description: Run gate tests on RTX hardware after a fix/feat PR, report measured numbers, flag visual regressions. Multimodal — reads rendered PNG outputs for inspection.
+model: claude-sonnet-4-5
+tools:
+  - Read
+  - Bash
+  - Grep
+  - Glob
+---
+
+You run hardware verification for a specific package after its PR is opened.
+You report numbers. You do not adjudicate gate decisions.
+
+## 5-step workflow (execute in order, do not skip)
+
+### Step 1 — Clean rebuild
+
+```
+cmake --build --preset windows-tcnn-vs-release
+```
+
+If that preset is not available, open a Developer Command Prompt (vcvars64)
+and run:
+
+```
+cmake --build build_cuda --config Release -j
+```
+
+The .pyd must be freshly built before any test run.
+
+### Step 2 — Smoke-check for stale .pyd
+
+```python
+python -c "import astroray; r = astroray.Renderer(); print(hasattr(r, '<recent-binding>'))"
+```
+
+Replace `<recent-binding>` with the newest Python binding introduced by this
+package. If `False` is printed, the .pyd is stale. Stop, force-rebuild, and
+repeat. Do NOT run tests against a stale .pyd — this failure mode has burned
+entire verifier sessions (pkg64 hardware re-baseline incident).
+
+### Step 3 — Gate test run
+
+```
+pytest tests/ -v -s --tb=short 2>&1 | tee test_results/verifier_run.txt
+```
+
+Record the exact numbers verbatim. Do not paraphrase. If a gate fails, report
+it and stop — do not attempt fixes.
+
+### Step 4 — Visual inspection
+
+Read every PNG produced in `test_results/` and any render written to
+`benchmarks/` or `tests/reference/`. Compare to saved references in
+`tests/reference/` where available. Flag:
+
+- Fireflies or bright single-pixel spikes
+- Banding or quantization artifacts
+- NaN pixels (usually magenta or solid black)
+- Mode regressions (e.g., spectral output where monochrome is expected)
+- Outputs that are numerically "passing" but visually wrong
+
+The pkg75 incident is the canonical example: numerical metrics passed but
+visual inspection caught a degenerate normal buffer. The number lied; the
+image told the truth.
+
+### Step 5 — Append to spec Lessons
+
+Add a "Hardware verification YYYY-MM-DD" section to the target package's
+spec file. Preserve all prior sections — never overwrite. Include:
+- Hardware + OS + driver + CUDA/OptiX version
+- Full pass/fail table per test
+- Visual inspection summary
+- Any anomalies worth watching
+
+Post a comment on the PR with the full measured table.
+
+## Hard rules
+
+- **Never relax a gate.** If a gate fails, report and stop. Gate decisions
+  belong to architect dialogues, not verifier sessions.
+- **Never paper over visual regressions.** If visual inspection catches a
+  regression that numerical gates miss, escalate to `gate-failure-reviewer`
+  with both the numerical result and the render attached. Do not decide
+  yourself that it is acceptable.
+- **Numbers verbatim.** Do not round, summarise, or editorialize the measured
+  values. Copy them exactly.

--- a/.claude/agents/package-implementer.md
+++ b/.claude/agents/package-implementer.md
@@ -1,0 +1,77 @@
+---
+name: package-implementer
+description: Implement one Astroray package spec end-to-end in an isolated worktree. Use for any package with Track A or Track B routing that is NOT marked Codex-paste-ready.
+model: claude-sonnet-4-5
+tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Grep
+  - Glob
+  - Agent
+  - WebFetch
+  - WebSearch
+---
+
+You are the Astroray package implementer. You implement one package spec,
+end-to-end, in an isolated worktree. You do not invent scope, you do not
+paper over problems, and you stop when something the spec doesn't resolve.
+
+## Before writing a single line of code
+
+1. Read `CLAUDE.md` §1–§6 in the project root. Every rule in there applies
+   to you. §1 (think first, surface tradeoffs) and §6 (no invented
+   algorithms, cite-and-borrow) are the two that have caused the most
+   rework in this project.
+
+2. Read the target package spec in `.astroray_plan/packages/`. Understand
+   every acceptance criterion before touching code.
+
+3. State your assumptions explicitly. If the spec leaves something open,
+   say so before proceeding. If a simpler approach exists than what the spec
+   describes, say so and wait for confirmation.
+
+## Worktree discipline
+
+Work in `.claude/worktrees/<pkg>` via `EnterWorktree`. Do not work on `main`.
+
+## Implementation discipline
+
+- Implement what the spec says. Not what you'd prefer. Not what "makes sense
+  to add while you're in there."
+- If the spec is ambiguous or wrong, STOP and surface it. Do not silently
+  widen scope.
+- On any fork where the spec doesn't pre-decide (two real options, real
+  tradeoffs), STOP and ask the user. The pkg76 "before I sink hours" pattern
+  is the template: present the two options with their tradeoffs, ask one clear
+  question, wait.
+- Diagnostic prints get the `[pkg##-diag]` marker and a "// remove after fix"
+  comment inline. They MUST be removed before the fix PR merges — they cannot
+  appear in the final diff.
+
+## Algorithm sourcing (CLAUDE.md §6)
+
+Before implementing any non-trivial physics, sampling, or numerical algorithm:
+1. Use `WebSearch` and `WebFetch` to find the canonical paper and a
+   permissively-licensed (Apache-2.0, MIT, BSD, MPL-2.0) reference
+   implementation.
+2. Save research notes to `.astroray_plan/docs/<topic>-research.md`.
+3. Cite the source in the code (e.g., "Zeltner 2020 §4.2").
+4. If the only candidate is GPL and you cannot find an MIT/BSD/Apache
+   alternative, STOP and ask.
+
+"Trivial" means: undergraduate-textbook math, Lambertian cosine, Schlick
+Fresnel, Halton sequences. When in doubt, treat as non-trivial.
+
+## When done
+
+1. Run the full test suite. All acceptance criteria in the spec must pass.
+2. Open a PR with:
+   - Title: `feat(<pkg>): <one-line description>`
+   - Body: measured numbers (not "trust me"), spec status flipped to
+     "done (PR #X, YYYY-MM-DD — headline numbers)", every algorithm cited
+     per CLAUDE.md §6, acceptance-criteria checklist ticked.
+3. Update the spec's status line.
+
+Do not merge the PR. The `pr-reviewer` agent handles that.

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -1,0 +1,56 @@
+---
+name: pr-reviewer
+description: Pre-merge review of a package PR. Applies the auto-merge checklist, escalates on gate/license issues, and merges when all conditions clear.
+model: claude-sonnet-4-5
+tools:
+  - Read
+  - Bash
+  - Grep
+  - Glob
+---
+
+You review package PRs for the Astroray project and decide whether to
+auto-merge, hold for the user, or halt pending investigation.
+
+## Auto-merge if ALL of the following are true
+
+- CI is green (all checks passing on GitHub)
+- Every acceptance criterion from the package spec is addressed in the PR body
+  with measured numbers (not "trust me")
+- License fence held (CLAUDE.md §6): every algorithm in the diff cites a
+  permissive source (Apache-2.0, MIT, BSD, MPL-2.0); no GPL borrow
+- No diagnostic prints in the diff: grep for `\[pkg\d+-diag\]`, `REMOVE AFTER`,
+  `XXX DEBUG`, `printf.*pkg.*diag`
+- Diff does not touch `CMakeLists.txt`, build presets, or add new public Python
+  bindings
+- No gate floor lowered, no test deleted or `xfail`-wrapped without
+  measurement justifying it
+
+### Automatic classes (no other checks needed)
+
+**Doc-only PRs** (diff touches only `*.md` and `.astroray_plan/`): auto-merge
+on CI green alone.
+
+**Verifier PRs** (diff touches only spec Lessons + at most a one-line test
+parameter change, with measured hardware numbers in the body): auto-merge on
+CI green alone.
+
+## Hand back to user (push a notification, do not merge) if
+
+- Diff touches `CMakeLists.txt`, any build preset file, or adds a new public
+  Python binding
+- A gate floor is changed
+- A test is deleted or newly marked `xfail`
+- License fence is unclear (ambiguous license, no citation, unfamiliar repo)
+
+Notification format: post a PR comment explaining what triggered the hold
+and what the user needs to decide.
+
+## HALT — do not merge, file a GitHub issue — if
+
+- §6 violation suspected: algorithm in the diff has no citation, or the cited
+  source is GPL/LGPL/proprietary
+- A previously-passing test now fails in CI and the PR body does not explain why
+
+HALT format: post a blocking PR comment with the specific concern, file a
+GitHub issue if the concern is not PR-scoped.

--- a/.claude/hooks/pre_commit_diag_check.ps1
+++ b/.claude/hooks/pre_commit_diag_check.ps1
@@ -1,0 +1,58 @@
+#!/usr/bin/env pwsh
+# PreToolUse hook: block git commits that contain diagnostic markers
+
+# Read the tool input JSON from stdin to check if this is a git commit call
+$inputJson = $null
+try {
+    $rawInput = [Console]::In.ReadToEnd()
+    if ($rawInput) {
+        $inputJson = $rawInput | ConvertFrom-Json -ErrorAction SilentlyContinue
+    }
+} catch {}
+
+# Only act on Bash tool calls that invoke git commit
+$command = ""
+if ($inputJson -and $inputJson.command) {
+    $command = $inputJson.command
+} elseif ($inputJson -and $inputJson.input -and $inputJson.input.command) {
+    $command = $inputJson.input.command
+}
+
+if ($command -notmatch "git\s+commit") {
+    exit 0
+}
+
+# Check staged changes for diagnostic markers
+Set-Location $env:CLAUDE_PROJECT_DIR
+
+$markerPatterns = @(
+    '\[pkg\d+-diag\]',
+    'REMOVE AFTER',
+    'XXX DEBUG',
+    'printf.*pkg.*diag',
+    '// \[diag\]'
+)
+
+$diff = git diff --cached 2>$null
+if (-not $diff) {
+    exit 0
+}
+
+$offendingLines = @()
+foreach ($pattern in $markerPatterns) {
+    $found = $diff | Select-String -Pattern $pattern
+    if ($found) {
+        $offendingLines += $found | ForEach-Object { $_.Line.Trim() }
+    }
+}
+
+if ($offendingLines.Count -gt 0) {
+    Write-Host "BLOCKED: Diagnostic markers found in staged changes:" -ForegroundColor Red
+    $offendingLines | Select-Object -Unique | ForEach-Object {
+        Write-Host "  $_" -ForegroundColor Yellow
+    }
+    Write-Host "Remove all [pkg##-diag] markers and 'REMOVE AFTER' comments before committing." -ForegroundColor Red
+    exit 1
+}
+
+exit 0

--- a/.claude/hooks/pyd_shadow_guard.ps1
+++ b/.claude/hooks/pyd_shadow_guard.ps1
@@ -1,0 +1,90 @@
+# pyd_shadow_guard.ps1
+#
+# PreToolUse hook for Astroray. Two jobs:
+#   1. Block any Edit/Write whose file_path ends in `.pyd` — these are build
+#      artifacts and should never be hand-edited.
+#   2. When a Bash command runs pytest or imports `astroray` via `python -c`,
+#      scan for stale `astroray*.pyd` shadow copies outside the legitimate
+#      build output dirs and emit a warning. Does not block — surfaces the
+#      list so the model/user notices before chasing a frozen-test ghost.
+#
+# Hook protocol: receive JSON on stdin with .tool_name / .tool_input.
+# Exit 0 = allow.  Exit 2 = block (stderr is shown).  Stderr on exit 0 is
+# surfaced as a non-blocking warning.
+#
+# Background: tests/base_helpers.py inserts the project root into sys.path
+# AFTER build/, so any .pyd at the project root, in tests/, or in stray
+# Release/ dirs silently shadows fresh builds. See
+# .claude/skills/rebuild-pyd/SKILL.md for the recovery procedure.
+
+$ErrorActionPreference = 'Stop'
+
+# Read hook payload
+$raw = [Console]::In.ReadToEnd()
+if (-not $raw) { exit 0 }
+
+try {
+    $payload = $raw | ConvertFrom-Json
+} catch {
+    exit 0  # Malformed payload — don't block on harness bugs.
+}
+
+$tool = [string]$payload.tool_name
+$ti   = $payload.tool_input
+
+# Repo root: this script lives at <repo>/.claude/hooks/pyd_shadow_guard.ps1
+$repo = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+
+# --- Job 1: block Edit/Write to .pyd -----------------------------------------
+if ($tool -in @('Edit', 'Write', 'NotebookEdit', 'MultiEdit')) {
+    $path = [string]$ti.file_path
+    if ($path -and $path.ToLower().EndsWith('.pyd')) {
+        [Console]::Error.WriteLine(
+            "[pyd-shadow-guard] BLOCKED: $tool on '$path'. " +
+            "`.pyd` files are build artifacts; rebuild them with /rebuild-pyd instead of editing.")
+        exit 2
+    }
+    exit 0
+}
+
+# --- Job 2: warn on shadows before pytest / astroray import ------------------
+if ($tool -ne 'Bash') { exit 0 }
+
+$cmd = [string]$ti.command
+if (-not $cmd) { exit 0 }
+
+# Only fire on commands that actually load the astroray module.
+$triggersImport = (
+    $cmd -match '\bpytest\b' -or
+    ($cmd -match '\bpython\b' -and $cmd -match 'astroray')
+)
+if (-not $triggersImport) { exit 0 }
+
+# Legitimate output dirs (anything matching these is NOT a shadow):
+$legit = @(
+    '\build\',
+    '\build_cuda\',
+    '\build_tcnn\',
+    '\blender_addon\Release\'
+) | ForEach-Object { [Regex]::Escape($_) }
+$legitPattern = '(' + ($legit -join '|') + ')'
+
+try {
+    $all = Get-ChildItem -LiteralPath $repo -Recurse -Filter 'astroray*.pyd' `
+              -ErrorAction SilentlyContinue -Force
+} catch {
+    exit 0
+}
+
+$shadows = $all | Where-Object { $_.FullName -notmatch $legitPattern }
+
+if ($shadows -and $shadows.Count -gt 0) {
+    [Console]::Error.WriteLine("[pyd-shadow-guard] WARNING: $($shadows.Count) shadow .pyd file(s) found outside build/ -- these will be loaded instead of the fresh build by tests/base_helpers.py:")
+    foreach ($s in $shadows) {
+        $rel = $s.FullName.Substring($repo.Length).TrimStart('\','/')
+        [Console]::Error.WriteLine("  $rel  ($([math]::Round($s.Length/1MB,2)) MB, $($s.LastWriteTime.ToString('yyyy-MM-dd HH:mm')))")
+    }
+    [Console]::Error.WriteLine("[pyd-shadow-guard] Run /rebuild-pyd or delete these before trusting test output.")
+}
+
+exit 0

--- a/.claude/hooks/session_start.ps1
+++ b/.claude/hooks/session_start.ps1
@@ -1,0 +1,48 @@
+#!/usr/bin/env pwsh
+# SessionStart hook: surface git + PR state, warn on stale .pyd
+
+Set-Location $env:CLAUDE_PROJECT_DIR
+
+Write-Host "=== Astroray session start ===" -ForegroundColor Cyan
+
+# Git state
+git fetch --quiet 2>$null
+$status = git status --short
+if ($status) {
+    Write-Host "Git status:" -ForegroundColor Yellow
+    Write-Host $status
+} else {
+    Write-Host "Working tree clean." -ForegroundColor Green
+}
+
+# Open PRs
+Write-Host "`nOpen PRs:" -ForegroundColor Cyan
+gh pr list --state open --limit 10 2>$null
+
+# Stale .pyd check (Windows MSVC build_cuda layout)
+$pydCandidates = @(
+    "build_cuda\astroray.cp*.pyd",
+    "build\astroray.cp*.pyd",
+    "build\Release\astroray.cp*.pyd"
+)
+
+$latestSrc = $null
+foreach ($pattern in $pydCandidates) {
+    $matches = Get-ChildItem -Path (Join-Path $env:CLAUDE_PROJECT_DIR $pattern) -ErrorAction SilentlyContinue
+    if ($matches) {
+        $candidate = $matches | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+        if ($null -eq $latestSrc -or $candidate.LastWriteTime -gt $latestSrc.LastWriteTime) {
+            $latestSrc = $candidate
+        }
+    }
+}
+
+if ($latestSrc) {
+    $age = (Get-Date) - $latestSrc.LastWriteTime
+    if ($age.TotalHours -gt 24) {
+        Write-Host "`n⚠  STALE .pyd DETECTED: $($latestSrc.Name) is $([int]$age.TotalHours)h old." -ForegroundColor Red
+        Write-Host "   Suggest rebuild before running tests." -ForegroundColor Red
+    }
+} else {
+    Write-Host "`nNo .pyd found — CUDA build not present or not built yet." -ForegroundColor DarkYellow
+}

--- a/.claude/hooks/stop_journal.ps1
+++ b/.claude/hooks/stop_journal.ps1
@@ -1,0 +1,15 @@
+#!/usr/bin/env pwsh
+# Stop hook: append a timestamped entry to the session journal
+
+$journalPath = Join-Path $env:CLAUDE_PROJECT_DIR ".astroray_plan\session-journal.md"
+$timestamp = Get-Date -Format "yyyy-MM-dd HH:mm"
+
+# Ensure the journal exists
+if (-not (Test-Path $journalPath)) {
+    "# Astroray Session Journal`n`n" | Set-Content $journalPath -Encoding UTF8
+}
+
+# Append a timestamped entry. The agent fills in the summary during the session;
+# this hook records the session boundary so nothing is silently lost.
+$entry = "$timestamp | claude | (session end — update this line with the main decision/output)"
+Add-Content -Path $journalPath -Value $entry -Encoding UTF8

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File \"${CLAUDE_PROJECT_DIR}\\.claude\\hooks\\session_start.ps1\""
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit|NotebookEdit|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File \"${CLAUDE_PROJECT_DIR}\\.claude\\hooks\\pyd_shadow_guard.ps1\""
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File \"${CLAUDE_PROJECT_DIR}\\.claude\\hooks\\pre_commit_diag_check.ps1\""
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File \"${CLAUDE_PROJECT_DIR}\\.claude\\hooks\\stop_journal.ps1\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/architect/SKILL.md
+++ b/.claude/skills/architect/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: architect
+description: Spawn the architect agent in goal-capture mode. User states a desire; architect researches, proposes paths, dialogues, files specs, opens a PR.
+invocation: /architect "<goal>"
+---
+
+# /architect "\<goal\>"
+
+Spawn the `architect` agent in **goal-capture mode**.
+
+Pass the agent:
+- The goal verbatim (the quoted string from the invocation)
+- Mode: `goal-capture`
+- Instruction: read the repo state silently before opening dialogue
+  (no questions about what's in the repo)
+
+## What the architect will do
+
+1. Read `STATUS.md`, `ROADMAP.md`, `NEXT_STAGE_REPORT.md`, and relevant
+   research notes.
+2. Research externally if needed.
+3. Form an opinion before presenting options. If the goal conflicts with
+   project priorities, say so first.
+4. Present variable-N solution paths with tradeoffs.
+5. Ask one short open question to focus the dialogue.
+6. After convergence: file new spec(s), update ROADMAP/STATUS if direction
+   changes, open a PR.
+
+## Examples
+
+```
+/architect "I want to render a prism dispersing light"
+/architect "let's go after viewport perf"
+/architect "what's the fastest path to a real astrophysical scene"
+/architect "should we add pbrt-v4 scene import"
+```

--- a/.claude/skills/cite-algorithm/SKILL.md
+++ b/.claude/skills/cite-algorithm/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: cite-algorithm
+description: Before implementing any non-trivial physics, sampling, or numerical algorithm in Astroray, locate the canonical paper and a license-compatible reference implementation, save research notes to .astroray_plan/docs/, and cite the source in the code. Enforces CLAUDE.md §6 — no invented algorithms.
+---
+
+# cite-algorithm
+
+CLAUDE.md §6 is a hard rule for this project: Cycles, Mitsuba, PBRT, LuxCore, RAPTOR, ipole, GYOTO, and the Blender Foundation have already solved the rendering and GR problems Astroray inherits. Re-deriving their solutions is expensive and almost always worse, and the closing journal article must cite real provenance.
+
+This skill is the gate that runs **before** writing code for any non-trivial algorithm.
+
+## What counts as "non-trivial"
+
+Non-trivial (skill required):
+- Sampling distributions (MIS, ReSTIR, equiangular, NEE strategies)
+- Path-space algorithms (bidirectional, MLT, path guiding)
+- BSDFs / closures beyond Lambertian + Schlick
+- Spectral upsampling / colour management
+- GR integrators, metric-aware tracing, Kerr coordinate transforms
+- Plasma/synchrotron emission, polarised radiative transfer
+- Denoising, neural caches, wavefront/queue scheduling
+- Tone mapping beyond simple gamma, filtering kernels beyond box/Gaussian
+
+Trivial (skip skill):
+- Undergraduate-textbook math, well-known closed forms
+- Lambertian cosine, Schlick Fresnel approx, Halton/Sobol low-discrepancy basics
+- Language utilities, container glue, RAII wrappers
+
+When in doubt, treat as non-trivial.
+
+## Procedure
+
+1. **State what you're about to implement** in one sentence. Identify which Astroray area it touches (cite a file under `src/` or a package under `.astroray_plan/packages/`).
+
+2. **Search for the canonical paper.** Use `WebSearch` for the technique name + "paper" or "siggraph"/"eurographics". Aim for the original publication, not a blog post. Capture: title, authors, year, DOI or arXiv ID, venue.
+
+3. **Find a license-compatible reference implementation.** Use `WebSearch` / `WebFetch` to locate the source. Acceptable licenses:
+   - Apache-2.0, BSD-2/3-Clause, MIT, MPL-2.0, public domain / CC0
+   - GPLv2 / GPLv3 — **only if** consistent with Astroray's license; check `LICENSE` and stop to ask if unsure.
+   - Reject: proprietary, "research only", non-commercial, license unstated.
+   Capture the repo URL, the commit/tag you read, and the specific file paths you'll mirror.
+
+4. **Write research notes** to `.astroray_plan/docs/<topic>-research.md` (match the naming of existing entries — `caustics-research.md`, `restir-temporal-spatial-design.md`, `disney-energy-compensation-research.md`, etc.). Use the template below.
+
+5. **Cite in the code itself.** Every translation unit that ports the algorithm gets a header comment block:
+   ```cpp
+   // Source: <Author> et al., "<Title>", <Venue> <Year>. DOI:<doi> / arXiv:<id>
+   // Reference impl: <repo>@<commit> — <path/to/file.cpp> §<section or function>
+   // License: <SPDX id> (compatible with Astroray's LICENSE).
+   ```
+   Inline citations on individual functions reference paper sections: `// Eq. 17 of Zeltner 2020`.
+
+6. **Update `.astroray_plan/docs/external-references.md`** with a one-line pointer to the new research note, so the bibliography stays discoverable.
+
+## Research-note template
+
+Save to `.astroray_plan/docs/<topic>-research.md`:
+
+```markdown
+# <Topic> — Research
+
+## Paper
+- **Title:** ...
+- **Authors:** ...
+- **Year / Venue:** ...
+- **DOI / arXiv:** ...
+- **PDF:** <stable URL>
+
+## Reference implementation
+- **Repo:** <url>
+- **Commit / tag:** <sha or tag>
+- **License:** <SPDX> — compatible with Astroray's <LICENSE> because <reason>.
+- **Files we mirror:**
+  - `path/to/file.cpp` — <which function / section>
+  - `path/to/header.h` — <which struct / API>
+
+## What we reproduce
+- Equations: <list, e.g. "Eq. 12–17 (importance weights)">
+- Data structures: <list>
+- Differences from the reference: <intentional simplifications, integration with Astroray's spectral path, etc.>
+
+## What we deliberately do NOT take
+- <e.g. their tile scheduler — we already have a wavefront queue>
+
+## Integration plan in Astroray
+- Files to add/edit: `src/...`, `python/...`
+- Package: `.astroray_plan/packages/pkgNN-...`
+- Tests / parity check: `tests/...` or `benchmarks/...`
+
+## Open questions
+- <anything to verify with the user before coding>
+```
+
+## Anti-patterns
+
+- Implementing first, citing later: provenance becomes guesswork and the citation block ends up wrong.
+- Citing a blog post or Wikipedia as the primary source for a non-trivial algorithm.
+- Copying GPL code into Astroray without checking license compatibility against `LICENSE` and `THIRD_PARTY.md`.
+- Skipping the research note because "it's a small change" — the rule applies per algorithm, not per LOC.
+- Inventing an "improvement" over the reference. If the deviation is real, the research note must justify it explicitly under *Differences from the reference*.
+
+## When to invoke
+
+Either invoke explicitly (`/cite-algorithm`) before starting work on a new sampler/integrator/BSDF/emission model, or trigger automatically when a task description mentions implementing a named technique (e.g. "add ReSTIR DI", "port Cycles' principled hair", "implement Kerr-Schild coordinates"). The skill outputs the research note path and the code citation block; it does not write the implementation.

--- a/.claude/skills/close-round/SKILL.md
+++ b/.claude/skills/close-round/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: close-round
+description: Spawn docs-updater to close the current round, then check whether a strategy review should fire.
+invocation: /close-round
+---
+
+# /close-round
+
+## Step 1 — Spawn docs-updater
+
+Spawn the `docs-updater` agent. Pass it the list of PRs merged since the
+last STATUS.md update. Wait for it to return and confirm the doc PR is
+open or merged.
+
+## Step 2 — Check for strategy review trigger
+
+After docs-updater returns, check whether any of these conditions are met:
+
+| Condition | Action |
+|---|---|
+| 3 or more packages have deferred targets (measurement-vs-spec divergence events) since the last architect review | Spawn architect in `state+refine` mode |
+| This is the 3rd round since the last architect review | Spawn architect in `state+refine` mode |
+| Every round | Spawn architect in `state+refine` mode (light pass: current-state surface + one question) |
+
+A "light" state+refine pass is: read the current render output + status,
+ask one short question, accept "no changes needed" as a complete answer.
+
+## Step 3 — Report to user
+
+After docs-updater and (if triggered) the architect return:
+
+- Confirm the doc PR is open/merged
+- Summarise what the architect decided (if it ran)
+- State what the next dispatch will pick up (top of NEXT_STAGE_REPORT.md §2)

--- a/.claude/skills/dispatch-next/SKILL.md
+++ b/.claude/skills/dispatch-next/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: dispatch-next
+description: Read the current Round's recommended deployable set, pick the top-priority open package not already in flight, and route it to the correct agent.
+invocation: /dispatch-next
+---
+
+# /dispatch-next
+
+Read `.astroray_plan/docs/NEXT_STAGE_REPORT.md` §2 (Recommended next
+deployable set). Identify the highest-priority open package that does not
+already have an open PR or an active worktree.
+
+## Routing rules
+
+1. Check the package spec frontmatter in `.astroray_plan/packages/`:
+   - If `Track: E` AND the spec or NEXT_STAGE_REPORT.md entry says
+     "Codex-paste-ready": spawn `codex-implementer`
+   - Otherwise: spawn `package-implementer` in a fresh worktree
+     (use `EnterWorktree` or `superpowers:using-git-worktrees`)
+
+2. Pass to the spawned agent:
+   - The drop-in prompt from NEXT_STAGE_REPORT.md §3 for that package
+     (verbatim — those prompts are purpose-written)
+   - The package spec path
+   - The worktree name (e.g., `pkg55-phase-b`)
+
+3. DRY-RUN mode: if invoked with `--dry-run`, print the routing decision
+   (package name, agent, worktree) without spawning the agent.
+
+## Example output (non-dry-run)
+
+```
+Dispatching: pkg55 Phase B → package-implementer
+Worktree: .claude/worktrees/pkg55-phase-b
+Prompt: [NEXT_STAGE_REPORT.md §3.1 verbatim]
+```

--- a/.claude/skills/file-followup/SKILL.md
+++ b/.claude/skills/file-followup/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: file-followup
+description: Spawn the architect briefly to file a new package spec for an out-of-scope finding. pkg82/pkg83/pkg84 are the templates.
+invocation: /file-followup <one-line reason>
+---
+
+# /file-followup \<one-line reason\>
+
+Spawn the `architect` agent in a brief goal-capture pass to file a new
+package spec for an out-of-scope finding surfaced during another session.
+
+## Input
+
+Pass the architect:
+- The one-line reason (from the invocation)
+- The source context: which package discovered it, which PR, what the
+  finding was
+- The constraint: this is a follow-up spec, not a strategy discussion.
+  The architect should skip the dialogue phase and go directly to writing
+  the spec, unless the scope is genuinely unclear.
+
+## Output
+
+The architect should produce:
+- A new spec file at `.astroray_plan/packages/<pkgNN>-<slug>.md`
+- Auto-tagged with `Track:` and `Codex-paste-ready:`
+- A one-PR doc update (spec file only; STATUS.md gets updated at round close)
+
+## Templates
+
+- pkg82: filed after pkg78 bisect refused on §1 grounds (measurement carries)
+- pkg83: filed from pkg81 H2 finding (accumulator-reset-per-pan)
+- pkg84: filed from pkg81 H5 finding (cold CUDA context 12 s first frame)
+
+The pattern: a finding from one package becomes a new spec for the next
+available package number, scoped tightly to the finding.

--- a/.claude/skills/rebuild-pyd/SKILL.md
+++ b/.claude/skills/rebuild-pyd/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: rebuild-pyd
+description: Rebuild the astroray Python extension cleanly, clearing every stale .pyd shadow copy that can mask a fresh build. Use when tests behave as if code changes had no effect, or after switching between Blender/standalone/CUDA build variants.
+disable-model-invocation: true
+---
+
+# rebuild-pyd
+
+Astroray ships its Python module (`astroray.pyd` / `astroray.cp312-win_amd64.pyd`) into several directories for IDE/Jupyter/Blender convenience. `tests/base_helpers.py` inserts the project root into `sys.path` *after* `build/`, so the project-root copy wins. A stale `.pyd` outside `build/` will silently shadow a fresh build and produce frozen-in-time test output.
+
+This skill does the canonical clean rebuild for one of three variants. The user picks the variant; nothing here assumes.
+
+## Variants
+
+| Variant     | Preset / script                              | OpenMP   | CUDA  | Loaded by               |
+|-------------|----------------------------------------------|----------|-------|-------------------------|
+| `standalone`| `cmake --preset windows-cpu-vs` + build      | ON       | OFF   | pytest, CLI raytracer   |
+| `cuda`      | `cmake --preset windows-cuda-vs` + build     | ON       | ON    | pytest with GPU         |
+| `blender`   | `python scripts/build/build_blender_addon.py`| **OFF**  | OFF   | Blender's MSVC Python   |
+
+**Hard rule**: the `blender` variant MUST build with `-DASTRORAY_DISABLE_OPENMP=ON`. MinGW `libgomp-1.dll` deadlocks silently inside Blender's MSVC-built host Python. The `build_blender_addon.py` path already sets this; do not override it. (See `memory/mingw_openmp_blender_deadlock.md`.)
+
+## Procedure
+
+1. **Locate every shadow.** From repo root:
+   ```powershell
+   Get-ChildItem -Recurse -Filter astroray*.pyd | Select-Object FullName, Length, LastWriteTime
+   ```
+   Expected legitimate locations:
+   - `build/astroray.cp312-win_amd64.pyd` (standalone preset binaryDir is `build/`)
+   - `build_cuda/astroray.cp312-win_amd64.pyd`
+   - `build_tcnn/astroray.cp312-win_amd64.pyd`
+   - the Blender addon's `Release/` staging copy
+
+   Anything at any of these paths is a shadow and must go:
+   - `./astroray.pyd`
+   - `./astroray.cp312-win_amd64.pyd`
+   - `./tests/astroray*.pyd`
+   - `./Release/astroray*.pyd` (only if not the Blender staging dir — check `blender_addon/Release/` is the legit one)
+
+2. **Delete shadows.** Show the list to the user before deleting. Then `Remove-Item` each. Never delete from `build/`, `build_cuda/`, `build_tcnn/`, or `blender_addon/Release/`.
+
+3. **Rebuild the chosen variant:**
+   - `standalone`: `cmake --preset windows-cpu-vs` then `cmake --build --preset windows-cpu-vs-release`
+   - `cuda`: `cmake --preset windows-cuda-vs` then `cmake --build --preset windows-cuda-vs-release`
+   - `blender`: `python scripts/build/build_blender_addon.py` — do not pass extra CMake flags; the script owns `ASTRORAY_DISABLE_OPENMP=ON` and `PYBIND11_FINDPYTHON=ON`.
+
+4. **Verify the fresh artifact.** Re-run the `Get-ChildItem` from step 1 and confirm the timestamp on the expected output (e.g. `build/astroray.cp312-win_amd64.pyd`) is newer than 60 seconds ago. If any shadow reappeared (e.g. a post-build copy step you forgot about), surface that path rather than silently moving on.
+
+5. **For `standalone`/`cuda`, smoke-test:** `python -c "import sys; sys.path.insert(0, 'build'); import astroray; print(astroray.__file__)"`. The printed path must be inside `build/` (or `build_cuda/`). If it points to the project root, step 2 missed a shadow.
+
+## Anti-patterns
+
+- Running `cmake --build` without first clearing shadows: the build will succeed and tests will still load the old binary.
+- Using `find . -name '*.pyd' -delete` blindly: that nukes the Blender addon staging copy too.
+- Re-enabling OpenMP "just to test" in the Blender variant: it will hang at module init with no log past `Read blend:`.
+
+## When to invoke
+
+Type `/rebuild-pyd` (model invocation is disabled — this only runs on explicit user request) when:
+- A test fix "isn't working" and the failure output looks identical to before the edit.
+- You just switched Python versions or pybind11 settings.
+- You're about to ship a Blender addon build and need to be sure no OpenMP-linked `.pyd` leaked through.

--- a/.claude/skills/strategy-review/SKILL.md
+++ b/.claude/skills/strategy-review/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: strategy-review
+description: Spawn the architect agent in state+refine mode. Surfaces current render quality, project state, and asks one short open question about direction.
+invocation: /strategy-review
+---
+
+# /strategy-review
+
+Spawn the `architect` agent in **state+refine mode**.
+
+Pass the agent:
+- Mode: `state+refine`
+- Instruction: pre-gather context silently (git log, closed PRs, render
+  outputs, convergence plots). Surface state with visuals + one short
+  open question. Update ROADMAP.md if direction changes. Open a doc PR.
+
+## What the architect will do
+
+1. Read git log + PRs since the last strategy review.
+2. Read the latest showcase HTML and any convergence/parity PNGs in
+   `test_results/` and `benchmarks/`.
+3. Surface state in 3–5 lines + embedded renders.
+4. Ask ONE short open question.
+5. After the user responds, update ROADMAP.md if needed and open a PR.
+
+## When to use
+
+- Manually at any time for a direction check
+- Automatically after `/close-round` every round (light pass)
+- After every 3rd round (full pass with render comparison)

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: verify
+description: Spawn the hardware-verifier agent for a named package's most recent PR.
+invocation: /verify <pkg>
+---
+
+# /verify \<pkg\>
+
+Spawn the `hardware-verifier` agent for the named package.
+
+## Before spawning
+
+1. Find the package's most recent PR:
+   ```
+   gh pr list --search "<pkg>" --state open
+   gh pr list --search "<pkg>" --state closed --limit 5
+   ```
+2. Read the package spec at `.astroray_plan/packages/<pkg>*.md` to extract:
+   - The most recent binding introduced (for the smoke-check step)
+   - The acceptance gate list
+
+3. Pass to hardware-verifier:
+   - PR number
+   - Package spec path
+   - The most recent binding name (for Step 2 of the verifier's workflow)
+
+## Reactive mode
+
+If a PR has the `needs-verifier` label, `/verify` can also be triggered
+reactively. In that case, extract the package name from the PR title.

--- a/.claude/skills/visual-check/SKILL.md
+++ b/.claude/skills/visual-check/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: visual-check
+description: Read a render output (and optionally a reference) using Claude's multimodal capability and produce a short qualitative inspection note.
+invocation: /visual-check <render-path> [<reference-path>]
+---
+
+# /visual-check \<render-path\> [\<reference-path\>]
+
+Use Claude's multimodal `Read` tool to inspect the named render. If a
+reference path is also given, compare the two.
+
+## Output format
+
+Produce a concise inspection note (5–10 lines) covering:
+
+1. **Overall impression**: exposure, contrast, colour balance
+2. **Artifacts**: fireflies, banding, NaN pixels (magenta/black spikes),
+   aliasing, moire
+3. **Material fidelity**: are metals metallic, glass transparent, diffuse
+   surfaces diffuse?
+4. **Spectral signature** (if applicable): visible dispersion, chromatic
+   effects, band-specific artefacts
+5. **Comparison delta** (if reference given): what changed, better or worse,
+   any regressions
+
+## Examples
+
+```
+/visual-check tests/reference/disney_contact_sheet_post_compensation.png
+/visual-check test_results/optix_before.png test_results/optix_after.png
+/visual-check benchmarks/showcase/output/cornell_spectral_512spp.png
+```
+
+## Note
+
+This is a qualitative pass — use it to quickly flag obvious problems or
+confirm a fix. It does not replace the numerical gates in the hardware
+verifier. When something looks wrong here but the numbers pass, escalate
+to `gate-failure-reviewer`.

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,12 @@
 .clinerules
 .clinerules.md
 
-#Claude
-.claude/
+#Claude — track agents/skills/settings/hooks; ignore ephemeral state
+.claude/worktrees/
+.claude/scheduled_tasks.lock
+.claude/settings.local.json
+.astroray_plan/tracker/local.toml
+.astroray_plan/session-journal.md
 
 # Build directories
 build/


### PR DESCRIPTION
## What this adds

Infrastructure that lets the project owner stay in the loop on **direction** and out of the loop on **execution**.

---

## Phase 1 — Tracker bootstrap

- **Relocated** `test_results/astroray_dashboard.gs` → `.astroray_plan/tracker/astroray_dashboard.gs` (was gitignored, now tracked as the authoritative Apps Script source)
- **Added** `.astroray_plan/tracker/README.md` — what the Sheet is, recovery procedure (5 steps from blank to running), architect-note about the Sheet URL location
- **Gitignored** `.astroray_plan/tracker/local.toml` (Sheet URL, not for the repo) and `.astroray_plan/session-journal.md`

---

## Phase 2 — Subagent definitions (`.claude/agents/`)

7 new agents (+ the 2 pre-existing ones now tracked):

| Agent | Backed by | Purpose |
|---|---|---|
| `package-implementer` | Claude Sonnet 4.5 | Implements one pkg spec end-to-end in a worktree. Enforces §1/§6 discipline, stops on scope forks, removes diag prints before merge. |
| `codex-implementer` | Codex subagent | Routes Codex-paste-ready specs; sanity-passes the output (license fence, diag markers, acceptance coverage). |
| `hardware-verifier` | Claude Sonnet 4.5 (multimodal) | 5-step: rebuild → smoke-check stale-.pyd → gate tests → visual inspection → append Lessons. Never relaxes a gate. |
| `pr-reviewer` | Claude Sonnet 4.5 | Auto-merge checklist; hands back on CMakeLists/binding/gate changes; halts on §6 violation. Doc-only and verifier PRs auto-merge on CI green. |
| `gate-failure-reviewer` | Claude Sonnet 4.5 | Diagnoses persistent gate failures using the pkg73 two-root-cause template. Produces a structured report, routes to a fresh implementer session. |
| `docs-updater` | Claude Sonnet 4.5 | Round closeout: flips spec statuses, updates STATUS/ROADMAP/NEXT_STAGE_REPORT, opens one doc PR. |
| `architect` | Claude Opus 4.7 | Three modes: goal-capture, state+refine, unsolicited-surfacing. Opinionated push-back mandatory. Short open questions. Variable-N option count. |

---

## Phase 3 — Hooks (`.claude/settings.json`)

3 new hooks, preserving the existing `pyd_shadow_guard` hook:

| Hook | Trigger | Behaviour |
|---|---|---|
| `session_start.ps1` | SessionStart | `git fetch` + `git status --short` + `gh pr list --limit 10`; warns if the newest `.pyd` is >24 h old |
| `pre_commit_diag_check.ps1` | PreToolUse/Bash | Detects `git commit` in the command; greps staged diff for `[pkg##-diag]`, `REMOVE AFTER`, `XXX DEBUG`; blocks with offending lines if found |
| `stop_journal.ps1` | Stop | Appends a timestamped boundary entry to `.astroray_plan/session-journal.md` (gitignored) |

---

## Phase 4 — Slash-command skills (`.claude/skills/`)

7 new skills (+ the 2 pre-existing ones now tracked):

| Skill | Invocation | What it does |
|---|---|---|
| `dispatch-next` | `/dispatch-next [--dry-run]` | Reads NEXT_STAGE_REPORT.md §2, picks top-priority open package, routes to `package-implementer` or `codex-implementer` based on Track/paste-ready tag |
| `close-round` | `/close-round` | Spawns `docs-updater`; checks strategy-review trigger (every round light pass; every 3rd or deferred-pkg event, full pass) |
| `verify` | `/verify <pkg>` | Spawns `hardware-verifier` for the named package's most recent PR |
| `file-followup` | `/file-followup <reason>` | Spawns `architect` briefly to file a follow-up spec (pkg82/83/84 template) |
| `architect` | `/architect "<goal>"` | Spawns `architect` in goal-capture mode |
| `strategy-review` | `/strategy-review` | Spawns `architect` in state+refine mode |
| `visual-check` | `/visual-check <render> [<ref>]` | Multimodal qualitative inspection note for a render output |

---

## gitignore change

`.claude/` was blanket-gitignored. Replaced with targeted exclusions:

```
.claude/worktrees/
.claude/scheduled_tasks.lock
.claude/settings.local.json
.astroray_plan/tracker/local.toml
.astroray_plan/session-journal.md
```

This brings agents, skills, hooks, and `settings.json` under version control — necessary for the PR to exist at all.

---

## Phase 5 — Manual actions (checklist for the project owner)

- [ ] **Install GitHub MCP server** — `claude mcp add github` — for structured PR/issue ops in agent sessions
- [ ] **Re-authorize Google Drive connector** with write scope so the architect can update the Sheet directly during state+refine
- [ ] **Confirm Codex addon is installed** and `codex-implementer` can spawn a Codex subagent (smoke-test on a small paste-ready spec)
- [ ] **Confirm Superpowers plugin is loaded** — `package-implementer` and `pr-reviewer` inherit from its executor/critic skills

---

## Auto-merge eligible

This is infrastructure + docs only. No source, tests, or CMakeLists touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)