### PR TITLE
feat(pkg110): general BSDF-driven photon bounce — focusing-caster caustics (auto-selected refraction)

### DIFF
--- a/benchmarks/reference_bank/scenes/glass-sphere-caustic/scene.py
+++ b/benchmarks/reference_bank/scenes/glass-sphere-caustic/scene.py
@@ -1,0 +1,74 @@
+"""Focusing-caster caustic — clear glass SPHERE + collimated sun (pkg110).
+
+The pkg106/109 forward light-tracer was prism-specific (a hard-coded 2-face
+refraction). pkg110 makes the photon bounce BSDF-driven, so photons traverse ANY
+glass shape via the material's sampleSpectral. This scene is the acceptance gate:
+a primitive glass *sphere* (a NON-triangle caustic caster the old 2-face code
+could not handle) FOCUSES a collimated sun into a concentrated caustic on the
+floor — a "burning-glass" spot/cardioid, much brighter than the surrounding
+direct-lit floor.
+
+Geometry: a clear ior-1.5 glass sphere flagged as a caustic caster; a distant
+collimated sun angled down (+x, -y) so the focused caustic lands on the floor
+offset from the sphere (not occluded by it); a white diffuse floor below; camera
+looking at the caustic landing zone.
+
+Integrator: `light_tracer_caustic` (forward; caustic baked in beginFrame).
+"""
+
+from __future__ import annotations
+
+import math
+
+
+NAME = "glass-sphere-caustic"
+WIDTH = 384
+HEIGHT = 288
+SAMPLES = 64
+MAX_DEPTH = 12
+SEED = 17
+
+
+def _norm(v):
+    n = math.sqrt(sum(c * c for c in v))
+    return [c / n for c in v]
+
+
+def _add_quad(r, corners, mat):
+    a, b, c, d = corners
+    r.add_triangle(a, b, c, mat)
+    r.add_triangle(a, c, d, mat)
+
+
+def make_scene(astroray):
+    r = astroray.Renderer()
+    r.set_background_color([0.0, 0.0, 0.0])
+
+    # Clear glass sphere (ior 1.5), flagged as a caustic caster. A sphere is a
+    # primitive (non-triangle) caster — the pkg110 general BSDF photon loop traces
+    # through it via Sphere::hit + dielectric sampleSpectral.
+    glass = r.create_material("dielectric", [1.0, 1.0, 1.0], {"ior": 1.5})
+    sphere_idx = r.scene_object_count()
+    r.add_sphere([0.0, 0.0, 0.0], 0.6, glass)
+    r.set_object_caustic_caster(sphere_idx, True)
+
+    # Distant collimated sun, angled down and +x so the focused caustic lands on
+    # the floor at ~x=+0.7 (offset from the sphere at the origin).
+    r.add_sun_light_dedicated(_norm([0.45, -1.0, 0.0]), 0.01,
+                              {"mode": "rgb", "color": [1.0, 1.0, 1.0]}, 6.0)
+
+    # White diffuse floor below the sphere.
+    floor = r.create_material("lambertian", [0.85, 0.85, 0.85], {})
+    _add_quad(r, [[-3.0, -1.6, -3.0], [4.0, -1.6, -3.0],
+                  [4.0, -1.6, 3.0], [-3.0, -1.6, 3.0]], floor)
+
+    r.set_integrator("light_tracer_caustic")
+    r.set_integrator_param("max_depth", MAX_DEPTH)
+    r.set_integrator_param("photon_count", 3000000)
+    # Direct float brightness multiplier (pkg-integrator-float-param route).
+    r.set_integrator_param_float("caustic_boost", 1.4)
+
+    # Camera looks at the caustic landing zone (~x=0.7 on the floor).
+    r.setup_camera([0.7, 1.1, 3.2], [0.7, -1.6, 0.0], [0.0, 1.0, 0.0],
+                   42.0, WIDTH / HEIGHT, 0.0, 3.6, WIDTH, HEIGHT)
+    return r

--- a/plugins/integrators/light_tracer_caustic.cpp
+++ b/plugins/integrators/light_tracer_caustic.cpp
@@ -13,21 +13,32 @@
 //     transport (light particles) for caustics.
 //   Jensen, "Global Illumination using Photon Maps", EGWR 1996 — diffuse-surface
 //     photon deposition + density estimation (here: a 2D grid on the receiver).
-//   Refraction/Fresnel mirror plugins/materials/dielectric.cpp; the prism faces
-//     are the setCausticCaster-flagged triangles (mesh_attempt.h gather).
+//   Refraction/Fresnel mirror plugins/materials/dielectric.cpp.
 //
-// Scope: deposits onto a horizontal (normal ~ +y) diffuse receiver. pkg109 swaps
-// the original 2D (x,z) grid for a world-space photon map (kd-tree, photon_map.h)
-// built in beginFrame (serial, before the parallel camera loop, so no contention);
-// the camera pass gathers via a k-NN density estimate (Jensen 1996 Eq. 8). The
-// per-wavelength CIE deposit (spectrum.h cieCmf1964_10deg) gives physically-based
-// rainbow colours. The kd-tree is the foundation for general caustics (pkg110/111).
+// pkg110: the photon bounce AUTO-SELECTS by caster geometry.
+//   * A FLAT prism (caster triangles forming exactly two planar refracting faces)
+//     uses the explicit 2-face refraction — a clean, dense, single dispersed-path
+//     deposit that yields a smooth rainbow. (A wide forward aperture through a
+//     *solid* prism scatters photons through the extra faces into chromatic noise,
+//     so the flat case is kept on the special 2-face path.)
+//   * Any OTHER caster (a curved/solid shape: sphere, lens, triangulated mesh) uses
+//     the GENERAL deterministic BVH refraction loop: at each transmissive hit it
+//     refracts (Snell + Schlick-Fresnel, enter/exit from the geometric-normal sign,
+//     per-wavelength iorAt) or reflects on TIR, through any number of faces — this
+//     is what makes a glass SPHERE focus a caustic.
+// Both paths deposit per-wavelength CIE flux into the same world-space photon map.
+//
+// Scope: deposits onto a horizontal (normal ~ +y) diffuse receiver (pkg111 lifts
+// this). pkg109 stores photons in a world-space kd-tree (photon_map.h) built in
+// beginFrame (serial, before the parallel camera loop); the camera pass gathers via
+// a k-NN density estimate (Jensen 1996 Eq. 8). The per-wavelength CIE deposit
+// (spectrum.h cieCmf1964_10deg) gives physically-based rainbow colours.
 
 #include "astroray/register.h"
 #include "astroray/integrator.h"
 #include "astroray/spectrum.h"
 #include "astroray/shapes.h"
-#include "astroray/manifold/mesh_attempt.h"   // gatherTriangleCasters, CausticTri
+#include "astroray/manifold/mesh_attempt.h"   // gatherTriangleCasters, CausticTri (flat-prism path)
 #include "astroray/manifold/mesh_caustic.h"    // rayTriHit
 #include "astroray/photon/photon_map.h"        // pkg109 world-space photon map (kd-tree)
 
@@ -35,6 +46,7 @@
 #include <cmath>
 #include <limits>
 #include <random>
+#include <utility>
 #include <vector>
 
 namespace amf = astroray::manifold;
@@ -117,8 +129,43 @@ public:
     }
 
 private:
-    // Nearest caster-triangle hit along (o,d); fills the geometric normal
-    // oriented against d. Returns t (>0) or -1 on miss.
+    // Union AABB of all caustic-caster objects (any shape: triangles, spheres,
+    // meshes) flagged via setCausticCaster. Only the combined bounds are needed to
+    // aim the emission aperture; the bounce uses the BVH + each hit's geometric
+    // normal + material iorAt, so no per-shape refraction code is needed.
+    static bool gatherCausticCasterBounds(Renderer& scene, AABB& out, int& count) {
+        AABB acc; bool any = false; count = 0;
+        for (const auto& obj : scene.getScene()) {
+            if (!obj || !obj->isCausticCaster()) continue;
+            AABB ob;
+            if (!obj->boundingBox(ob)) continue;
+            acc = any ? acc.merge(ob) : ob;
+            any = true; ++count;
+        }
+        if (any) out = acc;
+        return any;
+    }
+
+    // Number of distinct planar faces among flat triangle casters. A genuine prism
+    // is two coplanar-grouped refracting faces (== 2); a curved/triangulated mesh or
+    // many-faced solid is > 2. Used to route the flat prism to the clean 2-face path.
+    static int countDistinctCasterPlanes(const std::vector<amf::CausticTri>& tris) {
+        std::vector<std::pair<Vec3, float>> planes;  // (unit normal, |offset|)
+        for (const auto& t : tris) {
+            Vec3 n = (t.v1 - t.v0).cross(t.v2 - t.v0).normalized();
+            float d = std::fabs(n.dot(t.v0));
+            bool found = false;
+            for (const auto& pl : planes) {
+                if (std::fabs(pl.first.dot(n)) > 0.999f &&        // parallel or anti-parallel
+                    std::fabs(pl.second - d) < 1e-2f * (1.0f + d)) { found = true; break; }
+            }
+            if (!found) planes.emplace_back(n, d);
+        }
+        return static_cast<int>(planes.size());
+    }
+
+    // Nearest caster-triangle hit along (o,d); fills the geometric normal oriented
+    // against d. Returns t (>0) or -1 on miss. (explicit flat-prism 2-face path)
     static float nearestCaster(const std::vector<amf::CausticTri>& tris,
                                const Vec3& o, const Vec3& d, Vec3& nOut) {
         float best = std::numeric_limits<float>::max(); int bi = -1;
@@ -128,7 +175,7 @@ private:
         }
         if (bi < 0) return -1.0f;
         Vec3 n = (tris[bi].v1 - tris[bi].v0).cross(tris[bi].v2 - tris[bi].v0).normalized();
-        if (n.dot(d) > 0.0f) n = n * -1.0f;   // orient against the incident ray
+        if (n.dot(d) > 0.0f) n = n * -1.0f;
         nOut = n;
         return best;
     }
@@ -148,80 +195,130 @@ private:
 
     void buildPhotonMap(Renderer& scene) {
         ready_ = false; depositedFlux_ = 0.0f; gatherRadius_ = 0.0f; causticScale_ = 1.0f;
-        std::vector<amf::CausticTri> tris;
-        const Material* mat = amf::gatherTriangleCasters(scene, tris);
-        if (tris.empty() || !mat) return;
         const auto* bvh = scene.getBVH().get();
         if (!bvh) return;
 
-        // Sun propagation direction: sample the (collimated/distant) light.
+        // Casters can be ANY transmissive geometry flagged via setCausticCaster;
+        // only their combined bounds are needed to aim the emission aperture.
+        AABB casterBounds; int casterCount = 0;
+        if (!gatherCausticCasterBounds(scene, casterBounds, casterCount)) return;
+        const Vec3 casterC = casterBounds.centroid();
+        const float crad = (casterBounds.max - casterBounds.min).length() * 0.55f + 1e-3f;
+
         const auto& lights = scene.getLights();
         if (lights.empty()) return;
-        Vec3 prismC(0.0f), lo(1e30f), hi(-1e30f);
-        for (const auto& tr : tris) {
-            for (const Vec3& v : {tr.v0, tr.v1, tr.v2}) {
-                prismC = prismC + v;
-                lo = Vec3(std::min(lo.x, v.x), std::min(lo.y, v.y), std::min(lo.z, v.z));
-                hi = Vec3(std::max(hi.x, v.x), std::max(hi.y, v.y), std::max(hi.z, v.z));
-            }
-        }
-        prismC = prismC * (1.0f / (3.0f * tris.size()));
-        float prad = (hi - lo).length() * 0.55f;
 
         std::mt19937 gen(12345u);
         std::uniform_real_distribution<float> u01(0.0f, 1.0f);
         astroray::SampledWavelengths probe = astroray::SampledWavelengths::sampleUniform(0.5f);
-        LightSample ls; lights.sample(ls, prismC, Vec3(0, 1, 0), probe, gen);
-        Vec3 sunDir = (prismC - ls.position).normalized();   // propagation (toward prism)
+        LightSample ls; lights.sample(ls, casterC, Vec3(0, 1, 0), probe, gen);
+        Vec3 sunDir = (casterC - ls.position).normalized();   // propagation toward the casters
         if (sunDir.length2() < 1e-6f) return;
 
-        // Orthonormal frame around the sun direction for sampling the entry aperture.
+        // Aperture frame around the sun direction (sample the entry disc).
         Vec3 a = (std::fabs(sunDir.x) < 0.9f) ? Vec3(1, 0, 0) : Vec3(0, 1, 0);
         Vec3 fu = (a - sunDir * a.dot(sunDir)).normalized();
         Vec3 fv = sunDir.cross(fu);
-        Vec3 origin0 = prismC - sunDir * (prad + 2.0f);
+        Vec3 origin0 = casterC - sunDir * (crad + 2.0f);
 
-        // Pass 1: trace photons, deposit each on the first diffuse receiver hit.
         std::vector<astroray::photon::Photon> photons;
         photons.reserve(photons_ / 2);
         std::vector<float> ys;
         const float lmin = 380.0f, lmax = 720.0f;
-        for (int p = 0; p < photons_; ++p) {
-            float lambda = lmin + (lmax - lmin) * u01(gen);
-            float ior = mat->iorAt(lambda);
-            if (ior <= 1.0f) continue;
-            float ra = (u01(gen) * 2.0f - 1.0f) * prad;
-            float rb = (u01(gen) * 2.0f - 1.0f) * prad;
-            Vec3 o = origin0 + fu * ra + fv * rb;
-            Vec3 d = sunDir;
-            // entry face (air -> glass)
-            Vec3 n1; float t1 = nearestCaster(tris, o, d, n1);
-            if (t1 < 0) continue;
-            Vec3 p1 = o + d * t1;
-            float tr = fresnelT(d.dot(n1), ior);
-            Vec3 d1; if (!refract(d, n1, 1.0f / ior, d1)) continue;
-            // exit face (glass -> air)
-            Vec3 n2; float t2 = nearestCaster(tris, p1 + d1 * 1e-4f, d1, n2);
-            if (t2 < 0) continue;
-            Vec3 p2 = p1 + d1 * (t2 + 1e-4f);
-            tr *= fresnelT(d1.dot(n2), ior);
-            Vec3 d2; if (!refract(d1, n2, ior, d2)) continue;
-            // trace to the receiver (first non-caster, non-emissive surface)
-            HitRecord rec;
-            if (!bvh->hit(Ray(p2 + d2 * 1e-3f, d2), 1e-3f,
-                          std::numeric_limits<float>::max(), rec)) continue;
-            if (!rec.material || rec.material->isEmissive()) continue;
-            if (rec.hitObject && rec.hitObject->isCausticCaster()) continue;
-            if (rec.normal.y < 0.7f) continue;            // horizontal receiver only
-            astroray::XYZ cmf = astroray::cieCmf1964_10deg(lambda);
-            astroray::photon::Photon ph;
-            ph.position = rec.point;
-            ph.incidentDir = d2;                          // photon travel direction
-            ph.power = astroray::XYZ{cmf.X * tr, cmf.Y * tr, cmf.Z * tr};
-            ph.lambda = lambda;
-            photons.push_back(ph);
-            depositedFlux_ += ph.power.Y;
-            ys.push_back(rec.point.y);
+        const float eps = 1e-3f;
+
+        // Auto-select the tracing path by caster geometry (see file header). A flat
+        // prism (caster triangles forming exactly two planar faces) -> explicit
+        // 2-face refraction (clean single dispersed path); anything else -> the
+        // general deterministic BVH loop (curved/solid glass: sphere, lens, mesh).
+        std::vector<amf::CausticTri> tris;
+        const Material* prismMat = amf::gatherTriangleCasters(scene, tris);
+        const bool flatPrism = (prismMat != nullptr) && countDistinctCasterPlanes(tris) == 2;
+
+        if (flatPrism) {
+            // Explicit 2-face prism: entry face (air->glass) then exit face
+            // (glass->air) via the nearest caster triangle; deposit on the first
+            // horizontal diffuse receiver — one clean dispersed gradient per lambda.
+            for (int p = 0; p < photons_; ++p) {
+                const float lambda = lmin + (lmax - lmin) * u01(gen);
+                const float ior = prismMat->iorAt(lambda);
+                if (ior <= 1.0f) continue;
+                const float ra = (u01(gen) * 2.0f - 1.0f) * crad;
+                const float rb = (u01(gen) * 2.0f - 1.0f) * crad;
+                Vec3 o = origin0 + fu * ra + fv * rb;
+                Vec3 d = sunDir;
+                Vec3 n1; float t1 = nearestCaster(tris, o, d, n1);
+                if (t1 < 0) continue;
+                Vec3 p1 = o + d * t1;
+                float tr = fresnelT(d.dot(n1), ior);
+                Vec3 d1; if (!refract(d, n1, 1.0f / ior, d1)) continue;
+                Vec3 n2; float t2 = nearestCaster(tris, p1 + d1 * 1e-4f, d1, n2);
+                if (t2 < 0) continue;
+                Vec3 p2 = p1 + d1 * (t2 + 1e-4f);
+                tr *= fresnelT(d1.dot(n2), ior);
+                Vec3 d2; if (!refract(d1, n2, ior, d2)) continue;
+                HitRecord rec;
+                if (!bvh->hit(Ray(p2 + d2 * eps, d2), eps,
+                              std::numeric_limits<float>::max(), rec)) continue;
+                if (!rec.material || rec.material->isEmissive()) continue;
+                if (rec.hitObject && rec.hitObject->isCausticCaster()) continue;
+                if (rec.normal.y < 0.7f) continue;            // horizontal receiver only
+                astroray::XYZ cmf = astroray::cieCmf1964_10deg(lambda);
+                astroray::photon::Photon ph;
+                ph.position = rec.point;
+                ph.incidentDir = d2;
+                ph.power = astroray::XYZ{cmf.X * tr, cmf.Y * tr, cmf.Z * tr};
+                ph.lambda = lambda;
+                photons.push_back(ph);
+                depositedFlux_ += ph.power.Y;
+                ys.push_back(rec.point.y);
+            }
+        } else {
+            // General deterministic refraction loop (curved/solid glass). At each
+            // transmissive hit refract (Snell + Schlick-Fresnel, enter/exit from the
+            // geometric-normal sign, per-wavelength iorAt) or reflect on TIR; deposit
+            // on the first diffuse receiver, only on an L S+ D path (passed >= 1
+            // caster) so direct light is not double-counted.
+            for (int p = 0; p < photons_; ++p) {
+                const float lambda = lmin + (lmax - lmin) * u01(gen);
+                const float ra = (u01(gen) * 2.0f - 1.0f) * crad;
+                const float rb = (u01(gen) * 2.0f - 1.0f) * crad;
+                Vec3 o = origin0 + fu * ra + fv * rb;
+                Vec3 d = sunDir;
+                float tr = 1.0f;
+                bool passedCaster = false;
+                for (int bounce = 0; bounce < maxDepth_; ++bounce) {
+                    HitRecord rec;
+                    if (!bvh->hit(Ray(o, d), eps, std::numeric_limits<float>::max(), rec)) break;
+                    if (!rec.material || rec.material->isEmissive()) break;
+                    if (rec.material->isTransmissive()) {
+                        float ior = rec.material->iorAt(lambda);
+                        if (ior <= 1.0f) ior = 1.5f;
+                        const Vec3 ng = rec.normal;            // geometric outward normal
+                        Vec3 nf; float eta;
+                        if (d.dot(ng) < 0.0f) { nf = ng;         eta = 1.0f / ior; }  // entering
+                        else                  { nf = ng * -1.0f; eta = ior; }         // exiting
+                        Vec3 nd;
+                        if (refract(d, nf, eta, nd)) { tr *= fresnelT(d.dot(nf), ior); d = nd; }
+                        else { d = (d - nf * (2.0f * d.dot(nf))).normalized(); }       // TIR
+                        if (rec.hitObject && rec.hitObject->isCausticCaster()) passedCaster = true;
+                        o = rec.point + d * eps;
+                        continue;
+                    }
+                    if (passedCaster && rec.normal.y > 0.7f && tr > 0.0f) {
+                        astroray::XYZ cmf = astroray::cieCmf1964_10deg(lambda);
+                        astroray::photon::Photon ph;
+                        ph.position = rec.point;
+                        ph.incidentDir = d;
+                        ph.power = astroray::XYZ{cmf.X * tr, cmf.Y * tr, cmf.Z * tr};
+                        ph.lambda = lambda;
+                        photons.push_back(ph);
+                        depositedFlux_ += ph.power.Y;
+                        ys.push_back(rec.point.y);
+                    }
+                    break;
+                }
+            }
         }
         if (photons.size() < 16) return;
 

--- a/tests/test_glass_sphere_caustic.py
+++ b/tests/test_glass_sphere_caustic.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+"""pkg110 acceptance — glass-sphere focused caustic (general BSDF photon loop).
+
+A clear glass SPHERE (a NON-triangle caustic caster the old hard-coded 2-face
+prism path could not handle) focuses a collimated sun into a concentrated caustic
+on the floor, rendered by the general deterministic refraction loop in
+`light_tracer_caustic` (pkg110). Asserts the caustic is (1) PRESENT (a bright
+spot) and (2) FOCUSED (peak >> lit-floor median) — the concentration is what
+distinguishes a real refractive caustic from flat direct lighting, and proves the
+general loop refracts enter->exit correctly through an arbitrary solid.
+
+CPU-only; deterministic (fixed photon seed); runs on CI.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+
+import numpy as np
+import pytest
+
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+sys.path.insert(0, os.path.dirname(__file__))
+
+try:
+    import astroray  # noqa: E402
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray not built")
+
+_REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_SCENE = os.path.join(_REPO, "benchmarks", "reference_bank", "scenes",
+                      "glass-sphere-caustic", "scene.py")
+
+
+@pytest.mark.skipif(not os.path.exists(_SCENE), reason="glass-sphere scene not present")
+def test_glass_sphere_focused_caustic():
+    if not hasattr(astroray.Renderer(), "add_sun_light_dedicated"):
+        pytest.skip("build lacks add_sun_light_dedicated")
+    spec = importlib.util.spec_from_file_location("_gs_scene", _SCENE)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    r = mod.make_scene(astroray)
+    r.set_seed(mod.SEED)
+    img = np.asarray(r.render(mod.SAMPLES, mod.MAX_DEPTH, None, True), dtype=np.float32)
+    if img.ndim == 1:
+        img = img.reshape(mod.HEIGHT, mod.WIDTH, 3)
+
+    lum = 0.2126 * img[:, :, 0] + 0.7152 * img[:, :, 1] + 0.0722 * img[:, :, 2]
+    peak = float(lum.max())
+    lit = lum[lum > 0.002]                      # exclude the black background
+    med = float(np.median(lit)) if lit.size else 0.0
+    conc = peak / max(med, 1e-4)
+    bright_frac = float((lum > 0.3).mean())     # the caustic is a small bright spot
+
+    # Measured (deterministic, RTX): peak 0.673, conc 41.4, bright_frac 1e-4.
+    # Conservative gates with wide margin (the render is deterministic, so stable).
+    assert peak >= 0.25, f"no bright caustic spot (peak luminance {peak:.3f})"
+    assert conc >= 8.0, f"caustic not focused (peak/lit-median {conc:.1f} < 8)"
+    assert bright_frac < 0.05, \
+        f"bright region too large to be a focused caustic ({bright_frac:.3f})"


### PR DESCRIPTION
## What

Generalizes the forward caustic light-tracer (`light_tracer_caustic`) beyond the hard-coded 2-face prism, so a **glass sphere / lens / mesh focuses a caustic** through the same integrator — the next step in the general-caustics chain (pkg109 kd-tree → **pkg110 bounce** → pkg111 default-path gather).

## How — auto-select by caster geometry (owner-chosen hybrid)

The photon bounce routes on caster geometry:
- **Flat prism** (caster triangles forming exactly 2 planar faces, via `countDistinctCasterPlanes`) → the **explicit 2-face refraction** (unchanged). A wide forward aperture through a *solid* prism scatters photons through the extra faces into chromatic noise, so the clean flat-prism case keeps the special 2-face path.
- **Any other caster** (curved/solid: sphere, lens, triangulated mesh) → a **general deterministic BVH refraction loop**: at each transmissive hit, Snell refraction (per-wavelength `iorAt(λ)`; enter/exit from the geometric-normal sign) weighted by Schlick transmittance, or TIR-reflect; any number of faces; deposit on the first diffuse receiver on an `L S+ D` path.

Both paths deposit per-wavelength CIE flux into the pkg109 photon-map kd-tree. Refraction mirrors `plugins/materials/dielectric.cpp`; cites Jensen 1996 / Arvo 1986 (CLAUDE.md §6).

## Verification (RTX, MSVC+CUDA)

- **Glass-sphere caustic** (`tests/test_glass_sphere_caustic.py`, new): a focused "burning-glass" caustic — peak luminance **0.673**, **~41× concentration**, focused spot. **Visually confirmed** (bright central focus + faint glow).
- **Prism rainbow gate unchanged**: routes to the explicit path → hue_spread **0.751** ≥ 0.7, bright_coverage 0.615. **Visually confirmed a clean continuous red→violet band** (this was the key check — a low-K general-loop attempt produced salt-and-pepper noise that *passed the numeric gates*; the hybrid + visual check rejects that).
- **Full local suite: 1162 passed**, 15 skipped, 18 xfailed. Stale-call-site sweep clean (new helpers are private statics).

## Notes

The general loop is correct + validated for **focusing** casters (forward tracing is clean there). The flat prism is a non-focusing special case kept on the 2-face path — see [pkg110-status-finding.md](.astroray_plan/docs/pkg110-status-finding.md) for the full investigation (4 approaches; the visual check caught a metric-gaming noise mode). pkg111 will wire the gather into the default `path_tracer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)