### PR TITLE
docs: README refresh + pkg93 render spec

### DIFF
--- a/.astroray_plan/packages/pkg93-readme-renders.md
+++ b/.astroray_plan/packages/pkg93-readme-renders.md
@@ -1,0 +1,146 @@
+# pkg93 — README hero + gallery renders — SPEC
+
+**Pillar:** 5 (production polish / showcase)
+**Track:** A (renders need RTX 5070 Ti to match the validation-snapshot numbers)
+**Status:** open — spec filed alongside `docs/readme-refresh-pkg93` branch
+**Estimated effort:** 1–2 sessions (~4–8 h on RTX 5070 Ti); most cost is the
+  Kerr+jet hero scene composition (no checked-in source asset yet)
+**Depends on:** pkg42 (synchrotron jet plugin) done, pkg64 (SMS caustics) done,
+  pkg68 / pkg74 / pkg29a outputs exist as derive-from sources
+**Composes with:** the README rewrite landing on this branch — README places
+  the placeholder paths under `docs/renders/`; this spec produces the files.
+
+---
+
+## Goal
+
+**Before:** the refreshed `README.md` references 8 render placeholders
+under `docs/renders/`. None of the files exist yet. README is technically
+broken-image until the renders land.
+
+**After:** all 8 paths are populated with hero-quality renders that match
+the README's accompanying caption. Each render either derives from an
+existing `test_results/` asset (composite / crop / re-export) or is a new
+scene rendered on the RTX 5070 Ti at the resolutions and SPP counts
+listed below.
+
+---
+
+## Render list
+
+| Path | Source / derivation | Resolution | SPP | Integrator | Denoise | Notes |
+|---|---|---|---|---|---|---|
+| `docs/renders/hero_kerr_jet.png` | **NEW scene** — see "Kerr+jet composition" below. No checked-in source. | 1920×1080 | ≥4096 | `path_tracer` with `BlackHole` shape + `synchrotron_jet` volumetric emitter (pkg42) | OptiX HDR | Hero / masthead |
+| `docs/renders/gallery_prism_caustics.png` | Re-render of the pkg29a / pkg64 prism-to-screen scene at hero quality. Source: `test_results/pkg29a_prism_to_screen_caustic_path_tracer.png` (640×480, ~64 spp) — re-run the same scene at high quality. | 1920×1080 | ≥4096 | `path_tracer` with `use_refractive_caustics=true`, BK7 prism `is_caustic_caster=true` | OIDN HDR | Lead gallery tile; matches the pkg64 +8.83 dB receipt |
+| `docs/renders/gallery_material_contact_sheet.png` | Composite from `test_results/session_close_2026-05-14b/contact_sheet/` — already a finished contact sheet. Re-export at target resolution if source is smaller. | 1280×720 | 256–1024 (existing) | n/a (already rendered) | n/a | Pure asset re-export; cheapest tile |
+| `docs/renders/gallery_convergence_cornell.png` | Composite from `test_results/session_close_2026-05-14b/convergence/convergence_strip.png` + `convergence_mse.png` side-by-side at 1280×720. | 1280×720 | n/a (composite) | n/a | n/a | Pure compositing in PIL / ImageMagick |
+| `docs/renders/gallery_aov_stack.png` | Composite of `test_results/session_close_2026-05-14b/aov/{beauty,normal,depth,albedo}.png` in a 2×2 grid at 1280×720 with corner labels. | 1280×720 | n/a (composite) | n/a | n/a | Pure compositing |
+| `docs/renders/gallery_oidn_before_after.png` | Re-export of `test_results/pkg32_oidn_check/oidn_before_after.png` (already a before/after composite). Verify it's ≥1280 wide; if not, re-render at target. | 1280×720 | 64 (input) | `path_tracer` | OIDN (right half only) | Likely zero-work if source resolves |
+| `docs/renders/gallery_disney_sweep.png` | Composite from `test_results/mat_disney_r0.05.png`, `mat_disney_r0.30.png`, `mat_disney_r0.70.png`, `mat_glass_ior1.2.png`, `mat_glass_ior1.5.png`, `mat_glass_ior2.0.png` in a 2×3 grid at 1280×720. | 1280×720 | n/a (composite) | n/a | n/a | Pure compositing |
+| `docs/renders/gallery_hdri_world.png` | **NEW scene** — Disney metal + Disney glass spheres on a ground plane lit by a checked-in HDRI (`data/hdri/*.hdr` if present, else use Blender's `studio.hdr`). Demonstrates pkg63 MIS env-map. | 1280×720 | 1024 | `path_tracer` | OIDN HDR | Small new scene — ~200 LOC of Python scene-build |
+
+**Expected wall-clock on RTX 5070 Ti** (rough, based on pkg71 and pkg64
+measurements):
+
+- Hero Kerr+jet 1920×1080 @ 4096 spp: ~6–12 minutes (GR ray marching is
+  the bottleneck; pkg41 measurements suggest ~3-4× the Cornell cost).
+- Prism caustic 1920×1080 @ 4096 spp with SMS: ~3–5 minutes
+  (pkg64 measured 2.0% empty-hook overhead; SMS-on cost dominates).
+- HDRI world 1280×720 @ 1024 spp: ~30–60 seconds.
+- All composites: seconds (PIL).
+
+---
+
+## Kerr+jet hero composition — TODO
+
+**No checked-in source asset for this exists.** Past pkg40/41/42 tests
+produced validation renders (e.g., `test_results/test_bh_showcase.png`,
+`test_results/test_bh_shadow.png`), but none are hero-framed. The
+composition itself is the bulk of pkg93's work.
+
+Composition checklist:
+
+1. **Black hole:** Kerr metric, spin a ≈ 0.9, viewed from
+   inclination ≈ 75° (near edge-on so the lensed ring is visible but
+   the jet is not foreshortened to a line).
+2. **Accretion disk:** slim disk (pkg43) at ṁ ≈ 0.1, inner radius
+   r_ISCO, outer radius ~20 M. Disk temperature gradient drives the
+   blackbody emission.
+3. **Jet:** `synchrotron_jet` (pkg42) bipolar, opening angle ≈ 5°,
+   power-law electron index p ≈ 2.5. Length ~50 M along the spin axis.
+4. **Environment:** dark (no HDRI) or a faint starfield. Galactic
+   background optional.
+5. **Camera:** 35 mm equivalent, f/2.8, distance ≈ 100 M from event
+   horizon. Spectral mode (pkg11) so the temperature gradient produces
+   a visible blue→red disk gradient and the jet's synchrotron SED is
+   physical.
+6. **Sanity checks:** Einstein ring should be visible (pkg41 gate);
+   redshift on far side of disk should be visible as a temperature
+   shift (pkg67); jet should be brighter on the side moving toward the
+   camera (relativistic beaming, pkg42).
+
+If the first-cut framing isn't striking enough, the fallback hero
+candidate is the prism caustic. Don't ship a bad Kerr render — drop
+back to the prism if needed and demote `hero_kerr_jet.png` to a
+gallery tile.
+
+---
+
+## Validation gates
+
+- **G1 — README links resolve.** Every `![...](docs/renders/...)`
+  reference in `README.md` points at a file that exists in this PR.
+  Verify with a one-line grep.
+- **G2 — No broken provenance.** Every render either derives from a
+  checked-in `test_results/` asset (listed in the table above) or is a
+  new scene with a scripted producer (committed under
+  `scripts/diagnostics/` or similar). No "I rendered it on my machine,
+  trust me" assets.
+- **G3 — Resolution + SPP match the table.** New renders meet the
+  listed minimums; lower than that doesn't ship.
+- **G4 — File size sanity.** Each PNG ≤ 2 MB (re-export with PIL +
+  pngquant if needed). README repository load budget: ≤ ~10 MB total
+  for `docs/renders/`.
+- **G5 — Visual-check pass.** Run `Skill(visual-check)` on the hero
+  and prism tiles; record qualitative inspection notes in the pkg93
+  PR body.
+
+---
+
+## Files to add / modify
+
+```
+docs/renders/hero_kerr_jet.png              (new render — see TODO above)
+docs/renders/gallery_prism_caustics.png     (new render at hero quality)
+docs/renders/gallery_material_contact_sheet.png  (re-export / composite)
+docs/renders/gallery_convergence_cornell.png     (composite)
+docs/renders/gallery_aov_stack.png               (composite)
+docs/renders/gallery_oidn_before_after.png       (re-export)
+docs/renders/gallery_disney_sweep.png            (composite)
+docs/renders/gallery_hdri_world.png         (new small scene)
+scripts/diagnostics/render_readme_hero.py   (NEW — produces the Kerr+jet hero)
+scripts/diagnostics/render_readme_gallery.py (NEW — produces the prism + HDRI tiles + composites the rest)
+```
+
+Composite scripts MUST be idempotent and self-contained (`python
+scripts/diagnostics/render_readme_gallery.py` should regenerate every
+composite tile from the listed `test_results/` sources without manual
+steps). The hero render script is allowed to require RTX hardware.
+
+---
+
+## License fence
+
+All inputs are first-party (rendered by Astroray) or already-cleared
+test_results assets. No external image assets are imported. The
+`gallery_hdri_world.png` scene references the HDRI shipped under
+`data/hdri/` if one is already committed; if not, ship the scene with
+a procedural sky (no new asset bundling).
+
+---
+
+## When this spec is ready to dispatch
+
+Immediately. No owner-preference forks. The Kerr+jet composition
+choices are documented above and can be iterated visually; if the
+first-cut doesn't land, fall back to the prism caustic as hero.

--- a/README.md
+++ b/README.md
@@ -1,64 +1,132 @@
 # Astroray
 
-A modern C++17 physically based path tracer with a Blender addon and Python API.
-Plugin-driven architecture — new materials, integrators, and post-process passes
-drop in as single files.
+A physically based path tracer with a plugin core, a spectral pipeline, a
+Blender 5.1 addon, and a general-relativistic mode for astrophysical
+scenes. C++17 / CUDA on the inside, pybind11 + Python API on the outside.
+
+The design goal is **pluggability**: materials, shapes, lights, integrators,
+textures, and post-process passes all register into small factory registries.
+Adding a feature usually means dropping in one file.
+
+<!-- Hero render: derive from a new Kerr + synchrotron-jet scene per pkg93.
+     Target 1920×1080, ≥4096 SPP (offline). No checked-in source asset yet —
+     see pkg93 for composition TODO. Falls back to a placeholder until pkg93
+     produces the asset. -->
+![Kerr black hole with synchrotron-jet emission](docs/renders/hero_kerr_jet.png)
+
+> A Kerr black hole with a relativistic jet. Geodesics traced in the Kerr
+> metric (pkg40), validated against Bardeen-Press-Teukolsky 1972 and the
+> Chandrasekhar analytic photon-sphere solutions (pkg41, 39 tests).
+> Synchrotron emission from the bipolar jet follows Pandya et al. 2016
+> power-law + thermal fits (pkg42). Spectral SED and gravitational
+> redshift are unified through `MinkowskiMetric` + `SampledWavelengths::redshift`
+> (pkg67).
+
+---
+
+## What's in the box
+
+| Layer | What you get |
+|---|---|
+| **Core** | Plugin registries for integrators, materials, shapes, textures, lights, post-process passes. Each is a registry-discoverable name. |
+| **Light transport** | Path tracing with NEE + MIS, Russian roulette, adaptive sampling. Spectral path tracer with Jakob-Hanika RGB→spectrum upsampling and CIE 1964 10° CMFs. Specular Manifold Sampling for spectral caustics. ReSTIR DI and Neural Radiance Caching are wired as plugin integrators (CPU only today). |
+| **Materials** | Disney Principled BRDF with Kulla-Conty energy compensation tables (pkg60), Lambertian, Metal, Dielectric with Sellmeier dispersion, Subsurface, Emissive, Volumetric. CPU + GPU material capability metadata; no silent fallbacks. |
+| **GR / astrophysics** | Kerr metric (pkg40, pkg41), Schwarzschild extraction, synchrotron emission with Pandya 2016 fits and bipolar relativistic jets (pkg42), slim disk accretion model (pkg43, Abramowicz 1988 / Sadowski 2009). Spectral wavelengths transport gravitational redshift through `MinkowskiMetric` (pkg67). |
+| **Denoising** | OIDN persistent device with CUDA backend (pkg68), OptiX denoiser with HDR/AOV models (pkg70), OptiX temporal denoiser via motion vectors (pkg73). |
+| **GPU** | CUDA megakernel for path tracing and multi-wavelength rendering with measured CPU/GPU spectral parity (pkg54 chain). Wavefront SoA refactor in progress (pkg55). |
+| **Blender** | Blender 5.1 addon: viewport rendering, depsgraph-driven incremental scene sync (pkg56), persistent viewport session (pkg52), native shader nodes (pkg57), HDRI/World parity (pkg63). |
+| **I/O** | Pure-Python `.blend` reader walking Blender's SDNA — no `bpy` runtime dependency (pkg76). |
+
+---
+
+## Validation snapshot
+
+Numbers below trace to merged PRs and to `.astroray_plan/docs/STATUS.md`.
+All hardware-measured numbers are from the project workstation (NVIDIA RTX
+5070 Ti, OptiX 9.1, CUDA 12.8).
+
+| Validation | Measurement | Source |
+|---|---|---|
+| Cycles parity (Cornell, CPU) | SSIM **0.9536** vs Cycles 4.x CPU EXR reference | pkg71 |
+| Cycles parity (Cornell, GPU) | SSIM **0.9548** vs Cycles CPU EXR; **5.2× faster** than Cycles-CUDA on Cornell | pkg71 |
+| Kerr geodesic validation | **39 tests** — BPT 1972 + Chandrasekhar analytic + null circular photon residuals + Kerr a=0 vs Schwarzschild identity + shadow-contour image-plane regression | pkg41, PR #236 |
+| Multi-wavelength CPU/GPU parity | Visible-band SSIM **0.999263** at 8192 spp | pkg54c |
+| Spectral caustics (prism, SMS) | **+8.83 dB PSNR** vs path-tracer baseline; 1.18× receiver-energy ratio; 2.0% empty-hook overhead | pkg64 Phases 1+2+3 |
+| OIDN viewport denoise | **2.77× viewport speedup** at 256×256 vs first-call init cost | pkg68 + pkg75 |
+| OptiX denoiser | **1.86× faster** than OIDN-CUDA at 1080p; SSIM(OptiX, OIDN) = 0.9987 | pkg70 |
+| OptiX temporal denoise | **53.1% inter-frame variance reduction** vs ≥30% gate | pkg73, PR #249 |
+| Slim disk accretion | T(9M, ṁ=1) = **7.45×10⁶ K**; 14/14 tests vs Abramowicz 1988 / Sadowski 2009 | pkg43, PR #271 |
+| Cold-start viewport latency | First frame **83.3 ms** (was 12,079 ms before pkg84) — **145× improvement** | pkg84, PR #260 |
+| Test suite | **801 tests collected** on the Windows MSVC `build_cuda` configuration | STATUS.md, Round 8 close |
 
 ---
 
 ## Gallery
 
+<!-- Tile 1: spectral prism caustic. Derive from
+     test_results/pkg29a_prism_to_screen_caustic_path_tracer.png (re-render
+     1920×1080 at SMS-on, 4096 SPP, default path_tracer with
+     use_refractive_caustics=true). pkg64 receipts: +8.83 dB PSNR delta. -->
+![Spectral prism caustic — SMS dispersion through BK7 glass](docs/renders/gallery_prism_caustics.png)
+
+> **Spectral prism caustic.** A collimated white beam refracts through a
+> BK7 prism. Dispersion is computed per sampled wavelength via Sellmeier
+> coefficients (pkg31); the rainbow caustic on the receiver wall is
+> resolved by Specular Manifold Sampling folded into the default path
+> tracer as a per-bounce hook gated by `use_refractive_caustics` and
+> per-object `is_caustic_caster` (pkg64, Cycles-style opt-in). Measured
+> +8.83 dB PSNR over the no-SMS baseline.
+
 <table>
 <tr>
-<td align="center" colspan="2">
-<img src="docs/images/readme/bh_showcase.png" alt="General-relativistic black hole with gravitational lensing" width="100%"/>
-<sub><b>General-relativistic black hole</b> — Kerr geodesic tracing, gravitational lensing, Novikov-Thorne accretion disk, HDRI environment</sub>
+<td align="center" width="50%">
+<!-- Derive from test_results/session_close_2026-05-14b/contact_sheet/material_contact_sheet.png
+     (re-export at 1280×720 if needed). -->
+<img src="docs/renders/gallery_material_contact_sheet.png" alt="Material contact sheet" width="100%"/>
+<sub><b>Material contact sheet</b> — Disney glass r0/r35/r70, BK7 / SF11 / diamond / ruby / emerald spectral dielectrics, blackbody 2400K / 10000K, line emitters at 460 / 532 / 635 nm. All plugins.</sub>
+</td>
+<td align="center" width="50%">
+<!-- Derive from test_results/session_close_2026-05-14b/convergence/convergence_strip.png
+     and convergence_mse.png composited at 1280×720. -->
+<img src="docs/renders/gallery_convergence_cornell.png" alt="Cornell-box convergence strip" width="100%"/>
+<sub><b>Convergence — Cornell 1→1024 spp.</b> Log-log RMSE slope measured −0.453 vs −0.5 Monte Carlo target on the implementer machine (pkg74 Phase 2).</sub>
 </td>
 </tr>
 <tr>
 <td align="center" width="50%">
-<img src="docs/images/readme/cornell_box.png" alt="Cornell box — NEE + MIS" width="100%"/>
-<sub><b>Cornell box</b> — path tracing with NEE + MIS, glass and Disney BRDF spheres</sub>
+<!-- Derive from test_results/session_close_2026-05-14b/aov/{beauty,normal,depth,albedo}.png
+     composited 2×2 at 1280×720. -->
+<img src="docs/renders/gallery_aov_stack.png" alt="AOV stack — beauty / normal / depth / albedo" width="100%"/>
+<sub><b>AOV stack.</b> Beauty + first-hit normal + depth + albedo, all populated by the default integrator. Drives OIDN and OptiX guide inputs (pkg69, pkg75).</sub>
 </td>
 <td align="center" width="50%">
-<img src="docs/images/readme/disney_brdf_grid.png" alt="Disney BRDF parameter grid" width="100%"/>
-<sub><b>Disney BRDF</b> — metallic, roughness, clearcoat, transmission, subsurface sweep</sub>
+<!-- Derive from test_results/pkg32_oidn_check/oidn_before_after.png
+     (already a before/after composite, 1280×720). -->
+<img src="docs/renders/gallery_oidn_before_after.png" alt="OIDN before / after at low SPP" width="100%"/>
+<sub><b>OIDN denoise, before / after.</b> 64-spp input on the left, OIDN persistent-device output on the right (pkg68). OptiX backend is a one-flag swap; SSIM(OptiX, OIDN) = 0.9987.</sub>
 </td>
 </tr>
 <tr>
 <td align="center" width="50%">
-<img src="docs/images/readme/hdri_lit.png" alt="HDRI environment lighting" width="100%"/>
-<sub><b>HDRI lighting</b> — environment map importance sampling, specular response</sub>
+<!-- New scene per pkg93: Disney metal r0.05 / r0.30 / r0.70 + glass IOR 1.2 / 1.5 / 2.0
+     composited 1280×720. Derive from test_results/mat_disney_r*.png and mat_glass_ior*.png. -->
+<img src="docs/renders/gallery_disney_sweep.png" alt="Disney BRDF roughness sweep" width="100%"/>
+<sub><b>Disney BRDF sweep.</b> Roughness 0.05 / 0.30 / 0.70, dielectric vs metallic vs clearcoat. Kulla-Conty energy compensation tables ported from Cycles (pkg60). Worst-case directional hemispherical reflectance 1.0159 over 90 furnace-test combinations.</sub>
 </td>
 <td align="center" width="50%">
-<img src="docs/images/readme/material_comparison.png" alt="Material type comparison" width="100%"/>
-<sub><b>Material library</b> — Lambertian, Metal, Glass, Disney, Subsurface in one scene</sub>
+<!-- Derive from a new HDRI-lit hero scene per pkg93 (no checked-in asset yet).
+     Target 1280×720, 1024 SPP. -->
+<img src="docs/renders/gallery_hdri_world.png" alt="HDRI world / environment lighting" width="100%"/>
+<sub><b>HDRI environment + MIS.</b> Importance-sampled environment with Mapping XYZ rotation, color tint, and MIS env-map (pkg63). Spectral atlas via Jakob-Hanika upsampling (pkg14).</sub>
 </td>
 </tr>
 </table>
 
 ---
 
-## Features
-
-| Category | Capabilities |
-|---|---|
-| **Rendering** | Monte Carlo path tracing, NEE + MIS, adaptive sampling, RR termination |
-| **Materials** | Disney/Principled BRDF, Lambert, Phong, Metal, Glass, Subsurface, Volumetrics — all plugin-registered |
-| **Lights** | Point, directional (sun), area (disk/rect/ellipse/sphere), HDRI env maps with importance sampling |
-| **Geometry** | Spheres, triangles/meshes, SAH BVH; shapes are plugins |
-| **Textures** | Image, Checker, Noise, Gradient, Voronoi, Brick, Musgrave, Wave, Magic — all plugins |
-| **Integrators** | Path tracer, ambient occlusion — swap via `set_integrator(name)`; add custom integrators as single files |
-| **Post-process** | Pass registry: OIDN denoiser, depth/normal/albedo AOV — add via `add_pass(name)` |
-| **Black holes** | GR geodesic tracing (RK45/Dormand-Prince), Kerr metric, Novikov-Thorne disk, spectral emission |
-| **Performance** | OpenMP tile parallelism, optional CUDA backend |
-| **Integration** | Standalone CLI, Python module (`astroray`), Blender 5.1 addon |
-
----
-
 ## Quick start
 
-### Build (Linux/macOS)
+### Build (Linux / macOS)
 
 ```bash
 python3 -m pip install -r requirements.txt
@@ -67,7 +135,7 @@ cmake .. -DCMAKE_BUILD_TYPE=Release
 make -j$(nproc)
 ```
 
-### Build (Windows — MinGW/MSYS2)
+### Build (Windows — MinGW / MSYS2)
 
 ```bash
 mkdir build && cd build
@@ -75,24 +143,26 @@ cmake .. -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DASTRORAY_ENABLE_CUDA=
 cmake --build . -j
 ```
 
-### Build (Windows — CUDA/tiny-cuda-nn)
+### Build (Windows — CUDA / tiny-cuda-nn)
 
-The repo ships CMake presets for the CUDA + tiny-cuda-nn developer build. In
-VS Code with the CMake Tools extension, select the `Windows TCNN (VS 2022)`
-configure preset and build the `Build Windows TCNN Release` preset.
-OIDN is enabled in these presets; CMake uses a local OIDN install when present
-or fetches the Windows prebuilt package during configure.
+The repo ships CMake presets for the CUDA + tiny-cuda-nn developer
+build. In VS Code with the CMake Tools extension, select the
+`windows-tcnn-vs` configure preset and build with
+`windows-tcnn-vs-release`. OIDN is enabled in these presets; CMake
+uses a local OIDN install when present or fetches the Windows prebuilt
+package during configure.
 
 **Optional GPU dependencies** — auto-detected by CMake; quietly disabled
 if absent:
 
 - **CUDA Toolkit 12.x** — GPU path tracer + OIDN-CUDA denoiser backend.
-- **NVIDIA OptiX 8.x SDK** — OptiX AI denoiser backend (~2× faster than
-  OIDN-CUDA on Tensor Core GPUs). Manual download from
+- **NVIDIA OptiX 8.x or 9.x SDK** — OptiX AI denoiser backend
+  (~1.86× faster than OIDN-CUDA on Tensor Core GPUs, measured on RTX
+  5070 Ti / OptiX 9.1.0). Manual download from
   <https://developer.nvidia.com/designworks/optix/download> (NVIDIA
   developer account required; OptiX SDK License forbids redistribution
   so we cannot bundle it). The default install path
-  `C:\ProgramData\NVIDIA Corporation\OptiX SDK 8.x.x\` is auto-detected.
+  `C:\ProgramData\NVIDIA Corporation\OptiX SDK 9.x.x\` is auto-detected.
   Without OptiX, the denoiser silently falls back to OIDN.
 
 See [docs/QUICKSTART.md](docs/QUICKSTART.md#optional-nvidia-gpu-users) for
@@ -106,11 +176,12 @@ cmake --build --preset windows-tcnn-vs-release
 cmake --build --preset windows-tcnn-vs-pytest
 ```
 
-Artifacts land in `build_tcnn/`: the Python module is in `build_tcnn/Release/`
-for Visual Studio builds, and the standalone binaries are in
-`build_tcnn/bin/Release/`.
+Artifacts land in `build_tcnn/`: the Python module is in
+`build_tcnn/Release/` for Visual Studio builds, and the standalone
+binaries are in `build_tcnn/bin/Release/`.
 
-See [docs/QUICKSTART.md](docs/QUICKSTART.md) for full platform-specific instructions, including the Blender addon build.
+See [docs/QUICKSTART.md](docs/QUICKSTART.md) for full platform-specific
+instructions, including the Blender addon build.
 
 ### Run tests
 
@@ -137,7 +208,8 @@ r = astroray.Renderer()
 r.setup_camera([0, 0, 5], [0, 0, 0], [0, 1, 0], 60.0, 16/9, 0.0, 5.0, 800, 450)
 
 # Plugin-registered materials, integrators, passes
-mat = r.create_material("disney", [0.8, 0.4, 0.2], {"metallic": 0.4, "roughness": 0.3})
+mat = r.create_material("disney", [0.8, 0.4, 0.2],
+                        {"metallic": 0.4, "roughness": 0.3})
 r.add_sphere([0, 0, 0], 1.0, mat)
 r.set_integrator("path_tracer")   # swap integrators by name
 r.add_pass("oidn_denoiser")       # add post-process passes by name
@@ -170,7 +242,7 @@ Then in Blender: `Edit > Preferences > Get Extensions > Install from Disk...`
 Astroray/
 ├── apps/                    # Standalone CLI entrypoint
 ├── blender_addon/           # Blender 5.1 RenderEngine addon
-├── docs/                    # Docs, ADRs, agent context, images
+├── docs/                    # Docs, ADRs, agent context, images, renders
 ├── include/                 # Header-only renderer core
 │   ├── raytracer.h          # Vec3, Ray, Camera, BVH, Renderer, Framebuffer
 │   ├── advanced_features.h  # Disney BRDF, transforms
@@ -180,16 +252,18 @@ Astroray/
 │       ├── integrator.h     # Integrator base class
 │       ├── pass.h           # Pass base class
 │       ├── param_dict.h     # Plugin parameter passing
-│       └── …                # GR metric, accretion disk, spectral types
+│       └── ...              # GR metric, accretion disk, spectral types
 ├── module/                  # pybind11 Python bindings
 ├── plugins/                 # Plugin implementations (drop-in files)
-│   ├── integrators/         # path_tracer, ambient_occlusion
-│   ├── materials/           # disney, lambertian, metal, dielectric, …
-│   ├── passes/              # oidn_denoiser, depth_aov, normal_aov, albedo_aov
-│   ├── shapes/              # sphere, triangle, mesh, black_hole, …
-│   └── textures/            # checker, noise, voronoi, brick, …
-├── scripts/                 # build_blender_addon.py and other utilities
-├── tests/                   # pytest suite (227 collected tests as of 2026-04-28)
+│   ├── integrators/         # path_tracer, ambient_occlusion, restir_di, neural_cache
+│   ├── materials/           # disney, lambertian, metal, dielectric, ...
+│   ├── passes/              # oidn_denoiser, optix_denoiser, depth/normal/albedo AOV
+│   ├── shapes/              # sphere, triangle, mesh, black_hole, ...
+│   └── textures/            # checker, noise, voronoi, brick, ...
+├── src/gpu/                 # CUDA megakernel + wavefront scaffolding
+├── scripts/                 # Build, dev, benchmark, diagnostic helpers
+├── tests/                   # pytest suite (801 collected on build_cuda)
+├── .astroray_plan/          # Roadmap, package specs, research notes
 └── CMakeLists.txt
 ```
 
@@ -200,7 +274,24 @@ Astroray/
 - [Quickstart](docs/QUICKSTART.md) — build, test, Blender addon
 - [Docs index](docs/README.md)
 - [Renderer internals](docs/agent-context/renderer-internals.md) — architecture, pipeline, material conventions
+- [Roadmap](.astroray_plan/docs/ROADMAP.md) and [Status](.astroray_plan/docs/STATUS.md)
 - [Contributing](CONTRIBUTING.md)
+
+## References
+
+The project follows a strict "no invented algorithms" policy
+([CLAUDE.md §6](CLAUDE.md)). Key references:
+
+- **Cycles** (Apache-2.0) — material model, denoising glue, viewport sync patterns
+- **PBRT-v4** (Apache-2.0) — spectral path tracer, sampler design, AnimatedTransform
+- **Jakob & Hanika 2019** — RGB → spectrum upsampling
+- **Bardeen, Press & Teukolsky 1972** + **Chandrasekhar 1983** — Kerr geodesic validation gates
+- **Pandya et al. 2016** — synchrotron emissivity fits
+- **Abramowicz 1988** / **Sadowski 2009** — slim disk accretion
+- **Kulla & Conty 2017** / **Burley 2015** — Disney BRDF energy compensation
+
+Per-package research notes live in
+[`.astroray_plan/docs/`](.astroray_plan/docs/).
 
 ## License
 


### PR DESCRIPTION
## Summary

- Replaces `README.md` with a researcher-facing rewrite. Validation-snapshot table cites every measured number to a merged PR or STATUS.md (pkg71 SSIM, pkg64 +8.83 dB, pkg70 1.86x, pkg73 53.1%, pkg54c 0.999263, pkg84 145x, pkg43 T(9M,1)=7.45e6 K, 801 tests, etc.). Build commands preserved; preset names corrected to `windows-tcnn-vs` / `-release`.
- Hero ordering: Kerr+jet (masthead, unique-in-OSS differentiator, researcher signal) + spectral prism caustic (lead gallery tile, the high-receipt "oh wow" image). 6 gallery tiles total: prism caustic, material contact sheet, Cornell convergence, AOV stack, OIDN before/after, Disney sweep, HDRI world.
- New spec `.astroray_plan/packages/pkg93-readme-renders.md` carves off the render production: 8 placeholder paths under `docs/renders/`, each mapped to a derive-from `test_results/` source (or flagged as new). Kerr+jet hero composition is a TODO inside the spec (no checked-in source asset).

## What is new vs old README

- Validation-snapshot table did not exist; old README had a feature matrix only.
- Spectral / GR / denoiser stacks were under-documented; new "What's in the box" table names the specific specs (pkg40-43, pkg54 chain, pkg63-75, etc.).
- Hero image is Kerr+jet instead of the old `bh_showcase.png`; gallery is rebuilt around measured-receipt assets.

## Render work carved off (pkg93)

- Hero Kerr+jet: NEW scene, ~6-12 min on RTX, no checked-in source — composition TODO inside spec.
- Gallery prism: re-render of pkg29a/pkg64 scene at 1920x1080 / >=4096 SPP.
- 6 remaining tiles: composites / re-exports of existing `test_results/session_close_2026-05-14b/*` assets.

## Test plan

- [ ] Visual review of README on the PR page
- [ ] Verify all `docs/renders/*` paths are present after pkg93 ships
- [ ] Cross-check validation-snapshot numbers against STATUS.md before merge