### PR TITLE
feat(pkg106): MNEE Chunk B — surface (u,v) partials + analytic Newton solver

### DIFF
--- a/.astroray_plan/docs/NEXT_STAGE_REPORT.md
+++ b/.astroray_plan/docs/NEXT_STAGE_REPORT.md
@@ -1,8 +1,8 @@
 # Astroray Next Stage Report
 
-**Date:** 2026-05-24 (Round 15 pickup — Round 14 complete; pkg55-B' Session N+5 continuation is top live track)
-**Prepared by:** Claude (Anthropic Code) — updated after Round 14 closeout
-**Scope:** Round 15 pickup set.
+**Date:** 2026-05-28 (Round 15 active — pkg64-gpu Session 2 + pkg106 Chunk A + pkg105 shipped; pkg106 Chunk B next)
+**Prepared by:** Claude (Anthropic Code) — updated after Round 15 partial closeout
+**Scope:** Round 15 continuation.
 
 > Strategic gate: **RELEASED 2026-05-10** by pkg56 Phase C; Pillar 4
 > has been actively shipping since. Strategy in
@@ -11,6 +11,18 @@
 ---
 
 ## 1. Current state (one screen)
+
+**Done in Round 15 partial (3 PRs merged, 2026-05-28):**
+
+**Key achievements:**
+- **pkg64-gpu Session 2 DONE** (PR #385) — Root cause: GPU hero-wavelength distribution bug (lambda[0] confined to violet quarter). Fixed both GPU samplers + mirrored CPU terminateSecondary. Gates re-spec'd (SSIM ≥0.97 unreachable for independent MC streams, CPU-vs-CPU ~0.53 at 256 spp). New gates: SSIM ≥0.85 + ROI luminance-parity [0.5,2.0]. Measured: SSIM 0.928, energy 1.38×, PSNR +2.19 dB.
+- **pkg106 Chunk A DONE** (PR #387) — Analytic half-vector constraint Jacobian (Cycles mnee.h + Hanika 2015 §5). Root cause of SMS-on-triangles failure: central-difference Jacobian → spurious discontinuity on facet edges. Chunks B-E remain (surface (u,v) partials, Newton wiring, triangulated prism scene with hue_spread ≥0.7).
+- **pkg105 DONE** (PR #381) — BH Blender addon integration. Exposed r_obs_M (pkg107), Kerr spin, ADAF params (pkg44). Pillar 4 Blender surface complete for BH objects.
+
+**Merged:**
+1. **PR #385 — pkg64-gpu Session 2** (`806991b`) — Hero-wavelength sampler fix + terminateSecondary + gates re-spec'd. SSIM 0.928, energy 1.38×, PSNR +2.19 dB.
+2. **PR #387 — pkg106 Chunk A** (`53b279b`) — Analytic Jacobian + test. 5/5 new tests pass.
+3. **PR #381 — pkg105** (`e7435a6`) — BH addon panel params. 2 new tests pass.
 
 **Done in Round 14 (12 PRs merged, 2026-05-24 overnight):**
 
@@ -112,13 +124,18 @@
 
 ---
 
-## 2. Recommended next deployable set (Round 15)
+## 2. Recommended next deployable set (Round 15 continuation)
 
-**Round 14 complete (2026-05-24).** 12 PRs merged: pkg64-gpu-sellmeier-upload, pkg55-B' Session N+4 parts 1+2, pkg86-B Phase 1 (CPU SAOH), pkg76 CSV + 4 Classroom followup gaps, pkg-add-cuda-syntax-ci. **Session N+4 gates enforced** (PostLightSample/PostRR p99.9 = 2.21e-6, threshold 3.5e-6). Session N+3 gates remain green (PostInit ULP=2, PostIntersect ULP=32). **CUDA-port track continues.**
+**Round 15 partial complete (2026-05-28).** 3 PRs merged: pkg64-gpu Session 2, pkg106 Chunk A, pkg105. **pkg64-gpu Session 2 complete** (hero-wavelength bug fixed, gates re-spec'd + green). **pkg106 Chunk A complete** (analytic Jacobian). **pkg105 complete** (BH addon params).
 
-**Round 15 priorities**:
+**Round 15 continuation priorities**:
 
 **Lead track:**
+
+- **pkg106 Chunk B — surface (u,v) partials + analytic Newton solver wiring**
+  Chunk A (PR #387) added the analytic half-vector constraint Jacobian. Chunk B wires it into the Newton solver (replacing the central-difference path for caustic casters) and adds the surface (u,v) partials (dp_du/dp_dv/dn_du/dn_dv) to triangle/sphere intersection. Astroray's HitRecord currently carries only an arbitrary buildOrthonormalBasis frame, not the true surface partials. This is the direct continuation of the pkg106 implementation plan (see .astroray_plan/docs/pkg106-phase2-implementation-plan.md). Architect estimate: ~1-2 days for Chunk B, then Chunks C-E (triangle reprojection, integrator wiring, triangulated prism scene with hue_spread ≥0.7).
+
+**Second tier:**
 
 - **pkg55-B' Session N+5 — next CUDA port stage continuation**
   (multi-session continuation after Session N+4 complete).
@@ -184,7 +201,35 @@
 
 ## 3. Drop-in prompts per agent
 
-### 3.0 Claude Code (Track A) — pkg55-B' Session N+5 (next CUDA port stage continuation, TOP PRIORITY)
+### 3.0 Claude Code (Track A) — pkg106 Chunk B (surface partials + Newton wiring, TOP PRIORITY)
+
+```
+You are Claude Code on the RTX box. pkg106 Chunk B — surface (u,v) partials + analytic Newton solver wiring. Chunk A (PR #387, merged 2026-05-28) added the analytic half-vector constraint Jacobian (halfVectorConstraintJacobian in manifold/half_vector_constraint.h). Now wire it into the Newton solver and add surface (u,v) partials to intersection records.
+
+Read first:
+  - .astroray_plan/packages/pkg106-sms-on-triangulated-prisms.md (spec)
+  - .astroray_plan/docs/pkg106-phase2-implementation-plan.md (5-chunk breakdown)
+  - .astroray_plan/docs/pkg106-research-2026-05-28.md (Cycles math + citations)
+  - include/astroray/manifold/half_vector_constraint.h (Chunk A output)
+  - include/astroray/manifold/newton_iterate.h (central-difference Jacobian to replace)
+  - include/astroray/hit_record.h (add dp_du/dp_dv/dn_du/dn_dv)
+  - src/shapes/triangle.cpp + src/shapes/sphere.cpp (compute surface partials at intersection)
+
+Goal: Replace newton_iterate.h's central-difference Jacobian with the analytic one for caustic casters. Add surface (u,v) partial derivatives (dp_du/dp_dv/dn_du/dn_dv) to HitRecord and compute them in triangle/sphere hit methods. This closes the SMS-on-triangles root cause (central-difference → spurious discontinuity on facet edges).
+
+Acceptance (per spec):
+  - Analytic Jacobian used for caustic casters (triangles + spheres).
+  - Triangle hit computes dp_du/dp_dv/dn_du/dn_dv from edge vectors.
+  - Sphere hit computes dp_du/dp_dv/dn_du/dn_dv from parametric sphere partials.
+  - Existing SMS sphere caustic tests pass (no regression).
+  - New test: triangulated prism scene renders with reduced salt-and-pepper noise (visual inspection; hue_spread gate deferred to Chunk D).
+
+Constraints: CLAUDE.md 1,2,3,6. Cite Cycles mnee.h + Hanika 2015.
+
+When done: pkg106 spec Chunk B status → done + PR. PR titled "feat(pkg106 Chunk B): surface (u,v) partials + analytic Newton wiring".
+```
+
+### 3.1 Claude Code (Track A) — pkg55-B' Session N+5 (next CUDA port stage continuation, SECOND TIER)
 
 ```
 You are Claude Code on the RTX box. pkg55-B' CUDA-port track Session N+5. Session N+4 (PRs #355 + #356) COMPLETE — PostLightSample + PostRR kernel stages shipped with full threshold gates enforced (p99.9 = 2.21e-6, threshold 3.5e-6). Session N+3 gates remain green (PostInit ULP=2, PostIntersect=32, PostShade p99.9 in bound). Now continue CUDA kernel port.
@@ -218,33 +263,6 @@ material coverage (e.g., add metal BSDF).
 
 When done: pkg55 spec Session N+5 status + PR ref + gate numbers. PR title:
 "feat(pkg55-B'): Session N+5 — <scope>".
-```
-
-### 3.1 Claude Code (Track A) — pkg64-gpu-sellmeier-session2-multi-ior (second tier)
-
-```
-You are Claude Code on the RTX box. pkg64-gpu-sellmeier-upload (Session 1, PR #354) shipped hero-wavelength IOR. Session 2 adds per-wavelength multi-IOR GPU refraction to close the deferred PSNR floor + GPU↔CPU SSIM parity gates.
-
-Read first:
-  - .astroray_plan/packages/pkg64-gpu-sellmeier-session2-multi-ior.md (full spec)
-  - include/astroray/gpu_types.h (GMaterial + GDispersion from Session 1)
-  - src/gpu/gpu_dispersion.cuh (gpu_sellmeier_ior device function)
-  - include/astroray/gpu_materials.h (gpu_dielectric_sample_spectral — extend to sample per-wavelength IOR)
-  - tests/test_pkg64_gpu_phase3_*.py (the deferred PSNR + SSIM gates)
-
-Goal: Extend GPU dielectric BSDF to sample per-wavelength IOR (not just hero).
-Evaluate n(λ) for each sampled wavelength, apply wavelength-dependent refraction,
-and close the deferred PSNR floor delta ≥−0.5 dB + GPU↔CPU SSIM ≥0.97 gates.
-
-Acceptance (per spec):
-  - PSNR floor delta ≥−0.5 dB (prism scene).
-  - GPU↔CPU SSIM ≥0.97 at 256 spp (prism scene).
-  - Receiver-energy gate remains ≥1.10× (no regression from Session 1).
-
-Constraints: CLAUDE.md 1,2,3,6. Cite Cycles/PBRT-v4 for spectral refraction.
-
-When done: pkg64-gpu-sellmeier-session2-multi-ior spec status → done + PR. PR titled
-"feat(pkg64-gpu Session 2): per-wavelength multi-IOR GPU refraction".
 ```
 
 ### 3.2 Claude Code (Track A) — pkg86-B Phase 2+3 (second tier)

--- a/.astroray_plan/docs/ROADMAP.md
+++ b/.astroray_plan/docs/ROADMAP.md
@@ -178,6 +178,9 @@ fix:
   to pkg55 Phase B per the spec's escape clause; smaller H2/H5
   follow-ups split out as **pkg83** + **pkg84**.
 
+**Round 15 partial (2026-05-28, 3 PRs merged): pkg64-gpu Session 2 + pkg106 Chunk A + pkg105.**
+**pkg64-gpu Session 2 DONE** (PR #385) — Hero-wavelength distribution bug fixed (lambda[0] violet-only → full-band). Gates re-spec'd (SSIM ≥0.85 + ROI luminance-parity; 0.97 unreachable for independent MC). Measured: SSIM 0.928, energy 1.38×, PSNR +2.19 dB. **pkg106 Chunk A DONE** (PR #387) — Analytic half-vector constraint Jacobian (Cycles mnee.h + Hanika 2015); Chunks B-E in progress. **pkg105 DONE** (PR #381) — BH Blender addon params (r_obs_M + Kerr spin + ADAF). Pillar 4 Blender surface complete for BH objects.
+
 **Round 14 closeout (2026-05-24, 12 PRs merged): CUDA-port Session N+4 + Sellmeier + pkg76 Classroom audit wave.**
 **pkg55-B' Session N+4 COMPLETE** (PRs #355 + #356) — PostLightSample + PostRR CUDA kernel stages
 shipped with full CPU↔GPU threshold gates enforced (p99.9 = 2.21e-6, threshold 3.5e-6). Session N+3

--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -1,6 +1,30 @@
 # Astroray Status
 
-**Last updated:** 2026-05-24 (Round 14 closeout: 12 PRs merged overnight).
+**Last updated:** 2026-05-28 (Round 15 partial: 3 PRs merged — pkg64-gpu Session 2, pkg106 Chunk A, pkg105).
+
+## Round 15 partial closeout (3 PRs merged, 2026-05-28)
+
+**Key achievements:**
+- **pkg64-gpu Session 2 DONE** (PR #385) — Root cause: GPU hero-wavelength distribution bug (lambda[0] confined to violet quarter). Fixed both GPU samplers + mirrored CPU terminateSecondary. **Gates re-spec'd** (owner-adjudicated): SSIM ≥0.97 unreachable for independent MC streams (CPU-vs-CPU ~0.53 at 256 spp), new gates SSIM ≥0.85 + ROI luminance-parity [0.5,2.0]. Measured: SSIM 0.928, energy 1.38×, PSNR +2.19 dB. Test integrator mismatch fixed (GPU no-NEE vs CPU NEE). **Session 2 complete.**
+- **pkg106 Chunk A DONE** (PR #387) — Analytic half-vector constraint Jacobian (Cycles mnee.h + Hanika 2015 §5). Root cause of SMS-on-triangles failure: newton_iterate.h central-difference Jacobian → spurious discontinuity on facet edges. Chunk A adds halfVectorConstraintJacobian + test. **Chunks B-E remain** (surface (u,v) partials, Newton wiring, triangulated prism scene with hue_spread ≥0.7).
+- **pkg105 DONE** (PR #381) — Blender BH addon integration. Exposed r_obs_M (pkg107), Kerr spin, ADAF params (pkg44). **Pillar 4 Blender surface complete** for BH objects.
+
+**Merged 2026-05-28:**
+1. **PR #385 — pkg64-gpu Session 2** (`806991b`) — Hero-wavelength sampler fix + terminateSecondary + gates re-spec'd. SSIM 0.928 ≥0.85 PASS; energy 1.38× ≥1.045× PASS; PSNR +2.19 dB ≥−0.5 dB PASS.
+2. **PR #387 — pkg106 Chunk A** (`53b279b`) — Analytic Jacobian + test. Analytic-vs-FD validation ~2e-7 (C++ float32) / ~2e-10 (Python float64). 5/5 new tests pass.
+3. **PR #381 — pkg105** (`e7435a6`) — BH addon panel params. r_obs_M + spin + ADAF mdot_edd/electron_temp/beta_mag/r_inner/r_outer/flattening/alpha/s/intensity_scale. 2 new tests pass.
+
+**Additional merges (test-only, no packages):**
+4. **PR #386 — fix #298** (`f22d1cb`) — ReSTIR spatial-MSE flake: pinned reference seed (seed=0 std::random_device sentinel was re-randomising).
+5. **PR #384 — fix #276** (`89f8fe7`) — Clearcoat test flake: pinned seed.
+
+**In-flight / deferred:**
+- **pkg55-B' Session N+5** — next CUDA-port stage continuation (metal/dielectric/disney shade kernels or RR/miss handling). Lead track per NEXT_STAGE_REPORT §2.
+- **pkg106 Chunks B-E** — surface partials + Newton wiring + triangulated prism acceptance (hue_spread ≥0.7). In progress.
+
+**Full standup:** (not yet committed).
+
+---
 
 ## Round 14 closeout (12 PRs merged, 2026-05-24 overnight)
 

--- a/.astroray_plan/packages/pkg105-addon-black-hole-integration.md
+++ b/.astroray_plan/packages/pkg105-addon-black-hole-integration.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 4 (Astrophysics) + Pillar 5 (Production polish) — touches both
 **Track:** A (Blender addon Python + C++ binding glue)
-**Status:** open
+**Status:** done (PR #381, 2026-05-28 — r_obs_M + Kerr spin + ADAF params exposed)
 **Estimated effort:** 1–2 weeks (~25–50 h)
 **Depends on:** pkg40 (Kerr/Schwarzschild metric plugins, done) + pkg44 (ADAF model, done) + pkg103 wiring audit (done)
 

--- a/.astroray_plan/packages/pkg106-sms-on-triangulated-prisms.md
+++ b/.astroray_plan/packages/pkg106-sms-on-triangulated-prisms.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 2 (Spectral core) + 3 (Light transport)
 **Track:** A (CPU integrator + numerical work) + C (research)
-**Status:** open — investigation spec
+**Status:** in progress (Chunk A done PR #387, 2026-05-28 — analytic Jacobian; Chunks B-E remain)
 **Estimated effort:** 1–2 weeks investigation, then either 2–4 weeks port-and-validate or 1 week deferral note
 **Depends on:** pkg64-gpu Phase 1/2/3 (done) + pkg64-gpu-sellmeier-session2-multi-ior (filed)
 

--- a/.astroray_plan/packages/pkg64-gpu-sellmeier-session2-multi-ior.md
+++ b/.astroray_plan/packages/pkg64-gpu-sellmeier-session2-multi-ior.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 1
 **Track:** A
-**Status:** Session 2 implemented 2026-05-28 (PR pending merge); SSIM/PSNR gates re-spec'd, energy gate green
+**Status:** done (PR #385, 2026-05-28 — SSIM 0.928 ≥0.85, energy 1.38×, PSNR +2.19 dB)
 **Estimated effort:** 1–2 weeks
 **Depends on:** pkg64-gpu-sellmeier-upload (PR #354, merged Round 14 2026-05-24, hero-only) + pkg55-B' Session N+4 part 1+2 (PRs #355+#356, NEE infrastructure on GPU)
 **Reference research:** Sellmeier 1871 (public domain); Cycles `intern/cycles/kernel/svm/closure_principled.h` per-wavelength refraction (Apache-2.0); PBRT-v4 `src/pbrt/bxdfs.h` `DielectricBxDF::Sample_f` multi-wavelength branch (Apache-2.0); Hero-wavelength algorithm — Wilkie et al. 2014 "Hero Wavelength Spectral Sampling" (EGSR 2014), reference for the splitting strategy.

--- a/include/astroray/manifold/newton_iterate.h
+++ b/include/astroray/manifold/newton_iterate.h
@@ -26,6 +26,8 @@
 // optimization once the skeleton is validated.
 
 #include "../../raytracer.h"
+#include "half_vector_constraint.h"  // pkg106 Chunk B: analytic Jacobian path
+#include <cmath>
 #include <functional>
 
 namespace astroray::manifold {
@@ -112,6 +114,72 @@ inline NewtonResult solve(const Vec3& x1Init, const Vec3& n1Init,
         Vec3 xNew, nNew, sNew, tNew;
         if (!reproject(R.x1, R.s1, R.t1, du, dv, xNew, nNew, sNew, tNew)) break;
         R.x1 = xNew; R.n1 = nNew; R.s1 = sNew; R.t1 = tNew;
+    }
+    return R;
+}
+
+// ---------------------------------------------------------------------------
+// pkg106 Chunk B — analytic-Jacobian manifold solve.
+//
+// Same Newton loop as solve() above, but the 2x2 Jacobian comes from
+// halfVectorConstraintJacobian (Cycles mnee.h analytic derivatives) instead of
+// central differences. The FD path reprojects with +/-h tangent steps and
+// finite-differences the constraint; on a triangulated caster a +/-h step can
+// cross a triangle edge into a neighbour with a different normal, producing a
+// spurious Jacobian discontinuity that stalls/diverges Newton (the SMS-fails-
+// on-triangles failure, see pkg106-research-2026-05-28.md). The analytic
+// Jacobian has no such artefact.
+// ---------------------------------------------------------------------------
+struct AnalyticNewtonResult {
+    Vec3  x1, n1;                       // converged manifold vertex + normal
+    Vec3  dp_du, dp_dv, dn_du, dn_dv;   // surface partials at x1
+    bool  converged;
+    int   iterations;
+    float residualNorm;
+};
+
+// Reproject for the analytic path: given the current vertex x1 and a tangent
+// step (du, dv) in the constraint's (s, t) frame, return the new surface point,
+// its unit normal, and the surface partials there (from surface_partials.h on
+// real geometry; a closed form for analytic surfaces). Returns false if the
+// step leaves the surface.
+using ReprojectFnAnalytic = std::function<bool(
+    const Vec3& x1, const Vec3& s, const Vec3& t, float du, float dv,
+    Vec3& outX, Vec3& outN,
+    Vec3& outDpDu, Vec3& outDpDv, Vec3& outDnDu, Vec3& outDnDv)>;
+
+inline AnalyticNewtonResult solveAnalytic(
+        const Vec3& x0, const Vec3& x2, float eta, bool refraction,
+        const Vec3& x1Init, const Vec3& n1Init,
+        const Vec3& dpduInit, const Vec3& dpdvInit,
+        const Vec3& dnduInit, const Vec3& dndvInit,
+        const ReprojectFnAnalytic& reproject,
+        const NewtonConfig& cfg = {}) {
+    AnalyticNewtonResult R;
+    R.x1 = x1Init; R.n1 = n1Init;
+    R.dp_du = dpduInit; R.dp_dv = dpdvInit; R.dn_du = dnduInit; R.dn_dv = dndvInit;
+    R.converged = false; R.iterations = 0; R.residualNorm = 0.0f;
+
+    for (int it = 0; it < cfg.maxIterations; ++it) {
+        R.iterations = it + 1;
+        HalfVectorConstraint c = halfVectorConstraintJacobian(
+            x0, R.x1, x2, R.n1, R.dp_du, R.dp_dv, R.dn_du, R.dn_dv, eta, refraction);
+        if (!c.valid) break;
+        R.residualNorm = std::sqrt(c.residual.u * c.residual.u +
+                                   c.residual.v * c.residual.v);
+        if (R.residualNorm < cfg.tolerance) { R.converged = true; break; }
+
+        const float det = c.j00 * c.j11 - c.j01 * c.j10;
+        if (std::fabs(det) < 1e-12f) break;
+        const float invDet = 1.0f / det;
+        // Solve J * (du,dv) = -c  =>  (du,dv) = -J^{-1} c.
+        const float du = -invDet * ( c.j11 * c.residual.u - c.j01 * c.residual.v) * cfg.damping;
+        const float dv = -invDet * (-c.j10 * c.residual.u + c.j00 * c.residual.v) * cfg.damping;
+
+        Vec3 nx, nn, ndpu, ndpv, ndnu, ndnv;
+        if (!reproject(R.x1, c.s, c.t, du, dv, nx, nn, ndpu, ndpv, ndnu, ndnv)) break;
+        R.x1 = nx; R.n1 = nn;
+        R.dp_du = ndpu; R.dp_dv = ndpv; R.dn_du = ndnu; R.dn_dv = ndnv;
     }
     return R;
 }

--- a/include/astroray/manifold/surface_partials.h
+++ b/include/astroray/manifold/surface_partials.h
@@ -1,0 +1,80 @@
+#pragma once
+// pkg106 Chunk B — surface (u,v) parameterization partials for the analytic
+// manifold constraint Jacobian (half_vector_constraint.h).
+//
+// The analytic Jacobian (Cycles mnee.h / Hanika 2015 §5) needs the position and
+// normal partials dp_du, dp_dv, dn_du, dn_dv at the manifold vertex. Astroray's
+// HitRecord only carries an arbitrary buildOrthonormalBasis tangent frame, not
+// the true surface partials — and bloating that hot struct with 4 extra Vec3
+// for a caustic-caster-only feature is wasteful (CLAUDE.md §2). These helpers
+// compute the partials on demand from the primitive geometry; the manifold
+// reprojection (which already has the primitive at the vertex) calls them.
+//
+// dn_du / dn_dv are derivatives of the UNIT normal and are therefore always
+// perpendicular to n (a requirement of halfVectorConstraintJacobian).
+
+#include "../../raytracer.h"
+#include <cmath>
+
+namespace astroray::manifold {
+
+// Triangle barycentric parameterization p(u,v) = v0 + u*(v1-v0) + v*(v2-v0):
+//   dp_du = v1 - v0,  dp_dv = v2 - v0.
+// Flat-shaded facet => the geometric normal is constant across the face, so
+// dn_du = dn_dv = 0 (no edge-crossing discontinuity, unlike a finite-difference
+// step — this is the whole point of the analytic Jacobian on triangle meshes).
+inline void trianglePartials(const Vec3& v0, const Vec3& v1, const Vec3& v2,
+                             Vec3& dp_du, Vec3& dp_dv,
+                             Vec3& dn_du, Vec3& dn_dv) {
+    dp_du = v1 - v0;
+    dp_dv = v2 - v0;
+    dn_du = Vec3(0.0f);
+    dn_dv = Vec3(0.0f);
+}
+
+// Smooth-shaded triangle: interpolated shading normal n(u,v) =
+// normalize(n0 + u*(n1-n0) + v*(n2-n0)). The unit-normal partials are the
+// derivative of that normalization, projected perpendicular to n.
+// (Chunk B targets flat facets; this overload is provided for completeness and
+// future smooth-prism support — Cycles mnee.h uses the analogous shading-normal
+// interpolation.)
+inline void trianglePartialsSmooth(const Vec3& v0, const Vec3& v1, const Vec3& v2,
+                                   const Vec3& n0, const Vec3& n1, const Vec3& n2,
+                                   float u, float v,
+                                   Vec3& dp_du, Vec3& dp_dv,
+                                   Vec3& dn_du, Vec3& dn_dv) {
+    dp_du = v1 - v0;
+    dp_dv = v2 - v0;
+    Vec3 ni = n0 + (n1 - n0) * u + (n2 - n0) * v;
+    float len = std::sqrt(ni.length2());
+    if (len < 1e-12f) { dn_du = Vec3(0.0f); dn_dv = Vec3(0.0f); return; }
+    float invLen = 1.0f / len;
+    Vec3 nhat = ni * invLen;
+    // d/du normalize(ni) = (I - nhat nhat^T) (dni/du) / |ni|
+    Vec3 dni_du = n1 - n0;
+    Vec3 dni_dv = n2 - n0;
+    dn_du = (dni_du - nhat * nhat.dot(dni_du)) * invLen;
+    dn_dv = (dni_dv - nhat * nhat.dot(dni_dv)) * invLen;
+}
+
+// Sphere of radius r centred at `center`, evaluated at surface point p
+// (n = (p-center)/r). Build an orthonormal tangent pair; the unit normal
+// rotates with the tangent step at rate 1/r, so dn = dp / r (perpendicular to n,
+// as required).
+inline void spherePartials(const Vec3& center, const Vec3& p, float radius,
+                           Vec3& dp_du, Vec3& dp_dv,
+                           Vec3& dn_du, Vec3& dn_dv) {
+    float invR = (radius > 1e-12f) ? (1.0f / radius) : 0.0f;
+    Vec3 n = (p - center) * invR;
+    Vec3 a = (std::fabs(n.x) > 0.9f) ? Vec3(0.0f, 1.0f, 0.0f) : Vec3(1.0f, 0.0f, 0.0f);
+    Vec3 s = a - n * a.dot(n);
+    float ls = std::sqrt(s.length2());
+    s = (ls > 1e-12f) ? s * (1.0f / ls) : Vec3(1.0f, 0.0f, 0.0f);
+    Vec3 t = n.cross(s);
+    dp_du = s;
+    dp_dv = t;
+    dn_du = s * invR;
+    dn_dv = t * invR;
+}
+
+}  // namespace astroray::manifold

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -23,6 +23,8 @@
 #include "astroray/spectrum.h"
 #include "astroray/spectral_profile.h"
 #include "astroray/manifold/half_vector_constraint.h"  // pkg106 Chunk A test helper
+#include "astroray/manifold/surface_partials.h"         // pkg106 Chunk B test helper
+#include "astroray/manifold/newton_iterate.h"           // pkg106 Chunk B test helper
 #include "astroray/restir/reservoir.h"
 #include "astroray/restir/light_sample.h"
 #include "astroray/restir/frame_state.h"
@@ -2172,6 +2174,64 @@ PYBIND11_MODULE(astroray, m) {
           },
           "x0"_a, "x1"_a, "x2"_a, "n1"_a, "dp_du"_a, "dp_dv"_a,
           "dn_du"_a, "dn_dv"_a, "eta"_a, "refraction"_a);
+
+    // pkg106 Chunk B test helpers ----------------------------------------------
+    auto vtuple = [](const Vec3& v) { return py::make_tuple(v.x, v.y, v.z); };
+
+    // Triangle (u,v) partials: returns (dp_du, dp_dv, dn_du, dn_dv) each a 3-tuple.
+    m.def("_mnee_triangle_partials",
+          [vtuple](const std::array<float, 3>& v0, const std::array<float, 3>& v1,
+                   const std::array<float, 3>& v2) {
+              auto V = [](const std::array<float, 3>& a) { return Vec3(a[0], a[1], a[2]); };
+              Vec3 dpu, dpv, dnu, dnv;
+              astroray::manifold::trianglePartials(V(v0), V(v1), V(v2), dpu, dpv, dnu, dnv);
+              return py::make_tuple(vtuple(dpu), vtuple(dpv), vtuple(dnu), vtuple(dnv));
+          },
+          "v0"_a, "v1"_a, "v2"_a);
+
+    // Sphere (u,v) partials at point p on a sphere(center, radius).
+    m.def("_mnee_sphere_partials",
+          [vtuple](const std::array<float, 3>& center, const std::array<float, 3>& p,
+                   float radius) {
+              auto V = [](const std::array<float, 3>& a) { return Vec3(a[0], a[1], a[2]); };
+              Vec3 dpu, dpv, dnu, dnv;
+              astroray::manifold::spherePartials(V(center), V(p), radius, dpu, dpv, dnu, dnv);
+              return py::make_tuple(vtuple(dpu), vtuple(dpv), vtuple(dnu), vtuple(dnv));
+          },
+          "center"_a, "p"_a, "radius"_a);
+
+    // Analytic-Jacobian manifold Newton on a FLAT refractor (constant normal +
+    // partials; tangent step stays on the plane). Returns
+    // (converged, iterations, residual_norm, x1_u, x1_v, x1_w).
+    m.def("_mnee_newton_solve_flat",
+          [](const std::array<float, 3>& x0, const std::array<float, 3>& x2,
+             const std::array<float, 3>& n1, const std::array<float, 3>& dp_du,
+             const std::array<float, 3>& dp_dv, const std::array<float, 3>& x1_init,
+             float eta, bool refraction, int max_iter, float tol) {
+              auto V = [](const std::array<float, 3>& a) { return Vec3(a[0], a[1], a[2]); };
+              const Vec3 n = V(n1), dpu = V(dp_du), dpv = V(dp_dv);
+              // Flat reprojection: stay on the plane, normal + partials constant.
+              astroray::manifold::ReprojectFnAnalytic reproject =
+                  [n, dpu, dpv](const Vec3& x1, const Vec3& s, const Vec3& t,
+                                float du, float dv, Vec3& ox, Vec3& on,
+                                Vec3& odpu, Vec3& odpv, Vec3& odnu, Vec3& odnv) {
+                      ox = x1 + s * du + t * dv;
+                      on = n; odpu = dpu; odpv = dpv;
+                      odnu = Vec3(0.0f); odnv = Vec3(0.0f);
+                      return true;
+                  };
+              astroray::manifold::NewtonConfig cfg;
+              cfg.maxIterations = max_iter;
+              cfg.tolerance = tol;
+              astroray::manifold::AnalyticNewtonResult r =
+                  astroray::manifold::solveAnalytic(
+                      V(x0), V(x2), eta, refraction, V(x1_init), n,
+                      dpu, dpv, Vec3(0.0f), Vec3(0.0f), reproject, cfg);
+              return py::make_tuple(r.converged, r.iterations, r.residualNorm,
+                                    r.x1.x, r.x1.y, r.x1.z);
+          },
+          "x0"_a, "x2"_a, "n1"_a, "dp_du"_a, "dp_dv"_a, "x1_init"_a,
+          "eta"_a, "refraction"_a, "max_iter"_a = 20, "tol"_a = 1e-5f);
     m.def("synchrotron_thermal_emissivity",
           &astroray::synchrotron::jnuThermalI,
           "nu_hz"_a, "n_e_cm3"_a, "T_e_K"_a, "B_gauss"_a, "theta_B"_a,

--- a/tests/test_mnee_newton_analytic.py
+++ b/tests/test_mnee_newton_analytic.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+"""pkg106 Chunk B — surface (u,v) partials + analytic-Jacobian Newton.
+
+Validates:
+  1. trianglePartials / spherePartials (surface_partials.h) produce the correct
+     position + unit-normal derivatives (dn perpendicular to n, |dn|=1/r sphere).
+  2. solveAnalytic (newton_iterate.h) — the analytic-Jacobian manifold Newton —
+     converges to the analytic Snell-law refraction on a tilted plane.
+
+The analytic Jacobian (Chunk A) replaces newton_iterate.h's central-difference
+Jacobian, which diverges on triangulated casters (a +/-h tangent step crosses a
+facet edge into a neighbour with a different normal). See
+.astroray_plan/docs/pkg106-research-2026-05-28.md.
+
+Pure-CPU; runs on CI.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+sys.path.insert(0, os.path.dirname(__file__))
+
+try:
+    import astroray  # noqa: E402
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray not built")
+
+
+def _has(name):
+    return AVAILABLE and hasattr(astroray, name)
+
+
+def _norm(v):
+    return v / np.linalg.norm(v)
+
+
+@pytest.mark.skipif(not _has("_mnee_triangle_partials"),
+                    reason="_mnee_triangle_partials not in this build")
+def test_triangle_partials():
+    v0 = [0.0, 0.0, 0.0]
+    v1 = [1.3, 0.2, 0.0]
+    v2 = [0.1, 1.1, 0.4]
+    dpu, dpv, dnu, dnv = astroray._mnee_triangle_partials(v0, v1, v2)
+    assert np.allclose(dpu, [1.3, 0.2, 0.0])           # v1 - v0
+    assert np.allclose(dpv, [0.1, 1.1, 0.4])           # v2 - v0
+    assert np.allclose(dnu, [0.0, 0.0, 0.0])           # flat facet
+    assert np.allclose(dnv, [0.0, 0.0, 0.0])
+
+
+@pytest.mark.skipif(not _has("_mnee_sphere_partials"),
+                    reason="_mnee_sphere_partials not in this build")
+def test_sphere_partials():
+    center = np.array([0.0, -0.4, 0.15])
+    radius = 0.7
+    n_dir = _norm(np.array([0.3, 0.8, 0.2]))
+    p = center + n_dir * radius
+    dpu, dpv, dnu, dnv = (np.array(a) for a in
+                          astroray._mnee_sphere_partials(list(center), list(p), radius))
+    n = (p - center) / radius
+    # tangents perpendicular to n and unit length
+    assert abs(np.dot(dpu, n)) < 1e-5
+    assert abs(np.dot(dpv, n)) < 1e-5
+    assert abs(np.linalg.norm(dpu) - 1.0) < 1e-5
+    # unit-normal derivative: dn = dp / r, perpendicular to n
+    assert np.allclose(dnu, dpu / radius, atol=1e-5)
+    assert np.allclose(dnv, dpv / radius, atol=1e-5)
+    assert abs(np.dot(dnu, n)) < 1e-5
+
+
+def _tilted_plane_snell():
+    eta = 1.0 / 1.5
+    n1 = _norm(np.array([0.2, 1.0, 0.1]))
+    a = np.array([1.0, 0.0, 0.0])
+    dp_du = _norm(a - np.dot(a, n1) * n1) * 1.3
+    dp_dv = np.cross(n1, dp_du) * 0.9
+    s_dir = _norm(dp_du - np.dot(dp_du, n1) * n1)
+    theta_i = np.deg2rad(35.0)
+    wi = np.cos(theta_i) * n1 + np.sin(theta_i) * s_dir
+    wo_t = -np.sin(theta_i) / eta
+    wo = -np.sqrt(1 - wo_t ** 2) * n1 + wo_t * s_dir
+    x1_star = np.zeros(3)
+    x0 = x1_star + wi * 2.0
+    x2 = x1_star + wo * 3.0
+    return dict(eta=eta, n1=n1, dp_du=dp_du, dp_dv=dp_dv,
+                x0=x0, x2=x2, x1_star=x1_star)
+
+
+@pytest.mark.skipif(not _has("_mnee_newton_solve_flat"),
+                    reason="_mnee_newton_solve_flat not in this build")
+def test_analytic_newton_converges_to_snell():
+    g = _tilted_plane_snell()
+    # Seed off the manifold (on the plane), then solve.
+    x1_init = g["x1_star"] + g["dp_du"] * 0.25 + g["dp_dv"] * (-0.18)
+    converged, iters, residual, ux, uy, uz = astroray._mnee_newton_solve_flat(
+        list(g["x0"]), list(g["x2"]), list(g["n1"]),
+        list(g["dp_du"]), list(g["dp_dv"]), list(x1_init),
+        float(g["eta"]), True, 20, 1e-5,
+    )
+    x1 = np.array([ux, uy, uz])
+    assert converged, f"analytic Newton did not converge (residual={residual:.2e})"
+    assert iters <= 10, f"too many iterations: {iters}"
+    assert residual < 1e-5
+    # Converged to the analytic Snell-law vertex.
+    assert np.linalg.norm(x1 - g["x1_star"]) < 1e-3, (
+        f"converged to {x1}, expected {g['x1_star']}"
+    )
+
+
+@pytest.mark.skipif(not _has("_mnee_newton_solve_flat"),
+                    reason="_mnee_newton_solve_flat not in this build")
+def test_analytic_newton_already_at_solution():
+    """Seeded exactly at the solution -> converges in 1 iteration (residual ~0)."""
+    g = _tilted_plane_snell()
+    converged, iters, residual, ux, uy, uz = astroray._mnee_newton_solve_flat(
+        list(g["x0"]), list(g["x2"]), list(g["n1"]),
+        list(g["dp_du"]), list(g["dp_dv"]), list(g["x1_star"]),
+        float(g["eta"]), True, 20, 1e-5,
+    )
+    assert converged and iters == 1 and residual < 1e-5


### PR DESCRIPTION
## Summary
Second pkg106 chunk. Builds on Chunk A's analytic constraint Jacobian.

- **`manifold/surface_partials.h`** (new): `trianglePartials` (`dp_du=v1−v0`, `dp_dv=v2−v0`, `dn=0` for flat facets), `trianglePartialsSmooth` (interpolated shading-normal gradient, for future smooth prisms), `spherePartials` (`dn=dp/r`). Computed **on-demand from primitive geometry — not stored in `HitRecord`** (avoids bloating the per-ray hot struct with 4 `Vec3` for a caustic-caster-only feature; CLAUDE.md §2).
- **`newton_iterate.h`**: `solveAnalytic()` — the manifold Newton loop driven by `halfVectorConstraintJacobian` instead of central differences. The FD path diverges on triangulated casters (±h tangent step crosses a facet edge → spurious Jacobian discontinuity); the analytic path doesn't. The existing FD `solve()` is kept for backward-compat.
- **`blender_module.cpp`**: `_mnee_triangle_partials` / `_mnee_sphere_partials` / `_mnee_newton_solve_flat` test helpers.
- **`tests/test_mnee_newton_analytic.py`**: partials correctness (`dn ⊥ n`, `|dn|=1/r` sphere) + analytic Newton converges to the analytic Snell vertex on a tilted plane in ≤8 iterations.

## Validation
- Newton convergence prototyped in Python first (8 iters, residual 3.7e-6, `|x1−x1*|`=4.5e-6), then ported.
- 9/9 mnee tests pass (4 Chunk B + 5 Chunk A); `test_python_bindings` regression green (71 passed). No existing signatures changed.

## Scope / next
- **Chunk C**: triangle BVH reprojection (the current reproject is sphere-analytic / flat-plane only) so the Newton walks general triangulated casters.
- **Chunk D**: wire `solveAnalytic` into `sms_caustic_path_tracer`.
- **Chunk E**: triangulated prism scene + `hue_spread ≥ 0.7` acceptance.

## Test plan
- [x] 9/9 mnee tests pass (CPU; runs on CI)
- [x] python_bindings regression green
- [ ] CI green (build-and-test + cuda-syntax-check)

CPU-only header math + test-helper bindings; no CUDA/GPU code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)