### PR TITLE
docs(pkg87): file Cryptomatte spec (Psyop BSD-3 + Cycles Apache-2.0)

### DIFF
--- a/.astroray_plan/packages/pkg86-light-tree.md
+++ b/.astroray_plan/packages/pkg86-light-tree.md
@@ -1,0 +1,307 @@
+# pkg86 — Light Tree (Many-Lights Importance Sampling)
+
+**Pillar:** 3 (light transport)
+**Track:** A
+**Status:** open — ready to implement
+**Estimated effort:** 3 weeks (~60 h, multiple sessions) — 1 wk research + tree build, 1 wk traversal + integrator wire-up, 1 wk validation.
+**Depends on:** none (independent of pkg55; the build-once-sample-many pattern is integrator-agnostic and composes with every existing integrator)
+
+**Reference research:** to be filed at `.astroray_plan/docs/light-tree-research.md`
+during Phase 1 (see Specification §1). The research note must exist and be
+linked from this spec before any C++ is written (CLAUDE.md §6).
+
+---
+
+## Goal
+
+**Before:** `LightList::sample` (include/raytracer.h:1196) picks lights by
+**global power** (`luminance · area`) only — no spatial awareness. On a scene
+with one bright light close to the shading point and 50 dim lights on the
+far side of the room, every shading vertex spends ~50/51 of its NEE budget
+on lights the surface cannot effectively see. Variance scales as O(N) with
+the number of irrelevant lights.
+
+**After:** A binary light tree, built once per render, is traversed at each
+shade vertex using an importance heuristic that combines cluster energy,
+inverse squared distance to the shading point, and a bounding-cone
+orientation factor. Lights that contribute meaningfully to the local shade
+point are picked with high probability; clusters that cannot contribute are
+pruned in O(log N). On a 64-area-light reference scene we target ≥ 2×
+variance reduction at equal spp vs the current power-weighted sampler —
+Cycles' reported range is 2-10× depending on light distribution.
+
+---
+
+## Context
+
+This package closes the single largest Cycles-parity gap in our many-lights
+performance story (Round 8 strategy pass §3, 2026-05-14). It is not gated
+by pkg55-B: pkg86 lives on top of the existing `LightList` abstraction,
+which is consumed identically by CPU and CUDA paths. Once shipped, the
+exact same tree (or a GPU-flattened mirror) can be re-used for the
+megakernel/wavefront integrators when pkg55-B lands.
+
+Archviz, studio lighting, and any scene with practical-light arrays (the
+canonical Cycles "Junkshop" demo has > 100 lights) are the workloads that
+benefit. Astrophysical scenes (Pillar 4) rarely have many lights and will
+see ≈ 0 % improvement — that is fine, the tree-build cost on small light
+counts is sub-millisecond and the traversal cost is O(log N) ≤ existing
+linear-scan cost from N ≥ 8 or so. CPU first; GPU is the explicit
+follow-up pkg86-B.
+
+---
+
+## Reference
+
+External (must verify with `WebSearch` / `WebFetch` in Phase 1 before
+relying on):
+
+- **Algorithm.** Alejandro Conty Estevez & Christopher Kulla, "Importance
+  Sampling of Many Lights with Adaptive Tree Splitting", SIGGRAPH 2018
+  Talks / Sony Pictures Imageworks tech report. DOI
+  [10.2312/sr.20181174](https://doi.org/10.2312/sr.20181174) (the talk
+  citation in the Round 8 strategy doc — confirm during research; the full
+  EGSR/HPG-style write-up was later published as the
+  "Importance Sampling of Many Lights" tech paper).
+- **Reference implementation (mirror-permitted, Apache-2.0).**
+  Blender Cycles light tree:
+  - `intern/cycles/scene/light_tree.{h,cpp}` — host-side tree build,
+    cluster bounds, orientation cone, splitting heuristic.
+  - `intern/cycles/kernel/light/light_tree.h` — device-side traversal.
+  - `intern/cycles/scene/light_tree.cpp::light_tree_emission_with_orientation_bound`
+    is the canonical implementation of the Conty 2018 importance metric we
+    will mirror — cite by function name in the C++ at every call site.
+- Astroray internal:
+  - `include/raytracer.h:1180-1233` — `LightList` (current power-weighted
+    sampler being replaced).
+  - `plugins/integrators/multiwavelength_path_tracer.cpp`,
+    `spectral_path_tracer.cpp`, `restir_di.cpp`, `neural_cache.cpp` — all
+    NEE call sites that route through `LightList::sample`.
+
+**License note.** Cycles light tree is Apache-2.0, compatible with
+Astroray's MIT license (CLAUDE.md §6). Files mirrored from
+`intern/cycles/…` into Astroray must preserve their original Apache-2.0
+copyright headers; a new `external/cycles_light_tree/THIRD_PARTY_LICENSES.md`
+records attribution and the upstream commit SHA.
+
+---
+
+## Prerequisites
+
+- [ ] Phase 1 research note `.astroray_plan/docs/light-tree-research.md`
+      drafted and project-owner-signed-off, covering: Conty 2018 metric
+      derivation, the exact Cycles functions to mirror, license check on
+      the Cycles commit being pinned, and the four answers from the Key
+      design decisions section below.
+- [x] `LightList` already exposes accessors (`getLights`, `getPowerDist`,
+      `getTotalPower`) so a sibling sampler can read its contents without
+      ripping out the existing class.
+- [x] All NEE-using integrators go through a single `LightList::sample`
+      call — one chokepoint to replace.
+
+---
+
+## Specification
+
+### Phase 1 — Research note (≈ 1 week, ~10-15 h)
+
+Deliverable: `.astroray_plan/docs/light-tree-research.md`.
+
+Content:
+1. Conty 2018 importance metric derivation: cluster energy, inverse-r²,
+   orientation cone (θ_o, θ_e) bounding factor. State the exact closed-form
+   importance value, with paper §/eq pointers.
+2. Cycles' implementation walkthrough: `light_tree.cpp` (build) and
+   `kernel/light/light_tree.h` (traverse). Identify every function we
+   mirror, including
+   `light_tree_emission_with_orientation_bound` (the importance kernel),
+   the bounding-cone update during build, and the cluster split heuristic
+   (Cycles uses an adaptive split — confirm whether we mirror the
+   adaptive version or fall back to median-split for Phase 2).
+3. Pin the Cycles upstream commit SHA we are mirroring from.
+4. License re-check on that commit: confirm Apache-2.0, list every file
+   we will mirror, decide vendoring location (`external/cycles_light_tree/`).
+5. Answers to the six Key design decisions below — convert lean → owner-signed
+   commitment.
+
+No C++ is written in Phase 1. Owner sign-off on the research note is the
+gate.
+
+### Phase 2 — CPU implementation (≈ 1 week, ~25 h)
+
+#### Files to create
+
+| File | Purpose |
+|---|---|
+| `external/cycles_light_tree/` | Mirrored Apache-2.0 source from Cycles. Preserve original copyright headers. |
+| `external/cycles_light_tree/THIRD_PARTY_LICENSES.md` | Attribution + upstream commit SHA. |
+| `include/astroray/light_tree.h` | Astroray-facing tree API: `class LightTree` with `build(const LightList&)` and `pick(const Vec3& point, const Vec3& normal, float u, int& out_idx, float& out_pdf) const`. Thin wrapper around the mirrored Cycles code; no algorithm in the wrapper. |
+| `src/light_tree.cpp` | Build + traverse implementation. Mirror the Cycles functions named in Phase 1. Cite at every call site, e.g. `// Cycles light_tree.cpp::light_tree_emission_with_orientation_bound (Apache-2.0, commit <SHA>)`. |
+| `include/astroray/light_sampler.h` | Abstract base: `class LightSampler { virtual void pick(point, normal, u, &idx, &pdf) const = 0; virtual float pdf(point, normal, idx) const = 0; };`. Two implementations: `PowerLightSampler` (wraps existing `LightList::sample`'s power-weighted CDF for regression baseline) and `TreeLightSampler` (wraps `LightTree`). |
+| `tests/scenes/many_lights.py` | Reference scene: 64 area lights scattered through a Cornell-box-like volume. The acceptance gate scene. |
+| `tests/test_pkg86_light_tree.py` | Unit + integration tests (see Acceptance). |
+
+#### Files to modify
+
+| File | What changes |
+|---|---|
+| `include/raytracer.h` (`LightList`) | Internal change only: `LightList::sample` keeps its current signature for source-compat, but its body delegates to a stored `std::unique_ptr<LightSampler>` chosen at scene-build time. Default = `PowerLightSampler` (bit-equal to current behaviour); flipping to `TreeLightSampler` is the renderer-level toggle introduced in this package. |
+| `include/raytracer.h` (`Renderer`) | Add `setLightSampler(enum Mode { Power, Tree })`, default `Power` for safety. After Phase 3 validation, flip default to `Tree`. |
+| `plugins/integrators/multiwavelength_path_tracer.cpp` | No source change required (it goes through `LightList::sample`); confirm pdf-bookkeeping still balances after the new sampler is in. Same for the other four integrators — the entire point of routing through `LightList::sample` is that the call sites are stable. |
+| `module/blender_module.cpp` | Bind `set_light_sampler(mode: str)` (`"power"` / `"tree"`). |
+| `blender_addon/__init__.py` | Add a single dropdown in the Astroray Sampling panel mirroring Cycles' "Light Tree" toggle. Default off until Phase 3 acceptance gates clear; then default on. |
+| `.astroray_plan/docs/STATUS.md`, `CHANGELOG.md` | Update on landing. |
+
+#### Phase 3 — Validation (≈ 1 week, ~20 h)
+
+- Implement `tests/scenes/many_lights.py` (64 area lights, fixed seeds).
+- Render at 256 spp with `PowerLightSampler` and `TreeLightSampler`; compute
+  per-pixel variance estimate (multiple-seed re-render) and confirm the
+  ≥ 2× variance-reduction gate.
+- Render a single-bright-light scene (existing Cornell box) with both
+  samplers; confirm no regression: tree must match power-weighted to
+  within ≤ 0.5 dB PSNR (single-light traversal collapses to a trivial
+  path).
+- Measure tree-build wall time on a 1000-light synthetic scene; confirm
+  it stays sub-millisecond on the CPU (one build per render, not per
+  frame; viewport interactivity is unaffected — pkg83 progressive
+  accumulation already amortises this).
+
+---
+
+### Key design decisions (the six fork-points)
+
+1. **Integrator coverage — all of them, via a virtual sampler.** pkg86
+   targets *every* integrator that calls `LightList::sample`
+   (`multiwavelength_path_tracer`, `spectral_path_tracer`, `restir_di`,
+   `neural_cache`, `caustic_path_tracer`, `sms_caustic_path_tracer`).
+   The build-once-sample-many pattern is integrator-agnostic — Cycles
+   composes their tree with every integrator. We expose
+   `LightSampler::pick(point, normal, u, &idx, &pdf)` as the virtual
+   interface; `LightList::sample` delegates to it. Integrator call sites
+   are unchanged.
+
+2. **Tree structure — binary, mirror Cycles directly.** Conty 2018 and
+   Cycles both use a binary tree with bounding-cone (θ_o, θ_e) per
+   cluster. We do not invent a quaternary or k-d variant. CLAUDE.md §6.
+
+3. **Importance metric — Cycles'
+   `light_tree_emission_with_orientation_bound` verbatim.** Formula:
+   `importance = (cluster_energy / max(dist², ε)) · orientation_factor`,
+   where `orientation_factor` is the cosine-cone coverage between the
+   cluster's bounding cone and the shading-point normal as derived in
+   Conty 2018 §4. Reference: cite the Cycles function by name at every
+   call site, with the upstream commit SHA recorded in
+   `external/cycles_light_tree/THIRD_PARTY_LICENSES.md`.
+
+4. **GPU port — out of scope; spec'd separately as pkg86-B.** CPU first
+   mirrors the pkg64 → pkg64-gpu phase split. The GPU port is only
+   meaningful once pkg55-B unblocks the megakernel/wavefront integrator
+   restart anyway; landing CPU now gives the CPU-path users (the
+   majority during Round 8) the variance win immediately without
+   depending on pkg55-B's calendar. Cycles ships GPU traversal in
+   `kernel/light/light_tree.h` and pkg86-B will mirror that.
+
+5. **Acceptance gate — variance reduction on the new `many_lights.py`
+   scene.** 64 area lights, Cornell-box-style enclosure, fixed seeds,
+   256 spp, ≥ 2× variance reduction vs `PowerLightSampler` measured by
+   multi-seed pixel variance. Plus a single-bright-light non-regression
+   gate (≤ 0.5 dB PSNR delta on the existing Cornell scene) to prove
+   single-light cases collapse correctly.
+
+6. **Effort sizing — 3 weeks, 1 wk per phase.** Phase 1 (research note +
+   owner sign-off) is the biggest unknown; Phase 2 (mirror Cycles
+   code, wrap, wire) is mechanical port work; Phase 3 (build the new
+   test scene, run the gate, measure) is short. The Cycles light-tree
+   commit was a single tech-lead week of work upstream — this is
+   consistent.
+
+---
+
+## Acceptance criteria
+
+- [ ] **Research note signed off.** `.astroray_plan/docs/light-tree-research.md`
+      exists with the six items in Phase 1, project-owner approval recorded.
+- [ ] **Variance reduction gate (strict).** On `tests/scenes/many_lights.py`
+      at 256 spp, the per-pixel-variance estimate (from N=4 re-renders with
+      different seeds) under `TreeLightSampler` is ≤ 0.5× the variance
+      under `PowerLightSampler`. (Equivalent to ≥ 2× variance reduction;
+      ≥ 4× would clear Cycles' "best case" target band.)
+- [ ] **Single-light non-regression.** On the existing Cornell-box scene,
+      PSNR delta between `Tree` and `Power` samplers ≥ −0.5 dB at 256 spp.
+- [ ] **Tree-build cost.** Build wall time on a 1000-light synthetic scene
+      ≤ 5 ms on the implementer machine; not per-frame.
+- [ ] **Composability.** Every integrator listed in design decision §1
+      passes its existing focused test suite with `TreeLightSampler` set.
+      (No source change in the integrators; this test verifies the pdf
+      bookkeeping balances.)
+- [ ] **License hygiene.** `external/cycles_light_tree/` preserves
+      Apache-2.0 headers; `THIRD_PARTY_LICENSES.md` records attribution
+      and upstream commit SHA; CLAUDE.md §6 citations on every mirrored
+      function in `src/light_tree.cpp`.
+- [ ] **Blender UI.** "Light Tree" mode selectable from the Astroray
+      Sampling panel; flips between `Power` and `Tree`. Default flipped
+      to `Tree` once all gates above clear.
+
+---
+
+## Non-goals
+
+- **Do not GPU-port in this package.** pkg86-B (GPU light-tree traversal,
+  mirroring `intern/cycles/kernel/light/light_tree.h`) is the explicit
+  follow-up. Phase split mirrors pkg64 → pkg64-gpu.
+- **Do not change the `Light` / `Hittable::isLight` interface.** The new
+  sampler reads the existing `LightList`; no per-light virtual additions
+  unless the Conty importance metric strictly requires data not already
+  computable from `boundingBox`, `emittedRadiance`, and `directionFalloff`.
+  If it does require new accessors, surface that in the Phase 1 research
+  note for re-scoping — do not silently widen the interface.
+- **Do not invent a new importance metric.** Mirror Conty 2018 / Cycles
+  verbatim. CLAUDE.md §6.
+- **Do not implement adaptive tree-splitting (Conty 2018's "adaptive"
+  variant) in Phase 2.** Median-split is sufficient for the variance
+  gate; adaptive splitting is a phase-2 refinement spec'd as part of
+  pkg86-B if needed.
+- **Do not couple to Pillar 4 / GR.** Light-tree sampling is flat-space
+  Euclidean. GR scenes will fall back to `PowerLightSampler` automatically
+  (they have ≤ a handful of lights and the tree gives no win).
+- **Do not delete `LightList`'s power-weighted CDF.** `PowerLightSampler`
+  retains it as a tested regression baseline and the default for GR scenes.
+
+---
+
+## Progress
+
+- [ ] **Phase 1 — Research note.** WebSearch / WebFetch literature pass on
+      Conty 2018 + Cycles light tree; draft
+      `.astroray_plan/docs/light-tree-research.md`; pin Cycles commit;
+      license re-check; owner sign-off on the six design decisions.
+- [ ] **Phase 2 — CPU implementation.**
+  - [ ] Vendor Cycles light-tree sources into `external/cycles_light_tree/`
+        with `THIRD_PARTY_LICENSES.md` and preserved Apache-2.0 headers.
+  - [ ] Implement `LightTree::build` + `LightTree::pick` in
+        `src/light_tree.cpp`, mirroring the Cycles functions named in the
+        research note. Cite at every call site.
+  - [ ] Introduce `LightSampler` virtual; implement `PowerLightSampler`
+        and `TreeLightSampler`; route `LightList::sample` through it.
+  - [ ] Wire `Renderer::setLightSampler` + `module/blender_module.cpp`
+        binding + Blender-addon dropdown (default off pending gates).
+- [ ] **Phase 3 — Validation.**
+  - [ ] Implement `tests/scenes/many_lights.py` (64 area lights, fixed
+        seeds, Cornell-style enclosure).
+  - [ ] Implement `tests/test_pkg86_light_tree.py`: variance-reduction
+        gate, single-light non-regression, tree-build wall time,
+        per-integrator composability sweep.
+  - [ ] Measure on RTX 5070 Ti / Windows MSVC `build_cuda`; record
+        numbers in a Lessons section below.
+  - [ ] Flip Blender-addon default to `Tree` once gates clear.
+- [ ] STATUS.md + CHANGELOG.md updated; PR opened.
+
+---
+
+## Lessons
+
+(To be filled in by the implementer after Phase 3 — capture surprises in
+the Cycles port, any pdf-bookkeeping issues found across the five
+integrators, and the actual variance-reduction number measured on
+`many_lights.py`. Keep the structure used by pkg64 / pkg42.)

--- a/.astroray_plan/packages/pkg87-cryptomatte.md
+++ b/.astroray_plan/packages/pkg87-cryptomatte.md
@@ -1,0 +1,260 @@
+# pkg87 — Cryptomatte Passes
+
+**Pillar:** 5
+**Track:** A
+**Status:** open — ready to implement
+**Estimated effort:** 2–3 weeks
+**Depends on:** none (independent of pkg55-B and pkg86)
+
+---
+
+## Goal
+
+**Before:** Astroray has no way to isolate an individual object or material
+in the Blender compositor. The pass system emits AOVs (albedo, normal,
+depth, motion, uv_debug) but no per-pixel object-identity information.
+Production-style relighting / matte-extraction workflows are impossible.
+
+**After:** Renders include a Cryptomatte pass set
+(`CryptoObject*`, `CryptoMaterial*`) — a small fixed-size per-pixel
+histogram of `(hashed_name, coverage)` pairs, plus an EXR-header JSON
+manifest mapping hash floats back to human-readable names. The standard
+Cycles / Karma / Arnold compositor Cryptomatte node picks the passes up
+unchanged because we conform to the Psyop spec. Selecting an object in
+the compositor reconstructs its mask at ≥ 0.95 IoU vs a ground-truth
+isolated render.
+
+---
+
+## Context
+
+Architect's Round 8 strategy pass identified Cryptomatte as one of the
+two highest-leverage Cycles-parity wins not gated by pkg55-B (see
+`.astroray_plan/docs/round8-strategy-pass.md` §2.3 and §3). The user
+goal is "good Cycles parity in Blender — across performance, UI, and
+features." Cryptomatte directly closes the largest compositor-side
+feature gap: today there is no way to relight or extract per-object
+mattes after the render. Cycles ships it; "Cycles parity" requires it.
+
+The Cryptomatte format is an open standard published by Psyop
+(BSD-3, ISBA white paper 2015) and is the de-facto interchange format
+for object/material/asset mattes across Cycles, Arnold, Karma, V-Ray,
+RenderMan, and Redshift. Implementing the spec gives us free
+compatibility with every existing DCC compositor.
+
+---
+
+## Reference
+
+### Reference Implementations
+
+| Source | License | What we borrow |
+|---|---|---|
+| Psyop Cryptomatte specification (`Cryptomatte/specification/cryptomatte_specification.pdf`) | BSD-3-Clause | Wire format: float-encoded MurmurHash3_x86_32 IDs; per-pixel ranked `(id, weight)` pairs; EXR header manifest JSON; channel-naming convention (`<typename>00.{R,G,B,A}`, `<typename>01.{R,G,B,A}`, …). |
+| Psyop `Cryptomatte/sample_plugin/cryptomatte_arnold.cpp` | BSD-3-Clause | Per-pixel rank-and-merge algorithm (insert hit, sort by weight, merge same-hash, cap to N ranks). |
+| Cycles `intern/cycles/kernel/film/cryptomatte_passes.h` | Apache-2.0 | GPU-friendly write-side: `kernel_cryptomatte_post()` rank-merge, ID-from-shader plumbing, `u_cryptomatte_depth = 6` default. |
+| Cycles `intern/cycles/integrator/pass.cpp` (`PASS_CRYPTOMATTE_*`) | Apache-2.0 | Buffer allocation sizes (4 floats × depth-pairs per pixel per typename) and pass registration shape. |
+| Cycles `intern/cycles/scene/film.cpp` (`Film::update_passes`, cryptomatte manifest construction) | Apache-2.0 | Manifest JSON shape; EXR header key naming (`cryptomatte/<hash7>/{name,hash,conversion,manifest}`). |
+| smhasher `MurmurHash3.cpp` (Austin Appleby) | Public domain | The hash function itself. Direct port; no license entanglement. |
+
+### Research notes
+
+Save to `.astroray_plan/docs/cryptomatte-research.md` before implementation:
+- Psyop spec PDF DOI/SHA + ISBA 2015 paper full title.
+- License audit (BSD-3 + Apache-2.0 + public-domain — all compatible).
+- Exact Cycles source-file line ranges we will mirror.
+- Worked example: hash of `"cube"` → `0x...` → reinterpret_cast<float>.
+
+### External URLs
+
+- <https://github.com/Psyop/Cryptomatte>
+- <https://github.com/Psyop/Cryptomatte/blob/master/specification/cryptomatte_specification.pdf>
+- <https://projects.blender.org/blender/blender/src/branch/main/intern/cycles/kernel/film/cryptomatte_passes.h>
+- <https://projects.blender.org/blender/blender/src/branch/main/intern/cycles/integrator/pass.cpp>
+- <https://projects.blender.org/blender/blender/src/branch/main/intern/cycles/scene/film.cpp>
+- <https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.cpp>
+
+---
+
+## Prerequisites
+
+- [ ] Build passes on `main` (clean working tree).
+- [ ] No active pass-plugin refactor in flight (pkg72 motion-vector pass
+      landed; pkg69 albedo pass landed — the AOV machinery is stable).
+- [ ] Decision logged: OpenEXR multi-channel write lands inside this
+      package's scope (see Key design decision #3).
+
+---
+
+## Specification
+
+### Phase 1 — Hashing + per-pixel ranked accumulator (~1 week)
+
+#### Files to create
+
+| File | Purpose |
+|---|---|
+| `src/util/murmurhash3.{h,cpp}` | Port of MurmurHash3_x86_32 from smhasher. Header-only is acceptable. Cite Appleby/smhasher at the top of the .h. |
+| `include/astroray/cryptomatte.h` | `struct CryptoSample { float id; float weight; };` and `inline float crypto_hash_name(const std::string& s)` wrapping MurmurHash3 + `reinterpret_cast<float>`. Also the rank-merge function `void crypto_insert(CryptoSample* ranks, int depth, float id, float weight)` mirroring Cycles `cryptomatte_post`. |
+| `tests/test_cryptomatte_hashing.py` | Sanity tests: (a) known-name → known-hash (use Psyop spec test vectors, e.g. `"hero"` → `0x...`), (b) hash stability across runs, (c) rank-merge keeps the top-N weights and merges duplicates. |
+
+#### Files to modify
+
+| File | What changes |
+|---|---|
+| `include/astroray/gpu_types.h` | Add `uint32_t objectHash` to `GTriangle` and `GSphere`, and `uint32_t materialHash` to the GPU material struct (or via `materialId → materialHash` lookup table — see Key design decision #4). |
+| `src/scene/scene.cpp` (or wherever GPU upload lives) | At scene-upload time, hash each object's name into `objectHash` and each material's name into `materialHash`. Build the host-side hash→name manifest map (per typename). |
+
+### Phase 2 — Multi-channel EXR write + integration (~1 week)
+
+#### Files to create
+
+| File | Purpose |
+|---|---|
+| `src/io/exr_writer.{h,cpp}` | Thin wrapper around OpenEXR's `Imf::MultiPartOutputFile` or `Imf::OutputFile` with a vector of `Imf::Channel`s. Single entry point: `void write_exr(path, width, height, std::vector<ExrChannel>, std::map<std::string,std::string> header)`. |
+| `plugins/passes/cryptomatte_pass.cpp` | `Pass` plugin registered as `cryptomatte_object` and `cryptomatte_material`. Reads `fb.buffer("crypto_object")` / `fb.buffer("crypto_material")` (per-pixel `[id0,w0,id1,w1,…,idN-1,wN-1]` float arrays of length `4*ceil(depth/2)`). Sorts ranks, normalises weights, fills the EXR channels. |
+| `tests/scenes/cryptomatte_3_objects.py` | Test scene: three named cubes (`cube_red`, `cube_green`, `cube_blue`) with three named materials (`mat_red`, `mat_green`, `mat_blue`) on a single plane (`floor`). 256×256 render at low spp. |
+
+#### Files to modify
+
+| File | What changes |
+|---|---|
+| `include/raytracer.h` (`Framebuffer`) | Register `"crypto_object"` and `"crypto_material"` buffers, each sized `width*height*4*ceil(depth/2)` floats. Mirror `motion`/`uv` registration pattern at the existing buffer-name switch. |
+| `include/raytracer.h` (integrator hit-write site) | At every first-hit AND at indirect bounces that contribute to the pixel's coverage, call `crypto_insert(ranks_for_pixel, depth, hit.objectHash, weight)` and `crypto_insert(…, hit.materialHash, weight)`. Weight = throughput-weighted contribution-to-pixel (Cycles uses `average(throughput * bsdf_eval)`; mirror exactly). |
+| `module/blender_module.cpp` | Add `Renderer.get_cryptomatte_buffer(typename)` returning a zero-copy NumPy view; add the EXR-export Python binding `Renderer.write_cryptomatte_exr(path)`. |
+| `CMakeLists.txt` | Add `find_package(OpenEXR REQUIRED)` and link `OpenEXR::OpenEXR Imath::Imath` against the library and the new exr_writer translation unit. |
+
+### Phase 3 — Blender addon + acceptance (~1 week)
+
+#### Files to modify
+
+| File | What changes |
+|---|---|
+| `blender_addon/__init__.py` | Register the Cryptomatte passes via `RenderEngine.add_pass(name="CryptoObject00", channels=4, chan_id="RGBA", layer=view_layer.name)` (×3 layers for depth=6 — `00`,`01`,`02`). Same for `CryptoMaterial`. Expose `view_layer.use_pass_cryptomatte_object` and `view_layer.use_pass_cryptomatte_material` UI toggles in the Passes panel. |
+| `blender_addon/__init__.py` (`update_render_result`) | When the engine finishes a render, fetch the cryptomatte buffers and call `layer.passes["CryptoObject00"].foreach_set(...)` for each EXR layer. Embed the manifest JSON as the standard Cryptomatte metadata key on the render result. |
+| `tests/test_cryptomatte_pass.py` | (a) Render `cryptomatte_3_objects.py`. (b) Read the manifest. (c) For each named object, build a mask `selecting hash(name) == ranks[*,0::2]` weighted by `ranks[*,1::2]`. (d) Render a single-object ground-truth scene (only `cube_red`). (e) IoU between extracted mask and ground-truth coverage ≥ 0.95. (f) Repeat for `mat_red`. |
+
+### Key design decisions
+
+1. **Default depth = 6 ranks (3 EXR layers × 2 quadruples).**
+   Matches Cycles `u_cryptomatte_depth = 6` and the Psyop spec default.
+   Expose `bpy.context.scene.astroray.cryptomatte_depth` as a 2/4/6/8/16
+   integer property; 6 is the default. Memory cost at 1080p × depth 6 ×
+   2 typenames: `1920*1080*4*3*2*4 bytes = 191 MB`. Acceptable.
+
+2. **v1 typenames = `CryptoObject` + `CryptoMaterial` only.**
+   `CryptoAsset` requires asset/collection metadata propagation
+   from the Blender addon through the .blend importer (pkg76) into
+   the GPU scene. That plumbing is non-trivial and out of scope.
+   File `pkg87b-cryptoasset.md` as a follow-up when this lands.
+
+3. **EXR multi-channel write lands in this package.** A grep of
+   `plugins/` shows no existing EXR writer — output today is single-
+   channel PNG via the colourmap pass. We add a minimal
+   `src/io/exr_writer.cpp` (one screenful of OpenEXR `Imf::OutputFile`
+   API) here, scoped to Cryptomatte's needs (multi-channel float32, a
+   handful of header strings). Future packages can reuse it; we do not
+   pre-engineer for them. OpenEXR is BSD-3 (compatible).
+
+4. **GPU hash propagation: add `uint32_t objectHash` + `materialHash`
+   to `GTriangle` and `GSphere`.**
+   `GTriangle` is currently 13 floats + 1 int = 56 bytes; adding 8
+   bytes brings it to 64, which is cache-line-aligned and cheaper, not
+   more expensive. Alternative considered: a `materialId → hash` lookup
+   table on the device. Rejected because (a) the indirection costs a
+   gmem fetch per shade, (b) per-object hashes still need per-primitive
+   storage so we'd add the field anyway, (c) `GTriangle` is already the
+   right grain. Cite the MinGW large-struct-by-value memory note
+   (`mingw_large_struct_byval.md`) — at 64 bytes we are still well past
+   the 32-byte threshold, so any host-side pass-by-value of `GTriangle`
+   must continue to use `const T&`. No new exposure.
+
+5. **MurmurHash3 from smhasher (public domain).** Direct port of
+   `MurmurHash3_x86_32` from Austin Appleby's smhasher repo. ~50 LOC.
+   Cite as `// Adapted from smhasher MurmurHash3.cpp (public domain,
+   Austin Appleby)` at the top of `murmurhash3.h`. No license entry.
+
+6. **Weight model = `average(throughput · bsdf_eval)`.** Mirror Cycles
+   exactly (`kernel/film/cryptomatte_passes.h`, `kernel_write_data_passes`).
+   Per-pixel weights are normalised in the pass plugin before EXR
+   write so that `Σ weights == 1` per pixel on hit pixels and `== 0`
+   on sky pixels. The Psyop compositor node requires the normalised
+   sum, not raw radiance.
+
+7. **Acceptance gate: IoU ≥ 0.95 vs ground-truth isolated render.**
+   On the 3-object scene, render each object alone (others hidden) at
+   the same camera + spp, threshold its alpha to a binary mask, and
+   compare to the mask reconstructed by selecting the object's
+   hash-float from the Cryptomatte ranks. IoU is the standard
+   Cryptomatte-validation metric (Psyop spec §6, "Roundtrip Tests").
+   The 0.95 threshold is below the Cycles Cryptomatte regression bar
+   (0.97 internally) to leave headroom for early stochasticity at low
+   spp — we render at 64 spp for the acceptance scene.
+
+---
+
+## Acceptance criteria
+
+- [ ] `tests/test_cryptomatte_hashing.py` passes: known-name → known-
+      hash test vectors match the Psyop spec; rank-merge produces the
+      top-N weights sorted descending.
+- [ ] `tests/scenes/cryptomatte_3_objects.py` renders without crashing
+      at 256×256, depth=6, 64 spp.
+- [ ] Output EXR opens in Blender's compositor; the Cryptomatte node
+      lists `cube_red`, `cube_green`, `cube_blue` (CryptoObject) and
+      `mat_red`, `mat_green`, `mat_blue` (CryptoMaterial) in its
+      object picker.
+- [ ] For each of the 6 names, the compositor-reconstructed mask has
+      IoU ≥ 0.95 vs a single-object ground-truth render at the same
+      camera and spp.
+- [ ] EXR header contains valid `cryptomatte/<hash7>/{name,hash,
+      conversion,manifest}` entries per Psyop spec §3.
+- [ ] Manifest JSON parses; every name in the manifest matches the
+      MurmurHash3 of itself (round-trip integrity).
+- [ ] All existing tests still pass; no regression in `albedo_aov`,
+      `motion_vector_aov`, `normal_aov`, or the OIDN/OptiX denoisers.
+- [ ] Blender addon shows `Cryptomatte Object` / `Cryptomatte Material`
+      checkboxes under View Layer → Passes; toggling them adds/removes
+      the passes from `RenderResult.layers[0].passes`.
+
+---
+
+## Non-goals
+
+- Do not add `CryptoAsset` in this package. Asset/collection metadata
+  propagation is a separate follow-up (`pkg87b-cryptoasset.md`).
+- Do not change the existing `Pass` plugin interface
+  (`include/astroray/pass.h`). Cryptomatte fits the existing one-pass-
+  reads-named-buffer pattern.
+- Do not add light-group AOVs. That is pkg88 (Round 8 follow-up).
+- Do not implement motion-blur-aware Cryptomatte. Cycles disables
+  Cryptomatte when motion blur is on; we will when motion blur ships.
+- Do not pre-engineer the EXR writer for general AOV output. Scope it
+  to Cryptomatte's needs; let future packages widen it.
+- Do not optimise the hash propagation with bit-packing or per-prim
+  hash dedup tables. The 8-byte-per-primitive cost is acceptable.
+
+---
+
+## Progress
+
+- [ ] Phase 1: MurmurHash3 port + `crypto_insert` rank-merge +
+      Phase 1 tests.
+- [ ] Phase 1: research notes saved to
+      `.astroray_plan/docs/cryptomatte-research.md`.
+- [ ] Phase 1: `objectHash`/`materialHash` plumbed into `GTriangle` /
+      `GSphere` and populated at scene upload.
+- [ ] Phase 2: `src/io/exr_writer.cpp` lands with OpenEXR linked.
+- [ ] Phase 2: `crypto_object` / `crypto_material` framebuffer buffers
+      registered and written from the integrator.
+- [ ] Phase 2: `plugins/passes/cryptomatte_pass.cpp` plugin renders
+      EXR with manifest header.
+- [ ] Phase 2: `Renderer.get_cryptomatte_buffer` / `write_cryptomatte_exr`
+      Python bindings.
+- [ ] Phase 3: Blender addon registers `CryptoObject00/01/02` and
+      `CryptoMaterial00/01/02` passes; manifest metadata embedded in
+      render result.
+- [ ] Phase 3: `tests/scenes/cryptomatte_3_objects.py` + matching
+      ground-truth render harness.
+- [ ] Phase 3: IoU ≥ 0.95 verified for all 6 names.
+- [ ] STATUS.md updated; PR opened.


### PR DESCRIPTION
Files the pkg87 Cryptomatte package per the architect's Round 8 strategy assessment (`.astroray_plan/docs/round8-strategy-pass.md` §3, PR #263). Cryptomatte is one of the two highest-leverage Cycles-parity wins not gated by pkg55-B; this spec scopes a 2–3 week implementation.

## Fork-points resolved

1. **Default depth = 6 ranks** (3 EXR layers × 2 quadruples). Matches Cycles `u_cryptomatte_depth = 6` and the Psyop spec default. Exposed as a 2/4/6/8/16 enum on the addon. Memory at 1080p × depth 6 × 2 typenames ≈ 191 MB — acceptable.
2. **v1 typenames = CryptoObject + CryptoMaterial only.** CryptoAsset needs asset/collection metadata propagation through pkg76 → renderer; filed as a `pkg87b-cryptoasset.md` follow-up. The high-value object + material pair lands first.
3. **EXR multi-channel write lands inside pkg87's scope.** A grep of `plugins/` shows no existing EXR writer (today: single-channel PNG only). We add a minimal `src/io/exr_writer.cpp` (`Imf::OutputFile` + multi-channel float32 + header strings) scoped to Cryptomatte's needs. OpenEXR is BSD-3, compatible.
4. **Hash propagation: `uint32_t objectHash` + `materialHash` on `GTriangle` / `GSphere` directly.** Currently 56 B → 64 B with the fields added; that is cache-line aligned, not more expensive. Per-object lookup-table indirection considered and rejected (extra gmem fetch per shade; we'd need per-prim storage anyway).
5. **MurmurHash3 from smhasher** (Austin Appleby, public domain). Direct port, ~50 LOC, cited at the top of the header. No license entanglement.
6. **Weight model = `average(throughput · bsdf_eval)`,** normalised per pixel before EXR write. Mirrors Cycles `kernel/film/cryptomatte_passes.h` exactly. The Psyop compositor node requires the normalised sum.
7. **Acceptance: IoU ≥ 0.95** on a 3-object / 3-material test scene (`tests/scenes/cryptomatte_3_objects.py`) vs single-object ground-truth renders. Psyop spec §6 roundtrip method. Below Cycles' internal 0.97 bar to leave headroom for low-spp stochasticity.

## References

- Psyop Cryptomatte specification (BSD-3) — github.com/Psyop/Cryptomatte
- Cycles `intern/cycles/kernel/film/cryptomatte_passes.h` + `integrator/pass.cpp` + `scene/film.cpp` (Apache-2.0)
- smhasher `MurmurHash3.cpp` (Austin Appleby, public domain)

All licenses compatible.

## Status

Docs-only. Do not merge until owner reviews the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)