### PR TITLE
feat(pkg55-B' N+3 part 2b): CPU<->GPU threshold measurement + test gate

### DIFF
--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -2676,24 +2676,75 @@ PYBIND11_MODULE(astroray, m) {
 
     m.def("reference_pt_wavefront_render",
           [](PyRenderer& r, int samples, int max_depth, uint64_t seed,
-             bool record_snapshots) -> py::array_t<float> {
+             bool record_snapshots) -> py::object {
               auto cam = r.getCamera();
               if (!cam) {
                   throw std::runtime_error("Camera not set up. Call setup_camera() first.");
               }
               auto result = astroray::cpu_wavefront::reference_pt_wavefront_render(
                   r.getRenderer(), *cam, samples, max_depth, seed, record_snapshots);
-              // Return RGB buffer as numpy array (height, width, 3).
-              py::array_t<float> arr({cam->height, cam->width, 3});
-              auto buf = arr.request();
-              float* ptr = static_cast<float*>(buf.ptr);
-              std::copy(result.rgb.begin(), result.rgb.end(), ptr);
-              return arr;
+
+              if (!record_snapshots) {
+                  // Return RGB buffer only as numpy array (height, width, 3).
+                  py::array_t<float> arr({cam->height, cam->width, 3});
+                  auto buf = arr.request();
+                  float* ptr = static_cast<float*>(buf.ptr);
+                  std::copy(result.rgb.begin(), result.rgb.end(), ptr);
+                  return py::cast(arr);
+              } else {
+                  // Return dict with RGB and snapshots.
+                  py::dict d;
+
+                  // RGB image
+                  py::array_t<float> rgb_arr({cam->height, cam->width, 3});
+                  auto rgb_buf = rgb_arr.request();
+                  float* rgb_ptr = static_cast<float*>(rgb_buf.ptr);
+                  std::copy(result.rgb.begin(), result.rgb.end(), rgb_ptr);
+                  d["rgb"] = rgb_arr;
+
+                  // Snapshots as list of dicts
+                  py::list snapshot_list;
+                  for (const auto& snap : result.snapshots) {
+                      py::dict snap_dict;
+                      snap_dict["pixel_index"] = snap.pixel_index;
+                      snap_dict["sample_index"] = snap.sample_index;
+                      snap_dict["bounce"] = snap.bounce;
+                      snap_dict["stage"] = static_cast<int>(snap.stage);
+
+                      snap_dict["ray_origin"] = py::array_t<float>({3}, snap.ray_origin);
+                      snap_dict["ray_direction"] = py::array_t<float>({3}, snap.ray_direction);
+                      snap_dict["throughput"] = py::array_t<float>({4}, snap.throughput);
+                      snap_dict["lambdas"] = py::array_t<float>({4}, snap.lambdas);
+
+                      snap_dict["hit_valid"] = snap.hit_valid;
+                      snap_dict["hit_t"] = snap.hit_t;
+                      snap_dict["hit_point"] = py::array_t<float>({3}, snap.hit_point);
+                      snap_dict["hit_normal"] = py::array_t<float>({3}, snap.hit_normal);
+                      snap_dict["hit_material_id"] = snap.hit_material_id;
+
+                      snap_dict["bsdf_pdf"] = snap.bsdf_pdf;
+                      snap_dict["bsdf_is_delta"] = snap.bsdf_is_delta;
+
+                      snap_dict["nee_contribution"] = py::array_t<float>({4}, snap.nee_contribution);
+                      snap_dict["nee_light_pdf"] = snap.nee_light_pdf;
+                      snap_dict["nee_bsdf_pdf_at_dir"] = snap.nee_bsdf_pdf_at_dir;
+                      snap_dict["nee_mis_weight"] = snap.nee_mis_weight;
+
+                      snap_dict["rr_prob"] = snap.rr_prob;
+                      snap_dict["rr_survived"] = snap.rr_survived;
+
+                      snapshot_list.append(snap_dict);
+                  }
+                  d["snapshots"] = snapshot_list;
+
+                  return py::cast(d);
+              }
           },
           "renderer"_a, "samples"_a, "max_depth"_a, "seed"_a,
           "record_snapshots"_a = false,
-          "pkg55-B' Session 2b: wavefront-side reference PT (per-path RNG). "
-          "Diff oracle for CPU wavefront. Lambertian-Cornell only.");
+          "pkg55-B' Session 2b/N+3: wavefront-side reference PT (per-path RNG). "
+          "Diff oracle for CPU wavefront. Returns RGB array if record_snapshots=False, "
+          "or dict with 'rgb' and 'snapshots' if record_snapshots=True. Lambertian-Cornell only.");
 
     m.def("cpu_wavefront_render",
           [](PyRenderer& r, int samples, int max_depth, uint64_t seed) -> py::array_t<float> {

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -2690,7 +2690,7 @@ PYBIND11_MODULE(astroray, m) {
                   auto buf = arr.request();
                   float* ptr = static_cast<float*>(buf.ptr);
                   std::copy(result.rgb.begin(), result.rgb.end(), ptr);
-                  return py::cast(arr);
+                  return py::object(std::move(arr));
               } else {
                   // Return dict with RGB and snapshots.
                   py::dict d;
@@ -2737,7 +2737,7 @@ PYBIND11_MODULE(astroray, m) {
                   }
                   d["snapshots"] = snapshot_list;
 
-                  return py::cast(d);
+                  return py::object(std::move(d));
               }
           },
           "renderer"_a, "samples"_a, "max_depth"_a, "seed"_a,

--- a/tests/wavefront_diff/measure_thresholds.py
+++ b/tests/wavefront_diff/measure_thresholds.py
@@ -74,16 +74,27 @@ def _compute_ulp_distance(a, b):
     return int(np.max(ulp_dist))
 
 
-def _compute_p99_9_relative_error(a, b, epsilon=1e-8):
+def _compute_p99_9_relative_error(a, b, epsilon=1e-8, return_all=False):
     """Compute p99.9 percentile of relative error |a-b| / (|a| + epsilon).
 
     Relative error is more meaningful than absolute error for values that span
     multiple orders of magnitude (e.g., throughput 1e-6 vs 1.0).
+
+    Args:
+        a, b: arrays to compare
+        epsilon: small value to avoid division by zero
+        return_all: if True, return all relative errors; if False, return p99.9 percentile
+
+    Returns:
+        float (p99.9 percentile) or array (all relative errors)
     """
     abs_diff = np.abs(a - b)
     denom = np.abs(a) + epsilon
     rel_err = abs_diff / denom
-    return float(np.percentile(rel_err, 99.9))
+    if return_all:
+        return rel_err.flatten().tolist()
+    else:
+        return float(np.percentile(rel_err, 99.9))
 
 
 def _compute_ssim(img_a, img_b):
@@ -154,9 +165,10 @@ def measure_cpu_baseline(width=16, height=16, spp=1, seed=424242, max_depth=8):
 
 
 def measure_gpu_port(width=16, height=16, spp=1, seed=424242, max_depth=8):
-    """Measure CPU wavefront ↔ CUDA wavefront thresholds (Session N+3).
+    """Measure CPU wavefront ↔ CUDA wavefront thresholds (Session N+3 part 2b).
 
-    For PostInit stage only (Session N+3 part 1).
+    Full CPU↔GPU diff across PostInit, PostIntersect, PostShade stages.
+    Computes ULP for geometry stages, p99.9 relative error for shading stages, SSIM for final images.
     """
     ar = _lazy_import_astroray()
 
@@ -167,56 +179,261 @@ def measure_gpu_port(width=16, height=16, spp=1, seed=424242, max_depth=8):
 
     r = _build_renderer(width, height, seed, max_depth)
 
-    print(f"\n=== Measuring CPU<->GPU thresholds (PostInit stage) ===")
+    print(f"\n=== Measuring CPU<->GPU thresholds ===")
     print(f"Scene: session_n1_envmap_cornell ({width}x{height}, {spp} spp, seed {seed})")
 
-    # Run GPU stage_init
-    print("Running GPU stage_init...")
-    gpu_snapshot = ar.cuda_wavefront_snapshot_post_init(r, width, height, seed)
+    # Get CPU reference snapshots
+    print("\nRunning CPU reference path tracer with snapshots...")
+    cpu_result = ar.reference_pt_wavefront_render(r, spp, max_depth, seed, True)
+    cpu_snapshots_raw = cpu_result['snapshots']  # List of dicts
+    cpu_image = cpu_result['rgb']
 
-    # The GPU snapshot is (num_paths, 22) with fields:
-    #   [0..2]: ray_origin, [3..5]: ray_direction, [6..9]: lambdas,
-    #   [10..13]: throughput, [14..16]: pixel/sample/bounce, [17..21]: rng state.
+    print(f"CPU snapshots collected: {len(cpu_snapshots_raw)} total across all stages")
 
-    num_paths = width * height
-    print(f"\nGPU PostInit snapshot shape: {gpu_snapshot.shape}")
-    print(f"Sample values (first path):")
-    print(f"  ray_origin: {gpu_snapshot[0, 0:3]}")
-    print(f"  ray_direction: {gpu_snapshot[0, 3:6]}")
-    print(f"  lambdas: {gpu_snapshot[0, 6:10]}")
-    print(f"  throughput: {gpu_snapshot[0, 10:14]}")
+    # Extract CPU snapshots by stage
+    cpu_post_init = _extract_cpu_stage_snapshots(cpu_snapshots_raw, stage='PostInit')
+    cpu_post_intersect = _extract_cpu_stage_snapshots(cpu_snapshots_raw, stage='PostIntersect')
+    cpu_post_shade = _extract_cpu_stage_snapshots(cpu_snapshots_raw, stage='PostShade')
 
-    # For Session N+3 part 1, compute placeholder ULP / p99.9 values.
-    # Full CPU↔GPU comparison requires extracting CPU PostInit snapshots,
-    # which is deferred to a future refinement. For now, validate GPU kernel
-    # runs successfully and produces reasonable output.
+    print(f"  PostInit: {len(cpu_post_init)} snapshots")
+    print(f"  PostIntersect: {len(cpu_post_intersect)} snapshots")
+    print(f"  PostShade: {len(cpu_post_shade)} snapshots")
 
-    # Sanity checks:
-    # - throughput should be all 1s
-    throughput_ok = np.allclose(gpu_snapshot[:, 10:14], 1.0)
-    # - ray directions should be normalized
-    ray_dirs = gpu_snapshot[:, 3:6]
-    ray_lengths = np.linalg.norm(ray_dirs, axis=1)
-    ray_normalized_ok = np.allclose(ray_lengths, 1.0)
+    # Get GPU snapshots
+    print("\nRunning GPU wavefront stages...")
+    print("  Running stage_init...")
+    gpu_post_init = ar.cuda_wavefront_snapshot_post_init(r, width, height, seed)
+    print("  Running stage_init + stage_intersect...")
+    gpu_post_intersect = ar.cuda_wavefront_snapshot_post_intersect(r, width, height, seed)
+    print("  Running stage_init + stage_intersect + stage_shade_lambertian...")
+    gpu_post_shade = ar.cuda_wavefront_snapshot_post_shade(r, width, height, seed)
 
-    print(f"\nSanity checks:")
-    print(f"  Throughput all 1s: {throughput_ok}")
-    print(f"  Ray directions normalized: {ray_normalized_ok}")
+    print(f"\nGPU snapshot shapes:")
+    print(f"  PostInit: {gpu_post_init.shape}")
+    print(f"  PostIntersect: {gpu_post_intersect.shape}")
+    print(f"  PostShade: {gpu_post_shade.shape}")
 
-    if not throughput_ok or not ray_normalized_ok:
-        print("\n[FAIL] GPU PostInit snapshot failed sanity checks!")
-        return False
+    # Compare PostInit (geometry only: ULP + p99.9)
+    print(f"\n--- PostInit CPU<->GPU comparison ---")
+    post_init_ulp = _compare_stage_ulp(cpu_post_init, gpu_post_init, stage='PostInit')
+    post_init_p999 = _compare_stage_p999(cpu_post_init, gpu_post_init, stage='PostInit')
 
-    print(f"\n--- YAML for pkg55_cuda_thresholds.yaml (PostInit) ---")
+    # Compare PostIntersect (geometry only: ULP + p99.9)
+    print(f"\n--- PostIntersect CPU<->GPU comparison ---")
+    post_intersect_ulp = _compare_stage_ulp(cpu_post_intersect, gpu_post_intersect, stage='PostIntersect')
+    post_intersect_p999 = _compare_stage_p999(cpu_post_intersect, gpu_post_intersect, stage='PostIntersect')
+
+    # Compare PostShade (BSDF with transcendentals: p99.9 only)
+    print(f"\n--- PostShade CPU<->GPU comparison ---")
+    post_shade_p999 = _compare_stage_p999(cpu_post_shade, gpu_post_shade, stage='PostShade')
+
+    # Compute final image SSIM (requires rendering full image from GPU)
+    # For now, log informational message — full SSIM measurement needs end-to-end GPU wavefront pipeline
+    print(f"\n--- Final image SSIM ---")
+    print(f"  (Full CPU<->GPU image SSIM measurement deferred until end-to-end GPU wavefront pipeline)")
+    ssim_val = None  # Placeholder
+
+    # Print YAML output
+    print(f"\n--- YAML for pkg55_cuda_thresholds.yaml (measured values) ---")
+    print(f"cpu_to_gpu_thresholds:")
     print(f"  PostInit:")
-    print(f"    max_ulp: 4  # From spec 4.2 (to be verified via CPU<->GPU diff)")
+    print(f"    max_ulp: {post_init_ulp['max_ulp']}")
     print(f"    fields: [\"ray_origin\", \"ray_direction\", \"lambdas\"]")
-    print(f"    p99_9_relative_error: 1.0e-5  # Placeholder (to be measured)")
-    print(f'    note: "Session N+3 part 1 - GPU kernel functional - {datetime.now().strftime("%Y-%m-%d")}"')
+    print(f"    p99_9_relative_error: {post_init_p999['p99_9']:.6e}")
+    print(f'    note: "Session N+3 part 2b measured {datetime.now().strftime("%Y-%m-%d")}"')
+    print(f"")
+    print(f"  PostIntersect:")
+    print(f"    max_ulp: {post_intersect_ulp['max_ulp']}")
+    print(f"    fields: [\"hit_t\", \"hit_point\", \"hit_normal\", \"hit_material\"]")
+    print(f"    p99_9_relative_error: {post_intersect_p999['p99_9']:.6e}")
+    print(f'    note: "Session N+3 part 2b measured {datetime.now().strftime("%Y-%m-%d")}"')
+    print(f"")
+    print(f"  PostShade:")
+    print(f"    p99_9_relative_error: {post_shade_p999['p99_9']:.6e}")
+    print(f"    fields: [\"ray_origin\", \"ray_direction\", \"throughput\", \"wasSpecular\"]")
+    print(f'    note: "Session N+3 part 2b measured {datetime.now().strftime("%Y-%m-%d")}"')
     print(f"---")
 
-    print("\n[PASS] GPU stage_init runs successfully. Full CPU<->GPU diff deferred.")
+    print("\n[PASS] CPU<->GPU threshold measurement complete.")
     return True
+
+
+def _extract_cpu_stage_snapshots(snapshots_raw, stage):
+    """Extract CPU snapshots for a given stage from the raw snapshot list.
+
+    Returns: list of dicts with relevant fields extracted.
+    """
+    # The snapshots_raw is a list of dicts (from the Python binding).
+    # We need to filter by stage.
+    stage_map = {
+        'PostInit': 0,
+        'PostIntersect': 1,
+        'PostShade': 2,
+        'PostLightSample': 3,
+        'PostRR': 4,
+    }
+    stage_id = stage_map[stage]
+
+    result = []
+    for snap in snapshots_raw:
+        if snap['stage'] == stage_id:
+            result.append(snap)
+    return result
+
+
+def _compare_stage_ulp(cpu_snapshots, gpu_snapshot_array, stage):
+    """Compute max ULP distance for geometry fields.
+
+    Args:
+        cpu_snapshots: list of CPU WavefrontSnapshot dicts
+        gpu_snapshot_array: numpy array (num_paths, num_fields) from GPU
+        stage: 'PostInit' or 'PostIntersect'
+
+    Returns:
+        dict with max_ulp and per-field stats
+    """
+    if stage == 'PostInit':
+        # GPU PostInit: [0..2]: ray_origin, [3..5]: ray_direction, [6..9]: lambdas,
+        #               [10..13]: throughput, [14..16]: pixel/sample/bounce, [17..21]: rng
+        # Fields for ULP: ray_origin, ray_direction, lambdas
+        cpu_ray_origin = np.array([snap['ray_origin'] for snap in cpu_snapshots], dtype=np.float32)
+        cpu_ray_dir = np.array([snap['ray_direction'] for snap in cpu_snapshots], dtype=np.float32)
+        cpu_lambdas = np.array([snap['lambdas'] for snap in cpu_snapshots], dtype=np.float32)
+
+        gpu_ray_origin = gpu_snapshot_array[:, 0:3].astype(np.float32)
+        gpu_ray_dir = gpu_snapshot_array[:, 3:6].astype(np.float32)
+        gpu_lambdas = gpu_snapshot_array[:, 6:10].astype(np.float32)
+
+        ulp_origin = _compute_ulp_distance(cpu_ray_origin.flatten(), gpu_ray_origin.flatten())
+        ulp_dir = _compute_ulp_distance(cpu_ray_dir.flatten(), gpu_ray_dir.flatten())
+        ulp_lambdas = _compute_ulp_distance(cpu_lambdas.flatten(), gpu_lambdas.flatten())
+
+        max_ulp = max(ulp_origin, ulp_dir, ulp_lambdas)
+
+        print(f"  ULP distances:")
+        print(f"    ray_origin: {ulp_origin}")
+        print(f"    ray_direction: {ulp_dir}")
+        print(f"    lambdas: {ulp_lambdas}")
+        print(f"    max_ulp: {max_ulp}")
+
+        return {'max_ulp': max_ulp, 'fields': {'ray_origin': ulp_origin, 'ray_direction': ulp_dir, 'lambdas': ulp_lambdas}}
+
+    elif stage == 'PostIntersect':
+        # GPU PostIntersect: [0..2]: ray_origin, [3..5]: ray_direction, [6..9]: lambdas,
+        #                    [10..13]: throughput, [14]: hit_valid, [15]: hit_t,
+        #                    [16..18]: hit_point, [19..21]: hit_normal, [22]: hit_material_id
+        # Fields for ULP: hit_t, hit_point, hit_normal
+        cpu_hit_t = np.array([snap['hit_t'] for snap in cpu_snapshots], dtype=np.float32)
+        cpu_hit_point = np.array([snap['hit_point'] for snap in cpu_snapshots], dtype=np.float32)
+        cpu_hit_normal = np.array([snap['hit_normal'] for snap in cpu_snapshots], dtype=np.float32)
+
+        gpu_hit_t = gpu_snapshot_array[:, 15].astype(np.float32)
+        gpu_hit_point = gpu_snapshot_array[:, 16:19].astype(np.float32)
+        gpu_hit_normal = gpu_snapshot_array[:, 19:22].astype(np.float32)
+
+        ulp_hit_t = _compute_ulp_distance(cpu_hit_t, gpu_hit_t)
+        ulp_hit_point = _compute_ulp_distance(cpu_hit_point.flatten(), gpu_hit_point.flatten())
+        ulp_hit_normal = _compute_ulp_distance(cpu_hit_normal.flatten(), gpu_hit_normal.flatten())
+
+        max_ulp = max(ulp_hit_t, ulp_hit_point, ulp_hit_normal)
+
+        print(f"  ULP distances:")
+        print(f"    hit_t: {ulp_hit_t}")
+        print(f"    hit_point: {ulp_hit_point}")
+        print(f"    hit_normal: {ulp_hit_normal}")
+        print(f"    max_ulp: {max_ulp}")
+
+        return {'max_ulp': max_ulp, 'fields': {'hit_t': ulp_hit_t, 'hit_point': ulp_hit_point, 'hit_normal': ulp_hit_normal}}
+
+    else:
+        raise ValueError(f"ULP comparison not defined for stage {stage}")
+
+
+def _compare_stage_p999(cpu_snapshots, gpu_snapshot_array, stage):
+    """Compute p99.9 relative error for all numeric fields at a given stage.
+
+    Args:
+        cpu_snapshots: list of CPU WavefrontSnapshot dicts
+        gpu_snapshot_array: numpy array (num_paths, num_fields) from GPU
+        stage: 'PostInit', 'PostIntersect', or 'PostShade'
+
+    Returns:
+        dict with p99_9 and per-field stats
+    """
+    all_rel_errors = []
+
+    if stage == 'PostInit':
+        # Compare all fields: ray_origin, ray_direction, lambdas, throughput
+        cpu_ray_origin = np.array([snap['ray_origin'] for snap in cpu_snapshots], dtype=np.float32)
+        cpu_ray_dir = np.array([snap['ray_direction'] for snap in cpu_snapshots], dtype=np.float32)
+        cpu_lambdas = np.array([snap['lambdas'] for snap in cpu_snapshots], dtype=np.float32)
+        cpu_throughput = np.array([snap['throughput'] for snap in cpu_snapshots], dtype=np.float32)
+
+        gpu_ray_origin = gpu_snapshot_array[:, 0:3].astype(np.float32)
+        gpu_ray_dir = gpu_snapshot_array[:, 3:6].astype(np.float32)
+        gpu_lambdas = gpu_snapshot_array[:, 6:10].astype(np.float32)
+        gpu_throughput = gpu_snapshot_array[:, 10:14].astype(np.float32)
+
+        all_rel_errors.extend(_compute_p99_9_relative_error(cpu_ray_origin.flatten(), gpu_ray_origin.flatten(), return_all=True))
+        all_rel_errors.extend(_compute_p99_9_relative_error(cpu_ray_dir.flatten(), gpu_ray_dir.flatten(), return_all=True))
+        all_rel_errors.extend(_compute_p99_9_relative_error(cpu_lambdas.flatten(), gpu_lambdas.flatten(), return_all=True))
+        all_rel_errors.extend(_compute_p99_9_relative_error(cpu_throughput.flatten(), gpu_throughput.flatten(), return_all=True))
+
+    elif stage == 'PostIntersect':
+        # Compare all fields: ray, lambdas, throughput, hit_t, hit_point, hit_normal
+        cpu_ray_origin = np.array([snap['ray_origin'] for snap in cpu_snapshots], dtype=np.float32)
+        cpu_ray_dir = np.array([snap['ray_direction'] for snap in cpu_snapshots], dtype=np.float32)
+        cpu_lambdas = np.array([snap['lambdas'] for snap in cpu_snapshots], dtype=np.float32)
+        cpu_throughput = np.array([snap['throughput'] for snap in cpu_snapshots], dtype=np.float32)
+        cpu_hit_t = np.array([snap['hit_t'] for snap in cpu_snapshots], dtype=np.float32)
+        cpu_hit_point = np.array([snap['hit_point'] for snap in cpu_snapshots], dtype=np.float32)
+        cpu_hit_normal = np.array([snap['hit_normal'] for snap in cpu_snapshots], dtype=np.float32)
+
+        gpu_ray_origin = gpu_snapshot_array[:, 0:3].astype(np.float32)
+        gpu_ray_dir = gpu_snapshot_array[:, 3:6].astype(np.float32)
+        gpu_lambdas = gpu_snapshot_array[:, 6:10].astype(np.float32)
+        gpu_throughput = gpu_snapshot_array[:, 10:14].astype(np.float32)
+        gpu_hit_t = gpu_snapshot_array[:, 15].astype(np.float32)
+        gpu_hit_point = gpu_snapshot_array[:, 16:19].astype(np.float32)
+        gpu_hit_normal = gpu_snapshot_array[:, 19:22].astype(np.float32)
+
+        all_rel_errors.extend(_compute_p99_9_relative_error(cpu_ray_origin.flatten(), gpu_ray_origin.flatten(), return_all=True))
+        all_rel_errors.extend(_compute_p99_9_relative_error(cpu_ray_dir.flatten(), gpu_ray_dir.flatten(), return_all=True))
+        all_rel_errors.extend(_compute_p99_9_relative_error(cpu_lambdas.flatten(), gpu_lambdas.flatten(), return_all=True))
+        all_rel_errors.extend(_compute_p99_9_relative_error(cpu_throughput.flatten(), gpu_throughput.flatten(), return_all=True))
+        all_rel_errors.extend(_compute_p99_9_relative_error(cpu_hit_t, gpu_hit_t, return_all=True))
+        all_rel_errors.extend(_compute_p99_9_relative_error(cpu_hit_point.flatten(), gpu_hit_point.flatten(), return_all=True))
+        all_rel_errors.extend(_compute_p99_9_relative_error(cpu_hit_normal.flatten(), gpu_hit_normal.flatten(), return_all=True))
+
+    elif stage == 'PostShade':
+        # GPU PostShade: [0..2]: ray_origin, [3..5]: ray_direction, [6..9]: throughput,
+        #                [10..13]: lambdas, [14]: bsdf_pdf, [15]: bsdf_is_delta
+        # Compare: ray_origin, ray_direction, throughput, bsdf_pdf
+        cpu_ray_origin = np.array([snap['ray_origin'] for snap in cpu_snapshots], dtype=np.float32)
+        cpu_ray_dir = np.array([snap['ray_direction'] for snap in cpu_snapshots], dtype=np.float32)
+        cpu_throughput = np.array([snap['throughput'] for snap in cpu_snapshots], dtype=np.float32)
+        cpu_bsdf_pdf = np.array([snap['bsdf_pdf'] for snap in cpu_snapshots], dtype=np.float32)
+
+        gpu_ray_origin = gpu_snapshot_array[:, 0:3].astype(np.float32)
+        gpu_ray_dir = gpu_snapshot_array[:, 3:6].astype(np.float32)
+        gpu_throughput = gpu_snapshot_array[:, 6:10].astype(np.float32)
+        gpu_bsdf_pdf = gpu_snapshot_array[:, 14].astype(np.float32)
+
+        all_rel_errors.extend(_compute_p99_9_relative_error(cpu_ray_origin.flatten(), gpu_ray_origin.flatten(), return_all=True))
+        all_rel_errors.extend(_compute_p99_9_relative_error(cpu_ray_dir.flatten(), gpu_ray_dir.flatten(), return_all=True))
+        all_rel_errors.extend(_compute_p99_9_relative_error(cpu_throughput.flatten(), gpu_throughput.flatten(), return_all=True))
+        all_rel_errors.extend(_compute_p99_9_relative_error(cpu_bsdf_pdf, gpu_bsdf_pdf, return_all=True))
+
+    else:
+        raise ValueError(f"p99.9 comparison not defined for stage {stage}")
+
+    p99_9 = float(np.percentile(all_rel_errors, 99.9))
+
+    print(f"  p99.9 relative error: {p99_9:.6e}")
+    print(f"  mean relative error: {np.mean(all_rel_errors):.6e}")
+    print(f"  median relative error: {np.median(all_rel_errors):.6e}")
+
+    return {'p99_9': p99_9, 'mean': np.mean(all_rel_errors), 'median': np.median(all_rel_errors)}
 
 
 def main():

--- a/tests/wavefront_diff/test_pkg55_cuda_threshold_gate.py
+++ b/tests/wavefront_diff/test_pkg55_cuda_threshold_gate.py
@@ -107,34 +107,217 @@ def test_cpu_to_cpu_baseline_bit_identity():
           f"(max diff = {max_abs_diff!r}, diverging fields = {total_diverging_fields})")
 
 
-@pytest.mark.skip(reason="Session N+2: no CUDA kernel changes yet. Un-skip in Session N+3.")
 def test_cpu_to_gpu_threshold_gate():
     """CPU wavefront ↔ CUDA wavefront: ULP + p99.9 + SSIM gate (GATE 2 of 2).
 
-    This test is SKIPPED in Session N+2 (no CUDA kernel changes yet).
-    Session N+3 will un-skip this and implement:
-      1. CUDA wavefront stage kernels
-      2. CPU↔GPU per-stage diff harness (mirrors cpu_wavefront_snapshot_diff)
-      3. Measure actual ULP / p99.9 / SSIM on first CUDA port
-      4. Update pkg55_cuda_thresholds.yaml with measured values
-      5. Enforce thresholds in subsequent CUDA sessions (N+4..M)
+    Session N+3 part 2b: enforces measured thresholds at PostInit/PostIntersect/PostShade stages.
 
     Spec: §4.2 GATE-THRESHOLDS-PINNED blocks Sessions N+2..M until thresholds
     are measured. Session N+2 pins the *structure*; Session N+3 measures the
     *values*.
     """
     ar = _lazy_import_astroray()
+
+    if not hasattr(ar, 'cuda_wavefront_snapshot_post_init'):
+        pytest.skip("CUDA wavefront not available. Build with -DASTRORAY_WAVEFRONT_CUDA_N3=ON.")
+
     thresholds = _load_thresholds()
     gpu_thresholds = thresholds["cpu_to_gpu_thresholds"]
 
-    # TODO(Session N+3): implement CUDA wavefront stages + diff harness
-    # ar.cuda_wavefront_snapshot_diff(renderer, samples, max_depth, seed)
-    # Then enforce gpu_thresholds per stage:
-    #   PostInit/PostIntersect: max_ulp ≤ gpu_thresholds["PostInit"]["max_ulp"]
-    #   PostShade/LightSample/RR: p99.9 ≤ gpu_thresholds["PostShade"]["p99_9_relative_error"]
-    #   Final image: SSIM ≥ gpu_thresholds["final_image"]["ssim_visible"]
+    WIDTH, HEIGHT = 16, 16
+    SEED = 424242
+    SPP = 1
+    MAX_DEPTH = 8
 
-    pytest.fail("Session N+3: implement CUDA wavefront + diff harness here.")
+    r = _build_renderer(WIDTH, HEIGHT, SEED, MAX_DEPTH)
+
+    # Get CPU reference snapshots
+    cpu_result = ar.reference_pt_wavefront_render(r, SPP, MAX_DEPTH, SEED, True)
+    cpu_snapshots_raw = cpu_result['snapshots']
+
+    # Extract CPU snapshots by stage
+    cpu_post_init = _extract_cpu_stage_snapshots(cpu_snapshots_raw, stage='PostInit')
+    cpu_post_intersect = _extract_cpu_stage_snapshots(cpu_snapshots_raw, stage='PostIntersect')
+    cpu_post_shade = _extract_cpu_stage_snapshots(cpu_snapshots_raw, stage='PostShade')
+
+    # Get GPU snapshots
+    gpu_post_init = ar.cuda_wavefront_snapshot_post_init(r, WIDTH, HEIGHT, SEED)
+    gpu_post_intersect = ar.cuda_wavefront_snapshot_post_intersect(r, WIDTH, HEIGHT, SEED)
+    gpu_post_shade = ar.cuda_wavefront_snapshot_post_shade(r, WIDTH, HEIGHT, SEED)
+
+    # Gate 1: PostInit ULP + p99.9
+    post_init_ulp = _compute_stage_ulp(cpu_post_init, gpu_post_init, stage='PostInit')
+    post_init_p999 = _compute_stage_p999(cpu_post_init, gpu_post_init, stage='PostInit')
+
+    assert post_init_ulp <= gpu_thresholds["PostInit"]["max_ulp"], (
+        f"PostInit ULP gate FAILED: measured {post_init_ulp}, threshold {gpu_thresholds['PostInit']['max_ulp']}"
+    )
+    assert post_init_p999 <= gpu_thresholds["PostInit"]["p99_9_relative_error"], (
+        f"PostInit p99.9 gate FAILED: measured {post_init_p999:.6e}, threshold {gpu_thresholds['PostInit']['p99_9_relative_error']:.6e}"
+    )
+
+    # Gate 2: PostIntersect ULP + p99.9
+    post_intersect_ulp = _compute_stage_ulp(cpu_post_intersect, gpu_post_intersect, stage='PostIntersect')
+    post_intersect_p999 = _compute_stage_p999(cpu_post_intersect, gpu_post_intersect, stage='PostIntersect')
+
+    assert post_intersect_ulp <= gpu_thresholds["PostIntersect"]["max_ulp"], (
+        f"PostIntersect ULP gate FAILED: measured {post_intersect_ulp}, threshold {gpu_thresholds['PostIntersect']['max_ulp']}"
+    )
+    assert post_intersect_p999 <= gpu_thresholds["PostIntersect"]["p99_9_relative_error"], (
+        f"PostIntersect p99.9 gate FAILED: measured {post_intersect_p999:.6e}, threshold {gpu_thresholds['PostIntersect']['p99_9_relative_error']:.6e}"
+    )
+
+    # Gate 3: PostShade p99.9
+    post_shade_p999 = _compute_stage_p999(cpu_post_shade, gpu_post_shade, stage='PostShade')
+
+    assert post_shade_p999 <= gpu_thresholds["PostShade"]["p99_9_relative_error"], (
+        f"PostShade p99.9 gate FAILED: measured {post_shade_p999:.6e}, threshold {gpu_thresholds['PostShade']['p99_9_relative_error']:.6e}"
+    )
+
+    print(f"\n[pkg55-Session-N+3-part2b CPU↔GPU threshold gate] PASS:")
+    print(f"  PostInit: ULP={post_init_ulp}, p99.9={post_init_p999:.6e}")
+    print(f"  PostIntersect: ULP={post_intersect_ulp}, p99.9={post_intersect_p999:.6e}")
+    print(f"  PostShade: p99.9={post_shade_p999:.6e}")
+
+
+def _extract_cpu_stage_snapshots(snapshots_raw, stage):
+    """Extract CPU snapshots for a given stage from the raw snapshot list."""
+    stage_map = {
+        'PostInit': 0,
+        'PostIntersect': 1,
+        'PostShade': 2,
+        'PostLightSample': 3,
+        'PostRR': 4,
+    }
+    stage_id = stage_map[stage]
+
+    result = []
+    for snap in snapshots_raw:
+        if snap['stage'] == stage_id:
+            result.append(snap)
+    return result
+
+
+def _compute_ulp_distance(a, b):
+    """Compute max ULP distance between two float arrays."""
+    import numpy as np
+    a_int = np.frombuffer(a.astype(np.float32).tobytes(), dtype=np.int32)
+    b_int = np.frombuffer(b.astype(np.float32).tobytes(), dtype=np.int32)
+    ulp_dist = np.abs(a_int - b_int)
+    return int(np.max(ulp_dist))
+
+
+def _compute_stage_ulp(cpu_snapshots, gpu_snapshot_array, stage):
+    """Compute max ULP distance for geometry fields at a given stage."""
+    import numpy as np
+
+    if stage == 'PostInit':
+        cpu_ray_origin = np.array([snap['ray_origin'] for snap in cpu_snapshots], dtype=np.float32)
+        cpu_ray_dir = np.array([snap['ray_direction'] for snap in cpu_snapshots], dtype=np.float32)
+        cpu_lambdas = np.array([snap['lambdas'] for snap in cpu_snapshots], dtype=np.float32)
+
+        gpu_ray_origin = gpu_snapshot_array[:, 0:3].astype(np.float32)
+        gpu_ray_dir = gpu_snapshot_array[:, 3:6].astype(np.float32)
+        gpu_lambdas = gpu_snapshot_array[:, 6:10].astype(np.float32)
+
+        ulp_origin = _compute_ulp_distance(cpu_ray_origin.flatten(), gpu_ray_origin.flatten())
+        ulp_dir = _compute_ulp_distance(cpu_ray_dir.flatten(), gpu_ray_dir.flatten())
+        ulp_lambdas = _compute_ulp_distance(cpu_lambdas.flatten(), gpu_lambdas.flatten())
+
+        return max(ulp_origin, ulp_dir, ulp_lambdas)
+
+    elif stage == 'PostIntersect':
+        cpu_hit_t = np.array([snap['hit_t'] for snap in cpu_snapshots], dtype=np.float32)
+        cpu_hit_point = np.array([snap['hit_point'] for snap in cpu_snapshots], dtype=np.float32)
+        cpu_hit_normal = np.array([snap['hit_normal'] for snap in cpu_snapshots], dtype=np.float32)
+
+        gpu_hit_t = gpu_snapshot_array[:, 15].astype(np.float32)
+        gpu_hit_point = gpu_snapshot_array[:, 16:19].astype(np.float32)
+        gpu_hit_normal = gpu_snapshot_array[:, 19:22].astype(np.float32)
+
+        ulp_hit_t = _compute_ulp_distance(cpu_hit_t, gpu_hit_t)
+        ulp_hit_point = _compute_ulp_distance(cpu_hit_point.flatten(), gpu_hit_point.flatten())
+        ulp_hit_normal = _compute_ulp_distance(cpu_hit_normal.flatten(), gpu_hit_normal.flatten())
+
+        return max(ulp_hit_t, ulp_hit_point, ulp_hit_normal)
+
+    else:
+        raise ValueError(f"ULP comparison not defined for stage {stage}")
+
+
+def _compute_stage_p999(cpu_snapshots, gpu_snapshot_array, stage):
+    """Compute p99.9 relative error for all numeric fields at a given stage."""
+    import numpy as np
+
+    def rel_err_p999(a, b, epsilon=1e-8):
+        abs_diff = np.abs(a - b)
+        denom = np.abs(a) + epsilon
+        rel_err = abs_diff / denom
+        return float(np.percentile(rel_err, 99.9))
+
+    all_rel_errors = []
+
+    if stage == 'PostInit':
+        cpu_ray_origin = np.array([snap['ray_origin'] for snap in cpu_snapshots], dtype=np.float32)
+        cpu_ray_dir = np.array([snap['ray_direction'] for snap in cpu_snapshots], dtype=np.float32)
+        cpu_lambdas = np.array([snap['lambdas'] for snap in cpu_snapshots], dtype=np.float32)
+        cpu_throughput = np.array([snap['throughput'] for snap in cpu_snapshots], dtype=np.float32)
+
+        gpu_ray_origin = gpu_snapshot_array[:, 0:3].astype(np.float32)
+        gpu_ray_dir = gpu_snapshot_array[:, 3:6].astype(np.float32)
+        gpu_lambdas = gpu_snapshot_array[:, 6:10].astype(np.float32)
+        gpu_throughput = gpu_snapshot_array[:, 10:14].astype(np.float32)
+
+        all_rel_errors.append(rel_err_p999(cpu_ray_origin, gpu_ray_origin))
+        all_rel_errors.append(rel_err_p999(cpu_ray_dir, gpu_ray_dir))
+        all_rel_errors.append(rel_err_p999(cpu_lambdas, gpu_lambdas))
+        all_rel_errors.append(rel_err_p999(cpu_throughput, gpu_throughput))
+
+    elif stage == 'PostIntersect':
+        cpu_ray_origin = np.array([snap['ray_origin'] for snap in cpu_snapshots], dtype=np.float32)
+        cpu_ray_dir = np.array([snap['ray_direction'] for snap in cpu_snapshots], dtype=np.float32)
+        cpu_lambdas = np.array([snap['lambdas'] for snap in cpu_snapshots], dtype=np.float32)
+        cpu_throughput = np.array([snap['throughput'] for snap in cpu_snapshots], dtype=np.float32)
+        cpu_hit_t = np.array([snap['hit_t'] for snap in cpu_snapshots], dtype=np.float32)
+        cpu_hit_point = np.array([snap['hit_point'] for snap in cpu_snapshots], dtype=np.float32)
+        cpu_hit_normal = np.array([snap['hit_normal'] for snap in cpu_snapshots], dtype=np.float32)
+
+        gpu_ray_origin = gpu_snapshot_array[:, 0:3].astype(np.float32)
+        gpu_ray_dir = gpu_snapshot_array[:, 3:6].astype(np.float32)
+        gpu_lambdas = gpu_snapshot_array[:, 6:10].astype(np.float32)
+        gpu_throughput = gpu_snapshot_array[:, 10:14].astype(np.float32)
+        gpu_hit_t = gpu_snapshot_array[:, 15].astype(np.float32)
+        gpu_hit_point = gpu_snapshot_array[:, 16:19].astype(np.float32)
+        gpu_hit_normal = gpu_snapshot_array[:, 19:22].astype(np.float32)
+
+        all_rel_errors.append(rel_err_p999(cpu_ray_origin, gpu_ray_origin))
+        all_rel_errors.append(rel_err_p999(cpu_ray_dir, gpu_ray_dir))
+        all_rel_errors.append(rel_err_p999(cpu_lambdas, gpu_lambdas))
+        all_rel_errors.append(rel_err_p999(cpu_throughput, gpu_throughput))
+        all_rel_errors.append(rel_err_p999(cpu_hit_t, gpu_hit_t))
+        all_rel_errors.append(rel_err_p999(cpu_hit_point, gpu_hit_point))
+        all_rel_errors.append(rel_err_p999(cpu_hit_normal, gpu_hit_normal))
+
+    elif stage == 'PostShade':
+        cpu_ray_origin = np.array([snap['ray_origin'] for snap in cpu_snapshots], dtype=np.float32)
+        cpu_ray_dir = np.array([snap['ray_direction'] for snap in cpu_snapshots], dtype=np.float32)
+        cpu_throughput = np.array([snap['throughput'] for snap in cpu_snapshots], dtype=np.float32)
+        cpu_bsdf_pdf = np.array([snap['bsdf_pdf'] for snap in cpu_snapshots], dtype=np.float32)
+
+        gpu_ray_origin = gpu_snapshot_array[:, 0:3].astype(np.float32)
+        gpu_ray_dir = gpu_snapshot_array[:, 3:6].astype(np.float32)
+        gpu_throughput = gpu_snapshot_array[:, 6:10].astype(np.float32)
+        gpu_bsdf_pdf = gpu_snapshot_array[:, 14].astype(np.float32)
+
+        all_rel_errors.append(rel_err_p999(cpu_ray_origin, gpu_ray_origin))
+        all_rel_errors.append(rel_err_p999(cpu_ray_dir, gpu_ray_dir))
+        all_rel_errors.append(rel_err_p999(cpu_throughput, gpu_throughput))
+        all_rel_errors.append(rel_err_p999(cpu_bsdf_pdf, gpu_bsdf_pdf))
+
+    else:
+        raise ValueError(f"p99.9 comparison not defined for stage {stage}")
+
+    return max(all_rel_errors)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Session N+3 part 2b — implements the deferred CPU↔GPU threshold measurement from PR #343.

PR #343 landed the CUDA kernels (`stage_intersect_session_n3.cu`, `stage_shade_lambertian.cu`) + snapshot bindings (`cuda_wavefront_snapshot_post_init/intersect/shade`). But `measure_thresholds.py` only did a GPU sanity check — the actual CPU↔GPU diff (ULP / p99.9 / SSIM at all 5 stages) was unimplemented (the script literally said "Full CPU↔GPU comparison deferred").

This PR implements the full diff harness and test gate.

## Changes

### 1. Extended Python binding for CPU snapshot exposure (`module/blender_module.cpp`)

- Modified `reference_pt_wavefront_render` to return dict with both `rgb` and `snapshots` when `record_snapshots=True` (maintains backward compat: returns just RGB array when False).
- Snapshot fields exposed as Python dicts with numpy arrays for vectors (ray_origin, ray_direction, etc.).

### 2. Implemented full CPU↔GPU diff in `measure_thresholds.py`

- New `measure_gpu_port()` extracts CPU snapshots from `reference_pt_wavefront_render(..., record_snapshots=True)`.
- Gets GPU snapshots from the three CUDA bindings (PostInit, PostIntersect, PostShade).
- Compares per-stage:
  - **PostInit/PostIntersect (geometry)**: ULP distance + p99.9 relative error.
  - **PostShade (BSDF with transcendentals)**: p99.9 relative error only (ULP not meaningful for transcendental-heavy operations).
- Prints measured values in YAML format for copy-paste into `pkg55_cuda_thresholds.yaml`.

### 3. Un-skipped + implemented GPU threshold gate (`test_pkg55_cuda_threshold_gate.py`)

- Removed `@pytest.mark.skip` from `test_cpu_to_gpu_threshold_gate`.
- Implemented gate enforcement: loads pinned thresholds from `pkg55_cuda_thresholds.yaml`, runs CPU + GPU snapshots, asserts measured values stay within pinned bounds.
- Helper functions `_compute_stage_ulp` and `_compute_stage_p999` for per-stage comparison.

## What's deferred

- **PostLightSample/PostRR stages**: GPU snapshot bindings not present in PR #343. Session N+3 scope is PostInit/PostIntersect/PostShade only. LightSample/RR are Session N+4 (or later).
- **Final image SSIM**: requires end-to-end GPU wavefront render, which is not yet wired. Placeholder in measurement script + YAML.
- **pkg64-gpu gate #1 SMS rel-err**: spec mentions folding it into Session N+3, but SMS caustics are a separate code path not exercised by the Session N+1 envmap Cornell scene. The existing `test_pkg64_gpu_sms_attempt_unit.py` already has infrastructure for this gate; it's unclear if that should be part of this PR or handled separately.

## Test plan

**IMPORTANT:** This PR builds the threshold measurement harness, but **does not pin the measured values** into `pkg55_cuda_thresholds.yaml` yet. The workflow is:

1. Build on RTX box with `-DASTRORAY_WAVEFRONT_CUDA_N3=ON`.
2. Run `python tests/wavefront_diff/measure_thresholds.py --mode gpu_port`.
3. Copy the printed YAML output into `.astroray_plan/packages/pkg55_cuda_thresholds.yaml`, replacing the placeholder values.
4. Run `pytest tests/wavefront_diff/test_pkg55_cuda_threshold_gate.py` to verify the gate passes at the pinned thresholds.
5. Update pkg55 spec Session N+3 part 2b status + measured numbers.

## Acceptance criteria (from spec)

- [ ] `measure_thresholds.py --mode gpu_port` runs successfully and prints per-stage ULP / p99.9 values
- [ ] Measured thresholds pinned to `pkg55_cuda_thresholds.yaml`
- [ ] `test_cpu_to_gpu_threshold_gate` PASS at pinned thresholds
- [ ] pkg55 spec updated with Session N+3 part 2b status + measured numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)