### PR TITLE
fix(pkg85-C): close the pkg85 spec gate — material-lowering bugs + HDRI scene-upload trigger + audit continuation

### DIFF
--- a/.astroray_plan/packages/pkg85-D-hdri-world-only-ssim-parity.md
+++ b/.astroray_plan/packages/pkg85-D-hdri-world-only-ssim-parity.md
@@ -1,0 +1,48 @@
+# pkg85-D — HDRI world-only render GPU/CPU SSIM parity
+
+**Pillar:** 5
+**Track:** A (RTX verifier)
+**Status:** open (filed 2026-05-14 — surfaced by pkg85-C after the "Scene not uploaded" early-exit was removed)
+**Estimated effort:** ½ day (~4 h on RTX)
+**Depends on:** pkg85-C (the precondition fix that lets this test reach SSIM)
+
+---
+
+## Goal
+
+**Before:** `tests/test_world_hdri_parity.py::test_gpu_cpu_ssim_hdri` runs to completion (post-pkg85-C) but the GPU image is wildly different from the CPU image — SSIM ≈ 0.35 against a gate of 0.97. Scene is `load_environment_map(...) + setup_camera(...)` with no geometry; CPU path-traces against the env map, GPU does the same but produces a different image.
+
+**After:** GPU vs CPU SSIM ≥ 0.97 on the same 64×64×64-spp setup.
+
+---
+
+## Context
+
+pkg85-B's `RuntimeError("Scene not uploaded — call uploadScene() first")` masked this for months. pkg85-C unblocked the render path (geometry-less scenes are allowed if an env map is uploaded). The result is no longer a crash or an exception — it's a wrong picture.
+
+Probably one of:
+- `gpu_envmap_lookup` vs CPU `EnvironmentMap::sample` disagreeing on rotation matrix / color tint / strength multiplier.
+- `pathTraceKernel`'s miss-branch tonemapping differs (CPU integrator may multiply by a different factor or skip the `* 0.2f` fallback that the GPU applies when `envMap.loaded` is false).
+- The CPU first-bounce env contribution uses NEE; the GPU first-bounce env contribution uses BSDF MIS only (with no geometry, both should collapse to "miss → env lookup" — but the path may differ).
+
+## Reference
+
+- `src/gpu/path_trace_kernel.cu` — miss branch (lines ~265–285).
+- `include/astroray/gpu_materials.h` — `gpu_envmap_lookup` and friends.
+- `include/raytracer.h` — `EnvironmentMap::sample` and CPU `pathTrace` miss handling.
+- `tests/test_world_hdri_parity.py::test_gpu_cpu_ssim_hdri` — the gate.
+
+## Specification
+
+### Phase 1 — Localise the divergence
+
+Render the CPU and GPU images, save both to PNG, eyeball them. Then for the same camera ray (e.g., centre pixel), trace by hand on both backends and find where they diverge.
+
+### Phase 2 — Fix the env-lookup math
+
+Whatever Phase 1 surfaces. Pkg63 already baked the rotation matrix; this is likely a smaller miss (strength, tint, channel order, or the 0.2f sky-gradient fallback firing when it shouldn't).
+
+### Acceptance
+
+- `test_gpu_cpu_ssim_hdri` passes with margin (SSIM ≥ 0.97).
+- No regression on other env-map tests (`test_pkg63_*`, `test_world_hdri_parity::test_other_*`).

--- a/.astroray_plan/packages/pkg85-test-harness-cuda-state-leak.md
+++ b/.astroray_plan/packages/pkg85-test-harness-cuda-state-leak.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 5
 **Track:** A (RTX verifier)
-**Status:** done (pkg85-B PR pending, 2026-05-14 — 893 passed; two pre-existing GPU bugs surfaced as architectural_glass illegal-mem-access + HDRI uploadScene defect, filed as pkg85-C below)
+**Status:** done (pkg85-C PR pending, 2026-05-14 — 901 passed, 0 CUDA illegal-access crashes on the full sweep; remaining HDRI world-only SSIM parity defect filed as pkg85-D)
 **Estimated effort:** ½ day (~4 h on RTX)
 **Depends on:** pkg67 (the verifier that surfaced this defect)
 
@@ -134,3 +134,24 @@ Both are pre-existing bugs the audit revealed by no longer letting silent kernel
 `pytest tests/ --ignore=tests/test_wavefront_parity.py --ignore=tests/test_benchmark_showcase_phase2.py --deselect tests/test_world_hdri_parity.py::test_gpu_cpu_ssim_hdri`: **893 passed, 4 skipped, 18 xfailed, 1 xpassed** — zero CUDA illegal-access crashes across the rest of the sweep.
 
 Without the exclusions the sweep still crashes — but the crash is now blamed on the *correct* test (the showcase one with the actual buggy material) instead of test #370 inheriting dead context. That is the pkg85-B success condition: kernel errors no longer migrate across tests.
+
+---
+
+**pkg85-C complete 2026-05-14 (PR pending).**
+
+### Root causes and fixes
+
+1. **GPU/CPU BVH primitive-array misalignment (Phase A + B).** `BVHAccel` builds from the full CPU `scene`, which can include non-renderable primitives like `DistantLight` (added by `add_sun_light`). `scene_upload.cu` only pushed `Triangle`/`Sphere` entries into `r.prims`, so when the CPU BVH collapsed two equal-centroid primitives into a single leaf (`nPrimitives=2, primitivesOffset=0`), the GPU BVH walk read `prims[1]` past the end of the uploaded array → `cudaErrorIllegalAddress` in `pathTraceKernel`. The fault was localized via compute-sanitizer (size-1 OOB read at +8 past an 8-byte allocation = `sizeof(GPrimitive)`). Fix: add `GPRIM_SKIP` to `GPrimType` and push placeholder `GPRIM_SKIP` entries from `scene_upload.cu` for non-{Triangle,Sphere} prims; `gpu_bvh_hit` and the area-light branch of `sampleDirectGPU` skip them. This unblocks every material in the showcase test and the diagnostic contact sheet.
+2. **World-only render rejected with "Scene not uploaded" (Phase D).** `CUDARenderer::render` / `renderMultiwavelength` required `impl->d_bvhNodes != nullptr`, but a scene with only an environment map (and no geometry) is a legitimate render configuration — `gpu_bvh_hit` already returns false when `nodes` is null. Fix: gate the precondition on `(!d_bvhNodes && !envMap.loaded)` instead of `!d_bvhNodes` alone.
+
+### Gate result
+
+`pytest tests/ --ignore=tests/test_wavefront_parity.py --deselect tests/test_world_hdri_parity.py::test_gpu_cpu_ssim_hdri`: **901 passed, 13 skipped, 16 xfailed, 3 xpassed** (vs. 893 baseline for pkg85-B). Zero CUDA illegal-access crashes anywhere in the sweep. The previously-quarantined `test_benchmark_showcase_phase2.py` is fully back in scope.
+
+Material contact sheet (`scripts/diagnostics/material_contact_sheet.py --resolution 480 --samples 1024 --device auto`) renders cleanly across all materials with GPU lowerings.
+
+### pkg85-D (escalation — file as new spec)
+
+One real defect still surfaces after pkg85-C closes the original blockers:
+
+- **`test_world_hdri_parity::test_gpu_cpu_ssim_hdri`** — now runs to completion but the GPU vs CPU SSIM is ~0.35 (gate ≥0.97). Likely a difference in how the world-only path samples the env map between the CPU integrator and `pathTraceKernel`'s miss branch (tonemapping, rotation matrix, or `gpu_envmap_lookup` parity). Pre-existing — pkg85-B hid it behind the "Scene not uploaded" early-exit. Not a CUDA crash; pkg85 gate (no illegal-access in full sweep) is met without fixing it.

--- a/include/astroray/gpu_bvh.h
+++ b/include/astroray/gpu_bvh.h
@@ -118,8 +118,11 @@ __device__ inline bool gpu_bvh_hit(
                     bool isHit = false;
                     if (p.type == GPRIM_TRIANGLE) {
                         isHit = gpu_triangle_hit(tris[p.index], ray, tMin, tMax, tmpRec);
-                    } else {
+                    } else if (p.type == GPRIM_SPHERE) {
                         isHit = gpu_sphere_hit(spheres[p.index], ray, tMin, tMax, tmpRec);
+                    } else {
+                        // pkg85-C: GPRIM_SKIP placeholder — see gpu_types.h.
+                        isHit = false;
                     }
                     if (isHit) {
                         hit  = true;

--- a/include/astroray/gpu_types.h
+++ b/include/astroray/gpu_types.h
@@ -223,7 +223,13 @@ struct GBVHNode {
 // ---------------------------------------------------------------------------
 // Primitive descriptors
 // ---------------------------------------------------------------------------
-enum GPrimType : uint8_t { GPRIM_TRIANGLE = 0, GPRIM_SPHERE = 1 };
+// pkg85-C: GPRIM_SKIP is a placeholder used for CPU-only primitives
+// (e.g., DistantLight) that share the BVH with GPU-renderable prims.
+// scene_upload.cu pushes one of these for every orderedPrims entry that
+// isn't a Sphere or Triangle, so r.prims stays index-aligned with the
+// BVH's primitivesOffset and with GLight.primitiveIndex. gpu_bvh_hit
+// and the area-light sampler treat GPRIM_SKIP as a no-op.
+enum GPrimType : uint8_t { GPRIM_TRIANGLE = 0, GPRIM_SPHERE = 1, GPRIM_SKIP = 2 };
 struct GPrimitive {
     GPrimType type;
     int       index;   // index into d_triangles or d_spheres

--- a/src/gpu/cuda_renderer.cu
+++ b/src/gpu/cuda_renderer.cu
@@ -444,7 +444,13 @@ void CUDARenderer::render(
     int seed, int samplesPerPixel, int maxDepth)
 {
     if (!impl->available) throw std::runtime_error("No CUDA GPU available");
-    if (!impl->d_bvhNodes) throw std::runtime_error("Scene not uploaded — call uploadScene() first");
+    // pkg85-C: allow world-only renders. The path-trace kernel's
+    // gpu_bvh_hit() already returns false when d_bvhNodes is null, so a
+    // scene with an environment map but no geometry should produce a
+    // pure-env image rather than throwing here. Only fail if neither a
+    // scene nor an environment map has been uploaded.
+    if (!impl->d_bvhNodes && !impl->envMap.loaded)
+        throw std::runtime_error("Scene not uploaded — call uploadScene() first");
 
     astroray::gpu_profile::NvtxRange _nvtx_render("CUDARenderer::render");
     impl->ensureFramebuffer(width, height);
@@ -564,7 +570,9 @@ void CUDARenderer::renderMultiwavelength(
     float lambdaMin, float lambdaMax, bool useLuminanceOutput)
 {
     if (!impl->available) throw std::runtime_error("No CUDA GPU available");
-    if (!impl->d_bvhNodes) throw std::runtime_error("Scene not uploaded — call uploadScene() first");
+    // pkg85-C: see CUDARenderer::render() — world-only renders are valid.
+    if (!impl->d_bvhNodes && !impl->envMap.loaded)
+        throw std::runtime_error("Scene not uploaded — call uploadScene() first");
 
     astroray::gpu_profile::NvtxRange _nvtx_mw("CUDARenderer::renderMultiwavelength");
     impl->ensureFramebuffer(width, height);

--- a/src/gpu/path_trace_kernel.cu
+++ b/src/gpu/path_trace_kernel.cu
@@ -51,6 +51,9 @@ __device__ inline float gpu_light_pdf(
         int primIdx = l.primitiveIndex;
         if (primIdx < 0) continue;
         const GPrimitive& lp = prims[primIdx];
+        // pkg85-C: CPU-only light primitives (DistantLight, etc.) are
+        // GPRIM_SKIP on the GPU; they contribute no area-light PDF here.
+        if (lp.type == GPRIM_SKIP) continue;
         if (lp.type == GPRIM_SPHERE) {
             const GSphere& s = spheres[lp.index];
             float dist2 = (s.center - origin).length2();
@@ -139,6 +142,9 @@ __device__ GVec3 sampleDirectGPU(
 
         {
             const GPrimitive& lp = prims[primIdx];
+            // pkg85-C: CPU-only light primitives are GPRIM_SKIP on the GPU.
+            // No GPU area-light sample is possible — fall through to BSDF MIS.
+            if (lp.type == GPRIM_SKIP) goto bsdf_mis;
             GVec3 lightPoint, lightNormal;
             if (lp.type == GPRIM_SPHERE) {
                 const GSphere& s = spheres[lp.index];

--- a/src/gpu/scene_upload.cu
+++ b/src/gpu/scene_upload.cu
@@ -260,8 +260,15 @@ SceneUploadResult buildSceneArrays(const Renderer& cpu, const Camera* cam) {
             gs.materialId = getOrAddMat(sph->getMaterial());
             r.spheres.push_back(gs);
         } else {
-            // Skip unknown types (BVHAccel, etc.)
-            continue;
+            // pkg85-C: keep r.prims index-aligned with the BVH's orderedPrims
+            // by pushing a GPRIM_SKIP placeholder for non-{Triangle,Sphere}
+            // primitives (e.g., DistantLight). Without this, BVH leaves
+            // built from a 2-prim CPU scene whose centroids collide can
+            // produce a single leaf with nPrimitives=2, and gpu_bvh_hit
+            // reads prims[1] past the end of the uploaded r.prims array,
+            // crashing the path-trace kernel with cudaErrorIllegalAddress.
+            gp.type  = GPRIM_SKIP;
+            gp.index = -1;
         }
         r.prims.push_back(gp);
     }


### PR DESCRIPTION
Closes the pkg85 spec gate. Full pytest sweep
(`pytest tests/ --ignore=tests/test_wavefront_parity.py --deselect tests/test_world_hdri_parity.py::test_gpu_cpu_ssim_hdri`) is **901 passed, 13 skipped, 16 xfailed, 3 xpassed** with **zero CUDA illegal-access crashes**. pkg85-B's baseline was 893 passed with the showcase suite quarantined; pkg85-C brings that suite back in scope (+8 passing tests).

## Root causes

**1. GPU/CPU BVH primitive-array misalignment (Phase A + B).** `BVHAccel` builds from the full CPU `scene`, which can include non-renderable primitives like `DistantLight` (added by `add_sun_light`). `scene_upload.cu` only pushed `Triangle`/`Sphere` entries into `r.prims`, so when the CPU BVH collapsed two equal-centroid primitives into a single leaf (`nPrimitives=2, primitivesOffset=0`), the GPU BVH walk read `prims[1]` past the end of the uploaded array → `cudaErrorIllegalAddress` in `pathTraceKernel`. Localized via compute-sanitizer (size-1 OOB read at +8 past an 8-byte allocation = `sizeof(GPrimitive)`). Fix: add `GPRIM_SKIP` placeholder + sync `gpu_bvh_hit` and `sampleDirectGPU` to handle it.

**2. World-only render rejected with "Scene not uploaded" (Phase D).** `CUDARenderer::render`/`renderMultiwavelength` required `d_bvhNodes != nullptr`, but `gpu_bvh_hit` already returns false when nodes is null, so a scene with only an env map (no geometry) is a valid configuration. Gate the precondition on `(!d_bvhNodes && !envMap.loaded)`.

## Phase A/B/C/D progression

- **Phase A — Investigation.** Reproduced `test_gpu_flag_runs_without_cuda` failure (every material with a GPU lowering crashes). Wrote minimal single-sphere + sun-light reproducer. `compute-sanitizer --tool memcheck` pinpointed the OOB: `Invalid __global__ read of size 1 bytes at pathTraceKernel; Address 0x...208 is 1 bytes after the nearest allocation at 0x...200 of size 8 bytes` — i.e. \`prims[1].type\` when only one GPrimitive is allocated. Tracing the discrepancy back through `scene_upload.cu` and `BVHAccel` found the index-alignment defect.
- **Phase B — Material contact sheet.** `scripts/diagnostics/material_contact_sheet.py --resolution 480 --samples 1024 --device auto` now renders cleanly end-to-end (output in `test_results/pkg85-c-repro/contact_sheet/`). Same root cause as Phase A — one fix addresses both.
- **Phase C — Audit continuation.** After the GPRIM_SKIP fix, the full sweep stopped crashing. No additional unwrapped CUDA call sites surfaced from running to completion. pkg85-B already covered the silent leakers; Phase C is closed without further changes.
- **Phase D — HDRI parity.** Removed the over-strict `!d_bvhNodes` precondition. The test now reaches its SSIM gate; the assertion still fails (SSIM ≈ 0.35 vs 0.97 gate) because of an *unrelated* env-map lookup parity defect that pkg85-B was hiding behind the early-exit. Filed as **pkg85-D** since it is not a CUDA-state issue and the pkg85 gate (no illegal-access in the sweep) is met without it.

## Before/after pytest counts

| State | Command | Result |
|---|---|---|
| pkg85-B baseline | `pytest ... --ignore=test_wavefront_parity --ignore=test_benchmark_showcase_phase2 --deselect test_world_hdri_parity::test_gpu_cpu_ssim_hdri` | 893 passed |
| pkg85-C | `pytest ... --ignore=test_wavefront_parity --deselect test_world_hdri_parity::test_gpu_cpu_ssim_hdri` | **901 passed, 0 CUDA crashes** |
| pkg85-C without any deselect | same minus the SSIM deselect | 901 passed, 1 assertion failure (SSIM only — see pkg85-D), 0 CUDA crashes |

## Material contact sheet

Rendered cleanly: yes. Output path: `test_results/pkg85-c-repro/contact_sheet/material_contact_sheet.png` (854×480 wasn't a real flag — the script takes `--resolution`; rendered at 480×480, 1024 spp, `--device auto`).

## Algorithm sourcing (CLAUDE.md §6)

No new algorithms. Both fixes are bounds-check / precondition corrections in existing data-marshalling code. The GPRIM_SKIP pattern is a standard "valid-but-skip" sentinel; no external citation needed.

## Acceptance criteria (from pkg85 spec)

- [x] Full `pytest tests/ --ignore=tests/test_wavefront_parity.py` sweep completes without ANY CUDA illegal-access crash (one assertion failure remains in `test_gpu_cpu_ssim_hdri`, escalated to pkg85-D).
- [x] Material contact sheet renders cleanly at full resolution with `--device gpu`/`--device auto`.
- [x] pkg85 spec status flipped to `done (pkg85-C PR pending, 2026-05-14 — ...)`.
- [x] pkg85-D filed for the remaining SSIM-parity defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)