### PR TITLE
docs(pkg106): Phase 1 research — port Cycles MNEE for triangulated prism

### DIFF
--- a/.astroray_plan/docs/pkg106-research-2026-05-28.md
+++ b/.astroray_plan/docs/pkg106-research-2026-05-28.md
@@ -1,0 +1,186 @@
+# pkg106 — Research notes (2026-05-28)
+
+**Goal:** chromatic caustics through a triangulated equilateral glass prism on
+the CPU SMS pipeline. The pkg104 BK7 prism scene currently falls back to a
+sphere-as-lens because the existing SMS Newton iteration produces chromatic
+*noise* (high `hue_spread`, salt-and-pepper distribution) rather than a
+clean rainbow band on triangulated geometry.
+
+**Author:** Claude Code overnight (post-pkg104).
+**Status:** Phase 1 of pkg106 — read literature, pick approach, file note.
+
+---
+
+## Two candidate approaches (from pkg106 spec)
+
+### Option A — Smoothed-normal SMS
+
+Use interpolated vertex normals (Phong-style) when computing the Newton
+residual; intersection still uses the flat geometric normal. The Newton
+solver sees a smooth gradient; radiance evaluation sees the discrete
+surface.
+
+**Pros:** stays inside the existing SMS code path. Smaller diff.
+**Cons:** the Newton may converge to a position not actually on the
+discrete surface, producing biased radiance estimates. No widely-cited
+implementation precedent; this would be original research.
+
+### Option B — Port Cycles MNEE (Manifold Next Event Estimation)
+
+Cycles' `intern/cycles/kernel/integrator/mnee.h` (Apache-2.0) implements a
+manifold-walk caustic estimator that operates on triangle meshes directly
+via per-surface-parameterization `(u, v)` constraint derivatives. The
+chord-vertex formulation handles piecewise-flat surfaces naturally
+because the manifold positions are per-triangle parameterizations, not
+points on a smooth manifold.
+
+**Pros:**
+- Established algorithm with extensive validation in Cycles.
+- Apache-2.0 license, source-compatible.
+- Triangle-native: this is the design point.
+- Implementation precedent we can port + cite.
+
+**Cons:**
+- Larger diff (new file, ~1000 lines).
+- Cycles MNEE doesn't handle per-wavelength IOR (verified — see below).
+  We'd need to add chromatic layering on top.
+
+---
+
+## Investigation: what does Cycles MNEE actually do?
+
+Read of `blender/cycles@main:src/kernel/integrator/mnee.h` (2026-05-28):
+
+**Algorithm** (3 stages):
+1. **Seed-ray construction** (lines 29-44 of mnee.h): cast a ray from the
+   shading point toward the light, collecting intersections with
+   surfaces flagged `SD_OBJECT_CAUSTICS_CASTER`. This identifies the
+   manifold's candidate vertex chain.
+2. **Manifold walk** (lines 824-903): Newton-style solver that linearises
+   the specular constraint manifold locally. The constraint enforces
+   that "the generalized half-vector projection onto the interface local
+   tangent plane is null" — Fermat's principle at each refractive
+   vertex. Iteration step `beta` adapts based on whether the projection
+   stays on the surface; exits when `constraint_norm < MNEE_SOLVER_THRESHOLD`.
+3. **Path contribution** (lines 1008+): evaluate BSDFs at the discovered
+   vertices, compute the generalized geometry term, weight the path.
+
+**Public entry point:**
+```c
+ccl_device_inline ShaderEvalResult kernel_path_mnee_sample(
+    KernelGlobals kg, IntegratorState state,
+    ccl_private ShaderData *sd, ccl_private ShaderData *sd_mnee,
+    const ccl_private RNGState *rng_state,
+    ccl_private LightSample *ls, ccl_private BsdfEval *throughput,
+    ccl_private int &r_vertex_count);
+```
+
+**Manifold-vertex struct** (line ~72):
+```c
+struct ManifoldVertex {
+    float3 p, dp_du, dp_dv, n_w;     // position + tangent frame
+    float eta;                       // <- scalar IOR, NOT per-wavelength
+    ...
+};
+```
+
+**Critical observation:** `eta` is a single `float`, not a spectrum.
+Cycles MNEE handles refraction but **does NOT branch on wavelength**.
+Dispersive caustics in Cycles emerge from the integrator's *hero-
+wavelength MC sampling* layered on top of MNEE: each ray samples a hero
+wavelength, picks the IOR for that wavelength (via the closure's
+`closure_principled.h` hero-MIS branch), and MNEE finds the geometric
+manifold position for that single eta. Many rays with different heroes
+→ chromatic spread.
+
+This is the same pattern as `plugins/materials/dielectric.cpp:181-188`
+in Astroray: hero-IOR per ray + `terminateSecondary()` after refraction.
+
+## Decision
+
+**Port Cycles MNEE (Option B), chromatic layer via existing hero-wavelength infra.**
+
+Reasoning:
+1. Cycles MNEE is the canonical triangle-mesh caustic estimator. Its
+   manifold walk is precisely engineered to converge on piecewise-flat
+   surfaces.
+2. The chromatic layer is *already in place* in Astroray's CPU
+   dielectric (`plugins/materials/dielectric.cpp:181-188`). Porting
+   MNEE doesn't break that — the per-ray hero IOR continues to drive
+   chromatic spread.
+3. Option A (smoothed-normal SMS) has no published precedent and would
+   be open-ended research. The pkg104 night's experience with naive
+   SMS-on-triangles (chromatic noise floor instead of a rainbow band)
+   already demonstrates the failure mode.
+4. License: Apache-2.0 → MIT compatible. Cite Cycles file:line in every
+   ported function per CLAUDE.md §6.
+
+---
+
+## Implementation sketch
+
+**New files:**
+- `include/astroray/mnee.h` — port of `mnee.h` algorithm. ManifoldVertex
+  struct, mnee_compute_constraint_derivatives, mnee_solve, public
+  `mnee_sample()` entry.
+- `plugins/integrators/mnee_caustic_path_tracer.cpp` — sibling integrator
+  to `sms_caustic_path_tracer.cpp`. Selects MNEE when the path hits a
+  caustic-caster flagged surface.
+- `tests/test_mnee_chromatic_prism.py` — render the pkg104 prism scene
+  (BK7 equilateral prism, collimated sun, white receiver) with the new
+  integrator + assert hue_spread > 0.7 in a rainbow ROI on the receiver.
+
+**Modified files:**
+- `plugins/integrators/CMakeLists.txt` — register new integrator.
+- pkg104 `prism-bk7-collimated/scene.py` — switch back to a triangulated
+  prism + collimated sun + receiver (the original Phase 2a try that
+  produced chromatic noise on SMS). Use `mnee_caustic_path_tracer`.
+
+**Tests to write/preserve:**
+- Cornell-box parity: MNEE on a non-dispersive sphere produces the same
+  caustic as SMS at converged spp (regression guard).
+- Triangulated prism: hue_spread on receiver > 0.7 AND a continuous
+  rainbow region detected by a morphological band-finder (not isolated
+  chromatic pixels).
+- BK7 sphere via lens topology: existing pkg104 scene keeps passing.
+
+**Effort estimate:** 1-2 weeks. The bulk is the manifold walk port + the
+Newton constraint derivatives; the chromatic layer is reused as-is. The
+risk is in the geometry term computation and the seed-ray manifold
+discovery, both of which are heavily Cycles-specific.
+
+---
+
+## Why not just smoothed-normal SMS as a quick test?
+
+I considered prototyping smoothed-normal SMS as a half-day Phase 1.5
+step. Decided against it because:
+
+1. The existing SMS implementation evaluates the half-vector constraint
+   in object-space using flat triangle normals. Switching to interpolated
+   normals for the Newton residual while keeping flat normals for the
+   intersection point creates a *biased* estimator — the manifold the
+   Newton converges on isn't the manifold the path tracer traces.
+2. Even if it converged geometrically, the radiance contribution at the
+   resolved vertex would still use the flat normal at that vertex,
+   producing visibly-incorrect shading variation.
+3. There's no published correctness analysis for this approach; we
+   couldn't cite the algorithm per CLAUDE.md §6. The note says "follow
+   published work, don't invent."
+
+The smoothed-normal idea works for *display normal interpolation* but
+not for transport equations that depend on the actual scattering
+direction.
+
+---
+
+## Next actions
+
+- File this note as the Phase 1 deliverable (this commit).
+- Update pkg106 spec status from "open — investigation" to "Phase 1 done
+  (research filed); Phase 2 ready to start".
+- Spec amendment: Phase 2 = port the `mnee.h` ManifoldVertex + Newton
+  solver + public entry point; Phase 3 = wire into a new integrator
+  plugin; Phase 4 = validation against pkg104 prism scene.
+- Phase 2-4 are owner-scheduled (~1-2 weeks of focused work; not a
+  good unsupervised overnight target).


### PR DESCRIPTION
## Summary

Phase 1 deliverable for pkg106. Read Cycles `src/kernel/integrator/mnee.h` (Apache-2.0) end-to-end. Decision: **port Cycles MNEE** as the new `mnee_caustic_path_tracer` integrator; reject the smoothed-normal SMS alternative as biased + lacks published precedent.

## Key findings

- Cycles MNEE manifold walk operates per-surface-parameterization (u, v) — naturally handles piecewise-flat triangle meshes. This is the geometry the existing SMS Newton iteration can't converge on (verified during pkg104 night: tried a real triangulated equilateral prism + collimated sun, got chromatic noise floor rather than a rainbow band).
- Cycles MNEE eta is scalar (not per-wavelength). Chromatic dispersion in Cycles emerges from hero-wavelength MC sampling layered on top of MNEE. Astroray already has this layer in `plugins/materials/dielectric.cpp:181-188` — re-uses cleanly.
- Apache-2.0 license → MIT compatible; cite per CLAUDE.md §6.

## Implementation sketch (Phase 2-4 of pkg106)

- New `include/astroray/mnee.h` — ManifoldVertex + Newton + public mnee_sample.
- New `plugins/integrators/mnee_caustic_path_tracer.cpp`.
- pkg104 prism scene switches back to triangulated geometry + new integrator.
- 1-2 weeks effort, owner-scheduled.

## What lands here

Just the research note `.astroray_plan/docs/pkg106-research-2026-05-28.md`. No code changes.

## Test plan

- [x] Docs only; no engine code touched
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)