### PR TITLE
feat(pkg106): MNEE Chunk D (seed) — mesh seed-ray + chain on a triangulated prism

### DIFF
--- a/include/astroray/manifold/mesh_caustic.h
+++ b/include/astroray/manifold/mesh_caustic.h
@@ -1,0 +1,115 @@
+#pragma once
+// pkg106 Chunk D — mesh caustic-caster seed-ray construction.
+//
+// Generalises the sphere-only SMS seed (uniform-on-sphere) to triangle-mesh
+// casters. Mirrors Cycles mnee.h kernel_path_mnee_sample seed-ray construction
+// (lines 29-44): cast a ray from the shading point x0 toward the light and
+// collect the ordered intersections with caustic-caster surfaces — those become
+// the initial specular vertex chain (a prism between x0 and the light gives two:
+// the exit face then the entry face). The damped block Newton (manifold_chain.h)
+// then walks them onto the specular manifold.
+//
+// For flat facets the Newton tangent step stays on the triangle's plane, so the
+// per-vertex reprojection is the flat step already validated in manifold_chain.h
+// (no per-step ray-cast needed while the vertex stays on its face).
+
+#include "../../raytracer.h"
+#include "manifold_chain.h"
+#include <cmath>
+
+namespace astroray::manifold {
+
+// A flat caustic-caster triangle (geometric normal derived from the winding).
+struct CausticTri {
+    Vec3 v0, v1, v2;
+};
+
+// Möller-Trumbore ray-triangle intersection. Returns the front/back hit
+// distance t along `d` (which need not be normalised); false on miss.
+inline bool rayTriHit(const Vec3& o, const Vec3& d, const CausticTri& tri, float& tOut) {
+    const Vec3 e1 = tri.v1 - tri.v0;
+    const Vec3 e2 = tri.v2 - tri.v0;
+    const Vec3 p = d.cross(e2);
+    const float det = e1.dot(p);
+    if (std::fabs(det) < 1e-12f) return false;
+    const float inv = 1.0f / det;
+    const Vec3 tv = o - tri.v0;
+    const float u = tv.dot(p) * inv;
+    if (u < -1e-5f || u > 1.0f + 1e-5f) return false;
+    const Vec3 q = tv.cross(e1);
+    const float v = d.dot(q) * inv;
+    if (v < -1e-5f || u + v > 1.0f + 1e-5f) return false;
+    const float t = e2.dot(q) * inv;
+    tOut = t;
+    return t > 1e-5f;
+}
+
+// Construct the seed chain by casting x0 -> light and collecting the ordered
+// caustic-caster intersections (nearest x0 first). Each becomes a ChainVertex
+// with the triangle's flat partials, geometric normal oriented to face x0, and
+// the caster IOR. Returns the number of vertices (0 if the segment misses all
+// casters, or > maxV which is treated as unsupported).
+inline int seedChainFromRay(const CausticTri* tris, int nTris,
+                            const Vec3& x0, const Vec3& light, float ior,
+                            ChainVertex* outV, int maxV) {
+    const Vec3 seg = light - x0;
+    const float segLen = std::sqrt(seg.length2());
+    if (segLen < 1e-9f) return 0;
+    const Vec3 dir = seg * (1.0f / segLen);
+
+    // Collect hits (t in (0, segLen)).
+    float ts[2 * kMaxChainVertices];
+    int idx[2 * kMaxChainVertices];
+    int count = 0;
+    for (int i = 0; i < nTris; ++i) {
+        float t;
+        if (!rayTriHit(x0, dir, tris[i], t)) continue;
+        if (t <= 1e-4f || t >= segLen - 1e-4f) continue;
+        if (count < 2 * kMaxChainVertices) { ts[count] = t; idx[count] = i; ++count; }
+    }
+    if (count == 0 || count > maxV) return 0;
+
+    // Insertion-sort by t (nearest x0 first).
+    for (int i = 1; i < count; ++i) {
+        float kt = ts[i]; int ki = idx[i]; int j = i - 1;
+        while (j >= 0 && ts[j] > kt) { ts[j + 1] = ts[j]; idx[j + 1] = idx[j]; --j; }
+        ts[j + 1] = kt; idx[j + 1] = ki;
+    }
+
+    for (int i = 0; i < count; ++i) {
+        const CausticTri& tri = tris[idx[i]];
+        ChainVertex& v = outV[i];
+        v.p = x0 + dir * ts[i];
+        v.n = (tri.v1 - tri.v0).cross(tri.v2 - tri.v0).normalized();
+        // Build an ORTHONORMAL in-plane (u,v) frame — NOT the raw edge vectors.
+        // The manifold Newton steps along the unit tangents (s,t) and clamps the
+        // (du,dv) magnitude; a non-unit parameterization (raw edges, length ~|edge|)
+        // makes that clamp meaningless and the solve diverges. Verified: raw edges
+        // -> no convergence; orthonormal frame -> 3 iterations. dp_du/dp_dv here are
+        // exactly the (s,t) frame the constraint builds, so the flat reprojection
+        // (p += s*du + t*dv) is consistent with the Jacobian's (u,v) measure.
+        Vec3 e1 = tri.v1 - tri.v0;
+        Vec3 s = e1 - v.n * e1.dot(v.n);
+        float ls = std::sqrt(s.length2());
+        s = (ls > 1e-12f) ? s * (1.0f / ls) : Vec3(1.0f, 0.0f, 0.0f);
+        v.dp_du = s;
+        v.dp_dv = v.n.cross(s);
+        v.dn_du = Vec3(0.0f);   // flat facet
+        v.dn_dv = Vec3(0.0f);
+        v.eta = ior;
+    }
+    return count;
+}
+
+// Flat-facet reprojection for solveChain: the in-plane tangent step keeps the
+// vertex on its triangle's plane, so position updates and normal/partials are
+// unchanged (valid while the vertex stays on its face — true for large prism
+// faces and the small caustic footprint).
+inline ReprojectChainFn makeFlatReproject() {
+    return [](int, const Vec3& s, const Vec3& t, float du, float dv, ChainVertex& v) {
+        v.p = v.p + s * du + t * dv;
+        return true;
+    };
+}
+
+}  // namespace astroray::manifold

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -26,6 +26,7 @@
 #include "astroray/manifold/surface_partials.h"         // pkg106 Chunk B test helper
 #include "astroray/manifold/newton_iterate.h"           // pkg106 Chunk B test helper
 #include "astroray/manifold/manifold_chain.h"           // pkg106 Chunk C test helper
+#include "astroray/manifold/mesh_caustic.h"              // pkg106 Chunk D test helper
 #include "astroray/restir/reservoir.h"
 #include "astroray/restir/light_sample.h"
 #include "astroray/restir/frame_state.h"
@@ -2311,6 +2312,37 @@ PYBIND11_MODULE(astroray, m) {
               },
               "ps"_a, "ns"_a, "dp_dus"_a, "dp_dvs"_a, "etas"_a, "x0"_a, "light"_a,
               "refraction"_a, "max_iter"_a = 30, "tol"_a = 1e-5f, "max_step"_a = 0.3f);
+
+        // pkg106 Chunk D — mesh seed-ray + chain solve on a triangulated caster.
+        // tris is a flat list of 9 floats per triangle (v0,v1,v2). Returns
+        // (n_vertices, converged, iterations, residual, final_ps_flat[3N]).
+        m.def("_mnee_mesh_solve",
+              [](const std::vector<std::array<float, 9>>& tris,
+                 const std::array<float, 3>& x0, const std::array<float, 3>& light,
+                 float ior, int max_iter, float tol, float max_step) {
+                  std::vector<am::CausticTri> ctris(tris.size());
+                  for (size_t i = 0; i < tris.size(); ++i) {
+                      const auto& a = tris[i];
+                      ctris[i].v0 = Vec3(a[0], a[1], a[2]);
+                      ctris[i].v1 = Vec3(a[3], a[4], a[5]);
+                      ctris[i].v2 = Vec3(a[6], a[7], a[8]);
+                  }
+                  const Vec3 X0(x0[0], x0[1], x0[2]);
+                  const Vec3 L(light[0], light[1], light[2]);
+                  am::ChainVertex v[am::kMaxChainVertices];
+                  int N = am::seedChainFromRay(ctris.data(), (int)ctris.size(), X0, L,
+                                               ior, v, am::kMaxChainVertices);
+                  if (N == 0)
+                      return py::make_tuple(0, false, 0, 0.0f, std::vector<float>{});
+                  am::NewtonConfig cfg; cfg.maxIterations = max_iter; cfg.tolerance = tol;
+                  am::ChainResult r = am::solveChain(v, N, X0, L, /*refraction=*/true,
+                                                     am::makeFlatReproject(), cfg, max_step);
+                  std::vector<float> fp;
+                  for (int i = 0; i < N; ++i) { fp.push_back(v[i].p.x); fp.push_back(v[i].p.y); fp.push_back(v[i].p.z); }
+                  return py::make_tuple(N, r.converged, r.iterations, r.residualNorm, fp);
+              },
+              "tris"_a, "x0"_a, "light"_a, "ior"_a,
+              "max_iter"_a = 30, "tol"_a = 1e-5f, "max_step"_a = 0.3f);
     }
 
     m.def("synchrotron_thermal_emissivity",

--- a/tests/test_mnee_mesh.py
+++ b/tests/test_mnee_mesh.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+"""pkg106 Chunk D (part 1) — mesh seed-ray + chain solve on a triangulated caster.
+
+Validates manifold/mesh_caustic.h: casting x0 -> light through a triangulated
+two-face prism collects the ordered caster intersections (exit face, then entry
+face) as a 2-vertex seed chain, and the damped block Newton walks them onto the
+specular manifold (residual -> 0). Mirrors Cycles mnee.h seed-ray construction
+(lines 29-44). CPU-only; runs on CI.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+sys.path.insert(0, os.path.dirname(__file__))
+
+try:
+    import astroray  # noqa: E402
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray not built")
+
+
+def _has(name):
+    return AVAILABLE and hasattr(astroray, name)
+
+
+def _norm(v):
+    return v / np.linalg.norm(v)
+
+
+def _big_face_triangle(point, normal, extent=3.0):
+    """A large triangle lying on the plane(point, normal); winding gives +normal."""
+    n = _norm(normal)
+    a = np.array([1.0, 0.0, 0.0]) if abs(n[0]) < 0.9 else np.array([0.0, 1.0, 0.0])
+    s = _norm(a - np.dot(a, n) * n)
+    t = np.cross(n, s)
+    v0 = point + s * (-extent) + t * (-extent)
+    v1 = point + s * (2 * extent)
+    v2 = point + t * (2 * extent)
+    return [*v0, *v1, *v2]
+
+
+def _prism_scene():
+    """Thin two-face prism between receiver x0 and light L (matches the validated
+    chain geometry). Returns (tris, x0, light, ior)."""
+    ior = 1.5
+    nA = _norm(np.array([-1.0, 0.12, 0.0]))   # entry face (toward light)
+    nB = _norm(np.array([1.0, 0.12, 0.0]))    # exit face (toward receiver)
+    pA = np.array([-0.5, 0.0, 0.0])
+    pB = np.array([0.5, 0.0, 0.0])
+    x0 = np.array([2.4435, -0.5022, 0.0])     # receiver-side point
+    L = np.array([-3.0, 0.4, 0.0])            # light
+    tris = [_big_face_triangle(pB, nB), _big_face_triangle(pA, nA)]
+    return tris, x0, L, ior
+
+
+@pytest.mark.skipif(not _has("_mnee_mesh_solve"),
+                    reason="_mnee_mesh_solve not in this build")
+def test_seed_ray_finds_two_faces_and_converges():
+    tris, x0, L, ior = _prism_scene()
+    N, converged, iters, residual, finalP = astroray._mnee_mesh_solve(
+        [list(map(float, t)) for t in tris], list(x0), list(L), float(ior),
+        40, 1e-5, 0.25,
+    )
+    assert N == 2, f"seed ray should cross both prism faces, got {N} vertices"
+    assert converged, f"mesh chain Newton did not converge (residual={residual:.2e})"
+    assert residual < 1e-5
+    final = np.array(finalP).reshape(N, 3)
+    # Converged vertices lie near the two face planes (x ~ +0.5 exit, -0.5 entry).
+    assert final[0][0] > 0.0 > final[1][0], (
+        f"vertices not on the expected faces: {final}"
+    )
+
+
+@pytest.mark.skipif(not _has("_mnee_mesh_solve"),
+                    reason="_mnee_mesh_solve not in this build")
+def test_seed_ray_misses_returns_zero():
+    """A light segment that doesn't cross either face plane yields no seed chain."""
+    tris, _, _, ior = _prism_scene()
+    # Both points on the +x side of both faces (x > 0.5), so the segment never
+    # crosses the exit (x~0.5) or entry (x~-0.5) face plane.
+    x0 = np.array([3.0, 0.0, 0.0])
+    L = np.array([1.7, 0.0, 0.0])
+    N, converged, _, _, _ = astroray._mnee_mesh_solve(
+        [list(map(float, t)) for t in tris], list(x0), list(L), float(ior),
+        40, 1e-5, 0.25,
+    )
+    assert N == 0 and not converged


### PR DESCRIPTION
## Summary
Generalizes the SMS seed from **sphere-only** (uniform-on-sphere) to **triangle-mesh** casters — the prerequisite for a real prism. Completes the MNEE math+geometry foundation (Chunks A–D-seed).

- **`manifold/mesh_caustic.h`** (new): `CausticTri` + Möller-Trumbore `rayTriHit` + `seedChainFromRay` (cast x0→light, collect the ordered caustic-caster intersections as a multi-vertex seed chain — a prism gives two: exit face then entry face) + `makeFlatReproject`. Mirrors Cycles `mnee.h` seed-ray construction (lines 29-44, Apache-2.0).
- **`blender_module.cpp`**: `_mnee_mesh_solve` test helper (seed + `solveChain` on a triangulated caster).
- **`tests/test_mnee_mesh.py`**: a triangulated two-face prism between receiver and light → the x0→light ray seeds both faces and the damped block Newton walks the 2-vertex chain onto the specular manifold (residual→0); a miss returns 0.

## Key fix (documented in-code)
Seed vertices use an **orthonormal** in-plane (u,v) frame, **not** the raw triangle edges: the manifold Newton steps along unit tangents and clamps `(du,dv)` magnitude, so a non-unit parameterization makes the clamp meaningless and the solve diverges. Verified: raw edges → no convergence; orthonormal → **3 iterations**.

## Test plan
- [x] 14/14 mnee tests pass (CPU; runs on CI)
- [ ] CI green

## Remaining pkg106 work (render-iterative, no unit test)
- **Chunk D-radiance**: the generalized-geometry term (Cycles `mnee_compute_transfer_matrix` — block-tridiagonal LU of the chain Jacobian) + 2-face Fresnel + chromatic hero contribution, wired into the live `sms_caustic_path_tracer` gathering mesh casters from the scene.
- **Chunk E**: triangulated equilateral prism scene + render + `hue_spread ≥ 0.7` acceptance + tuning.

CPU-only header math + a test-helper binding; no CUDA/GPU code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)