### PR TITLE
feat(caustics): refractive caustic from arbitrary mesh casters + fix scaled-mesh invisibility

### DIFF
--- a/.astroray_plan/docs/visual-reference-bank-design-2026-05-30.md
+++ b/.astroray_plan/docs/visual-reference-bank-design-2026-05-30.md
@@ -115,6 +115,51 @@ vs vfov. Until resolved, scene 5's cross-engine SSIM gate is not trustworthy.
 
 ---
 
+## Update 2026-05-30 — refractive caustic showcase now uses the Glass.obj crystal mesh
+
+The owner provided `samples/Glass.obj` (a finely-tessellated cut-glass crystal,
+~470k tris) + a Cycles reference `Glass_Blender_ref.png` (crystal on the right,
+grazing spot-lamp from the right, a long focused caustic streak to the left) and
+asked to use it for the refractive-caustic showcase instead of a bare sphere.
+New scene: `benchmarks/reference_bank/scenes/glass-mesh-caustic/` — it reproduces
+that grazing-light caustic streak. The pkg110 forward light-tracer now drives an
+**arbitrary triangle-mesh caster** (previously only the prism + primitive sphere).
+
+Three engine fixes were needed (one was a real latent core bug), all in this PR:
+1. **`Scale::hit` t-units bug (core).** The `Scale` decorator transforms a ray
+   into mesh-local space by dividing origin+direction by the scale, but the `Ray`
+   ctor *normalizes* the direction — discarding the scale. The inner mesh then
+   measured `rec.t` in normalized scaled-space distance (~1/scale too large), so
+   the scene BVH mis-ordered the scaled mesh behind nearer primitives and a
+   **scaled mesh was invisible to all rays** (camera + caustic photons passed
+   through it → 0 deposited photons). Fixed by scaling the t-bounds in / `rec.t`
+   out by the scaled-direction length. Spheres were unaffected (Sphere::hit uses
+   `direction.length2()`), which is why only scaled *meshes* showed it. Guarded by
+   `tests/test_scaled_mesh_visible.py`. Full suite (1162) stays green — nothing
+   relied on the buggy `rec.t`.
+2. **`loadOBJ(smooth_normals=True)`** — area-weighted per-vertex normals (opt-in,
+   default off so existing flat meshes are unchanged). A tessellated smooth
+   surface then refracts continuously instead of per-facet, essential for a clean
+   caustic (and exposed via `add_mesh(..., smooth_normals=True)`).
+3. **light_tracer_caustic marks the L S⁺ D path on transmission**, not via the
+   per-hit caster flag — a mesh caster's flag lives on the wrapping Translate/Scale
+   decorator, not its per-triangle hits, so the flag check never tripped for a mesh.
+
+**Asset / CI note:** `*.obj` is gitignored and Glass.obj is ~18 MB, so it is NOT
+checked in. `glass-mesh-caustic` is a **local** showcase — `make_scene` raises a
+clear error if the mesh is absent; CI does not render it. Owner renders locally.
+
+**Known follow-up (glass body):** the caustic (the hero) is faithful, but the
+crystal *body* renders as a dark/grey smoky solid rather than the reference's
+clear glass. This is inherent to a cut crystal with many internal Fresnel/TIR
+surfaces under a uniform studio dome + a strong directional sun (path-traced
+glass-caustic fireflies on the body). Candidate improvements for a later pass: an
+HDRI environment (owner also added `samples/test_env_aerodynamics_workshop_exr_4k.exr`)
+so the body refracts a rich environment, firefly clamping, or higher spp. The
+caustic itself does not depend on this.
+
+---
+
 ## Caustic-path alignment with the 2026-05-30 fork decision
 
 The owner chose the **forward photon map as the canonical caustic path** (see

--- a/benchmarks/reference_bank/scenes/glass-mesh-caustic/scene.py
+++ b/benchmarks/reference_bank/scenes/glass-mesh-caustic/scene.py
@@ -1,0 +1,92 @@
+"""Refractive caustic showcase — a cut-glass crystal MESH (samples/Glass.obj).
+
+The pkg110 forward light-tracer focuses a collimated sun through a glass
+*caster* and deposits a caustic on the floor. `glass-sphere-caustic` exercises a
+primitive sphere caster; this scene exercises an arbitrary triangle **mesh**
+caster — the owner-provided `samples/Glass.obj`, a finely-tessellated cut-glass
+crystal — reproducing the grazing-light caustic streak of the Cycles reference
+`Glass_Blender_ref.png` (crystal on the right, lit from the right, a long
+focused caustic streaming left).
+
+Three fixes landed together to make a transformed mesh caster work (see the PR):
+  * Scale::hit t-units bug — a scaled mesh was invisible to rays (the Ray ctor
+    normalized away the scale, so rec.t came back ~1/scale too large and the
+    scene BVH mis-ordered the mesh). Without it the caster deposited 0 photons.
+  * loadOBJ(smooth_normals=True) — area-weighted per-vertex normals so a
+    tessellated smooth surface refracts continuously (clean caustic), not
+    per-facet.
+  * light_tracer_caustic marks the L S+ D path on transmission rather than the
+    per-hit caster flag (a mesh caster's flag lives on the wrapping decorator,
+    not its per-triangle hits).
+
+Asset note: `samples/Glass.obj` is ~18 MB and `*.obj` is gitignored, so it is
+NOT checked in. This is a LOCAL showcase scene — `make_scene` raises if the mesh
+is absent (CI does not render it). The owner renders it with the asset present.
+
+Integrator: `light_tracer_caustic` (CPU forward light-tracer; caustic baked in
+beginFrame so the camera pass needs few samples for the caustic itself — the
+glass body still benefits from more spp).
+"""
+
+from __future__ import annotations
+
+import math
+import os
+
+
+NAME = "glass-mesh-caustic"
+WIDTH = 768
+HEIGHT = 480
+SAMPLES = 96
+MAX_DEPTH = 32
+SEED = 17
+
+# samples/Glass.obj relative to the repo root (this file is 4 dirs deep:
+# benchmarks/reference_bank/scenes/glass-mesh-caustic/scene.py).
+_REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
+_MESH = os.path.join(_REPO, "samples", "Glass.obj")
+
+
+def _norm(v):
+    n = math.sqrt(sum(c * c for c in v))
+    return [c / n for c in v]
+
+
+def make_scene(astroray):
+    if not os.path.exists(_MESH):
+        raise FileNotFoundError(
+            f"glass-mesh-caustic needs the owner-provided crystal mesh at {_MESH} "
+            "(~18 MB, *.obj is gitignored). Render this showcase locally with the "
+            "asset present.")
+
+    r = astroray.Renderer()
+    r.set_background_color([0.95, 0.96, 0.98])
+
+    # Clear cut-glass crystal (ior 1.5), smooth-shaded so the tessellated surface
+    # refracts continuously. Scaled 0.1 (~15 units across) and lifted to sit on
+    # the floor; rotated for a pleasing facet orientation. Flagged as a caustic
+    # caster so the forward light-tracer aims photons at it.
+    glass = r.create_material("dielectric", [1.0, 1.0, 1.0], {"ior": 1.5})
+    mesh_idx = r.scene_object_count()
+    r.add_mesh(_MESH, glass, [5.0, 4.05, 0.0], [0.1, 0.1, 0.1], 25.0, smooth_normals=True)
+    r.set_object_caustic_caster(mesh_idx, True)
+
+    # Grazing collimated sun from the right (travelling down-left) -> a long,
+    # focused caustic streak landing on the floor to the left of the crystal.
+    r.add_sun_light_dedicated(_norm([-0.92, -0.33, 0.04]), 0.02,
+                              {"mode": "rgb", "color": [1.0, 1.0, 1.0]}, 10.0)
+
+    # White studio floor catches the caustic.
+    floor = r.create_material("lambertian", [0.9, 0.91, 0.93], {})
+    r.add_triangle([-60, 0, -60], [60, 0, -60], [60, 0, 60], floor)
+    r.add_triangle([-60, 0, -60], [60, 0, 60], [-60, 0, 60], floor)
+
+    r.set_integrator("light_tracer_caustic")
+    r.set_integrator_param("max_depth", MAX_DEPTH)
+    r.set_integrator_param("photon_count", 4000000)
+    r.set_integrator_param_float("caustic_boost", 2.0)
+
+    # Low, near-level camera: crystal on the right, caustic streaming left.
+    r.setup_camera([-1.0, 4.5, 23.0], [1.5, 1.2, 0.0], [0.0, 1.0, 0.0],
+                   40.0, WIDTH / HEIGHT, 0.0, 23.0, WIDTH, HEIGHT)
+    return r

--- a/include/advanced_features.h
+++ b/include/advanced_features.h
@@ -586,13 +586,22 @@ public:
     bool hit(const Ray& r, float tMin, float tMax, HitRecord& rec) const override {
         Vec3 o(r.origin.x/scale.x, r.origin.y/scale.y, r.origin.z/scale.z);
         Vec3 d(r.direction.x/scale.x, r.direction.y/scale.y, r.direction.z/scale.z);
+        // The Ray ctor normalizes the direction, discarding the length change the
+        // scale introduces. Track that factor so the hit parameter t stays a WORLD
+        // distance: the inner shape measures t in normalized scaled space, so scale
+        // the t-bounds in and rec.t back out by |d|. Without this, rec.t for a scaled
+        // mesh comes back ~1/scale too large and the scene BVH mis-orders the mesh
+        // behind nearer primitives, so a scaled mesh becomes invisible to rays.
+        const float sdlen = d.length();
+        if (sdlen <= 0.0f) return false;
         Ray scaled(o, d, r.time, r.screenU, r.screenV);
         scaled.hasCameraFrame = r.hasCameraFrame;
         scaled.cameraOrigin = r.cameraOrigin;
         scaled.cameraU = r.cameraU;
         scaled.cameraV = r.cameraV;
         scaled.cameraW = r.cameraW;
-        if (!object->hit(scaled, tMin, tMax, rec)) return false;
+        if (!object->hit(scaled, tMin * sdlen, tMax * sdlen, rec)) return false;
+        rec.t /= sdlen;
         rec.point = Vec3(rec.point.x*scale.x, rec.point.y*scale.y, rec.point.z*scale.z);
         Vec3 n(rec.normal.x/scale.x, rec.normal.y/scale.y, rec.normal.z/scale.z);
         rec.setFaceNormal(r, n.normalized());

--- a/include/astroray/shapes.h
+++ b/include/astroray/shapes.h
@@ -268,11 +268,13 @@ class Mesh : public Hittable {
 public:
     Mesh(std::shared_ptr<Material> mat) : material(mat) {}
 
-    bool loadOBJ(const std::string& filename) {
+    bool loadOBJ(const std::string& filename, bool smoothNormals = false) {
         std::ifstream file(filename);
         if (!file.is_open()) return false;
         std::vector<Vec3> positions;
         std::vector<Vec2> uvs;
+        struct Face { int v[3]; int t[3]; };          // triangulated faces
+        std::vector<Face> faces;
         std::string line;
         while (std::getline(file, line)) {
             std::istringstream iss(line);
@@ -298,15 +300,48 @@ public:
                     }
                 }
                 for (size_t i = 1; i + 1 < vi.size(); ++i) {
-                    Vec2 t0 = ti.size() > 0 ? uvs[ti[0]] : Vec2(0, 0);
-                    Vec2 t1 = ti.size() > i ? uvs[ti[i]] : Vec2(1, 0);
-                    Vec2 t2 = ti.size() > i + 1 ? uvs[ti[i + 1]] : Vec2(0, 1);
-                    triangles.push_back(std::make_shared<Triangle>(
-                        positions[vi[0]], positions[vi[i]], positions[vi[i + 1]], t0, t1, t2, material));
+                    Face f;
+                    f.v[0] = vi[0]; f.v[1] = vi[i]; f.v[2] = vi[i + 1];
+                    f.t[0] = ti.size() > 0     ? ti[0]     : -1;
+                    f.t[1] = ti.size() > i     ? ti[i]     : -1;
+                    f.t[2] = ti.size() > i + 1 ? ti[i + 1] : -1;
+                    faces.push_back(f);
                 }
             }
         }
-        if (triangles.empty()) return false;
+        if (faces.empty()) return false;
+
+        // Optional smooth shading: area-weighted per-vertex normals. The
+        // (un-normalized) face normal cross(e1,e2) has magnitude 2*area, so
+        // accumulating it into each vertex gives the standard area-weighted
+        // average. A finely-tessellated smooth surface (e.g. a cut-glass mesh
+        // with no vertex normals in the .obj) then refracts continuously instead
+        // of per-facet, which is essential for clean dielectric caustics.
+        std::vector<Vec3> vnormals;
+        if (smoothNormals) {
+            vnormals.assign(positions.size(), Vec3(0, 0, 0));
+            for (const auto& f : faces) {
+                Vec3 fn = (positions[f.v[1]] - positions[f.v[0]])
+                              .cross(positions[f.v[2]] - positions[f.v[0]]);
+                vnormals[f.v[0]] = vnormals[f.v[0]] + fn;
+                vnormals[f.v[1]] = vnormals[f.v[1]] + fn;
+                vnormals[f.v[2]] = vnormals[f.v[2]] + fn;
+            }
+            for (auto& n : vnormals) if (n.length2() > 0.0f) n = n.normalized();
+        }
+
+        auto uvAt = [&](int idx, Vec2 dflt) {
+            return (idx >= 0 && idx < static_cast<int>(uvs.size())) ? uvs[idx] : dflt;
+        };
+        for (const auto& f : faces) {
+            auto tri = std::make_shared<Triangle>(
+                positions[f.v[0]], positions[f.v[1]], positions[f.v[2]],
+                uvAt(f.t[0], Vec2(0, 0)), uvAt(f.t[1], Vec2(1, 0)), uvAt(f.t[2], Vec2(0, 1)),
+                material);
+            if (smoothNormals)
+                tri->setVertexNormals(vnormals[f.v[0]], vnormals[f.v[1]], vnormals[f.v[2]]);
+            triangles.push_back(tri);
+        }
         std::vector<std::shared_ptr<Hittable>> hits;
         for (auto& t : triangles) hits.push_back(t);
         bvh = std::make_shared<BVHAccel>(hits);

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -663,10 +663,10 @@ public:
     }
 
     void addMesh(const std::string& filename, int materialId, const std::vector<float>& position = {0,0,0},
-                const std::vector<float>& scale = {1,1,1}, float rotationY = 0) {
+                const std::vector<float>& scale = {1,1,1}, float rotationY = 0, bool smoothNormals = false) {
         auto mat = materials.count(materialId) ? materials[materialId] : std::make_shared<Lambertian>(Vec3(0.5f));
         auto mesh = std::make_shared<Mesh>(mat);
-        if (mesh->loadOBJ(filename)) {
+        if (mesh->loadOBJ(filename, smoothNormals)) {
             std::shared_ptr<Hittable> obj = mesh;
             if (scale[0] != 1 || scale[1] != 1 || scale[2] != 1)
                 obj = std::make_shared<Scale>(obj, Vec3(scale[0], scale[1], scale[2]));
@@ -1963,7 +1963,8 @@ PYBIND11_MODULE(astroray, m) {
              "n0"_a = std::vector<float>(), "n1"_a = std::vector<float>(), "n2"_a = std::vector<float>(),
              "object_pass_index"_a = 0, "material_pass_index"_a = 0)
         .def("add_mesh", &PyRenderer::addMesh, "filename"_a, "material_id"_a,
-             "position"_a = std::vector<float>{0,0,0}, "scale"_a = std::vector<float>{1,1,1}, "rotation_y"_a = 0.0f)
+             "position"_a = std::vector<float>{0,0,0}, "scale"_a = std::vector<float>{1,1,1}, "rotation_y"_a = 0.0f,
+             "smooth_normals"_a = false)
         .def("add_volume", &PyRenderer::addVolume,
              "center"_a, "radius"_a, "density"_a, "color"_a,
              "anisotropy"_a = 0.0f, "emission_strength"_a = 0.0f,

--- a/plugins/integrators/light_tracer_caustic.cpp
+++ b/plugins/integrators/light_tracer_caustic.cpp
@@ -274,11 +274,11 @@ private:
                 ys.push_back(rec.point.y);
             }
         } else {
-            // General deterministic refraction loop (curved/solid glass). At each
-            // transmissive hit refract (Snell + Schlick-Fresnel, enter/exit from the
-            // geometric-normal sign, per-wavelength iorAt) or reflect on TIR; deposit
-            // on the first diffuse receiver, only on an L S+ D path (passed >= 1
-            // caster) so direct light is not double-counted.
+            // General deterministic refraction loop (curved/solid glass: sphere,
+            // lens, mesh). At each transmissive hit refract (Snell + Schlick-Fresnel,
+            // enter/exit from the geometric-normal sign, per-wavelength iorAt) or
+            // reflect on TIR; deposit on the first diffuse receiver, only on an L S+ D
+            // path (passed >= 1 caster) so direct light is not double-counted.
             for (int p = 0; p < photons_; ++p) {
                 const float lambda = lmin + (lmax - lmin) * u01(gen);
                 const float ra = (u01(gen) * 2.0f - 1.0f) * crad;
@@ -301,7 +301,12 @@ private:
                         Vec3 nd;
                         if (refract(d, nf, eta, nd)) { tr *= fresnelT(d.dot(nf), ior); d = nd; }
                         else { d = (d - nf * (2.0f * d.dot(nf))).normalized(); }       // TIR
-                        if (rec.hitObject && rec.hitObject->isCausticCaster()) passedCaster = true;
+                        // Mark the path as a caustic path on transmission (not via the
+                        // per-hit caster flag): a mesh caster's flag sits on the wrapping
+                        // Translate/Scale decorator, not its per-triangle hits, so checking
+                        // rec.hitObject->isCausticCaster() would never trip for a mesh. The
+                        // integrator only runs when a flagged caster exists, so this is safe.
+                        passedCaster = true;
                         o = rec.point + d * eps;
                         continue;
                     }

--- a/tests/test_scaled_mesh_visible.py
+++ b/tests/test_scaled_mesh_visible.py
@@ -1,0 +1,95 @@
+"""Regression: a *scaled* triangle mesh must be visible to rays.
+
+The `Scale` decorator (include/advanced_features.h) transforms a ray into the
+mesh's local space by dividing origin and direction by the scale, then builds a
+new `Ray`. But the `Ray` ctor normalizes the direction, which discarded the
+length change from the scale — so the inner mesh measured `rec.t` in normalized
+scaled-space distance (~1/scale too large). The scene BVH then mis-ordered the
+scaled mesh behind nearer primitives and a scaled mesh became invisible to rays
+(camera AND caustic photons passed straight through it). This bit the
+samples/Glass.obj refractive-caustic showcase: the flagged mesh caster deposited
+zero photons because no ray ever hit it.
+
+The fix scales the t-bounds in and `rec.t` back out by the scaled-direction
+length in `Scale::hit`. This test guards it with a runtime-generated cube so it
+needs no large checked-in asset (and exercises the Scale-decorator path because
+scale != 1).
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import numpy as np
+import pytest
+
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+
+try:
+    import astroray  # noqa: E402
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray not built")
+
+# Unit cube (corners at +-1), triangulated. Loaded at scale 10 -> a 20-unit cube
+# routed through the Scale decorator.
+_CUBE_OBJ = """\
+v -1 -1 -1
+v  1 -1 -1
+v  1  1 -1
+v -1  1 -1
+v -1 -1  1
+v  1 -1  1
+v  1  1  1
+v -1  1  1
+f 1 2 3
+f 1 3 4
+f 5 7 6
+f 5 8 7
+f 1 6 2
+f 1 5 6
+f 2 7 3
+f 2 6 7
+f 3 8 4
+f 3 7 8
+f 4 5 1
+f 4 8 5
+"""
+
+
+def _render_scaled_cube(scale):
+    r = astroray.Renderer()
+    r.set_background_color([0.1, 0.2, 0.8])           # blue background
+    red = r.create_material("lambertian", [0.9, 0.1, 0.1], {})
+    fd, path = tempfile.mkstemp(suffix=".obj")
+    with os.fdopen(fd, "w") as f:
+        f.write(_CUBE_OBJ)
+    try:
+        r.add_mesh(path, red, [0.0, 0.0, 0.0], [scale, scale, scale], 0.0)
+        r.add_sun_light_dedicated([-0.4, -1.0, -0.5], 0.1,
+                                  {"mode": "rgb", "color": [1.0, 1.0, 1.0]}, 4.0)
+        r.set_integrator("path_tracer")
+        d = 2.0 * scale * 3.2
+        r.setup_camera([d * 0.5, d * 0.4, d], [0, 0, 0], [0, 1, 0],
+                       42.0, 1.0, 0.0, d * 2.0, 80, 80)
+        r.set_seed(7)
+        img = np.asarray(r.render(8, 6, None, True), dtype=np.float32).reshape(80, 80, 3)
+    finally:
+        os.unlink(path)
+    return img
+
+
+def test_scaled_mesh_is_visible():
+    img = _render_scaled_cube(10.0)
+    center = img[28:52, 28:52]                        # central region sits on the cube
+    blue_bg = float(center[:, :, 2].mean())
+    red_ch = float(center[:, :, 0].mean())
+    # If the scaled mesh were invisible the centre would be pure blue background
+    # (B ~= 0.8, R ~= 0.1). A visible red cube drops blue and raises red.
+    assert blue_bg < 0.55, f"centre still blue ({blue_bg:.3f}) -> scaled mesh invisible to rays"
+    assert red_ch > blue_bg, f"centre not reddish (R {red_ch:.3f} <= B {blue_bg:.3f}) -> scaled mesh invisible"


### PR DESCRIPTION
## Summary

The pkg110 forward light-tracer now focuses a refractive caustic through an **arbitrary triangle-mesh** glass caster (previously only a flat prism or a primitive sphere). New showcase scene `glass-mesh-caustic` reproduces the grazing-light caustic of the owner-provided `samples/Glass.obj` cut-glass crystal, matching the Cycles reference `Glass_Blender_ref.png` (crystal on the right, lit from the right, a long focused caustic streaming left).

## Three fixes (one a latent core bug)

1. **`Scale::hit` t-units bug (core).** The `Scale` decorator divides ray origin+direction by the scale to enter mesh-local space, but the `Ray` ctor *normalizes* the direction — discarding the scale. The inner mesh then returned `rec.t` in normalized scaled-space distance (~1/scale too large), so the scene BVH mis-ordered the scaled mesh behind nearer primitives and **a scaled mesh was invisible to all rays** (camera + caustic photons → 0 deposited). Spheres were immune (`Sphere::hit` uses `direction.length2()`), so only scaled *meshes* exhibited it. Fixed by scaling the t-bounds in / `rec.t` back out by the scaled-direction length. Guarded by `tests/test_scaled_mesh_visible.py`.
2. **`loadOBJ(smooth_normals=True)`** — opt-in area-weighted per-vertex normals (default off, so existing flat meshes are unchanged), exposed via `add_mesh(..., smooth_normals=True)`. A tessellated smooth surface then refracts continuously instead of per-facet, for a clean caustic.
3. **light_tracer_caustic** marks the L S⁺ D path **on transmission** rather than the per-hit caster flag — a mesh caster's flag lives on its wrapping Translate/Scale decorator, not its per-triangle hits.

## Testing

- Full suite: **1162 passed, 15 skipped, 18 xfailed, 2 xpassed** (no regressions; the Scale fix corrects a latent bug nothing relied on).
- Caustic gates green: `test_prism_caustic_rainbow`, `test_glass_sphere_caustic` (focus conc restored), `test_caustic_validation`.
- New `test_scaled_mesh_visible.py` guards the Scale fix with a runtime-generated cube (no large asset).
- Scene renders at 768×480 in ~21s, 381k deposited photons.

## Asset / CI note

`*.obj` is gitignored and `Glass.obj` is ~18 MB, so it is **not** checked in. `glass-mesh-caustic` is a **local** showcase — `make_scene` raises a clear error if the mesh is absent; CI does not render it.

## Known follow-up (glass body)

The caustic (the hero) is faithful, but the crystal *body* renders dark/smoky rather than clear — inherent to a cut crystal with many internal Fresnel/TIR surfaces under a uniform dome + strong sun. Candidates for a later pass: an HDRI environment, firefly clamping, or higher spp. The caustic does not depend on this. Details in `.astroray_plan/docs/visual-reference-bank-design-2026-05-30.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)