### PR TITLE
feat(pkg106): MNEE Chunk C — multi-vertex manifold chain (block-tridiagonal)

### DIFF
--- a/include/astroray/manifold/manifold_chain.h
+++ b/include/astroray/manifold/manifold_chain.h
@@ -1,0 +1,200 @@
+#pragma once
+// pkg106 Chunk C — multi-vertex specular manifold chain (block-tridiagonal
+// Newton). A prism rainbow needs TWO refractive vertices (entry + exit face);
+// the single-vertex solver (half_vector_constraint.h) cannot represent it.
+//
+// Ports Cycles mnee.h mnee_compute_constraint_derivatives (the a=prev / b=current
+// / c=next block-tridiagonal Jacobian, lines 248-365, Apache-2.0) + the
+// manifold-walk Newton, for a chain x0 -> v[0] -> ... -> v[N-1] -> light.
+// Astroray +h convention (h = wi + eta*wo); Hanika 2015 §5. Validated
+// analytic-vs-finite-difference to ~1e-11 and damped-Newton convergence on a
+// forward-traced 2-refraction chain (4 iters) — see
+// pkg106-research-2026-05-28.md.
+
+#include "../../raytracer.h"
+#include "half_vector_constraint.h"
+#include "newton_iterate.h"   // NewtonConfig
+#include <cmath>
+#include <functional>
+
+namespace astroray::manifold {
+
+inline constexpr int kMaxChainVertices = 4;  // prism uses 2; headroom for chains
+
+struct ChainVertex {
+    Vec3  p, n;                      // position + unit normal
+    Vec3  dp_du, dp_dv;              // surface position partials
+    Vec3  dn_du, dn_dv;              // unit-normal partials (perp to n; 0 if flat)
+    float eta = 1.0f;                // material IOR ratio (1 = reflection)
+};
+
+// 2x2 block written row-major into a (2N x 2N) dense matrix at block (bi, bj).
+inline void mnee_writeBlock(float* J, int n2, int bi, int bj,
+                            float m00, float m01, float m10, float m11) {
+    J[(2 * bi + 0) * n2 + (2 * bj + 0)] = m00;
+    J[(2 * bi + 0) * n2 + (2 * bj + 1)] = m01;
+    J[(2 * bi + 1) * n2 + (2 * bj + 0)] = m10;
+    J[(2 * bi + 1) * n2 + (2 * bj + 1)] = m11;
+}
+
+// Evaluate the chain constraint residual (length 2N) and the block-tridiagonal
+// Jacobian J (row-major 2N x 2N) and per-vertex tangent frames (s[i], t[i]).
+// `refraction` selects h = wi + eta*wo (true) vs wi + wo (false, reflection).
+// Returns false on a degenerate vertex (zero-length direction / half-vector).
+inline bool chainEval(const ChainVertex* v, int N, const Vec3& x0, const Vec3& light,
+                      bool refraction, float* residual, float* J, Vec3* sOut, Vec3* tOut) {
+    const int n2 = 2 * N;
+    for (int k = 0; k < n2 * n2; ++k) J[k] = 0.0f;
+
+    for (int i = 0; i < N; ++i) {
+        const ChainVertex& vi = v[i];
+        const Vec3 prev = (i == 0)     ? x0    : v[i - 1].p;
+        const Vec3 next = (i == N - 1) ? light : v[i + 1].p;
+
+        Vec3 wi = prev - vi.p; float li = std::sqrt(wi.length2());
+        Vec3 wo = next - vi.p; float lo = std::sqrt(wo.length2());
+        if (li < 1e-12f || lo < 1e-12f) return false;
+        float ili = 1.0f / li; wi = wi * ili;
+        float ilo = 1.0f / lo; wo = wo * ilo;
+
+        float eta = refraction ? vi.eta : 1.0f;
+        if (wi.dot(vi.n) < 0.0f) eta = 1.0f / eta;  // entering from inside
+
+        Vec3 h = wi + wo * eta; float lh = std::sqrt(h.length2());
+        if (lh < 1e-12f) return false;
+        const float ilh = 1.0f / lh; h = h * ilh;
+        ilo *= eta * ilh;
+        ili *= ilh;
+
+        const float dpdn = vi.dp_du.dot(vi.n);
+        Vec3 s = vi.dp_du - vi.n * dpdn;
+        float ls = std::sqrt(s.length2());
+        if (ls < 1e-12f) return false;
+        const float inv_len_s = 1.0f / ls; s = s * inv_len_s;
+        const Vec3 t = vi.n.cross(s);
+        sOut[i] = s; tOut[i] = t;
+
+        residual[2 * i + 0] = s.dot(h);
+        residual[2 * i + 1] = t.dot(h);
+
+        // b block (current vertex) — includes tangent-frame ds/dt terms (0 if flat).
+        Vec3 dH_du = vi.dp_du * (-(ili + ilo)) + wi * (wi.dot(vi.dp_du) * ili) + wo * (wo.dot(vi.dp_du) * ilo);
+        Vec3 dH_dv = vi.dp_dv * (-(ili + ilo)) + wi * (wi.dot(vi.dp_dv) * ili) + wo * (wo.dot(vi.dp_dv) * ilo);
+        dH_du = dH_du - h * dH_du.dot(h);
+        dH_dv = dH_dv - h * dH_dv.dot(h);
+        Vec3 ds_du = (vi.n * vi.dp_du.dot(vi.dn_du) + vi.dn_du * dpdn) * (-inv_len_s);
+        Vec3 ds_dv = (vi.n * vi.dp_du.dot(vi.dn_dv) + vi.dn_dv * dpdn) * (-inv_len_s);
+        ds_du = ds_du - s * s.dot(ds_du);
+        ds_dv = ds_dv - s * s.dot(ds_dv);
+        const Vec3 dt_du = vi.dn_du.cross(s) + vi.n.cross(ds_du);
+        const Vec3 dt_dv = vi.dn_dv.cross(s) + vi.n.cross(ds_dv);
+        mnee_writeBlock(J, n2, i, i,
+                        dH_du.dot(s) + h.dot(ds_du), dH_dv.dot(s) + h.dot(ds_dv),
+                        dH_du.dot(t) + h.dot(dt_du), dH_dv.dot(t) + h.dot(dt_dv));
+
+        // a block (w.r.t. previous manifold vertex) — projected on this vertex's frame.
+        if (i > 0) {
+            const ChainVertex& vp = v[i - 1];
+            Vec3 a_du = (vp.dp_du - wi * wi.dot(vp.dp_du)) * ili;
+            Vec3 a_dv = (vp.dp_dv - wi * wi.dot(vp.dp_dv)) * ili;
+            a_du = a_du - h * a_du.dot(h);
+            a_dv = a_dv - h * a_dv.dot(h);
+            mnee_writeBlock(J, n2, i, i - 1,
+                            a_du.dot(s), a_dv.dot(s), a_du.dot(t), a_dv.dot(t));
+        }
+        // c block (w.r.t. next manifold vertex).
+        if (i < N - 1) {
+            const ChainVertex& vn = v[i + 1];
+            Vec3 c_du = (vn.dp_du - wo * wo.dot(vn.dp_du)) * ilo;
+            Vec3 c_dv = (vn.dp_dv - wo * wo.dot(vn.dp_dv)) * ilo;
+            c_du = c_du - h * c_du.dot(h);
+            c_dv = c_dv - h * c_dv.dot(h);
+            mnee_writeBlock(J, n2, i, i + 1,
+                            c_du.dot(s), c_dv.dot(s), c_du.dot(t), c_dv.dot(t));
+        }
+    }
+    return true;
+}
+
+// Dense linear solve A x = b (row-major A, size m<=2*kMaxChainVertices) via
+// Gaussian elimination with partial pivoting. Returns false if singular.
+inline bool mnee_solveDense(float* A, float* b, int m) {
+    for (int col = 0; col < m; ++col) {
+        int piv = col; float best = std::fabs(A[col * m + col]);
+        for (int r = col + 1; r < m; ++r) {
+            float val = std::fabs(A[r * m + col]);
+            if (val > best) { best = val; piv = r; }
+        }
+        if (best < 1e-12f) return false;
+        if (piv != col) {
+            for (int c = 0; c < m; ++c) std::swap(A[col * m + c], A[piv * m + c]);
+            std::swap(b[col], b[piv]);
+        }
+        const float inv = 1.0f / A[col * m + col];
+        for (int r = col + 1; r < m; ++r) {
+            const float f = A[r * m + col] * inv;
+            if (f == 0.0f) continue;
+            for (int c = col; c < m; ++c) A[r * m + c] -= f * A[col * m + c];
+            b[r] -= f * b[col];
+        }
+    }
+    for (int r = m - 1; r >= 0; --r) {
+        float sum = b[r];
+        for (int c = r + 1; c < m; ++c) sum -= A[r * m + c] * b[c];
+        b[r] = sum / A[r * m + r];
+    }
+    return true;
+}
+
+struct ChainResult {
+    bool  converged = false;
+    int   iterations = 0;
+    float residualNorm = 0.0f;
+};
+
+// Reproject one chain vertex `i` after a tangent step (du,dv) in its (s,t)
+// frame back onto its surface, refreshing position/normal/partials.
+using ReprojectChainFn = std::function<bool(
+    int i, const Vec3& s, const Vec3& t, float du, float dv, ChainVertex& v)>;
+
+// Damped, step-clamped block Newton on the chain (mirrors Cycles' beta step
+// control). Updates v[] in place; returns convergence.
+inline ChainResult solveChain(ChainVertex* v, int N, const Vec3& x0, const Vec3& light,
+                              bool refraction, const ReprojectChainFn& reproject,
+                              const NewtonConfig& cfg = {}, float maxStep = 0.3f) {
+    ChainResult R;
+    if (N <= 0 || N > kMaxChainVertices) return R;
+    const int n2 = 2 * N;
+    float residual[2 * kMaxChainVertices];
+    float J[(2 * kMaxChainVertices) * (2 * kMaxChainVertices)];
+    Vec3  s[kMaxChainVertices], t[kMaxChainVertices];
+
+    for (int it = 0; it < cfg.maxIterations; ++it) {
+        R.iterations = it + 1;
+        if (!chainEval(v, N, x0, light, refraction, residual, J, s, t)) break;
+        float rn = 0.0f;
+        for (int k = 0; k < n2; ++k) rn += residual[k] * residual[k];
+        rn = std::sqrt(rn);
+        R.residualNorm = rn;
+        if (rn < cfg.tolerance) { R.converged = true; break; }
+
+        float rhs[2 * kMaxChainVertices];
+        for (int k = 0; k < n2; ++k) rhs[k] = -residual[k];
+        if (!mnee_solveDense(J, rhs, n2)) break;  // step now in rhs
+
+        // Clamp the largest component (Cycles beta-style) for stability.
+        float mx = 0.0f;
+        for (int k = 0; k < n2; ++k) mx = std::max(mx, std::fabs(rhs[k]));
+        const float beta = (mx > maxStep) ? (maxStep / mx) : 1.0f;
+
+        bool ok = true;
+        for (int i = 0; i < N && ok; ++i) {
+            ok = reproject(i, s[i], t[i], rhs[2 * i] * cfg.damping * beta,
+                           rhs[2 * i + 1] * cfg.damping * beta, v[i]);
+        }
+        if (!ok) break;
+    }
+    return R;
+}
+
+}  // namespace astroray::manifold

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -25,6 +25,7 @@
 #include "astroray/manifold/half_vector_constraint.h"  // pkg106 Chunk A test helper
 #include "astroray/manifold/surface_partials.h"         // pkg106 Chunk B test helper
 #include "astroray/manifold/newton_iterate.h"           // pkg106 Chunk B test helper
+#include "astroray/manifold/manifold_chain.h"           // pkg106 Chunk C test helper
 #include "astroray/restir/reservoir.h"
 #include "astroray/restir/light_sample.h"
 #include "astroray/restir/frame_state.h"
@@ -2232,6 +2233,86 @@ PYBIND11_MODULE(astroray, m) {
           },
           "x0"_a, "x2"_a, "n1"_a, "dp_du"_a, "dp_dv"_a, "x1_init"_a,
           "eta"_a, "refraction"_a, "max_iter"_a = 20, "tol"_a = 1e-5f);
+
+    // pkg106 Chunk C test helpers — multi-vertex manifold chain ----------------
+    {
+        namespace am = astroray::manifold;
+        auto buildChain = [](const std::vector<std::array<float, 3>>& ps,
+                             const std::vector<std::array<float, 3>>& ns,
+                             const std::vector<std::array<float, 3>>& dpus,
+                             const std::vector<std::array<float, 3>>& dpvs,
+                             const std::vector<std::array<float, 3>>& dnus,
+                             const std::vector<std::array<float, 3>>& dnvs,
+                             const std::vector<float>& etas,
+                             am::ChainVertex* v) {
+            auto V = [](const std::array<float, 3>& a) { return Vec3(a[0], a[1], a[2]); };
+            int N = static_cast<int>(ps.size());
+            for (int i = 0; i < N; ++i) {
+                v[i].p = V(ps[i]); v[i].n = V(ns[i]);
+                v[i].dp_du = V(dpus[i]); v[i].dp_dv = V(dpvs[i]);
+                v[i].dn_du = V(dnus[i]); v[i].dn_dv = V(dnvs[i]);
+                v[i].eta = etas[i];
+            }
+            return N;
+        };
+
+        // Returns (ok, residual[2N], J_flat[(2N)^2]) for the FD Jacobian check.
+        m.def("_mnee_chain_eval",
+              [buildChain](const std::vector<std::array<float, 3>>& ps,
+                           const std::vector<std::array<float, 3>>& ns,
+                           const std::vector<std::array<float, 3>>& dpus,
+                           const std::vector<std::array<float, 3>>& dpvs,
+                           const std::vector<std::array<float, 3>>& dnus,
+                           const std::vector<std::array<float, 3>>& dnvs,
+                           const std::vector<float>& etas,
+                           const std::array<float, 3>& x0,
+                           const std::array<float, 3>& light, bool refraction) {
+                  am::ChainVertex v[am::kMaxChainVertices];
+                  int N = buildChain(ps, ns, dpus, dpvs, dnus, dnvs, etas, v);
+                  int n2 = 2 * N;
+                  std::vector<float> residual(n2, 0.f), J(static_cast<size_t>(n2) * n2, 0.f);
+                  Vec3 s[am::kMaxChainVertices], t[am::kMaxChainVertices];
+                  bool ok = am::chainEval(v, N, Vec3(x0[0], x0[1], x0[2]),
+                                          Vec3(light[0], light[1], light[2]),
+                                          refraction, residual.data(), J.data(), s, t);
+                  return py::make_tuple(ok, residual, J);
+              },
+              "ps"_a, "ns"_a, "dp_dus"_a, "dp_dvs"_a, "dn_dus"_a, "dn_dvs"_a,
+              "etas"_a, "x0"_a, "light"_a, "refraction"_a);
+
+        // Damped block Newton on a FLAT chain (dn=0; tangent step stays on each
+        // plane). Returns (converged, iterations, residual_norm, final_ps_flat[3N]).
+        m.def("_mnee_chain_solve_flat",
+              [buildChain](const std::vector<std::array<float, 3>>& ps,
+                           const std::vector<std::array<float, 3>>& ns,
+                           const std::vector<std::array<float, 3>>& dpus,
+                           const std::vector<std::array<float, 3>>& dpvs,
+                           const std::vector<float>& etas,
+                           const std::array<float, 3>& x0,
+                           const std::array<float, 3>& light, bool refraction,
+                           int max_iter, float tol, float max_step) {
+                  std::vector<std::array<float, 3>> z(ps.size(), {0.f, 0.f, 0.f});
+                  am::ChainVertex v[am::kMaxChainVertices];
+                  int N = buildChain(ps, ns, dpus, dpvs, z, z, etas, v);
+                  am::ReprojectChainFn rp = [](int, const Vec3& s, const Vec3& t,
+                                               float du, float dv, am::ChainVertex& vv) {
+                      vv.p = vv.p + s * du + t * dv;  // flat: stay on the plane
+                      return true;
+                  };
+                  am::NewtonConfig cfg;
+                  cfg.maxIterations = max_iter;
+                  cfg.tolerance = tol;
+                  am::ChainResult r = am::solveChain(
+                      v, N, Vec3(x0[0], x0[1], x0[2]),
+                      Vec3(light[0], light[1], light[2]), refraction, rp, cfg, max_step);
+                  std::vector<float> finalP;
+                  for (int i = 0; i < N; ++i) { finalP.push_back(v[i].p.x); finalP.push_back(v[i].p.y); finalP.push_back(v[i].p.z); }
+                  return py::make_tuple(r.converged, r.iterations, r.residualNorm, finalP);
+              },
+              "ps"_a, "ns"_a, "dp_dus"_a, "dp_dvs"_a, "etas"_a, "x0"_a, "light"_a,
+              "refraction"_a, "max_iter"_a = 30, "tol"_a = 1e-5f, "max_step"_a = 0.3f);
+    }
+
     m.def("synchrotron_thermal_emissivity",
           &astroray::synchrotron::jnuThermalI,
           "nu_hz"_a, "n_e_cm3"_a, "T_e_K"_a, "B_gauss"_a, "theta_B"_a,

--- a/tests/test_mnee_chain.py
+++ b/tests/test_mnee_chain.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python
+"""pkg106 Chunk C — multi-vertex specular manifold chain (block-tridiagonal).
+
+A prism rainbow needs TWO refractive vertices (entry + exit face); the single-
+vertex solver (Chunks A/B) can't represent it. This validates manifold_chain.h:
+  1. The block-tridiagonal Jacobian (a=prev / b=current / c=next) matches a
+     float64 finite-difference of the same residual (2-refraction chain).
+  2. The damped block Newton converges to a forward-traced 2-refraction chain.
+
+Ports Cycles mnee.h mnee_compute_constraint_derivatives lines 248-365. See
+.astroray_plan/docs/pkg106-research-2026-05-28.md. CPU-only; runs on CI.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+sys.path.insert(0, os.path.dirname(__file__))
+
+try:
+    import astroray  # noqa: E402
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray not built")
+
+
+def _has(name):
+    return AVAILABLE and hasattr(astroray, name)
+
+
+def _norm(v):
+    return v / np.linalg.norm(v)
+
+
+def _refract(d, n, eta):
+    d = _norm(d)
+    cosi = -np.dot(d, n)
+    if cosi < 0:
+        n = -n
+        cosi = -np.dot(d, n)
+    s2 = eta * eta * (1 - cosi * cosi)
+    if s2 >= 1:
+        return None
+    return _norm(eta * d + (eta * cosi - np.sqrt(1 - s2)) * n)
+
+
+def _planar_partials(n):
+    a = np.array([1.0, 0.0, 0.0]) if abs(n[0]) < 0.9 else np.array([0.0, 1.0, 0.0])
+    du = _norm(a - np.dot(a, n) * n)
+    return du, np.cross(n, du)
+
+
+def _forward_traced_prism_chain():
+    """Thin prism, near-normal incidence -> transmits (no TIR), small angles.
+    Returns the SMS chain x0 -> v_exit(nB) -> v_entry(nA) -> light plus normals,
+    partials, etas. (Matches the validated _mnee_chain_proto geometry.)"""
+    ng = 1.5
+    nA = _norm(np.array([-1.0, 0.12, 0.0]))
+    nB = _norm(np.array([1.0, 0.12, 0.0]))
+    pA = np.array([-0.5, 0.0, 0.0])
+    pB = np.array([0.5, 0.0, 0.0])
+    L = np.array([-3.0, 0.4, 0.0])
+    d0 = _norm(np.array([1.0, -0.12, 0.0]))
+    tA = np.dot(pA - L, nA) / np.dot(d0, nA)
+    v_entry = L + d0 * tA
+    d1 = _refract(d0, nA, 1.0 / ng)
+    assert d1 is not None
+    tB = np.dot(pB - v_entry, nB) / np.dot(d1, nB)
+    v_exit = v_entry + d1 * tB
+    d2 = _refract(d1, nB, ng)
+    assert d2 is not None
+    x0 = v_exit + d2 * 2.0
+    duB, dvB = _planar_partials(nB)
+    duA, dvA = _planar_partials(nA)
+    # chain order: x0 -> v1=v_exit(nB) -> v2=v_entry(nA) -> light
+    return dict(
+        ps=[v_exit, v_entry], ns=[nB, nA], dpus=[duB, duA], dpvs=[dvB, dvA],
+        etas=[ng, ng], x0=x0, light=L,
+    )
+
+
+def _chain_residual_py(ps, ns, dpus, x0, light, etas, refraction=True):
+    """float64 reference residual (the C++ one is float32 -> FD of it is noise)."""
+    N = len(ps)
+    out = []
+    for i in range(N):
+        prev = x0 if i == 0 else ps[i - 1]
+        nxt = light if i == N - 1 else ps[i + 1]
+        wi = _norm(prev - ps[i])
+        wo = _norm(nxt - ps[i])
+        e = etas[i] if refraction else 1.0
+        if np.dot(wi, ns[i]) < 0:
+            e = 1.0 / e
+        h = wi + e * wo
+        h = h / np.linalg.norm(h)
+        s = dpus[i] - np.dot(dpus[i], ns[i]) * ns[i]
+        s = s / np.linalg.norm(s)
+        t = np.cross(ns[i], s)
+        out += [np.dot(s, h), np.dot(t, h)]
+    return np.array(out)
+
+
+def _fd_jacobian_py(g, h=1e-6):
+    ps, ns, dpus, dpvs = g["ps"], g["ns"], g["dpus"], g["dpvs"]
+    N = len(ps)
+    J = np.zeros((2 * N, 2 * N))
+    for j in range(N):
+        for k, dp in enumerate((dpus[j], dpvs[j])):
+            pp = [p.copy() for p in ps]
+            pm = [p.copy() for p in ps]
+            pp[j] = ps[j] + dp * h
+            pm[j] = ps[j] - dp * h
+            cp = _chain_residual_py(pp, ns, dpus, g["x0"], g["light"], g["etas"])
+            cm = _chain_residual_py(pm, ns, dpus, g["x0"], g["light"], g["etas"])
+            J[:, 2 * j + k] = (cp - cm) / (2 * h)
+    return J
+
+
+def _call_eval(g):
+    z = [[0.0, 0.0, 0.0]] * len(g["ps"])
+    ok, residual, Jflat = astroray._mnee_chain_eval(
+        [list(p) for p in g["ps"]], [list(n) for n in g["ns"]],
+        [list(d) for d in g["dpus"]], [list(d) for d in g["dpvs"]],
+        z, z, list(g["etas"]), list(g["x0"]), list(g["light"]), True,
+    )
+    N = len(g["ps"])
+    return ok, np.array(residual), np.array(Jflat).reshape(2 * N, 2 * N)
+
+
+@pytest.mark.skipif(not _has("_mnee_chain_eval"),
+                    reason="_mnee_chain_eval not in this build")
+def test_chain_residual_zero_at_forward_traced_solution():
+    g = _forward_traced_prism_chain()
+    ok, residual, _ = _call_eval(g)
+    assert ok
+    assert np.linalg.norm(residual) < 1e-4, f"residual {residual} should vanish"
+
+
+@pytest.mark.skipif(not _has("_mnee_chain_eval"),
+                    reason="_mnee_chain_eval not in this build")
+def test_chain_jacobian_matches_fd():
+    g = _forward_traced_prism_chain()
+    ok, _, Jcpp = _call_eval(g)
+    assert ok
+    Jfd = _fd_jacobian_py(g)
+    err = np.max(np.abs(Jcpp - Jfd))
+    assert err < 1e-3, f"chain analytic vs FD Jacobian mismatch {err:.2e}\n{Jcpp}\n{Jfd}"
+    # off-diagonal blocks must be non-zero (genuine multi-vertex coupling).
+    assert np.max(np.abs(Jcpp[0:2, 2:4])) > 1e-3, "c-block (vertex coupling) is zero"
+    assert np.max(np.abs(Jcpp[2:4, 0:2])) > 1e-3, "a-block (vertex coupling) is zero"
+
+
+@pytest.mark.skipif(not _has("_mnee_chain_solve_flat"),
+                    reason="_mnee_chain_solve_flat not in this build")
+def test_chain_newton_converges():
+    g = _forward_traced_prism_chain()
+    true_ps = [p.copy() for p in g["ps"]]
+    # Seed each vertex off the solution, on its plane.
+    seeded = []
+    for i, p in enumerate(g["ps"]):
+        s = _norm(g["dpus"][i] - np.dot(g["dpus"][i], g["ns"][i]) * g["ns"][i])
+        t = np.cross(g["ns"][i], s)
+        seeded.append(p + s * (0.06 * (1 - 2 * (i % 2))) + t * 0.04)
+    z = [[0.0, 0.0, 0.0]] * len(g["ps"])
+    converged, iters, residual, finalP = astroray._mnee_chain_solve_flat(
+        [list(p) for p in seeded], [list(n) for n in g["ns"]],
+        [list(d) for d in g["dpus"]], [list(d) for d in g["dpvs"]],
+        list(g["etas"]), list(g["x0"]), list(g["light"]), True, 30, 1e-5, 0.3,
+    )
+    assert converged, f"chain Newton did not converge (residual={residual:.2e})"
+    assert iters <= 12
+    final = np.array(finalP).reshape(len(g["ps"]), 3)
+    for i in range(len(true_ps)):
+        assert np.linalg.norm(final[i] - true_ps[i]) < 1e-2, (
+            f"vertex {i} converged to {final[i]}, expected {true_ps[i]}"
+        )


### PR DESCRIPTION
## Summary
Third pkg106 chunk: the multi-vertex specular manifold chain — the piece a real prism rainbow actually requires (a prism = **two** refractive vertices: entry + exit face; the single-vertex solver from Chunks A/B can't represent it).

- **`manifold/manifold_chain.h`** (new): `ChainVertex`; `chainEval` (residual + the block-tridiagonal `a`=prev / `b`=current / `c`=next Jacobian, `2N×2N`); a dense Gaussian-elimination solve with partial pivoting; `solveChain` — a damped, step-clamped block Newton (Cycles' `beta` step control) with a per-vertex reprojection callback. Ports Cycles `mnee.h` `mnee_compute_constraint_derivatives` lines 248–365 (Apache-2.0), `+h` convention.
- **`blender_module.cpp`**: `_mnee_chain_eval` / `_mnee_chain_solve_flat` test helpers.
- **`tests/test_mnee_chain.py`**: a forward-traced 2-refraction (thin-prism) chain → residual = 0; the block-tridiagonal Jacobian matches a float64 finite-difference (with the `a`/`c` vertex-coupling blocks asserted non-zero); the damped block Newton converges back to the chain from a perturbed seed.

## Validation
- Prototyped + validated in Python first: Jacobian-vs-FD ~1e-11, block Newton converges in 4 iterations on a real 2-refraction chain.
- 3/3 chain tests pass; full mnee suite (A+B+C) green (12 passed).

## Scope / next
- **Chunk D**: wire this into the SMS pipeline — generalize the sphere-only `SMSCaster`/`runSMSAttempt` to triangle-mesh casters, seed the 2-vertex chain via the receiver→light ray (Cycles seed-ray construction), reproject each vertex via BVH ray-cast onto the prism, and accumulate the 2-refraction hero contribution.
- **Chunk E**: triangulated equilateral prism scene + `hue_spread ≥ 0.7` acceptance.

## Test plan
- [x] 3/3 chain tests pass (CPU; runs on CI)
- [x] full mnee suite green
- [ ] CI green

CPU-only header math + test-helper bindings; no CUDA/GPU code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)