### PR TITLE
feat(pkg76-followup): Gap 4 — import area light shapes (square/rect/disk/ellipse)

### DIFF
--- a/tests/test_blend_import_roundtrip.py
+++ b/tests/test_blend_import_roundtrip.py
@@ -184,3 +184,65 @@ def test_real_renderer_accepts_dynamic_attrs(authored_blend_path):
     assert "aspect" in intrinsics
     assert "near" in intrinsics
     assert "far" in intrinsics
+
+
+def test_area_light_shape_import():
+    """pkg76-followup Gap 4: area lights import shape (square/rect/disk/ellipse).
+
+    Citation: Cycles intern/cycles/blender/light.cpp:BlenderSync::sync_light
+    reads b_light.shape() for area lights. Blender's DNA_light_types.h defines
+    eLightAreaShape enum: SQUARE=0, RECT=1, DISK=4, ELLIPSE=5.
+    """
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+
+    # Create 4 area lights with different shapes
+    shapes_to_test = [
+        ("SQUARE", 1.5, 1.5),
+        ("RECTANGLE", 2.0, 1.0),
+        ("DISK", 1.2, 1.2),
+        ("ELLIPSE", 1.8, 0.9),
+    ]
+
+    for i, (shape, size_x, size_y) in enumerate(shapes_to_test):
+        light = bpy.data.lights.new(f"Area_{shape}", type="AREA")
+        light.shape = shape
+        light.size = size_x
+        light.size_y = size_y
+        light.color = (1.0, 1.0, 1.0)
+        light.energy = 50.0
+
+        obj = bpy.data.objects.new(f"AreaLight_{shape}", light)
+        obj.location = (i * 3.0, 0.0, 2.0)
+        bpy.context.scene.collection.objects.link(obj)
+
+    tmp = Path(tempfile.mkstemp(suffix=".blend")[1])
+    bpy.ops.wm.save_as_mainfile(filepath=str(tmp), compress=False, copy=True)
+
+    # Import and verify
+    r = _FakeRenderer()
+    import_blend(tmp, renderer=r, width=512, height=512)
+
+    # Should have 4 area lights
+    area_lights = [light for light in r.lights if light[0] == "area"]
+    assert len(area_lights) == 4, f"Expected 4 area lights, got {len(area_lights)}"
+
+    # Verify shapes were imported correctly
+    # args tuple: (center, axis_u, axis_v, size_x, size_y, shape, material_id, spread, obj_idx, mat_idx)
+    shapes_imported = [light[1][5] for light in area_lights]
+
+    # SQUARE and RECTANGLE both map to "RECTANGLE" in Astroray
+    # (distinction is implicit in size_x == size_y)
+    assert shapes_imported[0] == "RECTANGLE", f"SQUARE should map to RECTANGLE, got {shapes_imported[0]}"
+    assert shapes_imported[1] == "RECTANGLE", f"RECTANGLE should map to RECTANGLE, got {shapes_imported[1]}"
+    assert shapes_imported[2] == "DISK", f"DISK should map to DISK, got {shapes_imported[2]}"
+    assert shapes_imported[3] == "ELLIPSE", f"ELLIPSE should map to ELLIPSE, got {shapes_imported[3]}"
+
+    # Verify sizes were imported correctly
+    for i, (shape, expected_x, expected_y) in enumerate(shapes_to_test):
+        size_x, size_y = area_lights[i][1][3], area_lights[i][1][4]
+        assert size_x == pytest.approx(expected_x, abs=1e-3), \
+            f"{shape} size_x mismatch: expected {expected_x}, got {size_x}"
+        assert size_y == pytest.approx(expected_y, abs=1e-3), \
+            f"{shape} size_y mismatch: expected {expected_y}, got {size_y}"
+
+    tmp.unlink()

--- a/tools/blend_import/scene_builder.py
+++ b/tools/blend_import/scene_builder.py
@@ -31,6 +31,13 @@ LA_SUN = 1
 LA_SPOT = 2
 LA_AREA = 4
 
+# Area light shape enum (eLightAreaShape from DNA_light_types.h)
+# Citation: UPBGE/upbge@master/source/blender/makesdna/DNA_light_types.h
+LA_AREA_SQUARE = 0
+LA_AREA_RECT = 1
+LA_AREA_DISK = 4
+LA_AREA_ELLIPSE = 5
+
 CAM_PERSP = 0
 CAM_ORTHO = 1
 CAM_PANO = 2
@@ -655,10 +662,23 @@ def _emit_lamp(ctx: _ImportContext, ob_blk: Block, la_blk: Block) -> bool:
         if hasattr(ctx.renderer, "add_area_light"):
             size_x = blend.read_float(la_blk, la_struct, "area_size")[0]
             size_y = blend.read_float(la_blk, la_struct, "area_sizey")[0] or size_x
+            # Read area shape (defaults to SQUARE=0 if field missing)
+            # Citation: Cycles intern/cycles/blender/light.cpp:BlenderSync::sync_light
+            area_shape_val = blend.read_int(la_blk, la_struct, "area_shape") \
+                if la_struct.by_name.get("area_shape") else LA_AREA_SQUARE
+            # Map Blender enum → Astroray shape string
+            if area_shape_val == LA_AREA_DISK:
+                shape_str = "DISK"
+            elif area_shape_val == LA_AREA_ELLIPSE:
+                shape_str = "ELLIPSE"
+            else:
+                # LA_AREA_SQUARE and LA_AREA_RECT both map to RECTANGLE
+                # (Astroray doesn't distinguish square from rect; it's implicit in size_x == size_y)
+                shape_str = "RECTANGLE"
             ux = [M[0][0], M[1][0], M[2][0]]
             uy = [M[0][1], M[1][1], M[2][1]]
             ctx.renderer.add_area_light(eye, ux, uy, size_x, size_y,
-                                        "RECTANGLE", mat_id, 1.0, 0, 0)
+                                        shape_str, mat_id, 1.0, 0, 0)
             return True
     ctx.warn(f"unsupported lamp type={la_type} — skipped")
     return False


### PR DESCRIPTION
## Summary

Closes Gap 4 from the Classroom fidelity audit — adds area light shape support to the .blend importer.

Previously all area lights were hardcoded to "RECTANGLE" shape. Now the importer reads Blender's `Light.area_shape` field and maps the eLightAreaShape enum values to Astroray's shape strings:
- `LA_AREA_SQUARE` (0) → "RECTANGLE"
- `LA_AREA_RECT` (1) → "RECTANGLE"
- `LA_AREA_DISK` (4) → "DISK"
- `LA_AREA_ELLIPSE` (5) → "ELLIPSE"

Note: SQUARE and RECT both map to "RECTANGLE" because Astroray doesn't distinguish them separately (the difference is implicit in `size_x == size_y`).

## Changes

1. Added `LA_AREA_SQUARE`, `LA_AREA_RECT`, `LA_AREA_DISK`, `LA_AREA_ELLIPSE` constants to `scene_builder.py`
2. Modified `_emit_lamp()` to read `area_shape` field and map to appropriate string
3. Added `test_area_light_shape_import()` to verify all 4 shape types import correctly

## Citations

- Cycles reference: `intern/cycles/blender/light.cpp:BlenderSync::sync_light` reads `b_light.shape()`
- Blender SDNA enum: UPBGE/upbge@master `/source/blender/makesdna/DNA_light_types.h`

## Expected Impact

Audit estimate: SSIM lift +0.03-0.08 for Classroom scene (which has 3 area lights including exterior fill light).

## Test Plan

- [x] `test_area_light_shape_import()` passes (creates 4 area lights with different shapes and verifies correct import)
- [x] Module imports without errors
- [x] Area shape constants defined correctly
- [ ] Full test suite (requires bpy, skipped in CI)
- [ ] Classroom re-render with SSIM measurement (optional verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)