### PR TITLE
fix(pkg101): extract viewport vfov from window_matrix, not perspective_matrix

### DIFF
--- a/.astroray_plan/packages/pkg101-addon-viewport-camera-vfov-from-perspective-matrix.md
+++ b/.astroray_plan/packages/pkg101-addon-viewport-camera-vfov-from-perspective-matrix.md
@@ -3,7 +3,7 @@
 **Pillar:** 5 (addon)
 **Track:** A (correctness, small Python-only fix)
 **Codex-paste-ready:** yes
-**Status:** open
+**Status:** done (PR #368, 2026-05-24 — test FAILS before (vfov=67.38° at pitch=30°), PASSES after; 90 Blender tests green)
 **Depends on:** none
 **Estimated effort:** small (<½ day; few-line fix + regression test)
 

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -1643,7 +1643,7 @@ class CustomRaytracerRenderEngine(RenderEngine):
     def _setup_viewport_camera(self, renderer, context, width, height):
         """Build a lookFrom/lookAt from the 3D View's RegionView3D state.
 
-        P4 fix (BUG-08): derives vfov from Blender's perspective_matrix (when available)
+        P4 fix (BUG-08): derives vfov from Blender's window_matrix (when available)
         instead of re-deriving from a hardcoded sensor_width guess, so the rendered
         framing matches Blender's viewport overlay by construction.
 
@@ -1651,7 +1651,7 @@ class CustomRaytracerRenderEngine(RenderEngine):
           viewport-only `view_camera_zoom` and `view_camera_offset` so
           wheel-zoom and pan actually change the rendered framing.
         - In PERSP / ORTHO view: derive position + direction from
-          `rv3d.view_matrix.inverted()` and vfov from `rv3d.perspective_matrix`.
+          `rv3d.view_matrix.inverted()` and vfov from `rv3d.window_matrix`.
         """
         rv3d = context.region_data
         space = context.space_data
@@ -1659,7 +1659,7 @@ class CustomRaytracerRenderEngine(RenderEngine):
         if rv3d is not None and rv3d.view_perspective == 'CAMERA' and context.scene.camera:
             zoom_scale = self._camera_view_zoom_scale(getattr(rv3d, 'view_camera_zoom', 0.0))
             offset = getattr(rv3d, 'view_camera_offset', (0.0, 0.0))
-            # P4 fix (BUG-08): pass rv3d so _apply_camera can use perspective_matrix
+            # P4 fix (BUG-08): pass rv3d so _apply_camera can use window_matrix
             self._apply_camera(renderer, context.scene.camera, width, height,
                                vfov_scale=zoom_scale,
                                viewport_shift=(float(offset[0]), float(offset[1])),
@@ -1676,16 +1676,17 @@ class CustomRaytracerRenderEngine(RenderEngine):
         look_at   = [loc.x + forward.x, loc.y + forward.y, loc.z + forward.z]
         vup       = [up.x, up.y, up.z]
 
-        # P4 fix (BUG-08): extract vfov from Blender's perspective_matrix instead
-        # of re-deriving from a hardcoded 32mm sensor. This ensures the rendered
-        # framing equals Blender's viewport overlay.
+        # P4 fix (BUG-08): extract vfov from Blender's window_matrix (projection-only)
+        # instead of re-deriving from a hardcoded 32mm sensor. This ensures the
+        # rendered framing equals Blender's viewport overlay.
+        # window_matrix[1][1] = 1 / tan(vfov/2) for a symmetric frustum (OpenGL convention).
         aspect = width / max(1, height)
-        if hasattr(rv3d, 'perspective_matrix'):
-            # perspective_matrix[1][1] = 1 / tan(vfov/2) for a symmetric frustum
-            # → vfov = 2 * atan(1 / perspective_matrix[1][1])
-            persp = rv3d.perspective_matrix
-            if abs(persp[1][1]) > 1e-6:
-                vfov = math.degrees(2.0 * math.atan(1.0 / persp[1][1]))
+        if hasattr(rv3d, 'window_matrix'):
+            # window_matrix is the pure projection; perspective_matrix = window_matrix @ view_matrix
+            # couples view rotation into [1][1], causing vfov to vary with camera orbit.
+            proj = rv3d.window_matrix
+            if abs(proj[1][1]) > 1e-6:
+                vfov = math.degrees(2.0 * math.atan(1.0 / proj[1][1]))
             else:
                 # Fallback: derive from space_data.lens (rare edge case)
                 lens = getattr(space, 'lens', 50.0)
@@ -1693,7 +1694,7 @@ class CustomRaytracerRenderEngine(RenderEngine):
                 hfov = 2.0 * math.atan(sensor_width / (2.0 * lens))
                 vfov = math.degrees(2.0 * math.atan(math.tan(hfov / 2.0) / aspect))
         else:
-            # Pre-2.80 fallback (perspective_matrix may not exist)
+            # Pre-2.80 fallback (window_matrix may not exist)
             lens = getattr(space, 'lens', 50.0)
             sensor_width = 32.0
             hfov = 2.0 * math.atan(sensor_width / (2.0 * lens))
@@ -1790,7 +1791,7 @@ class CustomRaytracerRenderEngine(RenderEngine):
         world rotation to get world-space directions.
 
         P4 fix (BUG-08): when called from viewport code with rv3d, derives vfov
-        from rv3d.perspective_matrix (after zoom scaling) instead of re-deriving
+        from rv3d.window_matrix (after zoom scaling) instead of re-deriving
         from the camera datablock's sensor/lens, so the rendered framing matches
         Blender's viewport overlay.
 
@@ -1802,7 +1803,7 @@ class CustomRaytracerRenderEngine(RenderEngine):
         is added to the camera datablock's own shift and passed as an
         image-plane shift to the C++ camera.
 
-        `rv3d` (optional): when present, vfov is extracted from rv3d.perspective_matrix
+        `rv3d` (optional): when present, vfov is extracted from rv3d.window_matrix
         instead of re-deriving from camera sensor/lens (P4 fix for viewport alignment).
         """
         matrix = cam_obj.matrix_world
@@ -1818,16 +1819,16 @@ class CustomRaytracerRenderEngine(RenderEngine):
         camera = cam_obj.data
 
         # P4 fix (BUG-08): when rv3d is available (viewport CAMERA view), extract
-        # vfov from Blender's perspective_matrix *after* accounting for zoom, rather
-        # than re-deriving from camera sensor/lens. This ensures alignment with the
-        # viewport overlay. For F12 batch renders (rv3d=None), fall back to datablock.
-        if rv3d is not None and hasattr(rv3d, 'perspective_matrix'):
-            persp = rv3d.perspective_matrix
-            if abs(persp[1][1]) > 1e-6:
-                # Extract vfov from perspective_matrix[1][1] = 1 / tan(vfov/2)
-                vfov = math.degrees(2.0 * math.atan(1.0 / persp[1][1]))
+        # vfov from Blender's window_matrix (projection-only) *after* accounting for
+        # zoom, rather than re-deriving from camera sensor/lens. This ensures alignment
+        # with the viewport overlay. For F12 batch renders (rv3d=None), fall back to datablock.
+        if rv3d is not None and hasattr(rv3d, 'window_matrix'):
+            proj = rv3d.window_matrix
+            if abs(proj[1][1]) > 1e-6:
+                # Extract vfov from window_matrix[1][1] = 1 / tan(vfov/2) (OpenGL convention)
+                vfov = math.degrees(2.0 * math.atan(1.0 / proj[1][1]))
             else:
-                # Fallback if perspective_matrix is degenerate
+                # Fallback if window_matrix is degenerate
                 vfov = self._compute_vfov_degrees(camera, width, height)
                 if vfov_scale != 1.0 and vfov_scale > 0.0:
                     half = math.radians(vfov) / 2.0

--- a/tests/test_addon_viewport_camera_vfov.py
+++ b/tests/test_addon_viewport_camera_vfov.py
@@ -1,0 +1,300 @@
+"""pkg101 — Blender addon viewport camera vfov extraction rotation-invariance.
+
+The addon must extract vfov from `rv3d.window_matrix[1][1]` (projection-only),
+not `rv3d.perspective_matrix[1][1]` (projection @ view). The latter couples
+view rotation into the vfov extraction, causing the rendered object to shrink/
+grow/flip as the user orbits the camera.
+
+This test constructs several synthetic `RegionView3D` states with **different
+rotations** but the **same projection matrix** and asserts the addon's vfov
+extractor returns the same vfov for all of them (rotation-invariant).
+"""
+
+import importlib.util
+import math
+import sys
+import types
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Shared loader helper (from test_blender_viewport_session.py pattern)
+# ---------------------------------------------------------------------------
+
+def _load_blender_addon(monkeypatch):
+    bpy_module = types.ModuleType("bpy")
+    bpy_types_module = types.ModuleType("bpy.types")
+    bpy_props_module = types.ModuleType("bpy.props")
+
+    class _Base:
+        pass
+
+    class _RenderEngineBase:
+        def report(self, *_a, **_k): return None
+        def update_progress(self, *_a, **_k): return None
+        def update_stats(self, *_a, **_k): return None
+        def test_break(self): return False
+
+    bpy_types_module.Panel = _Base
+    bpy_types_module.Operator = _Base
+    bpy_types_module.AddonPreferences = _Base
+    bpy_types_module.PropertyGroup = _Base
+    bpy_types_module.RenderEngine = _RenderEngineBase
+    bpy_module.types = bpy_types_module
+
+    for name in ("BoolProperty", "IntProperty", "FloatProperty", "StringProperty",
+                 "PointerProperty", "FloatVectorProperty", "EnumProperty"):
+        setattr(bpy_props_module, name, lambda **_kwargs: None)
+    bpy_module.props = bpy_props_module
+    bpy_module.path = types.SimpleNamespace(abspath=lambda p: p)
+
+    shader_blending_module = types.ModuleType("shader_blending")
+    shader_blending_module.blend_shader_specs = {}
+    shader_blending_module.add_shader_specs = {}
+
+    mathutils_module = types.ModuleType("mathutils")
+    mathutils_module.Vector = lambda values: values
+
+    astroray_module = types.ModuleType("astroray")
+    astroray_module.__version__ = "test"
+    astroray_module.__features__ = {"cuda": False, "spectral": True}
+    astroray_module.__file__ = "/fake/astroray.pyd"
+    astroray_module.integrator_registry_names = lambda: ["path_tracer"]
+    astroray_module.material_registry_names = lambda: ["lambertian"]
+    astroray_module.pass_registry_names = lambda: []
+
+    monkeypatch.setitem(sys.modules, "bpy", bpy_module)
+    monkeypatch.setitem(sys.modules, "bpy.types", bpy_types_module)
+    monkeypatch.setitem(sys.modules, "bpy.props", bpy_props_module)
+    monkeypatch.setitem(sys.modules, "shader_blending", shader_blending_module)
+    monkeypatch.setitem(sys.modules, "mathutils", mathutils_module)
+    monkeypatch.setitem(sys.modules, "astroray", astroray_module)
+
+    module_path = Path(__file__).parent.parent / "blender_addon" / "__init__.py"
+    spec = importlib.util.spec_from_file_location("astroray_blender_addon_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Matrix stubs
+# ---------------------------------------------------------------------------
+
+class _Vec3:
+    """Minimal 3D vector for matrix decomposition."""
+    def __init__(self, x, y, z):
+        self.x, self.y, self.z = x, y, z
+
+
+class _Matrix3:
+    """Minimal 3x3 matrix for rotation."""
+    def __init__(self, rows):
+        self.rows = [list(r) for r in rows]
+
+    def __matmul__(self, vec):
+        # Simple 3x3 @ vec3 multiply for camera direction extraction.
+        return _Vec3(
+            self.rows[0][0] * vec[0] + self.rows[0][1] * vec[1] + self.rows[0][2] * vec[2],
+            self.rows[1][0] * vec[0] + self.rows[1][1] * vec[1] + self.rows[1][2] * vec[2],
+            self.rows[2][0] * vec[0] + self.rows[2][1] * vec[1] + self.rows[2][2] * vec[2],
+        )
+
+
+class _Matrix4:
+    """Minimal 4x4 matrix that supports `mat[i][j]`, .translation, .to_3x3()."""
+    def __init__(self, rows):
+        self.rows = [list(r) for r in rows]
+
+    def __getitem__(self, i):
+        return self.rows[i]
+
+    @property
+    def translation(self):
+        """Extract translation from the last column."""
+        return _Vec3(self.rows[0][3], self.rows[1][3], self.rows[2][3])
+
+    def to_3x3(self):
+        """Extract upper-left 3x3 rotation submatrix."""
+        return _Matrix3([
+            [self.rows[0][0], self.rows[0][1], self.rows[0][2]],
+            [self.rows[1][0], self.rows[1][1], self.rows[1][2]],
+            [self.rows[2][0], self.rows[2][1], self.rows[2][2]],
+        ])
+
+    def inverted(self):
+        # For a pure rotation/translation matrix (no scale), the inverse is:
+        # [ R^T  | -R^T * t ]
+        # [  0   |    1     ]
+        # For simplicity, return an identity-ish inverse.
+        return _Matrix4([[1.0 if i == j else 0.0 for j in range(4)] for i in range(4)])
+
+
+def _make_projection_matrix(vfov_deg, aspect):
+    """Construct a perspective projection matrix for a given vfov (degrees)
+    and aspect ratio. OpenGL convention: [1][1] = 1 / tan(vfov/2)."""
+    vfov_rad = math.radians(vfov_deg)
+    f = 1.0 / math.tan(vfov_rad / 2.0)
+    # Symmetric frustum, near=0.1, far=100.
+    return _Matrix4([
+        [f / aspect, 0, 0, 0],
+        [0, f, 0, 0],
+        [0, 0, -1.001, -0.2001],
+        [0, 0, -1, 0],
+    ])
+
+
+def _make_view_matrix(pitch_deg):
+    """Construct a camera view matrix with a pitch rotation.
+    This represents the camera-to-world inverse."""
+    pitch_rad = math.radians(pitch_deg)
+    c = math.cos(pitch_rad)
+    s = math.sin(pitch_rad)
+    # Pitch rotation around X-axis.
+    return _Matrix4([
+        [1, 0, 0, 0],
+        [0, c, -s, 0],
+        [0, s, c, -5.0],  # camera at z=-5
+        [0, 0, 0, 1],
+    ])
+
+
+def _make_perspective_matrix(projection, view):
+    """Multiply projection @ view to create perspective_matrix."""
+    result = [[0.0]*4 for _ in range(4)]
+    for i in range(4):
+        for j in range(4):
+            result[i][j] = sum(projection.rows[i][k] * view.rows[k][j] for k in range(4))
+    return _Matrix4(result)
+
+
+# ---------------------------------------------------------------------------
+# Stub renderer
+# ---------------------------------------------------------------------------
+
+class _RecordingRenderer:
+    """Minimal renderer stub that records setup_camera calls."""
+    def __init__(self):
+        self.setup_camera_calls = []
+
+    def set_adaptive_sampling(self, *_): pass
+    def set_clamp_direct(self, *_): pass
+    def set_clamp_indirect(self, *_): pass
+    def set_filter_glossy(self, *_): pass
+    def set_use_reflective_caustics(self, *_): pass
+    def set_use_refractive_caustics(self, *_): pass
+    def set_wavelength_range(self, *_): pass
+    def set_output_mode(self, *_): pass
+    def set_integrator(self, *_): pass
+    def set_use_gpu(self, *_): pass
+
+    @property
+    def gpu_available(self):
+        return False
+
+    def setup_camera(self, *args, **_kw):
+        self.setup_camera_calls.append(args)
+
+
+# ---------------------------------------------------------------------------
+# Test: vfov extraction is rotation-invariant
+# ---------------------------------------------------------------------------
+
+def test_vfov_extraction_is_rotation_invariant(monkeypatch):
+    """The addon must extract vfov from `rv3d.window_matrix[1][1]`, not
+    `rv3d.perspective_matrix[1][1]`. The former is rotation-invariant; the
+    latter couples view rotation into element [1][1], causing the extracted
+    vfov to vary with camera pitch/yaw/roll.
+
+    This test constructs three synthetic `RegionView3D` states with **different
+    pitch angles** (0°, 30°, -45°) but the **same projection matrix**
+    (vfov=60°, aspect=4/3). The addon's vfov extractor must return ~60° for
+    all three.
+
+    On current HEAD (before fix): the test will FAIL because the addon reads
+    `perspective_matrix[1][1]`, which varies with pitch.
+
+    After fix: the test will PASS because the addon reads `window_matrix[1][1]`,
+    which is rotation-invariant.
+    """
+    addon = _load_blender_addon(monkeypatch)
+    engine = addon.CustomRaytracerRenderEngine()
+    renderer = _RecordingRenderer()
+
+    # Ground truth: vfov=60°, aspect=4/3 (320x240).
+    expected_vfov = 60.0
+    aspect = 320.0 / 240.0
+    projection = _make_projection_matrix(expected_vfov, aspect)
+
+    # Three camera poses with different pitch rotations.
+    pitches = [0.0, 30.0, -45.0]
+    extracted_vfovs = []
+
+    for pitch in pitches:
+        view = _make_view_matrix(pitch)
+        perspective = _make_perspective_matrix(projection, view)
+
+        # Construct a stub rv3d with both window_matrix (projection-only)
+        # and perspective_matrix (projection @ view).
+        rv3d = types.SimpleNamespace(
+            window_matrix=projection,
+            perspective_matrix=perspective,
+            view_matrix=view,
+            view_perspective='PERSP',
+            view_camera_zoom=0.0,
+            view_camera_offset=(0.0, 0.0),
+        )
+        region = types.SimpleNamespace(width=320, height=240)
+        space = types.SimpleNamespace(lens=50.0)
+        scene = types.SimpleNamespace(
+            camera=None,
+            custom_raytracer=types.SimpleNamespace(
+                use_adaptive_sampling=False,
+                clamp_direct=0.0, clamp_indirect=0.0, filter_glossy=0.0,
+                use_reflective_caustics=True, use_refractive_caustics=True,
+                device_mode='cpu',
+                preview_samples=1, max_bounces=4,
+                diffuse_bounces=2, glossy_bounces=2, transmission_bounces=2,
+                volume_bounces=0, transparent_bounces=2,
+                wavelength_preset='visible',
+                wavelength_min=380.0, wavelength_max=780.0,
+                colourmap='grayscale',
+                integrator_type='path_tracer',
+                viewport_display_pass='combined',
+                viewport_oidn=False,
+            )
+        )
+        context = types.SimpleNamespace(
+            region=region,
+            region_data=rv3d,
+            space_data=space,
+            scene=scene,
+        )
+
+        # Call _setup_viewport_camera, which internally extracts vfov.
+        engine._setup_viewport_camera(renderer, context, 320, 240)
+
+        # Extract the vfov from the setup_camera call.
+        # setup_camera signature: (look_from, look_at, vup, vfov, aspect, ...)
+        args = renderer.setup_camera_calls[-1]
+        extracted_vfov = args[3]
+        extracted_vfovs.append(extracted_vfov)
+
+    # All three extracted vfovs must be equal (rotation-invariant).
+    for i, pitch in enumerate(pitches):
+        assert abs(extracted_vfovs[i] - expected_vfov) < 1.0, (
+            f"At pitch={pitch}°: expected vfov≈{expected_vfov}°, "
+            f"got {extracted_vfovs[i]:.2f}°. "
+            f"Vfov extraction is NOT rotation-invariant — likely reading "
+            f"`perspective_matrix[1][1]` instead of `window_matrix[1][1]`."
+        )
+
+    # Sanity: all three must be within 0.5° of each other.
+    min_vfov = min(extracted_vfovs)
+    max_vfov = max(extracted_vfovs)
+    assert abs(max_vfov - min_vfov) < 0.5, (
+        f"Vfov extraction varies with rotation: "
+        f"{extracted_vfovs} across pitches {pitches}. "
+        f"Expected rotation-invariance."
+    )


### PR DESCRIPTION
## Summary

Fixes owner-reported symptom (2026-05-24): rotating/orbiting the 3D-view camera in Blender causes the rendered object to "shrink, grow, flip differently from how the camera is actually moving," and framing fails to line up with the viewport overlay.

**Root cause:** `blender_addon/__init__.py` extracted vfov from `rv3d.perspective_matrix[1][1]`. But `perspective_matrix = window_matrix @ view_matrix` (documented in Blender API), so rotation of the view couples into element `[1][1]`. As the user orbits, the extracted vfov grows and shrinks with `cos(pitch)`, etc.

**Fix:** Read `rv3d.window_matrix[1][1]`, which is the pure projection matrix (OpenGL convention `f = 1/tan(vfov/2)`) and is rotation-invariant.

**Affected sites:**
- `_setup_viewport_camera` (lines 1683-1700, PERSP/ORTHO branch)
- `_apply_camera` (lines 1824-1834, CAMERA-view branch)

## Test Evidence

**New test:** `tests/test_addon_viewport_camera_vfov.py`

Constructs synthetic `RegionView3D` states with different rotations (pitch 0°, 30°, -45°) but the **same projection matrix** (vfov=60°, aspect=4/3). Asserts the addon's vfov extractor returns the same vfov for all three (rotation-invariant).

**Before fix (on HEAD 130e25f):**
```
FAILED tests/test_addon_viewport_camera_vfov.py::test_vfov_extraction_is_rotation_invariant
AssertionError: At pitch=30.0°: expected vfov≈60.0°, got 67.38°.
Vfov extraction is NOT rotation-invariant — likely reading
`perspective_matrix[1][1]` instead of `window_matrix[1][1]`.
```

**After fix (this PR):**
```
tests/test_addon_viewport_camera_vfov.py::test_vfov_extraction_is_rotation_invariant PASSED [100%]
```

**Full Blender test suite:**
```
======================== 90 passed, 1 skipped in 1.52s ========================
```

## Reference

- **Spec:** `.astroray_plan/packages/pkg101-addon-viewport-camera-vfov-from-perspective-matrix.md`
- **Blender API:** `RegionView3D.perspective_matrix` (documented as `window_matrix @ view_matrix`)
- **OpenGL projection convention:** `window_matrix[1][1] = 1 / tan(vfov/2)` for symmetric frustum

🤖 Generated with [Claude Code](https://claude.com/claude-code)