### PR TITLE
refbank(pkg104): recompose prism rainbow into a 512² showcase

### DIFF
--- a/benchmarks/reference_bank/scenes/prism-bk7-collimated/scene.py
+++ b/benchmarks/reference_bank/scenes/prism-bk7-collimated/scene.py
@@ -32,9 +32,9 @@ import math
 
 
 NAME = "prism-bk7-collimated"
-WIDTH = 384
-HEIGHT = 288
-SAMPLES = 64
+WIDTH = 512
+HEIGHT = 512
+SAMPLES = 96
 MAX_DEPTH = 8
 SEED = 17
 
@@ -102,7 +102,7 @@ def make_scene(astroray):
     # (1.2 == the old int-knob 12 x 0.1) routed via set_integrator_param_float.
     r.set_integrator_param_float("caustic_boost", 1.2)
 
-    # Camera looks down the floor at the rainbow landing zone.
-    r.setup_camera([1.86, 1.5, 3.2], [1.86, -3.0, 0.0], [0.0, 1.0, 0.0],
-                   42.0, WIDTH / HEIGHT, 0.0, 4.5, WIDTH, HEIGHT)
+    # Camera zoomed onto the rainbow band (pkg104 showcase composition).
+    r.setup_camera([2.5, 0.1, 3.4], [2.5, -3.0, 0.0], [0.0, 1.0, 0.0],
+                   25.0, WIDTH / HEIGHT, 0.0, 4.5, WIDTH, HEIGHT)
     return r

--- a/tests/test_prism_caustic_rainbow.py
+++ b/tests/test_prism_caustic_rainbow.py
@@ -37,7 +37,7 @@ pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray not built")
 _REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _SCENE = os.path.join(_REPO, "benchmarks", "reference_bank", "scenes",
                       "prism-bk7-collimated", "scene.py")
-_ROI = (100, 192, 196, 258)  # band ROI in the 384x288 frame (see gates.toml)
+_ROI = (150, 390, 125, 322)  # band ROI (y0,y1,x0,x1) in the 512x512 showcase frame
 
 
 @pytest.mark.skipif(not os.path.exists(_SCENE), reason="prism scene not present")


### PR DESCRIPTION
First of the pkg104 Visual Reference Bank recompositions (design: `.astroray_plan/docs/visual-reference-bank-design-2026-05-30.md`).

**Owner feedback addressed:** "redo the dispersion scenes; zoom the camera onto the important part." The `prism-bk7-collimated` reference is recomposed from a small band in a black 384×288 frame to a **512×512 showcase** with the camera zoomed + centered on the dispersed rainbow. The forward light-tracer's explicit 2-face path renders a clean continuous red→violet band (visually confirmed).

**Gate:** ROI re-derived to the new band location (metric ROI is `(y0,y1,x0,x1)`); thresholds unchanged — measured **hue_spread 0.753** (≥0.7), **bright_coverage 0.80** (≥0.5). `test_integrator_float_param` (renders this scene) + `test_glass_sphere_caustic` still pass.

**Not in this PR:** the glass-sphere refractive caustic recomposition is deferred — its transmission caustic is inherently a hot point and the glass ball renders dark without a bright environment to refract, which is a composition/subject design call (surfaced to the owner), not a tuning fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)