### PR TITLE
fix(pkg100): stash _blend_import_stats best-effort + bpy-free regression test

### DIFF
--- a/tests/test_blend_import_format.py
+++ b/tests/test_blend_import_format.py
@@ -95,3 +95,29 @@ def test_pointer_resolution():
     sc = bf.follow(ptr)
     assert sc is not None
     assert sc.code == "SC"
+
+
+def test_import_blend_into_real_renderer_no_dynamic_attr():
+    """pkg100 regression: end-to-end import_blend against the real pybind11
+    Renderer using the committed synthetic_min.blend (no bpy needed).
+
+    The original pkg100 fix moved ``_cam_intrinsics`` off the renderer attribute,
+    but missed a second site that still did ``renderer._blend_import_stats = stats``.
+    On the real ``astroray.Renderer`` (no ``__dict__``) that second assignment
+    raised AttributeError, so any real-world import would fail. The
+    bpy-gated regression test in ``test_blend_import_roundtrip.py`` skipped
+    in CI (no bpy), so this regression rode into main. The current fix uses
+    a ``stats_out`` out-parameter; this test exercises that path with no bpy.
+    """
+    astroray = pytest.importorskip("astroray")
+    from tools.blend_import import import_blend
+
+    renderer = astroray.Renderer()
+    stats: dict = {}
+    result = import_blend(
+        FIXTURE, renderer=renderer, width=128, height=128, stats_out=stats,
+    )
+    assert result is renderer
+    assert isinstance(stats, dict)
+    # synthetic_min.blend has no real camera intrinsics; just verify the
+    # function returned without raising AttributeError on the real binding.

--- a/tests/test_blend_import_roundtrip.py
+++ b/tests/test_blend_import_roundtrip.py
@@ -156,15 +156,21 @@ def test_real_renderer_accepts_dynamic_attrs(authored_blend_path):
     renderer = astroray.Renderer()
 
     # This call must not raise AttributeError. Prior to the fix, it would fail at
-    # scene_builder.py:175 with "no attribute '_cam_intrinsics' and no __dict__".
-    result = import_blend(authored_blend_path, renderer=renderer, width=512, height=512)
+    # scene_builder.py:175 with "no attribute '_cam_intrinsics' and no __dict__",
+    # and (post-pkg100-original-fix) it would still fail one line later at
+    # blend_to_astroray.py:67 trying to set `_blend_import_stats`. The current
+    # fix uses an explicit ``stats_out`` out-parameter for the real binding
+    # because it has no ``__dict__``; the attribute-stash is best-effort.
+    stats = {}
+    result = import_blend(
+        authored_blend_path, renderer=renderer, width=512, height=512,
+        stats_out=stats,
+    )
 
     # Verify the renderer was populated and setup_camera was called.
     assert result is renderer
 
-    # Verify stats are attached and include camera intrinsics.
-    assert hasattr(renderer, "_blend_import_stats")
-    stats = renderer._blend_import_stats
+    # Verify stats include camera intrinsics.
     assert isinstance(stats, dict)
     assert "cam_intrinsics" in stats
     assert stats["cam_intrinsics"] is not None

--- a/tools/blend_import/blend_to_astroray.py
+++ b/tools/blend_import/blend_to_astroray.py
@@ -22,7 +22,8 @@ def import_blend(path: str | Path,
                  renderer: Any | None = None,
                  width: int | None = None,
                  height: int | None = None,
-                 on_warning: Callable[[str], None] | None = None) -> Any:
+                 on_warning: Callable[[str], None] | None = None,
+                 stats_out: dict | None = None) -> Any:
     """Build an Astroray Renderer from a .blend file at *path*.
 
     Parameters
@@ -42,12 +43,16 @@ def import_blend(path: str | Path,
         Otherwise the caller is responsible for calling setup_camera
         separately (camera intrinsics are available in the returned stats dict
         under the ``"cam_intrinsics"`` key).
+    stats_out
+        Optional dict; if provided, populated with import statistics
+        (objects/triangles/lights/materials counts + cam_intrinsics). This is
+        the preferred way to retrieve stats — the renderer-attribute path is
+        kept best-effort for the _FakeRenderer test stub but is impossible on
+        the real pybind11 ``astroray.Renderer`` (no ``__dict__``).
 
     Returns
     -------
-    The populated renderer. Import statistics (objects/triangles/lights/materials
-    counts plus camera intrinsics if decoded) are available via
-    ``renderer._blend_import_stats`` for inspection.
+    The populated renderer.
     """
     if renderer is None:
         import astroray  # deferred — lets unit tests import this module without astroray
@@ -64,7 +69,18 @@ def import_blend(path: str | Path,
             intrinsics["far"], width, height,
         )
 
-    renderer._blend_import_stats = stats
+    if stats_out is not None:
+        stats_out.clear()
+        stats_out.update(stats)
+
+    # Best-effort: stash stats on the renderer for the _FakeRenderer stub
+    # (has __dict__) and any pybind11 Renderer that opted into py::dynamic_attr().
+    # The real astroray.Renderer has no __dict__, so this silently no-ops there;
+    # callers who need stats from the real binding must pass ``stats_out``.
+    try:
+        renderer._blend_import_stats = stats
+    except AttributeError:
+        pass
     return renderer
 
 


### PR DESCRIPTION
## Summary
- Closeout sweep on the merged-Round-12 main found that pkg100's original PR (#339) only half-fixed the dynamic-attr defect: `_cam_intrinsics` was rerouted (Axis 2), but `renderer._blend_import_stats = stats` one line later still fails on the real pybind11 Renderer.
- The bpy-gated regression test (`test_real_renderer_accepts_dynamic_attrs`) skips silently in any environment without `bpy`, so CI never exercised it.

## Fix
- Add `stats_out: dict | None` out-parameter to `import_blend`. Real Renderer callers use this.
- Wrap the attribute stash in `try/except AttributeError` — no-ops on the real binding, still works for `_FakeRenderer` and any future `py::dynamic_attr()` opt-in.
- Add `test_import_blend_into_real_renderer_no_dynamic_attr` to the bpy-free `test_blend_import_format.py`. This is the CI-visible guard that should have existed for pkg100.
- Update the bpy-gated roundtrip test to use the same `stats_out` path.

## Verification
- End-to-end: `import_blend(synthetic_min.blend, ...)` populates a real `astroray.Renderer`, `setup_camera` invoked, render emits a 128×128 image (mean 0.337) — see `test_results/closeout-2026-05-22/pkg100_blend_import.png`.
- Local pytest: 1094 passed, 14 skipped, 16 xfailed, 4 xpassed.

## Test plan
- [x] `pytest tests/test_blend_import_format.py` — passes
- [x] Full `pytest tests/` — 1094 passed, 0 failed
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)