### PR TITLE
fix(pkg85): clear latent CUDA error + force GC between tests

### DIFF
--- a/src/gpu/cuda_renderer.cu
+++ b/src/gpu/cuda_renderer.cu
@@ -124,14 +124,28 @@ struct CUDARenderer::Impl {
         int count = 0;
         cudaError_t err = cudaGetDeviceCount(&count);
         if (err == cudaSuccess && count > 0) {
-            available = true;
             cudaDeviceProp prop;
-            cudaGetDeviceProperties(&prop, 0);
-            devName = prop.name;
+            err = cudaGetDeviceProperties(&prop, 0);
+            if (err == cudaSuccess) {
+                available = true;
+                devName = prop.name;
+            }
         }
+        // pkg85: Clear any latent error from cudaGetDeviceCount or
+        // cudaGetDeviceProperties so it doesn't contaminate future CUDA
+        // calls in other tests/renderers. Must be called unconditionally
+        // because even if we return early, a prior CUDA call may have left
+        // an error.
+        cudaGetLastError();
     }
 
-    ~Impl() { freeAll(); }
+    ~Impl() {
+        freeAll();
+        // pkg85: Clear any latent error from cleanup so it doesn't contaminate
+        // future CUDA calls. The destructor is noexcept so we can't throw; we
+        // must clear the error to prevent it from propagating.
+        cudaGetLastError();
+    }
 
     void freeAll() {
         if (d_bvhNodes)   { cudaFree(d_bvhNodes);   d_bvhNodes   = nullptr; }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,3 +54,49 @@ def standalone_executable():
     if path:
         return path
     pytest.skip("raytracer executable not found")
+
+
+@pytest.fixture(autouse=True)
+def cuda_cleanup_and_error_check():
+    """pkg85: Force Python GC and check for latent CUDA errors after each test.
+
+    The root cause: Python's garbage collector doesn't run immediately after
+    a test function ends, so Renderer objects with GPU state (CUDARenderer)
+    can accumulate across tests. Explicit gc.collect() forces cleanup.
+
+    When a CUDA operation fails but the error isn't checked immediately,
+    the error persists and contaminates the next CUDA call. This fixture
+    first forces GC to clean up all pending renderers, then synchronizes
+    the device and checks for latent errors.
+    """
+    yield  # Let the test run
+
+    import gc
+    gc.collect()  # pkg85: Force cleanup of any Renderer objects left by the test
+
+    try:
+        import astroray
+        # Only check if astroray module loaded successfully
+        try:
+            renderer = astroray.Renderer()
+            if renderer.gpu_available:
+                # Import ctypes to call CUDA runtime directly
+                import ctypes
+                try:
+                    # Try to load CUDA runtime DLL
+                    cuda = ctypes.CDLL("cudart64_12.dll") if sys.platform == "win32" else ctypes.CDLL("libcudart.so")
+                    # cudaDeviceSynchronize() and cudaGetLastError()
+                    sync_err = cuda.cudaDeviceSynchronize()
+                    last_err = cuda.cudaGetLastError()
+                    if sync_err != 0 or last_err != 0:
+                        # Get error string
+                        cuda.cudaGetErrorString.restype = ctypes.c_char_p
+                        sync_msg = cuda.cudaGetErrorString(sync_err).decode() if sync_err != 0 else ""
+                        last_msg = cuda.cudaGetErrorString(last_err).decode() if last_err != 0 else ""
+                        pytest.fail(f"[pkg85-diag] Latent CUDA error after test: sync={sync_err} ({sync_msg}), last={last_err} ({last_msg})")  # remove after fix
+                except (OSError, AttributeError):
+                    pass  # CUDA runtime not available, skip check
+        except Exception:
+            pass  # Renderer construction failed, skip check
+    except ImportError:
+        pass  # astroray not available, skip check


### PR DESCRIPTION
Partial fix for the test-harness CUDA state leak surfaced by the pkg67 verifier session: full pytest sweep crashed at a CUDA-heavy test (cudaMalloc at `src/gpu/cuda_renderer.cu:81` with `RuntimeError: an illegal memory access was encountered`), while the same test in isolation passed cleanly.

## Status

**⚠️ Acceptance gate NOT met.** The pkg85 spec requires the full pytest sweep to complete without CUDA illegal-access crash. This PR improves robustness but does not fully resolve the crash — see the bisect agent's findings below.

## What this PR does

1. **`tests/conftest.py`** — new autouse fixture forcing `gc.collect()` between tests so test-scoped objects holding device memory release promptly.
2. **`src/gpu/cuda_renderer.cu`** — `cudaGetLastError()` calls at CUDARenderer constructor + destructor to clear errors from probe operations (`cudaGetDeviceCount`, `cudaGetDeviceProperties`) and cleanup paths. Prevents probe-style instantiation (used by `gpu_available`) from leaving latent errors.

## What this PR does NOT fix

The fundamental issue is broader: somewhere in the test suite, an unchecked CUDA call leaves error state that propagates through subsequent tests. The bisect narrowed the dominant leaker to test #9 (`test_gpu_flag_runs_without_cuda`), but the full audit of CUDA API call sites (ensuring every call is wrapped in `CUDA_CHECK()` or followed by an explicit `cudaGetLastError()`) exceeds pkg85's ½-day estimate.

## Recommendation

Merge as a robustness improvement only. File a pkg85 follow-up (or expand pkg85 spec) for the full CUDA-call audit — that's a multi-day pass that should not block other work.

Spec: `.astroray_plan/packages/pkg85-test-harness-cuda-state-leak.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)