### PR TITLE
docs(architect): split pkg87 into pkg87a/b/c (per owner decision)

### DIFF
--- a/.astroray_plan/packages/pkg87-cryptomatte.md
+++ b/.astroray_plan/packages/pkg87-cryptomatte.md
@@ -2,9 +2,40 @@
 
 **Pillar:** 5
 **Track:** A
-**Status:** open — ready to implement
+**Status:** superseded — split into pkg87a/pkg87b/pkg87c (owner decision 2026-05-15)
 **Estimated effort:** 2–3 weeks
 **Depends on:** none (independent of pkg55-B and pkg86)
+
+---
+
+## SUPERSEDED — see pkg87a / pkg87b / pkg87c
+
+This single spec is **superseded**. During implementation the agent
+discovered the spec understated the integration depth: it modelled
+Cryptomatte as a first-hit AOV (one integrator bullet — "at first-hit
+and indirect bounces call `crypto_insert`"), but Psyop-conformant
+Cryptomatte requires **per-shade-point** histogram accumulation of
+`(hashed_name, coverage)` at *every* bounce across *every* integrator
+(7 CPU plugins + the GPU path-trace/multiwavelength kernels + the CPU
+wavefront reference oracles), exactly where Cycles calls
+`kernel_write_data_passes`. That is far more than the original Phase 2
+scoping implied. On 2026-05-15 the owner split the work into three
+phased, independently-reviewable packages:
+
+- **`pkg87a-cryptomatte-infrastructure.md`** — hashing, EXR manifest
+  writer, crypto framebuffer buffers, name plumbing, pass-plugin
+  skeleton. Scope = exactly the existing `pkg87-cryptomatte` branch;
+  becomes its own PR.
+- **`pkg87b-cryptomatte-integrator-integration.md`** — per-shade-point
+  `(hash, weight)` accumulation across all integrators (CPU + GPU).
+  Depends on pkg87a. This is the part this original spec understated.
+- **`pkg87c-cryptomatte-blender-acceptance.md`** — Blender pass
+  registration, manifest in RenderResult, UI toggles, IoU ≥ 0.95
+  acceptance gate. Depends on pkg87b.
+
+The remainder of this document is retained for historical context and
+as the source of the design decisions inherited by the three new specs.
+Do not implement from it directly.
 
 ---
 

--- a/.astroray_plan/packages/pkg87a-cryptomatte-infrastructure.md
+++ b/.astroray_plan/packages/pkg87a-cryptomatte-infrastructure.md
@@ -1,0 +1,177 @@
+# pkg87a — Cryptomatte Infrastructure
+
+**Pillar:** 5
+**Track:** A
+**Status:** open
+**Estimated effort:** done on branch — review-only (~0.5 day to verify + open PR)
+**Depends on:** none
+**Reference research:** `.astroray_plan/docs/cryptomatte-research.md`
+(Psyop spec v1.2.0 BSD-3, Friedman & Jones SIGGRAPH 2015; smhasher
+MurmurHash3 public domain, Austin Appleby; Cycles
+`intern/cycles/kernel/film/cryptomatte_passes.h` Apache-2.0; alShaders2
+`hash_to_float`). Do **not** duplicate that note — reference it.
+
+---
+
+## Why this package exists
+
+This is the first of three packages that replace the original
+`pkg87-cryptomatte.md`. The original single spec was filed assuming
+Cryptomatte was a first-hit AOV capture comparable to the albedo/normal
+passes. The implementer discovered that Psyop-conformant Cryptomatte
+requires per-shade-point histogram accumulation of `(hashed_name,
+coverage)` across **every bounce in 5+ integrators** (CPU + GPU), not a
+first-hit write. The owner split the work on 2026-05-15:
+
+- **pkg87a (this):** the hashing + EXR + buffer + name-plumbing
+  infrastructure — exactly the code already sitting on the
+  `pkg87-cryptomatte` branch.
+- **pkg87b:** the per-shade-point integrator integration (the part the
+  original spec understated).
+- **pkg87c:** the Blender addon registration + the IoU acceptance gate.
+
+This package's deliverable is **the existing `pkg87-cryptomatte`
+branch**, committed and turned into its own PR. No new code is written
+for pkg87a; its job is to define the contract the branch must satisfy so
+a reviewer can sign off on it as a standalone, integrator-free
+infrastructure layer.
+
+---
+
+## Goal
+
+**Before:** Astroray has the AOV machinery (albedo, normal, depth,
+motion) but no Cryptomatte primitives: no name→hash function, no
+per-pixel ranked histogram type, no multi-channel EXR writer, no crypto
+framebuffer buffers, and no human-readable names on `Hittable` /
+`Material`.
+
+**After:** The infrastructure exists and is unit-tested in isolation:
+
+- `crypto_hash_name()` produces stable, Psyop-conformant float IDs
+  (MurmurHash3_x86_32 seed 0 → `hash_to_float` subnormal/inf guard).
+- `crypto_insert()` maintains a depth-N ranked `(id, weight)` histogram
+  with duplicate-merge + weight-descending order.
+- A minimal multi-channel float32 OpenEXR writer with string header
+  attributes exists (`src/io/exr_writer.{h,cpp}`).
+- `Hittable` and `Material` carry a `name_` string with get/set.
+- `GTriangle` / `GSphere` carry `objectHash` + `materialHash`, populated
+  at scene upload from those names.
+- `Framebuffer` registers `crypto_object` / `crypto_material` buffers
+  sized `width*height*depth*2` floats (default depth 6).
+- A pass-plugin skeleton (`plugins/passes/cryptomatte_pass.cpp`) is
+  registered and compiles.
+
+**Explicitly NOT in this package:** no integrator writes into the crypto
+buffers yet (that is pkg87b), and there is no Blender pass registration
+or IoU gate (that is pkg87c). The buffers are allocated and zero-filled;
+nothing populates them per shade point.
+
+---
+
+## Scope — exactly the `pkg87-cryptomatte` branch
+
+The work is already implemented in the `pkg87-cryptomatte` worktree
+(`../Astroray-pkg87`). A reviewer can enumerate it read-only with:
+
+```
+git -C ../Astroray-pkg87 status --short
+git -C ../Astroray-pkg87 diff --stat HEAD
+```
+
+### Files created (must be present, committed)
+
+| File | Contract |
+|---|---|
+| `src/util/murmurhash3.{h,cpp}` | Direct port of `MurmurHash3_x86_32` from smhasher (public domain). Cited at top of header. Bit-exact with the canonical implementation. |
+| `include/astroray/cryptomatte.h` | `struct CryptoSample { float id; float weight; }`; `float hash_to_float(uint32_t)` (alShaders2 subnormal/inf guard — toggle bit 23 when exponent is 0 or 255); `float crypto_hash_name(const std::string&)` (MurmurHash3 seed 0 + `hash_to_float`); `void crypto_insert(float* ranks, int depth, float id, float weight)` mirroring Cycles `kernel_cryptomatte_post` (merge duplicate id, replace min-weight slot, sort weight-descending). |
+| `src/io/exr_writer.{h,cpp}` | Thin OpenEXR wrapper: write multi-channel float32 EXR + string header attributes. Scoped to Cryptomatte's needs; not a general AOV writer. Compiled only when `find_package(OpenEXR)` succeeds. |
+| `plugins/passes/cryptomatte_pass.cpp` | Pass-plugin skeleton, registered, reads the named crypto buffers. May be a non-functional skeleton at this stage (it has no populated data to consume until pkg87b) but must compile and register. |
+| `tests/test_cryptomatte_hashing.py` | Infrastructure unit tests (see Acceptance). |
+
+### Files modified (must show the documented deltas)
+
+| File | Contract |
+|---|---|
+| `include/astroray/gpu_types.h` | `uint32_t objectHash; uint32_t materialHash;` added to `GTriangle` and `GSphere`. Per original key design decision #4 this brings `GTriangle` to a cache-line-aligned 64 bytes; MinGW large-struct-by-value note still applies (pass `const T&`). |
+| `include/raytracer.h` | `std::string name_` + `setName`/`getName` on `Material` and `Hittable`. `Framebuffer` (Camera) gains `cryptoObjectBuffer` / `cryptoMaterialBuffer` (`std::vector<float>`, sized `width*height*cryptomatteDepth*2`) and `int cryptomatteDepth = 6`. `buffer()` returns them for names `"crypto_object"` / `"crypto_material"`. The old placeholder `cryptomatte*Buffer` Vec3 / coverage members are removed. |
+| `src/gpu/scene_upload.cu` | At `buildSceneArrays`, hash each primitive's object name and material name via `MurmurHash3_x86_32(... seed 0 ...)` into `gt.objectHash` / `gt.materialHash` (and the sphere equivalents), with `Unnamed_*` fallbacks for empty names. |
+| `CMakeLists.txt` | `find_package(OpenEXR CONFIG QUIET)`; gracefully degrade with a STATUS message when absent; add `src/util/murmurhash3.cpp` to `astroray_core_impl`; conditionally add `src/io/exr_writer.cpp` and link the OpenEXR target when found. |
+
+If the branch's diff diverges from the above table, that divergence
+must be reconciled (either the spec or the branch corrected) before the
+PR merges. The spec is the source of truth for *what infrastructure
+should exist*; the branch is the *implementation under review*.
+
+---
+
+## Acceptance criteria
+
+A reviewer signs off pkg87a when, on a clean checkout of the
+`pkg87-cryptomatte` branch:
+
+- [ ] The project builds (`astroray_core_impl` + plugins) with the new
+      translation units linked. When OpenEXR is present, `exr_writer.cpp`
+      compiles and links; when absent, the build still succeeds and the
+      STATUS message is emitted (graceful degradation is intentional).
+- [ ] `tests/test_cryptomatte_hashing.py` passes:
+  - [ ] **Hash determinism:** `crypto_hash_name("cube_red")` returns the
+        same float across repeated calls and process restarts; the
+        underlying `MurmurHash3_x86_32` matches the canonical smhasher
+        output for at least one fixed key (e.g. ASCII `"hello"`).
+  - [ ] **Float-encoding guard:** for an input whose raw hash has
+        exponent field 0 or 255, `hash_to_float` returns a normal
+        (non-subnormal, non-inf, non-NaN) float; round-trip
+        `memcpy`-back recovers the toggled bit pattern.
+  - [ ] **Rank-merge correctness:** `crypto_insert` over a hand-built
+        sequence keeps the top-`depth` weights sorted descending and
+        merges duplicate ids by summing weight (compare against a
+        hand-computed expected array for depth 6).
+  - [ ] **Manifest JSON schema:** the manifest produced for a small
+        fixed name set parses as JSON and conforms to the Psyop schema —
+        EXR header keys `cryptomatte/<hash7>/{name,hash,conversion,manifest}`
+        where `<hash7>` is the first 7 hex digits of
+        `MurmurHash3("CryptoObject")`, `conversion == "uint32_to_float32"`,
+        `hash == "MurmurHash3_32"`, and every `name` in the manifest
+        maps to `crypto_hash_name(name)` (round-trip integrity). This may
+        be exercised through the `exr_writer` + a manifest-builder helper
+        without any integrator.
+- [ ] **No integrator changes.** `git diff origin/main..pkg87-cryptomatte`
+      touches none of `plugins/integrators/*`, `src/gpu/path_trace_kernel.cu`,
+      `src/gpu/cuda_renderer.cu`, `src/gpu/multiwavelength_kernel.cu`,
+      `src/cpu/wavefront/*`, or the GPU wavefront stages. The crypto
+      buffers are allocated and zeroed but never written per shade point.
+      (Any such change belongs in pkg87b and must be reverted from this
+      branch.)
+- [ ] No regression in existing AOV/denoiser tests (`albedo_aov`,
+      `normal_aov`, `motion_vector_aov`, OIDN/OptiX) — this package adds
+      members and TUs but does not change the render path.
+- [ ] `.astroray_plan/docs/cryptomatte-research.md` is committed on the
+      branch (it currently exists untracked in the worktree).
+
+---
+
+## Non-goals
+
+- No integrator instrumentation (pkg87b).
+- No Blender addon pass registration, no UI toggles, no IoU acceptance
+  gate (pkg87c).
+- No `CryptoAsset` typename (separate future follow-up).
+- Do not widen `exr_writer` into a general AOV writer; keep it scoped to
+  Cryptomatte.
+- Do not optimise the hash propagation (bit-packing / dedup tables); the
+  8-bytes-per-primitive cost was accepted in the original design.
+
+---
+
+## Progress
+
+- [ ] Branch `pkg87-cryptomatte` work committed (currently
+      working-tree + untracked in `../Astroray-pkg87`).
+- [ ] `cryptomatte-research.md` added to the commit.
+- [ ] Infra unit tests (hash determinism, float-encoding guard,
+      rank-merge, manifest JSON schema) authored and green.
+- [ ] Build verified with and without OpenEXR present.
+- [ ] Branch diff confirmed to contain zero integrator changes.
+- [ ] PR opened (own PR, separate from pkg87b/pkg87c).
+- [ ] STATUS.md updated.

--- a/.astroray_plan/packages/pkg87b-cryptomatte-integrator-integration.md
+++ b/.astroray_plan/packages/pkg87b-cryptomatte-integrator-integration.md
@@ -1,0 +1,206 @@
+# pkg87b — Cryptomatte Integrator Integration
+
+**Pillar:** 5
+**Track:** A
+**Status:** open
+**Estimated effort:** 1.5–2 weeks (the depth the original spec
+understated — per-shade-point accumulation across every integrator,
+CPU + GPU)
+**Depends on:** pkg87a (hashing, `crypto_insert`, crypto framebuffer
+buffers, name plumbing, EXR writer must be merged first)
+**Reference research:** `.astroray_plan/docs/cryptomatte-research.md`
+(Psyop spec v1.2.0 BSD-3, Friedman & Jones SIGGRAPH 2015; Cycles
+`intern/cycles/kernel/film/cryptomatte_passes.h` + `kernel_write_data_passes`
+Apache-2.0). Reference it; do not duplicate.
+
+---
+
+## Why this package exists
+
+The original `pkg87-cryptomatte.md` modelled Cryptomatte as a first-hit
+AOV ("at every first-hit AND at indirect bounces … call
+`crypto_insert`", one bullet in the integrator). That bullet hid the
+real work: Psyop-conformant Cryptomatte is a **per-shade-point coverage
+histogram** that must be accumulated at *every* shade point along
+*every* path, in *every* integrator, on both the CPU and GPU back ends —
+exactly where Cycles calls `kernel_write_data_passes` (which invokes the
+cryptomatte post step at each shade vertex, not just the camera hit).
+This is the part the owner split out on 2026-05-15. pkg87a delivers the
+plumbing; this package wires it into the render path.
+
+---
+
+## Goal
+
+**Before:** pkg87a is merged. `crypto_object` / `crypto_material`
+framebuffer buffers exist and are zero-filled. `crypto_hash_name()` and
+`crypto_insert()` exist and are unit-tested. `GTriangle`/`GSphere` carry
+`objectHash`/`materialHash`. **Nothing writes into the crypto buffers.**
+
+**After:** Every integrator that produces a final image accumulates a
+per-pixel ranked `(id, weight)` histogram for object names and material
+names, where:
+
+- the contribution is written **at every shade point** along the path
+  (camera hit *and* every indirect bounce that carries throughput to the
+  pixel), mirroring Cycles `kernel_write_data_passes` which is invoked
+  per shade vertex;
+- `weight = average(throughput · bsdf_eval)` at that vertex — the exact
+  Cycles weight model (`kernel/film/cryptomatte_passes.h`), where
+  `throughput` is the path throughput *before* the BSDF at this vertex
+  and `bsdf_eval` is the evaluated BSDF response; component-wise product,
+  averaged over RGB (research note §"Weight Computation");
+- `id = crypto_hash_name(name)` resolved from the hit primitive's
+  `objectHash` / `materialHash` (already on `GTriangle`/`GSphere` from
+  pkg87a) for the GPU path, and from `Hittable::getName()` /
+  `Material::getName()` for the CPU path;
+- weights are accumulated raw; per-pixel normalisation
+  (`Σ weight == 1` on hit pixels, `== 0` on sky) is applied by the
+  pkg87c pass plugin at EXR-write time, not in the integrator (matches
+  the research note and Cycles, which normalises post-accumulation).
+
+---
+
+## Scope — exact integrator enumeration
+
+The crypto write must land in **every integrator that can be the
+configured final-image integrator**, on **both** the CPU plugin path and
+the GPU kernel path. Enumerated from `plugins/integrators/`,
+`src/gpu/`, and `src/cpu/wavefront/` at spec time (2026-05-15):
+
+### CPU integrator plugins (`plugins/integrators/`)
+
+| File | Registered name | In scope? | Rationale |
+|---|---|---|---|
+| `spectral_path_tracer.cpp` | `"path_tracer"` | **Yes — primary** | The default production integrator; the main acceptance target. |
+| `multiwavelength_path_tracer.cpp` | `"multiwavelength_path_tracer"` | **Yes** | Final-image integrator (spectral); shade points carry object/material identity. |
+| `caustic_path_tracer.cpp` | `"caustic_path_tracer"` | **Yes** | Final-image integrator; instrument the primary path-trace shade points (caustic-specific connection vertices follow the same Cycles weight rule). |
+| `sms_caustic_path_tracer.cpp` | `"sms_caustic_path_tracer"` | **Yes** | Final-image integrator; same as above for the SMS variant. |
+| `restir_di.cpp` | `"restir-di"` | **Yes** | Final-image integrator; accumulate at the resolved shade point after reservoir resampling (use the selected sample's surface identity and its contribution weight). |
+| `ambient_occlusion.cpp` | `"ambient_occlusion"` | **Yes (object/material id only)** | Produces a final image; AO has no BSDF chain, so write the first/visible shade point with `weight = visibility-fraction` (coverage), which is the degenerate-but-correct Cycles behaviour for non-lighting integrators. |
+| `neural_cache.cpp` | `"neural-cache"` | **Yes** | Final-image integrator; accumulate at the primary shade points the same as `path_tracer`; cache-query bounces inherit the parent vertex throughput. |
+
+All seven `ASTRORAY_REGISTER_INTEGRATOR` entry points must populate the
+crypto buffers when the crypto passes are enabled. (Verify the list is
+still complete at implementation time: `grep -rn
+ASTRORAY_REGISTER_INTEGRATOR plugins/integrators/` — add any integrator
+added after this spec.)
+
+### GPU kernels (`src/gpu/`)
+
+| File | In scope? | Rationale |
+|---|---|---|
+| `path_trace_kernel.cu` | **Yes** | The GPU mirror of `path_tracer`; the per-shade-point write must be added in the device path-trace loop using `GTriangle::objectHash` / `GSphere::objectHash` (already uploaded by pkg87a's `scene_upload.cu`). |
+| `multiwavelength_kernel.cu` | **Yes** | GPU spectral integrator; same treatment. |
+| `cuda_renderer.cu` | **Yes (orchestration)** | Allocate device crypto buffers, copy back to `Framebuffer::cryptoObjectBuffer/cryptoMaterialBuffer` after the kernel, mirroring the existing AOV copy-back. |
+
+### CPU wavefront reference (`src/cpu/wavefront/`)
+
+| File | In scope? | Rationale |
+|---|---|---|
+| `reference_pt_wavefront.cpp` / `reference_pt_production.cpp` | **Yes** | These are reference oracles used by the pkg55-B' bit-identity gates. They must accumulate crypto identically to the megakernel CPU path so future CUDA-port parity gates remain meaningful. Coordinate with the pkg55-B' keying contract — do not perturb RNG dimension counts. |
+
+### Shared helper
+
+Add one small CPU/GPU-shared helper (host + `__device__`) that, given a
+hit primitive and the current `(throughput, bsdf_eval)`, calls
+`crypto_insert` into the pixel's object and material rank arrays. Place
+it next to `crypto_insert` in `include/astroray/cryptomatte.h` (mark
+`__host__ __device__` so the GPU kernels can reuse it verbatim — this
+is the Cycles model: one rank-merge routine shared by all back ends).
+Cite Cycles `kernel_write_data_passes` (called at every shade point) and
+`kernel/film/cryptomatte_passes.h` (the rank-merge) in the code.
+
+---
+
+## Key design decisions
+
+1. **One shared `__host__ __device__` accumulation routine.** Do not
+   fork CPU and GPU rank-merge logic. Cycles uses a single
+   `kernel_cryptomatte_post`; divergence here is the classic source of
+   CPU/GPU matte mismatch. pkg87a's `crypto_insert` becomes
+   `__host__ __device__`.
+2. **Write site = every shade vertex, gated by a render flag.** The
+   accumulation must be a no-op (early return) when the crypto passes
+   are not requested, so the default render path pays ~zero cost. Gate
+   on a `bool cryptomatteEnabled` carried alongside the existing pass
+   flags, not on buffer-pointer-null checks scattered per integrator.
+3. **Weight = `average(throughput · bsdf_eval)` — Cycles-exact.** Do not
+   substitute radiance or luminance. The research note §"Weight
+   Computation" pins the formula; the Psyop compositor node assumes this
+   model after normalisation.
+4. **Sky / no-hit contributes nothing.** A path segment that escapes to
+   the environment adds no crypto sample; those pixels normalise to
+   `Σ weight == 0`, which the pkg87c pass relies on for IoU.
+5. **RNG-contract safety for the wavefront oracles.** The crypto write
+   must not consume RNG dimensions. It reads already-computed
+   `throughput`/`bsdf_eval` and hit identity only. Verify the pkg55-B'
+   bit-identity gates still pass after instrumentation
+   (`mc-noise-vs-deterministic` memory note: stable per-channel ratios
+   ⇒ a non-RNG bug; treat any gate movement as a wiring error, not
+   noise).
+
+---
+
+## Acceptance criteria
+
+- [ ] All seven CPU integrators and the GPU path-trace +
+      multiwavelength kernels populate `crypto_object` /
+      `crypto_material` when crypto is enabled; the buffers are exactly
+      zero (every float) when crypto is disabled.
+- [ ] **Hand-computed small-scene histogram test.** A deterministic
+      scene (e.g. two named quads `A`, `B` with named materials `mA`,
+      `mB`, fixed camera, fixed seed, low spp, no environment) where the
+      per-pixel coverage is analytically known. For a chosen interior
+      pixel on `A` and an edge pixel straddling `A`/`B`, the decoded
+      `(id, weight)` ranks match the hand-computed expectation within a
+      tight tolerance (rank 0 id == `crypto_hash_name("A")`, weight
+      within ε of the analytic coverage; the `A`/`B` edge pixel shows
+      both ids with weights summing to ~1 after normalisation). The
+      hand computation is written out in the test docstring.
+- [ ] **CPU/GPU agreement.** The same scene rendered through
+      `path_tracer` (CPU plugin) and `path_trace_kernel.cu` (GPU)
+      produces crypto histograms that agree per pixel within a tolerance
+      consistent with the existing CPU/GPU image-parity bar (decoded id
+      sets identical; weights within the same ε used for the colour
+      AOVs).
+- [ ] **Multi-bounce coverage.** A scene where a glossy/refractive
+      surface reveals a second object only via an indirect bounce: that
+      second object's hash appears in the pixel's ranks with non-zero
+      weight (proves accumulation is per-shade-point, not first-hit).
+- [ ] pkg55-B' bit-identity / reference-oracle gates still pass
+      (RNG-contract unperturbed).
+- [ ] No regression in existing AOV/denoiser/integrator tests.
+- [ ] Default render path (crypto disabled) shows no measurable
+      slowdown (the accumulation early-returns).
+
+---
+
+## Non-goals
+
+- No EXR write, no manifest emission, no normalisation here — that is
+  the pkg87c pass plugin's job (it consumes these buffers).
+- No Blender addon changes (pkg87c).
+- No `CryptoAsset` typename.
+- Do not change `crypto_insert`'s algorithm — only make it
+  `__host__ __device__` and call it from the shade points.
+- Do not add light-group AOVs (separate package).
+
+---
+
+## Progress
+
+- [ ] `crypto_insert` + accumulation helper made `__host__ __device__`.
+- [ ] `cryptomatteEnabled` render flag plumbed; accumulation early-exits
+      when off.
+- [ ] CPU: all seven integrators in `plugins/integrators/` instrumented.
+- [ ] CPU wavefront reference oracles instrumented; pkg55-B' gates
+      re-verified.
+- [ ] GPU: `path_trace_kernel.cu` + `multiwavelength_kernel.cu`
+      instrumented; `cuda_renderer.cu` copy-back added.
+- [ ] Hand-computed small-scene histogram test green.
+- [ ] CPU/GPU agreement test green.
+- [ ] Multi-bounce coverage test green.
+- [ ] Call-site sweep (CLAUDE.md): every changed signature grepped repo-
+      wide; tests/mocks/bindings updated.
+- [ ] PR opened (depends on pkg87a merged). STATUS.md updated.

--- a/.astroray_plan/packages/pkg87c-cryptomatte-blender-acceptance.md
+++ b/.astroray_plan/packages/pkg87c-cryptomatte-blender-acceptance.md
@@ -1,0 +1,166 @@
+# pkg87c — Cryptomatte Blender Integration + Acceptance
+
+**Pillar:** 5
+**Track:** A
+**Status:** open
+**Estimated effort:** 1 week
+**Depends on:** pkg87b (integrators must be populating the crypto
+histograms before the Blender passes and the IoU gate can be exercised);
+transitively pkg87a.
+**Reference research:** `.astroray_plan/docs/cryptomatte-research.md`
+(Psyop spec v1.2.0 BSD-3, Friedman & Jones SIGGRAPH 2015 — channel
+naming `<typename>NN.{R,G,B,A}`, EXR header manifest, IoU roundtrip
+validation; Cycles `intern/cycles/scene/film.cpp` `Film::update_passes`
+manifest construction + Blender D3538 pass registration, Apache-2.0).
+Reference it; do not duplicate.
+
+---
+
+## Why this package exists
+
+Third of the three packages replacing the original
+`pkg87-cryptomatte.md`. pkg87a built the infrastructure; pkg87b made
+every integrator accumulate the per-shade-point histogram. This package
+exposes the result to the Blender compositor through standard
+Cryptomatte passes + manifest metadata, and proves end-to-end
+correctness with the Psyop roundtrip IoU gate. This is the part of the
+original spec's Phase 3 plus the acceptance gate, now that it has real
+data to validate.
+
+---
+
+## Goal
+
+**Before:** pkg87b is merged. Every integrator fills
+`crypto_object` / `crypto_material` per-pixel rank arrays. There is a
+pass-plugin skeleton from pkg87a but no normalisation/EXR emission wired
+to Blender, no Blender pass registration, and no acceptance gate.
+
+**After:**
+
+- The Cryptomatte pass plugin
+  (`plugins/passes/cryptomatte_pass.cpp`, from pkg87a) normalises the
+  per-pixel weights (`Σ weight == 1` on hit pixels, `== 0` on sky),
+  packs the ranked `(id, weight)` pairs into `CryptoObject00/01/02` and
+  `CryptoMaterial00/01/02` channels (depth 6 → 3 RGBA layers ×
+  typename, per the Psyop naming convention), and emits the EXR with the
+  manifest header via pkg87a's `exr_writer`.
+- The Blender addon registers the passes and embeds the manifest so the
+  stock Blender / Cycles / Karma Cryptomatte compositor node picks them
+  up unchanged.
+- Selecting any object or material in the compositor reconstructs its
+  mask at **IoU ≥ 0.95** versus a ground-truth isolated render.
+
+---
+
+## Scope
+
+### Pass plugin finalisation (`plugins/passes/cryptomatte_pass.cpp`)
+
+| Behaviour | Contract |
+|---|---|
+| Normalisation | Per pixel, divide every rank weight by `Σ weight`; leave at 0 when the sum is 0 (sky). Cycles normalises post-accumulation; the Psyop node assumes the normalised sum. |
+| Channel packing | depth 6 → layers `00`,`01`,`02`. Each RGBA layer holds 2 pairs: `.R = id(2k)`, `.G = weight(2k)`, `.B = id(2k+1)`, `.A = weight(2k+1)`. Ranks sorted weight-descending (already enforced by `crypto_insert`). |
+| Manifest | Build `cryptomatte/<hash7>/{name,hash,conversion,manifest}` header entries via the pkg87a manifest builder. `<hash7>` = first 7 hex digits of `MurmurHash3("CryptoObject")` / `MurmurHash3("CryptoMaterial")`. `conversion = "uint32_to_float32"`, `hash = "MurmurHash3_32"`, `manifest` = JSON `{name: float_id, ...}`. Source the name→hash map built at scene upload (pkg87a). |
+| EXR write | Use pkg87a `exr_writer` to write all `CryptoObject*` + `CryptoMaterial*` channels + header into one EXR. Skip gracefully (with a clear message) when OpenEXR was not found at build time. |
+
+### Blender addon (`blender_addon/__init__.py`)
+
+| Change | Contract |
+|---|---|
+| Pass registration | Register `CryptoObject00/01/02` and `CryptoMaterial00/01/02` via `RenderEngine.add_pass(name=..., channels=4, chan_id="RGBA", layer=view_layer.name)` for depth 6. |
+| Name population | When building the scene for the engine, set each object's `Hittable::setName(obj.name)` and each material's `Material::setName(mat.name)` (the C++ setters landed in pkg87a) so the hashes match the names the compositor will look up. |
+| RenderResult manifest | In the render-result update path, `foreach_set` each `CryptoObjectNN`/`CryptoMaterialNN` pass from the corresponding crypto buffer, and embed the manifest JSON as the standard Cryptomatte metadata key on the render result so the compositor node auto-populates its picker. |
+| UI toggles | Expose `use_pass_cryptomatte_object` and `use_pass_cryptomatte_material` checkboxes under View Layer → Passes, and a `cryptomatte_depth` enum (2/4/6/8/16, default 6) on the scene Astroray settings. Toggling a checkbox adds/removes the passes from `RenderResult.layers[*].passes`. |
+
+### Acceptance harness
+
+- `tests/scenes/cryptomatte_3_objects.py` — three named cubes
+  (`cube_red`, `cube_green`, `cube_blue`) with three named materials
+  (`mat_red`, `mat_green`, `mat_blue`) on a named plane (`floor`),
+  256×256, depth 6, 64 spp.
+- A ground-truth harness that re-renders each of the 6 names in
+  isolation (other objects hidden) at the same camera + spp and
+  thresholds alpha to a binary mask.
+- `tests/test_cryptomatte_pass.py` — render the 3-object scene, parse
+  the EXR manifest, reconstruct each name's mask by selecting its
+  hash-float across the ranks weighted by the rank weights, and assert
+  **IoU ≥ 0.95** versus the isolated ground-truth for all 6 names.
+
+---
+
+## Key design decisions
+
+1. **IoU ≥ 0.95 gate, 64 spp acceptance scene.** This is the Psyop
+   roundtrip-test metric (spec §6). 0.95 sits below the Cycles internal
+   regression bar (~0.97) to leave headroom for low-spp stochasticity;
+   acceptance renders at 64 spp.
+2. **Default depth 6 (3 layers × 2 typenames).** Matches Cycles
+   `u_cryptomatte_depth = 6` and the Psyop default; the depth enum lets
+   power users widen it.
+3. **Normalisation lives in the pass plugin, not the integrator.**
+   Confirmed in pkg87b: integrators accumulate raw weights; this
+   package divides by the per-pixel sum at pack time. One normalisation
+   site, matching Cycles.
+4. **Manifest must round-trip.** Every name in the emitted manifest must
+   satisfy `manifest[name] == crypto_hash_name(name)`; the test asserts
+   this independently of the IoU gate (catches name/hash desync between
+   the Blender setName path and scene-upload hashing).
+5. **v1 typenames = `CryptoObject` + `CryptoMaterial` only.** No
+   `CryptoAsset` (needs collection-metadata propagation; out of scope,
+   future follow-up).
+
+---
+
+## Acceptance criteria
+
+- [ ] Output EXR opens in Blender's compositor; the stock Cryptomatte
+      node lists `cube_red/green/blue` (CryptoObject) and
+      `mat_red/green/blue` (CryptoMaterial) in its picker, with no
+      custom node.
+- [ ] For each of the 6 names, the compositor-reconstructed mask has
+      **IoU ≥ 0.95** versus a single-object/material ground-truth render
+      at identical camera + 64 spp.
+- [ ] EXR header contains valid
+      `cryptomatte/<hash7>/{name,hash,conversion,manifest}` entries per
+      Psyop spec §3; `conversion == "uint32_to_float32"`,
+      `hash == "MurmurHash3_32"`.
+- [ ] Manifest JSON parses; `manifest[name] == crypto_hash_name(name)`
+      for every entry (round-trip integrity).
+- [ ] Per-pixel `Σ weight == 1 ± ε` on hit pixels, `== 0` on sky.
+- [ ] Blender View Layer → Passes shows `Cryptomatte Object` /
+      `Cryptomatte Material` checkboxes; toggling them adds/removes the
+      passes from `RenderResult.layers`. The depth enum changes the
+      number of registered `NN` layers.
+- [ ] No regression in existing AOV/denoiser tests or other Blender
+      passes.
+
+---
+
+## Non-goals
+
+- No `CryptoAsset` typename (future follow-up; needs collection
+  metadata).
+- No motion-blur-aware Cryptomatte (Cycles disables Cryptomatte under
+  motion blur; match that).
+- Do not change the `Pass` plugin interface (`include/astroray/pass.h`);
+  Cryptomatte fits the existing named-buffer pattern.
+- Do not re-normalise or re-accumulate in the integrator (that boundary
+  was fixed in pkg87b).
+- Do not widen `exr_writer` beyond Cryptomatte's needs.
+
+---
+
+## Progress
+
+- [ ] Pass plugin: per-pixel normalisation implemented.
+- [ ] Pass plugin: channel packing into `CryptoObject/Material 00/01/02`.
+- [ ] Pass plugin: manifest header emitted via pkg87a `exr_writer`.
+- [ ] Blender: object/material `setName` wired from depsgraph.
+- [ ] Blender: `CryptoObject/Material NN` passes registered.
+- [ ] Blender: manifest embedded in RenderResult; node auto-populates.
+- [ ] Blender: UI toggles + depth enum.
+- [ ] `tests/scenes/cryptomatte_3_objects.py` + ground-truth harness.
+- [ ] `tests/test_cryptomatte_pass.py`: IoU ≥ 0.95 for all 6 names.
+- [ ] Manifest round-trip test green.
+- [ ] PR opened (depends on pkg87b merged). STATUS.md updated.


### PR DESCRIPTION
## Summary

The original `pkg87-cryptomatte.md` spec understated integration depth.
It modelled Cryptomatte as a first-hit AOV (a single integrator bullet),
but Psyop-conformant Cryptomatte requires **per-shade-point** histogram
accumulation of `(hashed_name, coverage)` at every bounce across **every
integrator** — 7 CPU plugins, the GPU path-trace/multiwavelength
kernels, and the CPU wavefront reference oracles — exactly where Cycles
calls `kernel_write_data_passes`.

Per owner decision (2026-05-15), the work is split into three phased,
independently-reviewable packages:

- **pkg87a — Cryptomatte infrastructure.** Scope = exactly the existing
  `pkg87-cryptomatte` branch (MurmurHash3 port, `crypto_insert`,
  `exr_writer`, crypto framebuffer buffers, `Hittable`/`Material` name
  plumbing, `GTriangle`/`GSphere` hash fields, pass-plugin skeleton).
  Acceptance = builds + infra unit tests (hash determinism,
  float-encoding guard, rank-merge, manifest JSON schema) + **zero
  integrator changes**. Deliverable is the branch as its own PR.
- **pkg87b — Cryptomatte integrator integration.** Per-shade-point
  `(hash, weight)` accumulation across all enumerated integrators
  (CPU + GPU + wavefront oracles), Cycles weight model
  `average(throughput · bsdf_eval)`, shared `__host__ __device__`
  rank-merge. Acceptance = hand-computed small-scene histogram +
  CPU/GPU agreement + multi-bounce coverage. Depends on pkg87a.
- **pkg87c — Cryptomatte Blender + acceptance.** Pass registration
  (`CryptoObject/Material 00/01/02`), manifest in RenderResult, UI
  toggles, **IoU ≥ 0.95** roundtrip gate vs ground-truth isolated
  renders. Depends on pkg87b.

The original spec is re-scoped to `status: superseded` with a pointer
paragraph and is retained for historical design context (it remains the
source of the inherited key design decisions).

Provenance per CLAUDE.md §6: all three specs reference the existing
`.astroray_plan/docs/cryptomatte-research.md` (Psyop spec v1.2.0 BSD-3,
Friedman & Jones SIGGRAPH 2015; smhasher MurmurHash3 public domain;
Cycles cryptomatte_passes.h / film.cpp Apache-2.0) rather than
duplicating it.

Docs/spec only — no source code changes.

## Test plan

- [ ] Verify the four spec files render and frontmatter matches the
      existing spec format (Pillar / Track / Status / Estimated effort /
      Depends on / Reference research).
- [ ] Confirm pkg87a's "scope = exactly the branch" table matches
      `git -C ../Astroray-pkg87 diff --stat HEAD` + untracked files.
- [ ] Confirm pkg87b's integrator enumeration matches
      `grep -rn ASTRORAY_REGISTER_INTEGRATOR plugins/integrators/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)