### PR TITLE
chore: repo cleanup — move pkg84 measurement scripts out of repo root

### DIFF
--- a/dev/measurement-scripts/test_prewarm_cold.py
+++ b/dev/measurement-scripts/test_prewarm_cold.py
@@ -4,7 +4,7 @@
 import sys, time
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "tests"))
 
 from runtime_setup import configure_test_imports

--- a/dev/measurement-scripts/test_prewarm_measurement.py
+++ b/dev/measurement-scripts/test_prewarm_measurement.py
@@ -15,7 +15,7 @@ import sys
 import time
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "tests"))
 
 from runtime_setup import configure_test_imports

--- a/dev/measurement-scripts/test_prewarm_warm.py
+++ b/dev/measurement-scripts/test_prewarm_warm.py
@@ -4,7 +4,7 @@
 import sys, time
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "tests"))
 
 from runtime_setup import configure_test_imports


### PR DESCRIPTION
Repo hygiene pass authorized by the 2026-05-14 cleanup dispatch.

## What this PR does

Moves three one-shot pkg84 measurement scripts out of the repo root and into `dev/measurement-scripts/`:

- `test_prewarm_cold.py` → `dev/measurement-scripts/test_prewarm_cold.py`
- `test_prewarm_measurement.py` → `dev/measurement-scripts/test_prewarm_measurement.py`
- `test_prewarm_warm.py` → `dev/measurement-scripts/test_prewarm_warm.py`

These are not pytest tests — they are pedagogical measurement scripts demonstrating cold-vs-warm first-frame latency for the pkg84 pre-warm work (PR #260, merged). They were committed to the repo root by accident.

`REPO_ROOT` path computation updated from `.parent` to `.parents[2]` to account for the new directory depth, so the scripts still resolve `tests/runtime_setup.py` correctly.

## What this PR deliberately does NOT touch

- `sitecustomize.py` stays at the repo root — it is part of the Python interpreter bootstrap (auto-imported via sys.path) and adds OIDN/CUDA DLL directories on Windows.
- No behavioral changes to main.

## Other cleanup performed in this session (no PR needed)

- Pruned merged-and-gone remote-tracking branches via `git fetch --prune`.
- Deleted 12 squash-merged local branches (`claude/friendly-khorana-af3130`, `claude/pkg64-3-rebuild-verification`, `claude/sleepy-khorana-455ac7`, `claude/strange-curie-a9e093`, `claude/tender-yonath-604649`, `codex/pkg42-synchrotron-emission`, `feat/autonomous-dev-loop-setup`, `pkg85`, `pr258`, `pr259`, `pr260`, `pr261`).
- Deregistered 11 stale worktrees from git's worktree registry (filesystem dirs could not be removed due to OneDrive permission sandboxing — see report).
- Dropped 4 obsolete stashes (content verified already on main or no longer relevant).

Kept per dispatch: `pkg55-phase-b` + `pkg55-B-restart` branches and their worktrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)