### PR TITLE
fix(addon): instanced lights + camera frustum parity tests; Blender-integration parity specs (pkg112/114/115/116/117)

### DIFF
--- a/.astroray_plan/docs/blender-depsgraph-sync-research.md
+++ b/.astroray_plan/docs/blender-depsgraph-sync-research.md
@@ -321,3 +321,34 @@ The work decomposes into three phases, each landable as its own PR. Phase A is m
 - Apache-2.0 → MIT: compatible (Apache-2.0 patent-grant clause is preserved when integrated into MIT codebases per standard re-licensing practice; per-file headers retain the Apache notice).
 - GPL-3.0 → MIT: incompatible, BlendLuxCore is reference-only.
 - Blender Python API (GPL): consuming the documented Python API from a Python addon is the normal extension contract, not a derivative work concern.
+
+---
+
+## Future work note — GPU `view_draw` viewport & color management (added 2026-05-30, rabbit-hole #3)
+
+**Context:** today Astroray's viewport path writes a CPU pixel buffer back to
+Blender (linear scene-referred float → Blender applies the view transform; see
+[blender-integration-parity-report-2026-05-30.md](blender-integration-parity-report-2026-05-30.md)
+Q4). A future performance step is a **true GPU `view_draw` viewport** that draws
+the engine's framebuffer directly via the `gpu` module instead of round-tripping
+pixels through a render result. This would be the big interactivity leap once the
+sync work (pkg56) and batched upload (pkg112) land.
+
+**The catch to remember when that work starts:** the canonical Blender
+`RenderEngine.py` example applies color management in `view_draw` via
+`bind_display_space_shader(scene)` / `unbind_display_space_shader()`. That is the
+**legacy GPU-draw color-management surface**. Blender 4.x/5.x has reworked
+viewport color management in the `gpu` module
+(`developer.blender.org/docs/features/gpu/viewports/color_management/`), so the
+exact API to apply the scene view transform on a GPU-drawn buffer may differ from
+the legacy example.
+
+**Invariant that does NOT change:** the engine still outputs **linear
+scene-referred** data and lets Blender apply the view transform (AgX/Filmic/OCIO).
+Do not bake a tonemapper into the engine buffer (that is the LuxCore deviation we
+deliberately avoid — parity report Q4). When a GPU-viewport package is opened,
+verify the **current** `gpu`-module color-management API before wiring, rather
+than copying the legacy `bind_display_space_shader` snippet.
+
+**No spec yet** — this note exists so the consideration is picked up when a GPU
+`view_draw` viewport package is eventually scoped.

--- a/.astroray_plan/docs/blender-integration-parity-report-2026-05-30.md
+++ b/.astroray_plan/docs/blender-integration-parity-report-2026-05-30.md
@@ -1,0 +1,360 @@
+# Blender Integration Parity Report — Camera, Scene Sync, Textures, Color Management
+
+**Date:** 2026-05-30
+**Author:** Claude (research + codebase audit)
+**Scope:** Four owner questions about how Astroray's Blender addon compares to Cycles
+and other third-party Blender render engines, with a verdict on current Astroray state
+and concrete refactor recommendations.
+
+**Method:** Repo audit (3 parallel Explore agents over `blender_addon/`, `include/`,
+`.astroray_plan/`) + an adversarially-verified web-research pass (22 primary/secondary
+sources, 25 claims verified 3-vote, 23 confirmed / 2 refuted). Sources cited inline.
+
+---
+
+## TL;DR verdict table
+
+| Area | Astroray today | Blender/Cycles convention | Gap |
+|---|---|---|---|
+| **1. Camera frustum / viewport alignment** | Symptoms fixed (pkg100/101/102, merged). FOV now from `window_matrix`. | Derive frustum from camera datablock + inverted view matrix; branch on viewport context. | **Minor.** No parity-regression gate; bridge is hand-wired. Architecturally aligned now. |
+| **2. Scene conversion / interactivity** | Two paths. Viewport = incremental depsgraph diff (pkg56 done). F12 = full re-export. | Incremental per-domain cache + Change bitflags keyed off `depsgraph.updates`. | **Moderate.** Per-triangle pybind11 marshalling dominates; no per-domain cache objects. This is the real perf bottleneck, not the sync *logic*. |
+| **3. Textures / UVs / procedurals** | Engine-native: 8+ own procedural textures, own coord-space model. Addon adds 5 custom nodes. | Shared Blender shader node tree; `ShaderNodeTexCoord` spaces are Blender-core, inherited by all engines. | **Large & strategic.** Astroray reinvents what Cycles/EEVEE/RPR/LuxCore all share. |
+| **4. Color management / compositor** | ✅ Outputs linear scene-referred; addon writes linear to Combined; Blender does view transform. Denoise + split passes registered. | Output linear, let Blender's display-space shader + compositor handle it (Cycles convention). | **Done.** Matches the canonical convention. (Your original goal is met.) |
+
+---
+
+## Question 1 — Camera frustum / Blender viewport alignment: **has it been fixed?**
+
+### Verdict: PARTIALLY FIXED — symptoms resolved and merged; no parity guarantee.
+
+**The diagnosis was correct.** The "recent analysis" you remember is
+[addon-remediation-first-principles-plan-2026-05-16.md](.astroray_plan/docs/addon-remediation-first-principles-plan-2026-05-16.md),
+which named this **Primitive P4 — "camera re-derived, not taken from Blender"**
+(root cause RC-7, symptom BUG-08: "rendered output and viewport never line up").
+The invariant it states is exactly right: *engine frustum ≡ Blender frustum.*
+
+**Three surgical fixes landed in `main`:**
+
+- **pkg101** ([PR #368](https://github.com/) — `pkg101-addon-viewport-camera-vfov-from-perspective-matrix.md`, Status: DONE):
+  the addon was extracting vertical FOV from `rv3d.perspective_matrix[1][1]`, which is
+  `window_matrix @ view_matrix` — so the FOV changed as the camera *orbited*
+  (`cos(pitch)` etc. leaked in). That is precisely your "objects shrink, grow, flip and
+  rotate differently from the camera" symptom. Now reads `rv3d.window_matrix[1][1]`
+  (pure projection, rotation-invariant). Code: `blender_addon/__init__.py:1690-1717`.
+- **pkg100** (PR #339/#341, Status: DONE): `.blend` importer camera intrinsics now
+  threaded up the call chain instead of stashed as dynamic attributes.
+- **pkg102** (PR #369, Status: DONE): DOF aperture unit bug — was producing ~45 mm blur
+  at a 45 mm lens; now `aperture_radius = focal_length_m / (2·fstop)` per Cycles'
+  `intern/cycles/blender/camera.cpp`. Code: `blender_addon/__init__.py:1930-1935`.
+
+**The C++ frustum math itself was never wrong.** `include/raytracer.h:1840-1875`
+implements a standard pinhole model with correct `shift_x/shift_y` film-offset support.
+The bug was always in *what the addon passed in*.
+
+### How Cycles / RPR / LuxCore do it (and what's still missing)
+
+The cross-engine convention (verified 3-0):
+
+- **Derive the frustum from the Blender camera datablock + the inverted view matrix.**
+  RPR reads `camera.lens`, `sensor_fit`/`sensor_width`, `ortho_scale`, clip planes, and
+  feeds them plus the inverted view matrix to backend setters (`set_focal_length`,
+  `set_sensor_size`, `set_transform`) and lets the *backend* build the projection — it
+  never derives its own frustum.
+  ([RPR addon source](https://github.com/GPUOpen-LibrariesAndSDKs/RadeonProRenderBlenderAddon))
+- **One camera-convert entry point that branches on viewport context.** BlendLuxCore's
+  `convert(exporter, scene, depsgraph, context=None, ...)`: if `context` is present it's a
+  viewport render and it dispatches on `context.region_data.view_perspective` into
+  ORTHO / PERSP-free-nav / CAMERA-locked helpers; if `context=None` it's a final render
+  off `scene.camera`.
+  ([BlendLuxCore export/camera.py](https://github.com/LuxCoreRender/BlendLuxCore/blob/main/export/camera.py))
+
+Astroray now matches the *spirit* of this. **What's still missing is a parity-regression
+gate** — there is no automated test that renders a known scene and asserts the Astroray
+frustum matches the Blender camera overlay across rotation, zoom, shift, and lens changes.
+The fixes are tactical; nothing prevents a future edit to either side of the hand-wired
+bridge from silently re-breaking alignment. **Recommendation:** add a property-based or
+reference-image test that locks `(vfov, aspect, shift_x/y, focus, aperture)` parity.
+
+---
+
+## Question 2 — Scene conversion on every render: normal, or does Cycles have "magic"?
+
+### Verdict: There is no magic. Cycles does exactly what pkg56 already built — incremental depsgraph diffing. Your viewport path already does this; the slowness is elsewhere.
+
+**There are two paths in Astroray, and they behave very differently:**
+
+- **F12 final render** (`render()` → `convert_scene()`, `blender_addon/__init__.py:889, 1735`):
+  full re-export every time (`renderer.clear()` then re-convert materials/objects/lights/world).
+  Zero caching. *This is intentional and correct* — a one-shot render doesn't benefit from
+  caching. Cycles does the same.
+- **Viewport / "Rendered" shading** (`view_update`/`view_draw`, lines 1522/1575):
+  already **incremental** as of **pkg56 (all 3 phases done)** — persistent renderer,
+  progressive sample accumulation, and `_apply_depsgraph_updates()` (line 1264) that
+  buckets `depsgraph.updates` by domain and dispatches only the affected uploader
+  (geometry / transform / materials / lights / world). Idle frames cost ≤5 ms.
+
+**This is precisely the Cycles architecture.** Cycles' `BlenderSync::sync_recalc()` diffs
+the depsgraph and only re-exports changed datablock IDs — there is no secret. The Blender
+dev docs state the principle directly: *"the dependency graph only updates what was
+dependent on the modified value and will not update anything which was not changed"*
+([Blender depsgraph docs](https://developer.blender.org/docs/features/core/depsgraph/)).
+The canonical `RenderEngine.py` example shows `view_update` iterating `depsgraph.updates`
+and calling `depsgraph.id_type_updated('MATERIAL'/'OBJECT')`
+([bpy.types.RenderEngine.py](https://github.com/dfelinto/blender/blob/master/doc/python_api/examples/bpy.types.RenderEngine.py)).
+Your own [blender-depsgraph-sync-research.md](.astroray_plan/docs/blender-depsgraph-sync-research.md)
+already documented this and pkg56 implemented it.
+
+### So why does it still feel slow? Two real bottlenecks, both confirmed in-repo:
+
+1. **Per-triangle pybind11 marshalling.** On a geometry change, `convert_objects()`
+   (`__init__.py:3355-3579`) loops every loop-triangle in Python and calls
+   `renderer.add_triangle(...)` once per triangle — ~150–400 ms for 100k tris just in
+   call overhead (per the Phase-A benchmark in the sync research doc). **Fix:** batch the
+   upload — build NumPy arrays and pass them in one `foreach_get`-style call, the way
+   you already write pixels back with `foreach_set`. This is the single biggest win.
+2. **BVH rebuild on transform-only edits.** Astroray's single-level BVH means moving an
+   object rebuilds the whole BVH. Cycles/RPR/LuxCore use a **two-level BVH (TLAS/BLAS)** so
+   a transform is a cheap top-level refit. This is already noted as a deferred limitation
+   in pkg56 §4. **Fix:** two-level BVH → instance transforms become near-free.
+
+### The proper architectural pattern other engines use (and Astroray should adopt)
+
+Both LuxCore and RPR keep the `RenderEngine` subclass **thin** and put sync in a dedicated
+**exporter with per-domain cache objects**:
+
+- BlendLuxCore: `engine/` (the `RenderEngine` subclass) is separate from a top-level
+  `export/` module. The engine holds an `Exporter` that owns `CameraCache`, `ObjectCache2`,
+  `MaterialCache`, `VisibilityCache`, `WorldCache`, `StringCache`, plus a `node_cache`.
+  `get_changes()` ORs `Change.OBJECT | Change.MATERIAL | ...` bitflags and `update()` applies
+  only the diff.
+  ([BlendLuxCore export/__init__.py](https://github.com/LuxCoreRender/BlendLuxCore/blob/master/export/__init__.py))
+- RPR processes `depsgraph.updates` by datablock type in priority order
+  (Scene → World → Material → Object → Collection → Light), delegating
+  `view_update→sync_update`, `view_draw→draw`, `update→sync` to internal engine objects.
+
+Astroray's `_apply_depsgraph_updates` does the dispatch but lacks the **persistent
+per-domain cache objects with diff()/Change-flag** structure. Promoting your bucketing into
+real cache classes would make the code match LuxCore's proven design and make
+partial-update correctness easier to reason about.
+
+**Honest caveat from the research:** incremental is *not universal* even in mature engines.
+BlendLuxCore falls back to a **full session restart** for viewport resize and render-setting
+changes (a documented memory-leak workaround), and Blender's depsgraph is **datablock-grained,
+not per-property** (Blender issue #121019), so it over-updates. "Incremental" everywhere means
+coarse-grained, not minimal-diff. Don't over-invest chasing per-property granularity Blender
+itself doesn't provide.
+
+---
+
+## Question 3 — Textures / UVs / procedurals: should Astroray follow Blender instead of reinventing?
+
+### Verdict: You are NOT misunderstanding. Astroray reinvents what every other engine inherits from Blender. This is the biggest strategic divergence.
+
+**What Astroray does today:**
+
+- Its own coordinate-space machinery: a `CoordMode` enum (UV/Object/World/Generated) and
+  per-texture UV transforms baked in (`include/advanced_features.h:95-170`).
+- Its **own** procedural texture library — Checker, Noise, Marble, Wood, Gradient, Wave,
+  Magic, Voronoi, Musgrave, Brick — all hand-written
+  (`include/advanced_features.h:145-450`).
+- The addon adds 5 *custom* Astroray shader nodes (pkg57) and the `.blend` importer (pkg76)
+  extracts only base color (procedural node graphs are explicitly out of scope).
+
+**What Cycles, EEVEE, RPR, and LuxCore do (verified 3-0):**
+
+Texture-coordinate spaces and the material model are **shared Blender shader-node-tree
+constructs**, not per-engine inventions. The `Texture Coordinate` node (`ShaderNodeTexCoord`)
+supplies **Generated** (0–1 over the undeformed bounding box), **Normal, UV, Object,
+Camera, Window, Reflection** — and `ShaderNodeTexCoord` inherits from `ShaderNode`
+(Blender-*core*, not Cycles-private). The Blender manual states EEVEE "uses the same shader
+nodes as Cycles."
+([Texture Coordinate node manual](https://docs.blender.org/manual/en/latest/render/shader_nodes/input/texture_coordinate.html),
+[ShaderNodeTexCoord API](https://docs.blender.org/api/current/bpy.types.ShaderNodeTexCoord.html))
+
+Every external engine **reads the same `material.node_tree`**, dispatches from
+`ShaderNodeOutputMaterial`, and locates coordinate nodes (e.g. `ShaderNodeUVMap`) by
+`bl_idname` — then *translates* them into its own backend. RPR does exactly this and adds
+its *own* extension nodes **additively** on top of the shared tree, rather than replacing it.
+([RPR addon source](https://github.com/GPUOpen-LibrariesAndSDKs/RadeonProRenderBlenderAddon))
+
+**Important nuance (the one claim that split 2-1):** the space *definitions and interface*
+are shared, but the *numerical evaluation* of each space still happens per-engine in the
+kernel (e.g. Cycles `svm/tex_coord.h`, `NODE_TEXCO_CAMERA` uses `cam.worldtocamera`). So
+"follow Blender" means: **inherit the node-tree interface and coordinate-space semantics,
+evaluate them in your own kernel.** You don't avoid writing a Voronoi evaluator — but you
+*do* stop inventing a private texture-coordinate model and a private node system, and you
+gain every Blender procedural the user already knows how to wire.
+
+### Recommendation (strategic, not a quick fix)
+
+Pivot from "engine defines textures, Blender follows" to "**Blender's node tree is the
+source of truth, Astroray translates it.**" Concretely:
+
+1. Walk `material.node_tree` from `ShaderNodeOutputMaterial` (the RPR/LuxCore pattern).
+2. Map Blender's standard texture/coordinate nodes (`ShaderNodeTexCoord`, `ShaderNodeUVMap`,
+   `ShaderNodeTexNoise`, `ShaderNodeTexVoronoi`, `ShaderNodeMapping`, etc.) onto your existing
+   kernel evaluators — you already *have* Voronoi/Musgrave/Noise, so this is wiring, not new
+   math. Match Blender's parameterization so results agree.
+3. Keep your 5 custom nodes as **additive extensions** (spectral/Sellmeier/IR-UV/NRC) — that's
+   the sanctioned RPR pattern.
+4. Treat anything not yet mapped as a graceful-degrade fallback (base color), which is what
+   pkg76 already does.
+
+This is the highest-leverage refactor for "feel like a normal Blender render engine,"
+because procedural/texture authoring is where users spend the most node-editor time.
+
+---
+
+## Question 4 — Color management: was Blender-owned color management fully implemented? Does the compositor work?
+
+### Verdict: YES — fully implemented and matches the canonical Cycles convention. Your original goal is met.
+
+The package you remember was about **not double-processing color**. The current pipeline does
+exactly the right thing:
+
+- **Engine outputs linear scene-referred data.** No tonemapping; gamma is off by default
+  (`applyGamma=false`). The path is spectral → XYZ → linear sRGB (D65) with only an exposure
+  multiplier and finite-clamping (`include/raytracer.h:2925-2942`, `include/astroray/spectral.h`).
+- **Addon hands linear float32 straight to Blender.** `write_pixels()`
+  (`blender_addon/__init__.py:3785-3890`) copies the linear buffer into the `Combined` pass
+  via `foreach_set`, with only a Y-flip — **no view transform applied.** Blender then applies
+  AgX/Filmic/OCIO.
+- **Compositor-ready passes are registered.** Denoise guide passes (albedo + normal, pkg69,
+  PR #339) and split passes (`diffuse_direct/indirect`, `glossy_*`, `transmission_*`,
+  `volume_*`, pkg62) feed Blender's compositor/Denoise node. Tests
+  (`tests/test_blender_compositor_denoise_passes.py`) pass.
+
+**This is verbatim the Cycles convention (verified 3-0):** Blender's color-management docs
+and the canonical `RenderEngine.py` example show the engine emitting linear scene-referred
+pixels and binding the **display-space shader** (`bind_display_space_shader(scene)` /
+`unbind_display_space_shader`) so Blender applies the view transform; the comment in the
+example reads *"Bind shader that converts from scene linear to display space."*
+([bpy.types.RenderEngine.py](https://github.com/dfelinto/blender/blob/master/doc/python_api/examples/bpy.types.RenderEngine.py),
+[RenderEngine API](https://docs.blender.org/api/current/bpy.types.RenderEngine.html))
+
+**The compositor should "just work"** with the current setup, because you deliver
+scene-referred linear data into named passes — which is exactly what the compositor expects to
+operate on before the view transform. No double-processing.
+
+### Two caveats worth knowing
+
+1. **An agent initially flagged "color management NOT DONE."** That refers to an *in-test-harness*
+   OpenColorIO ACES step (`metrics/color_pipeline.py`, pkg104 — used to compute ΔE2000 in a
+   perceptual space for the reference-image bank). That is *benchmark infrastructure*, not the
+   render path, and is unrelated to your goal. The render path is correct.
+2. **LuxCore is the cautionary counter-example.** It does **not** follow the convention — it
+   bakes its *own* imagepipeline tonemapper
+   (`scene.camera.data.luxcore.imagepipeline.tonemapper`) into the buffer before Blender sees
+   it, and even warns about conflicts with multiple render layers. So "all engines defer color
+   to Blender" is false — Cycles defers, LuxCore does not. **Astroray is on the correct
+   (Cycles) side of this line; keep it there.** Don't add an in-engine tonemapper.
+   ([BlendLuxCore](https://github.com/LuxCoreRender/BlendLuxCore))
+3. **Modern API drift:** the `bind_display_space_shader` pattern in the canonical example is the
+   legacy GPU-draw path; Blender 4.x/5.x viewport color management has evolved
+   (dev doc `features/gpu/viewports/color_management`). The *linear-scene-referred principle*
+   holds, but if/when Astroray implements a true GPU `view_draw` viewport (vs. the current
+   pixel-buffer approach), verify the current GPU-module API surface.
+
+---
+
+## Cross-cutting: what to learn from other Blender render-engine addons
+
+Synthesized from BlendLuxCore, RPR, Malt, and Cycles (all primary-source verified):
+
+1. **Read evaluated depsgraph data, never original `bpy.data`/DNA.** Blender evaluates a
+   copy-on-write copy (modifiers/constraints applied); engines consume `depsgraph.scene_eval`
+   / `depsgraph.object_instances` / `evaluated_get`. The interactive depsgraph comes from
+   the Window+Workspace, the F12 one from the Render structure — same scene, two evaluations,
+   no conflict.
+   ([Blender depsgraph docs](https://developer.blender.org/docs/features/core/depsgraph/))
+   *Action: audit Astroray's `convert_*` to confirm it reads evaluated meshes, not originals.*
+   **(Audited 2026-05-30: CLEAN — `convert_objects`/`convert_lights` iterate
+   `depsgraph.object_instances`, whose `.object` is already evaluated. `convert_lights`
+   was fixed this round to iterate `object_instances` instead of `depsgraph.objects` so
+   instanced lights render.)**
+2. **Thin `RenderEngine` subclass + dedicated exporter/cache layer.** LuxCore `export/` +
+   `Exporter`, RPR internal engine objects. *Action: promote `_apply_depsgraph_updates`
+   bucketing into real per-domain cache classes with `diff()` + `Change` bitflags.*
+3. **Decouple the engine core from Blender entirely.** Cycles builds standalone (its own XML
+   scene API) and as a **Hydra render delegate** (runs in Usdview/Houdini/Omniverse) — the
+   Blender addon is just an integration shim.
+   ([Cycles repo](https://github.com/blender/cycles),
+   [Cycles standalone](https://developer.blender.org/docs/features/cycles/standalone/))
+   *Astroray already has this shape (C++/CUDA core + thin addon) — this validates the
+   architecture. Consider a standalone scene-description entry point as a forcing function to
+   keep the boundary clean.* **→ tracked as a future/milestone item in GitHub issue #398.**
+4. **Write results via `begin_result()`/`end_result()` layer passes** — never a private image
+   window. Astroray already does this. ✓
+5. **Two-level BVH (TLAS/BLAS)** is the standard answer to "transforms shouldn't rebuild the
+   accel structure." Single-level BVH is Astroray's current sync bottleneck for object motion.
+
+---
+
+## Prioritized recommendations
+
+_Status as of 2026-05-30: specs written and items actioned this round (see annotations)._
+
+1. **(High leverage, medium effort) Batch geometry upload.** Replace per-triangle
+   `add_triangle()` with a single NumPy `foreach_get`→buffer→one pybind11 call. Biggest
+   single viewport-responsiveness win; doesn't change architecture. **→ spec
+   [pkg112](../packages/pkg112-batched-geometry-upload.md).**
+2. **(High leverage, large effort, strategic) Consume Blender's shader node tree** for
+   textures/UVs/procedurals instead of the private node/texture system. Map standard Blender
+   texture & coordinate nodes onto your existing kernel evaluators; keep custom nodes additive.
+   **→ spec [pkg115](../packages/pkg115-adopt-blender-shader-node-textures.md).**
+3. **(Medium) Two-level BVH** so object transforms refit instead of rebuild — closes the
+   pkg56 transform-only deferral. **→ spec [pkg114](../packages/pkg114-two-level-bvh-tlas-blas.md).**
+4. **(Medium) Promote sync into a real exporter + per-domain caches with Change bitflags**
+   (LuxCore pattern) for correctness and maintainability. **→ spec
+   [pkg116](../packages/pkg116-exporter-cache-refactor.md).**
+5. **(Low effort, closes Q1) Add a camera-frustum parity-regression test** locking
+   vfov/aspect/shift/focus/aperture against the Blender camera overlay. **→ DONE 2026-05-30:
+   `tests/test_addon_viewport_camera_vfov.py` extended with sensor_fit (H/V/AUTO), shift,
+   aspect, and known-vfov parity tests (7 tests green).**
+6. **Keep color management exactly as-is** (linear out, Blender does view transform). Do not
+   add an in-engine tonemapper (the LuxCore mistake).
+
+### Also actioned this round (rabbit holes)
+
+- **Non-MESH geometry dropped** (curves/text/metaballs) → spec
+  [pkg117](../packages/pkg117-nonmesh-geometry-to-mesh.md).
+- **Instanced lights not rendered** → fixed in `convert_lights` (iterate `object_instances`);
+  regression test `tests/test_addon_instanced_lights.py`.
+- **Hydra/standalone engine-decoupling** → GitHub issue #398 (future/milestone).
+- **GPU `view_draw` viewport color-management drift** → note added to
+  [blender-depsgraph-sync-research.md](blender-depsgraph-sync-research.md) (future-work section).
+- **Don't over-engineer incremental sync** (datablock-grained depsgraph) → baked into pkg116 as
+  an explicit non-goal.
+
+---
+
+## Sources (primary unless noted)
+
+- Blender `bpy.types.RenderEngine` canonical example —
+  https://github.com/dfelinto/blender/blob/master/doc/python_api/examples/bpy.types.RenderEngine.py
+- `bpy.types.RenderEngine` API — https://docs.blender.org/api/current/bpy.types.RenderEngine.html
+- Blender Dependency Graph dev docs — https://developer.blender.org/docs/features/core/depsgraph/
+- `bpy.types.Depsgraph` API — https://docs.blender.org/api/current/bpy.types.Depsgraph.html
+- Texture Coordinate node manual —
+  https://docs.blender.org/manual/en/latest/render/shader_nodes/input/texture_coordinate.html
+- `ShaderNodeTexCoord` API — https://docs.blender.org/api/current/bpy.types.ShaderNodeTexCoord.html
+- Cycles repo (standalone + Hydra delegate) — https://github.com/blender/cycles
+- Cycles standalone dev docs — https://developer.blender.org/docs/features/cycles/standalone/
+- BlendLuxCore exporter — https://github.com/LuxCoreRender/BlendLuxCore/blob/master/export/__init__.py
+- BlendLuxCore camera — https://github.com/LuxCoreRender/BlendLuxCore/blob/main/export/camera.py
+- BlendLuxCore viewport — https://github.com/LuxCoreRender/BlendLuxCore/blob/main/engine/viewport.py
+- BlendLuxCore final — https://github.com/LuxCoreRender/BlendLuxCore/blob/master/engine/final.py
+- Radeon ProRender Blender addon — https://github.com/GPUOpen-LibrariesAndSDKs/RadeonProRenderBlenderAddon
+- Malt (BlenderMalt) — https://github.com/bnpr/Malt
+- Legacy RenderEngine API wiki (archive) —
+  https://archive.blender.org/wiki/2015/index.php/Dev:Source/Render/RenderEngineAPI/
+
+**Two refuted claims** (excluded; verifier vote 1-2): a specific LuxCore final-render
+`update_session(changes)` delta path, and a Malt geometry-only incremental-unload mechanism —
+neither survived adversarial verification, so don't rely on those specifics.
+
+**Repo cross-references:**
+[addon-remediation-first-principles-plan-2026-05-16.md](.astroray_plan/docs/addon-remediation-first-principles-plan-2026-05-16.md),
+[blender-depsgraph-sync-research.md](.astroray_plan/docs/blender-depsgraph-sync-research.md),
+[blender-shader-nodes-research.md](.astroray_plan/docs/blender-shader-nodes-research.md),
+pkg56 / pkg57 / pkg62 / pkg69 / pkg76 / pkg100 / pkg101 / pkg102 / pkg104.

--- a/.astroray_plan/packages/pkg112-batched-geometry-upload.md
+++ b/.astroray_plan/packages/pkg112-batched-geometry-upload.md
@@ -1,0 +1,93 @@
+# pkg112 — Batched geometry upload (NumPy arrays) to cut per-triangle pybind11 overhead
+
+**Pillar:** 5 (addon) + core bindings
+**Track:** A
+**Codex-paste-ready:** no (C++ binding + addon change + clean rebuild + RTX verify)
+**Status:** open — proposed 2026-05-30. **GPU-gated: pixel-parity must be RTX-`/verify`-ed; CI has no GPU and CI-green ≠ correct.**
+**Depends on:** none (independent of pkg114; complementary). Plays well with pkg117.
+**Estimated effort:** M (~1 week incl. one RTX session)
+
+---
+
+## Goal
+
+**Before:** `convert_objects` (`blender_addon/__init__.py:3355`) walks every
+loop-triangle in Python and calls `renderer.add_triangle(...)` once per triangle
+(binding `module/blender_module.cpp:1957`, impl `PyRenderer::addTriangle`
+`blender_module.cpp:601`). On a 100k-triangle scene this is ~150–400 ms of pure
+pybind11 marshalling per geometry sync — the dominant viewport/F12 upload cost
+per the Phase-A benchmark in `.astroray_plan/docs/blender-depsgraph-sync-research.md`.
+
+**After:** A single bulk binding ingests contiguous NumPy arrays (vertices,
+triangle indices, per-loop UVs, normals, per-triangle material ids) and uploads
+them in one call. `convert_objects` fills these arrays with Blender's C-speed
+`foreach_get` and calls the bulk API once per mesh. Target **≥5× reduction** in
+geometry-upload wall-clock on the 100k-tri benchmark, with pixel-identical output.
+
+---
+
+## References
+
+### Internal
+- `module/blender_module.cpp:1957-1960` — `add_triangle` binding; `:1961` —
+  `add_triangle_layers` (multi-UV variant); `:1965` — `add_mesh` (existing bulk
+  `.obj` ingest, proves the C++ side can build geometry without per-tri Python
+  round-trips). `PyRenderer::addTriangle` `:601-627`.
+- `blender_addon/__init__.py:3498-3564` — the hot per-triangle loop.
+- `blender_addon/__init__.py:3785+` — pixel writeback already uses
+  `foreach_set` over a NumPy buffer: the proven NumPy↔Blender bridge pattern to
+  mirror on the input side.
+
+### External
+- Blender `bpy.types.Mesh` `vertices.foreach_get` / `loop_triangles.foreach_get`
+  (docs.blender.org) — the standard C-speed bulk extract used by Cycles' own
+  exporter (`intern/cycles/blender/mesh.cpp`, Apache-2.0).
+- pybind11 `py::array_t` / buffer protocol for zero-copy array ingestion
+  (pybind11 docs).
+
+CLAUDE.md §6: N/A — this is an engineering/marshalling optimization, no novel
+numerical algorithm.
+
+---
+
+## Approach
+
+1. **C++ binding.** Add `add_triangles_bulk(verts, tri_indices, material_ids,
+   uvs=…, normals=…, object_pass_index=0, material_pass_index=0)` taking
+   `py::array_t` arguments; validate shapes; loop entirely in C++ (no per-tri
+   Python boundary). Keep `add_triangle` for fallback/standalone use.
+2. **Addon.** In `convert_objects`, replace the per-tri loop with `foreach_get`
+   into preallocated NumPy arrays; remap Blender material slot indices → engine
+   material ids; issue one bulk call per mesh. Preserve the caustic-caster flag
+   and Cryptomatte object-name tagging via the existing
+   `scene_object_count()` range trick (`:3569`).
+3. **Multi-UV.** Mirror `add_triangle_layers` — pass a layered UV array plus the
+   `uvLayerNames` list so named-UV scenes (test_blender_named_uv_layers) keep working.
+
+---
+
+## Acceptance criteria
+
+- [ ] Bulk binding compiles via a **clean** rebuild (see memory
+      *incremental-build-signature-staleness*); call-site sweep for
+      `add_triangle` shows no broken callers.
+- [ ] Geometry-upload time on the pkg56 Phase-A 100k-tri benchmark **≥5×**
+      faster; before/after numbers recorded in the PR.
+- [ ] **Pixel-identical** render vs the per-tri path on a textured, multi-UV,
+      multi-material scene (RTX `/verify`, paired stills).
+- [ ] Existing stubbed addon tests green; a new CPU/stub test asserts the bulk
+      path emits the same triangle/material/UV set as the per-tri path on a
+      small mesh.
+
+## Hard non-goals
+
+- Not a BVH change (pkg114). Not removing `add_triangle` (kept for fallback +
+  standalone). Not touching the final-render-vs-viewport dispatch.
+
+---
+
+## Provenance
+
+Blender-integration parity report 2026-05-30 (Q2 bottleneck #1), owner-prioritized
+as the highest-value performance item. Rabbit-hole #5: `add_mesh` already
+demonstrates a C++ ingest path, lowering the cost of this work.

--- a/.astroray_plan/packages/pkg114-two-level-bvh-tlas-blas.md
+++ b/.astroray_plan/packages/pkg114-two-level-bvh-tlas-blas.md
@@ -1,0 +1,82 @@
+# pkg114 — Two-level BVH (TLAS/BLAS) for cheap instance + transform refit
+
+**Pillar:** 5 (GPU) + 3 (light transport)
+**Track:** A
+**Codex-paste-ready:** no (core CUDA + CPU; large; multi-session RTX verify)
+**Status:** open — proposed 2026-05-30. **GPU-gated.** This is the follow-up
+acceleration-structure package explicitly deferred by pkg56 §4.1.
+**Depends on:** pkg56 (done — provides the `_renderer_object_id_map` placeholder
+and transform-only dispatch hook). Complementary to pkg112.
+**Estimated effort:** L (~3–4 weeks, multiple RTX sessions)
+
+---
+
+## Goal
+
+**Before:** Astroray's BVH is single-level (one combined tree). Moving a single
+object rebuilds the **entire** BVH; pkg56's transform-only viewport path still
+pays a full CPU rebuild (~80–200 ms on 100k tris per the Phase-A benchmark), and
+the "transform-only ≤50% of baseline" gate was **deferred** (pkg56 §4 non-goals).
+Instanced geometry is not deduplicated.
+
+**After:** A two-level acceleration structure — per-mesh **bottom-level (BLAS)**
+built once and cached, and a **top-level (TLAS)** over instance transforms,
+rebuilt/refitted cheaply when an object moves. Instances of the same mesh share
+one BLAS. Transform-only viewport edits meet the pkg56 ≤50%-of-baseline budget.
+
+---
+
+## References
+
+### Internal
+- pkg56 `.astroray_plan/packages/pkg56-incremental-scene-sync.md` §4.1
+  (deferred TLAS-refit) and Phase-B `update_object_transform` uploader.
+- The single-level BVH build (CPU) and CUDA traversal in `include/` /
+  `astroray/` (the structure this package splits in two).
+
+### External (cite the reproduced reference in code; license-clean)
+- **PBRT-v4 §4.3** `BVHAccel` and the instancing/two-level pattern
+  (pbr-book.org; BSD) — canonical structure.
+- **Cycles** `intern/cycles/bvh/bvh2.{h,cpp}` and object/instance BVH
+  (Apache-2.0) — TLAS-over-instances + per-object BLAS layout to mirror.
+- Wald et al. / Embree + NVIDIA OptiX TLAS-BLAS concept (papers) for the
+  device-traversal transform-into-local-space approach.
+
+CLAUDE.md §6: this is a non-trivial structural algorithm — cite the exact
+reference (PBRT §4.3 / Cycles `bvh2`) in the C++/CUDA, and save a research note
+to `.astroray_plan/docs/two-level-bvh-research.md` before coding.
+
+---
+
+## Approach (phased)
+
+1. **BLAS cache.** Build per-mesh BVH keyed by the mesh datablock; reuse across
+   instances and across frames when the mesh is unchanged.
+2. **TLAS.** Build over `(instance_id → BLAS ref + 4×4 transform)`; ray
+   traversal transforms the ray into BLAS-local space.
+3. **CUDA.** Device-side two-level traversal; upload only the instance transform
+   table on a transform edit (cheap), not geometry.
+4. **Depsgraph wiring.** Transform-only update → TLAS rebuild only; geometry
+   update → rebuild only that BLAS. Hooks into pkg56's dispatch.
+
+---
+
+## Acceptance criteria
+
+- [ ] Research note saved; references cited in code.
+- [ ] Instanced geometry (collection/particle instances) renders correctly and
+      shares one BLAS (memory/timing evidence).
+- [ ] Transform-only viewport edit ≤ **50%** of the pkg56 Phase-A baseline.
+- [ ] **Pixel parity** vs single-level BVH on static scenes (RTX `/verify`).
+- [ ] CPU/GPU parity gate green.
+
+## Hard non-goals
+
+- Not motion-blur BVH (separate). Not deformable-mesh refit (rebuild the BLAS for
+  now). Not a build-algorithm change (LBVH/SAH) beyond what BLAS reuse requires.
+
+---
+
+## Provenance
+
+Blender-integration parity report 2026-05-30 (Q2); explicit pkg56 §4.1 deferral.

--- a/.astroray_plan/packages/pkg115-adopt-blender-shader-node-textures.md
+++ b/.astroray_plan/packages/pkg115-adopt-blender-shader-node-textures.md
@@ -1,0 +1,113 @@
+# pkg115 — Adopt Blender's shader node tree for textures/UVs; retire addon-side texture duplication
+
+**Pillar:** 5 (addon) + 2 (materials/textures)
+**Track:** A
+**Codex-paste-ready:** no (large, staged; RTX visual verify)
+**Status:** open — proposed 2026-05-30. **Strategic/large.** Owner-endorsed:
+gut the engine-side texture redundancy on the Blender path, keep a slim
+standalone texturing API.
+**Depends on:** pkg57 (done — established the additive custom-node pattern and
+the `convert_node_material` traversal). Benefits from pkg112.
+**Estimated effort:** L (multi-week, staged)
+
+---
+
+## Goal
+
+**Before:** The Blender addon does **not** translate Blender's standard
+procedural/coordinate texture nodes onto the engine. pkg57 added Astroray
+*physics* nodes additively, but procedural texture nodes are left to the legacy
+path. Meanwhile the engine ships its own coordinate-space model and 12 procedural
+textures (`include/advanced_features.h`, ~539 LOC) plus a clean standalone
+string-factory API (`create_procedural_texture`, `set_texture_coord_mode`,
+`set_texture_uv_transform`, `set_texture_uv_layer` —
+`module/blender_module.cpp:1907-1919`). Net effect: textures authored as Blender
+nodes don't render with native fidelity, and the addon duplicates concepts
+Blender already owns.
+
+**After:** The addon walks `material.node_tree` from `ShaderNodeOutputMaterial`
+and **translates Blender's standard texture & coordinate nodes onto the engine's
+existing evaluators**, matching Blender's parameterization so a Blender
+Noise/Voronoi/Mapping node looks the same in Astroray. The standalone
+string-factory texture API is **preserved** (engine-native texturing stays usable
+without Blender). Addon-side private texture/coordinate-model duplication is
+removed. Astroray-specific nodes stay additive (pkg57).
+
+---
+
+## Key reframe (research-verified, parity report 2026-05-30 Q3)
+
+Coordinate spaces (Generated/Object/UV/Camera/Window/Normal/Reflection) and the
+shader node tree are **shared Blender-core constructs** — `ShaderNodeTexCoord`
+inherits `ShaderNode` (not a Cycles-private type), and EEVEE "uses the same
+shader nodes as Cycles." RPR and LuxCore read the *same* tree and add their nodes
+additively. The **interface/semantics are shared; numerical evaluation stays
+per-engine.** So we **keep our evaluators** and drive them from Blender node
+parameters — we are not deleting the kernel math, only the duplication and the
+private node/coordinate model on the addon side.
+
+---
+
+## References
+
+### Internal
+- `blender_addon/__init__.py:1949+` — `convert_node_material` / node traversal.
+- `include/advanced_features.h` — `Texture` base + `CoordMode` + 12 procedurals
+  (`:145-450`); `TexturedLambertian` `:507-539`.
+- `module/blender_module.cpp:1907-1919` — standalone texture factory bindings (kept).
+- pkg57 spec — additive node pattern + non-goal "do not migrate procedural nodes"
+  (this package is that deferred migration, done right).
+
+### External (cite per evaluator; match the math)
+- Blender Texture Coordinate node + `bpy.types.ShaderNodeTexCoord` (docs.blender.org).
+- Blender/Cycles procedural math to reproduce for parity (Apache-2.0):
+  `intern/cycles/kernel/svm/noise.h` (Perlin), `voronoi.h`, `musgrave.h`,
+  `wave.h`, `magic.h`, `brick.h`, and the `mapping`/`tex_coord` nodes.
+
+CLAUDE.md §6: cite the exact Cycles `svm/*` file each evaluator mirrors; verify
+our evaluators against Blender's parameterization (scale/detail/roughness/
+lacunarity, Voronoi distance metric, octave count) and fix divergences. Save
+`.astroray_plan/docs/blender-procedural-parity-research.md`.
+
+---
+
+## Approach (staged)
+
+1. **Audit.** Diff each engine procedural against the corresponding Cycles
+   `svm` node parameterization; record divergences.
+2. **Translator.** Map `ShaderNodeTexCoord`, `ShaderNodeUVMap`,
+   `ShaderNodeMapping`, `ShaderNodeTexNoise`, `ShaderNodeTexVoronoi`,
+   `ShaderNodeTexMusgrave/Wave/Magic/Brick/Gradient/Checker`, and
+   `ShaderNodeTexImage` onto `create_procedural_texture` + coord-mode + UV-transform.
+3. **Parameter parity.** Align engine evaluators to Blender's math (cite svm).
+4. **Remove duplication.** Delete the now-unused addon-side private
+   texture-definition paths (CLAUDE.md §3: only orphans this change creates).
+5. **Standalone.** Keep the factory API and add/keep a standalone example that
+   builds a textured material without Blender (CI-testable).
+
+---
+
+## Acceptance criteria
+
+- [ ] Research notes saved; per-evaluator Cycles citations in code.
+- [ ] A Blender material using Noise/Voronoi/Mapping/TexCoord renders in Astroray
+      **visually matching** Cycles' node semantics (RTX `/verify`, paired stills).
+- [ ] Standalone script still builds a textured material via
+      `create_procedural_texture` (CPU test).
+- [ ] pkg57 nodes unaffected; per-evaluator parity unit tests where feasible.
+
+## Hard non-goals
+
+- Not full OSL/shader-graph parity. Not a GPU procedural-node compiler. Not
+  removing the engine evaluators (kept + shared). Not an image-pipeline overhaul
+  beyond wiring.
+
+---
+
+## Provenance
+
+Owner goal-capture this round: *"gut some of it and adopt convention; keep a slim
+standalone texturing capability if it isn't too hefty."* Research finding: the
+standalone texture layer is separable (only used by `TexturedLambertian` and the
+`normal_mapped` plugin), so keeping it is cheap; the real work is Blender-
+parameterization parity + removing the addon-side duplication.

--- a/.astroray_plan/packages/pkg116-exporter-cache-refactor.md
+++ b/.astroray_plan/packages/pkg116-exporter-cache-refactor.md
@@ -1,0 +1,87 @@
+# pkg116 — Exporter/cache refactor: thin RenderEngine + per-domain caches with Change bitflags
+
+**Pillar:** 5 (addon architecture)
+**Track:** A (Python-only; mostly CI-testable)
+**Codex-paste-ready:** no (sizable refactor; behavior-preserving)
+**Status:** open — proposed 2026-05-30.
+**Depends on:** pkg56 (done) — promotes its `_apply_depsgraph_updates` bucketing
+into structured cache objects.
+**Estimated effort:** M
+
+---
+
+## Goal
+
+**Before:** pkg56 landed depsgraph-diff dispatch in `_apply_depsgraph_updates`,
+but the `RenderEngine` subclass holds the sync logic directly and there are **no
+persistent per-domain cache objects**. Partial-update correctness is harder to
+reason about and extend.
+
+**After:** A dedicated **exporter module** owns scene sync. Per-domain cache
+objects (Camera, Objects, Materials, Lights, World, Config) each expose
+`diff(depsgraph) -> bool`; an aggregator ORs `Change` bitflags and applies only
+the diff. The `RenderEngine` subclass becomes a thin shim delegating
+`view_update` / `view_draw` / `update` / `render` to the exporter. This mirrors
+the proven architecture of other Blender engines.
+
+---
+
+## References
+
+### Internal
+- `blender_addon/__init__.py:1264` — `_apply_depsgraph_updates`; the
+  `upload_geometry/materials/lights/environment` + `update_object_transform`
+  uploaders; `convert_scene:1735`; `_sync_viewport_scene:1381`.
+
+### External (architectural pattern reference — no code copied)
+- **BlendLuxCore** `export/__init__.py` (`Exporter`, `ObjectCache2`,
+  `MaterialCache`, `CameraCache`, `WorldCache`, `Change` bitflags),
+  `engine/viewport.py` (`get_changes` / `update`), `engine/final.py`.
+- **Radeon ProRender** addon — `view_update → sync_update`, datablock-type
+  priority dispatch (Scene → World → Material → Object → Collection → Light).
+
+CLAUDE.md §6: pattern reference only (architecture), no algorithm/code port.
+
+---
+
+## Approach
+
+1. Extract `blender_addon/exporter.py`; move sync/session logic out of the
+   `RenderEngine` subclass.
+2. Define cache classes with `diff()` and a `Change` flag enum; the aggregator
+   ORs flags and dispatches to the matching uploader(s).
+3. Keep behavior **identical** (refactor, not feature change); the subclass
+   becomes a thin delegator.
+4. Add per-cache `diff()` unit tests (stub depsgraph).
+
+---
+
+## RH4 — explicit non-goal (do not over-engineer)
+
+Do **not** chase per-property minimal diffs. Blender's depsgraph is
+**datablock-grained** (Blender issue #121019) and even mature engines
+(BlendLuxCore) fall back to a **full session restart** for some change classes
+(viewport resize, render-settings). Aim for LuxCore-parity **coarse-grained**
+incrementality, not theoretical minimal diff. (Owner-agreed, 2026-05-30.)
+
+---
+
+## Acceptance criteria
+
+- [ ] All existing stubbed addon tests green (behavior preserved).
+- [ ] New per-cache `diff()` unit tests.
+- [ ] Idle / material-only / transform-only dispatch behavior matches the pkg56
+      gates (≤5 ms idle, material-only skips geometry, etc.).
+- [ ] No perf regression vs pkg56.
+
+## Hard non-goals
+
+- No new sync features. No GPU changes. No per-property diffing (RH4). No
+  final-render caching.
+
+---
+
+## Provenance
+
+Blender-integration parity report 2026-05-30 (Q2 "proper architectural pattern");
+rabbit-hole #4 baked in as a non-goal.

--- a/.astroray_plan/packages/pkg117-nonmesh-geometry-to-mesh.md
+++ b/.astroray_plan/packages/pkg117-nonmesh-geometry-to-mesh.md
@@ -1,0 +1,78 @@
+# pkg117 — Render non-MESH geometry (curve/text/metaball/surface) via evaluated `to_mesh()`
+
+**Pillar:** 5 (addon) + geometry
+**Track:** A
+**Codex-paste-ready:** no (addon change + RTX visual verify)
+**Status:** open — proposed 2026-05-30.
+**Depends on:** none. Complements pkg112 (reuses the triangle-upload path).
+**Estimated effort:** S–M
+
+---
+
+## Goal
+
+**Before:** `convert_objects` skips everything that isn't a mesh —
+`if obj.type != 'MESH': continue` (`blender_addon/__init__.py:3431`). Curves,
+text, metaballs, and surface objects — which Blender evaluates to renderable
+geometry and shows in the viewport — **silently don't render**. Cycles and EEVEE
+render them.
+
+**After:** For evaluated objects that can produce a mesh, `convert_objects`
+obtains a temporary mesh via the evaluated object's `to_mesh()`, triangulates and
+uploads it like a mesh, then frees it with `to_mesh_clear()`. Curves/text/
+metaball/surface render and match the viewport; plain meshes are unchanged.
+
+---
+
+## References
+
+### Internal
+- `blender_addon/__init__.py:3355-3434` — the `convert_objects` instance loop and
+  the `obj.type != 'MESH'` gate at `:3431`. The existing per-tri upload (or the
+  pkg112 bulk path) is reused for the produced mesh.
+
+### External
+- Blender `bpy.types.Object.to_mesh()` / `to_mesh_clear()` and the requirement
+  that the object be **evaluated** (from the depsgraph) for modifiers/curve
+  resolution to apply (docs.blender.org).
+- Cycles `intern/cycles/blender/mesh.cpp` `BlenderSync::sync_mesh` uses
+  `b_ob.to_mesh()` for non-mesh types (Apache-2.0) — the reference behavior.
+
+CLAUDE.md §6: N/A (Blender API usage, no novel algorithm).
+
+---
+
+## Approach
+
+Replace the hard `continue` with:
+
+- `MESH` → `mesh = obj.data` (unchanged).
+- `CURVE`, `SURFACE`, `FONT`, `META` → `mesh = obj.to_mesh()` on the
+  **evaluated** object; guard `None`; reuse the triangle upload; `finally:
+  obj.to_mesh_clear()`.
+
+Notes: objects in `depsgraph.object_instances` are already evaluated. Metaballs
+polygonize only on the evaluated **basis** object — the non-basis members return
+`None` from `to_mesh()`; skip those gracefully.
+
+---
+
+## Acceptance criteria
+
+- [ ] A scene with a beveled curve, a text object, and a metaball renders
+      non-empty and matches the viewport (RTX `/verify`, paired stills).
+- [ ] Plain-mesh scenes are **pixel-identical** to before (no regression).
+- [ ] Stub test asserts a `CURVE` object routes through `to_mesh()` (mockable
+      via the existing addon stub pattern), and `to_mesh_clear()` is called.
+
+## Hard non-goals
+
+- Not hair/curves-as-strands (separate). Not volume objects. Not grease pencil.
+  Not particle systems. Just static `to_mesh()`-able object types.
+
+---
+
+## Provenance
+
+Blender-integration parity report 2026-05-30, rabbit-hole #1; owner: *"write the
+spec for it."*

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -3617,10 +3617,15 @@ class CustomRaytracerRenderEngine(RenderEngine):
                     'color': list(light.color)
                 }
 
-        for obj in depsgraph.objects:
-            if obj.type != 'LIGHT': continue
+        # Iterate object_instances (not depsgraph.objects) so lights created by
+        # instancing (collection instances, particle/dupli systems) are rendered,
+        # matching convert_objects. Real (non-instanced) lights still appear once
+        # with is_instance=False, so existing non-instanced scenes are unaffected.
+        for obj_instance in depsgraph.object_instances:
+            obj = obj_instance.object
+            if obj is None or obj.type != 'LIGHT': continue
             light = obj.data
-            matrix = obj.matrix_world
+            matrix = obj_instance.matrix_world
             position = list(matrix.translation)
             ies_path = _resolve_ies_path(light)
             emission_dict = _build_emission_dict(light)

--- a/tests/test_addon_instanced_lights.py
+++ b/tests/test_addon_instanced_lights.py
@@ -1,0 +1,115 @@
+"""Instanced-light coverage: convert_lights must iterate
+`depsgraph.object_instances` (not `depsgraph.objects`) so lights created by
+instancing (collection instances, particle/dupli systems) are rendered, the
+same way convert_objects already does.
+
+This test puts a POINT light ONLY in `object_instances` (with `objects` empty,
+simulating a light that exists solely via instancing) and asserts the renderer
+receives one add_point_light call. If convert_lights regressed to iterating
+`depsgraph.objects`, zero lights would be added and this test would fail.
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _load_blender_addon(monkeypatch):
+    bpy_module = types.ModuleType("bpy")
+    bpy_types_module = types.ModuleType("bpy.types")
+    bpy_props_module = types.ModuleType("bpy.props")
+
+    class _Base:
+        pass
+
+    class _RenderEngineBase:
+        def report(self, *_a, **_k): return None
+        def update_progress(self, *_a, **_k): return None
+        def update_stats(self, *_a, **_k): return None
+        def test_break(self): return False
+
+    bpy_types_module.Panel = _Base
+    bpy_types_module.Operator = _Base
+    bpy_types_module.AddonPreferences = _Base
+    bpy_types_module.PropertyGroup = _Base
+    bpy_types_module.RenderEngine = _RenderEngineBase
+    bpy_module.types = bpy_types_module
+
+    for name in ("BoolProperty", "IntProperty", "FloatProperty", "StringProperty",
+                 "PointerProperty", "FloatVectorProperty", "EnumProperty"):
+        setattr(bpy_props_module, name, lambda **_kwargs: None)
+    bpy_module.props = bpy_props_module
+    bpy_module.path = types.SimpleNamespace(abspath=lambda p: p)
+
+    shader_blending_module = types.ModuleType("shader_blending")
+    shader_blending_module.blend_shader_specs = {}
+    shader_blending_module.add_shader_specs = {}
+
+    mathutils_module = types.ModuleType("mathutils")
+    mathutils_module.Vector = lambda values: values
+
+    astroray_module = types.ModuleType("astroray")
+    astroray_module.__version__ = "test"
+    astroray_module.__features__ = {"cuda": False, "spectral": True}
+    astroray_module.__file__ = "/fake/astroray.pyd"
+    astroray_module.integrator_registry_names = lambda: ["path_tracer"]
+    astroray_module.material_registry_names = lambda: ["lambertian"]
+    astroray_module.pass_registry_names = lambda: []
+
+    monkeypatch.setitem(sys.modules, "bpy", bpy_module)
+    monkeypatch.setitem(sys.modules, "bpy.types", bpy_types_module)
+    monkeypatch.setitem(sys.modules, "bpy.props", bpy_props_module)
+    monkeypatch.setitem(sys.modules, "shader_blending", shader_blending_module)
+    monkeypatch.setitem(sys.modules, "mathutils", mathutils_module)
+    monkeypatch.setitem(sys.modules, "astroray", astroray_module)
+
+    module_path = Path(__file__).parent.parent / "blender_addon" / "__init__.py"
+    spec = importlib.util.spec_from_file_location("astroray_blender_addon_lights_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class _RecordingRenderer:
+    def __init__(self):
+        self.point_light_calls = []
+
+    def add_point_light(self, *args, **_kw):
+        self.point_light_calls.append(args)
+
+    # Other light types are not exercised by this test.
+    def add_sun_light_dedicated(self, *a, **k): pass
+    def add_area_light_dedicated(self, *a, **k): pass
+    def add_spot_light_dedicated(self, *a, **k): pass
+
+
+def _make_point_light_instance():
+    light = types.SimpleNamespace(
+        type='POINT',
+        color=(1.0, 1.0, 1.0),
+        energy=100.0,
+        shadow_soft_size=0.0,
+    )
+    obj = types.SimpleNamespace(type='LIGHT', data=light, pass_index=0)
+    matrix = types.SimpleNamespace(translation=[0.0, 0.0, 5.0])
+    return types.SimpleNamespace(object=obj, matrix_world=matrix, is_instance=True)
+
+
+def test_instance_only_light_is_rendered(monkeypatch):
+    addon = _load_blender_addon(monkeypatch)
+    engine = addon.CustomRaytracerRenderEngine()
+    renderer = _RecordingRenderer()
+
+    instance = _make_point_light_instance()
+    # `objects` is empty: the light exists ONLY via instancing. A loop over
+    # depsgraph.objects would add nothing; the fix iterates object_instances.
+    depsgraph = types.SimpleNamespace(object_instances=[instance], objects=[])
+
+    engine.convert_lights(depsgraph, renderer)
+
+    assert len(renderer.point_light_calls) == 1, (
+        "instance-only POINT light was not rendered — convert_lights is likely "
+        "iterating depsgraph.objects instead of depsgraph.object_instances"
+    )

--- a/tests/test_addon_viewport_camera_vfov.py
+++ b/tests/test_addon_viewport_camera_vfov.py
@@ -298,3 +298,118 @@ def test_vfov_extraction_is_rotation_invariant(monkeypatch):
         f"{extracted_vfovs} across pitches {pitches}. "
         f"Expected rotation-invariance."
     )
+
+
+# ---------------------------------------------------------------------------
+# Full frustum parity for the F12 camera-datablock path
+# (_apply_camera / _compute_vfov_degrees).
+#
+# pkg101 covered viewport vfov *rotation-invariance*. It did NOT cover the
+# remaining frustum parameters that decide whether the F12 render lines up
+# with Blender's camera: sensor_fit (which sensor axis is used), film shift,
+# and aspect ratio. These tests lock that parity so a future edit to the
+# bridge can't silently re-break alignment (closes the Q1 "no parity gate" gap).
+# ---------------------------------------------------------------------------
+
+
+class _Quat:
+    """Identity rotation quaternion stub. `rot @ vec` returns the vector
+    unchanged as a _Vec3. Camera direction is not under test here (vfov / shift
+    / aspect are), so an identity rotation is sufficient."""
+    def __matmul__(self, vec):
+        return _Vec3(vec[0], vec[1], vec[2])
+
+
+class _CamMatrix4:
+    """4x4 camera world-matrix stub supporting `.decompose()` and `.translation`."""
+    def __init__(self, loc=(0.0, 0.0, 0.0)):
+        self._loc = loc
+
+    @property
+    def translation(self):
+        return _Vec3(*self._loc)
+
+    def decompose(self):
+        return _Vec3(*self._loc), _Quat(), _Vec3(1.0, 1.0, 1.0)
+
+
+def _make_camera_obj(lens=50.0, sensor_fit='AUTO', sensor_width=36.0,
+                     sensor_height=24.0, shift_x=0.0, shift_y=0.0,
+                     cam_type='PERSP'):
+    dof = types.SimpleNamespace(use_dof=False, aperture_fstop=0.0,
+                                focus_object=None, focus_distance=10.0)
+    camera = types.SimpleNamespace(
+        type=cam_type, lens=lens, sensor_fit=sensor_fit,
+        sensor_width=sensor_width, sensor_height=sensor_height,
+        shift_x=shift_x, shift_y=shift_y, dof=dof,
+    )
+    return types.SimpleNamespace(data=camera, matrix_world=_CamMatrix4())
+
+
+def _apply_camera_args(monkeypatch, width=160, height=90, **cam_kwargs):
+    """Run the F12 path (_apply_camera with rv3d=None) and return the
+    positional args of the resulting setup_camera call:
+      (look_from, look_at, vup, vfov, aspect, aperture, focus, w, h, shift_x, shift_y)
+    """
+    addon = _load_blender_addon(monkeypatch)
+    engine = addon.CustomRaytracerRenderEngine()
+    renderer = _RecordingRenderer()
+    cam_obj = _make_camera_obj(**cam_kwargs)
+    engine._apply_camera(renderer, cam_obj, width, height)  # rv3d=None → F12 datablock path
+    return renderer.setup_camera_calls[-1]
+
+
+def test_apply_camera_sensor_fit_horizontal_vs_vertical(monkeypatch):
+    """sensor_fit must pick the sensor axis. On a non-square image, HORIZONTAL
+    and VERTICAL fits must yield different vfov, each matching the Cycles/Eevee
+    formula independently recomputed here."""
+    w, h = 160, 90
+    aspect = w / h
+    h_args = _apply_camera_args(monkeypatch, width=w, height=h,
+                                sensor_fit='HORIZONTAL',
+                                sensor_width=36.0, sensor_height=24.0, lens=50.0)
+    v_args = _apply_camera_args(monkeypatch, width=w, height=h,
+                                sensor_fit='VERTICAL',
+                                sensor_width=36.0, sensor_height=24.0, lens=50.0)
+    # HORIZONTAL: hfov from sensor_width, then convert to vfov via aspect.
+    exp_h = math.degrees(2.0 * math.atan((36.0 / (2 * 50.0)) / aspect))
+    # VERTICAL: vfov directly from sensor_height.
+    exp_v = math.degrees(2.0 * math.atan(24.0 / (2 * 50.0)))
+    assert abs(h_args[3] - exp_h) < 0.05
+    assert abs(v_args[3] - exp_v) < 0.05
+    assert abs(h_args[3] - v_args[3]) > 1.0, "sensor_fit branch had no effect on vfov"
+
+
+def test_apply_camera_auto_fit_landscape_matches_horizontal(monkeypatch):
+    """AUTO on a landscape image (width >= height) must equal HORIZONTAL fit."""
+    auto = _apply_camera_args(monkeypatch, width=160, height=90, sensor_fit='AUTO')
+    horiz = _apply_camera_args(monkeypatch, width=160, height=90, sensor_fit='HORIZONTAL')
+    assert abs(auto[3] - horiz[3]) < 1e-6
+
+
+def test_apply_camera_auto_fit_portrait_matches_vertical(monkeypatch):
+    """AUTO on a portrait image (height > width) must equal VERTICAL fit."""
+    auto = _apply_camera_args(monkeypatch, width=90, height=160, sensor_fit='AUTO')
+    vert = _apply_camera_args(monkeypatch, width=90, height=160, sensor_fit='VERTICAL')
+    assert abs(auto[3] - vert[3]) < 1e-6
+
+
+def test_apply_camera_shift_passthrough(monkeypatch):
+    """camera.shift_x / shift_y (film offset) must reach setup_camera unchanged."""
+    args = _apply_camera_args(monkeypatch, shift_x=0.125, shift_y=-0.0625)
+    assert abs(args[9] - 0.125) < 1e-9, "shift_x not passed through"
+    assert abs(args[10] - (-0.0625)) < 1e-9, "shift_y not passed through"
+
+
+def test_apply_camera_aspect_ratio(monkeypatch):
+    """The aspect ratio passed to setup_camera must equal width / height."""
+    args = _apply_camera_args(monkeypatch, width=320, height=200)
+    assert abs(args[4] - (320.0 / 200.0)) < 1e-9
+
+
+def test_apply_camera_known_square_vfov(monkeypatch):
+    """Hardcoded ground truth: 50 mm lens, 36 mm sensor, square image → vfov ≈ 39.6°.
+    Independent of the addon's formula; locks against unit / parameter drift."""
+    args = _apply_camera_args(monkeypatch, width=100, height=100,
+                              sensor_fit='HORIZONTAL', sensor_width=36.0, lens=50.0)
+    assert abs(args[3] - 39.598) < 0.1, f"expected ~39.6deg, got {args[3]:.3f}"


### PR DESCRIPTION
## Summary

Implements the **Bucket-1 fixes** and files the **follow-up specs** from the Blender-integration parity research (camera frustum, scene sync, textures/UVs, color management; compared against Cycles / LuxCore / RPR).

## Code fixes (verified, CPU/stub)

- **Instanced-light coverage:** `convert_lights` now iterates `depsgraph.object_instances` (was `depsgraph.objects`), so lights created by collection/particle instancing render — matching `convert_objects`. Method signature unchanged → no call sites to update.
- **Camera frustum parity tests:** extends `tests/test_addon_viewport_camera_vfov.py` with the F12 `_apply_camera` cases pkg101 never covered — `sensor_fit` (HORIZONTAL/VERTICAL/AUTO), film `shift_x/y`, aspect ratio, known-vfov. Closes the Q1 "no parity gate" gap.
- New `tests/test_addon_instanced_lights.py` locks the instanced-light fix.

Tests: `test_addon_viewport_camera_vfov.py` (7) + `test_addon_instanced_lights.py` (1) green; full stubbed addon suite **57 passed, 1 skipped**, no regressions.

> ⚠️ **Needs RTX visual verify before merge:** the `convert_lights` change touches the render path. The unit tests are CPU/stub only — please `/verify` an instanced-light scene on hardware.

## Docs / specs

- Parity report: `.astroray_plan/docs/blender-integration-parity-report-2026-05-30.md`
- New specs: **pkg112** (batched geometry upload), **pkg114** (two-level BVH/TLAS-BLAS), **pkg115** (adopt Blender shader node tree for textures; keep slim standalone API), **pkg116** (exporter + per-domain cache refactor), **pkg117** (non-MESH geometry via `to_mesh()`).
- GPU `view_draw` color-management future-work note added to `blender-depsgraph-sync-research.md`.
- Engine-decoupling / Hydra direction tracked separately in #398.

## Notes from the research (corrections worth recording)

- Evaluated-data audit came back **CLEAN** — `object_instances[].object` is already evaluated (an earlier claim that meshes were read un-evaluated was a false alarm).
- Color management is already correct (engine outputs linear scene-referred; Blender does the view transform) — no change needed; do **not** add an in-engine tonemapper.

## Test plan

- [x] `pytest tests/test_addon_viewport_camera_vfov.py tests/test_addon_instanced_lights.py`
- [x] Stubbed addon suite (no regressions)
- [ ] RTX `/verify`: instanced-light scene renders the instanced lights

🤖 Generated with [Claude Code](https://claude.com/claude-code)