### PR TITLE
docs(pkg55-B): Phase B' (restart) spec amendment + session 1 summary

### DIFF
--- a/.astroray_plan/docs/pkg55-B-restart-session1-summary.md
+++ b/.astroray_plan/docs/pkg55-B-restart-session1-summary.md
@@ -1,0 +1,195 @@
+# pkg55 Phase B' — Restart Session 1 Summary
+
+**Date:** 2026-05-14
+**Branch:** `pkg55-B-restart`
+**Output:** spec amendment only — no code.
+
+---
+
+## Why this session pivoted from implementation to spec amendment
+
+The restart scope that the previous 8 sessions of fork-resolution had been
+dispatching against lived only in dispatch briefs and the architect's
+strategy doc. It was NOT in the on-disk `pkg55-wavefront-soa-refactor.md`
+spec. Per `CLAUDE.md` §2 (simplicity first) and §3 (surgical changes), the
+spec is authoritative; everything else is supporting material.
+
+Continuing to resolve ambiguities against a non-authoritative source was
+silently widening scope across multiple sessions. The productive output
+from Session 1 is therefore to capture all of the work done across those
+sessions into authoritative spec language, so the next implementer works
+from the spec — not from a chain of dispatch briefs whose decisions only
+exist in chat history.
+
+The pivot was: **stop implementing, write down what we already decided.**
+
+---
+
+## The 8 ambiguities that surfaced and their resolutions
+
+Each resolution is now authoritative spec text under Phase B' §"Design
+decisions" in `.astroray_plan/packages/pkg55-wavefront-soa-refactor.md`.
+The short form, with rationale:
+
+### §1 — Spectral oracle, not RGB
+
+**Question.** Should the CPU reference oracle and CPU wavefront carry
+spectral state (`SampledWavelengths`, `SampledSpectrum`) end-to-end, or
+should we build an RGB-only oracle first and add spectral later?
+
+**Resolution.** Spectral end-to-end. RGB only at the final
+XYZ→sRGB conversion.
+
+**Rationale.** The eventual GPU wavefront is spectral (matching production
+`SpectralPathTracer`). An RGB-only oracle would require a wholesale
+transcription pass when adding spectral, which is exactly the kind of
+"oracle drift" Phase B' is designed to avoid. Better to pay the spectral
+cost on day one and have the oracle stay structurally aligned with the
+production target.
+
+### §2 — Per-path RNG keying for wavefront; tile-shared for production
+
+**Question.** What RNG scheme does the CPU wavefront use? Match
+production's tile-shared `mt19937(baseSeed + tileIdx)`, or match Phase
+A.1's GPU per-path `mt19937(hash(pixel, sample, 0))`?
+
+**Resolution.** The wavefront side uses per-path keying. The production
+side keeps tile-shared. The two are byte-incompatible but statistically
+equivalent.
+
+**Rationale.** The wavefront pipeline must match what Phase A.1 already
+established on the GPU — per-path keying is mandatory there because there
+are no "tiles" in the wavefront sense. Forcing the production CPU path
+tracer to also adopt per-path keying would change production output and
+break unrelated SSIM gates. So we accept the two schemes and validate
+their statistical equivalence (see §3).
+
+### §3 — Two reference PTs (Option Z), not one
+
+**Question.** One reference PT, or two? If one, which RNG scheme?
+
+**Resolution.** Two. `reference_pt_production` uses tile-shared RNG
+(matches production); `reference_pt_wavefront` uses per-path RNG (matches
+wavefront). A trip-wire test asserts `reference_pt_production` ==
+production at the byte level. An equivalence test asserts SSIM ≥ 0.99
+between the two oracles at 64 spp.
+
+**Rationale.** A single oracle can't simultaneously be byte-equal to
+production (which needs tile-RNG) and byte-equal to the wavefront (which
+needs per-path RNG). Two oracles, one for each comparison, is the only
+way to get both bit-exact gates.
+
+### §4 — Scoped oracles (Option C), not full-surface transcription
+
+**Question.** Do the reference PTs cover the full production feature
+surface from day one (Disney, dielectric, SMS, GR, spectral upsampling
+etc.), or only what the current CPU wavefront actually supports?
+
+**Resolution.** Scoped. Session 2 reference PTs cover lambertian +
+area lights + Cornell only. The oracles grow alongside the wavefront,
+session by session.
+
+**Rationale.** A full-surface oracle would trip on noise from features
+the wavefront doesn't yet implement, defeating the diff harness's
+purpose. And building a 100% transcription of pkg64 SMS / pkg67 GR /
+pkg54c spectral upsampling / Disney / dielectric on day one is the kind
+of scope explosion that killed the original Phase B.
+
+### §5 — Callable driver, not a registered plugin (yet)
+
+**Question.** Should the CPU wavefront be exposed as a registered
+integrator plugin (`wavefront_path_tracer`) from Session 2, or as a
+callable driver behind a pybind11 entry point?
+
+**Resolution.** Callable driver. Plugin registration is deferred to the
+final phase of B'.
+
+**Rationale.** Plugin registration brings Blender-dropdown wiring,
+`integrator_capabilities` flags, and dropdown-state migration concerns
+into every session. None of that helps the per-stage diff work. Keep the
+surface tight; register the plugin once it actually works.
+
+### §6 — Reference PT is a separate file (Option C2), not hooks on production
+
+**Question.** Add instrumentation hooks to production
+`Renderer::pathTraceSpectral` so that the same code can be run as oracle,
+or write a separate transcription file?
+
+**Resolution.** Separate file. Production is untouched.
+
+**Rationale.** Instrumentation hooks bloat production with diff-harness
+state and risk perturbing production output. A separate file with a
+trip-wire that asserts bit-equality is cleaner: production stays clean,
+drift is detected by the test rather than by branching in production
+code.
+
+### §7 — Snapshot data structures
+
+**Question.** How does the diff harness compare wavefront vs reference
+PT? At the pixel level (final image), at the path level (final
+radiance), or at each stage boundary?
+
+**Resolution.** Stage-boundary snapshots. Both reference PTs emit
+`WavefrontSnapshot` records at each stage boundary (post-init,
+post-intersect, post-shade, post-light-sample, post-RR). The diff
+harness compares snapshots element-by-element to localize divergence.
+
+**Rationale.** Final-pixel comparison localizes the bug to "somewhere in
+the pipeline" — useless when the original Phase B had three cascading
+bugs at different stages. Stage-boundary snapshots tell you "the bug is
+in stage_shade_lambertian, slot 47, field path_throughput, after sample
+2" — actionable.
+
+### §8 — Growing-oracle lifecycle
+
+**Question.** Once we have the lambertian-Cornell oracle in Session 2,
+what happens to it in Session 3 (metal)? Does it stay frozen, get
+deleted, or grow?
+
+**Resolution.** Growing oracle. Reference PTs grow incrementally as the
+CPU wavefront adds materials. When the wavefront adds metal, the
+reference PTs add metal in the same PR. The oracles never lead the
+wavefront and never lag it.
+
+**Rationale.** "Frozen oracle" forces every new material to invent its
+own diff strategy. "Deleted oracle" loses the per-stage gate the moment
+we move past lambertian. "Growing oracle" keeps the gate alive forever
+with O(material) effort per session, which is the same effort we'd spend
+anyway on the wavefront side.
+
+---
+
+## Next-session pickup instructions
+
+The next implementer (Session 2) should:
+
+1. **Read the amended spec, not these dispatch briefs.** The
+   authoritative scope lives in
+   `.astroray_plan/packages/pkg55-wavefront-soa-refactor.md`, Phase B'
+   subsection. The 8 design decisions there are authoritative — do not
+   re-litigate them.
+2. **Write the design doc first** at
+   `.astroray_plan/docs/pkg55-B-cpu-reference-design.md`, expanding the
+   8 decisions into code-level detail (field layouts, function
+   signatures, snapshot record format).
+3. **Implement Session 2 deliverables** as listed in the spec's
+   Phase B' staged plan §2. The close gate is bit-identity of CPU
+   wavefront vs `reference_pt_wavefront` on Lambertian-only Cornell at
+   1 spp.
+4. **Do not touch** the AoS megakernel or `origin/pkg55-phase-b`.
+   Phase B's branch is held, not deleted; the historical work stays
+   reachable.
+5. **Do not widen scope.** If something feels under-specified, stop and
+   ask — do not silently extend. The 8 forks above are what 8 sessions
+   of silent scope-widening cost; don't add a 9th.
+
+---
+
+## Deliverables (this session)
+
+- Spec amendment landed in
+  `.astroray_plan/packages/pkg55-wavefront-soa-refactor.md` (Phase B
+  status note + new Phase B' subsection inserted between Phase B and
+  Phase C; acceptance summary table updated to include B').
+- This summary doc.
+- PR opened against `main` (do not merge — owner reviews).

--- a/.astroray_plan/packages/pkg55-wavefront-soa-refactor.md
+++ b/.astroray_plan/packages/pkg55-wavefront-soa-refactor.md
@@ -197,6 +197,8 @@ Notes: (a) the off↔on delta is within run-to-run noise; the small gap on `corn
 
 ### Phase B — Shade queue + material dispatch + wavefront pixel output
 
+> **Status note (2026-05-14):** Phase B attempted on `origin/pkg55-phase-b` 2026-05-13 → 2026-05-14; reached PR #257 with cascading radiance bugs (`path_alive` ✓, material guards ✓, sample accumulation REGRESSED 2.5× → 21× brightness vs megakernel). Held pending **Phase B' (below)** per architect Round 8 strategy (PR #263). The Phase B section below is retained as historical record of the attempted approach + lessons; the authoritative execution plan for the wavefront rebuild lives in Phase B'.
+
 **Estimated effort:** 4 weeks
 
 **Goal:** Wire all six stages. The wavefront integrator produces its own framebuffer output and is exposed as `wavefront_path_tracer`. Compare SSIM against the megakernel and against the CPU `path_tracer`.
@@ -247,6 +249,60 @@ Notes: (a) the off↔on delta is within run-to-run noise; the small gap on `corn
 
 ---
 
+### Phase B' — Restart (CPU-first methodical rebuild)
+
+**Status:** open (authoritative; supersedes the Phase B execution plan above as of 2026-05-14).
+**Estimated effort:** rolling, scoped per session.
+
+**Goal:** Restart Phase B methodically using a **CPU wavefront reference oracle**, building the per-stage diff harness that the original Phase B lacked. Mirror Cycles' kernel order, do bit-exact stage-by-stage parity on CPU first, then port to CUDA. The architecture goal is unchanged from Phase B; the **execution methodology** is the change. Phase B's deliverables (7 shade kernels, shadow/miss/terminate, sort-by-material, `wavefront_path_tracer` plugin, SSIM gates, 1.5× perf gate, viewport-parity gate) all close out under Phase B'.
+
+#### Phase B' staged plan
+
+1. **Session 1 — scope amendment (this session).** Capture 8 resolved design decisions into the spec. No code. Deliverable: this subsection + `.astroray_plan/docs/pkg55-B-restart-session1-summary.md`.
+2. **Session 2 — Lambertian-Cornell foundation.**
+   - Design doc at `.astroray_plan/docs/pkg55-B-cpu-reference-design.md` recording all 8 design decisions in code-level detail.
+   - Two reference path tracers:
+     - `src/cpu/wavefront/reference_pt_production.cpp` — tile-shared RNG; mirrors production CPU `Renderer::pathTraceSpectral` bit-for-bit.
+     - `src/cpu/wavefront/reference_pt_wavefront.cpp` — per-path RNG keyed `hash(pixel_index, sample_index, 0)`, matching the Phase A.1 GPU convention.
+     - Both scoped to lambertian-Cornell only.
+   - Trip-wire test `tests/test_pkg55_reference_pt_production_parity.py` — bit-exact equality of `reference_pt_production` vs production `pathTraceSpectral` at fixed seed, 1 spp.
+   - Equivalence test `tests/test_pkg55_reference_pt_oracles_equivalent.py` — SSIM ≥ 0.99 at 64 spp between the two oracles (validates RNG-scheme interchangeability).
+   - Test scene `tests/scenes/lambertian_cornell.py` if it doesn't exist.
+   - CPU wavefront skeleton at `src/cpu/wavefront/`: state header, `stage_init`, `stage_intersect`, `stage_shade_lambertian`, callable driver (not yet a registered plugin).
+   - Per-stage diff harness at `tests/wavefront_diff/` — runs `reference_pt_wavefront` and the CPU wavefront in lockstep, reports the first per-stage mismatch by slot and field.
+   - **Close gate:** bit-identity of CPU wavefront vs `reference_pt_wavefront` on Lambertian-only Cornell at 1 spp.
+3. **Sessions 3..N — Growing-oracle expansion.** As each new shade kernel (metal, dielectric, disney, thin_glass, diffuse_light, closure_graph) is added to the CPU wavefront, both reference PTs grow alongside to cover the same feature surface. Trip-wire test scene grows; equivalence test scene grows. The reference PTs are "growing oracles" — they always match the current CPU wavefront feature surface; never lead, never lag.
+4. **Session N+1 — Shadow/miss/terminate stages on CPU.** Once all seven material types pass per-stage diff, add the remaining stages.
+5. **Sessions N+2..M — CUDA port stage-by-stage.** For each CPU stage, write the CUDA mirror; run a CPU↔GPU per-stage diff harness (mirrors the CPU↔CPU one). Bit-identity gates each port.
+6. **Plugin registration (final phase of B').** After the full CUDA wavefront passes all gates, register `wavefront_path_tracer` plugin and wire `multiwavelength_path_tracer::renderGPU()` to it behind `use_wavefront` (matches the original Phase B deliverable in §"Files to modify" above).
+
+#### Phase B' design decisions (authoritative — 8 resolved forks)
+
+1. **Spectral oracle, not RGB.** Both reference PTs and the CPU wavefront carry `SampledWavelengths` and `SampledSpectrum` end-to-end, matching production `SpectralPathTracer`. RGB only at final XYZ→sRGB conversion. *Rationale:* the eventual GPU wavefront is spectral; building an RGB-only oracle wastes a transcription pass later.
+2. **Per-path RNG keying for the wavefront side; tile-shared for the production side.** CPU wavefront and `reference_pt_wavefront` use `mt19937(hash(pixel_index, sample_index, 0))` per slot — same scheme Phase A.1 used on GPU. Production CPU `pathTraceSpectral` uses tile-shared `mt19937(baseSeed + tileIdx)`. The two are byte-incompatible but statistically equivalent.
+3. **Two reference PTs (Option Z), not one.** `reference_pt_production` mirrors production tile-RNG and is a trip-wire for production drift (bit-exact gate). `reference_pt_wavefront` mirrors the GPU-shaped per-path RNG and is the wavefront's diff oracle. An equivalence test asserts the two RNG schemes produce statistically equivalent renders (SSIM ≥ 0.99 at 64 spp).
+4. **Scoped oracles (Option C), not full-surface transcription.** Both reference PTs cover ONLY what the current CPU wavefront supports. Session 2 = lambertian + area lights + Cornell-only. Reference PTs grow alongside the wavefront, session by session. Avoids the trip-wire firing on noise (unrelated material/light changes) and avoids over-scoped transcription of pkg64 SMS / pkg67 GR / pkg54c spectral / Disney / dielectric code paths.
+5. **Callable driver, not a registered plugin (yet).** CPU wavefront exposed via a pybind11 entry point and a direct C++ test executable. Plugin registration happens in the final phase of B' once everything works. Avoids premature Blender-dropdown wiring.
+6. **Reference PT is a separate file (Option C2), not instrumentation hooks on production.** Production `Renderer::pathTraceSpectral` is not touched. The reference PTs are independent transcriptions. The trip-wire test detects drift via bit-comparison.
+7. **Snapshot data structures.** Both reference PTs emit `WavefrontSnapshot` records at each stage boundary (post-init, post-intersect, post-shade, post-light-sample, post-RR). The diff harness compares snapshots element-by-element to localize divergence.
+8. **Growing-oracle lifecycle.** The two reference PTs grow incrementally as the CPU wavefront adds support for more materials/features. They are "specifications by code" of the current wavefront feature surface — they never lead and never lag. When the wavefront adds metal, the reference PTs add metal in the same PR.
+
+#### Phase B' acceptance gates (per session)
+
+- **Session 2:** trip-wire test passes (max abs diff = 0); equivalence test passes (SSIM ≥ 0.99); CPU wavefront bit-identical to `reference_pt_wavefront` on Lambertian-Cornell at 1 spp.
+- **Sessions 3..N:** trip-wire + equivalence + bit-identity gates pass for each new material/feature.
+- **Session N+1:** stages all wired end-to-end; CPU wavefront SSIM ≥ 0.985 vs CPU `path_tracer` on the full pkg54 visible-band scene at 64 spp.
+- **Sessions N+2..M (CUDA port):** CPU↔GPU per-stage diff gates pass; final perf gate from the original Phase B (≥ 1.5× megakernel on the 7-material scene) closes the package.
+
+#### Phase B' non-goals
+
+- Don't touch the AoS megakernel or `origin/pkg55-phase-b`.
+- Don't widen scope beyond the staged plan in any single session.
+- Don't re-implement pkg64 SMS, pkg67 redshift, or pkg82 thresholds — those are at integrator surface.
+- No CUDA in Session 2 (CPU foundation only).
+
+---
+
 ### Phase C — MIS/NEE parity + megakernel removal
 
 **Estimated effort:** 3 weeks
@@ -294,7 +350,8 @@ Notes: (a) the off↔on delta is within run-to-run noise; the small gap on `corn
 |---|---|---|
 | A.0 | Megakernel baseline JSON + occupancy cliff documented | done (PR #238) |
 | A.1 | Intersect parity test bit-exact; megakernel output unchanged; SoA reg pressure < 158 cliff | **done — 0/576 mismatches; 40–56 regs/thread vs 158** |
-| B | Wavefront SSIM ≥ 0.985 (visible) / ≥ 0.97 (NIR); ≥ 1.5× speedup on 7-material scene | open |
+| B | Wavefront SSIM ≥ 0.985 (visible) / ≥ 0.97 (NIR); ≥ 1.5× speedup on 7-material scene | held — superseded by B' execution plan (2026-05-14) |
+| B' | CPU reference-oracle bit-identity, per-stage diff harness, CPU-first then CUDA port; closes B's gates | open (Session 1 — spec amendment — done; Session 2 next) |
 | C | All pkg54 SSIM gates pass with megakernel deleted; ≥ 2× speedup on 7-material scene | open |
 
 ---


### PR DESCRIPTION
## Summary

This PR is **docs-only**. It captures the work of the pkg55-B restart Session 1 — 8 design decisions resolved across the session — into authoritative spec language, instead of leaving them in dispatch briefs and chat history.

No code changes. The next implementer (Session 2) works from the amended spec.

## Why docs-only this session

The restart scope I had been dispatching against lived only in dispatch briefs and the architect's strategy doc. It was NOT in the on-disk pkg55 spec. Per CLAUDE.md the spec is authoritative; continuing to resolve ambiguities against a non-authoritative source was silently widening scope across 8 sessions. The productive output from Session 1 is therefore to capture the work into the spec itself.

## What changed

1. `.astroray_plan/packages/pkg55-wavefront-soa-refactor.md`:
   - Added a status note at the top of Phase B explaining the held attempt (PR #257, cascading radiance bugs).
   - Inserted a new **Phase B' — Restart (CPU-first methodical rebuild)** subsection between Phase B and Phase C. Contains: staged plan (Sessions 1..M), 8 authoritative design decisions, per-session acceptance gates, non-goals.
   - Updated the acceptance summary table to include a B' row.
2. `.astroray_plan/docs/pkg55-B-restart-session1-summary.md` (new):
   - Why the session pivoted from implementation to spec amendment.
   - The 8 ambiguities + their resolutions, each with rationale.
   - Next-session pickup instructions.

## The 8 design decisions (now authoritative)

1. **Spectral oracle, not RGB** — `SampledWavelengths` + `SampledSpectrum` end-to-end.
2. **Per-path RNG keying for wavefront; tile-shared for production** — byte-incompatible, statistically equivalent.
3. **Two reference PTs (Option Z)** — `reference_pt_production` (trip-wire) + `reference_pt_wavefront` (diff oracle).
4. **Scoped oracles (Option C)** — grow alongside the wavefront; Session 2 = Lambertian-Cornell only.
5. **Callable driver, not a registered plugin (yet)** — plugin registration is the final phase of B'.
6. **Separate reference PT file (Option C2)** — production `pathTraceSpectral` untouched.
7. **`WavefrontSnapshot` at each stage boundary** — diff harness localizes divergence by slot/field.
8. **Growing-oracle lifecycle** — reference PTs add features in the same PR as the wavefront; never lead, never lag.

## Phase B' close gates (per session)

- Session 2: trip-wire (max abs diff = 0); equivalence (SSIM ≥ 0.99); CPU wavefront bit-identical to `reference_pt_wavefront` on Lambertian-Cornell at 1 spp.
- Sessions 3..N: same gates per new material/feature.
- Session N+1: end-to-end CPU wavefront SSIM ≥ 0.985 vs CPU `path_tracer` on the pkg54 visible-band scene at 64 spp.
- Sessions N+2..M (CUDA port): CPU↔GPU per-stage diff; ≥ 1.5× megakernel on the 7-material scene closes the package.

## Do not merge

Owner reviews. The `pr-reviewer` agent handles merge.

---
Generated with [Claude Code](https://claude.com/claude-code)