### PR TITLE
fix(pkg99): drop exposureScale from volumetric emission path

### DIFF
--- a/include/astroray/black_hole.h
+++ b/include/astroray/black_hole.h
@@ -359,9 +359,15 @@ public:
             return result;
         }
 
+        // pkg99 (2026-05-22): exposureScale (5e-14) is a Novikov-Thorne disk
+        // brightness normalization (raw Planck values ~2e14 → ~1). It does NOT
+        // belong on volumetric emissions — those have their own intensity_scale
+        // parameters carrying any unit conversion they need. Multiplying by
+        // 5e-14 here made ADAF effectively invisible (ON==OFF) and forced jet
+        // scenes to use intensity_scale ~1e28 as empirical compensation. Scene
+        // files updated separately to use physically-meaningful scale values.
         result.emission = diskEmissionSpectral(ir, lambdas)
-                        + volumetricEmissionSpectral(incomingRay, lambdas)
-                            * exposureScale;
+                        + volumetricEmissionSpectral(incomingRay, lambdas);
         result.hasEmission = !result.emission.isZero();
         result.exitDirection = sanitizedExitDirection(ir);
         // pkg67: expose the integrator's frequency-shift factor so the caller

--- a/scripts/diagnostics/render_readme_hero.py
+++ b/scripts/diagnostics/render_readme_hero.py
@@ -102,7 +102,7 @@ def build_scene(astroray, *, width: int, height: int, spin: float = 0.9):
         "power_law_index": 2.5,
         "base_density": 1.0e12,
         "magnetic_field": 1.0e6,
-        "intensity_scale": 1.0e28,
+        "intensity_scale": 5.0e13,  # pkg99 (2026-05-22): was 1.0e28 to compensate for 5e-14 exposureScale; that multiplication removed from black_hole.h → rescale by 5e-14 to preserve visual.
         "r_base": 1.0,
         "r_max": 50.0,
     }

--- a/tests/scenes/synchrotron_jet.py
+++ b/tests/scenes/synchrotron_jet.py
@@ -38,7 +38,7 @@ def build_scene(astroray, width: int = 24, height: int = 24):
             "power_law_index": 2.5,
             "base_density": 1.0e12,
             "magnetic_field": 1.0e6,
-            "intensity_scale": 1.0e28,
+            "intensity_scale": 5.0e13,  # pkg99 (2026-05-22): was 1.0e28 to compensate for 5e-14 exposureScale; that multiplication removed from black_hole.h → rescale by 5e-14 to preserve visual.
             "r_base": 1.0,
             "r_max": 120.0,
         },

--- a/tests/test_pkg99_adaf_wiring_regression.py
+++ b/tests/test_pkg99_adaf_wiring_regression.py
@@ -1,0 +1,81 @@
+"""pkg99 regression: ADAF VolumetricEmission must reach the renderer.
+
+Before pkg99 fix (commit pre-2026-05-22): ADAF ON and ADAF OFF produced
+pixel-identical output because `black_hole.h` multiplied volumetric emission
+by `exposureScale = 5e-14`, a Novikov-Thorne disk normalization factor that
+made all volumetric contributions effectively zero.
+
+After fix: ADAF ON must produce a measurably different image than ADAF OFF.
+
+This is a wiring regression test, not a physics correctness test. It does not
+assert a particular glow shape, brightness, or radial profile — only that
+toggling `enable_adaf` materially changes pixel values.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+import numpy as np
+import pytest
+
+SCENE_DIR = Path(__file__).resolve().parent / "scenes"
+if str(SCENE_DIR) not in sys.path:
+    sys.path.insert(0, str(SCENE_DIR))
+
+
+def _build_adaf_scene(astroray, enable_adaf: bool, width=32, height=32):
+    """Single-black-hole scene; ADAF emission toggleable."""
+    r = astroray.Renderer()
+    r.setup_camera(
+        look_from=[0.0, 0.0, 30.0],
+        look_at=[0.0, 0.0, 0.0],
+        vup=[0.0, 1.0, 0.0],
+        vfov=20.0,
+        aspect_ratio=width / height,
+        aperture=0.0,
+        focus_dist=30.0,
+        width=width,
+        height=height,
+    )
+    r.add_black_hole(
+        [0.0, 0.0, 0.0], 4.0e6, 16.0,
+        {
+            "enable_adaf": enable_adaf,
+            "adaf_mdot_eddington": 1.0e-4,
+            "adaf_electron_temp": 1.0e10,
+            "adaf_beta_mag": 0.1,
+            "adaf_r_inner": 1.5,
+            "adaf_r_outer": 100.0,
+            "adaf_flattening": 0.0,
+            "adaf_alpha": 0.1,
+            "adaf_s": 0.3,
+            "adaf_intensity_scale": 1.0e30,
+        },
+    )
+    r.set_integrator("path_tracer")
+    return r
+
+
+def test_adaf_on_differs_from_off():
+    """ADAF ON must produce different pixels than ADAF OFF.
+
+    Pre-pkg99-fix this failed (pixel-identical due to 5e-14 multiplication
+    in black_hole.h annihilating the volumetric contribution).
+    """
+    import astroray
+
+    r_off = _build_adaf_scene(astroray, enable_adaf=False)
+    pixels_off = np.asarray(r_off.render(8, 1))
+
+    r_on = _build_adaf_scene(astroray, enable_adaf=True)
+    pixels_on = np.asarray(r_on.render(8, 1))
+
+    # Identical RNG seed + identical scene (except enable_adaf) must give
+    # measurably different pixels.
+    max_abs_diff = float(np.max(np.abs(pixels_on - pixels_off)))
+    assert max_abs_diff > 1e-6, (
+        f"pkg99 regression: ADAF ON == OFF (max abs diff {max_abs_diff:.2e}). "
+        "VolumetricEmission contribution is not reaching the renderer. "
+        "Check black_hole.h traceGRSpectral does not multiply volumetric "
+        "emission by exposureScale."
+    )


### PR DESCRIPTION
## Summary

Root cause of the pkg99 ADAF "invisible glow" was a wiring bug in `black_hole.h:362-364`: the path tracer multiplied **volumetric** emission by `exposureScale = 5e-14`, a Novikov-Thorne disk brightness normalization. That factor wiped out all VolumetricEmission plugins (ADAF, jet, slim disk) which already carry their own `intensity_scale` parameter. The jet worked anyway because pkg42's scene files set `intensity_scale = 1.0e28` as empirical compensation; ADAF, which used its physically-meaningful spec value, came out pixel-identical to ADAF-OFF.

## Changes

- `include/astroray/black_hole.h:362-364` — remove `* exposureScale` from the volumetric emission sum. Disk emission keeps its normalization.
- `tests/scenes/synchrotron_jet.py` — `intensity_scale` `1.0e28` → `5.0e13` (= `1e28 * 5e-14`) to preserve the jet's current visual output.
- `scripts/diagnostics/render_readme_hero.py` — same rescale.
- `tests/test_pkg99_adaf_wiring_regression.py` (new) — regression test asserting ADAF ON ≠ ADAF OFF.

ADAF scene (`tests/scenes/adaf_sgra.py`) untouched; `intensity_scale = 1.0e30` (spec value) should now produce visible glow. Empirical visual tuning is a separate follow-up.

## Test plan
- [x] CI: regression test passes (ADAF ON ≠ OFF)
- [x] CI: existing pkg42 jet tests still green at new `intensity_scale = 5.0e13`
- [ ] RTX visual gate: jet visual unchanged
- [ ] RTX visual gate: ADAF quasi-spherical glow now appears (pkg99 spec acceptance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)