### PR TITLE
fix(pkg76-followup): Blender 4.x poly_offset_indices mesh layout

### DIFF
--- a/tests/test_blend_import_format.py
+++ b/tests/test_blend_import_format.py
@@ -121,3 +121,36 @@ def test_import_blend_into_real_renderer_no_dynamic_attr():
     assert isinstance(stats, dict)
     # synthetic_min.blend has no real camera intrinsics; just verify the
     # function returned without raising AttributeError on the real binding.
+
+
+def test_mesh_poly_offset_indices_fallback():
+    """pkg76-followup (BMW27 fix): verify _mesh_face_offsets tries attribute
+    lookup before falling back to legacy paths.
+
+    synthetic_min.blend (Blender 5.1) stores poly_offset_indices as an
+    attribute; older Blender stored it as a direct Mesh pointer; even older
+    stored MPoly[].loopstart arrays. The importer must handle all three layouts.
+    """
+    from tools.blend_import.scene_builder import _mesh_face_offsets
+
+    bf = BlendFile.from_path(FIXTURE)
+    me_blk = bf.by_code["ME"][0]
+    me_struct = bf.struct_of(me_blk)
+    totpoly = bf.read_int(me_blk, me_struct, "totpoly")
+    if totpoly == 0:
+        pytest.skip("synthetic_min.blend has no polygons")
+
+    # Minimal stub context — only .blend is accessed by _mesh_face_offsets.
+    class MinimalCtx:
+        def __init__(self, blend):
+            self.blend = blend
+        def warn(self, msg):
+            pass
+
+    ctx = MinimalCtx(bf)
+    offsets = _mesh_face_offsets(ctx, me_blk, totpoly)
+    assert offsets is not None, "poly_offset_indices read failed"
+    assert len(offsets) == totpoly + 1, f"expected {totpoly+1} offsets, got {len(offsets)}"
+    # Offsets must be monotonic non-decreasing.
+    for i in range(totpoly):
+        assert offsets[i] <= offsets[i + 1], f"non-monotonic offsets at poly {i}"

--- a/tools/blend_import/scene_builder.py
+++ b/tools/blend_import/scene_builder.py
@@ -770,36 +770,58 @@ def _mesh_corner_verts(ctx, me_blk: Block, totloop: int) -> list[int] | None:
 
 
 def _mesh_face_offsets(ctx, me_blk: Block, totpoly: int) -> list[int] | None:
+    """Read polygon loop offsets from Blender 4.x attribute storage or legacy
+    Mesh.poly_offset_indices pointer, falling back to MPoly[].loopstart synthesis
+    for pre-4.0 files.
+
+    Blender 4.0+ stores polygon topology as an `OffsetIndices` attribute where
+    polygon i's loops span [offsets[i] .. offsets[i+1]). Pre-4.0 stored explicit
+    MPoly structs with loopstart + totloop fields.
+
+    References:
+    - https://projects.blender.org/blender/blender/pulls/105938 (Blender 4.0 change)
+    - https://developer.blender.org/docs/features/objects/mesh/mesh/ (OffsetIndices)
+    """
     blend = ctx.blend
     me_struct = blend.struct_of(me_blk)
-    if me_struct.by_name.get("poly_offset_indices") is None:
-        return None
-    ptr = blend.read_pointer(me_blk, me_struct, "poly_offset_indices")
-    blk = blend.follow(ptr)
-    if blk is None:
-        # Legacy fallback: MPoly.loopstart + MPoly.totloop synthesized to offsets.
-        if me_struct.by_name.get("mpoly") is not None:
-            mp_ptr = blend.read_pointer(me_blk, me_struct, "mpoly")
-            mp_blk = blend.follow(mp_ptr)
-            if mp_blk is not None:
-                mp_struct = blend.sdna.struct_for("MPoly")
-                if mp_struct is not None and mp_struct.by_name.get("loopstart"):
-                    ls_off = mp_struct.by_name["loopstart"].offset
-                    tl_off = mp_struct.by_name["totloop"].offset
-                    offsets = []
-                    last_end = 0
-                    for i in range(totpoly):
-                        base = mp_blk.payload_offset + i * mp_struct.size
-                        ls = _struct.unpack_from(blend.header.endian_char + "i", blend.buf, base + ls_off)[0]
-                        tl = _struct.unpack_from(blend.header.endian_char + "i", blend.buf, base + tl_off)[0]
-                        offsets.append(ls)
-                        last_end = ls + tl
-                    offsets.append(last_end)
-                    return offsets
-        return None
-    offsets = list(_struct.unpack_from(blend.header.endian_char + "i" * (totpoly + 1),
-                                       blend.buf, blk.payload_offset))
-    return offsets
+
+    # Modern Blender 4.x: poly_offset_indices as attribute.
+    blk = _attribute_data_block(blend, me_blk, "poly_offset_indices")
+    if blk is not None:
+        offsets = list(_struct.unpack_from(blend.header.endian_char + "i" * (totpoly + 1),
+                                           blend.buf, blk.payload_offset))
+        return offsets
+
+    # Older Blender (or 4.x with direct pointer): Mesh.poly_offset_indices field.
+    if me_struct.by_name.get("poly_offset_indices") is not None:
+        ptr = blend.read_pointer(me_blk, me_struct, "poly_offset_indices")
+        blk = blend.follow(ptr)
+        if blk is not None:
+            offsets = list(_struct.unpack_from(blend.header.endian_char + "i" * (totpoly + 1),
+                                               blend.buf, blk.payload_offset))
+            return offsets
+
+    # Legacy fallback: MPoly.loopstart + MPoly.totloop synthesized to offsets.
+    if me_struct.by_name.get("mpoly") is not None:
+        mp_ptr = blend.read_pointer(me_blk, me_struct, "mpoly")
+        mp_blk = blend.follow(mp_ptr)
+        if mp_blk is not None:
+            mp_struct = blend.sdna.struct_for("MPoly")
+            if mp_struct is not None and mp_struct.by_name.get("loopstart"):
+                ls_off = mp_struct.by_name["loopstart"].offset
+                tl_off = mp_struct.by_name["totloop"].offset
+                offsets = []
+                last_end = 0
+                for i in range(totpoly):
+                    base = mp_blk.payload_offset + i * mp_struct.size
+                    ls = _struct.unpack_from(blend.header.endian_char + "i", blend.buf, base + ls_off)[0]
+                    tl = _struct.unpack_from(blend.header.endian_char + "i", blend.buf, base + tl_off)[0]
+                    offsets.append(ls)
+                    last_end = ls + tl
+                offsets.append(last_end)
+                return offsets
+
+    return None
 
 
 def _mesh_material_index(ctx, me_blk: Block, totpoly: int) -> list[int] | None:


### PR DESCRIPTION
## Summary

Fixes BMW27 (Blender 4.x) import crash where all meshes were skipped with `"no poly_offset_indices"` error, resulting in 0 primitives uploaded and 0-SSIM measurement (PR #357).

## Changes

**Root cause:** `_mesh_face_offsets` only tried the direct `Mesh.poly_offset_indices` pointer, missing the modern attribute storage path that Blender 4.0+ uses.

**Blender 4.0 storage change:**
- **Pre-4.0:** `MPoly[]` array with explicit `loopstart` + `totloop` per polygon
- **4.0+:** `poly_offset_indices` as an attribute in `AttributeStorage`, where polygon *i*'s loops span `[offsets[i] .. offsets[i+1])`

**Fix:** Added attribute storage lookup to `_mesh_face_offsets`, matching the pattern used by `_mesh_positions` and `_mesh_corner_verts`. The function now tries three paths in order:
1. **Attribute storage lookup** (Blender 4.x) — NEW
2. **Direct Mesh.poly_offset_indices pointer** (transitional layout)
3. **Legacy MPoly synthesis** (pre-4.0)

**Test coverage:** New `test_mesh_poly_offset_indices_fallback` validates attribute-path reading against `synthetic_min.blend` (Blender 5.1) and checks monotonic offset invariants.

## Citations

Per CLAUDE.md §6:
- [Blender 4.0 PR #105938: Mesh: Replace MPoly struct with offset indices](https://projects.blender.org/blender/blender/pulls/105938)
- [Blender developer docs: OffsetIndices design](https://developer.blender.org/docs/features/objects/mesh/mesh/)

## Verification

**Local tests (no astroray module needed):**
```
$ pytest tests/test_blend_import_format.py -v
8 passed, 1 skipped (astroray not built)
```

**BMW27 integration test:** Requires `.blend` cache download. If cache is available, `python scripts/run_parity.py` for BMW27 should now import + render + measure SSIM instead of crashing with 0 primitives.

## Acceptance

- [x] All blend_import_format tests pass
- [x] New test exercises attribute storage path
- [x] Backward compatible with pre-4.0 .blend files (legacy MPoly fallback intact)
- [x] Citations included per CLAUDE.md §6
- [ ] BMW27 SSIM measurable (requires cache; not verified locally — no .blend file)

## Related

Fixes: PR #357 BMW27 0-SSIM crash (parity CSV row blank)

Generated with [Claude Code](https://claude.com/claude-code)