### PR TITLE
docs: round 15 wave 5 closeout — GPU glass energy (#404) + refbank showcase (#405)

### DIFF
--- a/.astroray_plan/docs/NEXT_STAGE_REPORT.md
+++ b/.astroray_plan/docs/NEXT_STAGE_REPORT.md
@@ -1,37 +1,43 @@
 # Astroray Next Stage Report
 
-**Date:** 2026-05-29 (Round 15 Wave 3 — pkg106 DONE; next = general caustics)
-**Prepared by:** Claude (Anthropic Code) — rewritten after the pkg106 forward-light-tracer finish (PR #393).
-**Scope:** post-pkg106 next stage.
+**Date:** 2026-05-30 (Round 15 Wave 5 closeout — GPU glass energy + Heitz-2018 VNDF rough transmission, PR #404; refbank showcase re-author, PR #405)
+**Prepared by:** Claude (Anthropic Code) — rewritten at the Wave 5 closeout (glass-energy fix + showcase polish).
+**Scope:** post-Wave-5 next stage.
 
 > Strategic gate: **RELEASED 2026-05-10** by pkg56 Phase C. Strategy in
-> [`ROADMAP.md`](ROADMAP.md), full status in [`STATUS.md`](STATUS.md) (Round 15
-> Wave 3 section is authoritative for the current state).
+> [`ROADMAP.md`](ROADMAP.md), full status in [`STATUS.md`](STATUS.md) (the
+> Round 15 Wave 5 section is authoritative for the current state).
 
-> ⚠️ This file was rewritten 2026-05-29. The previous version's "pkg106 Chunk
-> D-radiance / wire-MNEE-into-the-integrator" lead track and drop-in prompt are
-> **ABANDONED** — pkg106 shipped via a *forward light-tracer*, not camera-side
-> MNEE. Do NOT resurrect that work.
+> ⚠️ The previous version's lead track was the general-caustics chain
+> (pkg109→pkg110→pkg111). That chain is now **CPU-complete** (PRs #395/#397/#403).
+> The new lead pool is the **glass / rough-transmission follow-ups** + the
+> **CPU-only small fixes** + **pkg76 Classroom Gap 2 continuation**. The GPU
+> photon-map port (pkg113) and the pkg64-gpu re-baseline are GPU-gated (no GPU
+> in CI) — do them on RTX, not overnight.
 
 ---
 
 ## 1. Current state (one screen)
 
-- **pkg106 DONE (PR #393 / `6e6fd74`):** a triangulated equilateral BK7 prism
-  throws a clean continuous rainbow caustic — `hue_spread` 0.754 (≥0.7),
-  `bright_coverage` 0.88 (continuity). New integrator
-  `plugins/integrators/light_tracer_caustic.cpp` (forward light-tracing: Arvo
-  1986 / Jensen 1996). The Cycles-`mnee.h` MNEE transfer-matrix geometry term was
-  ported + FD-validated and is KEPT (`include/astroray/manifold/`) for focusing
-  casters, but camera-side MNEE is unsuitable for a flat prism (salt-and-pepper;
-  see `pkg106-forward-lighttracing-research.md`).
+- **General-caustics chain CPU-COMPLETE.** pkg109 (world-space photon-map kd-tree,
+  PR #395) → pkg110 (BSDF-driven photon bounce, hybrid auto-select, PR #397) →
+  pkg111 (k-NN gather on any receiver into the default `path_tracer`, PR #403).
+  "Drop ANY glass + light → caustics on ANY surface through the default path" now
+  works on CPU.
+- **GPU clear-glass energy bug FIXED (PR #404 / `8b7184b`).** The delta refraction
+  `f = eta^2` was albedo-clamped to [0,1] by the JH upsampler in
+  `gpu_material_sample_spectral`; white-furnace went **0.705 → 0.991 flat @ ior 1.5**
+  (CPU was always 0.985). Also landed a **Heitz-2018 VNDF microfacet-dielectric
+  rough-transmission rewrite** (PBRT-v4 `DielectricBxDF`, BSD-3-Clause; cross-checked
+  vs Cycles `bsdf_microfacet.h`) — GPU rough glass is now energy-conserving for R≥0.1.
+- **Showcase polish (PR #405 / `07a7d65`).** 6 reference-bank scenes re-authored
+  (≥512², gate-green on RTX): true SF11 prism, glass-sphere-caustic, sms-reflective-
+  metal-sphere, gr-schwarzschild, gr-kerr-94-faceon. pkg104's full harness/CI
+  acceptance is **not** complete — these are Phase 2/3 implementation progress only.
 - **No open PRs.** The PR queue is empty.
-- **The caustic feature is NOT general yet.** The light-tracer is prism-specific
-  (2-face refraction, horizontal floor receiver, flagged triangle casters, distant
-  sun, dedicated integrator). "Drop ANY glass + light → caustics on ANY surface,
-  through the default path" is the general-caustics chain in §2.
-- **Blocked / not-overnight:** pkg64-gpu multi-IOR, pkg55-B' CUDA sessions, pkg86-B
-  GPU light tree — all need RTX hardware-verified gates (CI has NO GPU).
+- **Blocked / not-overnight:** pkg113 (GPU photon-map port), the pkg64-gpu re-baseline,
+  pkg55-B' CUDA sessions, pkg86-B GPU light tree — all need RTX hardware-verified gates
+  (CI has NO GPU).
 
 ---
 
@@ -40,29 +46,69 @@
 Ordered by value × overnight-shippability. CI is **Linux/CPU only** — pick CPU
 work whose correctness can be gated without a GPU.
 
-1. **pkg109 — photon-map kd-tree core** (S/M, cite: Jensen 1996). Replace the
-   light-tracer's 2D floor grid with a world-space kd-tree photon store; reproduce
-   the prism band (regression). FOUNDATION of general caustics.
-2. **pkg110 — BSDF-driven photon bounce** (M, cite: Jensen 1996). Photon loop via
-   `Material::sampleSpectral`+`iorAt` → any glass / TIR / multi-bounce; new
-   glass-sphere caustic gate. Depends on pkg109.
-3. **pkg111 — k-NN gather on any receiver, into the default path** (M). Removes the
-   horizontal-floor restriction; caustics on the default `path_tracer`. Ships a
-   `prism-tilted-receiver` red test first. Depends on pkg109+pkg110.
-4. **pkg101 / pkg102 / pkg100** (S each, no research) — addon viewport vfov, HDRI/DOF
-   aperture units, .blend importer camera intrinsics. Branches exist on origin;
-   re-verify vs current main, finish, merge. Independent — parallelizable.
-5. **Integrator float-param ergonomics** (S) — `set_integrator_param` is int-only;
-   `light_tracer_caustic.cpp:58-60` flags `caustic_boost` as an int×0.1 hack. Add a
-   float route + test.
-6. **pkg76 Classroom Gap 2** (M, partial) — non-Principled shader-graph walk; land
-   the importer code + bpy-free unit tests (defer the GPU SSIM gate).
+**OPEN ITEMS surfaced at the Wave 5 closeout (top of queue — pick these up first):**
 
-NOT overnight: pkg64-gpu multi-IOR, pkg55-B' sessions, pkg86-B, SPPM-progressive
-(pkg112, large), VCM (owner decision), and **pkg113 — GPU photon-map caustics +
-CPU/GPU parity** (all GPU-gated; CI has no GPU). The full CPU↔GPU-equivalence
-picture + the SMS-vs-photon-map caustics fork is in
-`.astroray_plan/docs/cpu-gpu-parity-status.md`.
+1. **CPU rough-glass low-α residual** (S/M, CPU, gated locally). The Heitz-2018 VNDF
+   rewrite fixed high roughness, but the CPU still loses energy at the R=0.05–0.1
+   boundary (alpha 0.0064 floor) and lags GPU by a few % mid-roughness. Currently
+   **xfail'd** (`test_disney_rough_glass_furnace_energy_cpu`). Needs the deeper
+   low-alpha / smooth-fallthrough investigation (where does the rough lobe hand off to
+   the delta lobe; is the alpha floor or the masking-shadowing term the loss). Likely a
+   focused follow-up package. **Cite:** Heitz 2018 VNDF + PBRT-v4 `DielectricBxDF` (the
+   same sources the GPU path already uses) — see
+   `.astroray_plan/docs/vndf-microfacet-dielectric-research.md`.
+
+2. **Two GPU gates need re-baselining/recalibration with written justification**
+   (GPU-gated — do on RTX, NOT overnight; flag for the next HW sweep). The Wave 5 glass
+   fixes legitimately changed GPU output for the better, so two pkg64-gpu gates now read
+   below their floor: **pkg64-gpu parity SSIM 0.835 < 0.85** (dielectric caustic — GPU
+   now diverges from the CPU's residual) and **pkg64-gpu Phase-3 prism PSNR delta
+   −0.59 < −0.5 dB** (SMS caustic shift). These do **not** run on CI (no GPU) so they
+   merged green. Re-baseline the references and/or recalibrate the floors **with written
+   justification** under owner adjudication; do not silently lower a floor. Specs:
+   `packages/pkg64-gpu-sellmeier-session2-multi-ior.md`,
+   `packages/pkg64-gpu-spectral-caustics.md` (gate floors left UNCHANGED at this closeout
+   pending that adjudication).
+
+3. **disney-sweep Cycles reference.png needs a Blender re-render by the owner**
+   (owner action, not an agent task). The Astroray-side fix landed (PR #405:
+   `cycles_bless.py` sets `sensor_fit=VERTICAL` before `angle` so Blender derives the
+   30° vfov on the vertical axis, matching Astroray), but the cross-engine Cycles
+   `reference.png` is cross-engine and cannot be auto-blessed — it must be re-rendered
+   via Blender by the owner.
+
+4. **Rough-glass variance reduction / denoising-default** (M, CPU+GPU, candidate future
+   package — NOT a correctness bug). Rough glass is high-variance: verified it frosts
+   correctly at high spp; the see-through look at 72 spp is MC noise, not an energy bug.
+   A rough-glass variance-reduction or denoising-default optimization is a candidate
+   future package (cite the OIDN/OptiX denoiser path already in-tree, or a roughness-
+   aware MIS / multiple-importance-sampled transmission lobe).
+
+**Standing CPU-shippable pool (work top-down after the open items above):**
+
+5. **pkg101 / pkg102 / pkg100** (S each, no research) — addon viewport vfov, HDRI/DOF
+   aperture units, .blend importer camera intrinsics. Branches exist on origin;
+   re-verify vs current main (some may already be on main — the Wave-4 re-verify check
+   found pkg100/101/102 already landed for those), finish + merge any genuine gaps.
+   Independent — parallelizable.
+6. **pkg76 Classroom Gap 2 continuation** (M, partial) — Gap 2 landed the non-Principled
+   shader-graph walk (PR #394), but the Classroom SSIM ≥0.85 gate is GPU-gated and was
+   deferred. Land any remaining importer-side code + bpy-free unit tests on CI; defer the
+   GPU SSIM gate to the next HW sweep.
+7. **pkg104 reference-bank harness/CI completion** (M) — PRs #400/#405 re-authored
+   showcase *scenes*, but the spec's harness/CI acceptance criteria (smoke job <60 s in
+   CI, deliberately-broken-PR fails ≥1 gate, dark_disk / hue_spread sign-flip checks)
+   are not all met. Finish the CPU-checkable harness pieces; the disney-sweep Cycles
+   gate is blocked on open item 3.
+
+NOT overnight: **pkg113 — GPU photon-map caustics + CPU/GPU parity** (the GPU port of the
+now-CPU-complete chain), the pkg64-gpu re-baseline (open item 2), pkg55-B' CUDA sessions,
+pkg86-B GPU light tree, SPPM-progressive + VCM (owner decision). All GPU-gated; CI has no
+GPU. The full CPU↔GPU-equivalence picture + the SMS-vs-photon-map caustics fork is in
+`.astroray_plan/docs/cpu-gpu-parity-status.md`. **Owner decision (2026-05-30):** the photon
+map is the canonical caustic path on CPU+GPU; SMS-GPU (pkg64-gpu) is frozen/legacy — no
+further SMS-GPU work, but the existing pkg64-gpu gates still need the documented re-baseline
+above so the HW sweep isn't reporting a phantom regression.
 
 ---
 
@@ -70,9 +116,45 @@ picture + the SMS-vs-photon-map caustics fork is in
 
 The authoritative overnight instructions live with the owner (the "overnight
 ship-packages" prompt). In short: **work the §2 set top-down, one mergeable PR per
-package, CPU-only, full local test + stale-call-site sweep before each push, poll
-CI then `gh pr merge --squash --delete-branch`.** Start the general-caustics chain
-at pkg109 (it gates pkg110→pkg111); run the small fixes (pkg100/101/102, float
-params) in parallel. Cite papers per CLAUDE.md §6 for any new algorithm
-(`/cite-algorithm`). Do NOT touch GPU-gated packages (no GPU in CI). Specs:
-`.astroray_plan/packages/pkg109-*.md`, `pkg110-*.md`, `pkg111-*.md`.
+package, CPU-only, full local test + stale-call-site sweep before each push, poll CI
+then `gh pr merge --squash --delete-branch`.** Start with the §2 OPEN ITEMS — item 1
+(CPU rough-glass low-α residual) is the highest-value CPU-shippable follow-up; items 2
+and 3 are GPU/owner-side and should be left for the HW sweep / owner, not attempted
+overnight. Then work the standing pool (pkg101/102/100 re-verify, pkg76 Gap 2
+continuation, pkg104 harness completion) in parallel. Cite papers per CLAUDE.md §6 for
+any new algorithm (`/cite-algorithm`); for the rough-glass residual the sources are
+already in `vndf-microfacet-dielectric-research.md`. Do NOT touch GPU-gated packages
+(no GPU in CI) — pkg113, pkg64-gpu re-baseline, pkg55-B', pkg86-B all wait for RTX.
+
+---
+
+## 4. Coordination
+
+- **One PR per package**, doc-only closeouts auto-merge on green CI (pr-reviewer
+  doc-only rule). Source PRs need the independent-review SIGN-OFF/BLOCK gate (pkg98)
+  before push.
+- **CI is blind to GPU correctness** — a green CI is necessary but not sufficient for
+  any glass/caustic/GR render change. Do not declare a round clean on CI green alone;
+  run the full RTX hardware sweep at closeout (memory: `ci_has_no_gpu_runtime_blindspot`).
+  The Wave 5 pkg64-gpu gate drift (open item 2) is exactly this class — it merged green
+  and only the HW sweep will see it.
+- **Visual check is mandatory for caustic/dispersion/rough-glass renders** — both
+  `hue_spread` and `bright_coverage` can pass on dense chromatic salt-and-pepper noise,
+  and rough glass looks see-through at low spp (MC noise, not a bug). Eyeball the PNG
+  (memory: `general-photon-loop-needs-solid-glass`).
+- **Grep `^Status:` (or `**Status:**`) in the spec before dispatching** — this report's
+  §2 prose can go stale vs STATUS.md; the spec header is authoritative for done/open
+  (memory: `orchestrator-next-stage-report-stale`).
+
+---
+
+## 5. After the round
+
+- Flip any landed spec `Status:` lines to `done (PR #N, date — headline numbers)`.
+- Update STATUS.md (new Wave section + the next pickup queue), ROADMAP.md (pillar
+  status + long-tail), and rewrite this report's §1/§2 for the next round.
+- Run the RTX hardware sweep; in particular re-baseline the two pkg64-gpu gates
+  (open item 2) with written justification and re-confirm the Wave 5 glass fixes hold
+  on hardware (white-furnace 0.991 flat across IOR, GPU rough glass energy-conserving
+  for R≥0.1).
+- Open ONE doc PR for the closeout; it is doc-only and auto-merge eligible.

--- a/.astroray_plan/docs/ROADMAP.md
+++ b/.astroray_plan/docs/ROADMAP.md
@@ -178,6 +178,27 @@ fix:
   to pkg55 Phase B per the spec's escape clause; smaller H2/H5
   follow-ups split out as **pkg83** + **pkg84**.
 
+**Round 15 Waves 3–5 (2026-05-29→30): forward-light-tracer prism rainbow → general caustics → GPU glass energy + showcase.**
+**pkg106 FINISHED** (PR #393) — a triangulated BK7 prism throws a clean continuous rainbow caustic
+(hue_spread 0.754 ≥0.7, bright_coverage 0.88) via a NEW forward light-tracer integrator
+`plugins/integrators/light_tracer_caustic.cpp` (Arvo 1986 / Jensen 1996); camera-side MNEE is
+ABANDONED for flat prisms (the MNEE math is kept for focusing casters). **General-caustics chain
+CPU-complete: pkg109** (world-space photon-map kd-tree, PR #395) → **pkg110** (BSDF-driven photon
+bounce — hybrid auto-select by caster geometry, PR #397) → **pkg111** (k-NN gather on any receiver,
+into the default `path_tracer`, PR #403). "Drop ANY glass + light → caustics on ANY surface through
+the default path" now works on CPU. Also: **pkg76 Classroom Gap 2** (non-Principled shader-graph
+walk, PR #394), **integrator float-param** ergonomics (PR #396), mesh-caster caustics + scaled-mesh
+visibility fix (PR #401), and the **glass-dark frontFace fix** (PR #402 — key enter/exit off
+`rec.frontFace`, CPU+GPU). **Wave 5 quality:** **PR #404** fixes the dominant GPU clear-glass
+energy bug (delta refraction eta^2 was albedo-clamped to [0,1] by the JH upsampler; white-furnace
+0.705 → 0.991 flat @ ior 1.5) and lands a **Heitz-2018 VNDF microfacet-dielectric rough-transmission
+rewrite** (PBRT-v4 `DielectricBxDF`, BSD-3-Clause — GPU rough glass now energy-conserving for R≥0.1);
+**PR #405** re-authors 6 reference-bank showcase scenes (≥512², gate-green on RTX). The forward
+photon-map caustics are CPU-only by design; the GPU port is specced as **pkg113** (GPU-gated). The
+glass-energy fix legitimately moved GPU output, so **two pkg64-gpu HW gates need re-baselining with
+written justification** (parity SSIM 0.835 < 0.85; Phase-3 prism PSNR delta −0.59 < −0.5 dB) — these
+do not run on CI (no GPU); flagged for the next HW sweep.
+
 **Round 15 Wave 2 (2026-05-28, 3 PRs merged): pkg106 Chunks B/C/D-seed — MNEE foundation complete.**
 **pkg106 MNEE foundation COMPLETE** (PRs #389/#390/#391) — Chunks B/C/D-seed shipped: surface (u,v) partials (`manifold/surface_partials.h`), analytic Newton solver (`newton_iterate.h::solveAnalytic`), multi-vertex manifold chain (`manifold/manifold_chain.h` — block-tridiagonal Jacobian + damped Newton), mesh seed-ray + chain convergence on triangulated prism (`manifold/mesh_caustic.h`). All CPU-only header math + unit tests, validated to ~1e-11 vs finite-difference / analytic Snell. **Remaining: Chunk D-radiance** (wire multi-vertex MNEE into live integrator — transfer-matrix geometry term + finite prism faces + in-triangle validity + visibility; currently renders chromatic noise on wip/pkg106-chunk-d-radiance) + **Chunk E** (prism scene + hue_spread ≥0.7).
 

--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -1,6 +1,48 @@
 # Astroray Status
 
-**Last updated:** 2026-05-30 (Round 15 Wave 4: pkg109 photon-map kd-tree DONE, PR #395; pkg76 Gap 2 DONE, PR #394; integrator float-param DONE, PR #396; pkg110 general photon bounce DONE — hybrid auto-select, PR #397).
+**Last updated:** 2026-05-30 (Round 15 Wave 5: GPU clear-glass energy fix + Heitz-2018 VNDF rough transmission, PR #404; refbank showcase re-author, PR #405. Wave 5 also landed pkg111 caustic-gather-default-path PR #403, glass-dark frontFace fix PR #402, mesh-caustic + scaled-mesh fix PR #401, refbank prism recompose PR #400, addon parity tests PR #399).
+
+## Round 15 Wave 5 — GPU glass energy + showcase polish (overnight, 2026-05-30)
+
+**Two quality PRs merged this closeout: PR #404 (GPU clear-glass energy + Heitz-2018 VNDF rough transmission) and PR #405 (re-author 6 reference-bank showcase scenes). Both verified on RTX.**
+
+- **PR #404 — GPU clear-glass energy + Disney rough transmission (`8b7184b`).** The dominant
+  GPU glass-energy bug: a plain `dielectric` and Disney glass lower to `GMAT_CLOSURE_GRAPH`
+  on the GPU, and the delta refraction `f = eta^2` was routed through
+  `gpu_rgbToSampledSpectrum` in `GSPEC_RGB_ALBEDO` mode (the JH upsampler clamps rgb to
+  [0,1]), clipping the exit eta^2 (2.25 @ ior 1.5) so the enter/exit radiance-transport
+  factors no longer cancelled. **White-furnace (clear glass): GPU 0.705 → 0.991 flat @ ior 1.5
+  (CPU was always 0.985).** Fix in `gpu_material_sample_spectral`: factor any >1 delta
+  magnitude out as a flat spectral scalar, upsample only the normalized tint (mirrors the CPU).
+  Also: a **Heitz-2018 VNDF microfacet-dielectric rough-transmission rewrite** (ported from
+  PBRT-v4 `DielectricBxDF`, BSD-3-Clause; cross-checked vs Cycles `bsdf_microfacet.h`)
+  replaced the bespoke NDF path that lost ~70% at R≥0.3 — **GPU rough glass now
+  energy-conserving for R≥0.1** (`test_disney_rough_glass_furnace_energy_gpu` passes). Fixed a
+  CPU Disney specular-reflection regression the VNDF rewrite introduced (CPU spec lobe sampled
+  VNDF against an NDF pdf → below-surface directions → Disney metal rendered PURE BLACK on CPU;
+  reverted to NDF sampling). New regression tests: `test_dielectric_glass_furnace.py`,
+  `test_disney_rough_glass_furnace.py`, `test_disney_reflection_not_black.py`. Research:
+  `.astroray_plan/docs/vndf-microfacet-dielectric-research.md` + UPDATE 2 in
+  `disney-rough-transmission-walter2007.md`.
+- **PR #405 — re-author 6 showcase reference-bank scenes (`07a7d65`).** Visual-checked +
+  gate-green re-authoring of CPU showcase scenes (all ≥512²): true SF11 prism (15° apex,
+  hue_spread 0.892 vs BK7 0.753 — the A/B distinguisher), glass-sphere-caustic (tight framing +
+  brighter), sms-reflective-metal-sphere (smooth normals → clear nephroid crescent),
+  gr-schwarzschild + gr-kerr-94-faceon (high-contrast equirectangular checker background,
+  upres 512²). All six gate-green on RTX. `glass-sphere` + `prism-bk7` were reverted to keep
+  their standalone physics gates green. `disney-sweep` `cycles_bless.py` gets a `sensor_fit=VERTICAL`
+  FOV fix — but the cross-engine Cycles `reference.png` still needs an owner Blender re-render
+  (cannot be auto-blessed). These re-authored scenes are pkg104 Phase 2/3 implementation
+  progress; pkg104's full harness/CI acceptance is NOT yet complete (stays open).
+
+**Flag for the next HW sweep (NOT a regression — the glass fixes changed GPU output for the
+better):** two pkg64-gpu gates now need re-baselining with written justification — pkg64-gpu
+parity SSIM 0.835 < 0.85 (dielectric caustic: GPU now diverges from the CPU's residual) and
+pkg64-gpu Phase-3 prism PSNR delta −0.59 < −0.5 dB (SMS caustic shift). These do NOT run on CI
+(no GPU) so they merged green. Spec gate floors are unchanged pending owner adjudication; see
+NEXT_STAGE_REPORT.md §2 open item 2. Also tracked: CPU rough-glass low-α residual (xfail'd,
+`test_disney_rough_glass_furnace_energy_cpu`) and a rough-glass high-variance / denoising-default
+optimization candidate.
 
 ## Round 15 Wave 4 — general-caustics foundation (overnight, 2026-05-30)
 
@@ -52,9 +94,12 @@
   stale leftovers — no work needed (the "re-verify vs current main" check caught it).
 
 **Next deployable set (post-Wave-4):**
-- **pkg111** — k-NN gather on any receiver, wired into the default `path_tracer`
-  (lifts the horizontal-floor restriction; caustics on the default path). The lead
-  track's final piece.
+- **pkg111 — k-NN gather on any receiver, into the default `path_tracer` DONE
+  (PR #403 / `ae138b6`, 2026-05-30).** Lifts the horizontal-floor restriction;
+  caustics now render on the default path (tilted-receiver hue_spread 0.37,
+  bright_coverage 0.65; horizontal-floor regression passes). The lead general-
+  caustics chain (pkg109→pkg110→pkg111) is now CPU-complete. _(Landed in Wave 5;
+  see the Wave 5 section above for the glass-energy + showcase follow-ons.)_
 - **GPU port of the photon-map caustics — now specced: pkg113** (GPU-gated, do on
   RTX not CI). pkg109–111 are CPU-only by design; the forward photon-map caustics
   have NO GPU equivalence yet. The refactor did NOT invalidate any existing parity

--- a/.astroray_plan/packages/pkg111-caustic-gather-default-path.md
+++ b/.astroray_plan/packages/pkg111-caustic-gather-default-path.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 3 (Light transport)
 **Track:** A (CPU integrator)
-**Status:** done (PR #TBD, 2026-05-30 — caustics render on arbitrary receivers via default path; tilted-receiver hue_spread 0.37, bright_coverage 0.65; horizontal-floor regression passes)
+**Status:** done (PR #403, 2026-05-30 — caustics render on arbitrary receivers via default path; tilted-receiver hue_spread 0.37, bright_coverage 0.65; horizontal-floor regression passes)
 **Estimated effort:** M (~3-4 days)
 **Depends on:** pkg109 (kd-tree store), pkg110 (BSDF-driven photons)
 


### PR DESCRIPTION
Doc-only closeout for Round 15 Wave 5. Touches only `.astroray_plan/` — no source, tests, or CMake.

## What landed this wave (the two PRs in scope)
- **PR #404 — GPU clear-glass energy + Disney rough transmission** (`8b7184b`). The delta refraction `f = eta^2` was albedo-clamped to [0,1] by the JH upsampler in `gpu_material_sample_spectral`; **white-furnace 0.705 → 0.991 flat @ ior 1.5** (CPU was always 0.985). Plus a **Heitz-2018 VNDF microfacet-dielectric rough-transmission rewrite** (PBRT-v4 `DielectricBxDF`, BSD-3-Clause; cross-checked vs Cycles `bsdf_microfacet.h`) — GPU rough glass now energy-conserving for R≥0.1. Reverted a CPU Disney spec-reflection regression the rewrite introduced (Disney metal was rendering PURE BLACK on CPU).
- **PR #405 — re-author 6 reference-bank showcase scenes** (`07a7d65`). SF11 prism, glass-sphere-caustic, sms-reflective-metal-sphere, gr-schwarzschild, gr-kerr-94-faceon, all ≥512² and gate-green on RTX. pkg104's full harness/CI acceptance is NOT complete — these are Phase 2/3 implementation progress only, so pkg104 stays open.

## Doc changes
- **STATUS.md** — new Wave 5 section; pkg111 (PR #403) marked done in the next-deployable list; flagged the two pkg64-gpu HW gates that now read below floor.
- **ROADMAP.md** — Waves 3–5 roll-up note (general-caustics chain CPU-complete via pkg109/110/111; Wave 5 glass-energy + showcase; pkg64-gpu re-baseline flag).
- **NEXT_STAGE_REPORT.md** — rewritten for the next round. §2 top = the 4 owner open items.
- **pkg111 spec** — `PR #TBD` → `PR #403`.

## Open items surfaced (top of NEXT_STAGE_REPORT §2 — next dispatch picks these up)
1. **CPU rough-glass low-α residual** (xfail'd `test_disney_rough_glass_furnace_energy_cpu`) — VNDF fixed high roughness; CPU still loses energy at R=0.05–0.1 (alpha 0.0064 floor). Focused CPU follow-up.
2. **Two pkg64-gpu gates need re-baselining with written justification** (GPU-gated, next HW sweep): parity SSIM 0.835 < 0.85, Phase-3 prism PSNR delta −0.59 < −0.5 dB. The glass fixes legitimately changed GPU output; gate floors left UNCHANGED pending owner adjudication.
3. **disney-sweep Cycles reference.png needs an owner Blender re-render** — Astroray-side FOV fix landed; cross-engine, can't auto-bless.
4. **Rough glass is high-variance** (not a bug; frosts correctly at high spp) — variance-reduction / denoising-default candidate package.

## Constraints honored
- Touched ONLY `.astroray_plan/` (the working-tree `docs/renders/*.png` edits + stray `..Astroray-vndf/` dir are pre-existing local artifacts, deliberately left unstaged).
- No gate floors / acceptance criteria changed in any spec.
- Current state derived from git log + closed PR bodies only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)