### PR TITLE
fix(pkg85): wrap autouse GC fixture cleanup so exceptions don't surface as test teardown ERROR

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,37 +72,48 @@ def cuda_cleanup_and_error_check():
     yield  # Let the test run
 
     import gc
-    gc.collect()  # pkg85: Force cleanup of any Renderer objects left by the test
+    import warnings
 
+    # Wrap entire cleanup to prevent non-test-failure exceptions from
+    # surfacing as teardown ERROR. Intentional pytest.fail() is NOT caught
+    # (it raises BaseException), so legitimate CUDA regression guards still
+    # fail the test properly.
     try:
-        import astroray
-        # Only check if astroray module loaded successfully
+        gc.collect()  # pkg85: Force cleanup of any Renderer objects left by the test
+
         try:
-            renderer = astroray.Renderer()
-            if renderer.gpu_available:
-                # Import ctypes to call CUDA runtime directly
-                import ctypes
-                try:
-                    # Try to load CUDA runtime DLL
-                    cuda = ctypes.CDLL("cudart64_12.dll") if sys.platform == "win32" else ctypes.CDLL("libcudart.so")
-                    # cudaDeviceSynchronize() and cudaGetLastError()
-                    sync_err = cuda.cudaDeviceSynchronize()
-                    last_err = cuda.cudaGetLastError()
-                    if sync_err != 0 or last_err != 0:
-                        # Get error string
-                        cuda.cudaGetErrorString.restype = ctypes.c_char_p
-                        sync_msg = cuda.cudaGetErrorString(sync_err).decode() if sync_err != 0 else ""
-                        last_msg = cuda.cudaGetErrorString(last_err).decode() if last_err != 0 else ""
-                        # pkg85-B: this is now a permanent regression guard,
-                        # not a diagnostic. Any latent CUDA error after a
-                        # test indicates a missing CUDA_CHECK or a real
-                        # GPU-side bug; fail loudly at the boundary so the
-                        # culprit test is the one blamed, not whichever
-                        # test happens to make the next CUDA call.
-                        pytest.fail(f"Latent CUDA error after test: sync={sync_err} ({sync_msg}), last={last_err} ({last_msg})")
-                except (OSError, AttributeError):
-                    pass  # CUDA runtime not available, skip check
-        except Exception:
-            pass  # Renderer construction failed, skip check
-    except ImportError:
-        pass  # astroray not available, skip check
+            import astroray
+            # Only check if astroray module loaded successfully
+            try:
+                renderer = astroray.Renderer()
+                if renderer.gpu_available:
+                    # Import ctypes to call CUDA runtime directly
+                    import ctypes
+                    try:
+                        # Try to load CUDA runtime DLL
+                        cuda = ctypes.CDLL("cudart64_12.dll") if sys.platform == "win32" else ctypes.CDLL("libcudart.so")
+                        # cudaDeviceSynchronize() and cudaGetLastError()
+                        sync_err = cuda.cudaDeviceSynchronize()
+                        last_err = cuda.cudaGetLastError()
+                        if sync_err != 0 or last_err != 0:
+                            # Get error string
+                            cuda.cudaGetErrorString.restype = ctypes.c_char_p
+                            sync_msg = cuda.cudaGetErrorString(sync_err).decode() if sync_err != 0 else ""
+                            last_msg = cuda.cudaGetErrorString(last_err).decode() if last_err != 0 else ""
+                            # pkg85-B: this is now a permanent regression guard,
+                            # not a diagnostic. Any latent CUDA error after a
+                            # test indicates a missing CUDA_CHECK or a real
+                            # GPU-side bug; fail loudly at the boundary so the
+                            # culprit test is the one blamed, not whichever
+                            # test happens to make the next CUDA call.
+                            pytest.fail(f"Latent CUDA error after test: sync={sync_err} ({sync_msg}), last={last_err} ({last_msg})")
+                    except (OSError, AttributeError):
+                        pass  # CUDA runtime not available, skip check
+            except Exception as e:
+                # Renderer construction failed; log for diagnostic but don't fail
+                warnings.warn(f"cuda_cleanup_and_error_check: Renderer construction failed: {type(e).__name__}: {e}", stacklevel=2)
+        except ImportError:
+            pass  # astroray not available, skip check
+    except Exception as e:
+        # Catch any other unexpected cleanup exception and warn instead of ERROR
+        warnings.warn(f"cuda_cleanup_and_error_check: cleanup exception: {type(e).__name__}: {e}", stacklevel=2)


### PR DESCRIPTION
## Summary

Wraps the entire teardown phase of the `cuda_cleanup_and_error_check` autouse fixture in try/except to prevent unexpected exceptions from surfacing as pytest teardown ERROR status.

## Problem

The fixture's teardown phase had nested try/except blocks but didn't wrap the outermost operations (particularly `gc.collect()`). If gc.collect() triggered __del__ methods that threw exceptions, or if Renderer construction failed in an unexpected way, these exceptions could propagate as teardown ERROR, breaking pytest's exit code and masking real test failures.

## Solution

- Wrapped entire teardown in try/except Exception
- Preserved intentional pytest.fail() for CUDA regression guards (pytest.fail raises BaseException subclass, not caught by except Exception)
- Added diagnostic warnings to surface which specific cleanup operation fails

## Verification

Before fix: test_benchmark_showcase_phase2::test_gpu_flag_runs_without_cuda showed "1 passed, 1 error" due to intentional CUDA regression guard (correct behavior, preserved).

After fix: test_aov_passes.py shows 7 passed with no teardown errors (clean tests remain clean). The intentional CUDA regression guards still work correctly.

Generated with Claude Code