### PR TITLE
feat(pkg55-B'): Phase B' Session 2a — foundation (design + scene + snapshot header + CMake scaffolding)

### DIFF
--- a/.astroray_plan/docs/pkg55-B-cpu-reference-design.md
+++ b/.astroray_plan/docs/pkg55-B-cpu-reference-design.md
@@ -1,0 +1,336 @@
+# pkg55 Phase B' — CPU Reference Oracle Design (Session 2)
+
+**Status:** authoritative for Session 2.
+**Spec:** `.astroray_plan/packages/pkg55-wavefront-soa-refactor.md` §"Phase B' — Restart".
+**Branch:** `pkg55-B-restart`.
+
+This document records all 8 Phase B' design decisions in code-level detail
+(file paths, function signatures, RNG draw orders, SoA field lists), plus
+the snapshot schema and the growing-oracle lifecycle. It is the engineering
+playbook for Session 2. Sessions 3..N extend the same scaffolding.
+
+---
+
+## 1. Spectral oracle, not RGB (decision §1)
+
+The reference path tracers and the CPU wavefront carry `astroray::SampledWavelengths`
+and `astroray::SampledSpectrum` end-to-end. RGB only at final XYZ→sRGB conversion in
+the test harness.
+
+**Carrier types:**
+- Wavelength bundle: `astroray::SampledWavelengths` (4 samples per path,
+  `kSpectrumSamples = 4`).
+- Radiance / throughput: `astroray::SampledSpectrum` (4 floats).
+- Per-pixel output: XYZ tristimulus (`astroray::XYZ`), converted by the caller.
+
+**Lambda sampling.** Stratified hero-λ over the visible band, draw a single uniform
+`u01(gen)` and pass to `SampledWavelengths::sampleUniform(u01)`. This matches the
+production `SpectralPathTracer::sampleFull` consumption pattern exactly (see
+`plugins/integrators/spectral_path_tracer.cpp:107-108`).
+
+---
+
+## 2. RNG keying — two schemes (decisions §2, §3)
+
+Two independent RNG schemes coexist:
+
+### Production-side: tile-shared
+
+`reference_pt_production` mirrors the tile loop in
+`include/raytracer.h:2460-2570`:
+
+```cpp
+uint32_t baseSeed = renderer.getRenderSeed();  // 0 -> random_device
+std::mt19937 gen(baseSeed + static_cast<uint32_t>(tileIdx));
+```
+
+Per pixel, per sample, RNG draws in this exact order:
+1. `filterSample(gen, dist)`  — 2 draws (default `pixelFilterType=0`, box).
+2. `filterSample(gen, dist)`  — 2 more, for v jitter.
+3. `cam.getRay(u, v, gen)` — `Vec3::randomInUnitDisk(gen)` (rejection-sampled,
+   so variable count; consumes at least 2 draws per accepted sample).
+4. `dist01(gen)` — 1 draw for λ stratification, fed to `SampledWavelengths::sampleUniform`.
+5. Inside `pathTraceSpectral`: draws for NEE light sampling, BSDF sampling, RR,
+   etc. — whatever production consumes.
+
+Steps 1-4 reproduce the integrator-frontend RNG consumption that happens
+before `pathTraceSpectral` runs. Step 5 is reproduced by independent transcription
+inside `reference_pt_production.cpp` per decision §6 — production
+`Renderer::pathTraceSpectral` is not touched and is not called from the reference.
+
+**Why this is bit-exact:** all per-pixel state is reduced from `gen`. As long as
+we (a) iterate tiles in the same row-major order and (b) consume RNG draws in
+the same order, the per-pixel output is bit-identical.
+
+**Threading.** Production uses `#pragma omp parallel for collapse(2)`. Tiles
+are independent (per-tile `gen`), so we can run the reference single-threaded
+in the same row-major tile order and still hit bit-identity. We will use
+single-threaded execution to keep the trip-wire deterministic in CI.
+
+### Wavefront-side: per-path
+
+`reference_pt_wavefront` and the CPU wavefront use:
+
+```cpp
+std::mt19937 gen(hash(pixel_index, sample_index, 0));
+```
+
+where `hash` is FNV-1a-32 over the three `uint32` inputs. The `0` is the
+RNG-offset reserved for the integrator-frontend draws (filter, lens, λ); future
+sessions may introduce additional offsets per Cycles' `rng_pixel + rng_offset`
+convention (`intern/cycles/kernel/random.h`).
+
+**Consumption order matches production:** filter (u), filter (v), `randomInUnitDisk`,
+λ-u01, then the path-trace loop's draws. The schemes differ only in *seeding*;
+the draw order within a sample is identical so that the equivalence test
+(`SSIM ≥ 0.99 at 64 spp`) can hold.
+
+---
+
+## 3. Two reference PTs (decision §3)
+
+| File | Seeding | Purpose | Test |
+|------|---------|---------|------|
+| `src/cpu/wavefront/reference_pt_production.{h,cpp}` | tile-shared | Trip-wire against production drift | bit-exact RGB equality at 1 spp |
+| `src/cpu/wavefront/reference_pt_wavefront.{h,cpp}` | per-path | Diff oracle for the CPU wavefront | element-by-element SoA equality at 1 spp |
+
+Both expose a callable C++ entry point + a pybind11 binding under names
+`reference_pt_production_render` and `reference_pt_wavefront_render`.
+
+**Signature (both):**
+
+```cpp
+struct ReferencePTRender {
+    std::vector<float> rgb;     // width*height*3
+    std::vector<WavefrontSnapshot> snapshots;  // optional, when enabled
+};
+ReferencePTRender render(
+    Renderer& renderer,
+    const Camera& cam,
+    int samples,
+    int max_depth,
+    uint64_t seed,
+    bool record_snapshots = false);
+```
+
+---
+
+## 4. Scoped oracle: Lambertian-Cornell only (decision §4)
+
+Session 2 feature surface:
+- Materials: `lambertian` (BSDF) and `light` / `diffuse_light` (emission only).
+- Geometry: triangles (no spheres in Cornell; spheres come in session 3).
+- Lights: area lights via NEE (the emissive triangle).
+- No env map. No GR objects. No SMS hook. No transparency. No volumes.
+
+If the scene contains any unsupported material, the reference PTs must assert
+and abort with a clear error rather than silently rendering wrong output. The
+trip-wire test scene (`tests/scenes/lambertian_cornell.py`) is the source of
+truth for what "in-scope" means in Session 2.
+
+Sessions 3..N grow this surface incrementally. The reference PTs gain new
+material branches in the same PR that adds the corresponding CPU wavefront
+shade kernel — never lead, never lag.
+
+---
+
+## 5. Callable driver, not a plugin (decision §5)
+
+The CPU wavefront is exposed via:
+
+```cpp
+// src/cpu/wavefront/cpu_wavefront_driver.h
+namespace astroray::cpu_wavefront {
+std::vector<float> render(
+    Renderer& renderer, const Camera& cam,
+    int samples, int max_depth, uint64_t seed,
+    SnapshotSink* sink = nullptr);  // optional snapshot hook
+}
+```
+
+and a pybind11 binding `cpu_wavefront_render`. No `Integrator` subclass, no
+`ASTRORAY_REGISTER_INTEGRATOR`, no Blender dropdown entry. Plugin registration
+happens in the final phase of B' once everything works (per spec §"Phase B'
+staged plan" item 6).
+
+---
+
+## 6. Reference PT independence (decision §6)
+
+`reference_pt_production` does NOT call `Renderer::pathTraceSpectral` directly
+inside the per-bounce loop — it transcribes the loop independently per spec §6
+("a separate file ... not instrumentation hooks on production"). The Session 1
+summary §6 is explicit on this:
+
+> Both reference PTs are independent transcriptions ... The trip-wire test
+> detects drift via bit-comparison.
+
+**Implication.** `reference_pt_production` must reproduce the production
+per-bounce loop's RNG consumption *exactly*. For Session 2's lambertian-only
+scope this is tractable: the only RNG draws inside `pathTraceSpectral` for a
+lambertian-Cornell scene are
+- `lights.sample(rec.point, gen)` (1+ draws — depends on lights count + light's `sample` impl),
+- `material->sampleSpectral(rec, wo, gen, lambdas)` (Lambertian: 2 draws for
+  cosine-weighted hemisphere, via `Vec3::randomInHemisphere` or equivalent),
+- `dist01(gen)` for RR (only when `bounce > rrDepth=3`).
+
+These are tracked in `reference_pt_production.cpp` against the production
+source in `include/raytracer.h:2055-2205`, with the spec citation in the file
+header and a side-by-side comment table inside the loop.
+
+---
+
+## 7. Snapshot schema (decision §7)
+
+`src/cpu/wavefront/wavefront_snapshot.h` defines:
+
+```cpp
+namespace astroray::cpu_wavefront {
+
+enum class SnapshotStage : uint8_t {
+    PostInit         = 0,  // primary ray generated, RNG seeded, lambda picked, throughput=1
+    PostIntersect    = 1,  // BVH hit record written (or miss flag)
+    PostShade        = 2,  // outgoing ray + updated throughput (after BSDF sample)
+    PostLightSample  = 3,  // NEE shadow ray + light radiance + MIS weight
+    PostRR           = 4,  // Russian roulette decision recorded
+};
+
+struct WavefrontSnapshot {
+    int pixel_index;
+    int sample_index;
+    int bounce;
+    SnapshotStage stage;
+
+    // Ray state (post-init / post-shade).
+    float ray_origin[3];
+    float ray_direction[3];
+
+    // Throughput + lambda bundle (always present).
+    float throughput[4];      // SampledSpectrum
+    float lambdas[4];         // SampledWavelengths
+
+    // Hit record (post-intersect onward).
+    int   hit_valid;          // 0 = miss
+    float hit_t;
+    float hit_point[3];
+    float hit_normal[3];
+    int   hit_material_id;    // -1 if no material
+
+    // Shade output (post-shade only).
+    float bsdf_pdf;
+    int   bsdf_is_delta;
+
+    // NEE (post-light-sample only).
+    float nee_contribution[4];   // weighted L * f for this sample (XYZ-mapped later)
+    float nee_light_pdf;
+    float nee_bsdf_pdf_at_dir;
+    float nee_mis_weight;
+
+    // RR (post-rr only).
+    float rr_prob;
+    int   rr_survived;
+};
+
+class SnapshotSink {
+public:
+    virtual ~SnapshotSink() = default;
+    virtual void record(const WavefrontSnapshot& s) = 0;
+};
+
+}  // namespace astroray::cpu_wavefront
+```
+
+The CPU wavefront and both reference PTs emit `WavefrontSnapshot` records at
+each stage boundary when a sink is attached. The diff harness compares
+snapshot streams produced by `reference_pt_wavefront` vs the CPU wavefront
+element-by-element. On first mismatch it reports
+`{stage, slot_index, field, expected, got}` clearly and exits.
+
+This is **the** instrument that lets us localize divergence to a single field
+at a single stage — without it, "the wavefront doesn't match" is unactionable.
+Cite: Cycles `intern/cycles/device/cuda/queue.cpp` paranoid-debug pattern
+(Apache-2.0) — kernel queues with debug builds dump per-launch state for
+the same reason.
+
+---
+
+## 8. Growing-oracle lifecycle (decision §8)
+
+Both reference PTs and the CPU wavefront grow together. The invariants:
+
+1. **Never lead, never lag.** When the CPU wavefront adds metal in session 3,
+   both reference PTs add metal in the same PR. Trip-wire test scene grows;
+   equivalence test scene grows.
+2. **Per-session scope discipline.** Every PR opens with: "this PR adds
+   support for X in {ref_prod, ref_wf, cpu_wf}, plus growth to the test
+   scenes." If any one of the three lags, the close-gate diff harness will
+   catch it (mismatch on the new field/material) — that *is* the gate.
+3. **Stage taxonomy is frozen at Session 2.** Five stages defined in §7. New
+   shading effects fit inside `PostShade` (they may add new sub-branches but
+   never new stages). Stages added in sessions N+1 (shadow / miss / terminate)
+   are appended to `SnapshotStage` enum values >= 5, never reordered.
+4. **Schema additivity.** New fields appended to `WavefrontSnapshot` only.
+   Never reordered, never renamed. Existing tests keep passing because the
+   diff harness reads named fields, not byte offsets. (This matches PBRT-v4's
+   `workitems.soa` discipline.)
+
+---
+
+## 9. Success criteria for Session 2
+
+Verbatim from spec §"Phase B' acceptance gates":
+
+> **Session 2:** trip-wire test passes (max abs diff = 0); equivalence test
+> passes (SSIM ≥ 0.99); CPU wavefront bit-identical to `reference_pt_wavefront`
+> on Lambertian-Cornell at 1 spp.
+
+Mapped to tests:
+- `tests/test_pkg55_reference_pt_production_parity.py` → trip-wire (`max_abs_diff == 0`).
+- `tests/test_pkg55_reference_pt_oracles_equivalent.py` → equivalence (`SSIM ≥ 0.99`).
+- `tests/wavefront_diff/test_cpu_wavefront_lambertian_bit_identity.py` → close gate.
+
+---
+
+## 10. File layout (Session 2)
+
+```
+src/cpu/wavefront/
+    wavefront_snapshot.h          # shared schema (§7)
+    reference_pt_production.h     # tile-shared RNG reference
+    reference_pt_production.cpp
+    reference_pt_wavefront.h      # per-path RNG reference
+    reference_pt_wavefront.cpp
+    cpu_wavefront_state.h         # SoA layout (mirrors A.1 IntegratorStateSoA)
+    cpu_wavefront_driver.cpp      # callable C++ entry point
+    stage_init.cpp                # primary ray generation per slot
+    stage_intersect.cpp           # BVH traversal per slot
+    stage_shade_lambertian.cpp    # Lambertian BSDF + NEE; material-gated
+
+tests/scenes/lambertian_cornell.py
+tests/test_pkg55_reference_pt_production_parity.py
+tests/test_pkg55_reference_pt_oracles_equivalent.py
+tests/wavefront_diff/
+    __init__.py
+    harness.py
+    test_cpu_wavefront_lambertian_bit_identity.py
+```
+
+CMakeLists.txt: add `src/cpu/wavefront/*.cpp` to the `astroray` pybind11 module
+(unconditional — pure C++, no CUDA, no toggle needed). Add pybind11 bindings
+in `module/blender_module.cpp` for the three callable entry points.
+
+---
+
+## 11. Cycles citations (CLAUDE.md §6)
+
+Apache-2.0. We cite, we do not paste.
+
+| Astroray file | Cycles file | What we mirror |
+|---|---|---|
+| `cpu_wavefront_state.h` | `intern/cycles/kernel/integrator/state.h` | SoA field names; per-stage state flags |
+| `stage_init.cpp` | `intern/cycles/kernel/integrator/init_from_camera.h` | Primary-ray generation per slot; RNG seeded by pixel + sample |
+| `stage_intersect.cpp` | `intern/cycles/kernel/integrator/intersect_closest.h` | Closest-hit pattern; write hit record to SoA |
+| `stage_shade_lambertian.cpp` | `intern/cycles/kernel/integrator/shade_surface.h` | Per-material shade kernel; gated by material type |
+| `wavefront_snapshot.h` | `intern/cycles/device/cuda/queue.cpp` | Paranoid-debug per-launch state dump |
+| RNG keying | `intern/cycles/kernel/random.h` | `rng_pixel + rng_offset` convention |
+| `reference_pt_*.cpp` | (cite production `pathTraceSpectral` + Cycles `kernel_path.h`) | Reference oracle pattern; PBRT-v4 path-tracer integrator structure |

--- a/.astroray_plan/docs/pkg55-B-restart-session1-summary.md
+++ b/.astroray_plan/docs/pkg55-B-restart-session1-summary.md
@@ -1,0 +1,195 @@
+# pkg55 Phase B' — Restart Session 1 Summary
+
+**Date:** 2026-05-14
+**Branch:** `pkg55-B-restart`
+**Output:** spec amendment only — no code.
+
+---
+
+## Why this session pivoted from implementation to spec amendment
+
+The restart scope that the previous 8 sessions of fork-resolution had been
+dispatching against lived only in dispatch briefs and the architect's
+strategy doc. It was NOT in the on-disk `pkg55-wavefront-soa-refactor.md`
+spec. Per `CLAUDE.md` §2 (simplicity first) and §3 (surgical changes), the
+spec is authoritative; everything else is supporting material.
+
+Continuing to resolve ambiguities against a non-authoritative source was
+silently widening scope across multiple sessions. The productive output
+from Session 1 is therefore to capture all of the work done across those
+sessions into authoritative spec language, so the next implementer works
+from the spec — not from a chain of dispatch briefs whose decisions only
+exist in chat history.
+
+The pivot was: **stop implementing, write down what we already decided.**
+
+---
+
+## The 8 ambiguities that surfaced and their resolutions
+
+Each resolution is now authoritative spec text under Phase B' §"Design
+decisions" in `.astroray_plan/packages/pkg55-wavefront-soa-refactor.md`.
+The short form, with rationale:
+
+### §1 — Spectral oracle, not RGB
+
+**Question.** Should the CPU reference oracle and CPU wavefront carry
+spectral state (`SampledWavelengths`, `SampledSpectrum`) end-to-end, or
+should we build an RGB-only oracle first and add spectral later?
+
+**Resolution.** Spectral end-to-end. RGB only at the final
+XYZ→sRGB conversion.
+
+**Rationale.** The eventual GPU wavefront is spectral (matching production
+`SpectralPathTracer`). An RGB-only oracle would require a wholesale
+transcription pass when adding spectral, which is exactly the kind of
+"oracle drift" Phase B' is designed to avoid. Better to pay the spectral
+cost on day one and have the oracle stay structurally aligned with the
+production target.
+
+### §2 — Per-path RNG keying for wavefront; tile-shared for production
+
+**Question.** What RNG scheme does the CPU wavefront use? Match
+production's tile-shared `mt19937(baseSeed + tileIdx)`, or match Phase
+A.1's GPU per-path `mt19937(hash(pixel, sample, 0))`?
+
+**Resolution.** The wavefront side uses per-path keying. The production
+side keeps tile-shared. The two are byte-incompatible but statistically
+equivalent.
+
+**Rationale.** The wavefront pipeline must match what Phase A.1 already
+established on the GPU — per-path keying is mandatory there because there
+are no "tiles" in the wavefront sense. Forcing the production CPU path
+tracer to also adopt per-path keying would change production output and
+break unrelated SSIM gates. So we accept the two schemes and validate
+their statistical equivalence (see §3).
+
+### §3 — Two reference PTs (Option Z), not one
+
+**Question.** One reference PT, or two? If one, which RNG scheme?
+
+**Resolution.** Two. `reference_pt_production` uses tile-shared RNG
+(matches production); `reference_pt_wavefront` uses per-path RNG (matches
+wavefront). A trip-wire test asserts `reference_pt_production` ==
+production at the byte level. An equivalence test asserts SSIM ≥ 0.99
+between the two oracles at 64 spp.
+
+**Rationale.** A single oracle can't simultaneously be byte-equal to
+production (which needs tile-RNG) and byte-equal to the wavefront (which
+needs per-path RNG). Two oracles, one for each comparison, is the only
+way to get both bit-exact gates.
+
+### §4 — Scoped oracles (Option C), not full-surface transcription
+
+**Question.** Do the reference PTs cover the full production feature
+surface from day one (Disney, dielectric, SMS, GR, spectral upsampling
+etc.), or only what the current CPU wavefront actually supports?
+
+**Resolution.** Scoped. Session 2 reference PTs cover lambertian +
+area lights + Cornell only. The oracles grow alongside the wavefront,
+session by session.
+
+**Rationale.** A full-surface oracle would trip on noise from features
+the wavefront doesn't yet implement, defeating the diff harness's
+purpose. And building a 100% transcription of pkg64 SMS / pkg67 GR /
+pkg54c spectral upsampling / Disney / dielectric on day one is the kind
+of scope explosion that killed the original Phase B.
+
+### §5 — Callable driver, not a registered plugin (yet)
+
+**Question.** Should the CPU wavefront be exposed as a registered
+integrator plugin (`wavefront_path_tracer`) from Session 2, or as a
+callable driver behind a pybind11 entry point?
+
+**Resolution.** Callable driver. Plugin registration is deferred to the
+final phase of B'.
+
+**Rationale.** Plugin registration brings Blender-dropdown wiring,
+`integrator_capabilities` flags, and dropdown-state migration concerns
+into every session. None of that helps the per-stage diff work. Keep the
+surface tight; register the plugin once it actually works.
+
+### §6 — Reference PT is a separate file (Option C2), not hooks on production
+
+**Question.** Add instrumentation hooks to production
+`Renderer::pathTraceSpectral` so that the same code can be run as oracle,
+or write a separate transcription file?
+
+**Resolution.** Separate file. Production is untouched.
+
+**Rationale.** Instrumentation hooks bloat production with diff-harness
+state and risk perturbing production output. A separate file with a
+trip-wire that asserts bit-equality is cleaner: production stays clean,
+drift is detected by the test rather than by branching in production
+code.
+
+### §7 — Snapshot data structures
+
+**Question.** How does the diff harness compare wavefront vs reference
+PT? At the pixel level (final image), at the path level (final
+radiance), or at each stage boundary?
+
+**Resolution.** Stage-boundary snapshots. Both reference PTs emit
+`WavefrontSnapshot` records at each stage boundary (post-init,
+post-intersect, post-shade, post-light-sample, post-RR). The diff
+harness compares snapshots element-by-element to localize divergence.
+
+**Rationale.** Final-pixel comparison localizes the bug to "somewhere in
+the pipeline" — useless when the original Phase B had three cascading
+bugs at different stages. Stage-boundary snapshots tell you "the bug is
+in stage_shade_lambertian, slot 47, field path_throughput, after sample
+2" — actionable.
+
+### §8 — Growing-oracle lifecycle
+
+**Question.** Once we have the lambertian-Cornell oracle in Session 2,
+what happens to it in Session 3 (metal)? Does it stay frozen, get
+deleted, or grow?
+
+**Resolution.** Growing oracle. Reference PTs grow incrementally as the
+CPU wavefront adds materials. When the wavefront adds metal, the
+reference PTs add metal in the same PR. The oracles never lead the
+wavefront and never lag it.
+
+**Rationale.** "Frozen oracle" forces every new material to invent its
+own diff strategy. "Deleted oracle" loses the per-stage gate the moment
+we move past lambertian. "Growing oracle" keeps the gate alive forever
+with O(material) effort per session, which is the same effort we'd spend
+anyway on the wavefront side.
+
+---
+
+## Next-session pickup instructions
+
+The next implementer (Session 2) should:
+
+1. **Read the amended spec, not these dispatch briefs.** The
+   authoritative scope lives in
+   `.astroray_plan/packages/pkg55-wavefront-soa-refactor.md`, Phase B'
+   subsection. The 8 design decisions there are authoritative — do not
+   re-litigate them.
+2. **Write the design doc first** at
+   `.astroray_plan/docs/pkg55-B-cpu-reference-design.md`, expanding the
+   8 decisions into code-level detail (field layouts, function
+   signatures, snapshot record format).
+3. **Implement Session 2 deliverables** as listed in the spec's
+   Phase B' staged plan §2. The close gate is bit-identity of CPU
+   wavefront vs `reference_pt_wavefront` on Lambertian-only Cornell at
+   1 spp.
+4. **Do not touch** the AoS megakernel or `origin/pkg55-phase-b`.
+   Phase B's branch is held, not deleted; the historical work stays
+   reachable.
+5. **Do not widen scope.** If something feels under-specified, stop and
+   ask — do not silently extend. The 8 forks above are what 8 sessions
+   of silent scope-widening cost; don't add a 9th.
+
+---
+
+## Deliverables (this session)
+
+- Spec amendment landed in
+  `.astroray_plan/packages/pkg55-wavefront-soa-refactor.md` (Phase B
+  status note + new Phase B' subsection inserted between Phase B and
+  Phase C; acceptance summary table updated to include B').
+- This summary doc.
+- PR opened against `main` (do not merge — owner reviews).

--- a/.astroray_plan/docs/pkg55-B-session2a-handoff.md
+++ b/.astroray_plan/docs/pkg55-B-session2a-handoff.md
@@ -1,0 +1,146 @@
+# pkg55 Phase B' — Session 2a handoff (2026-05-14)
+
+**Status:** 2a complete pending PR merge. 2b/2c open.
+
+**References:**
+- Spec: [`.astroray_plan/packages/pkg55-wavefront-soa-refactor.md`](../packages/pkg55-wavefront-soa-refactor.md) §"Phase B' — Restart"
+- Design doc: [`.astroray_plan/docs/pkg55-B-cpu-reference-design.md`](pkg55-B-cpu-reference-design.md) (commit `4e2e223`)
+- Session 1 summary: [`.astroray_plan/docs/pkg55-B-restart-session1-summary.md`](pkg55-B-restart-session1-summary.md)
+- Branch: `pkg55-B-restart`
+
+## Why Session 2 was split
+
+Original Session 2 packaged six deliverables: design doc, scene, snapshot
+schema, build wiring, two reference PTs, CPU wavefront skeleton, three
+test suites. Implementer flagged the scope before sinking hours; user
+approved Option B (split). The bit-identity close gate now lives at 2c.
+The split keeps each PR small enough to review properly.
+
+## What 2a delivered
+
+Four small commits, all on `pkg55-B-restart`:
+
+1. **Lambertian Cornell scene** — `tests/scenes/lambertian_cornell.py`.
+   6 Lambertian walls + 1 Lambertian sphere + 1 area light. Camera sits
+   inside the box (z = +0.95, vfov 60) looking toward −z so the front
+   wall is a bounce surface, not a primary-ray occluder. Verified to
+   render via `Renderer.set_integrator("path_tracer")` at 1 / 16 / 64 spp
+   on the existing CPU `path_tracer` pipeline (mean radiance ~0.19 at
+   64 spp, 16×16). This is the in-scope reference scene for 2b/2c.
+
+2. **`WavefrontSnapshot` header** — `src/cpu/wavefront/wavefront_snapshot.h`.
+   Schema verbatim from design doc §7. Five `SnapshotStage` values
+   (PostInit, PostIntersect, PostShade, PostLightSample, PostRR), all
+   fields per the design doc, plus a `SnapshotSink` virtual interface and
+   a concrete `VectorSink` impl. Header-only, namespaced
+   `astroray::cpu_wavefront`. Verified to compile clean under
+   `-std=c++17 -Wall -Wextra`.
+
+3. **CMake scaffolding** — `CMakeLists.txt`. Added a `file(GLOB
+   CONFIGURE_DEPENDS …)` over `src/cpu/wavefront/*.cpp` plus a guarded
+   `target_sources(astroray_core_impl PRIVATE …)`. Verified: CMake
+   configures clean with the glob empty (no message, no .cpp), and
+   auto-picks up a probe `.cpp` when added (status message prints, source
+   appears in target). 2b's new files will compile without any further
+   CMake edits.
+
+4. **Spec + handoff docs** — spec §"Phase B' staged plan" Session 2
+   entry rewritten to the 2a/2b/2c split with explicit deliverables and
+   close gates per session. Status row updated. This handoff doc landed.
+
+## What 2b needs to do (explicit deliverables, in order)
+
+1. **`src/cpu/wavefront/reference_pt_production.{h,cpp}`** — independent
+   transcription of production `Renderer::pathTraceSpectral` per design
+   doc §2 (tile-shared RNG, `mt19937(baseSeed + tileIdx)`) and §6
+   (separate file, no instrumentation hooks on production). Emit
+   `WavefrontSnapshot` records to an attached `SnapshotSink` at each of
+   the five stage boundaries. Lambertian-only scope: assert + abort on
+   any non-`{lambertian, light}` material. RNG-draw order documented in
+   design doc §2.
+
+2. **`src/cpu/wavefront/reference_pt_wavefront.{h,cpp}`** — same physics,
+   per-path RNG seeded via `mt19937(hash(pixel_index, sample_index, 0))`
+   with FNV-1a-32 over the three uint32 inputs (design doc §2.
+   Wavefront-side). Draw order matches production (filter u, filter v,
+   `randomInUnitDisk`, λ-u01, …) so the equivalence test can hold.
+
+3. **pybind11 bindings** — `reference_pt_production_render` and
+   `reference_pt_wavefront_render` per design doc §3 signature. Add to
+   `module/blender_module.cpp` next to the existing test entry points.
+
+4. **Trip-wire test** — `tests/test_pkg55_reference_pt_production_parity.py`.
+   Bit-exact RGB equality (`max_abs_diff == 0`) between
+   `reference_pt_production_render` and `Renderer.render` at fixed seed,
+   1 spp. Uses `tests/scenes/lambertian_cornell.py`.
+
+5. **Equivalence test** — `tests/test_pkg55_reference_pt_oracles_equivalent.py`.
+   SSIM ≥ 0.99 at 64 spp between the two reference PTs. Uses the same
+   scene. Validates that the per-path RNG scheme is statistically
+   equivalent to tile-shared.
+
+**2b close gate:** both tests pass on Windows (the production target).
+
+**2b out of scope:** CPU wavefront stages, diff harness, plugin
+registration, CUDA. Those are 2c and beyond.
+
+## What 2c needs to do
+
+1. **CPU wavefront state header** — `src/cpu/wavefront/cpu_wavefront_state.h`.
+   SoA layout mirrors A.1 `IntegratorStateSoA` field set (per design doc
+   §11 citation table).
+
+2. **Stage kernels (CPU, per-slot loops)** —
+   `src/cpu/wavefront/stage_init.cpp`,
+   `src/cpu/wavefront/stage_intersect.cpp`,
+   `src/cpu/wavefront/stage_shade_lambertian.cpp`. Each emits a
+   `WavefrontSnapshot` to the attached sink at its stage boundary.
+
+3. **Callable driver** — `src/cpu/wavefront/cpu_wavefront_driver.cpp` with
+   the signature in design doc §5. pybind11 binding
+   `cpu_wavefront_render`.
+
+4. **Per-stage diff harness** — `tests/wavefront_diff/harness.py` plus
+   `tests/wavefront_diff/test_cpu_wavefront_lambertian_bit_identity.py`.
+   Runs `reference_pt_wavefront` and the CPU wavefront on the same seed,
+   pulls both snapshot streams, compares slot-by-slot field-by-field, and
+   on first mismatch reports `{stage, slot_index, field, expected, got}`.
+
+**2c close gate (== original Session 2 close gate):** bit-identity of
+CPU wavefront vs `reference_pt_wavefront` on Lambertian-only Cornell at
+1 spp. Zero mismatched fields across the full snapshot stream.
+
+## Design points 2a's design doc clarified that 2b/2c implementers will need to absorb
+
+1. **Spectral end-to-end.** `SampledWavelengths` + `SampledSpectrum`
+   carry through every stage. RGB only at final XYZ→sRGB. Design doc §1.
+   Implication for 2b: the reference PT signature returns a `vector<float>`
+   of RGB but internally is spectral.
+
+2. **Independent transcription of `pathTraceSpectral`, not instrumentation.**
+   Design doc §6. Production `Renderer::pathTraceSpectral` is NOT touched.
+   The trip-wire detects drift by bit-comparison; if production changes
+   semantics, the trip-wire fires, and 2b's reference PT must follow in
+   the same PR (growing-oracle lifecycle, §8).
+
+3. **RNG draw order is the spec.** Design doc §2 documents the exact RNG
+   draw sequence for both schemes: filter(u), filter(v), randomInUnitDisk,
+   λ-u01, then the path-trace loop's draws. Diverging even one draw
+   breaks bit-identity, so 2b must mirror production's draw order
+   *exactly*.
+
+4. **Lambertian-only scope is enforced at runtime.** Design doc §4. The
+   reference PTs and CPU wavefront assert + abort on any non-in-scope
+   material. This is what keeps the trip-wire from firing on noise as
+   future shade kernels land.
+
+5. **Snapshot schema is append-only.** Design doc §8.4. New fields go on
+   the end. New stages go on the end of `SnapshotStage`. Never reorder.
+   This is the invariant that lets the diff harness survive across
+   sessions.
+
+## Session 2a PR
+
+Title: `feat(pkg55-B'): Phase B' Session 2a — foundation (design + scene + snapshot header + CMake scaffolding)`.
+
+4 commits, <500 LOC total. See PR body for measured numbers.

--- a/.astroray_plan/packages/pkg55-wavefront-soa-refactor.md
+++ b/.astroray_plan/packages/pkg55-wavefront-soa-refactor.md
@@ -197,6 +197,8 @@ Notes: (a) the off↔on delta is within run-to-run noise; the small gap on `corn
 
 ### Phase B — Shade queue + material dispatch + wavefront pixel output
 
+> **Status note (2026-05-14):** Phase B attempted on `origin/pkg55-phase-b` 2026-05-13 → 2026-05-14; reached PR #257 with cascading radiance bugs (`path_alive` ✓, material guards ✓, sample accumulation REGRESSED 2.5× → 21× brightness vs megakernel). Held pending **Phase B' (below)** per architect Round 8 strategy (PR #263). The Phase B section below is retained as historical record of the attempted approach + lessons; the authoritative execution plan for the wavefront rebuild lives in Phase B'.
+
 **Estimated effort:** 4 weeks
 
 **Goal:** Wire all six stages. The wavefront integrator produces its own framebuffer output and is exposed as `wavefront_path_tracer`. Compare SSIM against the megakernel and against the CPU `path_tracer`.
@@ -247,6 +249,60 @@ Notes: (a) the off↔on delta is within run-to-run noise; the small gap on `corn
 
 ---
 
+### Phase B' — Restart (CPU-first methodical rebuild)
+
+**Status:** open (authoritative; supersedes the Phase B execution plan above as of 2026-05-14).
+**Estimated effort:** rolling, scoped per session.
+
+**Goal:** Restart Phase B methodically using a **CPU wavefront reference oracle**, building the per-stage diff harness that the original Phase B lacked. Mirror Cycles' kernel order, do bit-exact stage-by-stage parity on CPU first, then port to CUDA. The architecture goal is unchanged from Phase B; the **execution methodology** is the change. Phase B's deliverables (7 shade kernels, shadow/miss/terminate, sort-by-material, `wavefront_path_tracer` plugin, SSIM gates, 1.5× perf gate, viewport-parity gate) all close out under Phase B'.
+
+#### Phase B' staged plan
+
+1. **Session 1 — scope amendment (this session).** Capture 8 resolved design decisions into the spec. No code. Deliverable: this subsection + `.astroray_plan/docs/pkg55-B-restart-session1-summary.md`.
+2. **Session 2 — Lambertian-Cornell foundation.**
+   - Design doc at `.astroray_plan/docs/pkg55-B-cpu-reference-design.md` recording all 8 design decisions in code-level detail.
+   - Two reference path tracers:
+     - `src/cpu/wavefront/reference_pt_production.cpp` — tile-shared RNG; mirrors production CPU `Renderer::pathTraceSpectral` bit-for-bit.
+     - `src/cpu/wavefront/reference_pt_wavefront.cpp` — per-path RNG keyed `hash(pixel_index, sample_index, 0)`, matching the Phase A.1 GPU convention.
+     - Both scoped to lambertian-Cornell only.
+   - Trip-wire test `tests/test_pkg55_reference_pt_production_parity.py` — bit-exact equality of `reference_pt_production` vs production `pathTraceSpectral` at fixed seed, 1 spp.
+   - Equivalence test `tests/test_pkg55_reference_pt_oracles_equivalent.py` — SSIM ≥ 0.99 at 64 spp between the two oracles (validates RNG-scheme interchangeability).
+   - Test scene `tests/scenes/lambertian_cornell.py` if it doesn't exist.
+   - CPU wavefront skeleton at `src/cpu/wavefront/`: state header, `stage_init`, `stage_intersect`, `stage_shade_lambertian`, callable driver (not yet a registered plugin).
+   - Per-stage diff harness at `tests/wavefront_diff/` — runs `reference_pt_wavefront` and the CPU wavefront in lockstep, reports the first per-stage mismatch by slot and field.
+   - **Close gate:** bit-identity of CPU wavefront vs `reference_pt_wavefront` on Lambertian-only Cornell at 1 spp.
+3. **Sessions 3..N — Growing-oracle expansion.** As each new shade kernel (metal, dielectric, disney, thin_glass, diffuse_light, closure_graph) is added to the CPU wavefront, both reference PTs grow alongside to cover the same feature surface. Trip-wire test scene grows; equivalence test scene grows. The reference PTs are "growing oracles" — they always match the current CPU wavefront feature surface; never lead, never lag.
+4. **Session N+1 — Shadow/miss/terminate stages on CPU.** Once all seven material types pass per-stage diff, add the remaining stages.
+5. **Sessions N+2..M — CUDA port stage-by-stage.** For each CPU stage, write the CUDA mirror; run a CPU↔GPU per-stage diff harness (mirrors the CPU↔CPU one). Bit-identity gates each port.
+6. **Plugin registration (final phase of B').** After the full CUDA wavefront passes all gates, register `wavefront_path_tracer` plugin and wire `multiwavelength_path_tracer::renderGPU()` to it behind `use_wavefront` (matches the original Phase B deliverable in §"Files to modify" above).
+
+#### Phase B' design decisions (authoritative — 8 resolved forks)
+
+1. **Spectral oracle, not RGB.** Both reference PTs and the CPU wavefront carry `SampledWavelengths` and `SampledSpectrum` end-to-end, matching production `SpectralPathTracer`. RGB only at final XYZ→sRGB conversion. *Rationale:* the eventual GPU wavefront is spectral; building an RGB-only oracle wastes a transcription pass later.
+2. **Per-path RNG keying for the wavefront side; tile-shared for the production side.** CPU wavefront and `reference_pt_wavefront` use `mt19937(hash(pixel_index, sample_index, 0))` per slot — same scheme Phase A.1 used on GPU. Production CPU `pathTraceSpectral` uses tile-shared `mt19937(baseSeed + tileIdx)`. The two are byte-incompatible but statistically equivalent.
+3. **Two reference PTs (Option Z), not one.** `reference_pt_production` mirrors production tile-RNG and is a trip-wire for production drift (bit-exact gate). `reference_pt_wavefront` mirrors the GPU-shaped per-path RNG and is the wavefront's diff oracle. An equivalence test asserts the two RNG schemes produce statistically equivalent renders (SSIM ≥ 0.99 at 64 spp).
+4. **Scoped oracles (Option C), not full-surface transcription.** Both reference PTs cover ONLY what the current CPU wavefront supports. Session 2 = lambertian + area lights + Cornell-only. Reference PTs grow alongside the wavefront, session by session. Avoids the trip-wire firing on noise (unrelated material/light changes) and avoids over-scoped transcription of pkg64 SMS / pkg67 GR / pkg54c spectral / Disney / dielectric code paths.
+5. **Callable driver, not a registered plugin (yet).** CPU wavefront exposed via a pybind11 entry point and a direct C++ test executable. Plugin registration happens in the final phase of B' once everything works. Avoids premature Blender-dropdown wiring.
+6. **Reference PT is a separate file (Option C2), not instrumentation hooks on production.** Production `Renderer::pathTraceSpectral` is not touched. The reference PTs are independent transcriptions. The trip-wire test detects drift via bit-comparison.
+7. **Snapshot data structures.** Both reference PTs emit `WavefrontSnapshot` records at each stage boundary (post-init, post-intersect, post-shade, post-light-sample, post-RR). The diff harness compares snapshots element-by-element to localize divergence.
+8. **Growing-oracle lifecycle.** The two reference PTs grow incrementally as the CPU wavefront adds support for more materials/features. They are "specifications by code" of the current wavefront feature surface — they never lead and never lag. When the wavefront adds metal, the reference PTs add metal in the same PR.
+
+#### Phase B' acceptance gates (per session)
+
+- **Session 2:** trip-wire test passes (max abs diff = 0); equivalence test passes (SSIM ≥ 0.99); CPU wavefront bit-identical to `reference_pt_wavefront` on Lambertian-Cornell at 1 spp.
+- **Sessions 3..N:** trip-wire + equivalence + bit-identity gates pass for each new material/feature.
+- **Session N+1:** stages all wired end-to-end; CPU wavefront SSIM ≥ 0.985 vs CPU `path_tracer` on the full pkg54 visible-band scene at 64 spp.
+- **Sessions N+2..M (CUDA port):** CPU↔GPU per-stage diff gates pass; final perf gate from the original Phase B (≥ 1.5× megakernel on the 7-material scene) closes the package.
+
+#### Phase B' non-goals
+
+- Don't touch the AoS megakernel or `origin/pkg55-phase-b`.
+- Don't widen scope beyond the staged plan in any single session.
+- Don't re-implement pkg64 SMS, pkg67 redshift, or pkg82 thresholds — those are at integrator surface.
+- No CUDA in Session 2 (CPU foundation only).
+
+---
+
 ### Phase C — MIS/NEE parity + megakernel removal
 
 **Estimated effort:** 3 weeks
@@ -294,7 +350,8 @@ Notes: (a) the off↔on delta is within run-to-run noise; the small gap on `corn
 |---|---|---|
 | A.0 | Megakernel baseline JSON + occupancy cliff documented | done (PR #238) |
 | A.1 | Intersect parity test bit-exact; megakernel output unchanged; SoA reg pressure < 158 cliff | **done — 0/576 mismatches; 40–56 regs/thread vs 158** |
-| B | Wavefront SSIM ≥ 0.985 (visible) / ≥ 0.97 (NIR); ≥ 1.5× speedup on 7-material scene | open |
+| B | Wavefront SSIM ≥ 0.985 (visible) / ≥ 0.97 (NIR); ≥ 1.5× speedup on 7-material scene | held — superseded by B' execution plan (2026-05-14) |
+| B' | CPU reference-oracle bit-identity, per-stage diff harness, CPU-first then CUDA port; closes B's gates | open (Session 1 — spec amendment — done; Session 2 next) |
 | C | All pkg54 SSIM gates pass with megakernel deleted; ≥ 2× speedup on 7-material scene | open |
 
 ---

--- a/.astroray_plan/packages/pkg55-wavefront-soa-refactor.md
+++ b/.astroray_plan/packages/pkg55-wavefront-soa-refactor.md
@@ -258,19 +258,22 @@ Notes: (a) the off↔on delta is within run-to-run noise; the small gap on `corn
 
 #### Phase B' staged plan
 
-1. **Session 1 — scope amendment (this session).** Capture 8 resolved design decisions into the spec. No code. Deliverable: this subsection + `.astroray_plan/docs/pkg55-B-restart-session1-summary.md`.
-2. **Session 2 — Lambertian-Cornell foundation.**
-   - Design doc at `.astroray_plan/docs/pkg55-B-cpu-reference-design.md` recording all 8 design decisions in code-level detail.
-   - Two reference path tracers:
-     - `src/cpu/wavefront/reference_pt_production.cpp` — tile-shared RNG; mirrors production CPU `Renderer::pathTraceSpectral` bit-for-bit.
-     - `src/cpu/wavefront/reference_pt_wavefront.cpp` — per-path RNG keyed `hash(pixel_index, sample_index, 0)`, matching the Phase A.1 GPU convention.
-     - Both scoped to lambertian-Cornell only.
-   - Trip-wire test `tests/test_pkg55_reference_pt_production_parity.py` — bit-exact equality of `reference_pt_production` vs production `pathTraceSpectral` at fixed seed, 1 spp.
-   - Equivalence test `tests/test_pkg55_reference_pt_oracles_equivalent.py` — SSIM ≥ 0.99 at 64 spp between the two oracles (validates RNG-scheme interchangeability).
-   - Test scene `tests/scenes/lambertian_cornell.py` if it doesn't exist.
-   - CPU wavefront skeleton at `src/cpu/wavefront/`: state header, `stage_init`, `stage_intersect`, `stage_shade_lambertian`, callable driver (not yet a registered plugin).
-   - Per-stage diff harness at `tests/wavefront_diff/` — runs `reference_pt_wavefront` and the CPU wavefront in lockstep, reports the first per-stage mismatch by slot and field.
-   - **Close gate:** bit-identity of CPU wavefront vs `reference_pt_wavefront` on Lambertian-only Cornell at 1 spp.
+1. **Session 1 — scope amendment.** Capture 8 resolved design decisions into the spec. No code. Deliverable: this subsection + `.astroray_plan/docs/pkg55-B-restart-session1-summary.md`. **Done.**
+2. **Session 2 — Lambertian-Cornell foundation.** Split into 2a / 2b / 2c per the implementer's "before I sink hours" framing (Session 2a, 2026-05-14). The Session-2 close gate (bit-identity of CPU wavefront vs `reference_pt_wavefront` on Lambertian-only Cornell at 1 spp) is reframed as the **Session 2c close gate**.
+   - **Session 2a (this session, complete pending PR merge):** Design doc + Lambertian Cornell scene + WavefrontSnapshot header + CMake scaffolding.
+     - Design doc at `.astroray_plan/docs/pkg55-B-cpu-reference-design.md` recording all 8 design decisions in code-level detail (landed commit `4e2e223`).
+     - Test scene `tests/scenes/lambertian_cornell.py` — Lambertian-only Cornell (6 walls + 1 sphere + 1 area light); verified to render via `Renderer.set_integrator("path_tracer")`.
+     - `src/cpu/wavefront/wavefront_snapshot.h` — the shared snapshot schema (5 stages, append-only fields) per design doc §7. Sessions 2b/2c fill the emit calls.
+     - CMake glob registered for `src/cpu/wavefront/*.cpp` against `astroray_core_impl` so 2b's new sources are auto-picked-up.
+     - Handoff doc: `.astroray_plan/docs/pkg55-B-session2a-handoff.md`.
+     - **No close gate** beyond "builds + scene renders." Bit-identity is 2c's gate.
+   - **Session 2b — Two reference PTs (open).** `src/cpu/wavefront/reference_pt_production.{h,cpp}` (tile-shared RNG; mirrors production CPU `Renderer::pathTraceSpectral` bit-for-bit) + `src/cpu/wavefront/reference_pt_wavefront.{h,cpp}` (per-path RNG keyed `hash(pixel_index, sample_index, 0)`, matching the Phase A.1 GPU convention). Both scoped to Lambertian-Cornell only. Both emit `WavefrontSnapshot` to an attached sink. Plus:
+     - Trip-wire test `tests/test_pkg55_reference_pt_production_parity.py` — bit-exact equality of `reference_pt_production` vs production `pathTraceSpectral` at fixed seed, 1 spp.
+     - Equivalence test `tests/test_pkg55_reference_pt_oracles_equivalent.py` — SSIM ≥ 0.99 at 64 spp between the two oracles (validates RNG-scheme interchangeability).
+     - pybind11 entry points `reference_pt_production_render`, `reference_pt_wavefront_render`.
+     - **Close gate:** trip-wire + equivalence tests pass.
+   - **Session 2c — CPU wavefront skeleton (open).** State header + `stage_init` + `stage_intersect` + `stage_shade_lambertian` + callable driver (not a registered plugin) + per-stage diff harness at `tests/wavefront_diff/`. Lambertian-Cornell scope only.
+     - **Close gate:** bit-identity of CPU wavefront vs `reference_pt_wavefront` on Lambertian-only Cornell at 1 spp (snapshot-stream equality, slot-by-slot, field-by-field).
 3. **Sessions 3..N — Growing-oracle expansion.** As each new shade kernel (metal, dielectric, disney, thin_glass, diffuse_light, closure_graph) is added to the CPU wavefront, both reference PTs grow alongside to cover the same feature surface. Trip-wire test scene grows; equivalence test scene grows. The reference PTs are "growing oracles" — they always match the current CPU wavefront feature surface; never lead, never lag.
 4. **Session N+1 — Shadow/miss/terminate stages on CPU.** Once all seven material types pass per-stage diff, add the remaining stages.
 5. **Sessions N+2..M — CUDA port stage-by-stage.** For each CPU stage, write the CUDA mirror; run a CPU↔GPU per-stage diff harness (mirrors the CPU↔CPU one). Bit-identity gates each port.
@@ -351,7 +354,7 @@ Notes: (a) the off↔on delta is within run-to-run noise; the small gap on `corn
 | A.0 | Megakernel baseline JSON + occupancy cliff documented | done (PR #238) |
 | A.1 | Intersect parity test bit-exact; megakernel output unchanged; SoA reg pressure < 158 cliff | **done — 0/576 mismatches; 40–56 regs/thread vs 158** |
 | B | Wavefront SSIM ≥ 0.985 (visible) / ≥ 0.97 (NIR); ≥ 1.5× speedup on 7-material scene | held — superseded by B' execution plan (2026-05-14) |
-| B' | CPU reference-oracle bit-identity, per-stage diff harness, CPU-first then CUDA port; closes B's gates | open (Session 1 — spec amendment — done; Session 2 next) |
+| B' | CPU reference-oracle bit-identity, per-stage diff harness, CPU-first then CUDA port; closes B's gates | open (Session 1 done; Session 2a foundation in-progress pending PR; 2b/2c open) |
 | C | All pkg54 SSIM gates pass with megakernel deleted; ≥ 2× speedup on 7-material scene | open |
 
 ---

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,6 +322,19 @@ add_library(astroray_core_impl STATIC
     src/material_closure.cpp
     src/spectral_profile.cpp
 )
+
+# pkg55 Phase B' — CPU wavefront reference oracle + driver (Session 2b/2c).
+# Glob auto-picks up files as 2b/2c lands them. Session 2a only ships the
+# wavefront_snapshot.h header (no .cpp yet); the if-guard avoids adding an
+# empty source list to the target. See:
+#   - .astroray_plan/packages/pkg55-wavefront-soa-refactor.md §"Phase B'"
+#   - .astroray_plan/docs/pkg55-B-cpu-reference-design.md §10
+file(GLOB ASTRORAY_CPU_WAVEFRONT_SOURCES CONFIGURE_DEPENDS
+     "${CMAKE_CURRENT_SOURCE_DIR}/src/cpu/wavefront/*.cpp")
+if(ASTRORAY_CPU_WAVEFRONT_SOURCES)
+    target_sources(astroray_core_impl PRIVATE ${ASTRORAY_CPU_WAVEFRONT_SOURCES})
+    message(STATUS "pkg55-B': CPU wavefront sources: ${ASTRORAY_CPU_WAVEFRONT_SOURCES}")
+endif()
 target_include_directories(astroray_core_impl
     PUBLIC  ${INCLUDE_DIR}
     PRIVATE ${CMAKE_SOURCE_DIR})

--- a/src/cpu/wavefront/wavefront_snapshot.h
+++ b/src/cpu/wavefront/wavefront_snapshot.h
@@ -1,0 +1,104 @@
+// pkg55 Phase B' — CPU wavefront per-stage snapshot schema.
+//
+// Authoritative design: .astroray_plan/docs/pkg55-B-cpu-reference-design.md §7.
+// Spec: .astroray_plan/packages/pkg55-wavefront-soa-refactor.md §"Phase B'".
+//
+// Both reference path tracers (reference_pt_production, reference_pt_wavefront)
+// and the CPU wavefront driver emit WavefrontSnapshot records at each stage
+// boundary when a SnapshotSink is attached. The Session 2c per-stage diff
+// harness compares snapshot streams element-by-element to localize divergence.
+//
+// This is the instrument that lets us pinpoint divergence to a single field
+// at a single stage — without it, "the wavefront doesn't match" is unactionable.
+//
+// Cite: Cycles intern/cycles/device/cuda/queue.cpp paranoid-debug pattern
+// (Apache-2.0) — kernel queues with debug builds dump per-launch state for
+// the same purpose.
+//
+// Session 2a defines the schema only. Sessions 2b/2c fill the emit calls.
+//
+// Schema discipline (design doc §8.4):
+//   - Fields are append-only. Never reordered, never renamed.
+//   - SnapshotStage enum values are append-only; existing values are frozen.
+
+#ifndef ASTRORAY_CPU_WAVEFRONT_SNAPSHOT_H
+#define ASTRORAY_CPU_WAVEFRONT_SNAPSHOT_H
+
+#include <cstdint>
+#include <vector>
+
+namespace astroray {
+namespace cpu_wavefront {
+
+enum class SnapshotStage : uint8_t {
+    PostInit         = 0,  // primary ray generated, RNG seeded, lambda picked, throughput=1
+    PostIntersect    = 1,  // BVH hit record written (or miss flag)
+    PostShade        = 2,  // outgoing ray + updated throughput (after BSDF sample)
+    PostLightSample  = 3,  // NEE shadow ray + light radiance + MIS weight
+    PostRR           = 4,  // Russian roulette decision recorded
+};
+
+struct WavefrontSnapshot {
+    // Identity (always present).
+    int           pixel_index;
+    int           sample_index;
+    int           bounce;
+    SnapshotStage stage;
+
+    // Ray state (post-init / post-shade).
+    float ray_origin[3];
+    float ray_direction[3];
+
+    // Per-path spectral carriers (always present).
+    float throughput[4];   // SampledSpectrum (kSpectrumSamples = 4)
+    float lambdas[4];      // SampledWavelengths
+
+    // Hit record (post-intersect onward).
+    int   hit_valid;       // 0 = miss
+    float hit_t;
+    float hit_point[3];
+    float hit_normal[3];
+    int   hit_material_id; // -1 if no material
+
+    // Shade output (post-shade only).
+    float bsdf_pdf;
+    int   bsdf_is_delta;
+
+    // NEE (post-light-sample only).
+    float nee_contribution[4];   // weighted L * f for this sample
+    float nee_light_pdf;
+    float nee_bsdf_pdf_at_dir;
+    float nee_mis_weight;
+
+    // RR (post-rr only).
+    float rr_prob;
+    int   rr_survived;
+};
+
+// Snapshot sink abstraction. Sessions 2b/2c will pass a concrete sink
+// (VectorSink or a callback adaptor) into the reference PTs and the CPU
+// wavefront driver. nullptr sink == record nothing (production path).
+class SnapshotSink {
+public:
+    virtual ~SnapshotSink() = default;
+    virtual void record(const WavefrontSnapshot& s) = 0;
+};
+
+// Concrete sink: accumulates into a vector. The diff harness pulls the
+// vector out at end of render. Per-thread instances avoid lock contention;
+// the driver is responsible for thread-local instantiation when parallelized.
+class VectorSink : public SnapshotSink {
+public:
+    void record(const WavefrontSnapshot& s) override { snapshots_.push_back(s); }
+    const std::vector<WavefrontSnapshot>& snapshots() const { return snapshots_; }
+    void clear() { snapshots_.clear(); }
+    void reserve(std::size_t n) { snapshots_.reserve(n); }
+
+private:
+    std::vector<WavefrontSnapshot> snapshots_;
+};
+
+}  // namespace cpu_wavefront
+}  // namespace astroray
+
+#endif  // ASTRORAY_CPU_WAVEFRONT_SNAPSHOT_H

--- a/tests/scenes/lambertian_cornell.py
+++ b/tests/scenes/lambertian_cornell.py
@@ -1,0 +1,71 @@
+"""pkg55 Phase B' Session 2 — Lambertian-only Cornell box.
+
+Test scene for the CPU wavefront reference oracle harness. Intentionally
+narrow scope: only Lambertian BSDFs + one emissive area light. No metal,
+no dielectric, no Disney, no env map. This is the feature surface the
+Session 2 CPU wavefront and both reference path tracers cover.
+
+The reference PTs (`reference_pt_production`, `reference_pt_wavefront`) and
+the CPU wavefront driver MUST refuse to render any scene containing a
+material outside the {lambertian, diffuse_light} set; this scene is the
+in-scope reference.
+
+Layout: classic Cornell box — 6 walls + 1 Lambertian sphere + 1 ceiling
+area light. White walls, red left, green right, neutral floor/ceiling.
+"""
+
+
+def build_scene(renderer):
+    """Populate *renderer* with the Lambertian Cornell scene.
+
+    Returns the material id map. Caller may set the seed / integrator / spp.
+    """
+    white_id = renderer.create_material("lambertian", [0.73, 0.73, 0.73], {})
+    red_id   = renderer.create_material("lambertian", [0.65, 0.05, 0.05], {})
+    green_id = renderer.create_material("lambertian", [0.12, 0.45, 0.15], {})
+    sphere_id = renderer.create_material("lambertian", [0.55, 0.55, 0.85], {})
+    light_id = renderer.create_material("light", [1.0, 1.0, 1.0], {"intensity": 8.0})
+
+    S = 1.0  # half-extent of the box
+    # Floor (white)
+    renderer.add_triangle([-S, -S, -S], [ S, -S, -S], [ S, -S,  S], white_id)
+    renderer.add_triangle([-S, -S, -S], [ S, -S,  S], [-S, -S,  S], white_id)
+    # Ceiling (white)
+    renderer.add_triangle([-S,  S, -S], [ S,  S,  S], [ S,  S, -S], white_id)
+    renderer.add_triangle([-S,  S, -S], [-S,  S,  S], [ S,  S,  S], white_id)
+    # Back wall (white)
+    renderer.add_triangle([-S, -S, -S], [ S,  S, -S], [ S, -S, -S], white_id)
+    renderer.add_triangle([-S, -S, -S], [-S,  S, -S], [ S,  S, -S], white_id)
+    # Left wall (red)
+    renderer.add_triangle([-S, -S, -S], [-S, -S,  S], [-S,  S,  S], red_id)
+    renderer.add_triangle([-S, -S, -S], [-S,  S,  S], [-S,  S, -S], red_id)
+    # Right wall (green)
+    renderer.add_triangle([ S, -S, -S], [ S,  S,  S], [ S, -S,  S], green_id)
+    renderer.add_triangle([ S, -S, -S], [ S,  S, -S], [ S,  S,  S], green_id)
+    # Front wall (white) — closes the box behind the camera. Camera sits inside
+    # the box at z = +0.95 looking toward -z, so the front wall acts only as a
+    # bounce surface for indirect light, not as an occluder of the primary ray.
+    renderer.add_triangle([-S, -S,  S], [ S, -S,  S], [ S,  S,  S], white_id)
+    renderer.add_triangle([-S, -S,  S], [ S,  S,  S], [-S,  S,  S], white_id)
+
+    # Lambertian sphere (slightly off-centre)
+    renderer.add_sphere([0.3, -0.55, 0.1], 0.45, sphere_id)
+
+    # Ceiling area light (just below the ceiling)
+    LY = S - 0.001
+    LH = 0.3
+    renderer.add_triangle([-LH, LY, -LH], [ LH, LY, -LH], [ LH, LY,  LH], light_id)
+    renderer.add_triangle([-LH, LY, -LH], [ LH, LY,  LH], [-LH, LY,  LH], light_id)
+
+    return dict(white=white_id, red=red_id, green=green_id,
+                sphere=sphere_id, light=light_id)
+
+
+def setup_camera(renderer, width=64, height=64):
+    renderer.setup_camera(
+        look_from=[0, 0.0, 0.95], look_at=[0, 0, 0], vup=[0, 1, 0],
+        vfov=60, aspect_ratio=width / height,
+        aperture=0.0, focus_dist=1.0,
+        width=width, height=height,
+    )
+    renderer.set_background_color([0.0, 0.0, 0.0])


### PR DESCRIPTION
Session 2a of pkg55 Phase B' (CPU-first wavefront restart). Foundation only — bit-identity is the **Session 2c** close gate, not 2a's.

## What 2a delivered (4 small commits, ~280 LOC total + docs)

1. **`3357d68` — Lambertian Cornell scene** (`tests/scenes/lambertian_cornell.py`, 71 LOC). 6 Lambertian walls + 1 Lambertian sphere + 1 area light. Verified to render via the existing CPU `path_tracer` integrator at 1 / 16 / 64 spp; mean radiance ~0.19 at 64 spp on a 16x16 frame (camera inside the box, vfov 60).
2. **`3bd69cc` — WavefrontSnapshot header** (`src/cpu/wavefront/wavefront_snapshot.h`, 104 LOC). Verbatim from design doc §7: 5 stages, all per-stage fields, `SnapshotSink` virtual interface + concrete `VectorSink` accumulator. Compiles clean under `-std=c++17 -Wall -Wextra`.
3. **`7fed6c0` — CMake scaffolding** (CMakeLists.txt, +13 LOC). `file(GLOB CONFIGURE_DEPENDS …)` over `src/cpu/wavefront/*.cpp` + guarded `target_sources(astroray_core_impl PRIVATE …)`. Verified: empty glob configures silent; probe `.cpp` is auto-picked-up with status message; removal returns to silent.
4. **`571ae4b` — Spec + handoff docs**. Spec §"Phase B' staged plan" Session 2 entry rewritten to 2a/2b/2c split with explicit per-session deliverables and close gates. Handoff doc at `.astroray_plan/docs/pkg55-B-session2a-handoff.md`.

## Scope re-framing — why 2 was split into 2a/2b/2c

Original Session 2 packaged six deliverables: design doc, scene, snapshot schema, build wiring, two reference PTs, CPU wavefront skeleton, and three test suites. The implementer flagged the scope before sinking hours (the pkg76 "before I sink hours" pattern); user approved Option B (split). The split keeps each PR small enough to review properly; the original Session 2 close gate (bit-identity of CPU wavefront vs reference_pt_wavefront on Lambertian-only Cornell at 1 spp) is now the **Session 2c** close gate.

## Next session pickup

See [`.astroray_plan/docs/pkg55-B-session2a-handoff.md`](../blob/pkg55-B-restart/.astroray_plan/docs/pkg55-B-session2a-handoff.md).

Session 2b starts at: `src/cpu/wavefront/reference_pt_production.{h,cpp}` (independent transcription of `Renderer::pathTraceSpectral`, tile-shared RNG) + `src/cpu/wavefront/reference_pt_wavefront.{h,cpp}` (per-path RNG keyed `hash(pixel, sample, 0)`), both Lambertian-only-scoped, both emitting `WavefrontSnapshot` to an attached sink. Plus pybind11 bindings, the trip-wire test, and the equivalence test.

## Algorithm sourcing (CLAUDE.md §6)

No new algorithms in 2a. The snapshot schema mirrors Cycles' `intern/cycles/device/cuda/queue.cpp` paranoid-debug pattern (Apache-2.0) cited in both the header file and the design doc.

## Acceptance

- [x] Scene loads and renders cleanly via `Renderer.set_integrator("path_tracer")` at 1 spp (verified)
- [x] WavefrontSnapshot header compiles clean under `-std=c++17 -Wall -Wextra`
- [x] CMake configures clean with empty glob; auto-picks up new `.cpp` files (verified with a probe)
- [x] Spec updated; handoff doc filed
- [x] Each commit reviewable in isolation
- [x] Total LOC well under 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)