### PR TITLE
fix: GPU diffuse/spectral shading ~2x-dark regression (Round-9 closeout blocker)

### DIFF
--- a/include/astroray/gpu_renderer.h
+++ b/include/astroray/gpu_renderer.h
@@ -71,7 +71,8 @@ public:
                                int width, int height, int seed,
                                int samplesPerPixel, int maxDepth,
                                float lambdaMin, float lambdaMax,
-                               bool useLuminanceOutput);
+                               bool useLuminanceOutput,
+                               bool enableNEE = true);
 
     // pkg54d: test hook for the profile table uploaded by the latest
     // uploadScene() call.

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -891,11 +891,17 @@ public:
                     useLum = !(lmin >= 379.5f && lmax <= 780.5f);
                 else
                     useLum = (mode == "luminance");
+                // The GPU megakernel mirrors whichever CPU integrator the
+                // name selects: `path_tracer` -> Renderer::pathTraceSpectral
+                // (area-light NEE + MIS); `multiwavelength_path_tracer` ->
+                // the naive no-NEE MultiwavelengthPathTracer. The two share
+                // the kernel, so NEE must be gated by integrator identity.
+                bool enableNEE = (integratorName_ == "path_tracer");
                 cudaRenderer->renderMultiwavelength(
                     camera->pixels,
                     camera->width, camera->height, renderer.getSeed(),
                     samplesPerPixel, maxDepth,
-                    lmin, lmax, useLum);
+                    lmin, lmax, useLum, enableNEE);
             } else {
                 cudaRenderer->render(camera->pixels,
                                      camera->width, camera->height, renderer.getSeed(),

--- a/src/gpu/cuda_renderer.cu
+++ b/src/gpu/cuda_renderer.cu
@@ -61,11 +61,13 @@ void launchMultiwavelengthKernel(
     float* d_framebuffer, int width, int height,
     int samplesPerPixel, int maxDepth,
     float lambdaMin, float lambdaMax, bool useLuminanceOutput,
+    bool enableNEE,
     const GBVHNode*  d_bvhNodes,
     const GPrimitive* d_prims,
     const GTriangle*  d_tris,
     const GSphere*    d_spheres,
     const GMaterial*  d_materials,
+    const GLight*     d_lights, int numLights, float totalLightPower,
     GEnvMap envMap,
     GCameraParams cam,
     GVec3 backgroundColor, bool hasBackgroundColor,
@@ -567,7 +569,8 @@ void CUDARenderer::render(
 void CUDARenderer::renderMultiwavelength(
     std::vector<Vec3>& pixels, int width, int height,
     int seed, int samplesPerPixel, int maxDepth,
-    float lambdaMin, float lambdaMax, bool useLuminanceOutput)
+    float lambdaMin, float lambdaMax, bool useLuminanceOutput,
+    bool enableNEE)
 {
     if (!impl->available) throw std::runtime_error("No CUDA GPU available");
     // pkg85-C: see CUDARenderer::render() — world-only renders are valid.
@@ -591,9 +594,10 @@ void CUDARenderer::renderMultiwavelength(
 
     launchMultiwavelengthKernel(
         impl->d_framebuffer, width, height, samplesPerPixel, maxDepth,
-        lambdaMin, lambdaMax, useLuminanceOutput,
+        lambdaMin, lambdaMax, useLuminanceOutput, enableNEE,
         impl->d_bvhNodes, impl->d_prims, impl->d_triangles, impl->d_spheres,
         impl->d_materials,
+        impl->d_lights, impl->numLights, impl->totalLightPower,
         impl->envMap,
         impl->camera,
         impl->backgroundColor, impl->hasBackgroundColor,

--- a/src/gpu/multiwavelength_kernel.cu
+++ b/src/gpu/multiwavelength_kernel.cu
@@ -419,18 +419,139 @@ __device__ inline bool isInsideVisible(float lmin, float lmax) {
 }
 
 // ---------------------------------------------------------------------------
-// Spectral path trace — naive, no NEE (mirrors the CPU MW integrator).
+// MIS power heuristic — mirrors CPU pathTraceSpectral (raytracer.h:2420)
+//   wt = a*a / (a*a + b*b + 1e-8) ; and path_trace_kernel.cu::powerHeuristic.
+// ---------------------------------------------------------------------------
+__device__ inline float gpu_mw_powerHeuristic(float a, float b) {
+    return (a * a) / (a * a + b * b + 1e-8f);
+}
+
+// ---------------------------------------------------------------------------
+// Spectral next-event estimation — mirrors CPU Renderer::pathTraceSpectral
+// area-light NEE (include/raytracer.h:2405-2424): power-weighted light
+// selection, area-light point/solid-angle sampling, occlusion test, spectral
+// f * L, and an MIS power heuristic against the BSDF pdf. The area-light
+// geometric sampling (sphere solid angle, triangle area->solid-angle pdf)
+// reuses the exact construction already validated in
+// src/gpu/path_trace_kernel.cu::sampleDirectGPU (same codebase, CPU-faithful
+// port of Renderer::sampleDirect). CLAUDE.md §6 — no new algorithm.
+//
+// This closes the ~2x deficit caused by the previous "no NEE" megakernel:
+// the emissive-on-hit term is gated by (bounce==0 || wasSpecular) exactly
+// like the CPU, so without NEE all diffuse->emitter direct light was dropped.
+// ---------------------------------------------------------------------------
+__device__ GSampledSpectrum sampleDirectSpectralMW(
+    const GHitRecord& rec, const GVec3& wo,
+    const GSampledWavelengths& lambdas,
+    const GBVHNode*  bvhNodes,
+    const GPrimitive* prims,
+    const GTriangle*  tris,
+    const GSphere*    spheres,
+    const GMaterial*  materials,
+    const GLight*     lights, int numLights, float totalLightPower,
+    curandState*      rng)
+{
+    GSampledSpectrum direct(0.f);
+    if (rec.isDelta || numLights <= 0 || totalLightPower <= 0.f) return direct;
+
+    const GMaterial& mat = materials[rec.materialId];
+
+    // Power-weighted light selection via CDF (mirrors LightList::sample).
+    float u  = curand_uniform(rng) * totalLightPower;
+    int   li = 0;
+    for (int i = 0; i < numLights; ++i) { if (u <= lights[i].cumulativePower) { li = i; break; } li = i; }
+    float selPdf = lights[li].power / totalLightPower;
+    int primIdx  = lights[li].primitiveIndex;
+    if (primIdx < 0) return direct;
+
+    const GPrimitive& lp = prims[primIdx];
+    if (lp.type == GPRIM_SKIP) return direct;
+
+    GVec3 wi;
+    float lightPdf;     // solid-angle pdf (incl. selPdf), mirrors LightList::sample s.pdf
+    float maxDist;      // shadow-ray extent
+    int   lightMatId;
+    bool  lightFront;
+
+    if (lp.type == GPRIM_SPHERE) {
+        const GSphere& s = spheres[lp.index];
+        GVec3 toC    = s.center - rec.point;
+        float distSq = toC.length2();
+        if (distSq <= s.radius * s.radius + 1e-8f) return direct;
+        GVec3 dir   = toC.normalized();
+        float cosTM = sqrtf(fmaxf(0.f, 1.f - s.radius * s.radius / distSq));
+        if (cosTM >= 1.f) return direct;
+        float z   = 1.f + curand_uniform(rng) * (cosTM - 1.f);
+        float phi = 2.f * M_PI_F * curand_uniform(rng);
+        GVec3 tu, tv; gpu_buildONB(dir, tu, tv);
+        float sinTh = sqrtf(fmaxf(0.f, 1.f - z * z));
+        wi          = (tu * cosf(phi) * sinTh + tv * sinf(phi) * sinTh + dir * z).normalized();
+        lightPdf    = (1.f / (2.f * M_PI_F * (1.f - cosTM))) * selPdf;
+        maxDist     = 1e30f;       // hit-the-sphere check below bounds it
+        lightMatId  = s.materialId;
+        GHitRecord sh;
+        if (!gpu_bvh_hit(bvhNodes, prims, tris, spheres,
+                         GRay(rec.point, wi), 0.001f, maxDist, sh) ||
+            sh.materialId != lightMatId)
+            return direct;
+        lightFront = sh.frontFace;
+    } else {
+        const GTriangle& t = tris[lp.index];
+        float r1 = curand_uniform(rng), r2 = curand_uniform(rng);
+        if (r1 + r2 > 1.f) { r1 = 1.f - r1; r2 = 1.f - r2; }
+        GVec3 lpos = t.v0 + (t.v1 - t.v0) * r1 + (t.v2 - t.v0) * r2;
+        GVec3 d    = lpos - rec.point;
+        float dist = d.length();
+        wi         = d * (1.f / fmaxf(dist, 1e-8f));
+        GVec3 e1   = t.v1 - t.v0, e2 = t.v2 - t.v0;
+        float area = e1.cross(e2).length() * 0.5f;
+        float NdotWi = fabsf(t.n0.dot(wi));
+        if (NdotWi < 1e-8f || area < 1e-8f) return direct;
+        lightPdf   = (dist * dist) / (NdotWi * area) * selPdf;
+        maxDist    = dist - 0.001f;
+        lightMatId = t.materialId;
+        lightFront = true;
+        GHitRecord sh;
+        if (gpu_bvh_hit(bvhNodes, prims, tris, spheres,
+                        GRay(rec.point, wi), 0.001f, maxDist, sh))
+            return direct;          // occluded
+    }
+
+    if (lightPdf <= 0.f) return direct;
+
+    // Spectral BSDF and emission — mirrors CPU pathTraceSpectral lines
+    // 2414-2421:  f_spec = evalSpectral ; L_spec = emission_spec (illuminant).
+    GSampledSpectrum f_spec =
+        gpu_material_eval_spectral(mat, const_cast<GHitRecord&>(rec), wo, wi, lambdas);
+    GSampledSpectrum L_spec =
+        gpu_material_emitted_spectral(materials[lightMatId], lightFront, lambdas);
+    if (f_spec.maxValue() <= 0.f || L_spec.maxValue() <= 0.f) return direct;
+
+    float bsdfPdf = gpu_material_pdf(mat, rec, wo, wi);
+    float wt      = gpu_mw_powerHeuristic(lightPdf, bsdfPdf);
+    // color += throughput * f_spec * L_spec * (wt / (ls.pdf + 0.001f))
+    return f_spec * L_spec * (wt / (lightPdf + 0.001f));
+}
+
+// ---------------------------------------------------------------------------
+// Spectral path trace — area-light NEE + MIS, mirroring the CPU
+// Renderer::pathTraceSpectral integrator (the CPU `path_tracer` selects this;
+// see plugins/integrators/spectral_path_tracer.cpp). The emissive-on-hit term
+// stays gated by (bounce==0 || wasSpecular) — the BSDF-sampling half of MIS —
+// while sampleDirectSpectralMW supplies the area-light direct term.
 // Returns raw per-sample SampledSpectrum radiance.
 // ---------------------------------------------------------------------------
 __device__ GSampledSpectrum tracePathMW(
     GRay ray, int maxDepth,
     GSampledWavelengths& lambdas,
     bool useLuminanceOutput,
+    bool enableNEE,
     const GBVHNode*  bvhNodes,
     const GPrimitive* prims,
     const GTriangle*  tris,
     const GSphere*    spheres,
     const GMaterial*  materials,
+    const GLight*     lights, int numLights, float totalLightPower,
     const GEnvMap&    envMap,
     const GVec3&      backgroundColor,
     bool              hasBackgroundColor,
@@ -524,6 +645,17 @@ __device__ GSampledSpectrum tracePathMW(
 
         GVec3 wo = -ray.direction.normalized();
 
+        // Area-light NEE (MIS via power heuristic). Skipped on delta lobes.
+        // Mirrors CPU pathTraceSpectral (include/raytracer.h:2405-2424).
+        // enableNEE is false when the kernel mirrors the naive no-NEE
+        // MultiwavelengthPathTracer (gated by integrator name in
+        // module/blender_module.cpp).
+        if (enableNEE && !rec.isDelta && numLights > 0) {
+            color += throughput * sampleDirectSpectralMW(
+                rec, wo, lambdas, bvhNodes, prims, tris, spheres, materials,
+                lights, numLights, totalLightPower, rng);
+        }
+
         // Russian roulette
         if (bounce > rrDepth) {
             float p;
@@ -586,11 +718,13 @@ __global__ void multiwavelengthKernel(
     int samplesPerPixel, int maxDepth,
     float lambdaMin, float lambdaMax,
     bool  useLuminanceOutput,
+    bool  enableNEE,
     const GBVHNode*  bvhNodes,
     const GPrimitive* prims,
     const GTriangle*  tris,
     const GSphere*    spheres,
     const GMaterial*  materials,
+    const GLight*     lights, int numLights, float totalLightPower,
     GEnvMap envMap,
     GCameraParams cam,
     GVec3 backgroundColor, bool hasBackgroundColor,
@@ -631,8 +765,9 @@ __global__ void multiwavelengthKernel(
             gpu_sampleBandWavelengths(&localRng, lambdaMin, lambdaMax);
 
         GSampledSpectrum rad = tracePathMW(
-            ray, maxDepth, lambdas, useLuminanceOutput,
+            ray, maxDepth, lambdas, useLuminanceOutput, enableNEE,
             bvhNodes, prims, tris, spheres, materials,
+            lights, numLights, totalLightPower,
             envMap, backgroundColor, hasBackgroundColor, &localRng);
 
         GVec3 sample;
@@ -684,11 +819,13 @@ void launchMultiwavelengthKernel(
     float* d_framebuffer, int width, int height,
     int samplesPerPixel, int maxDepth,
     float lambdaMin, float lambdaMax, bool useLuminanceOutput,
+    bool enableNEE,
     const GBVHNode*  d_bvhNodes,
     const GPrimitive* d_prims,
     const GTriangle*  d_tris,
     const GSphere*    d_spheres,
     const GMaterial*  d_materials,
+    const GLight*     d_lights, int numLights, float totalLightPower,
     GEnvMap envMap,
     GCameraParams cam,
     GVec3 backgroundColor, bool hasBackgroundColor,
@@ -704,8 +841,9 @@ void launchMultiwavelengthKernel(
             (const void*)multiwavelengthKernel, blocks, threadsPerBlock);
         multiwavelengthKernel<<<blocks, threadsPerBlock>>>(
             d_framebuffer, width, height, samplesPerPixel, maxDepth,
-            lambdaMin, lambdaMax, useLuminanceOutput,
+            lambdaMin, lambdaMax, useLuminanceOutput, enableNEE,
             d_bvhNodes, d_prims, d_tris, d_spheres, d_materials,
+            d_lights, numLights, totalLightPower,
             envMap, cam, backgroundColor, hasBackgroundColor,
             d_rngStates);
 


### PR DESCRIPTION
## Summary

The GPU multiwavelength megakernel had **no next-event estimation**, while
its emissive-on-hit term was gated by `(bounce==0 || wasSpecular)` exactly
like the CPU. With no NEE to supply the area-light direct term, **all
diffuse→emitter light was silently dropped**, producing a deterministic,
SPP-independent **~0.45×** deficit versus the CPU `path_tracer` integrator
(`Renderer::pathTraceSpectral`, which has full NEE+MIS).

## Root cause (bisected, not guessed)

- **SPP-independence confirmed:** ratio stable at 0.41 / 0.45 / 0.45 for
  spp = 4 / 16 / 64 (16× span). Per `[[mc-noise-vs-deterministic]]` this is
  a deterministic missing-factor bug, not MC noise.
- **NOT a Round-9 (pkg89) change.** `git diff d26d56f~1 HEAD -- src/gpu/
  include/astroray/gpu_materials.h` is **empty** — zero GPU-side code
  changes since before pkg89. The GPU MW kernel has never had NEE. The
  closeout sweep is the first GPU parity run since pkg54c (CI has no GPU),
  so it merged green continuously.
- **Exact mechanism:** isolating integrators on the RTX box —
  - CPU `path_tracer` (NEE+MIS) = 0.3673 (correct reference)
  - CPU `multiwavelength_path_tracer` (naive no-NEE, same gate) = 0.1658 → **0.451×**
  - GPU `path_tracer` (MW kernel) = 0.1673 → 0.456×
  - **GPU MW vs CPU MW = 1.009×** (parity) — the GPU correctly mirrored the
    *wrong* CPU integrator. The bug is the missing NEE term, not the
    spectral/diffuse shade (which matches its CPU twin to <1%).

## Fix (surgical, cite-and-borrow per CLAUDE.md §6)

Add area-light spectral NEE to the megakernel, mirroring CPU
`Renderer::pathTraceSpectral` (`include/raytracer.h:2405-2424`) and reusing
the CPU-faithful area-light sampling geometry already validated in
`src/gpu/path_trace_kernel.cu::sampleDirectGPU`. No invented algorithm.

The megakernel serves **both** `path_tracer` (NEE) and
`multiwavelength_path_tracer` (naive no-NEE); NEE is gated by an `enableNEE`
flag set from the integrator name in `module/blender_module.cpp`, so the
kernel stays a faithful mirror of whichever CPU integrator is selected
(this also keeps `tests/test_gpu_multiwavelength.py` — which asserts GPU↔CPU
*no-NEE* parity — passing).

## RTX 5070 Ti results (gates NOT loosened)

| material | pre-fix rel | post-fix rel | gate | result |
|---|---|---|---|---|
| lambertian | 0.548 | **0.001** | <0.45 | PASS |
| metal | 0.582 | **0.064** | <0.55 | PASS |
| dielectric | — | 0.000 | <0.60 | PASS |
| disney | — | 0.027 | <0.60 | PASS |

- `test_gpu_renders_match_cpu`: GPU↔CPU ratio → 1.000 (was 0.486×), SPP-stable
- GPU material contact sheet: **24/24** tiles + stats CSV (was 3/24, no CSV)
- Full suite: **941 passed, 9 skipped, 17 xfailed, 2 xpassed, 0 failed**
  (baseline: 3 failed, 938 passed; 2 known flakes #276/#298 unrelated, green)
- Clean rebuild verified: `astroray.__file__` → canonical
  `build_cuda/Release/astroray.cp313-win_amd64.pyd`, CUDA enabled

**CI cannot validate this fix** (no GPU in CI — it structurally could not
catch the original regression either). The proof is the RTX numbers above.

## Test plan

- [x] 3 named closeout tests pass with real parity (rel 0.001–0.064, gates unchanged)
- [x] GPU contact-sheet diagnostic emits 24/24 + CSV (secondary anomaly resolved → same root cause)
- [x] No regression: full suite 0 failed, ≥938 passed
- [x] `test_gpu_multiwavelength.py` (GPU↔CPU no-NEE parity) still green via enableNEE gating
- [x] Clean rebuild, canonical .pyd path verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)