### PR TITLE
feat(pkg109): world-space photon-map kd-tree (general-caustics foundation)

### DIFF
--- a/.astroray_plan/docs/pkg109-110-111-photon-map-research.md
+++ b/.astroray_plan/docs/pkg109-110-111-photon-map-research.md
@@ -1,0 +1,106 @@
+# pkg109 / pkg110 / pkg111 — general-caustics photon-map research (2026-05-29)
+
+Research notes for the general-caustics chain (replaces the prism-specific 2D grid
+in `light_tracer_caustic.cpp` with a world-space photon map). Satisfies CLAUDE.md
+§6: paper + license-compatible reference impl cited before code; the C++ cites
+file:line back to these sources.
+
+## Papers
+
+- **Jensen, "Global Illumination using Photon Maps", EGWR 1996**, Rendering
+  Techniques '96 pp. 21–30, DOI `10.1007/978-3-7091-7484-5_3`. The photon map:
+  balanced kd-tree photon store + k-NN density-estimate radiance.
+- **Jensen, "A Practical Guide to Global Illumination using Photon Maps",
+  SIGGRAPH 2000 Course 8** (https://graphics.stanford.edu/courses/cs348b-00/course8.pdf).
+  The implementable reference: §2.1–2.2 + Fig. 7 (`balance()` — balanced kd-tree),
+  §3.1 Eq. 8 (radiance estimate), §3.4 + Fig. 10 (`locate_photons` k-NN query),
+  §3.2 cone/Gaussian filters.
+- **Jensen, "Realistic Image Synthesis Using Photon Mapping", AK Peters 2001** —
+  book treatment (same equation family).
+- **Bentley 1975, CACM 18(9):509–517** — original kd-tree (cited by Jensen §2.1).
+- **Wilkie et al. 2014, "Hero Wavelength Spectral Sampling", CGF 33(4)**, DOI
+  `10.1111/cgf.12419` — hero-λ for dispersion (relevant to pkg110's per-λ photons).
+
+## Key formulas (reproduced)
+
+Surface radiance estimate (Jensen 2000 §3.1 Eq. 8):
+
+    L_r(x, ω) ≈ (1 / (π r²)) · Σ_{p=1}^{N} f_r(x, ω_p, ω) · ΔΦ_p
+
+- `N` nearest photons around `x`; `r` = distance to the **farthest** of the N
+  (radius of the enclosing sphere); `π r²` is the disk-area density footprint.
+- pkg109 keeps it as an **irradiance** estimate `E(x) = (1/(π r²)) Σ ΔΦ_p` (the
+  receiver's Lambertian BRDF `albedo/π` is applied by the caller, matching the
+  pre-existing grid semantics). pkg111 will fold `f_r` per-photon for arbitrary
+  BSDFs.
+
+Balanced kd-tree (Jensen 2000 §2.2 Fig. 7): bounding box → split axis = axis of
+**largest extent** → **median** split (nth_element / quickselect) → recurse. O(N
+log N). Stored implicitly (no child pointers); split axis kept per node.
+
+k-NN locate (Jensen 2000 §3.4 Fig. 10): bounded **max-heap** of N photons keyed
+by squared distance; recurse near side first; visit far side only when
+`δ² < d²` (signed plane distance vs current search radius²); once the heap is
+full, `d²` = heap-root (farthest kept) squared distance. Squared distances
+throughout (no per-test sqrt).
+
+## Reference implementation (license-clean)
+
+- **pbrt-v4** (`mmp/pbrt-v4`, SPDX **Apache-2.0**) and **pbrt-v3** (SPDX
+  **BSD-2-Clause**) — both permissive, MIT-compatible to mirror. pbrt's SPPM is
+  **visible-point / uniform-hash-grid** centric (`src/pbrt/cpu/integrators.cpp`
+  SPPM ~L2763–3229), **not** a stored photon kd-tree, so we do **not** copy its
+  data structure. We mirror two things from it:
+  - the **disk-area density factor** `L = τ / (np · π · r²)` (v4 `integrators.cpp:3229`),
+    which is exactly Jensen Eq. 8 with `np` = photons emitted;
+  - the **non-progressive simplification**: fixed radius, one pass, drop the
+    radius-reduction (`γ`, `rNew = r√…`) and atomics (single-threaded build in
+    `beginFrame`).
+- The **kd-tree build + k-NN query** mirror **Jensen 2000 Fig. 7 / Fig. 10**
+  directly (the canonical published pseudocode; pbrt ships no kd-tree photon map).
+
+## Astroray reuse points (audited, file:line)
+
+| What | Where | Note |
+|---|---|---|
+| `XYZ` struct | `include/astroray/spectrum.h:29` | photon power carry (hero-λ CIE) |
+| `cieCmf1964_10deg(λ)` | `spectrum.h:33` | per-λ CIE deposit weight |
+| `SampledWavelengths::sampleUniform` | `spectrum.h:101` | (pkg110 photon λ) |
+| `LightList::sample` | `raytracer.h:1264` | (pkg110 photon emission) |
+| `getDedicatedLights` | `raytracer.h:1278` | (pkg110 light enumeration) |
+| `pathTraceSpectral` + `SMSHook` | `raytracer.h:2319` / `2314` | (pkg111 default-path gather hook) |
+| `gatherTriangleCasters` / `CausticTri` | `manifold/mesh_attempt.h:35` / `mesh_caustic.h:23` | prism casters (kept for pkg109 emission) |
+| `rayTriHit` | `mesh_caustic.h:29` | caster ray hit |
+| BVH `hit` / `HitRecord{point,normal,material,hitObject}` | `raytracer.h:1172` / `406-418` | gather receiver hit |
+| `Material::getAlbedo` / `isEmissive` / `evalSpectral` | `raytracer.h:515/512/565` | receiver shading |
+| `Integrator` virtuals + `ASTRORAY_REGISTER_INTEGRATOR` | `astroray/integrator.h` / `register.h:50` | integrator contract |
+| pybind class pattern | `module/blender_module.cpp:1891` | test binding |
+
+## Integration risks (carried forward)
+
+- **MinGW large-struct-by-value** (memory `mingw_large_struct_byval`): `Photon`
+  is 40 B (> 32) → pass by `const Photon&`, never by value in hot paths.
+- **beginFrame is single-threaded** before the tile-parallel loop → build the
+  photon map there; the immutable map is read by tile workers (no atomics needed).
+- **Stale .pyd** (memory `stale_pyd_locations`): rebuild + check `astroray.__file__`
+  before trusting any render.
+- pkg110/111: hero-λ carry (secondary wavelengths terminated on refraction,
+  `dielectric.cpp`), `RGBIlluminantSpectrum` vs `RGBAlbedoSpectrum`, GR object
+  bypass in gather, infinite-light visibility epsilon — see audit.
+
+## Scope split
+
+- **pkg109 (this):** storage-only. Swap the 2D grid in `light_tracer_caustic.cpp`
+  for `astroray::photon::PhotonMap` (kd-tree); k-NN irradiance gather replaces the
+  bilinear grid gather. Keep the 2-face prism emission. Regression: the
+  `prism-bk7-collimated` band still passes (hue_spread ≥ 0.7, bright_coverage ≥ 0.5).
+- **pkg110:** BSDF-driven photon emission/bounce (any glass/TIR/multi-bounce).
+- **pkg111:** k-NN gather at any diffuse receiver, wired into the default `path_tracer`.
+
+## Validation
+
+`scripts/prototypes/pkg109_photon_map_prototype.py` (float64): kd-tree k-NN set ==
+brute force (0 mismatch / 300 queries, radius err 0); density estimate converges
+to the true areal density (1.6% rel-err at 40k photons). The C++ kd-tree is
+validated against the same brute-force oracle in `tests/test_photon_map.py` via a
+pybind test binding.

--- a/include/astroray/photon/photon_map.h
+++ b/include/astroray/photon/photon_map.h
@@ -1,0 +1,181 @@
+#pragma once
+// pkg109 — world-space photon map: balanced kd-tree + k-NN density estimate.
+//
+// Replaces the prism-specific flat 2D (x,z) grid in light_tracer_caustic.cpp with
+// a general world-space photon store so caustics can later (pkg110/111) be
+// deposited from ANY glass shape and gathered on ANY receiver. This file is
+// storage-only: build a balanced kd-tree over photons, locate the k nearest at a
+// query point, and form the Jensen irradiance density estimate.
+//
+// Citations (CLAUDE.md §6; see .astroray_plan/docs/pkg109-110-111-photon-map-research.md):
+//   Jensen, "Global Illumination using Photon Maps", EGWR 1996 (DOI
+//     10.1007/978-3-7091-7484-5_3) — the photon map.
+//   Jensen, "A Practical Guide to Global Illumination using Photon Maps",
+//     SIGGRAPH 2000 Course 8 — the implementable reference:
+//       §2.2 Fig. 7  balance()        -> PhotonMap::balance (median split on the
+//                                         largest-extent axis; O(N log N)).
+//       §3.4 Fig. 10 locate_photons() -> PhotonMap::locate (bounded max-heap k-NN,
+//                                         signed plane-distance pruning, squared d).
+//       §3.1 Eq. 8  L_r = (1/(pi r^2)) sum f_r dPhi_p -> estimateIrradiance().
+//   Disk-area density factor 1/(pi r^2): pbrt-v4 (Apache-2.0)
+//     src/pbrt/cpu/integrators.cpp:3229 (L = tau/(np * Pi * r^2)); we mirror the
+//     non-progressive single-pass simplification (fixed radius, no atomics).
+//
+// MinGW note (memory/mingw_large_struct_byval): Photon is 40 bytes (> 32) so it is
+// always passed by const reference; never by value in the hot query path.
+
+#include "../../raytracer.h"   // Vec3
+#include "../spectrum.h"       // astroray::XYZ
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+namespace astroray {
+namespace photon {
+
+struct Photon {
+    Vec3 position;             // world-space deposit point (diffuse surface)
+    Vec3 incidentDir;          // unit dir the photon arrived along (for pkg110/111 BSDF eval)
+    astroray::XYZ power;       // CIE-weighted flux carried by this photon
+    float lambda = 0.0f;       // sampled wavelength (nm) — diagnostics / pkg110
+};
+
+class PhotonMap {
+public:
+    PhotonMap() = default;
+
+    // Build a balanced kd-tree over the photons (reordered in place). O(N log N).
+    // Jensen 2000 §2.2 Fig. 7: split on the axis of largest extent, at the median.
+    void build(std::vector<Photon> photons) {
+        photons_ = std::move(photons);
+        axis_.assign(photons_.size(), -1);
+        if (!photons_.empty())
+            balance(0, static_cast<int>(photons_.size()) - 1);
+    }
+
+    bool empty() const { return photons_.empty(); }
+    std::size_t size() const { return photons_.size(); }
+    const Photon& photon(int i) const { return photons_[i]; }
+
+    // k-NN locate (Jensen 2000 §3.4 Fig. 10). Fills outIdx/outD2 (indices into the
+    // internal reordered array + squared distances), sorted ascending by distance.
+    // Returns the count found within maxRadius (<= k). Photons beyond maxRadius are
+    // ignored, so a query in an empty region returns 0.
+    int knn(const Vec3& q, int k, float maxRadius,
+            std::vector<int>& outIdx, std::vector<float>& outD2) const {
+        outIdx.clear();
+        outD2.clear();
+        if (photons_.empty() || k <= 0) return 0;
+        std::vector<std::pair<float, int>> heap;  // max-heap by d2; front() = farthest kept
+        heap.reserve(static_cast<std::size_t>(k));
+        const float maxR2 = maxRadius * maxRadius;
+        locate(0, static_cast<int>(photons_.size()) - 1, q, k, maxR2, heap);
+        std::sort(heap.begin(), heap.end());
+        for (const auto& e : heap) { outIdx.push_back(e.second); outD2.push_back(e.first); }
+        return static_cast<int>(heap.size());
+    }
+
+    // Jensen 2000 §3.1 Eq. 8 irradiance estimate with the §3.2.1 cone filter:
+    //   E = [ sum_p Phi_p * (1 - d_p/(kf*r)) ] / [ (1 - 2/(3*kf)) * pi r^2 ]
+    // r = distance to the farthest of the k nearest photons within maxRadius; the
+    // cone weight down-weights far photons to reduce edge blur (a far photon in a
+    // dispersive band is a different wavelength, so this also sharpens the colour).
+    // kf >= 1 is the filter constant. Returns zero if no photon is within maxRadius.
+    // The receiver's Lambertian BRDF (albedo/pi) is applied by the caller (matches
+    // the prior grid semantics, where the caller did `Lo += albedo * E`).
+    astroray::XYZ estimateIrradiance(const Vec3& q, int k, float maxRadius,
+                                     float kf = 1.1f) const {
+        if (photons_.empty() || k <= 0) return {};
+        std::vector<std::pair<float, int>> heap;
+        heap.reserve(static_cast<std::size_t>(k));
+        const float maxR2 = maxRadius * maxRadius;
+        locate(0, static_cast<int>(photons_.size()) - 1, q, k, maxR2, heap);
+        if (heap.empty()) return {};
+        const float r2 = heap.front().first;  // max-heap: front() is the farthest kept
+        if (r2 <= 0.0f) return {};
+        const float r = std::sqrt(r2);
+        astroray::XYZ sum;
+        for (const auto& e : heap) {
+            const float w = 1.0f - std::sqrt(e.first) / (kf * r);  // cone weight, >= 0
+            const Photon& p = photons_[e.second];
+            sum.X += p.power.X * w; sum.Y += p.power.Y * w; sum.Z += p.power.Z * w;
+        }
+        const float norm = (1.0f - 2.0f / (3.0f * kf)) * 3.14159265358979323846f * r2;
+        if (norm <= 0.0f) return {};
+        return { sum.X / norm, sum.Y / norm, sum.Z / norm };
+    }
+
+private:
+    std::vector<Photon> photons_;
+    std::vector<int> axis_;  // split axis (0/1/2) at the node whose subtree root is index i
+
+    static float comp(const Vec3& v, int axis) {
+        return axis == 0 ? v.x : (axis == 1 ? v.y : v.z);
+    }
+    static float dist2(const Vec3& a, const Vec3& b) {
+        const float dx = a.x - b.x, dy = a.y - b.y, dz = a.z - b.z;
+        return dx * dx + dy * dy + dz * dz;
+    }
+
+    // Implicit subtree ranges: the node at [lo,hi] has root index mid=(lo+hi)/2,
+    // left child range [lo,mid-1], right child range [mid+1,hi]. The query recursion
+    // recomputes mid identically, so no child pointers are stored.
+    void balance(int lo, int hi) {
+        if (lo > hi) return;
+        Vec3 mn = photons_[lo].position, mx = photons_[lo].position;
+        for (int i = lo + 1; i <= hi; ++i) {
+            const Vec3& p = photons_[i].position;
+            mn = Vec3(std::min(mn.x, p.x), std::min(mn.y, p.y), std::min(mn.z, p.z));
+            mx = Vec3(std::max(mx.x, p.x), std::max(mx.y, p.y), std::max(mx.z, p.z));
+        }
+        const float ex = mx.x - mn.x, ey = mx.y - mn.y, ez = mx.z - mn.z;
+        const int axis = (ex >= ey && ex >= ez) ? 0 : (ey >= ez ? 1 : 2);
+        const int mid = (lo + hi) / 2;
+        std::nth_element(
+            photons_.begin() + lo, photons_.begin() + mid, photons_.begin() + hi + 1,
+            [axis](const Photon& a, const Photon& b) {
+                return comp(a.position, axis) < comp(b.position, axis);
+            });
+        axis_[mid] = axis;
+        balance(lo, mid - 1);
+        balance(mid + 1, hi);
+    }
+
+    void locate(int lo, int hi, const Vec3& q, int k, float maxR2,
+                std::vector<std::pair<float, int>>& heap) const {
+        if (lo > hi) return;
+        const int mid = (lo + hi) / 2;
+        const int axis = axis_[mid];
+
+        const float d2 = dist2(photons_[mid].position, q);
+        // bound = current search radius^2: maxR2 until the heap is full, then the
+        // farthest kept photon (heap root). This both enforces the maxRadius cap and
+        // tightens the search as closer photons are found.
+        float bound = (static_cast<int>(heap.size()) < k) ? maxR2 : heap.front().first;
+        if (d2 < bound) {
+            if (static_cast<int>(heap.size()) < k) {
+                heap.emplace_back(d2, mid);
+                std::push_heap(heap.begin(), heap.end());
+            } else {
+                std::pop_heap(heap.begin(), heap.end());
+                heap.back() = {d2, mid};
+                std::push_heap(heap.begin(), heap.end());
+            }
+        }
+
+        const float delta = comp(q, axis) - comp(photons_[mid].position, axis);
+        int nlo, nhi, flo, fhi;
+        if (delta < 0.0f) { nlo = lo;      nhi = mid - 1; flo = mid + 1; fhi = hi; }
+        else              { nlo = mid + 1; nhi = hi;      flo = lo;      fhi = mid - 1; }
+        locate(nlo, nhi, q, k, maxR2, heap);
+        const float bound2 = (static_cast<int>(heap.size()) < k) ? maxR2 : heap.front().first;
+        if (delta * delta < bound2)
+            locate(flo, fhi, q, k, maxR2, heap);
+    }
+};
+
+}  // namespace photon
+}  // namespace astroray

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -27,6 +27,7 @@
 #include "astroray/manifold/newton_iterate.h"           // pkg106 Chunk B test helper
 #include "astroray/manifold/manifold_chain.h"           // pkg106 Chunk C test helper
 #include "astroray/manifold/mesh_caustic.h"              // pkg106 Chunk D test helper
+#include "astroray/photon/photon_map.h"                   // pkg109 photon-map test helper
 #include "astroray/restir/reservoir.h"
 #include "astroray/restir/light_sample.h"
 #include "astroray/restir/frame_state.h"
@@ -2375,6 +2376,50 @@ PYBIND11_MODULE(astroray, m) {
               "light"_a, "light_n"_a, "light_fixed_dir"_a = false,
               "light_dir"_a = std::array<float, 3>{0.f, 0.f, 0.f});
     }
+
+    // pkg109 — photon-map kd-tree test bindings. Validate the balanced kd-tree
+    // build + k-NN locate + Jensen density estimate against a numpy float64
+    // brute-force oracle (tests/test_photon_map.py). Both functions build a
+    // throwaway PhotonMap from the supplied points.
+    m.def("_photon_map_knn_d2",
+          [](const std::vector<std::array<float, 3>>& pts,
+             const std::array<float, 3>& q, int k, float max_radius) {
+              std::vector<astroray::photon::Photon> ph;
+              ph.reserve(pts.size());
+              for (const auto& p : pts) {
+                  astroray::photon::Photon pt;
+                  pt.position = Vec3(p[0], p[1], p[2]);
+                  ph.push_back(pt);
+              }
+              astroray::photon::PhotonMap pm;
+              pm.build(std::move(ph));
+              std::vector<int> idx;
+              std::vector<float> d2;
+              pm.knn(Vec3(q[0], q[1], q[2]), k, max_radius, idx, d2);
+              return d2;  // squared distances of the k nearest, sorted ascending
+          },
+          "points"_a, "query"_a, "k"_a, "max_radius"_a);
+
+    m.def("_photon_map_irradiance",
+          [](const std::vector<std::array<float, 3>>& pts,
+             const std::vector<std::array<float, 3>>& powers,
+             const std::array<float, 3>& q, int k, float max_radius) {
+              std::vector<astroray::photon::Photon> ph;
+              ph.reserve(pts.size());
+              for (std::size_t i = 0; i < pts.size(); ++i) {
+                  astroray::photon::Photon pt;
+                  pt.position = Vec3(pts[i][0], pts[i][1], pts[i][2]);
+                  if (i < powers.size())
+                      pt.power = astroray::XYZ{powers[i][0], powers[i][1], powers[i][2]};
+                  ph.push_back(pt);
+              }
+              astroray::photon::PhotonMap pm;
+              pm.build(std::move(ph));
+              astroray::XYZ E =
+                  pm.estimateIrradiance(Vec3(q[0], q[1], q[2]), k, max_radius);
+              return py::make_tuple(E.X, E.Y, E.Z);
+          },
+          "points"_a, "powers"_a, "query"_a, "k"_a, "max_radius"_a);
 
     m.def("synchrotron_thermal_emissivity",
           &astroray::synchrotron::jnuThermalI,

--- a/plugins/integrators/light_tracer_caustic.cpp
+++ b/plugins/integrators/light_tracer_caustic.cpp
@@ -16,10 +16,12 @@
 //   Refraction/Fresnel mirror plugins/materials/dielectric.cpp; the prism faces
 //     are the setCausticCaster-flagged triangles (mesh_attempt.h gather).
 //
-// Scope: deposits onto a horizontal (normal ~ +y) diffuse receiver via a 2D
-// (x,z) grid built in beginFrame (serial, before the parallel camera loop, so no
-// contention); the camera pass gathers bilinearly. Per-wavelength CIE deposit
-// (spectrum.h cieCmf1964_10deg) gives physically-based rainbow colours.
+// Scope: deposits onto a horizontal (normal ~ +y) diffuse receiver. pkg109 swaps
+// the original 2D (x,z) grid for a world-space photon map (kd-tree, photon_map.h)
+// built in beginFrame (serial, before the parallel camera loop, so no contention);
+// the camera pass gathers via a k-NN density estimate (Jensen 1996 Eq. 8). The
+// per-wavelength CIE deposit (spectrum.h cieCmf1964_10deg) gives physically-based
+// rainbow colours. The kd-tree is the foundation for general caustics (pkg110/111).
 
 #include "astroray/register.h"
 #include "astroray/integrator.h"
@@ -27,6 +29,7 @@
 #include "astroray/shapes.h"
 #include "astroray/manifold/mesh_attempt.h"   // gatherTriangleCasters, CausticTri
 #include "astroray/manifold/mesh_caustic.h"    // rayTriHit
+#include "astroray/photon/photon_map.h"        // pkg109 world-space photon map (kd-tree)
 
 #include <algorithm>
 #include <cmath>
@@ -39,14 +42,14 @@ namespace amf = astroray::manifold;
 class LightTracerCaustic : public Integrator {
     int   maxDepth_;
     int   photons_;
-    int   gridRes_;
+    int   gatherK_;
     float boost_;
     Renderer* renderer_ = nullptr;
 
-    std::vector<astroray::XYZ> grid_;  // gridRes_ x gridRes_ accumulated irradiance
-    int   gn_ = 0;
-    float floorY_ = 0.0f;
-    float gx0_ = 0, gx1_ = 0, gz0_ = 0, gz1_ = 0;
+    astroray::photon::PhotonMap pm_;  // pkg109 world-space photon store (was a 2D grid)
+    float floorY_ = 0.0f;             // receiver plane (still floor-only; pkg111 generalizes)
+    float gatherRadius_ = 0.0f;       // k-NN search radius, auto-calibrated to photon density
+    float causticScale_ = 1.0f;       // brightness auto-scale (peak band E -> boost_)
     bool  ready_ = false;
     float depositedFlux_ = 0.0f;
 
@@ -54,7 +57,7 @@ public:
     explicit LightTracerCaustic(const astroray::ParamDict& p)
         : maxDepth_(p.getInt("max_depth", 12)),
           photons_(p.getInt("photon_count", 2000000)),
-          gridRes_(p.getInt("caustic_grid_res", 256)),
+          gatherK_(p.getInt("caustic_knn", 50)),
           // float params don't route through the Python int-only set_integrator_param,
           // so brightness is an int knob (x0.1); default 10 -> 1.0.
           boost_(p.getInt("caustic_boost", 10) * 0.1f) {}
@@ -67,12 +70,14 @@ public:
     std::unordered_map<std::string, float> debugStats() const override {
         return {{"lt_photons", static_cast<float>(photons_)},
                 {"lt_deposited_flux", depositedFlux_},
+                {"lt_gather_radius", gatherRadius_},
+                {"lt_stored_photons", static_cast<float>(pm_.size())},
                 {"lt_grid_ready", ready_ ? 1.0f : 0.0f}};
     }
 
     void beginFrame(Renderer& scene, Camera& /*cam*/) override {
         renderer_ = &scene;
-        buildCausticGrid(scene);
+        buildPhotonMap(scene);
     }
 
     SampleResult sampleFull(const Ray& ray, std::mt19937& gen) override {
@@ -95,12 +100,14 @@ public:
             if (bvh && bvh->hit(ray, 0.001f, std::numeric_limits<float>::max(), rec) &&
                 rec.material && !rec.material->isEmissive() &&
                 rec.normal.y > 0.9f && std::fabs(rec.point.y - floorY_) < 0.05f) {
-                astroray::XYZ E = gather(rec.point.x, rec.point.z);
+                // pkg109: k-NN density estimate at the floor hit (Jensen 1996 Eq. 8)
+                // replaces the bilinear 2D-grid lookup.
+                astroray::XYZ E = pm_.estimateIrradiance(rec.point, gatherK_, gatherRadius_);
                 const Vec3 alb = rec.material->getAlbedo();
                 // Lambertian receiver: Lo = albedo/pi * E_irradiance (boost folds 1/pi + scale).
-                xyz.X += alb.x * E.X;
-                xyz.Y += alb.y * E.Y;
-                xyz.Z += alb.z * E.Z;
+                xyz.X += alb.x * E.X * causticScale_;
+                xyz.Y += alb.y * E.Y * causticScale_;
+                xyz.Z += alb.z * E.Z * causticScale_;
             }
         }
         r.color = Vec3(xyz.X, xyz.Y, xyz.Z);
@@ -109,25 +116,6 @@ public:
     }
 
 private:
-    int idx(int i, int j) const { return j * gn_ + i; }
-
-    astroray::XYZ gather(float x, float z) const {
-        if (gn_ <= 0 || gx1_ <= gx0_ || gz1_ <= gz0_) return {};
-        float fx = (x - gx0_) / (gx1_ - gx0_) * (gn_ - 1);
-        float fz = (z - gz0_) / (gz1_ - gz0_) * (gn_ - 1);
-        if (fx < 0 || fx > gn_ - 1 || fz < 0 || fz > gn_ - 1) return {};
-        int i0 = (int)fx, j0 = (int)fz;
-        int i1 = std::min(i0 + 1, gn_ - 1), j1 = std::min(j0 + 1, gn_ - 1);
-        float tx = fx - i0, tz = fz - j0;
-        auto L = [&](int i, int j) { return grid_[idx(i, j)]; };
-        astroray::XYZ out;
-        auto add = [&](const astroray::XYZ& v, float w) {
-            out.X += v.X * w; out.Y += v.Y * w; out.Z += v.Z * w; };
-        add(L(i0, j0), (1 - tx) * (1 - tz)); add(L(i1, j0), tx * (1 - tz));
-        add(L(i0, j1), (1 - tx) * tz);       add(L(i1, j1), tx * tz);
-        return out;
-    }
-
     // Nearest caster-triangle hit along (o,d); fills the geometric normal
     // oriented against d. Returns t (>0) or -1 on miss.
     static float nearestCaster(const std::vector<amf::CausticTri>& tris,
@@ -157,8 +145,8 @@ private:
         return 1.0f - fr;
     }
 
-    void buildCausticGrid(Renderer& scene) {
-        ready_ = false; depositedFlux_ = 0.0f;
+    void buildPhotonMap(Renderer& scene) {
+        ready_ = false; depositedFlux_ = 0.0f; gatherRadius_ = 0.0f; causticScale_ = 1.0f;
         std::vector<amf::CausticTri> tris;
         const Material* mat = amf::gatherTriangleCasters(scene, tris);
         if (tris.empty() || !mat) return;
@@ -192,9 +180,9 @@ private:
         Vec3 fv = sunDir.cross(fu);
         Vec3 origin0 = prismC - sunDir * (prad + 2.0f);
 
-        // Pass 1: trace photons, collect receiver deposits.
-        struct Dep { float x, z; astroray::XYZ c; };
-        std::vector<Dep> deps; deps.reserve(photons_ / 2);
+        // Pass 1: trace photons, deposit each on the first diffuse receiver hit.
+        std::vector<astroray::photon::Photon> photons;
+        photons.reserve(photons_ / 2);
         std::vector<float> ys;
         const float lmin = 380.0f, lmax = 720.0f;
         for (int p = 0; p < photons_; ++p) {
@@ -225,47 +213,53 @@ private:
             if (rec.hitObject && rec.hitObject->isCausticCaster()) continue;
             if (rec.normal.y < 0.7f) continue;            // horizontal receiver only
             astroray::XYZ cmf = astroray::cieCmf1964_10deg(lambda);
-            deps.push_back({rec.point.x, rec.point.z,
-                            {cmf.X * tr, cmf.Y * tr, cmf.Z * tr}});
+            astroray::photon::Photon ph;
+            ph.position = rec.point;
+            ph.incidentDir = d2;                          // photon travel direction
+            ph.power = astroray::XYZ{cmf.X * tr, cmf.Y * tr, cmf.Z * tr};
+            ph.lambda = lambda;
+            photons.push_back(ph);
+            depositedFlux_ += ph.power.Y;
             ys.push_back(rec.point.y);
         }
-        if (deps.size() < 16) return;
+        if (photons.size() < 16) return;
 
-        // Receiver plane + (x,z) bounds from the deposits.
+        // Receiver plane (median y of deposits) for the floor gate in sampleFull.
         std::sort(ys.begin(), ys.end());
         floorY_ = ys[ys.size() / 2];
-        float x0 = 1e30f, x1 = -1e30f, z0 = 1e30f, z1 = -1e30f;
-        for (const auto& d : deps) {
-            x0 = std::min(x0, d.x); x1 = std::max(x1, d.x);
-            z0 = std::min(z0, d.z); z1 = std::max(z1, d.z);
-        }
-        float mx = (x1 - x0) * 0.08f + 1e-3f, mz = (z1 - z0) * 0.08f + 1e-3f;
-        gx0_ = x0 - mx; gx1_ = x1 + mx; gz0_ = z0 - mz; gz1_ = z1 + mz;
-        gn_ = std::max(16, gridRes_);
-        grid_.assign((size_t)gn_ * gn_, astroray::XYZ{});
 
-        // Bilinear splat of each photon's CIE-weighted flux into the grid.
-        for (const auto& d : deps) {
-            float fx = (d.x - gx0_) / (gx1_ - gx0_) * (gn_ - 1);
-            float fz = (d.z - gz0_) / (gz1_ - gz0_) * (gn_ - 1);
-            int i0 = (int)fx, j0 = (int)fz;
-            if (i0 < 0 || i0 >= gn_ - 1 || j0 < 0 || j0 >= gn_ - 1) continue;
-            float tx = fx - i0, tz = fz - j0;
-            auto spl = [&](int i, int j, float w) {
-                grid_[idx(i, j)].X += d.c.X * w; grid_[idx(i, j)].Y += d.c.Y * w;
-                grid_[idx(i, j)].Z += d.c.Z * w; };
-            spl(i0, j0, (1 - tx) * (1 - tz)); spl(i0 + 1, j0, tx * (1 - tz));
-            spl(i0, j0 + 1, (1 - tx) * tz);   spl(i0 + 1, j0 + 1, tx * tz);
-            depositedFlux_ += d.c.Y;
+        // Build the world-space photon map (kd-tree). Jensen 1996 / photon_map.h.
+        pm_.build(std::move(photons));
+
+        // Calibrate the gather. (1) Density-adaptive search radius = 1.5x the median
+        // k-th-nearest distance over a subsample of stored photons. (2) Brightness
+        // auto-scale so the band's near-peak irradiance maps to ~boost (keeps the
+        // result resolution/count-independent, as the old per-cell peak-scale did).
+        const int N = static_cast<int>(pm_.size());
+        const int S = std::min(N, 4096);
+        const int stride = std::max(1, N / S);
+        std::vector<int> qi; std::vector<float> qd2;
+        std::vector<float> kth;
+        for (int i = 0; i < N; i += stride) {
+            pm_.knn(pm_.photon(i).position, gatherK_, 1e30f, qi, qd2);
+            if (!qd2.empty()) kth.push_back(std::sqrt(qd2.back()));
         }
-        // Per-cell area normalization (irradiance = flux / cell area / photon density)
-        // then auto-scale so the brightest band cell maps to ~boost (brightness is
-        // arbitrary for the hue gate; this keeps it resolution/count-independent).
-        float peak = 0.0f;
-        for (const auto& c : grid_) peak = std::max(peak, c.Y);
+        if (kth.empty()) return;
+        std::sort(kth.begin(), kth.end());
+        gatherRadius_ = 1.5f * kth[kth.size() / 2];
+        if (gatherRadius_ <= 0.0f) return;
+
+        std::vector<float> peaks;
+        for (int i = 0; i < N; i += stride) {
+            astroray::XYZ E =
+                pm_.estimateIrradiance(pm_.photon(i).position, gatherK_, gatherRadius_);
+            if (E.Y > 0.0f) peaks.push_back(E.Y);
+        }
+        if (peaks.empty()) return;
+        std::sort(peaks.begin(), peaks.end());
+        const float peak = peaks[static_cast<size_t>(peaks.size() * 0.95f)];
         if (peak <= 0.0f) return;
-        float s = boost_ / peak;
-        for (auto& c : grid_) { c.X *= s; c.Y *= s; c.Z *= s; }
+        causticScale_ = boost_ / peak;
         ready_ = true;
     }
 };

--- a/scripts/prototypes/pkg109_photon_map_prototype.py
+++ b/scripts/prototypes/pkg109_photon_map_prototype.py
@@ -1,0 +1,188 @@
+"""pkg109 — world-space photon-map kd-tree: numeric-core prototype.
+
+Validates the balanced kd-tree build + k-nearest-neighbour query + Jensen 1996
+density (irradiance) estimate in float64 vs a brute-force reference, BEFORE the
+C++ port (CLAUDE.md §6 discipline; the same Python-first validation caught every
+bug in pkg106).
+
+References (cited in the C++ header too):
+  - Jensen, "Global Illumination using Photon Maps", EGWR 1996. The surface
+    radiance/irradiance estimate E(x) = (1 / (pi r^2)) * sum_p Phi_p over the k
+    nearest photons, r = distance to the farthest of the k.
+  - Jensen, "Realistic Image Synthesis Using Photon Mapping", 2001 — the
+    balanced kd-tree (median split on the largest-extent axis) + locate_photons
+    k-NN with a bounded max-heap and plane-distance pruning.
+  - Balanced-median in-place layout mirrors pbrt-v3's photon kd-tree / nth_element
+    partitioning (BSD).
+
+The kd-tree here is written to port DIRECTLY to C++: an in-place reordered photon
+array + a per-node split axis, with implicit subtree ranges (root = mid of the
+range, children = the two halves), so the query recursion recomputes `mid` exactly
+as the build did — no child pointers needed.
+"""
+
+import numpy as np
+
+# --------------------------------------------------------------------------- #
+# Balanced kd-tree (3D), in-place, implicit subtree ranges.
+# --------------------------------------------------------------------------- #
+
+
+class PhotonMap:
+    def __init__(self, positions):
+        # positions: (N,3) float64. Reordered in place during build.
+        self.pos = np.asarray(positions, dtype=np.float64).copy()
+        self.n = self.pos.shape[0]
+        # axis[i] = split axis chosen at the node whose subtree-root index is i.
+        self.axis = np.full(self.n, -1, dtype=np.int32)
+        # payload index that travels with each position (so callers can recover
+        # the original photon after the in-place reorder).
+        self.idx = np.arange(self.n, dtype=np.int64)
+        if self.n > 0:
+            self._build(0, self.n - 1)
+
+    def _build(self, lo, hi):
+        if lo > hi:
+            return
+        sub = self.pos[lo : hi + 1]
+        extent = sub.max(axis=0) - sub.min(axis=0)
+        axis = int(np.argmax(extent))
+        mid = (lo + hi) // 2
+        # Partition [lo,hi] so that element `mid` is the median along `axis`
+        # (np.argpartition gives the same selection nth_element would in C++).
+        order = np.argpartition(self.pos[lo : hi + 1, axis], mid - lo)
+        self.pos[lo : hi + 1] = self.pos[lo : hi + 1][order]
+        self.idx[lo : hi + 1] = self.idx[lo : hi + 1][order]
+        self.axis[mid] = axis
+        self._build(lo, mid - 1)
+        self._build(mid + 1, hi)
+
+    def knn(self, q, k):
+        """Return (indices_into_reordered_array, squared_dists) of the k nearest
+        photons to q, sorted by distance. Mirrors the C++ bounded-max-heap query.
+        """
+        q = np.asarray(q, dtype=np.float64)
+        # bounded max-heap as parallel arrays; we keep it simple in the prototype
+        # (the C++ uses a real binary max-heap of size k).
+        heap_d2 = []  # squared distances
+        heap_i = []   # node indices
+
+        def consider(i):
+            d2 = float(np.sum((self.pos[i] - q) ** 2))
+            if len(heap_d2) < k:
+                heap_d2.append(d2)
+                heap_i.append(i)
+            elif d2 < max(heap_d2):
+                j = int(np.argmax(heap_d2))
+                heap_d2[j] = d2
+                heap_i[j] = i
+
+        def worst():
+            return max(heap_d2) if heap_d2 else np.inf
+
+        def search(lo, hi):
+            if lo > hi:
+                return
+            mid = (lo + hi) // 2
+            axis = self.axis[mid]
+            consider(mid)
+            delta = q[axis] - self.pos[mid][axis]
+            if delta < 0.0:
+                near, far = (lo, mid - 1), (mid + 1, hi)
+            else:
+                near, far = (mid + 1, hi), (lo, mid - 1)
+            search(*near)
+            if len(heap_d2) < k or delta * delta < worst():
+                search(*far)
+
+        search(0, self.n - 1)
+        d2 = np.array(heap_d2)
+        ii = np.array(heap_i)
+        srt = np.argsort(d2)
+        return ii[srt], d2[srt]
+
+    def irradiance(self, q, k, powers):
+        """Jensen 1996 density estimate at q: E = (sum_p Phi_p) / (pi r^2),
+        r^2 = farthest of the k nearest. `powers` is per-photon flux aligned to the
+        REORDERED array (use self.idx to map from original)."""
+        ii, d2 = self.knn(q, k)
+        if ii.size == 0:
+            return 0.0
+        r2 = float(d2[-1])
+        if r2 <= 0.0:
+            return 0.0
+        return float(np.sum(powers[ii])) / (np.pi * r2)
+
+
+# --------------------------------------------------------------------------- #
+# Brute-force reference (the pytest oracle).
+# --------------------------------------------------------------------------- #
+
+
+def brute_knn(positions, q, k):
+    d2 = np.sum((positions - q) ** 2, axis=1)
+    order = np.argsort(d2, kind="stable")[:k]
+    return order, d2[order]
+
+
+# --------------------------------------------------------------------------- #
+# Validation
+# --------------------------------------------------------------------------- #
+
+
+def main():
+    rng = np.random.default_rng(20260529)
+    n = 4000
+    k = 20
+    positions = rng.uniform(-5.0, 5.0, size=(n, 3))
+
+    pm = PhotonMap(positions)
+
+    # 1) k-NN set correctness vs brute force.
+    max_radius_err = 0.0
+    set_mismatch = 0
+    n_queries = 300
+    for _ in range(n_queries):
+        q = rng.uniform(-6.0, 6.0, size=3)
+        ii, d2 = pm.knn(q, k)
+        # map reordered -> original photon ids
+        kd_ids = set(int(pm.idx[i]) for i in ii)
+        bf_ids_order, bf_d2 = brute_knn(positions, q, k)
+        bf_ids = set(int(j) for j in bf_ids_order)
+        if kd_ids != bf_ids:
+            set_mismatch += 1
+        # enclosing radius must match the k-th brute distance
+        max_radius_err = max(max_radius_err, abs(float(d2[-1]) - float(bf_d2[-1])))
+
+    print(f"[knn] queries={n_queries} k={k} set_mismatches={set_mismatch} "
+          f"max_radius_err={max_radius_err:.3e}")
+    assert set_mismatch == 0, "kd-tree k-NN set must match brute force exactly"
+    assert max_radius_err < 1e-9, "enclosing radius must match brute force"
+
+    # 2) Density estimate: uniform photons on a unit-flux plane.  With N photons
+    # spread over area A and unit power each, the true areal flux density is N/A.
+    # Jensen's estimate at an interior point should converge to that density.
+    side = 4.0
+    npl = 40000
+    plane = np.zeros((npl, 3))
+    plane[:, 0] = rng.uniform(-side / 2, side / 2, size=npl)
+    plane[:, 2] = rng.uniform(-side / 2, side / 2, size=npl)
+    powers_plane = np.full(npl, 1.0)
+    pmp = PhotonMap(plane)
+    # remap powers to the reordered array
+    powers_reordered = np.empty(npl)
+    powers_reordered[np.arange(npl)] = powers_plane[pmp.idx]
+    true_density = npl / (side * side)
+    est = [pmp.irradiance(np.array([x, 0.0, 0.0]), 200, powers_reordered)
+           for x in (-1.0, 0.0, 1.0)]
+    mean_est = float(np.mean(est))
+    rel_err = abs(mean_est - true_density) / true_density
+    print(f"[density] true={true_density:.2f} est={mean_est:.2f} "
+          f"rel_err={rel_err:.3%}")
+    assert rel_err < 0.10, "density estimate must converge to true areal density"
+
+    print("OK — pkg109 photon-map numeric core validated vs brute force.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_photon_map.py
+++ b/tests/test_photon_map.py
@@ -1,0 +1,95 @@
+"""pkg109 — world-space photon-map kd-tree: C++ correctness vs a numpy oracle.
+
+Validates the C++ `astroray::photon::PhotonMap` (balanced kd-tree build + k-NN
+locate + Jensen 1996 density estimate) through the `_photon_map_knn_d2` /
+`_photon_map_irradiance` test bindings against the same float64 brute-force
+reference used by scripts/prototypes/pkg109_photon_map_prototype.py.
+
+References: Jensen, "A Practical Guide to Global Illumination using Photon Maps",
+SIGGRAPH 2000 Course 8, §2.2 (balanced kd-tree), §3.4 (locate_photons), §3.1
+Eq. 8 (radiance/irradiance estimate). See
+.astroray_plan/docs/pkg109-110-111-photon-map-research.md.
+"""
+
+import math
+
+import numpy as np
+import pytest
+
+import astroray
+
+pytestmark = pytest.mark.skipif(
+    not hasattr(astroray, "_photon_map_knn_d2"),
+    reason="photon-map test bindings not present — rebuild astroray.pyd (pkg109)",
+)
+
+
+def _brute_knn_d2(points, q, k):
+    d2 = np.sum((points - q) ** 2, axis=1)
+    return np.sort(d2)[:k]
+
+
+def test_knn_matches_brute_force():
+    """The C++ k-NN must return exactly the k nearest (by squared distance) as a
+    numpy brute-force search, for many random queries (set + radii identical)."""
+    rng = np.random.default_rng(20260529)
+    n, k = 3000, 20
+    points = rng.uniform(-5.0, 5.0, size=(n, 3))
+    pts_list = points.tolist()
+    big_radius = 1.0e6  # so the radius cap never clips — pure k-NN
+
+    max_err = 0.0
+    for _ in range(120):
+        q = rng.uniform(-6.0, 6.0, size=3)
+        cpp_d2 = np.asarray(
+            astroray._photon_map_knn_d2(pts_list, q.tolist(), k, big_radius)
+        )
+        bf_d2 = _brute_knn_d2(points, q, k)
+        assert cpp_d2.shape == bf_d2.shape, (cpp_d2.shape, bf_d2.shape)
+        # squared distances are reorder-invariant; compare element-wise.
+        max_err = max(max_err, float(np.max(np.abs(cpp_d2 - bf_d2))))
+    # float32 kd-tree vs float64 oracle: distances agree to single-precision.
+    assert max_err < 1e-3, f"k-NN squared-distance mismatch: {max_err:.3e}"
+
+
+def test_knn_radius_cap():
+    """With a small max_radius, only photons within that radius are returned."""
+    rng = np.random.default_rng(7)
+    points = rng.uniform(-5.0, 5.0, size=(2000, 3))
+    q = np.array([0.0, 0.0, 0.0])
+    radius = 1.0
+    cpp_d2 = np.asarray(astroray._photon_map_knn_d2(points.tolist(), q.tolist(), 64, radius))
+    bf_d2 = np.sum((points - q) ** 2, axis=1)
+    within = np.sort(bf_d2[bf_d2 < radius * radius])[:64]
+    assert cpp_d2.shape == within.shape
+    assert np.max(cpp_d2) <= radius * radius + 1e-5
+
+
+def test_irradiance_converges_to_areal_density():
+    """Jensen Eq. 8 with unit-power photons on a plane recovers the true areal
+    flux density N/A = (1/(pi r^2)) * sum over the k nearest."""
+    rng = np.random.default_rng(20260529)
+    side, npl, k = 4.0, 40000, 200
+    plane = np.zeros((npl, 3))
+    plane[:, 0] = rng.uniform(-side / 2, side / 2, size=npl)
+    plane[:, 2] = rng.uniform(-side / 2, side / 2, size=npl)
+    powers = np.ones((npl, 3))  # unit XYZ power per photon
+    true_density = npl / (side * side)
+
+    ests = []
+    for x in (-1.0, 0.0, 1.0):
+        X, Y, Z = astroray._photon_map_irradiance(
+            plane.tolist(), powers.tolist(), [x, 0.0, 0.0], k, 1.0e6
+        )
+        ests.append(Y)
+    rel_err = abs(np.mean(ests) - true_density) / true_density
+    assert rel_err < 0.10, f"density estimate rel_err {rel_err:.3%} (true {true_density})"
+
+
+def test_irradiance_empty_region_is_dark():
+    """A query far from any photon (beyond max_radius) returns zero irradiance —
+    this is what keeps the receiver dark outside the caustic band."""
+    points = [[0.0, 0.0, 0.0], [0.1, 0.0, 0.0], [0.0, 0.0, 0.1]]
+    powers = [[1.0, 1.0, 1.0]] * 3
+    X, Y, Z = astroray._photon_map_irradiance(points, powers, [100.0, 0.0, 0.0], 8, 1.0)
+    assert (X, Y, Z) == (0.0, 0.0, 0.0)


### PR DESCRIPTION
## What

First package of the **general-caustics chain** (pkg109 → pkg110 → pkg111). Replaces the prism-specific flat 2D `(x,z)` grid in `light_tracer_caustic` with a **world-space photon map**: a balanced kd-tree + k-NN density-estimate gather. Storage-only — the 2-face prism emission is unchanged; this swaps the backend and reproduces the band.

## How (cited — CLAUDE.md §6)

- `include/astroray/photon/photon_map.h` — balanced kd-tree (median split on the largest-extent axis, O(N log N)) + bounded max-heap k-NN locate (plane-distance pruning, squared distances) + Jensen cone-filtered irradiance density estimate `E = [Σ Φ_p(1−d_p/(kf·r))] / [(1−2/(3kf))·π r²]`.
  - Mirrors **Jensen, "A Practical Guide to Global Illumination using Photon Maps", SIGGRAPH 2000 Course 8** — Fig. 7 (`balance`), Fig. 10 (`locate_photons`), Eq. 8 (§3.1), cone filter (§3.2.1). Disk-area `1/(π r²)` factor per **pbrt-v4** `integrators.cpp:3229` (Apache-2.0). `Photon` (40 B) passed by `const&` per the MinGW >32 B rule.
- `plugins/integrators/light_tracer_caustic.cpp` — deposit photons into the kd-tree; gather via the k-NN estimate with a **density-adaptive radius** (1.5× median k-th-NN distance) + a **brightness auto-scale** (replaces the per-cell grid normalization).
- `module/blender_module.cpp` — `_photon_map_knn_d2` / `_photon_map_irradiance` test bindings.

## Validation

- **`tests/test_photon_map.py` (4 tests):** C++ kd-tree k-NN matches a numpy float64 brute-force oracle exactly (squared distances, 120 random queries); radius cap; Jensen density estimate converges to the true areal density; empty-region returns 0.
- **Numeric prototype** (`scripts/prototypes/pkg109_photon_map_prototype.py`) validated the design vs brute force before the C++ port (the discipline that caught every pkg106 bug).
- **Prism regression** (`prism-bk7-collimated`) still passes via the kd-tree backend: **hue_spread 0.750** (≥0.7), **bright_coverage 0.615** (≥0.5) — faithful to pkg106 (grid 0.754 / 0.88; the density estimate is inherently tighter than bilinear splatting, which the spec's 0.5 gate anticipates).
- **Full local suite: 1155 passed, 15 skipped, 18 xfailed** (RTX, MSVC+CUDA build). Stale-call-site sweep clean (removed members were all private to the integrator).

## Non-goals (per spec)

Not BSDF-driven photon bouncing (pkg110), not the default-path gather (pkg111), not GPU, not SPPM-progressive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)