### PR TITLE
feat: float route for integrator params (set_integrator_param_float + ParamDict::getNumber)

### DIFF
--- a/benchmarks/reference_bank/scenes/prism-bk7-collimated/scene.py
+++ b/benchmarks/reference_bank/scenes/prism-bk7-collimated/scene.py
@@ -98,8 +98,9 @@ def make_scene(astroray):
     r.set_integrator("light_tracer_caustic")
     r.set_integrator_param("max_depth", MAX_DEPTH)
     r.set_integrator_param("photon_count", 3000000)
-    r.set_integrator_param("caustic_grid_res", 256)
-    r.set_integrator_param("caustic_boost", 12)
+    # pkg-integrator-float-param: caustic_boost is now a direct float multiplier
+    # (1.2 == the old int-knob 12 x 0.1) routed via set_integrator_param_float.
+    r.set_integrator_param_float("caustic_boost", 1.2)
 
     # Camera looks down the floor at the rainbow landing zone.
     r.setup_camera([1.86, 1.5, 3.2], [1.86, -3.0, 0.0], [0.0, 1.0, 0.0],

--- a/include/astroray/param_dict.h
+++ b/include/astroray/param_dict.h
@@ -33,6 +33,19 @@ public:
 
     float              getFloat     (const std::string& key, float              dflt = 0.0f) const { return get_<float>(key, dflt); }
     int                getInt       (const std::string& key, int                dflt = 0)    const { return get_<int>(key, dflt); }
+
+    // Numeric accessor that returns a float whether the value was stored as a
+    // float or an int. get_<T> uses std::get_if<T> (exact-type match), so a value
+    // set via the int route is invisible to getFloat and vice-versa; getNumber
+    // bridges that so an integrator param can be supplied as either from Python
+    // (set_integrator_param / set_integrator_param_float). pkg-integrator-float-param.
+    float getNumber(const std::string& key, float dflt = 0.0f) const {
+        auto it = data_.find(key);
+        if (it == data_.end()) return dflt;
+        if (const float* f = std::get_if<float>(&it->second)) return *f;
+        if (const int*   i = std::get_if<int>(&it->second))   return static_cast<float>(*i);
+        return dflt;
+    }
     bool               getBool      (const std::string& key, bool               dflt = false) const { return get_<bool>(key, dflt); }
     std::string        getString    (const std::string& key, std::string        dflt = "")   const { return get_<std::string>(key, dflt); }
     Vec3               getVec3      (const std::string& key, Vec3               dflt = {})   const { return get_<Vec3>(key, dflt); }

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -1559,6 +1559,19 @@ public:
         }
     }
 
+    // pkg-integrator-float-param: float route mirroring setIntegratorParam.
+    // ParamDict distinguishes int and float storage (std::get_if exact-type match),
+    // so a float-valued integrator param must be set via this route; integrators
+    // read such params with ParamDict::getNumber (accepts either int or float).
+    void setIntegratorParamFloat(const std::string& key, float value) {
+        integratorParams_.set(key, value);
+        if (!integratorName_.empty()) {
+            auto integrator = astroray::IntegratorRegistry::instance().create(
+                integratorName_, integratorParams_);
+            renderer.setIntegrator(integrator);
+        }
+    }
+
     // pkg39: multi-wavelength rendering helpers
     void setWavelengthRange(float lambdaMin, float lambdaMax) {
         integratorParams_.set("lambda_min", lambdaMin);
@@ -2121,6 +2134,10 @@ PYBIND11_MODULE(astroray, m) {
         .def("set_integrator_param", &PyRenderer::setIntegratorParam,
              "key"_a, "value"_a,
              "Set an integer parameter passed to the integrator constructor.")
+        .def("set_integrator_param_float", &PyRenderer::setIntegratorParamFloat,
+             "key"_a, "value"_a,
+             "Set a float parameter passed to the integrator constructor "
+             "(read via ParamDict::getNumber, which accepts int or float).")
         // pkg39: multi-wavelength rendering
         .def("set_wavelength_range", &PyRenderer::setWavelengthRange,
              "lambda_min"_a, "lambda_max"_a,

--- a/plugins/integrators/light_tracer_caustic.cpp
+++ b/plugins/integrators/light_tracer_caustic.cpp
@@ -58,9 +58,10 @@ public:
         : maxDepth_(p.getInt("max_depth", 12)),
           photons_(p.getInt("photon_count", 2000000)),
           gatherK_(p.getInt("caustic_knn", 50)),
-          // float params don't route through the Python int-only set_integrator_param,
-          // so brightness is an int knob (x0.1); default 10 -> 1.0.
-          boost_(p.getInt("caustic_boost", 10) * 0.1f) {}
+          // pkg-integrator-float-param: caustic_boost is now a direct float
+          // brightness multiplier read via getNumber (accepts the int or float
+          // Python route: set_integrator_param_float / set_integrator_param).
+          boost_(p.getNumber("caustic_boost", 1.0f)) {}
 
     IntegratorCapabilities capabilities() const override {
         return {false, "forward light-tracer caustic (CPU-only)"};

--- a/tests/test_integrator_float_param.py
+++ b/tests/test_integrator_float_param.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+"""pkg-integrator-float-param — float route for integrator params.
+
+`set_integrator_param` stores an int, and `ParamDict::get_<T>` matches the exact
+variant type, so float-valued integrator params previously had no route from
+Python (light_tracer_caustic's `caustic_boost` was an int x 0.1 hack). This adds
+`set_integrator_param_float` + `ParamDict::getNumber` (reads int OR float as
+float) and wires `caustic_boost` to it.
+
+The decisive test that the value is honored as a FLOAT (not truncated to int):
+a fractional boost in (0,1) produces a caustic; if it were truncated to int 0 the
+caustic would be absent (black). Brightness also scales with the float magnitude,
+and the int route still works (back-compat via getNumber).
+
+CPU-only; deterministic; runs on CI.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+
+import numpy as np
+import pytest
+
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+sys.path.insert(0, os.path.dirname(__file__))
+
+try:
+    import astroray  # noqa: E402
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray not built")
+
+_REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_SCENE = os.path.join(_REPO, "benchmarks", "reference_bank", "scenes",
+                      "prism-bk7-collimated", "scene.py")
+
+
+def _prism_caustic_signal(boost, route_float):
+    """Render the prism scene with the given caustic_boost (via the float or int
+    route) and return the total floor caustic luminance (background is black, the
+    floor is unlit except by the baked caustic, so the image-sum tracks the
+    caustic energy). Uses a reduced photon count + samples for speed."""
+    spec = importlib.util.spec_from_file_location("_prism_fp", _SCENE)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    r = mod.make_scene(astroray)
+    r.set_seed(mod.SEED)
+    r.set_integrator_param("photon_count", 500000)
+    if route_float:
+        r.set_integrator_param_float("caustic_boost", float(boost))
+    else:
+        r.set_integrator_param("caustic_boost", int(round(boost)))
+    img = np.asarray(r.render(16, mod.MAX_DEPTH, None, True), dtype=np.float32)
+    if img.ndim == 1:
+        img = img.reshape(mod.HEIGHT, mod.WIDTH, 3)
+    lum = 0.2126 * img[:, :, 0] + 0.7152 * img[:, :, 1] + 0.0722 * img[:, :, 2]
+    return float(lum.sum())
+
+
+@pytest.mark.skipif(not os.path.exists(_SCENE), reason="prism scene not present")
+def test_integrator_float_param_route():
+    if not hasattr(astroray.Renderer(), "set_integrator_param_float"):
+        pytest.skip("build lacks set_integrator_param_float")
+    if not hasattr(astroray.Renderer(), "add_sun_light_dedicated"):
+        pytest.skip("build lacks add_sun_light_dedicated")
+
+    base = _prism_caustic_signal(0.0, route_float=True)   # no caustic (scale 0)
+    quarter = _prism_caustic_signal(0.25, route_float=True)
+    half = _prism_caustic_signal(0.5, route_float=True)
+    int_one = _prism_caustic_signal(1.0, route_float=False)  # int route -> getNumber
+
+    # A fractional float boost MUST produce a caustic — proving the value is honored
+    # as a float, not truncated to int 0 (which would leave the floor black).
+    assert quarter > base * 1.1 + 1.0, \
+        f"float boost 0.25 produced no caustic (truncated to int?): {quarter:.1f} vs base {base:.1f}"
+    # Brightness scales with the float magnitude.
+    assert half > quarter * 1.15, \
+        f"float boost does not scale brightness: half {half:.1f} <= 1.15 * quarter {quarter:.1f}"
+    # The int route still works (back-compat: getNumber reads int as float).
+    assert int_one > base * 1.1 + 1.0, \
+        f"int route regressed (no caustic): {int_one:.1f} vs base {base:.1f}"


### PR DESCRIPTION
## What

Adds a float route for integrator parameters and removes the `caustic_boost` int×0.1 hack in `light_tracer_caustic`.

## Why

`set_integrator_param` stores an **int**, and `ParamDict::get_<T>` matches the exact variant type (`std::get_if`), so a value set via the int route is invisible to `getFloat` (and vice-versa). Float-valued integrator params therefore had no route from Python — `light_tracer_caustic.cpp:58-60` worked around it with `caustic_boost = getInt(...) * 0.1f` (an int knob).

## How

- **`include/astroray/param_dict.h`** — `getNumber(key, dflt)` returns a `float` whether the value was stored as a `float` or an `int`, bridging the exact-type-match gap.
- **`module/blender_module.cpp`** — `set_integrator_param_float(key, value)` mirroring `set_integrator_param` (stores a float, rebuilds the active integrator per the pkg91 lifecycle).
- **`plugins/integrators/light_tracer_caustic.cpp`** — `caustic_boost` is now a direct float multiplier read via `getNumber`; the int×0.1 hack is gone.
- **`prism-bk7-collimated/scene.py`** — sets `caustic_boost = 1.2` via the float route (== the old int knob `12 × 0.1`, **identical brightness** → the pkg106 prism gate is unchanged). Also drops the dead `caustic_grid_res` no-op (the 2D grid was removed in pkg109).

## Test

`tests/test_integrator_float_param.py` — the decisive check that the value is honored as a **float** (not truncated to int): a fractional boost in (0,1) produces a caustic, whereas int-truncation to 0 would leave the floor black. Also asserts brightness scales with the float magnitude, and the int route still works (back-compat via `getNumber`).

## Verification

- Float-param test passes; **prism rainbow gate unchanged** (boost 1.2 via float == old 12×0.1).
- **Full local suite: 1161 passed**, 15 skipped, 19 xfailed (RTX, MSVC+CUDA build). Stale-call-site sweep clean (all new symbols additive; `caustic_boost` consumed only by the integrator + set by the prism scene).

🤖 Generated with [Claude Code](https://claude.com/claude-code)