### PR TITLE
docs(pkg64-gpu): Session 2 Phase 1 research — naive port breaks receiver-energy

### DIFF
--- a/.astroray_plan/docs/pkg64-gpu-session2-research.md
+++ b/.astroray_plan/docs/pkg64-gpu-session2-research.md
@@ -1,0 +1,133 @@
+# pkg64-gpu Session 2 — Research notes (2026-05-28)
+
+**Author:** Claude Code overnight session
+**Status:** investigation only, no implementation landed
+**Triggers acceptance:** Phase 1 of pkg64-gpu-sellmeier-session2-multi-ior
+
+---
+
+## Goal recap
+
+Close the deferred Phase 3 gates from pkg64-gpu Session 1 (PR #354):
+- `test_pkg64_gpu_cpu_parity_ssim`: SSIM ≥ 0.97 (baseline 0.523)
+- `test_pkg64_gpu_phase3_prism_psnr_floor`: PSNR floor ≥ −0.5 dB (baseline −2.13 dB)
+
+Without losing the receiver-energy gate (≥ 1.10×, baseline 1.17×).
+
+---
+
+## What I tried tonight
+
+**Naive "mirror CPU" approach:** call `lambdas.terminateSecondary()` on the GPU dielectric path after a wavelength-dependent refraction (mirrors `plugins/materials/dielectric.cpp:181-188` exactly).
+
+**Result:** the receiver-energy gate regressed from 1.17× → 0.98× (caustic energy effectively vanishes). SSIM did NOT improve — it went from 0.523 → 0.485.
+
+**Diagnosis:** terminating secondaries on the GPU side reduces the spectral throughput by ~4× (only the hero contributes after the dispersive vertex). The CPU does the same operation but its receiver-energy gate continues to pass; either:
+1. The CPU's spectral path-integration applies a compensation factor that the GPU integration doesn't.
+2. The CPU's deferred-tests baseline was captured with `terminateSecondary` active AND a smaller absolute energy.
+3. The GPU receiver-energy gate compares with-caustics-ON vs OFF, and the OFF baseline implicitly carries the 4-wavelength contribution; after `terminateSecondary` only the ON branch shrinks, breaking the ratio.
+
+Hypothesis (3) is the most plausible: the test reads `ratio = E_on / E_off`. Before my change, both branches were at "4-wavelength energy" so the caustic energy added a clean +17%. After my change, the ON branch's caustic contribution is per-ray ~1/4 the size, so the ratio drops below 1.0.
+
+The fix is therefore NOT a one-line `terminateSecondary` call. It needs either:
+- A compensation factor that re-normalises the hero's contribution to account for the killed secondaries (the actual Wilkie 2014 hero-wavelength MIS formulation).
+- Or splitting into N rays per dispersive hit (Option A from the spec).
+
+This matches what the original spec said: Option B is NOT a trivial port; it's a real MIS implementation. The "naive terminate-only" approach is below what Session 2 actually needs.
+
+---
+
+## What the proper Option B implementation looks like
+
+Cycles `intern/cycles/kernel/svm/closure_principled.h` hero-wavelength branch (Apache-2.0). Key points:
+
+1. **At a dispersive vertex**, evaluate `n(λ_i)` for **all** sampled wavelengths.
+2. **Pick the hero** wavelength's refraction direction.
+3. **Compute MIS weight** per wavelength i: `w_i = power_heuristic(pdf_i_at_hero_direction, sum_j(pdf_j))`. For delta materials, `pdf_i` at the hero's direction is 1 if `n_i == n_hero` (i.e., only the hero itself contributes), else 0. This effectively makes the weights `[1, 0, 0, 0]` — the hero gets full weight, others get zero.
+4. **Update throughput**: `throughput[i] *= w_i * eta_i^2` for each i. For Option B's full formulation, `w_i` is the MIS weight (1 for hero, 0 for others at a delta vertex), so secondaries DO get killed — but the hero is NOT also scaled by 1/4. So the energy is preserved.
+
+The key difference from the naive `terminateSecondary` approach: in proper MIS, the hero's contribution is **not divided by N**. The hero carries the full energy because we sampled it with the full pdf.
+
+In practice: `throughput[hero] *= eta^2` (unchanged), `throughput[non-hero] *= 0`. The pdf array gets `[1, 0, 0, 0]` in some sense, but the wavelength sample-count is preserved by the path's downstream integration.
+
+---
+
+## Recommended Phase 2 implementation
+
+```cuda
+__device__ inline GBSDFSample gpu_dielectric_sample_spectral(
+    const GMaterial& mat, GHitRecord& rec, const GVec3& wo,
+    GSampledWavelengths& lambdas, curandState* rng)
+{
+    GBSDFSample s;
+    s.isDelta = true;
+    rec.isDelta = true;
+
+    // Evaluate IOR at hero — same as Session 1.
+    float ior = mat.isDispersive
+        ? gpu_sellmeier_ior(mat.dispersion, lambdas.lambda[0])
+        : mat.ior;
+
+    // ... compute fresnel, decide reflect vs refract ...
+
+    if (reflected) {
+        s.wi  = ...;
+        s.f   = GVec3(1.f);   // wavelength-independent at reflection
+        s.pdf = 1.f;
+    } else {
+        s.wi  = ...refract at hero IOR...;
+        // The hero gets full throughput (NOT divided by N).
+        s.f   = GVec3(eta * eta);
+        s.pdf = 1.f;
+
+        // KEY: also need to set s.fSpectral here, NOT compute it from s.f.
+        // The hero gets eta^2; secondaries get 0.
+        if (mat.isDispersive) {
+            // Override the default RGB→spectrum conversion at this vertex.
+            // hero throughput = eta^2 * (hero's RGB→spectrum at λ_hero)
+            // secondary throughput = 0
+            // This requires gpu_material_sample_spectral to honour an
+            // override flag from gpu_dielectric_sample_spectral.
+            s.fSpectral[0] = (eta * eta) * gpu_rgbSpectrumAt(GVec3(1.f), lambdas.lambda[0], mat.spectralMode);
+            for (int i = 1; i < G_SPECTRUM_SAMPLES; ++i) {
+                s.fSpectral[i] = 0.f;
+            }
+            // Also flag the wavelengths so downstream NEE / RR can see this.
+            lambdas.terminateSecondary();  // OK to do this here for downstream behaviour
+            s.useExplicitSpectral = true;   // new field — see below
+        }
+    }
+    return s;
+}
+```
+
+This requires adding a `useExplicitSpectral` flag to `GBSDFSample` so `gpu_material_sample_spectral` doesn't overwrite the explicit per-wavelength values with RGB→spectrum conversion. Then in the calling kernel:
+
+```cuda
+if (bs.useExplicitSpectral) {
+    // Don't recompute from s.f.
+} else {
+    bs.fSpectral = gpu_rgbToSampledSpectrum(bs.f, wl, mat.spectralMode);
+}
+```
+
+---
+
+## Why this is a tomorrow-job, not a tonight-job
+
+The above involves:
+1. Adding a field to `GBSDFSample` (every kernel that constructs one must initialise it).
+2. Modifying both `multiwavelength_kernel.cu` and `path_trace_kernel.cu` callers.
+3. Verifying the receiver-energy gate stays passing (the math has to balance such that hero's full eta² ≈ old per-ray's RGB-uniform eta² × 4-wavelength-sum).
+4. Visual + numeric validation against CPU baseline.
+
+Each step is a CUDA build cycle (~5 minutes). Steps 3-4 need RTX hardware testing. A clean implementation is ~½ day of focused work; rolling it out under unsupervised overnight with bisecting the energy mismatch is high-risk.
+
+---
+
+## Recommendation
+
+- **Do not implement Session 2 tonight.** The naive `terminateSecondary` patch broke the receiver-energy gate, and the proper MIS implementation needs a non-trivial integration-side change that should be done with the owner's eyes on the math.
+- **Keep Session 1's hero-only GPU dielectric as the shipping baseline.** Receiver-energy gate passes; PSNR/SSIM remain documented as deferred.
+- **File this note as the Phase 1 artifact** so a future implementation session can pick up cold with the implementation sketch above.
+- **The pkg104 reference bank's `prism-bk7-collimated` scene runs on CPU** (forced via the SMS caustic integrator, which is CPU-only). The visible chromatic ring is already there. GPU port of that scene is gated on this work landing properly.


### PR DESCRIPTION
## Summary

Documents the Session 2 Phase 1 investigation. The naive 'mirror CPU `terminateSecondary()`' approach on the GPU dielectric refraction path **broke the receiver-energy gate** without improving SSIM. The proper Option B (Wilkie 2014 hero-wavelength MIS) needs an integrator-side `useExplicitSpectral` flag on `GBSDFSample` and a real MIS weight computation, not a one-line port.

## Measurements

| Gate | Before tonight | After naive patch | Goal |
|------|----------------|-------------------|------|
| Receiver-energy ratio | 1.17× | **0.98×** (regression) | ≥ 1.10× |
| GPU↔CPU SSIM | 0.523 | **0.485** (regression) | ≥ 0.97 |

The patch was reverted. Engine code is unchanged; hero-only GPU dielectric (Session 1, PR #354) remains the shipping baseline.

## What lands here

Just the research note: `.astroray_plan/docs/pkg64-gpu-session2-research.md`. It documents what was tried, why it fails, and the sketch of what a proper Option B implementation needs (~½ day of focused work + RTX validation).

## Test plan

- [x] No engine code changes; existing tests unaffected
- [x] Reverted `gpu_materials.h` after measurement
- [x] Rebuilt locally to verify clean baseline
- [ ] CI green (docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)