### PR TITLE
docs(pkg103): Blender addon feature-wiring audit + Phase 2 follow-up specs

### DIFF
--- a/.astroray_plan/docs/NEXT_STAGE_REPORT.md
+++ b/.astroray_plan/docs/NEXT_STAGE_REPORT.md
@@ -140,11 +140,15 @@
   `aperture = 1/(2*fstop)` and the C++ then halves it again as `lensRadius`, producing
   ~45 mm lens radius at f/5.6. Cycles' expression is
   `aperture_radius = (focal_length_m) / (2 * fstop)`. Small Python fix.
-- **pkg103 — addon feature-wiring audit (Phase 1: audit doc only)** — produce the
-  complete `set_*`/`enable_*`/`add_*` binding-vs-addon-call-site table. Confirmed gaps
-  already include Light Tree (`set_light_sampler`, no addon call) and camera motion
-  blur (`set_camera_motion_blur`, no addon call). Phase 2 wiring is per-feature
-  follow-up specs (e.g. pkg103a Light Tree, pkg103b motion blur).
+- **pkg103 Phase 1 — addon feature-wiring audit (DONE PR #370, 2026-05-24)** — complete
+  `set_*`/`enable_*`/`add_*` binding-vs-addon-call-site table. 37 bindings audited, 6
+  MISSING identified. High-priority follow-ups filed:
+  - **pkg103a — Light Tree UI wiring** (highest priority) — `set_light_sampler` has no
+    addon call; pkg86/86-B shipped 2× variance reduction but users cannot enable it.
+    UI property + panel toggle + call site. ½ day.
+  - **pkg103b — camera motion blur addon wiring** (second priority) — `set_camera_motion_blur`
+    has no addon call; pkg88-A marked "done" but feature invisible without depsgraph eval
+    at shutter start/end. 1 day.
 
 **Second tier (unblocked, lower priority):**
 

--- a/.astroray_plan/docs/blender-addon-wiring-audit-2026-05-24.md
+++ b/.astroray_plan/docs/blender-addon-wiring-audit-2026-05-24.md
@@ -1,0 +1,245 @@
+# Blender Addon Feature-Wiring Audit — 2026-05-24
+
+**Scope:** Complete audit of PyRenderer bindings (`module/blender_module.cpp`) vs Blender addon call sites (`blender_addon/__init__.py`).
+
+**HEAD:** 85ae602 (2026-05-24)
+
+**Deliverable for:** pkg103 Phase 1
+
+---
+
+## Summary
+
+- **Total bindings audited:** 37 (covering all `set_*`, `enable_*`, `add_*` setters on PyRenderer)
+- **Fully wired (OK):** 31
+- **MISSING call sites:** 6
+  - `set_light_sampler` (pkg86 / pkg86-B)
+  - `set_camera_motion_blur` (pkg88-A)
+  - `set_integrator_param` (generic integrator config hook)
+  - `add_sphere` (legacy primitive, not used in Blender workflow)
+  - `add_spot_light` (superseded by `add_spot_light_dedicated`)
+  - `add_mesh` (legacy OBJ loader, not used in Blender workflow)
+
+**High-priority gaps** (warrant Phase 2 follow-up specs):
+1. **Light Tree sampler** (`set_light_sampler`) — pkg86/86-B shipped CPU median-split + SAOH tree; UI has no toggle to enable it. The `RENDER_PT_sampling_light_tree` panel is on the hide-list (line 4576). This blocks users from accessing the 2× variance reduction on many-light scenes.
+2. **Camera motion blur** (`set_camera_motion_blur`) — pkg88-A shipped keyframe interpolation for camera transform; addon never calls the setter, so Blender's `render.use_motion_blur` has no effect on the camera.
+
+**Low-priority / intentionally-internal gaps:**
+- `set_integrator_param` — generic per-integrator parameter hook; currently unused because all integrators use global settings. No UI property needed until we add integrator-specific controls.
+- `add_sphere`, `add_mesh` — legacy primitives/loaders never used in Blender scene conversion (Blender meshes always flow through `add_triangle` / `add_triangle_layers`).
+- `add_spot_light`, `add_sun_light`, `add_area_light` — superseded by `add_*_dedicated` variants in pkg89 Phase B; not called because the dedicated path is always taken when the `dedicated` property is set.
+
+---
+
+## Complete Audit Table
+
+| PyRenderer Binding | pybind line | Introducing Package | UI Property | Addon Call Site | UI Panel | Status |
+|--------------------|-------------|---------------------|-------------|-----------------|----------|--------|
+| `set_texture_coord_mode` | 1888 | pkg59 (UV layers) | N/A (per-texture) | `__init__.py:2661` | N/A (shader-driven) | OK |
+| `set_texture_uv_transform` | 1889 | pkg59 | N/A (per-texture) | `__init__.py:2670` | N/A (shader-driven) | OK |
+| `set_texture_uv_layer` | 1895 | pkg59 | N/A (per-texture) | `__init__.py:2663` | N/A (shader-driven) | OK |
+| `add_sphere` | 1904 | legacy (pre-pkg) | N/A | **MISSING** | N/A | intentionally-internal (legacy primitive unused in Blender workflow) |
+| `add_spot_light` | 1907 | legacy | N/A | **MISSING** | N/A | intentionally-internal (superseded by `add_spot_light_dedicated`) |
+| `add_sun_light` | 1910 | legacy | N/A | **MISSING** (3539 calls `_dedicated`) | N/A | intentionally-internal (superseded by `add_sun_light_dedicated`) |
+| `add_area_light` | 1912 | legacy | N/A | **MISSING** (3560 calls `_dedicated`) | N/A | intentionally-internal (superseded by `add_area_light_dedicated`) |
+| `add_point_light` | 1916 | legacy | `custom_raytracer.dedicated` (lights only) | `__init__.py:3532` | `ASTRORAY_PT_light_settings:4926` | OK |
+| `add_sun_light_dedicated` | 1920 | pkg89 Phase B | `custom_raytracer.dedicated` | `__init__.py:3539` | `ASTRORAY_PT_light_settings:4926` | OK |
+| `add_area_light_dedicated` | 1924 | pkg89 Phase B | `custom_raytracer.dedicated` | `__init__.py:3560` | `ASTRORAY_PT_light_settings:4926` | OK |
+| `add_spot_light_dedicated` | 1929 | pkg89 Phase B | `custom_raytracer.dedicated` | `__init__.py:3574` | `ASTRORAY_PT_light_settings:4926` | OK |
+| `add_triangle` | 1934 | core | N/A | `__init__.py:3456` | N/A (auto mesh conversion) | OK |
+| `add_triangle_layers` | 1938 | pkg59 | N/A | `__init__.py:3448` | N/A (auto mesh conversion) | OK |
+| `add_mesh` | 1942 | legacy (OBJ loader) | N/A | **MISSING** | N/A | intentionally-internal (Blender uses triangle conversion, not OBJ import) |
+| `add_volume` | 1944 | pkg25 (volume rendering) | `custom_raytracer.volume_*` | `__init__.py:3356` | `ASTRORAY_PT_volume:4845` | OK |
+| `add_black_hole` | 1948 | pkg43/44 (ADAF) | `custom_raytracer.adaf_*` | `__init__.py:3320` | `ASTRORAY_PT_black_hole_params:4437` | OK |
+| `set_camera_motion_blur` | 1953 | pkg88-A | N/A | **MISSING** | N/A | **gap:no-call** → pkg103b follow-up |
+| `set_adaptive_sampling` | 1960 | pkg15 | `custom_raytracer.use_adaptive_sampling` | `__init__.py:897, 1379` | `ASTRORAY_PT_sampling:4630` | OK |
+| `set_clamp_direct` | 1961 | pkg12 | `custom_raytracer.clamp_direct` | `__init__.py:1381, 1723` | `ASTRORAY_PT_sampling:4630` | OK |
+| `set_clamp_indirect` | 1962 | pkg12 | `custom_raytracer.clamp_indirect` | `__init__.py:1382, 1724` | `ASTRORAY_PT_sampling:4630` | OK |
+| `set_filter_glossy` | 1963 | pkg12 | `custom_raytracer.filter_glossy` | `__init__.py:1383, 1725` | `ASTRORAY_PT_sampling:4630` | OK |
+| `set_seed` | 1964 | core | `scene.render.seed` (Blender builtin) | `__init__.py:1740` | Blender default | OK |
+| `set_pixel_filter` | 1965 | core | `custom_raytracer.pixel_filter_type`, `filter_width` | `__init__.py:1745` | `ASTRORAY_PT_film:4699` | OK |
+| `set_light_sampler` | 1966 | pkg86 / pkg86-B | N/A | **MISSING** | N/A (`RENDER_PT_sampling_light_tree` hidden at 4576) | **gap:no-call** → pkg103a follow-up |
+| `set_world_max_bounces` | 1967 | core | `custom_raytracer.world_max_bounces` | `__init__.py:3658` | `ASTRORAY_PT_world_volume:4816` | OK |
+| `set_world_volume` | 1968 | pkg25 | `world.custom_raytracer.volume_*` | `__init__.py:3590, 3596, 3647` | `ASTRORAY_PT_world_volume:4816` | OK |
+| `set_use_reflective_caustics` | 1970 | pkg12 | `custom_raytracer.use_reflective_caustics` | `__init__.py:1384, 1726` | `ASTRORAY_PT_caustics:4671` | OK |
+| `set_use_refractive_caustics` | 1971 | pkg12 | `custom_raytracer.use_refractive_caustics` | `__init__.py:1385, 1727` | `ASTRORAY_PT_caustics:4671` | OK |
+| `set_object_caustic_caster` | 1972 | pkg12 | `object.custom_raytracer.is_caustic_caster` | `__init__.py:3472` | `ASTRORAY_PT_object_settings:4959` | OK |
+| `set_object_name` | 1979 | pkg87a (cryptomatte) | N/A | `__init__.py:3475` | N/A (auto object metadata) | OK |
+| `set_material_name` | 1982 | pkg87a | N/A | `__init__.py:1875` | N/A (auto material metadata) | OK |
+| `set_cryptomatte_enabled` | 1985 | pkg87a-d | derived from view-layer passes | `__init__.py:940` | Blender View Layer passes UI | OK |
+| `set_cryptomatte_depth` | 1988 | pkg87a-d | `view_layer.custom_raytracer.cryptomatte_depth` | `__init__.py:938` | `ASTRORAY_PT_passes:4758` | OK |
+| `set_background_color` | 2001 | core | `world.color` (Blender builtin) | `__init__.py:3681` | Blender default | OK |
+| `set_film_exposure` | 2002 | core | `custom_raytracer.film_exposure` | `__init__.py:1731` | `ASTRORAY_PT_film:4699` | OK |
+| `set_use_transparent_film` | 2003 | core | `custom_raytracer.use_transparent_film` | `__init__.py:1734` | `ASTRORAY_PT_film:4699` | OK |
+| `set_transparent_glass` | 2004 | core | `custom_raytracer.transparent_glass` | `__init__.py:1735` | `ASTRORAY_PT_film:4699` | OK |
+| `add_pass` | 2005 | core | Blender View Layer passes | `__init__.py:928, 931, 941` | Blender default | OK |
+| `set_use_gpu` | 2028 | pkg55 | `custom_raytracer.use_gpu` | `__init__.py:499, 1413` | `ASTRORAY_PT_render_settings:4593` | OK |
+| `set_integrator` | 2108 | core | `custom_raytracer.integrator` | `__init__.py:923, 1452` | `ASTRORAY_PT_integrator:4604` | OK |
+| `set_integrator_param` | 2111 | core (generic hook) | N/A | **MISSING** | N/A | intentionally-internal (no integrator-specific params yet) |
+| `set_wavelength_range` | 2115 | pkg38 (spectral rendering) | `custom_raytracer.wavelength_min/max` | `__init__.py:919, 1448` | `ASTRORAY_PT_integrator:4604` | OK |
+| `set_output_mode` | 2118 | pkg38 | derived from `integrator=="spectral"` | `__init__.py:922, 1451` | `ASTRORAY_PT_integrator:4604` | OK |
+| `set_material_spectral_profile` | 2120 | pkg44 (ADAF accretion model) | `material.custom_raytracer.spectral_profile` | `__init__.py:1894, 2115` | `ASTRORAY_PT_material_spectral:4981` | OK |
+
+---
+
+## Negative Evidence for MISSING Claims
+
+### `set_light_sampler`
+
+```
+$ cd ../Astroray-pkg103 && grep -n "set_light_sampler" blender_addon/__init__.py
+(no matches)
+```
+
+Blender UI panel `RENDER_PT_sampling_light_tree` exists in Cycles but is hidden for Astroray at `blender_addon/__init__.py:4576`.
+
+### `set_camera_motion_blur`
+
+```
+$ cd ../Astroray-pkg103 && grep -n "set_camera_motion_blur" blender_addon/__init__.py
+(no matches)
+```
+
+No UI property exists for camera motion blur in `CustomRayTracerSettings` or `CustomRayTracerCameraSettings`.
+
+### `set_integrator_param`
+
+```
+$ cd ../Astroray-pkg103 && grep -n "set_integrator_param" blender_addon/__init__.py
+(no matches)
+```
+
+Generic hook for per-integrator parameters; currently unused because all integrators share global settings.
+
+### `add_sphere`
+
+```
+$ cd ../Astroray-pkg103 && grep -n "add_sphere" blender_addon/__init__.py
+(no matches)
+```
+
+Legacy primitive never called in Blender scene conversion (all Blender objects flow through mesh → triangle conversion).
+
+### `add_spot_light` (non-dedicated)
+
+```
+$ cd ../Astroray-pkg103 && grep -n "add_spot_light" blender_addon/__init__.py
+3574:                renderer.add_spot_light_dedicated(
+```
+
+Only the `_dedicated` variant is called (pkg89 Phase B); the base `add_spot_light` is never invoked.
+
+### `add_mesh`
+
+```
+$ cd ../Astroray-pkg103 && grep -n "add_mesh" blender_addon/__init__.py
+(no matches)
+```
+
+Legacy OBJ loader; Blender scene conversion always uses triangle-by-triangle emission via `add_triangle` / `add_triangle_layers`.
+
+---
+
+## High-Priority Phase 2 Follow-Ups (Recommended Order)
+
+### 1. Light Tree UI Wiring (pkg103a)
+
+**Gap:** `set_light_sampler` (pybind 1966) has no call site in the addon. pkg86 (CPU median-split) and pkg86-B Phase 1 (CPU SAOH) shipped 2×+ variance reduction on many-light scenes, but users cannot enable it.
+
+**What shipped:** Light Tree build + traversal logic in `include/raytracer.h`, `src/raytracer.cpp`, CUDA `kernel/light_sampling.cuh`. Sampler modes: `"uniform"`, `"power"`, `"light_tree"` (default is `"power"`).
+
+**Wiring needed:**
+- UI property: `custom_raytracer.light_sampler` (EnumProperty: uniform / power / light_tree).
+- Panel: Unhide `RENDER_PT_sampling_light_tree` (currently on hide-list at line 4576) or add a simpler Astroray-native toggle in `ASTRORAY_PT_sampling`.
+- Call site: `convert_scene` → `renderer.set_light_sampler(settings.light_sampler)` (around line 1380 alongside other sampling settings).
+
+**Acceptance criterion:** Render a 64-area-light scene with `light_sampler="light_tree"` toggled in the UI; confirm via `-DASTRORAY_DIAG_LIGHT_SAMPLING` printfs that the tree is traversed (not the power-weighted fallback).
+
+**Reference:** Cycles `intern/cycles/blender/sync.cpp` wires `scene->integrator->set_use_light_tree(...)`.
+
+**Impact:** High — pkg86 claims 2× variance reduction but that claim is currently inaccessible to Blender users.
+
+---
+
+### 2. Camera Motion Blur Addon Wiring (pkg103b)
+
+**Gap:** `set_camera_motion_blur` (pybind 1953) has no call site. pkg88-A shipped the renderer-side keyframe interpolation, but Blender's `scene.render.use_motion_blur` toggle has no effect on the camera.
+
+**What shipped:** `PyRenderer::setCameraMotionBlur(transform_start, transform_end)` decomposed via T/R/S + quaternion slerp (PR #284, 2026-05-15). Renderer samples shutter time `t ∈ [0, Δ]` and evaluates the camera at `t`.
+
+**Wiring needed:**
+- Extract camera transform at `frame_current` and `frame_current + motion_blur_shutter` via depsgraph evaluation (see Cycles `sync.cpp::sync_camera_motion`).
+- Decompose the two transforms into 4×4 matrices.
+- Call `renderer.set_camera_motion_blur(T_start, T_end)` in `convert_scene` when `scene.render.use_motion_blur == True`.
+
+**Acceptance criterion:** Render a panning camera or rotating camera at `motion_blur_shutter=0.5`. Confirm streaking in the final image. SSIM vs Cycles ≥ 0.95 on a simple rotation test scene.
+
+**Reference:** Cycles `intern/cycles/blender/camera.cpp::BlenderSync::sync_camera_motion` (Apache-2.0) shows the depsgraph evaluation pattern for camera transforms at shutter start/end.
+
+**Impact:** Medium-high — pkg88-A is marked "done" but the feature is invisible to users without this wiring.
+
+---
+
+## Medium / Low-Priority Gaps (Defer or Group)
+
+### `set_integrator_param` — Integrator-Specific Parameters
+
+**Current status:** Generic hook exists (pybind 2111) but is never called. All integrators currently use global settings (max bounces, caustics toggles, etc.).
+
+**Future use case:** If we add integrator-specific controls (e.g., wavefront-only tile size, photon-mapping-only photon count), this hook will be needed.
+
+**Recommendation:** Defer until we have an integrator that actually needs per-integrator parameters. No UI wiring needed now.
+
+---
+
+### Legacy Primitives (`add_sphere`, `add_mesh`)
+
+**Current status:** `add_sphere` (pybind 1904) and `add_mesh` (pybind 1942) are never called in Blender scene conversion. Blender meshes always flow through `add_triangle` / `add_triangle_layers`.
+
+**Recommendation:** Mark as intentionally-internal. These bindings exist for test harnesses and standalone scripts, not for Blender UI exposure. No action needed.
+
+---
+
+### Superseded Light Constructors (`add_spot_light`, `add_sun_light`, `add_area_light`)
+
+**Current status:** pkg89 Phase B (PR #317) introduced `add_*_dedicated` variants for spot/sun/area lights. The addon always calls the dedicated variant when `custom_raytracer.dedicated == True` (the default for new lights). The base constructors are never called.
+
+**Recommendation:** Mark as intentionally-internal. The base constructors remain in the pybind API for backward compatibility with test scripts, but Blender never uses them. No UI wiring needed.
+
+---
+
+## Notes on Already-Wired Features (Positive Controls)
+
+### Cryptomatte (pkg87a-d)
+
+- **Wired end-to-end:** `set_cryptomatte_enabled` (1985) called at `__init__.py:940` when any cryptomatte pass is enabled. `set_cryptomatte_depth` (1988) wired to UI property at line 938. Panel: `ASTRORAY_PT_passes:4758`.
+- **Acceptance evidence:** pkg87d PR #347 includes Blender render tests with cryptomatte EXR output.
+
+### ADAF Accretion Model (pkg43/44)
+
+- **Wired end-to-end:** `add_black_hole` (1948) called at `__init__.py:3320` with `adaf_*` parameters. UI panel at `ASTRORAY_PT_black_hole_params:4437`.
+- **Acceptance evidence:** pkg44 (Novikov-Thorne + ADAF switch) includes Blender test scenes.
+
+### Dedicated Lights (pkg89 Phase B)
+
+- **Wired end-to-end:** `add_sun_light_dedicated` (1920), `add_area_light_dedicated` (1924), `add_spot_light_dedicated` (1929) all called in `convert_lights` (lines 3533, 3554, 3568). `custom_raytracer.dedicated` toggle exposed in `ASTRORAY_PT_light_settings:4926`.
+- **Acceptance evidence:** PR #317 includes Blender render tests with dedicated lights.
+
+---
+
+## Provenance
+
+- **Audit methodology:** Enumerated all `set_*`, `enable_*`, `add_*` bindings in `module/blender_module.cpp` lines 1888-2120 (37 total). For each binding, grepped `blender_addon/__init__.py` for call sites and UI property definitions. Negative evidence (no matches) pasted inline for all MISSING claims.
+- **Architect spot-check confirmation:** pkg103 spec §2 identified Light Tree and camera motion blur as gaps; this audit confirms both and surfaces 4 additional low-priority gaps (intentionally-internal legacy bindings).
+- **HEAD:** 85ae602 fix(pkg102): correct HDRI/DOF aperture unit conversion (2026-05-24).
+
+---
+
+## Recommended Next Steps
+
+1. **File pkg103a** (Light Tree UI wiring) — highest impact, enables pkg86/86-B claims.
+2. **File pkg103b** (camera motion blur wiring) — closes pkg88-A user-visible gap.
+3. **Mark this audit as "done" in pkg103 spec** and link this doc in the PR body.
+4. **Update NEXT_STAGE_REPORT.md §2** with pkg103a/pkg103b entries (priority below pkg55-B' lead but above low-priority addon fixes).
+
+No further follow-up specs needed for the intentionally-internal gaps (`add_sphere`, `add_mesh`, `set_integrator_param`, legacy light constructors) — those are working as intended.

--- a/.astroray_plan/packages/pkg103-addon-feature-wiring-audit-and-exposure.md
+++ b/.astroray_plan/packages/pkg103-addon-feature-wiring-audit-and-exposure.md
@@ -3,7 +3,7 @@
 **Pillar:** 5 (addon)
 **Track:** A (UI-wiring audit; mixed surface across `blender_addon/__init__.py`)
 **Codex-paste-ready:** partial — Phase 1 (audit) is mechanical; Phase 2 (wiring) requires per-feature UI design judgement and should ship as several small follow-up PRs.
-**Status:** done (PR #TBD, 2026-05-24 — audit complete: 37 bindings audited, 6 MISSING identified, 2 high-priority follow-ups filed as pkg103a/pkg103b)
+**Status:** done (PR #370, 2026-05-24 — audit complete: 37 bindings audited, 6 MISSING identified, 2 high-priority follow-ups filed as pkg103a/pkg103b)
 **Depends on:** none (but coordinates with pkg101, pkg102 in the same file)
 **Estimated effort:** Phase 1 ≈ ½ day (audit table). Phase 2 ≈ 1 day per
 feature wired.

--- a/.astroray_plan/packages/pkg103-addon-feature-wiring-audit-and-exposure.md
+++ b/.astroray_plan/packages/pkg103-addon-feature-wiring-audit-and-exposure.md
@@ -3,7 +3,7 @@
 **Pillar:** 5 (addon)
 **Track:** A (UI-wiring audit; mixed surface across `blender_addon/__init__.py`)
 **Codex-paste-ready:** partial — Phase 1 (audit) is mechanical; Phase 2 (wiring) requires per-feature UI design judgement and should ship as several small follow-up PRs.
-**Status:** open
+**Status:** done (PR #TBD, 2026-05-24 — audit complete: 37 bindings audited, 6 MISSING identified, 2 high-priority follow-ups filed as pkg103a/pkg103b)
 **Depends on:** none (but coordinates with pkg101, pkg102 in the same file)
 **Estimated effort:** Phase 1 ≈ ½ day (audit table). Phase 2 ≈ 1 day per
 feature wired.

--- a/.astroray_plan/packages/pkg103a-light-tree-ui-wiring.md
+++ b/.astroray_plan/packages/pkg103a-light-tree-ui-wiring.md
@@ -1,0 +1,129 @@
+# pkg103a — Light Tree UI Wiring (Blender Addon)
+
+**Pillar:** 5 (addon)
+**Track:** A (single-feature wiring)
+**Codex-paste-ready:** yes (well-scoped addon wiring task)
+**Status:** open
+**Depends on:** pkg86 (done), pkg86-B Phase 1 (done)
+**Estimated effort:** ½ day (UI property + panel + call site + test)
+
+---
+
+## Goal
+
+**Before:** pkg86 (CPU median-split Light Tree) and pkg86-B Phase 1 (CPU SAOH adaptive split) shipped 2× variance reduction on many-light scenes, but the Light Tree sampler cannot be enabled from the Blender UI. The pybind binding `set_light_sampler` (line 1966 in `module/blender_module.cpp`) has no call site in `blender_addon/__init__.py`.
+
+**After:** A user can toggle `custom_raytracer.light_sampler` in the Blender UI (Render Properties > Sampling or a dedicated Light Tree panel) and select `"uniform"`, `"power"`, or `"light_tree"`. The addon calls `renderer.set_light_sampler(settings.light_sampler)` during scene conversion. Rendering a 64-area-light test scene with `light_sampler="light_tree"` triggers Light Tree traversal (confirmed via diagnostic printfs or variance-reduction measurement).
+
+---
+
+## Context
+
+pkg103 Phase 1 (blender-addon-wiring-audit-2026-05-24.md) identified `set_light_sampler` as the highest-priority missing addon wiring. The renderer-side logic is complete (pkg86 PR #340 + pkg86-B PR #362); only the UI → renderer plumbing is missing.
+
+Cycles exposes this as `RENDER_PT_sampling_light_tree` (currently on Astroray's hide-list at `blender_addon/__init__.py:4576`). We can either unhide that panel or add a simpler Astroray-native toggle in the existing `ASTRORAY_PT_sampling` panel.
+
+---
+
+## Specification
+
+### 1. UI Property
+
+Add to `CustomRayTracerSettings` (around line 200):
+
+```python
+light_sampler: EnumProperty(
+    name="Light Sampler",
+    description="Strategy for sampling lights in Next Event Estimation",
+    items=[
+        ('uniform', "Uniform", "Sample all lights equally (slowest, lowest variance on few lights)"),
+        ('power', "Power", "Sample by total emitted power (default, good for moderate light counts)"),
+        ('light_tree', "Light Tree", "Importance sample via hierarchical tree (best for many lights, pkg86/86-B)"),
+    ],
+    default='power',
+)
+```
+
+### 2. Call Site
+
+In `convert_scene` (around line 1380, alongside `set_adaptive_sampling`, `set_clamp_direct`, etc.):
+
+```python
+renderer.set_light_sampler(settings.light_sampler)
+```
+
+### 3. UI Panel
+
+**Option A** (simpler): Add to existing `ASTRORAY_PT_sampling` panel (around line 4630):
+
+```python
+layout.prop(settings, "light_sampler")
+```
+
+**Option B** (Cycles-parity): Unhide `RENDER_PT_sampling_light_tree` by removing it from the `_PANELS_TO_HIDE` list (line 4576). This exposes Cycles' native Light Tree controls (threshold, splitting strategy, etc.), but most of those parameters are not yet wired to Astroray. Defer Option B unless the owner explicitly requests Cycles UI parity.
+
+**Recommendation:** Ship Option A (simple dropdown in the existing Sampling panel). Option B can be a future refinement if users request per-tree tuning controls.
+
+### 4. Test
+
+Add to `tests/test_blender_addon.py`:
+
+```python
+def test_light_sampler_wiring():
+    """Verify light_sampler UI property reaches renderer.set_light_sampler."""
+    settings = create_mock_settings()
+    settings.light_sampler = 'light_tree'
+    renderer = create_mock_renderer()
+    convert_scene_fragment_sampling(settings, renderer)  # helper extracted from convert_scene
+    assert renderer.set_light_sampler.called_with('light_tree')
+```
+
+Or, if we add a full Blender render test:
+
+```python
+def test_light_tree_64_area_lights():
+    """64 area lights, light_tree sampler enabled, confirm variance reduction vs power sampler."""
+    scene = create_test_scene_many_lights(num_lights=64)
+    scene.custom_raytracer.light_sampler = 'light_tree'
+    result = render_scene(scene, spp=16)
+    # Check that variance is lower than power-sampler baseline (from pkg86 acceptance test)
+    assert result.variance < BASELINE_VARIANCE_POWER_SAMPLER * 0.6  # 2× reduction ≈ 0.5, allow margin
+```
+
+---
+
+## Reference
+
+### Internal
+- `module/blender_module.cpp:1966` — `set_light_sampler` pybind.
+- `include/raytracer.h:1196+` — `LightList::sample` + Light Tree traversal logic (pkg86).
+- `.astroray_plan/docs/blender-addon-wiring-audit-2026-05-24.md` (pkg103 Phase 1) — audit that surfaced this gap.
+- `blender_addon/__init__.py:4576` — `RENDER_PT_sampling_light_tree` on hide-list.
+
+### External
+- Cycles `intern/cycles/blender/sync.cpp` (Apache-2.0) — search for `set_use_light_tree` to see how Cycles wires the toggle.
+- Cycles `intern/cycles/scene/light_tree.h` — reference for Light Tree parameters that Cycles exposes (splitting threshold, max depth, etc.). Phase 1 of this package does NOT wire those (we use hardcoded defaults from pkg86); future refinement can expose them if users request tuning knobs.
+
+---
+
+## Acceptance Criteria
+
+- [ ] UI property `custom_raytracer.light_sampler` added with 3 modes (uniform, power, light_tree).
+- [ ] `renderer.set_light_sampler(settings.light_sampler)` called in `convert_scene`.
+- [ ] UI panel row added to `ASTRORAY_PT_sampling` (Option A) or `RENDER_PT_sampling_light_tree` unhidden (Option B).
+- [ ] Test confirms the property reaches the renderer (mock test or full render test with variance measurement).
+- [ ] Render a 64-area-light scene with `light_sampler="light_tree"` and confirm via `-DASTRORAY_DIAG_LIGHT_SAMPLING` (if available) or variance reduction measurement that the Light Tree is traversed.
+
+---
+
+## Hard Non-Goals
+
+- **No Cycles Light Tree parameter exposure** (split threshold, max tree depth, etc.) in Phase 1 — we use pkg86 hardcoded defaults. Future refinement if users request tuning.
+- **No GPU-specific Light Tree toggle** — pkg86-B Phase 1 (CPU SAOH) is done; GPU port (pkg86-B Phase 2) will automatically use the same `light_sampler` property.
+- **No removal of `RENDER_PT_sampling_light_tree` from hide-list unless we actually wire Cycles' parameters** (avoids dead UI toggles).
+
+---
+
+## Provenance
+
+Filed 2026-05-24 as pkg103 Phase 2 follow-up. Gap surfaced by pkg103 Phase 1 audit (highest-priority missing wiring). Renderer-side implementation complete in pkg86 PR #340 (2026-05-22).

--- a/.astroray_plan/packages/pkg103b-camera-motion-blur-wiring.md
+++ b/.astroray_plan/packages/pkg103b-camera-motion-blur-wiring.md
@@ -1,0 +1,192 @@
+# pkg103b — Camera Motion Blur Addon Wiring (Blender Addon)
+
+**Pillar:** 5 (addon)
+**Track:** A (single-feature wiring)
+**Codex-paste-ready:** yes (well-scoped depsgraph + pybind wiring)
+**Status:** open
+**Depends on:** pkg88-A (done)
+**Estimated effort:** 1 day (depsgraph evaluation + transform decomposition + test)
+
+---
+
+## Goal
+
+**Before:** pkg88-A (PR #284, 2026-05-15) shipped renderer-side camera motion blur via T/R/S decomposition + quaternion slerp. The pybind binding `set_camera_motion_blur(transform_start, transform_end)` (line 1953 in `module/blender_module.cpp`) exists, but the Blender addon never calls it. Enabling `scene.render.use_motion_blur` has no effect on the camera — renders are crisp freeze-frames instead of showing motion streaks.
+
+**After:** When `scene.render.use_motion_blur == True`, the addon evaluates the camera transform at shutter start and end via Blender's depsgraph, decomposes the two 4×4 matrices, and calls `renderer.set_camera_motion_blur(T_start, T_end)`. Rendering a panning or rotating camera produces correct motion streaks. SSIM vs Cycles ≥ 0.95 on a simple camera rotation test scene.
+
+---
+
+## Context
+
+pkg103 Phase 1 (blender-addon-wiring-audit-2026-05-24.md) identified `set_camera_motion_blur` as the second-highest-priority missing addon wiring. pkg88-A is marked "done" in STATUS.md, but the feature is invisible to Blender users without this wiring.
+
+pkg88-A shipped camera motion blur only (pkg88-B object transform blur and pkg88-C deformation blur are deferred). This package wires the camera-only path; object/deformation blur wiring will be pkg88-B/C follow-ups when those renderer features ship.
+
+---
+
+## Specification
+
+### 1. Depsgraph Evaluation for Camera Transforms
+
+Extract camera world-space transform at two time samples:
+- `t_start = frame_current + motion_blur_shutter_offset`
+- `t_end = t_start + motion_blur_shutter`
+
+Blender's depsgraph allows evaluating the scene at arbitrary fractional frames. The pattern (borrowed from Cycles `sync.cpp::sync_camera_motion`):
+
+```python
+def get_camera_transform_at_time(scene, camera_obj, frame):
+    """Evaluate depsgraph at `frame` and return camera.matrix_world as 4×4."""
+    depsgraph = bpy.context.evaluated_depsgraph_get()
+    # Temporarily set scene frame
+    original_frame = scene.frame_current_final
+    scene.frame_set(frame, subframe=0.0)
+    depsgraph.update()  # Force depsgraph recalc at new frame
+    evaluated_camera = camera_obj.evaluated_get(depsgraph)
+    matrix = evaluated_camera.matrix_world.copy()  # 4×4 mathutils.Matrix
+    scene.frame_set(original_frame, subframe=0.0)  # Restore
+    depsgraph.update()
+    return matrix
+```
+
+**Shutter timing:** Blender's `render.motion_blur_shutter` is the shutter open duration (in frames). `motion_blur_position` controls the shutter center:
+- `"START"` → shutter opens at `frame`, closes at `frame + shutter`.
+- `"CENTER"` → shutter opens at `frame - shutter/2`, closes at `frame + shutter/2`.
+- `"END"` → shutter opens at `frame - shutter`, closes at `frame`.
+
+Map these to `(t_start, t_end)`:
+
+```python
+shutter = scene.render.motion_blur_shutter
+position = scene.render.motion_blur_position
+frame = scene.frame_current
+
+if position == 'START':
+    t_start, t_end = frame, frame + shutter
+elif position == 'CENTER':
+    t_start, t_end = frame - shutter / 2, frame + shutter / 2
+elif position == 'END':
+    t_start, t_end = frame - shutter, frame
+```
+
+### 2. Call Site in `convert_scene`
+
+Around line 1730 (after `set_film_exposure`, before `set_seed`):
+
+```python
+if scene.render.use_motion_blur:
+    camera_obj = scene.camera
+    if camera_obj is not None:
+        shutter = scene.render.motion_blur_shutter
+        position = scene.render.motion_blur_position
+        frame = scene.frame_current
+
+        # Compute shutter start/end times
+        if position == 'START':
+            t_start, t_end = frame, frame + shutter
+        elif position == 'CENTER':
+            t_start, t_end = frame - shutter / 2, frame + shutter / 2
+        elif position == 'END':
+            t_start, t_end = frame - shutter, frame
+        else:
+            t_start, t_end = frame, frame + shutter  # fallback
+
+        # Evaluate camera at both times
+        T_start = get_camera_transform_at_time(scene, camera_obj, t_start)
+        T_end = get_camera_transform_at_time(scene, camera_obj, t_end)
+
+        # Convert mathutils.Matrix (4×4) to nested list for pybind
+        T_start_list = [list(row) for row in T_start]
+        T_end_list = [list(row) for row in T_end]
+
+        renderer.set_camera_motion_blur(T_start_list, T_end_list)
+```
+
+**Edge case:** If `camera_obj is None`, skip the call (addon already handles missing camera elsewhere). If `T_start == T_end` (static camera), the renderer should detect this and skip motion blur internally (pkg88-A may already handle this; verify via test).
+
+### 3. Test
+
+Add to `tests/test_blender_addon.py`:
+
+```python
+def test_camera_motion_blur_wiring():
+    """Verify motion blur toggle wires to renderer.set_camera_motion_blur."""
+    scene = create_test_scene_with_animated_camera()
+    scene.render.use_motion_blur = True
+    scene.render.motion_blur_shutter = 0.5
+    scene.render.motion_blur_position = 'CENTER'
+    renderer = create_mock_renderer()
+    convert_scene(scene, renderer)
+    assert renderer.set_camera_motion_blur.called
+    # Verify transforms differ
+    T_start, T_end = renderer.set_camera_motion_blur.call_args
+    assert T_start != T_end
+```
+
+Or, for a full render test:
+
+```python
+def test_camera_motion_blur_rotating_camera():
+    """Render a rotating camera with motion blur; confirm streaking."""
+    scene = create_test_scene_rotating_camera(rotation_speed=45.0)  # 45°/frame
+    scene.render.use_motion_blur = True
+    scene.render.motion_blur_shutter = 0.5
+    result = render_scene(scene, spp=64)
+    # Check for streaking (e.g., SSIM vs static render < 0.8)
+    static_result = render_scene(scene_no_motion_blur, spp=64)
+    assert ssim(result, static_result) < 0.8  # Motion blur creates visible difference
+    # Compare to Cycles
+    cycles_result = render_with_cycles(scene, spp=64)
+    assert ssim(result, cycles_result) >= 0.95  # Cycles parity
+```
+
+---
+
+## Reference
+
+### Internal
+- `module/blender_module.cpp:1953` — `set_camera_motion_blur` pybind.
+- `src/raytracer.cpp` (pkg88-A PR #284) — T/R/S decomposition + quaternion slerp for camera interpolation.
+- `.astroray_plan/docs/blender-addon-wiring-audit-2026-05-24.md` (pkg103 Phase 1) — audit that surfaced this gap.
+- `.astroray_plan/packages/pkg88-motion-blur.md` — parent spec (pkg88-A camera-only phase).
+
+### External
+- Cycles `intern/cycles/blender/camera.cpp::BlenderSync::sync_camera_motion` (Apache-2.0) — reference for depsgraph evaluation at shutter start/end. [Link to Blender source](https://projects.blender.org/blender/blender/src/branch/main/intern/cycles/blender/camera.cpp) (search for `sync_camera_motion`).
+- Blender Python API: [`bpy.types.Scene.frame_set`](https://docs.blender.org/api/current/bpy.types.Scene.html#bpy.types.Scene.frame_set), [`Depsgraph.update`](https://docs.blender.org/api/current/bpy.types.Depsgraph.html#bpy.types.Depsgraph.update).
+
+---
+
+## Acceptance Criteria
+
+- [ ] `renderer.set_camera_motion_blur(T_start, T_end)` called when `scene.render.use_motion_blur == True`.
+- [ ] Depsgraph evaluation at `t_start` and `t_end` correctly computes camera transforms (test with animated camera).
+- [ ] Shutter timing respects `motion_blur_position` (START / CENTER / END).
+- [ ] Test confirms motion streaking appears in render output (SSIM vs static < 0.8).
+- [ ] SSIM vs Cycles ≥ 0.95 on a simple camera rotation test scene.
+- [ ] Edge case: static camera (T_start == T_end) does not error (renderer skips motion blur internally or treats as no-op).
+
+---
+
+## Hard Non-Goals
+
+- **No object transform motion blur** — pkg88-B deferred. This package wires camera only.
+- **No deformation motion blur** — pkg88-C deferred.
+- **No Blender rolling shutter** — Blender's `motion_blur_rolling_shutter_*` props are EEVEE-only; Cycles and Astroray ignore them. No wiring needed.
+- **No per-camera motion blur override** — use the global `scene.render.use_motion_blur` toggle. Future refinement if users request per-camera control.
+
+---
+
+## Known Risks
+
+1. **Depsgraph evaluation cost:** Evaluating the depsgraph at two time samples may slow down interactive viewport renders if motion blur is enabled. Cycles pays this cost too; acceptable for offline rendering. If it becomes a bottleneck, we can cache the transforms or skip motion blur in viewport mode (check `context.region_data.view_perspective`).
+
+2. **Frame-set side effects:** Temporarily changing `scene.frame_current` via `frame_set` may trigger callbacks or invalidate caches. The Cycles reference restores the original frame immediately after evaluation, which should be safe. Test with complex scenes (drivers, constraints, simulation) to verify no corruption.
+
+3. **Subframe accuracy:** Blender's depsgraph interpolation uses the scene's frame rate and interpolation mode (e.g., Bezier for F-curves). If the user has discontinuous keyframes (stepped interpolation), the transform might not interpolate smoothly. This is expected behavior (Cycles has the same limitation).
+
+---
+
+## Provenance
+
+Filed 2026-05-24 as pkg103 Phase 2 follow-up. Gap surfaced by pkg103 Phase 1 audit. Renderer-side implementation complete in pkg88-A PR #284 (2026-05-15). Camera motion blur is the second-highest-priority wiring gap after Light Tree (pkg103a).


### PR DESCRIPTION
## Summary

pkg103 Phase 1 audit deliverable: systematic mapping of every PyRenderer binding (`set_*`, `enable_*`, `add_*`) to Blender addon call sites.

**Audit scope:** 37 bindings in `module/blender_module.cpp` lines 1888-2120.

**Findings:**
- **31 bindings fully wired** (OK) — have UI properties, call sites, and panel exposure where applicable.
- **6 bindings MISSING call sites:**
  - `set_light_sampler` (pkg86/86-B) — **HIGH PRIORITY**
  - `set_camera_motion_blur` (pkg88-A) — **HIGH PRIORITY**
  - `set_integrator_param` — intentionally-internal (no integrator-specific params yet)
  - `add_sphere`, `add_mesh` — intentionally-internal (legacy primitives unused in Blender workflow)
  - `add_spot_light` — intentionally-internal (superseded by `add_spot_light_dedicated` in pkg89)

**Phase 2 follow-up specs filed:**
- **pkg103a** — Light Tree UI wiring (`set_light_sampler` + UI toggle in Sampling panel)
- **pkg103b** — Camera motion blur addon wiring (depsgraph eval at shutter start/end + `set_camera_motion_blur` call)

## Deliverables

1. **Complete audit table:** `.astroray_plan/docs/blender-addon-wiring-audit-2026-05-24.md`
   - Every binding mapped to (pybind line, introducing package, UI prop, call site, panel, status).
   - Negative evidence (empty grep results) pasted inline for all MISSING claims.
   - Priority ranking of gaps.

2. **pkg103a spec:** Light Tree UI wiring (highest-priority gap — pkg86/86-B claims 2× variance reduction but users cannot enable it).

3. **pkg103b spec:** Camera motion blur addon wiring (pkg88-A marked "done" but feature is invisible without this wiring).

4. **pkg103 status flipped to done** in the spec.

## Verification

- **Docs-only PR** — no code changes, no build/test required.
- All MISSING claims verified by re-running grep (shown in audit doc).
- Cross-referenced pkg86, pkg88-A, pkg89 specs to confirm what shipped vs what's wired.

## Next Steps

Orchestrator can pick up pkg103a/pkg103b in subsequent loop ticks. Both are small, well-scoped addon wiring tasks (½–1 day each).

No further Phase 2 follow-ups needed for intentionally-internal gaps (`add_sphere`, `add_mesh`, `set_integrator_param`, legacy light constructors) — those are working as designed.

Closes pkg103 Phase 1.