### PR TITLE
docs: Round 8 sync #2 — pkg43/pkg85-C/pkg88-89/pkg38-light-source-spectra landed; pkg85-D + issue #276 recorded

### DIFF
--- a/.astroray_plan/docs/NEXT_STAGE_REPORT.md
+++ b/.astroray_plan/docs/NEXT_STAGE_REPORT.md
@@ -1,20 +1,18 @@
 # Astroray Next Stage Report
 
-**Date:** 2026-05-14 (Round 8 mid-cycle — doc/spec/research wave landed; implementation wave starts next session)
+**Date:** 2026-05-14 (Round 8 mid-cycle sync #2 — implementation wave in progress)
 **Prepared by:** Claude (Anthropic Code, Sonnet 4.5 in Max 5x)
-**Scope:** Round 8 implementation wave. The **Round 8 doc/spec/research wave** has **landed on main** (8 PRs merged 2026-05-14):
-- Round 8 strategy pass (architect assessment; pkg55-B fork decision → CPU-first restart)
-- pkg55 Phase B' amendment (CPU-first restart spec now authoritative; 8 design decisions)
-- pkg86 Light Tree spec (open, ready after pkg89 Phase A)
-- pkg87 Cryptomatte spec (open, independent)
-- pkg88 motion blur research + DRAFT spec
-- pkg89 dedicated lights research + DRAFT spec (Q1/Q6/Q7/Q11 answered)
-- pkg85 partial fix (PR #268 — conftest + cuda_renderer robustness; spec gate NOT met)
-- round8-dispatch-queue.md (owner's session-close answers)
+**Scope:** Round 8 implementation wave. The **Round 8 doc/spec/research wave** landed on main (8 PRs, 2026-05-14 sync #1); the **implementation wave has started** (7 PRs merged since sync #1, 2026-05-14 sync #2):
+- **pkg43 slim disk** (PR #271) — Abramowicz 1988 / Sadowski 2009, 14/14 tests pass
+- **pkg88 + pkg89 spec promotion** (PR #273) — DRAFT specs promoted to real specs with owner answers
+- **pkg38-light-source-spectra** (PR #274) — 7 SPDs filed, unblocks pkg89 Phase A
+- **pkg85-C gate cleared** (PR #278) — 901 passed, 0 CUDA crashes; GPU/CPU BVH misalignment + material-lowering bugs fixed
+- **Repo cleanup** (PR #275, #277) — moved measurement scripts, autouse GC fixture wrapped
+- **Direct pushes** (ec28667, 4ae14d7, eff21fd, 28ea478) — handoff notes, dispatch queue, CLAUDE.md sections, `/pkg-ship` skill
 
-**Implementation wave starts next session.** The dispatch queue
+**Round 8 continues.** The dispatch queue
 (`.astroray_plan/docs/round8-dispatch-queue.md`) is the authoritative
-pickup order; this report summarizes the state that queue assumes.
+pickup order; this report summarizes the updated state.
 
 > Strategic gate: **RELEASED 2026-05-10** by pkg56 Phase C; Pillar 4
 > has been actively shipping since. Strategy in
@@ -24,55 +22,31 @@ pickup order; this report summarizes the state that queue assumes.
 
 ## 1. Current state (one screen)
 
-**Done since the previous report (Round 8 doc/spec wave — 8 PRs merged 2026-05-14):**
+**Done since the previous report (Round 8 implementation wave — 7 PRs merged 2026-05-14 sync #2):**
 
-- **Round 8 strategy pass** (PR #263, 2026-05-14) — architect assessment
-  of pkg55-B fork decision; Cycles-parity gap decomposed into performance
-  (pkg55-B only gap remaining after pkg82/83/84), UI (Cryptomatte +
-  light-group AOVs highest compositor-side gap), and features (Light Tree
-  highest engine-side performance lever). Recommendation: **restart pkg55-B
-  from pkg55-A.1 baseline with CPU reference implementation first** (not
-  continue debugging, not wait for non-existent Phase C, not abandon
-  viewport-parity gate). Filed at
-  `.astroray_plan/docs/round8-strategy-pass.md`.
-- **pkg55 Phase B' amendment** (PR #266, 2026-05-14) — **CPU-first
-  restart spec now authoritative on main**. 8 design decisions: (1) CPU
-  wavefront first, (2) per-stage diff harness, (3) bit-identical gate vs
-  path_tracer, (4) staged CUDA port one kernel at a time, (5) no
-  premature optimization, (6) Phase B.1 acceptance is CUDA parity not
-  speedup, (7) spectral state first-class, (8) clean plugin
-  registrations. Session 1 summary at
-  `.astroray_plan/docs/pkg55-B-restart-session1-summary.md`.
-  **origin/pkg55-phase-b HELD as reference; do not merge.**
-- **pkg86 Light Tree spec filed** (PR #265, 2026-05-14) — Conty 2018
-  many-lights importance sampling + Cycles Apache-2.0 reference. Status
-  open, ready to implement **after pkg89 Phase A** ships
-  `Light::orientationCone()` + `Light::power()` accessors per pkg89
-  research note.
-- **pkg87 Cryptomatte spec filed** (PR #264, 2026-05-14) — Psyop BSD-3 +
-  Cycles Apache-2.0. Status open, ready to implement; independent.
-  Highest compositor-side Cycles-parity gap per strategy pass.
-- **pkg88 motion blur research + DRAFT spec** (PR #267, 2026-05-14) —
-  research signed off; DRAFT spec; design questions deferred per owner
-  ("get to that later"). 4 phases: A camera, B object, C deformation, D
-  wavefront hook.
-- **pkg89 dedicated lights research + DRAFT spec** (PR #269, 2026-05-14)
-  — research signed off; DRAFT spec; Q1/Q6/Q7/Q11 answered in
-  round8-dispatch-queue.md (Q1 `std::variant` tagged union, Q6 extend
-  `LightSample.emission_spec`, Q7 staged signature break, Q11
-  implementer's judgment on normalize flag). Ready to promote to real
-  spec + start Phase A.
-- **pkg85 partial fix** (PR #268, 2026-05-14) — conftest autouse fixture
-  + cuda_renderer error clearing. **Spec gate NOT met** (full pytest
-  sweep crash still reproduces). Robustness improvement only. Full
-  CUDA-call audit queued as pkg85-B follow-up per
-  round8-dispatch-queue.md.
-- **round8-dispatch-queue.md** (direct push 4ae14d7, 2026-05-14) —
-  captures owner's session-close answers: pkg43 worktree version
-  canonical, pkg55-B restart next session, pkg64-gpu owner's call on
-  timing, pkg86 after pkg89 Phase A, pkg87 independent, pkg88 design Qs
-  deferred, pkg89 Q answers, pkg85-B filing + clearcoat investigation
-  follow-ups.
+- **pkg43 slim disk accretion model** (PR #271, 2026-05-14) — Abramowicz 1988 / Sadowski 2009 advective slim-disk model implemented. Includes `SampledWavelengths::fromLambdas` factory addition to `spectrum.h`. Units fix: r_s → r_g convention. Spec measurement-corrected: 1.62e8 K → 7.45e6 K at canonical point (9M, mdot=1). 14/14 slim-disk tests pass, no pkg42 regression. **Pillar 4 now 40% complete** (pkg40 + pkg41 + pkg42 + pkg43 done).
+- **pkg88 + pkg89 spec promotion** (PR #273, 2026-05-14) — DRAFT specs promoted to real specs after architect spec-promotion pass + owner answers locked in. **pkg88**: box-shutter only, scene-wide steps, Cycles default 0.5 frame center, single consistent stratification policy. **pkg89**: extended 4-mode emission UX with blackbody+color-as-filter, RGB upsample, MeasuredSPD presets, Composite. DRAFT files deleted. Both specs now **open** and ready to dispatch.
+- **pkg38-light-source-spectra amendment spec** (PR #274, 2026-05-14) — 7 SPDs: CIE F2/F3 fluorescent (CIE 15:2018), LED 3000/5000/6500K (CIE 224:2017 LED-B3/B4/B5 + LSPDD fallback), sodium vapor + mercury vapor (NIST ASD). All public-domain / CC. Unblocks pkg89 Phase A `EmissionSpectrum::MeasuredSPD` preset buttons. Status **open**, ready to implement, ~½ day.
+- **pkg85-C closes pkg85 spec gate** (PR #278, 2026-05-14) — **901 passed, 0 CUDA illegal-access crashes** on the full sweep. Two root causes fixed: (1) GPU/CPU BVH primitive-array index misalignment — `scene_upload.cu` silently dropped non-{Triangle,Sphere} primitives but CPU BVH was built from full scene; localized via compute-sanitizer as 1-byte OOB read at +8 past 8-byte allocation; fixed by introducing `GPRIM_SKIP` placeholder. (2) World-only GPU render rejected with "Scene not uploaded" — gate fixed to `(!d_bvhNodes && !envMap.loaded)`. Material contact sheet now renders cleanly at 480×480 / 1024 spp. **pkg85-D filed** as new follow-up (HDRI world-only SSIM parity bug surfaced once the original blockers cleared).
+- **Repo cleanup + robustness** (PR #275 + #277, 2026-05-14) — moved 3 dev measurement scripts to `dev/measurement-scripts/` (`sitecustomize.py` correctly kept at root for Windows DLL discovery bootstrap); wrapped autouse GC fixture cleanup in try/except so cleanup exceptions don't surface as test teardown ERROR.
+- **Direct pushes** (ec28667, 4ae14d7, eff21fd, 28ea478, 2026-05-14) — pkg43 handoff notes restoration after stash drop, round8 dispatch queue + owner answers, CLAUDE.md Shell Conventions + Build & Verification + PR & Git Workflow sections, `/pkg-ship` skill + design notes codification.
+
+**Hardware verification headline (RTX 5070 Ti, commit 063bd42 + later):**
+- 910/911 pytest passed (1 known ReSTIR spatial MSE flake; pkg85 gate cleared)
+- Build 4m20s, 52 MB, all features enabled (CUDA + OptiX + OIDN + tcnn + WAVEFRONT_INTERSECT)
+- Caustics rendered at 8192 spp (prism + glass + line emitter, clean — note pkg64 is CPU-only currently)
+- Material contact sheet rendered at 854×480 / 1024 spp with --gpu (24 materials distinct, clean)
+- AOV passes + convergence grid produced cleanly
+
+**Previous report (Round 8 doc/spec wave — 8 PRs merged 2026-05-14 sync #1):**
+- Round 8 strategy pass (PR #263) — architect assessment; pkg55-B fork decision → CPU-first restart
+- pkg55 Phase B' amendment (PR #266) — CPU-first restart spec now authoritative; 8 design decisions
+- pkg86 Light Tree spec (PR #265) — open, ready after pkg89 Phase A
+- pkg87 Cryptomatte spec (PR #264) — open, independent
+- pkg88 motion blur research + DRAFT spec (PR #267) — now promoted to real spec (see above)
+- pkg89 dedicated lights research + DRAFT spec (PR #269) — now promoted to real spec (see above)
+- pkg85 partial fix (PR #268) — conftest + cuda_renderer robustness; spec gate NOT met; full audit landed as pkg85-B (see pkg85-C above for gate closure)
+- round8-dispatch-queue.md (direct push 4ae14d7) — owner's session-close answers
 
 **HELD on branch (do not merge):**
 
@@ -89,18 +63,19 @@ pickup order; this report summarizes the state that queue assumes.
 
 | Track | Type | Effort | Notes |
 |---|---|---|---|
-| **pkg43 finish** | implementer (CUDA) | ~1 session | Worktree exists; handoff doc lists exact next steps; static-init registration debug is blocker |
-| **pkg55-B Phase B' Session 2** | implementer (CPU-only) | ~1-2 weeks | Spec now authoritative on main; brief should quote 8 design decisions verbatim; worktree `pkg55-restart` exists |
-| **pkg89 spec promotion → Phase A** | doc + implementer | ~2-3 weeks Phase A | Promote DRAFT to real spec with 4 Q answers; then Light interface + 5 type stubs, no rewiring yet |
-| **pkg85-B spec filing** | doc-only | ~1 h | File follow-up spec for full CUDA-call audit; multi-day implementation later |
+| **pkg38-light-source-spectra** | implementer | ~½ day | Spec on main (PR #274); 7 SPDs; unblocks pkg89 Phase A |
+| **pkg55-B Phase B' Session 2+** | implementer (CPU-only) | ~1-2 weeks | Spec now authoritative on main; brief should quote 8 design decisions verbatim; worktree `pkg55-restart` exists |
+| **pkg89 Phase A** | implementer | ~2-3 weeks Phase A | Spec promoted (PR #273); Light interface + 5 type stubs + emission UX; blocked on pkg38-light-source-spectra implementation |
+| **pkg85-D** | implementer (RTX) | ~½ day | HDRI world-only GPU/CPU SSIM parity (≈0.35 vs 0.97 gate); spec on main |
 
 **Session 2 (assumes Session 1 lands):**
 
 | Track | Type | Effort | Notes |
 |---|---|---|---|
-| **pkg44 ADAF** | implementer | ~2 weeks | After pkg43; same VolumetricEmission interface, handle-based API |
-| **pkg89 Phase A continued** | implementer | — | Light types + emission interface + addon wiring |
-| **pkg87 Cryptomatte** | implementer | ~2-3 weeks | Spec on main; independent; highest compositor-side Cycles-parity gap |
+| **pkg44 ADAF** | implementer | ~2 weeks | After pkg43 ✓; same VolumetricEmission interface, handle-based API |
+| **pkg89 Phase A continued** | implementer | — | After pkg38-light-source-spectra lands; Light types + emission interface + addon wiring |
+| **pkg87 Cryptomatte** | implementer | ~2-3 weeks | Spec on main (PR #264); independent; highest compositor-side Cycles-parity gap |
+| **pkg88 Phase A** | implementer | ~1-2 weeks | Camera motion blur; spec promoted (PR #273); ready to implement |
 | **pkg64-gpu Phase 1** | implementer (CUDA) | ~2-3 weeks | Megakernel target; acknowledged pkg55-C will re-port; owner's call on timing |
 
 **Session 3+ (depends on earlier):**
@@ -109,7 +84,7 @@ pickup order; this report summarizes the state that queue assumes.
 |---|---|---|
 | **pkg86 Light Tree** | ~3 weeks | After pkg89 Phase A ships `Light::orientationCone()` + `Light::power()` |
 | **pkg55-B Phase B' Session 3+** | ~weeks | Continued CPU wavefront + diff harness expansion |
-| **pkg85-B full audit** | multi-day | When prioritized |
+| **Issue #276 / pkg90** | TBD | `test_disney_clearcoat_adds_gloss` chronic flake + suspected clearcoat correctness defect; when prioritized |
 
 **Carried / deferred:**
 
@@ -130,15 +105,16 @@ pickup order; this report summarizes the state that queue assumes.
 This report summarizes; the dispatch queue is the pickup order.
 
 **Session 1 (next session):**
-- pkg43 finish (worktree exists; static-init debug)
-- pkg55-B Phase B' Session 2 (CPU wavefront; 8 design decisions)
-- pkg89 spec promotion → Phase A (Light interface + 5 type stubs)
-- pkg85-B spec filing (doc-only; full CUDA-call audit follow-up)
+- pkg38-light-source-spectra (7 SPDs; unblocks pkg89 Phase A)
+- pkg55-B Phase B' Session 2+ (CPU wavefront; 8 design decisions)
+- pkg89 Phase A (Light interface + 5 type stubs; after pkg38-light-source-spectra)
+- pkg85-D (HDRI world-only SSIM parity; RTX verifier)
 
 **Session 2 (assumes Session 1 lands):**
-- pkg44 ADAF (after pkg43)
-- pkg89 Phase A continued
-- pkg87 Cryptomatte
+- pkg44 ADAF (after pkg43 ✓)
+- pkg89 Phase A continued (after pkg38-light-source-spectra lands)
+- pkg87 Cryptomatte (independent)
+- pkg88 Phase A (camera motion blur)
 - pkg64-gpu Phase 1 (megakernel target; owner's call on timing)
 
 **Session 3+ (depends on earlier):**

--- a/.astroray_plan/docs/ROADMAP.md
+++ b/.astroray_plan/docs/ROADMAP.md
@@ -87,12 +87,14 @@ back without user intervention.
 
 ### Pillar 4 — Astrophysics platform
 
-> **Thaw notice (2026-05-10) + shipping (2026-05-11):** the strategic
+> **Thaw notice (2026-05-10) + shipping (2026-05-11+):** the strategic
 > gate released, and Pillar 4 is actively shipping. pkg40 (Kerr
 > metric) + **pkg41 (Kerr validation, PR #236)** + **pkg42 (synchrotron
 > emission, PR #245 — VolumetricEmission interface, Pandya 2016 fits,
-> bipolar jet plugin, 9 tests)** all done. **pkg43 (slim disk)** is
-> the next Codex pickup; pkg44–pkg49 specs unfrozen and queued.
+> bipolar jet plugin, 9 tests)** + **pkg43 (slim disk accretion model,
+> PR #271 — Abramowicz 1988 / Sadowski 2009, 14/14 tests, T(9M,mdot=1) =
+> 7.45e6 K)** all done. **Pillar 4 now 40% complete.** **pkg44 (ADAF)**
+> is the next Codex pickup; pkg45–pkg51 specs queued.
 
 Kerr metric, synchrotron emission, HII recombination lines, simulation
 data import (FITS, HDF5, yt), telescope PSF. Each phenomenon is a
@@ -179,12 +181,13 @@ RTX, **pkg83**/**pkg84** addon-only viewport polish. pkg67 (metric-
 aware path tracer) is now unblocked alongside Pillar 4; revisit once
 pkg40 + pkg55 maturity is in place.
 
-**Pillar 4 thawed and shipping (2026-05-11).** pkg40 (Kerr metric),
-**pkg41 Kerr validation** (PR #236), and **pkg42 synchrotron
-emission** (PR #245 — VolumetricEmission interface, Pandya 2016 fits,
-bipolar jet plugin) all done. **pkg43 (slim disk)** + **pkg44 (ADAF)**
-are next in series for Round 7 Codex; pkg45–pkg49 paste-ready specs
-queued.
+**Pillar 4 thawed and shipping (2026-05-11+).** pkg40 (Kerr metric),
+**pkg41 Kerr validation** (PR #236), **pkg42 synchrotron emission**
+(PR #245 — VolumetricEmission interface, Pandya 2016 fits, bipolar jet
+plugin), and **pkg43 slim disk accretion model** (PR #271 — Abramowicz
+1988 / Sadowski 2009, 14/14 tests) all done. **Pillar 4 now 40%
+complete.** **pkg44 (ADAF)** is next in series for Round 8 Codex;
+pkg45–pkg51 paste-ready specs queued.
 
 - `pkg34-material-backend-capabilities.md` — capability metadata,
   no silent grey-Lambertian GPU fallback, CPU/GPU contact-sheet diffs.

--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -114,7 +114,7 @@ personally should pick up.
 | 1 | Plugin architecture | **Done** | 100% | — | — |
 | 2 | Spectral core | **Done** | 100% | — | — |
 | 3 | Light transport | **Validation** | 90% | NRC batched-inference speedup target | CUDA kernels for ReSTIR/NRC are not implemented |
-| 4 | Astrophysics platform | **Active, shipping** | 35% | pkg43 slim disk accretion model | gate released; pkg40 + pkg41 + pkg42 done; pkg43–51 queued |
+| 4 | Astrophysics platform | **Active, shipping** | 40% | pkg44 ADAF accretion model | gate released; pkg40 + pkg41 + pkg42 + pkg43 done; pkg44–51 queued |
 | 5 | Production polish / Blender parity | **Feature-complete on planned scope; viewport-parity gate now owned by pkg55 Phase B** | ~98% (counter) | pkg55 Phase B (per-material shade kernels — owns the viewport-parity claim) | pkg73 ✓ + pkg80 ✓ + pkg81 P1+P2 ✓ + pkg55-A.1 ✓ all done 2026-05-11; pkg55-B is the long-tail |
 
 **Pillar 1 package summary:**
@@ -242,7 +242,7 @@ forgotten):
 | pkg40 | Kerr metric plugin and Schwarzschild extraction | **done** |
 | pkg41 | Kerr geodesic validation | **done** (PR #236 — 39 tests; BPT 1972 + Chandrasekhar analytic + null circular photon residuals + Kerr a=0 vs Schwarzschild identity + shadow-contour image-plane regression) |
 | pkg42 | Synchrotron emission and relativistic jets | **done** (PR #245, 2026-05-11 — VolumetricEmission interface, `synchrotron_jet` plugin, Pandya 2016 power-law/thermal fits, bipolar jet plugin, Blender jet controls, 9 focused tests) |
-| pkg43 | Slim disk accretion model | open |
+| pkg43 | Slim disk accretion model | **done** (PR #271, 2026-05-14 — Abramowicz 1988 / Sadowski 2009, 14/14 tests, T(9M,mdot=1) = 7.45e6 K) |
 | pkg44 | ADAF accretion model | open |
 | pkg45 | CLOUDY emissivity table preprocessing | open |
 | pkg46 | HII region emission plugin | open |
@@ -402,11 +402,13 @@ events are summarized in the changelog below.
 | pkg82 | A | **done** | PR #261; gate 0.999→0.998; closes issue #237 |
 | pkg83 | A | **done** | PR #259; spp_trace accumulates across camera pans |
 | pkg84 | A | **done** | PR #260; first frame 83.3 ms (was 12,079 ms) |
-| pkg85 | A | partial | PR #268 conftest+cuda_renderer robustness; spec gate NOT met; full audit queued as pkg85-B |
+| pkg85 | A | **done** | PR #278 (pkg85-C) — 901 passed, 0 CUDA illegal-access crashes; GPU/CPU BVH primitive-array index misalignment fixed; material-lowering bugs fixed; world-only GPU render trigger fixed; pkg85-D filed for HDRI world-only SSIM parity |
 | pkg86 | A | open — ready to implement | Light Tree after pkg89 Phase A ships Light::orientationCone() + power() |
 | pkg87 | A | open — ready to implement | Cryptomatte passes; independent |
-| pkg88 | A | open — research signed off, DRAFT spec | Motion blur; design Qs deferred; see round8-dispatch-queue.md |
-| pkg89 | A | open — research signed off, DRAFT spec | Dedicated Light objects; Q1/Q6/Q7/Q11 answered in dispatch queue |
+| pkg38-light-source-spectra | A | open — ready to implement | Amendment to pkg38: 7 emission SPDs (CIE F2/F3 fluorescent, LED 3000/5000/6500K, sodium vapor, mercury vapor); unblocks pkg89 Phase A MeasuredSPD presets |
+| pkg85-D | A | open | HDRI world-only GPU/CPU SSIM parity (≈0.35 vs 0.97 gate); surfaced after pkg85-C cleared "Scene not uploaded" early-exit |
+| pkg88 | A | open — spec promoted | Motion blur (PR #273 spec promotion); Phase A camera blur ready; Phase D blocked by pkg55-B/C |
+| pkg89 | A | open — spec promoted | Dedicated Light objects (PR #273 spec promotion); Phase A blocked by pkg38-light-source-spectra implementation |
 | pkg68 | A | **done** | persistent OIDN device, CUDA-first init, member-cached filter; CUDA verifier session 2026-05-10 on RTX 5070 Ti: 13/13 pytest green (incl. `test_cuda_capable_build_reports_cuda_device`), `[OIDN] Using CUDA device` confirmed, single device init across N=4 renders verified; viewport timing 256×256 spp=2: OIDN-on 50.67 ms/frame vs OIDN-off baseline 23.81 ms/frame (Δ=26.86 ms persistent-device overhead) |
 | pkg69 | A | **done** | Blender compositor denoise Albedo/Normal data passes |
 | pkg70 | A | **done** | OptiX denoiser plugin co-equal with OIDN; persistent OptixDeviceContext + OptixDenoiser handle, lazy init, HDR vs AOV model selection by guide presence; `gpu_optix_available()` Python probe; addon `denoiser_backend` Auto/OptiX/OIDN with OptiX preferred when both present. **Verified 2026-05-10 on RTX 5070 Ti + OptiX 9.1.0**: 17/17 pytest green; 5.31× synthetic-noise reduction at 256×256; 1.86× faster than OIDN-CUDA at 1080p (728.94 ms vs 1356.09 ms); SSIM(OptiX, OIDN) = 0.9987. Empty-normal-buffer defect surfaced upstream during verification → tracked as pkg75 |
@@ -428,11 +430,9 @@ events are summarized in the changelog below.
   landed (15d98f0); do not merge until architect decides whether to debug-spiral-
   more, restart from a clean baseline, or wait for pkg55-C wavefront/megakernel
   decision.
-- **Test-harness CUDA state leak (pkg85)** — `pytest tests/ --ignore=tests/test_wavefront_parity.py`
-  crashes at test #370 (`test_visible_band_cpu_gpu_ssim`) with illegal memory
-  access at `cuda_renderer.cu:81`; same test in isolation passes cleanly. Bisect
-  candidate range: tests 360–369. Discovered during pkg67 verification. Spec filed
-  at `.astroray_plan/packages/pkg85-test-harness-cuda-state-leak.md`.
+- **Disney clearcoat flake + suspected correctness defect** — [Issue #276](https://github.com/HendrikGC02/Astroray/issues/276): `test_disney_clearcoat_adds_gloss` chronic variance flake (PASSED/FAILED on identical scenes), owner notes clearcoat "may not be working well." Suggested package number `pkg90` in the issue body. Labels: bug, material.
+- **Pyd-shadow-guard hook upgrade** — `.claude/hooks/pre-pytest` warns on shadow pyds but doesn't auto-delete. Stale `astroray.pyd` (pkg84-era legacy name) at repo root shadowed fresh `astroray.cp313-win_amd64.pyd` from `build_cuda/Release/` twice in 2026-05-14 sessions. Potential follow-up package to upgrade hook to auto-delete before pytest.
+- **Stale orphan worktree directories** — 18 in `.claude/worktrees/*` from 2026-05-14 sessions: git registry removed them but OneDrive perm-denied the directory unlink. Cosmetic; clean later with non-sandboxed shell.
 - `include/raytracer.h` and `include/advanced_features.h` still contain texture class bodies (`CheckerTexture`, `NoiseTexture`, etc.). These are used directly by `blender_module.cpp` and will be cleaned up in a future package if the plan calls for it.
 - ReSTIR/NRC work is implemented through pkg28 but remains in validation:
   the target NRC batched-inference speedup is not proven, and `restir-di` /
@@ -501,6 +501,16 @@ events are summarized in the changelog below.
 ## Changelog
 
 Brief notes on notable events.
+
+- **2026-05-14 (Round 8 mid-cycle sync #2)** — implementation wave in progress. **7 PRs merged since previous sync:**
+  - **PR #271** (5e081ee) — **pkg43 slim disk accretion model** (Abramowicz 1988 / Sadowski 2009). Includes `SampledWavelengths::fromLambdas` factory addition to `spectrum.h`. Units fix: r_s → r_g convention. Spec measurement-corrected: 1.62e8 K → 7.45e6 K at canonical point. 14/14 tests pass + pkg42 no regression.
+  - **PR #273** (e093a70) — **pkg88 + pkg89 DRAFT specs promoted to real specs** (architect spec-promotion pass + owner answers locked in). pkg88: box-shutter only, scene-wide steps, Cycles default 0.5 frame center, single consistent stratification policy. pkg89: extended 4-mode emission UX with blackbody+color-as-filter, RGB upsample, MeasuredSPD presets, Composite. DRAFT files deleted.
+  - **PR #274** (81a1b18) — **pkg38-light-source-spectra amendment spec filed** (7 SPDs: CIE F2/F3 fluorescent, LED 3000/5000/6500K, sodium vapor, mercury vapor; all public-domain / CC; unblocks pkg89 Phase A).
+  - **PR #275** (2f03ee6) — repo cleanup (moved 3 dev measurement scripts to `dev/measurement-scripts/`; `sitecustomize.py` correctly kept at root for Windows DLL discovery bootstrap).
+  - **PR #277** (59fb543) — **pkg85 partial follow-up** (wrap autouse GC fixture cleanup in try/except so cleanup exceptions don't surface as test teardown ERROR).
+  - **PR #278** (063bd42) — **pkg85-C closes pkg85 spec gate**. Two root causes: (1) GPU/CPU BVH primitive-array index misalignment (`scene_upload.cu` silently dropped non-{Triangle,Sphere} primitives but CPU BVH was built from full scene; localized via compute-sanitizer as 1-byte OOB read at +8 past 8-byte allocation; fixed by introducing `GPRIM_SKIP` placeholder). (2) World-only GPU render rejected with "Scene not uploaded" (gate fixed to `(!d_bvhNodes && !envMap.loaded)`). Result: **901 passed, 0 CUDA illegal-access crashes**. Material contact sheet now renders cleanly at 480×480 / 1024 spp. pkg85-D filed as new follow-up (HDRI world-only SSIM parity bug surfaced once the original blockers cleared).
+  - **Direct pushes** (ec28667, 4ae14d7, eff21fd, 28ea478) — pkg43 handoff notes restoration, round8 dispatch queue + owner answers, CLAUDE.md workflow sections, `/pkg-ship` skill + design notes codification.
+  **Status changes:** pkg85 → done (pkg85-C gate cleared); pkg43 → done (PR #271); pkg88 + pkg89 → open with promoted specs; pkg38-light-source-spectra → open (new amendment spec). **New issues/follow-ups:** pkg85-D (HDRI world-only SSIM parity, SSIM ≈0.35 vs 0.97 gate), [Issue #276](https://github.com/HendrikGC02/Astroray/issues/276) (`test_disney_clearcoat_adds_gloss` chronic flake + suspected clearcoat correctness defect, suggested pkg90). **Hardware verification headline (RTX 5070 Ti, commit 063bd42):** 910/911 pytest passed (1 known ReSTIR spatial MSE flake), build 4m20s / 52 MB, caustics + material contact sheet rendered cleanly at 8192 spp + 1024 spp respectively.
 
 - **2026-05-14 (Round 8 mid-cycle docs sync)** — doc/spec/research wave landed; implementation wave starts next session. **8 PRs merged:**
   - **PR #263** (c476308) — Round 8 strategy pass (architect assessment of pkg55-B fork decision, Cycles-parity gap decomposition, top 3 non-pkg55 follow-ups ranked: Light Tree + Cryptomatte highest leverage).

--- a/.astroray_plan/packages/pkg43-slim-disk.md
+++ b/.astroray_plan/packages/pkg43-slim-disk.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 4
 **Track:** B (plugin, self-contained)
-**Status:** done (PR TBD, 2026-05-14 — T(9M, mdot=1) = 7.45e6 K matches Page-Thorne 1974 eq. 11n + Sadowski 2009 advective; 14/14 slim-disk tests pass; no pkg42 regression; units fix r_s→r_g)
+**Status:** done (PR #271, 2026-05-14 — T(9M, mdot=1) = 7.45e6 K matches Page-Thorne 1974 eq. 11n + Sadowski 2009 advective; 14/14 slim-disk tests pass; no pkg42 regression; units fix r_s→r_g)
 **Estimated effort:** 2 sessions (~5 h) — bumped from "1-2 sessions
 (~4 h)" after research; the advective-fraction fit and the
 exponential-clamp logic for super-Eddington need their own unit tests.

--- a/.astroray_plan/packages/pkg85-test-harness-cuda-state-leak.md
+++ b/.astroray_plan/packages/pkg85-test-harness-cuda-state-leak.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 5
 **Track:** A (RTX verifier)
-**Status:** done (pkg85-C PR pending, 2026-05-14 — 901 passed, 0 CUDA illegal-access crashes on the full sweep; remaining HDRI world-only SSIM parity defect filed as pkg85-D)
+**Status:** done (PR #278, 2026-05-14 — 901 passed, 0 CUDA illegal-access crashes on the full sweep; remaining HDRI world-only SSIM parity defect filed as pkg85-D)
 **Estimated effort:** ½ day (~4 h on RTX)
 **Depends on:** pkg67 (the verifier that surfaced this defect)
 


### PR DESCRIPTION
## Summary

Second mid-cycle sync within Round 8 to flush the docs-stale state before session handoff. Updates planning documents to reflect the **7 PRs merged since Round 8 sync #1** (commit 1c4a36e → 28ea478):

### PRs merged

| PR | Commit | Package | Summary |
|---|---|---|---|
| #271 | 5e081ee | **pkg43** | Slim disk accretion model (Abramowicz 1988 / Sadowski 2009). T(9M,mdot=1) = 7.45e6 K. 14/14 tests pass + pkg42 no regression. |
| #273 | e093a70 | **pkg88 + pkg89** | DRAFT specs promoted to real specs (architect spec-promotion pass + owner answers locked in). |
| #274 | 81a1b18 | **pkg38-light-source-spectra** | Amendment spec filed (7 SPDs: CIE F2/F3 fluorescent, LED 3000/5000/6500K, sodium vapor, mercury vapor; unblocks pkg89 Phase A). |
| #275 | 2f03ee6 | — | Repo cleanup (moved 3 dev measurement scripts to `dev/measurement-scripts/`). |
| #277 | 59fb543 | **pkg85** | Partial follow-up (wrap autouse GC fixture cleanup so exceptions don't surface as test teardown ERROR). |
| #278 | 063bd42 | **pkg85-C** | Closes pkg85 spec gate. Two root causes: GPU/CPU BVH primitive-array index misalignment + world-only GPU render trigger. **901 passed, 0 CUDA illegal-access crashes**. Material contact sheet renders cleanly. pkg85-D filed as follow-up. |
| Direct | ec28667, 4ae14d7, eff21fd, 28ea478 | — | pkg43 handoff notes, round8 dispatch queue + owner answers, CLAUDE.md workflow sections, `/pkg-ship` skill + design notes. |

### Status flips

- **pkg43**: open → **done** (PR #271)
- **pkg85**: partial → **done** (PR #278 pkg85-C gate cleared)
- **pkg88**: DRAFT spec → **promoted spec** (PR #273)
- **pkg89**: DRAFT spec → **promoted spec** (PR #273)

### New packages added

- **pkg38-light-source-spectra**: open, ready to implement (~½ day)
- **pkg85-D**: open (HDRI world-only GPU/CPU SSIM parity bug, SSIM ≈0.35 vs 0.97 gate)

### Known issues recorded

- **Issue #276**: `test_disney_clearcoat_adds_gloss` chronic flake + suspected clearcoat correctness defect (suggested pkg90). Labels: bug, material.
- **Pyd-shadow-guard hook upgrade**: stale `astroray.pyd` shadowed fresh build twice in 2026-05-14 sessions. Hook warns but doesn't auto-delete; potential follow-up package.
- **Stale orphan worktree directories**: 18 in `.claude/worktrees/*` from 2026-05-14 sessions (git registry removed, OneDrive perm-denied unlink; cosmetic).

### Hardware verification headline (RTX 5070 Ti, commit 063bd42+)

- **910/911 pytest passed** (1 known ReSTIR spatial MSE flake; pkg85 gate cleared)
- Build 4m20s, 52 MB, all features enabled (CUDA + OptiX + OIDN + tcnn + WAVEFRONT_INTERSECT)
- Caustics rendered at 8192 spp (prism + glass + line emitter, clean)
- Material contact sheet rendered at 854×480 / 1024 spp with --gpu (24 materials distinct, clean)
- AOV passes + convergence grid produced cleanly

## Files changed

- `.astroray_plan/packages/pkg43-slim-disk.md`: PR TBD → PR #271
- `.astroray_plan/packages/pkg85-test-harness-cuda-state-leak.md`: PR pending → PR #278
- `.astroray_plan/docs/STATUS.md`:
  - Header: updated to reflect implementation wave in progress
  - Pillar 4: 35% → 40%, next milestone pkg44 ADAF
  - Package board: pkg43 + pkg85 done-flipped; pkg88/89/pkg38-light-source-spectra/pkg85-D added
  - Known issues: added issue #276, pyd-shadow-guard upgrade note, stale worktree note
  - Changelog: new entry for sync #2 with 7 PRs + hardware verification numbers
- `.astroray_plan/docs/NEXT_STAGE_REPORT.md`:
  - Header: doc wave → implementation wave in progress
  - Current state: pkg43/85-C/88-89/38-light-source-spectra/85-D details + hardware verification
  - Session 1 pickup pool: pkg43 finish → pkg38-light-source-spectra; added pkg85-D
  - Session 2: added pkg88 Phase A
  - Session 3+: pkg85-B → issue #276 / pkg90
- `.astroray_plan/docs/ROADMAP.md`:
  - Pillar 4 thaw notice: pkg43 added as done, 40% complete, pkg44 next

## Pillar 4 progress

**pkg40 + pkg41 + pkg42 + pkg43 done.** Pillar 4 now **40% complete**. Next: **pkg44 (ADAF)**.

Generated with [Claude Code](https://claude.com/claude-code)