### PR TITLE
docs(round15): file pkg101/102/103 addon defect specs from 2026-05-24 owner triage

### DIFF
--- a/.astroray_plan/docs/NEXT_STAGE_REPORT.md
+++ b/.astroray_plan/docs/NEXT_STAGE_REPORT.md
@@ -130,6 +130,22 @@
   the pkg81 harness scene) — the still-unmet competitive claim that pkg55 Phase B formally
   owns. Architect estimate: ~3-5 sessions to parity claim (~3 material kernels).
 
+**Addon defect triage (filed 2026-05-24, owner-reported bugs):**
+
+- **pkg101 — viewport camera vfov mis-extracted from `perspective_matrix`** — Blender
+  PERSP/ORTHO orbit causes apparent object shrink/grow/flip because the addon reads
+  `rv3d.perspective_matrix[1][1]` (projection × view, rotation-coupled) instead of
+  `rv3d.window_matrix[1][1]`. Small Python fix + rotated-view regression test.
+- **pkg102 — HDRI blur from DOF aperture unit mismatch** — addon computes
+  `aperture = 1/(2*fstop)` and the C++ then halves it again as `lensRadius`, producing
+  ~45 mm lens radius at f/5.6. Cycles' expression is
+  `aperture_radius = (focal_length_m) / (2 * fstop)`. Small Python fix.
+- **pkg103 — addon feature-wiring audit (Phase 1: audit doc only)** — produce the
+  complete `set_*`/`enable_*`/`add_*` binding-vs-addon-call-site table. Confirmed gaps
+  already include Light Tree (`set_light_sampler`, no addon call) and camera motion
+  blur (`set_camera_motion_blur`, no addon call). Phase 2 wiring is per-feature
+  follow-up specs (e.g. pkg103a Light Tree, pkg103b motion blur).
+
 **Second tier (unblocked, lower priority):**
 
 - **pkg64-gpu-sellmeier-session2-multi-ior** (spec filed) — per-wavelength multi-IOR GPU

--- a/.astroray_plan/packages/pkg101-addon-viewport-camera-vfov-from-perspective-matrix.md
+++ b/.astroray_plan/packages/pkg101-addon-viewport-camera-vfov-from-perspective-matrix.md
@@ -1,0 +1,136 @@
+# pkg101 — Blender addon viewport camera: vfov mis-extracted from `perspective_matrix`
+
+**Pillar:** 5 (addon)
+**Track:** A (correctness, small Python-only fix)
+**Codex-paste-ready:** yes
+**Status:** open
+**Depends on:** none
+**Estimated effort:** small (<½ day; few-line fix + regression test)
+
+---
+
+## Goal
+
+**Before:** Rotating/orbiting the 3D-view camera in a Blender PERSP or
+ORTHO view causes the rendered object to "shrink, grow, flip, and rotate
+differently from how the camera is actually moving," and the framing
+fails to line up with Blender's viewport overlay. Owner-reported
+symptom 2026-05-24.
+
+**After:** Camera orbit/pan/dolly in PERSP/ORTHO and CAMERA views
+produces a rendered frame whose vertical FOV and framing match
+Blender's viewport overlay to within float tolerance. A pytest exercises
+several rotated `RegionView3D` states and asserts the vfov extracted by
+the addon equals the vfov implied by `rv3d.window_matrix` (the projection
+matrix), not by `rv3d.perspective_matrix` (the projection × view product).
+
+---
+
+## The defect (verified on HEAD 24b5701, 2026-05-24)
+
+`blender_addon/__init__.py` extracts the rendered vfov in two sites:
+
+- `_setup_viewport_camera` lines 1683–1700 (PERSP/ORTHO branch).
+- `_apply_camera` lines 1824–1834 (CAMERA-view branch, called from
+  `_setup_viewport_camera` via line 1663–1666).
+
+Both sites read:
+
+```python
+persp = rv3d.perspective_matrix
+if abs(persp[1][1]) > 1e-6:
+    vfov = math.degrees(2.0 * math.atan(1.0 / persp[1][1]))
+```
+
+with the comment *"perspective_matrix[1][1] = 1 / tan(vfov/2) for a
+symmetric frustum."* That identity is only true of the **projection
+matrix alone**.
+
+In Blender's `bpy.types.RegionView3D`, `perspective_matrix =
+window_matrix @ view_matrix` (documented). `window_matrix` is the pure
+projection; `view_matrix` is the camera-to-world inverse including
+rotation. Their product mixes the rotation of the view into element
+`[1][1]`. As the camera orbits, `perspective_matrix[1][1]` changes
+with `cos(pitch)` etc., so the extracted vfov grows and shrinks with
+camera rotation — exactly the reported symptom.
+
+The fix is to read `rv3d.window_matrix[1][1]` (the projection matrix),
+which is the OpenGL convention `1 / tan(vfov/2)` for a symmetric
+frustum and is rotation-invariant.
+
+**Why this shipped:** pkg95 added the perspective-matrix extraction as
+"BUG-08" specifically to align with Blender's overlay (PR #305). The
+intent was correct (read Blender's projection rather than re-derive
+from sensor/lens) but the matrix attribute chosen carries view rotation.
+No test exercises a rotated view, so a fixed-identity-rotation manual
+check looked correct.
+
+---
+
+## Reference
+
+### Internal
+- `blender_addon/__init__.py` lines 1683–1700 (PERSP/ORTHO) and 1824–1834
+  (CAMERA view).
+- `module/blender_module.cpp` lines 790–816 (`setupCamera`) and
+  `include/raytracer.h` lines 1840–1875 (`Camera` constructor) — the
+  consumer. `vh = 2 * tan(vfov/2) * focusDist`; an over-large vfov
+  scales the image plane and changes apparent object size.
+- `tools/blend_import/scene_builder.py` `_emit_camera` (line 144) —
+  importer-side vfov extraction; uses sensor/lens directly and is **not
+  affected** (no `perspective_matrix` use).
+
+### External
+- Blender Python API `RegionView3D` docs: `perspective_matrix = window_matrix @
+  view_matrix` (see `bpy.types.RegionView3D.perspective_matrix`).
+- Cycles `intern/cycles/blender/camera.cpp` `BlenderCamera::sync` uses
+  `cam->sensor_height / cam->sensor_width` and `cam->lens`, not
+  `perspective_matrix`, for the projection axis. Apache-2.0.
+
+CLAUDE.md §6 N/A (no novel numerical algorithm; this is a Blender API
+read fix).
+
+---
+
+## Fix
+
+Replace `rv3d.perspective_matrix[1][1]` with `rv3d.window_matrix[1][1]`
+at both sites. Keep the existing degenerate-fallback (`abs(...) <
+1e-6`) and the existing CAMERA-view zoom scaling
+(`vfov_scale`) intact. **Do not** touch `_emit_camera` or other
+camera-math code (CLAUDE.md §3 surgical).
+
+---
+
+## Acceptance criteria
+
+- [ ] A pytest in `tests/test_addon_viewport_camera_vfov.py` constructs a
+      handful of synthetic `RegionView3D`-like stubs with **different
+      rotations** but the **same projection** (same `window_matrix`) and
+      asserts the addon's vfov extractor returns the same vfov for all
+      of them (rotation-invariant). The test must fail on current HEAD
+      and pass after the fix.
+- [ ] Manual visual check on RTX: orbit the camera around a primitive
+      cube; the rendered frame's framing and apparent object size remain
+      stable, and the rendered image aligns with Blender's viewport
+      overlay (no "shrink/grow/flip" while orbiting). Recorded in the
+      PR description with a short before/after gif or paired stills.
+- [ ] CI green.
+
+## Hard non-goals
+
+- No refactor of `_apply_camera` or `_setup_viewport_camera` beyond the
+  matrix swap.
+- No change to the F12 batch-render path that already uses sensor/lens.
+- No change to `tools/blend_import/scene_builder.py`.
+
+---
+
+## Provenance
+
+Owner-reported in goal-capture 2026-05-24: *"As I rotate the camera
+around the object, the object appears to shrink and grow, flip and
+rotate completely different from how the camera is actually moving. It
+also obviously because of this doesn't line up with the viewport."*
+Architect traced to `perspective_matrix[1][1]` misuse (pkg95 BUG-08
+fix).

--- a/.astroray_plan/packages/pkg102-addon-hdri-dof-aperture-unit-mismatch.md
+++ b/.astroray_plan/packages/pkg102-addon-hdri-dof-aperture-unit-mismatch.md
@@ -1,0 +1,152 @@
+# pkg102 — Blender addon DOF aperture unit mismatch causes "HDRI blur"
+
+**Pillar:** 5 (addon)
+**Track:** A (correctness, small Python-only fix)
+**Codex-paste-ready:** yes
+**Status:** open
+**Depends on:** none
+**Estimated effort:** small (<½ day; few-line fix + regression test)
+
+---
+
+## Goal
+
+**Before:** Adding an HDRI to a Blender scene renders the HDRI as
+heavily blurred even when DOF was not intentionally configured.
+Owner-reported 2026-05-24: *"when I added an HDRI, it was completely
+blurry, presumably because of some DOF bug."*
+
+**After:** With Blender's camera DOF disabled the rendered HDRI is
+sharp. With DOF enabled the aperture maps to a physically reasonable
+lens radius in scene units (meters) — i.e. an f/5.6 50mm lens
+produces a ~4.5 mm radius lens, not a 0.089 m radius.
+
+---
+
+## The defect (verified on HEAD 24b5701, 2026-05-24)
+
+`blender_addon/__init__.py:1843-1850` computes:
+
+```python
+aperture, focus_dist = 0.0, 10.0
+if camera.dof.use_dof:
+    if camera.dof.aperture_fstop > 0:
+        aperture = 1.0 / (2 * camera.dof.aperture_fstop)
+    ...
+```
+
+`aperture` is then passed to `Renderer.setup_camera(...)` and ends up
+as `lensRadius = aperture / 2` in `include/raytracer.h:1854` — i.e.
+the lens **radius in scene units (meters)**.
+
+For an f/5.6 setting this produces `lensRadius = 1/(2·5.6)/2 ≈ 0.045
+m = 45 mm` — a lens 90mm across. Combined with a typical
+`focus_distance` of a few meters this produces a circle-of-confusion
+on the order of centimeters at object distance, which appears as
+extreme blur on anything not exactly at the focus plane (the HDRI is
+at infinity → maximum blur).
+
+The correct relation is the photographic one used by Cycles
+(`intern/cycles/blender/camera.cpp`, `BlenderCamera::sync`):
+`aperture_radius = (focal_length / fstop) / 2` with `focal_length` in
+**meters** (Blender's `camera.lens` is in millimetres → multiply by
+1e-3).
+
+**Two bugs in one expression:**
+
+1. The fstop relation is missing the focal length entirely
+   (`aperture_radius = focal_length / (2 · fstop)`).
+2. The result is then halved again at the C++ side (`lensRadius =
+   aperture/2`), so the addon must pass **diameter**, not radius.
+
+**Note on default state:** Blender 4.x defaults `camera.dof.use_dof =
+False` on new scenes, so the bug only manifests when a user enables
+DOF (or imports a scene that has it on). A second-order question is
+whether `aperture_fstop`'s default of `2.8` should ever render this
+heavily blurred for `use_dof=False` — it should not, and the
+`use_dof` guard prevents that. If the owner reports blur with DOF
+off, that is a separate defect (likely camera-data scoping inside
+the live-viewport update loop).
+
+---
+
+## Reference
+
+### Internal
+- `blender_addon/__init__.py:1843-1858` — the buggy expression and the
+  `setup_camera` call.
+- `include/raytracer.h:1854` — `lensRadius = aperture / 2`. The addon
+  must pass **diameter in meters**.
+- `tools/blend_import/scene_builder.py` — the importer does not
+  currently extract DOF at all (`aperture=0, focus_dist=10` hardcoded
+  by the harness). Out of scope for this package.
+
+### External
+- Cycles `intern/cycles/blender/camera.cpp` `BlenderCamera::sync` (Apache-2.0):
+  ```
+  bcam->aperturesize = (b_camera.dof().aperture_fstop() > 0.0f) ?
+      (b_camera.lens() * 1e-3f) / (2.0f * b_camera.dof().aperture_fstop()) :
+      0.0f;
+  ```
+  `aperturesize` is the **radius in meters**. The addon should mirror
+  this expression exactly, then pass `2 * aperturesize` to
+  `setup_camera` so the C++ `lensRadius = aperture/2` yields the
+  intended radius.
+- PBRT-v4 `RealisticCamera` (BSD-3): same physical lens-radius
+  derivation. Cite Cycles as the closer reference.
+
+CLAUDE.md §6: cite Cycles' `camera.cpp` expression directly in the
+fix; this is a physical-units formula, not a novel algorithm.
+
+---
+
+## Fix
+
+```python
+aperture, focus_dist = 0.0, 10.0
+if camera.dof.use_dof:
+    if camera.dof.aperture_fstop > 0:
+        # Cycles intern/cycles/blender/camera.cpp::BlenderCamera::sync (Apache-2.0):
+        # aperture_radius = (focal_length_m) / (2 * fstop). camera.lens is in mm.
+        focal_length_m = float(camera.lens) * 1e-3
+        aperture_radius = focal_length_m / (2.0 * float(camera.dof.aperture_fstop))
+        # C++ Camera takes diameter (lensRadius = aperture/2), so pass 2x.
+        aperture = 2.0 * aperture_radius
+    if camera.dof.focus_object:
+        focus_dist = (loc - camera.dof.focus_object.matrix_world.translation).length
+    else:
+        focus_dist = camera.dof.focus_distance
+```
+
+---
+
+## Acceptance criteria
+
+- [ ] Pytest in `tests/test_addon_dof_aperture.py` constructs a stub
+      Blender camera (lens=50mm, fstop=5.6, use_dof=True) and asserts
+      the value passed to `Renderer.setup_camera` for `aperture` is
+      within 1% of `2 * (0.050 / (2*5.6)) ≈ 0.00893`. Also asserts
+      that with `use_dof=False`, `aperture == 0.0`. Test must fail on
+      HEAD, pass after fix.
+- [ ] Manual RTX visual: load any HDRI in a Blender scene with `Camera
+      → Depth of Field` unchecked (default); the rendered HDRI is
+      sharp. Then enable DOF at f/5.6 50mm focused on a 2 m subject;
+      the HDRI shows visible but moderate (~physically plausible) blur,
+      not the previous extreme blur.
+- [ ] CI green.
+
+## Hard non-goals
+
+- No refactor of `_apply_camera`. Touch only the aperture lines.
+- No change to C++ `Camera` semantics. The addon passes
+  diameter-in-meters; the C++ continues to halve.
+- No new DOF features (`focus_object` chains, `aperture_blades`,
+  `aperture_ratio` already-passed paths — out of scope).
+
+---
+
+## Provenance
+
+Owner-reported 2026-05-24: *"when I added an HDRI, it was completely
+blurry, presumably because of some DOF bug."* Architect verified the
+units error against Cycles' reference expression.

--- a/.astroray_plan/packages/pkg103-addon-feature-wiring-audit-and-exposure.md
+++ b/.astroray_plan/packages/pkg103-addon-feature-wiring-audit-and-exposure.md
@@ -1,0 +1,159 @@
+# pkg103 — Blender addon feature-wiring audit: expose shipped renderer features in the UI
+
+**Pillar:** 5 (addon)
+**Track:** A (UI-wiring audit; mixed surface across `blender_addon/__init__.py`)
+**Codex-paste-ready:** partial — Phase 1 (audit) is mechanical; Phase 2 (wiring) requires per-feature UI design judgement and should ship as several small follow-up PRs.
+**Status:** open
+**Depends on:** none (but coordinates with pkg101, pkg102 in the same file)
+**Estimated effort:** Phase 1 ≈ ½ day (audit table). Phase 2 ≈ 1 day per
+feature wired.
+
+---
+
+## Goal
+
+**Before:** Several renderer-side features have shipped (pkg44 ADAF,
+pkg86/86-B Light Tree, pkg88 motion blur, pkg89 dedicated lights,
+others) but their addon UI exposure is inconsistent — some are wired
+end-to-end, some have pybind bindings but no UI property, some have a
+UI property but the property never reaches the renderer. The owner
+reports *"a lot of the new features and things and lights-related
+features still need their blender addon wiring and exposure in the
+UI."*
+
+**After:** A concrete audit table maps every PyRenderer setter to
+(a) whether a `custom_raytracer.<prop>` UI property exists,
+(b) whether `convert_scene`/`setup_world`/`convert_lights` calls the
+setter, and (c) whether a UI panel exposes the prop. Each gap becomes
+either a documented intentional non-exposure or a small wiring PR.
+
+---
+
+## Confirmed gaps on HEAD 24b5701 (architect spot-check, non-exhaustive)
+
+1. **Light Tree sampler** (`set_light_sampler`, pybind 1966).
+   - **No call site in addon** (`grep set_light_sampler blender_addon/`
+     returns nothing). pkg86 (CPU median-split) and pkg86-B Phase 1
+     (CPU SAOH) are shipped; Cycles' `RENDER_PT_sampling_light_tree`
+     panel is hidden from Astroray's UI register (line 4570 of the
+     blacklist). User cannot turn on the light tree from the addon.
+
+2. **Camera motion blur** (`set_camera_motion_blur`, pybind 1953).
+   - **No call site in addon**. pkg88-A shipped the renderer-side
+     keyframe interpolation but the addon never invokes
+     `set_camera_motion_blur`, so Blender's `render.use_motion_blur`
+     toggle has no effect on the camera. Geometric motion blur was
+     explicit non-goal of pkg88-A.
+
+3. **Spot/sun/area dedicated lights** (pkg89 Phase B, PR #317).
+   - Wired (lines 3533, 3554, 3568). The `dedicated` toggle is
+     UI-exposed; **leave as-is**, listed here only as the positive
+     control showing the wiring pattern.
+
+4. **ADAF / accretion model selector** (pkg43 + pkg44).
+   - Wired via `add_black_hole(params=…)` (line 3314 area); UI panel at
+     line 4437. **Leave as-is.**
+
+5. **Cryptomatte** (pkg87a-d).
+   - Wired via `set_cryptomatte_enabled` (line 939). **Leave as-is.**
+
+The audit deliverable (Phase 1) is the **complete** version of the
+above list, not these five spot-checks.
+
+---
+
+## Phase 1 — audit (this package's only required deliverable)
+
+Produce a single markdown table in
+`.astroray_plan/docs/blender-addon-wiring-audit-2026-05-24.md` with
+columns:
+
+| PyRenderer setter | pybind line | UI prop name | `convert_scene` call site | UI panel | Status |
+|---|---|---|---|---|---|
+
+Generation procedure:
+
+1. `grep -nE '^\s*\.def\("(set_|enable_|add_|use_)' module/blender_module.cpp`
+   → seed the rows.
+2. For each row, grep `blender_addon/__init__.py` for the setter name.
+3. Mark each row as `OK`, `gap:no-call`, `gap:no-prop`, `gap:no-panel`,
+   or `intentionally-internal` (with one-line justification).
+
+The audit must include every `enable_*` / `set_*` / `add_*` binding,
+not only the obvious ones. The audit is a docs-only deliverable in
+this package's PR.
+
+## Phase 2 — wiring follow-ups (out of scope here; file as follow-up specs)
+
+For each non-`intentionally-internal` gap surfaced in Phase 1, the
+follow-up is its own small spec (template pkg99/pkg100 style): one
+property, one panel row, one `convert_scene` call, one test. Do **not**
+attempt to land all of Phase 2 inside this package.
+
+The architect-recommended initial follow-up cuts (file as separate
+specs after audit lands):
+
+- **pkg103a** — Light Tree UI toggle + `set_light_sampler` call.
+- **pkg103b** — Camera motion-blur addon wiring (decompose
+  `camera.matrix_world` at shutter start/end, call
+  `set_camera_motion_blur`).
+
+Any further pkg103x specs are determined by the Phase 1 audit table.
+
+---
+
+## Reference
+
+### Internal
+- `module/blender_module.cpp` lines ~1880-2130 (PyRenderer setter
+  bindings).
+- `blender_addon/__init__.py` (the consumer).
+- `.astroray_plan/packages/pkg89-dedicated-lights.md` (positive
+  reference for end-to-end light wiring).
+- `.astroray_plan/packages/pkg86-light-tree.md` and
+  `pkg86-B-light-tree-gpu.md` (Light Tree renderer side).
+- `.astroray_plan/packages/pkg88-motion-blur.md` (camera motion blur
+  renderer side; pkg88-A was camera-only by design).
+
+### External
+- Cycles `intern/cycles/blender/sync.cpp` (Apache-2.0) — reference for
+  walking a Blender scene and pushing each setting to the renderer.
+  Cite when wiring individual follow-ups (Phase 2).
+
+CLAUDE.md §6 N/A in Phase 1 (audit is mechanical). Phase 2 follow-ups
+that touch sampling/physics (Light Tree mode plumbing, motion-blur
+shutter-position mapping) must cite Cycles.
+
+---
+
+## Acceptance criteria (this package — Phase 1 only)
+
+- [ ] Audit doc filed at
+      `.astroray_plan/docs/blender-addon-wiring-audit-2026-05-24.md`
+      covering every PyRenderer `set_*` / `enable_*` / `add_*`
+      binding.
+- [ ] Audit table marks ≥3 concrete `gap:*` rows (we already know of
+      Light Tree, motion-blur, and the audit will surface more).
+- [ ] PR body links the audit and lists which follow-up specs the
+      architect should file next.
+- [ ] CI green (docs-only PR).
+
+## Hard non-goals
+
+- **No Phase 2 wiring in this package** — surgical scope discipline
+  (CLAUDE.md §3). Wiring follow-ups are separate small PRs.
+- No refactor of the existing wiring for already-wired features.
+- No removal of the `RENDER_PT_sampling_light_tree` panel from the
+  hide-list until pkg103a actually wires the call site (avoids a
+  dead-toggle UI).
+
+---
+
+## Provenance
+
+Owner-reported 2026-05-24: *"A lot of the new features and things and
+lights-related features still need their blender addon wiring and
+exposure in the UI."* Architect spot-checked five renderer features
+and confirmed at least two concrete gaps (Light Tree sampler, camera
+motion blur); a full mechanical audit is the right next step before
+filing per-feature wiring PRs.


### PR DESCRIPTION
## Summary

Three small docs-only specs in response to the owner's 2026-05-24 goal-capture, which surfaced three concrete Blender addon defects plus a wiring-audit claim. Architect read the addon + importer + Camera implementation silently before filing.

**Bugs traced to root cause, not just symptoms:**

- **pkg101** (camera shrink/grow on orbit) - `blender_addon/__init__.py` lines 1683-1700 and 1824-1834 read `rv3d.perspective_matrix[1][1]` to extract vfov, but in Blender that matrix is `window_matrix @ view_matrix` (projection composed with view rotation). As the camera orbits, `[1][1]` changes with `cos(pitch)`, so the extracted vfov grows and shrinks with rotation - exactly the reported symptom. Fix: read `rv3d.window_matrix[1][1]` (the pure projection).

- **pkg102** (HDRI blurry) - `blender_addon/__init__.py:1845` computes `aperture = 1/(2*fstop)` with no focal length and treats the result as a length in scene units; C++ `Camera` then halves it as `lensRadius`. Yields ~45 mm lens radius at f/5.6 - massively over-aperture. Fix per Cycles `intern/cycles/blender/camera.cpp`: `aperture_radius = (focal_length_m) / (2 * fstop)`, pass diameter to C++.

- **pkg103** (wiring audit) - Phase 1 mechanical audit doc. Spot-checked gaps already confirmed: Light Tree (`set_light_sampler` exists, no addon call site), camera motion blur (`set_camera_motion_blur` exists, no addon call site). Phase 2 wiring will be per-feature follow-up specs.

`NEXT_STAGE_REPORT.md` §2 updated with an "Addon defect triage" block; Round 15 lead remains pkg55-B' Session N+5 (CUDA port) per the existing roadmap.

## Scope decision

Three small specs vs one big "addon health" spec: chose split because the three defects touch disjoint code paths (camera math, world/DOF defaults, UI exposure) and let the orchestrator dispatch them independently.

## Test plan

- [ ] Owner skims pkg101/102/103 to sanity-check the root-cause traces.
- [ ] On merge, owner runs `/loop /implement-next` - the orchestrator should dispatch pkg101 and pkg102 immediately (small Python fixes, no HW gate needed).
- [ ] pkg103 Phase 1 is a docs-only audit; Phase 2 follow-up specs (pkg103a Light Tree, pkg103b motion blur) get filed after the audit lands.

## Notes

- Docs-only PR; no source touched.
- Branched from `origin/main` (not local main) because local main has two unrelated commits including one with a secret that trips GitHub push protection; owner should investigate `1e85cd7` (`Google_Apps_Script.txt:23`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)