### PR TITLE
docs(pkg98): fold in structure-aware HW-gate criterion

### DIFF
--- a/.astroray_plan/packages/pkg98-orchestrator-independent-review-gate.md
+++ b/.astroray_plan/packages/pkg98-orchestrator-independent-review-gate.md
@@ -285,6 +285,51 @@ review applied only when the docs ship alongside code
 low-risk and the existing doc-only fast path is preserved (no
 independent review on pure-docs — keeps the gate minimal).
 
+### Phase 2b — structure-aware HW-gate acceptance criteria (folded-in scope)
+
+The pkg44 ADAF re-gate (PR #310 → merged commit `11644df`)
+exposed a *third*, complementary hole: a structure-blind HW-gate
+threshold passed a visually-inadequate render. After the
+`enable_adaf` wire was fixed the HW gate measured
+`shadow_fraction = 0.0015` and **auto-merged**, but visual
+inspection showed only a tiny central shadow dot in an otherwise
+uniform background-noise field — the structure pkg44-adaf.md L243
+*requires* ("a quasi-spherical glow around the black hole … with
+the shadow visible as a dark silhouette") was **not** met. A
+`shadow_fraction > 0` check alone is too lenient: mere *presence*
+of a dark region is not the spec's intended structure.
+
+Scope (minimal, per-package — **not** a gate-rework): where a
+package spec's acceptance criteria demand a specific render
+*structure* (e.g. glow-type packages requiring a quasi-spherical /
+radially-concentrated intensity profile, not just "a dark region
+exists"), the per-package HW-gate acceptance criterion in the
+verifier path MUST additionally assert that structure — e.g. a
+radial intensity-profile / quasi-spherical-concentration check —
+rather than a structure-blind presence-only threshold like bare
+`shadow_fraction > ε`. This reuses the package's *existing*
+acceptance criteria as the source of the required structure; it
+adds **no** new gate framework, no new metric registry, and no
+universal structural-gate mandate — only packages whose spec text
+already demands structure get the structure-aware assertion, and
+the assertion lives in that package's own acceptance criteria /
+verifier path, not in the orchestrator.
+
+This is the HW-gated-side analogue of pkg98's independent-review
+theme: independent (different-model) review and structure-aware
+per-package gate criteria are **complementary** defences against
+the same CI/gate blindspot (memory
+`ci_has_no_gpu_runtime_blindspot`). Independent review catches
+what tests and CI miss on non-HW-gated work; a structure-aware
+HW-gate criterion catches what a presence-only threshold rubber-
+stamps on HW-gated work. Like independent review, it is **not a
+substitute for integration tests** — the end-to-end scene
+assertions required by memory `gr-emission-model-wiring-checklist`
+(through `add_black_hole`, central-dark-region + radial-falloff)
+remain mandatory; the structure-aware gate criterion is a second,
+orthogonal line of defence on the empirical visual gate, not a
+relaxation of it.
+
 ### Rubber-stamp decay — explicit countermeasures
 
 A second model that habitually agrees is worthless. This package
@@ -342,6 +387,17 @@ hard-codes three countermeasures, stated in BOTH agent prompts:
       provably targets a different model lineage than the
       fix/PR author (assert the invocation uses the Codex/
       different-model path, not a same-lineage agent).
+- [ ] Structure-aware HW-gate (Phase 2b): for a package whose
+      spec acceptance criteria demand a render *structure*, the
+      per-package HW-gate criterion asserts that structure (e.g. a
+      radial-profile / quasi-spherical-concentration check), not a
+      structure-blind presence-only threshold; a render that
+      reproduces the pkg44 #310 failure mode (`shadow_fraction`
+      barely > 0 but no quasi-spherical glow per pkg44-adaf.md
+      L243) provably does **not** PASS that criterion. No new gate
+      framework introduced (assert: change is per-package
+      acceptance-criteria text in the verifier path, not an
+      orchestrator-wide gate change).
 - [ ] `--dry-run` performs **zero** review dispatches and zero
       ledger/standup mutations (regression guard on design spec §5).
 - [ ] Existing orchestrator test suite stays green


### PR DESCRIPTION
## Summary

Folds one additional orchestrator-quality scope item into the already-merged **pkg98** spec (`.astroray_plan/packages/pkg98-orchestrator-independent-review-gate.md`, originally PR #313). Owner decision: same orchestrator-quality theme, so amend the existing spec rather than file a new package.

**Scope item added:** HW-gate acceptance criteria must assert render **structure** (not merely presence of a dark region) wherever the package spec demands structure.

## Motivating evidence

pkg44 ADAF PR #310 **passed** the HW gate with `shadow_fraction=0.0015` and auto-merged (commit `11644df`), but visual inspection showed only a tiny central shadow dot in an otherwise uniform background-noise field. `pkg44-adaf.md` L243 requires *"a quasi-spherical glow around the black hole … with the shadow visible as a dark silhouette"* — that structure was **not** met. A structure-blind threshold rubber-stamped a visually-inadequate render.

## What changed (surgical — additions only)

- **New `### Phase 2b — structure-aware HW-gate acceptance criteria (folded-in scope)`** subsection (inserted before the existing "Rubber-stamp decay" section, same heading style): per-package HW-gate criteria must assert the spec's intended structure (e.g. a radial-profile / quasi-spherical-concentration check) where the spec text demands it — reusing the package's *existing* acceptance criteria, **no** new gate framework, no orchestrator-wide rework. Explicitly tied to pkg98's independent-review theme (complementary defences against the same CI/gate blindspot) and to the existing "not a substitute for integration tests" point + `gr-emission-model-wiring-checklist` memory reference.
- **One matching acceptance-criteria bullet** inserted in the existing `### Acceptance criteria` list.

56 insertions, 0 deletions, single file. All prior sections / tags / structure preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)