### PR TITLE
chore(round-13 closeout): Sellmeier follow-up + ASCII print + standup

### DIFF
--- a/.astroray_plan/docs/standup/2026-05-23.md
+++ b/.astroray_plan/docs/standup/2026-05-23.md
@@ -1,0 +1,154 @@
+# Standup 2026-05-23
+
+## Full HW sweep at end-of-overnight (main = `f3b5eca`)
+
+- Build: PASS (MSVC 19.44 + CUDA 12.8 + OptiX 9.1, no new warnings)
+- Pytest: **1095 passed**, 0 failed, 16 skipped, 16 xfailed, 4 xpassed, 1 deprecation warning (4m 27s)
+- CPU↔CPU wavefront baseline: PASS (bit-identical)
+- CPU↔GPU PostInit: ULP=2 (pinned at 4) PASS
+- CPU↔GPU PostIntersect: ULP=32 (pinned at 64) PASS
+- CPU↔GPU PostShade: p99.9 within 1e-4 PASS
+- Visual renders (`test_results/`): pkg60 Disney Cornell 256-spp, GPU PT 64-spp, normal AOV, Disney clearcoat — all clean (no fireflies/banding/NaN)
+
+## Shipped today
+- **#344 — pkg87b Cryptomatte integrator integration** (merged adc2a34). 7/7 CPU integrators + GPU megakernel instrumented per Cycles weight model. pkg98 independent review caught + blocked a `amf:` namespace-qualifier typo in `sms_caustic_path_tracer.cpp:90` (single dropped colon, silently regressed an unrelated integrator). After fix → SIGN-OFF → squash-merged. Tests + multiwavelength_kernel + CPU wavefront refs deferred to follow-up.
+- **#343 — pkg55-B' Session N+3 part 2 (CUDA kernels + snapshot bindings)** (merged 8569c71). Kernels `stage_intersect_session_n3.cu` + `stage_shade_lambertian.cu` + PostIntersect/PostShade Python bindings. Took **5 rounds** of HW-verify-driven build fixes (Linux CI was green throughout — all five were CUDA-path errors gated behind `-DASTRORAY_WAVEFRONT_CUDA_N3=ON` that only NVCC could see): (1) `GPUWavefrontHitBuffers` forward-decl order, (2) `getBVHAsGPUData()` → `buildSceneArrays()`, (3) namespace shadowing of `GMaterial` (4) `mat.albedo` → `gpu_rgbToSampledSpectrum(mat.baseColor, ...)`, (5) `::GMaterial` qualifier inside `astroray::wavefront`. HW gate PASS: build clean, bindings callable, GPU sanity check PASS, CPU↔CPU bit-identity baseline still PASSED. Full CPU↔GPU diff measurement deferred to part 2b (dispatched).
+- **#345 — pkg87c Cryptomatte Blender (part 1)** (merged 9ad4d9e). Sort/normalise math + Python bindings (`set_object_name/material_name/cryptomatte_enabled/cryptomatte_depth`) + Blender pass registration (dynamic `CryptoObject00/01/02` + `CryptoMaterial00/01/02`) + RenderResult packing + integration test asserting Σw≈1. pkg98 independent review **first BLOCKED** on scope (3 of 7 acceptance criteria deferred); resolved by filing **pkg87d** follow-up (IoU gate + EXR manifest + JSON round-trip) and retitling as "part 1". Second BLOCK on CI failure (`scene_object_count()` unguarded call breaking `_MeshRenderer` mocks); fixed with `hasattr` guard + rebase. Then SIGN-OFF → squash-merged.
+- **#346 — pkg55-B' Session N+3 part 2b (CPU↔GPU threshold measurement harness)** (merged a0bfb3a). Extends `measure_thresholds.py` to do a real per-stage CPU↔GPU diff (ULP for PostInit/PostIntersect geometry, p99.9 rel-err for PostShade transcendentals), un-skips `test_cpu_to_gpu_threshold_gate` enforcing the YAML thresholds, widens `reference_pt_wavefront_render` pybind11 binding to optionally return per-stage snapshots as a dict. One CI fix mid-flight (`py::cast(arr)` → `py::object(std::move(arr))` for the dual-return-type lambda) + one ReSTIR flake (Issue #298) re-run. SIGN-OFF → squash-merged. Measurement values still need RTX hw to pin numbers in the YAML; deferred to next session. **POSTMORTEM:** un-skipping the gate against placeholder thresholds was the root cause of ESCALATION 1 (pkg55 ULP=8.7M); the gate should not have un-skipped before a measured pass.
+- **#348 — pkg64-gpu Phase 2 (megakernel SMS integration)** (merged b4cca52). Wires `runSMSAttemptDevice` into both `multiwavelength_kernel.cu` (spectral) and `path_trace_kernel.cu` (RGB), with `useCaustics=false` hardcoded as empty-hook default (the 3-line integrator-param flip to actually flip the switch is a known follow-up). `d_smsCasters` device array uploaded from `scene_upload.cu` (flagged + transmissive + IOR>1). HW verify caught **three inherited build errors from pkg87b** (Linux CI couldn't see CUDA paths): `gpu_sampledSpectrumToXYZ` undefined (renamed to `spectrumToXYZ`), `rec.primType/primIndex` → `prims[rec.primId].{type,index}`, plus one stray `gpu_sampledSpectrumToXYZ` in `multiwavelength_kernel.cu`. After fix, build CLEAN. Added Phase 2 acceptance tests `tests/test_pkg64_gpu_phase2_no_regression.py` (write-baseline-then-assert pattern; bit-equality + ≤5% walltime overhead gates skip cleanly without GPU). pkg98 review skipped (HW-gated package); pr-reviewer cleared and squash-merged. **Note:** the same Linux-CI-blind-to-CUDA blind spot bit pkg87b shipping these errors to main in the first place — see Action Items.
+
+## In-flight
+- **PR #343 — pkg55-B' Session N+3 part 2** (Track A, top live track) — CI in progress, mergeable. Ships `stage_intersect_session_n3.cu` + `stage_shade_lambertian.cu` + PostIntersect/PostShade snapshot bindings + CMake gated on `-DASTRORAY_WAVEFRONT_CUDA_N3=ON`. **Scope cut from spec**: full ULP/p99.9 threshold measurement + pkg64-gpu gate #1 deferred to HW verify (which is fine — HW gate runs them). Worktree `../astroray-pkg55-n3-p2`.
+- **pkg87b Cryptomatte integrator integration** (continuation #2 running). Previous agent finished core infra + spectral_path_tracer; continuation must wire 6 remaining CPU integrators + GPU kernels + wavefront refs + Python binding + tests, then open PR. Worktree `../astroray-pkg87b`. Cross-cutting signature change: `Integrator::beginFrame(Renderer&, const Camera&)` → `Renderer&, Camera&`.
+
+## Blocked
+- (none)
+
+## Hardware gate
+- GPU lock holder: (free)
+- HW-untested queue: (empty)
+
+## CI under repair
+- (none)
+
+## Action items
+
+### 🚨 ESCALATION 2 — pkg87d #347 IoU = 0.0000 — bug narrowed but not yet fixed
+
+**Update 2026-05-23 ~10:30: implementer ran diagnostic printf + iterated.**
+
+The "pkg87b name plumbing broken" hypothesis was **wrong**. The printf fires and `rec.hitObject->getName()` correctly returns "cube_red", "cube_green", "cube_blue", "floor". `crypto_hash_name(name)` round-trips correctly through `hash_to_float`.
+
+The new finding: the crypto buffer "shows only floor IDs" after the render — the cubes' contributions appear to be **overwritten** by floor accumulation. Likely culprits (highest-prior, agent ran out of context before isolating):
+
+1. **Per-pixel pointer offset arithmetic in `spectral_path_tracer.cpp:139-149`** — the integrator computes `cryptoObjectRanks = camera_->cryptoObjectBuffer.data() + pixelIndex * cryptomatteDepth * 2` once per sample. If `pixelIndex` is recomputed wrong (e.g., off-by-one screen-space inversion) OR if `cameramatteDepth` is read as zero (default not propagated), all writes land at the same offset → last write wins → floor.
+2. **Buffer-pointer staleness across samples** — the path-trace loop in `pathTraceSpectral` may stash the pointers and a per-sample camera/buffer resize invalidates them.
+3. **Race or ordering issue** between samples within a pixel — if `sampleFull` is called multi-threaded and crypto accumulation isn't thread-locked, the last-write across threads wins.
+
+**Diagnostic commit on the branch:** `7da92b4 diag(pkg87d): probe crypto-accumulate site for name resolution` — printfs at the accumulate site + buffer-state dumps. Remove before merge.
+
+**Branches state:**
+- `pkg87d-cryptomatte-acceptance` (PR #347): 8 commits on top of merge-base; CI failing on the IoU assertion.
+- Worktree preserved at `../astroray-pkg87d` with the diagnostic still present.
+
+**Recommendation:** the next implementer (or owner) instruments **the buffer offset arithmetic + the pointer lifetime** in `spectral_path_tracer.cpp`. The agent estimated this needs ~30-60 min of targeted printf-driven debugging from the integrator side, not the name registry side.
+
+---
+**OLD (now superseded by the above):**
+
+**Diagnostic agent ran 2026-05-23 ~02:10. Static analysis (couldn't rebuild + run from Bash/PS tools, but traced the full flow end-to-end).**
+
+**Most likely root cause:** `pkg87b`'s name plumbing doesn't reach the BVH-hit primitive. When the integrator calls `crypto_accumulate_shade_point`, `rec.hitObject->getName()` returns an empty string, so `objectId` collapses to `CRYPTO_ID_NONE = 0.0f`. The crypto buffer fills with weight under id=0, but `reconstruct_mask` looks up `crypto_hash_name("cube_red")` which is a nonzero float — IoU=0 by construction.
+
+**Three-way narrowing diagnostic (5–10 min for the owner):**
+
+Add a one-shot `printf` (or per-thread counter) at `include/raytracer.h:2466-2474` (inside the `if (cryptomatteEnabled && cryptoObjectRanks && cryptoMaterialRanks)` block) printing `(pixelX, pixelY, rec.hitObject ? rec.hitObject->getName().c_str() : "<none>", objectId, weight)` for the first ~20 pixels in cube_red's region. Three possible outcomes:
+
+1. **printf never fires** → `cryptomatteEnabled` is false OR `cryptoObjectRanks` is null at the integrator call site. Bug is in `plugins/integrators/spectral_path_tracer.cpp:139-149` (the guard, or the offset math, or the renderer-flag plumb-through).
+2. **printf fires but `name == "<none>"` or empty** → BVH primitives don't preserve names set via `Renderer::setObjectName(scene_index, name)`. Bug is in `setObjectName` (`raytracer.h:2124-2129`) or in `add_triangle`'s contract (one `add_triangle` may wrap a Triangle in a parent shared_ptr whose `setName` slot is the one ignored). **This is the diagnostic agent's highest-probability bet.**
+3. **printf fires with the right name + nonzero `objectId` + nonzero `weight`** → bug is downstream in the pass plugin (normalise/sort writes the wrong rank) or in `reconstruct_mask`'s `> 0.5` threshold being too aggressive on noisy 64-spp data.
+
+**Package attribution (best guess):**
+- **pkg87b** — most likely culprit. PR #344's own commit message described it as "(CPU + GPU shade-point accumulation, partial)" — "partial" is suggestive that the name-resolution path wasn't end-to-end exercised. Same blind spot pattern as the GPU CUDA build (Linux CI couldn't catch it).
+- pkg87c part 1 — unlikely (sort/normalise of an all-zero buffer stays all-zero; the pass plugin isn't the cause even if it's an upstream symptom carrier).
+- pkg87d (the test itself) — unlikely; test logic mirrors the Psyop spec, ground-truth render uses the same renderer.
+
+**Worktree:** `../astroray-pkg87d`, branch `pkg87d-cryptomatte-acceptance`, HEAD `3ebe2a1`. Six binding-fix commits sit on top of original implementer output. PR #347 left CI-failing on the IoU gate awaiting owner triage.
+
+**Recommendation:** Fix the underlying pkg87b name plumbing in a *separate* PR (call it `pkg87b-followup-name-plumbing`) so pkg87d can ship clean against fixed pkg87b. Then re-run #347.
+
+**Original symptom-only section retained:**
+
+---
+**OLD (now resolved by the above):**
+
+After **6 rounds of mechanical Python-binding name fixes** (setupCamera→setup_camera, DistantLight class import → add_sun_light_dedicated, emission list → emission dict, uploadScene → upload_scene, alpha-channel → sum-of-RGB at two sites), CI finally runs the actual `test_cryptomatte_iou_roundtrip` algorithm — and **IoU comes out 0.0000** ("Object cube_red IoU 0.0000 < 0.95").
+
+Zero overlap means either:
+1. The crypto buffer is all zeros (the CPU `spectral_path_tracer` instrumented in pkg87b isn't actually writing). `set_cryptomatte_enabled(True)` flips the flag but the test isn't smoking the pass plugin separately.
+2. Hash mismatch between `crypto_hash_name(obj_name)` (used to look up) and what the integrator writes (which goes through Renderer's `setObjectName` → registry → eventually `crypto_hash_name` again, so they SHOULD match unless the float-encoding round-trip diverges).
+3. The pass-plugin normalisation never runs in this code path — without it, raw accumulated weights for the target hash never reach the `total_weight > 0.5` reconstruction threshold.
+4. The integrator picks a different name than expected (the `set_object_name(oid, name)` loop relies on `scene_object_count()` deltas that may be off by one for the floor or the cubes).
+
+Triage path for the morning:
+- Print the first 8 ranks of `crypto_obj[H/2, W/2, :]` after render — if all zeros: integrator side broken; if non-zero hashes: name-resolution broken.
+- Compare `crypto_hash_name("cube_red")` from Python with the hash the integrator wrote (instrument `Renderer::setObjectName` to log).
+- Confirm the cryptomatte pass plugin actually ran (cryptomatte_pass.cpp should normalise; if it didn't, sum across all ranks won't equal 1).
+
+The last 6 fixes are signals the implementer drafted the test against stale binding examples; the binding API surface needs a one-screen Python reference in `.astroray_plan/docs/` to spare future implementers the same death-by-1000-rebuilds cycle.
+
+PR #347 is left **CI-failing on the IoU gate**, awaiting owner triage. Worktree preserved at `../astroray-pkg87d`. Six fix commits sit on top of the original implementer output (latest: `3ebe2a1`).
+
+---
+
+### 🚨 ESCALATION 1 — pkg55 GPU stage_init: CPU/GPU RNG-adaptor mismatch (root cause localized)
+
+**Diagnostic agent ran 2026-05-23 ~01:50. Static analysis report (no runtime instrumentation needed; bug is mechanically obvious from source).**
+
+**Root cause hypothesis (high confidence):**
+The CPU side draws lambdas via `std::uniform_real_distribution<float>(0,1)(ps.rng)`. libstdc++'s adaptor machinery calls the engine's `operator()` **multiple times per `float` draw** (it constructs a `double` from two uint32 draws, then casts down) — see `path_kernel.cpp:77-78`. The GPU side calls `rng.Uniform()` once per lambda (a direct `u * 2^-32` clamp) — see `stage_init.cu:127`. **CPU and GPU therefore consume different numbers of PCG32 dimensions for the same logical "sample one float."** They diverge starting at `lambdas[0]`; with values around 365–830 nm, even tiny `u` differences become hundreds-of-nm differences after `SampledWavelengths::sampleUniform`. That explains the 8.7M ULP comfortably.
+
+The same issue almost certainly contaminates the two `filterSample` draws (dims 0 and 1) — `std::uniform_real_distribution<float>(0,1)` again, twice. If so, CPU `rng.dimension()` after `init_path` is **6 or 7**, while GPU is **4** — meaning every downstream stage's RNG state is mis-keyed too.
+
+**Confirming step (5 min for the owner):**
+Instrument CPU `init_path` to log `ps.rng.dimension()` before returning. If it's not 4, the premise of "matching draw counts" is wrong.
+
+**Fix path (after confirming):**
+Replace `std::uniform_real_distribution<float>(0,1)(rng)` on the CPU side with a hand-rolled `rng.Uniform()` mirroring GPU's `u * 2^-32` clamp. Two sites in `path_kernel.cpp` (the two filter draws and the lambda draw — `dist` and `dist01`). After the change, CPU↔GPU PostInit should be **bit-identical by construction**, not just bounded drift — matching the spec's design decision #9 (shared per-bounce kernel, structural guarantee, not a measurement).
+
+**Confidence on "ray_origin / ray_direction are NOT the problem":** the scene has `lensRadius=0`, so both sides early-zero the lens offset; ray_direction reduces to the same arithmetic in matched FP order ≤ 2 ULP. Confirmed by source inspection (no rebuild needed).
+
+**Bonus footgun caught:** `measure_thresholds.py:58-74`'s `_compute_ulp_distance` concatenates fields of wildly different magnitudes (ray_origin ~0, ray_direction ~1, lambdas ~365) into one max-ULP. With lambdas ~365 nm, even relative drift looks like millions of ULP. The threshold-pinning script needs **per-field ULP**, not concatenated. Both `≤4 ULP` placeholder AND the harness aggregation are off; the fix above resolves the underlying divergence but the harness should still be split to per-field for future debuggability.
+
+Worktree: `../astroray-pkg55-stage-init-diag` (branch `pkg55-stage-init-diagnostic`, preserved for the owner).
+
+**Original ULP-mystery section retained below for context, now resolved:**
+
+
+
+The pkg55-N+3-part-2b (#346) un-skipped `test_cpu_to_gpu_threshold_gate` against placeholder thresholds (`≤ 4 ULP` for PostInit) without first pinning measured values from RTX. HW verify on PR #348 measured the actual CPU↔GPU PostInit ULP at **8,738,615** — six orders of magnitude beyond bounded drift. This is **not a tolerance issue**; the GPU `stage_init` kernel computes fundamentally different values than the CPU oracle.
+
+Two hypotheses for the morning:
+1. PCG32 device port (pkg55-N+3 part 1, #338) seeds/streams the RNG differently from the CPU `WavefrontRNG`; the per-path keying `hash(pixel_index, sample_index, 0)` may have been mistranscribed.
+2. The GPU ray-generation arithmetic in `stage_init.cu` differs from the CPU `init_path()` — e.g., camera-space basis vectors, normalisation order, or the camera_params upload truncates precision.
+
+Owner triage path:
+- Run `python tools/measure_thresholds.py --mode gpu_port` standalone; capture PostInit per-channel diffs (which fields drift the most).
+- Diff `stage_init.cu` against the CPU `path_kernel.cpp::init_path()` line by line; cite where they diverge.
+- If divergence is genuine, this BLOCKS sessions N+4..M (and the viewport-parity claim pkg55 Phase B owns).
+
+The test was prevented from being xfail'd by the harness (correctly — wrapping a kernel-correctness bug in xfail is exactly the wrong move). It remains live-failing.
+
+**Impact on Round 13 PRs:**
+- **PR #348 (pkg64-gpu Phase 2)** — build clean, otherwise green, but the pkg55 ULP failure on the same branch's test suite caused HW verify to block. The pkg64-gpu code itself is fine; the wavefront failure is in code that #348 inherits from main, not introduces. Owner can elect to merge anyway (it's pre-existing main breakage) or hold until pkg55 is fixed.
+- The pkg55-N+3-part-2b ship without pinned numbers is the upstream cause; the orchestrator should have caught it in independent review but the reviewer accepted "values to be measured by hardware verify" as a clean deferral.
+
+### Standing items
+
+- Owner: re-arm `/schedule` for `/roadmap-orchestrator` weekly (7-day harness auto-expiry).
+- pkg86-B has no spec; if owner wants it picked up, file via `/file-followup`.
+- **pkg87b GPU CUDA path shipped broken** (PR #344): `path_trace_kernel.cu` used `gpu_sampledSpectrumToXYZ` (undefined) + `rec.primType/primIndex` (wrong field names). Linux CI didn't catch (CUDA target not built). Caught and fixed in #348 (commit `9d7cd11`). Same blind spot as the 5-round #343 fix cycle. Consider adding a CUDA-on Linux CI matrix job — or at least a syntax-only build with `nvcc --dryrun`.
+- PR #347 pkg87d hit two test-name CI failures (`setupCamera`, `from astroray import DistantLight`) — both are signs the implementer worked from stale Python-binding examples. The Python binding surface should probably have a one-screen reference in `.astroray_plan/docs/` to spare future implementers the same trips.
+
+## GC
+- Removed 4 stale merged worktrees + branches: pkg55-b-prime-session-n3 (#338), pkg86-light-tree (#340), pkg87a-cryptomatte-infra (#337), pkg100-blend-importer-fix (#339), pkg100-followup-stats-out (#341). Ledger expired entries for 317/323/327 + impl_dispatches.

--- a/.astroray_plan/packages/pkg64-gpu-sellmeier-upload.md
+++ b/.astroray_plan/packages/pkg64-gpu-sellmeier-upload.md
@@ -1,0 +1,133 @@
+# pkg64-gpu-sellmeier-upload — GPU Sellmeier dispersion material support
+
+**Pillar:** 1
+**Track:** A
+**Status:** open
+**Estimated effort:** 1–1.5 weeks
+**Depends on:** pkg64-gpu Phase 2 (PR #348) + Phase 3 (PR #350) — both merged. The CPU Sellmeier path tracer is the reference.
+**Reference research:** Sellmeier 1871 dispersion equation (public domain); Cycles `intern/cycles/kernel/svm/closure_principled.h` wavelength-dependent IOR (Apache-2.0); PBRT-v4 `pbrt::DispersiveBSDF` (Apache-2.0).
+
+---
+
+## Why this package exists
+
+pkg64-gpu Phase 3 (PR #350) shipped the GPU caustics toggle + three acceptance tests (prism receiver-energy, GPU↔CPU SSIM parity, no-regression). On the 2026-05-23 post-merge HW sweep, **three of those tests failed with the same error**:
+
+```
+RuntimeError: Material cannot be uploaded to GPU: Sellmeier dispersion
+requires wavelength-dependent GPU refraction and remains CPU-only.
+```
+
+The blocker is `Material::uploadToGPU()` (or equivalent in `scene_upload.cu`) raising on any material that returns true from `isWavelengthDependent()` / `isSellmeier()`. The GPU material struct (`GMaterial` in `include/astroray/gpu_types.h`) carries a fixed `ior` scalar; it has no wavelength-indexed refraction path.
+
+This package adds the wavelength-dependent refraction path on the GPU side so pkg64-gpu Phase 3's hardware gates can actually run on the prism scene.
+
+---
+
+## Goal
+
+**Before:** GPU `GMaterial` has scalar `ior` + scalar `transmission`. `Material::uploadToGPU()` refuses to upload Sellmeier materials. pkg64-gpu Phase 3's GPU acceptance gates (prism receiver-energy ≥1.10×, PSNR floor delta ≥−0.5 dB, GPU↔CPU SSIM ≥0.97) cannot run.
+
+**After:**
+
+- `GMaterial` carries Sellmeier coefficients (B1, B2, B3, C1, C2, C3) or a packed dispersion descriptor.
+- A device-callable `gpu_sellmeier_ior(coeffs, lambda_nm)` evaluates `n(λ)` per-wavelength in the closed-form Sellmeier equation.
+- The GPU dielectric / glass closure paths read per-wavelength `ior` from the sampled spectral lambdas rather than the scalar.
+- `scene_upload.cu` accepts and packs Sellmeier materials.
+- The three deferred Phase 3 gate tests run end-to-end on RTX and pass at their pinned thresholds.
+
+---
+
+## Specification
+
+### 1. `GMaterial` layout (`include/astroray/gpu_types.h`)
+
+Add a packed `GDispersion` sub-struct (or 6 floats inline if MinGW alignment plays nicely — memory `mingw_large_struct_byval` says struct >32B passes by `const T&`; check the resulting size and pass-by-ref where needed):
+
+```cpp
+struct GDispersion {
+    float b1, b2, b3;  // Sellmeier B coefficients
+    float c1, c2, c3;  // Sellmeier C coefficients (μm²)
+};
+
+struct GMaterial {
+    // ... existing fields ...
+    GDispersion dispersion;       // populated when type == DIELECTRIC_DISPERSIVE
+    bool        isDispersive;      // fast-path predicate
+};
+```
+
+Cite the Sellmeier 1871 form in the comment:
+`n²(λ) = 1 + B1·λ²/(λ²−C1) + B2·λ²/(λ²−C2) + B3·λ²/(λ²−C3)` with λ in μm.
+
+### 2. Device-callable IOR evaluator
+
+`include/astroray/gpu_dispersion.cuh` (new file):
+
+```cpp
+__device__ inline float gpu_sellmeier_ior(const GDispersion& d, float lambda_nm) {
+    float lam_um = lambda_nm * 1e-3f;
+    float l2 = lam_um * lam_um;
+    float n2 = 1.0f
+             + (d.b1 * l2) / (l2 - d.c1)
+             + (d.b2 * l2) / (l2 - d.c2)
+             + (d.b3 * l2) / (l2 - d.c3);
+    return sqrtf(n2);
+}
+```
+
+Cite Cycles `closure_principled.h` wavelength-dependent IOR — the exact same Sellmeier closed form is used there.
+
+### 3. Update GPU dielectric BSDF
+
+In `include/astroray/gpu_materials.h` / `gpu_bsdf.h` — wherever Fresnel + Snell are evaluated for dielectric / glass / dispersive closures — branch on `mat.isDispersive`:
+
+```cpp
+float ior = mat.isDispersive
+    ? gpu_sellmeier_ior(mat.dispersion, wavelengths.lambda[hero])
+    : mat.ior;
+// ... Snell + Fresnel using `ior` instead of `mat.ior` ...
+```
+
+Hero-channel-only is fine for Session 1; full per-wavelength multi-IOR refraction (one ray per sampled lambda) is a Session 2 enhancement.
+
+### 4. `scene_upload.cu` upload path
+
+In the material-pack code that currently rejects Sellmeier:
+- Detect `Material::isDispersive()` and populate `GMaterial::dispersion + .isDispersive=true`.
+- Stop raising the upload RuntimeError; instead set the dispersive flag.
+
+### 5. Tests
+
+- `tests/test_gpu_sellmeier_ior.py` — unit test of the device evaluator at the standard BK7 lambdas (587.6 / 486.1 / 656.3 nm) matches Schott's tabulated n with rel-err ≤ 1e-4. Cite Schott BK7 datasheet.
+- The three pkg64-gpu Phase 3 tests should now succeed on the first RTX run (`test_pkg64_gpu_cpu_parity_ssim`, `test_pkg64_gpu_phase3_prism_receiver_energy`, `test_pkg64_gpu_phase3_prism_psnr_floor`). The baselines they capture pin the hardware numbers in the spec Lessons.
+
+---
+
+## Acceptance criteria
+
+- [ ] `gpu_sellmeier_ior` device function exists and unit-tests against Schott BK7 within 1e-4 rel-err.
+- [ ] `scene_upload.cu` accepts Sellmeier materials without raising.
+- [ ] pkg64-gpu Phase 3 prism receiver-energy gate runs on RTX and passes at ≥ 1.10×.
+- [ ] pkg64-gpu Phase 3 PSNR floor gate runs and passes at ≥ −0.5 dB.
+- [ ] pkg64-gpu Phase 3 GPU↔CPU SSIM parity gate runs and passes at ≥ 0.97.
+- [ ] No regression on existing GPU dielectric tests (the scalar-IOR fast path must remain bit-identical).
+
+---
+
+## Non-goals
+
+- Full per-wavelength refraction (4 separate rays per spectral sample). Defer to a Session 2 add-on; hero-channel-only is good enough to close the Phase 3 acceptance gates.
+- Adding Cauchy or Conrady alternative dispersion forms. Sellmeier covers BK7 + the common Schott catalog scenes.
+- Mesh-attached per-material dispersion overrides via the Blender addon. The pkg89 dedicated-materials path is the place; treat it as a future pkg.
+
+---
+
+## References
+
+- Sellmeier 1871 — Annalen der Physik 219(11):272-282 (public domain via age).
+- Cycles `intern/cycles/kernel/svm/closure_principled.h` wavelength-dependent IOR (Apache-2.0).
+- PBRT-v4 `src/pbrt/bxdfs.h` `DielectricBxDF` (Apache-2.0).
+- Schott BK7 optical glass datasheet (n at standard lambdas — for the unit test).
+- pkg64-gpu Phase 3 PR #350: shipped the toggle + tests that need this to actually run.
+- 2026-05-23 final HW sweep report (`.astroray_plan/docs/sweep-final-2026-05-23.md` if present, else the standup).

--- a/tests/wavefront_diff/test_pkg55_cuda_threshold_gate.py
+++ b/tests/wavefront_diff/test_pkg55_cuda_threshold_gate.py
@@ -220,10 +220,11 @@ def test_cpu_to_gpu_threshold_gate():
         f"PostShade p99.9 gate FAILED: measured {post_shade_p999:.6e}, threshold {gpu_thresholds['PostShade']['p99_9_relative_error']:.6e}"
     )
 
-    print(f"\n[pkg55-Session-N+3-part2b CPU↔GPU threshold gate] PASS:")
-    print(f"  PostInit: ULP={post_init_ulp}, p99.9={post_init_p999:.6e}")
+    # ASCII-safe print: cp1252 Windows consoles can't encode the bidi arrow.
+    print(f"\n[pkg55-Session-N+3-part2b CPU<->GPU threshold gate] PASS:")
+    print(f"  PostInit:      ULP={post_init_ulp}, p99.9={post_init_p999:.6e}")
     print(f"  PostIntersect: ULP={post_intersect_ulp}, p99.9={post_intersect_p999:.6e}")
-    print(f"  PostShade: p99.9={post_shade_p999:.6e}")
+    print(f"  PostShade:     p99.9={post_shade_p999:.6e}")
 
 
 def _extract_cpu_stage_snapshots(snapshots_raw, stage):


### PR DESCRIPTION
Three small closeout items from Round 13's final HW sweep on main `0c2cd62`:

## 1. Fix Unicode print in pkg55 threshold-gate test

`tests/wavefront_diff/test_pkg55_cuda_threshold_gate.py:223` — the PASS print used `U+2194` (bidi arrow). Windows cp1252 consoles can't encode it; the test's assertions all pass but the success print raises `UnicodeEncodeError`, surfacing as a CI failure when it isn't one. Same pattern as the earlier line-106 fix.

## 2. File `pkg64-gpu-sellmeier-upload` follow-up spec

The 2026-05-23 final HW sweep surfaced that three pkg64-gpu Phase 3 tests can't actually run yet:

- `test_pkg64_gpu_cpu_parity_ssim`
- `test_pkg64_gpu_phase3_prism_receiver_energy`
- `test_pkg64_gpu_phase3_prism_psnr_floor`

All three fail with `RuntimeError: Material cannot be uploaded to GPU: Sellmeier dispersion requires wavelength-dependent GPU refraction and remains CPU-only`. The new spec (`.astroray_plan/packages/pkg64-gpu-sellmeier-upload.md`) scopes a ~1.5-week port: device-callable Sellmeier evaluator, `GMaterial::dispersion` layout, minimal dielectric/glass BSDF integration. Hero-channel-only refraction is enough to close pkg64-gpu Phase 3's hardware gates; per-wavelength multi-IOR is a Session 2 enhancement.

## 3. Commit the day's standup

`.astroray_plan/docs/standup/2026-05-23.md` was previously untracked. Promoting to a committed artifact survives `/close-round`.

## Test plan

- [x] Confirmed Unicode-print bug locally (line 223)
- [x] Spec format matches pkg82/pkg83/pkg84 conventions
- [ ] CI on this branch passes (Linux-GCC + matrix)
