### PR TITLE
docs(pkg118): root-cause CPU rough-glass furnace residual + file follow-up

### DIFF
--- a/.astroray_plan/docs/vndf-microfacet-dielectric-research.md
+++ b/.astroray_plan/docs/vndf-microfacet-dielectric-research.md
@@ -70,6 +70,28 @@ DO NOT re-derive. Mirror PBRT-v4's transmission formula EXACTLY. The objective c
 5. `test_dielectric_glass_furnace.py` still passes CPU+GPU.
 6. No caustic gate test regressions.
 
+## UPDATE 3 (2026-05-31): CPU residual root-caused — it is multi-scatter, not VNDF
+
+A full instrumented pass (env `DISNEY_DBG=1`, see `scripts/diag_rough_glass_*.py`)
+showed the remaining CPU residual is NOT a VNDF/low-alpha bug. The VNDF rewrite is
+correct. The residual is **missing multiple-scattering energy compensation** for the
+rough dielectric, masked by a **forced-TIR delta over-count**:
+- At R=0.05, ~1.3M rough samples fall through to the delta path (grazing exit-TIR
+  reflections whose VNDF `wi` lands below the surface — PBRT discards these). The
+  delta-reflect branch then over-counts forced TIR at throughput ~21× (=1/Fresnel)
+  instead of 1.0.
+- The single-scattering Smith-G masking loss (transmission lobe has NO Kulla-Conty
+  compensation, unlike the reflection lobe's `ggxCompensationFactor`) is only
+  partly offset by that over-count. They balance at high R (~0.96) and diverge at
+  low R (0.77).
+- A faceforward of the VNDF sampling frame to `wo` was tried and is a **verified
+  no-op** (`rec.normal` is already faceforwarded by the integrator) — do not repeat.
+
+Fix = (A) correct the forced-TIR delta pdf to `transmission_` (not `F·transmission_`)
++ (B) Kulla-Conty 2017 multi-scatter compensation for the rough-dielectric lobe
+(precompute `E_glass(alpha,mu,eta)`; apply `1+F_avg·(1-E)/E`). Full spec:
+`packages/pkg118-rough-dielectric-multiscatter-energy.md`.
+
 ## Notes
 - PBRT-v4's BSD-3-Clause license is compatible with Astroray's Apache-2.0.
 - The VNDF algorithm is from a peer-reviewed academic paper (JCGT 2018), freely implementable.

--- a/.astroray_plan/packages/pkg118-rough-dielectric-multiscatter-energy.md
+++ b/.astroray_plan/packages/pkg118-rough-dielectric-multiscatter-energy.md
@@ -1,0 +1,134 @@
+# pkg118 — Rough-dielectric multiple-scattering energy compensation (CPU)
+
+**Pillar:** 2 (materials / BSDF correctness)
+**Track:** A (CPU-gated; furnace test runs on CI — no GPU needed)
+**Codex-paste-ready:** no (numerical precompute + furnace verification)
+**Status:** open — proposed 2026-05-31. Root cause fully diagnosed (this spec).
+**Depends on:** none. Extends the existing `DisneyEnergyCompensationTables` (pkg60).
+**Estimated effort:** M (a precompute pass + apply + furnace re-gate)
+
+---
+
+## Goal
+
+**Before:** CPU Disney **rough** glass (`transmission=1`, `roughness>0.03`) loses
+energy in the white furnace, worst at LOW roughness:
+
+| R | 0.05 | 0.10 | 0.30 | 0.60 | 1.00 |
+|---|------|------|------|------|------|
+| CPU furnace @256spp | 0.771 | 0.815 | 0.921 | 0.967 | 0.962 |
+
+Gate wants ∈ [0.95, 1.02] for R∈{0.1,0.3,0.6,1.0}. R=0.1 and R=0.3 FAIL.
+Tracked by the non-strict xfail `test_disney_rough_glass_furnace_energy_cpu`.
+
+**After:** CPU rough-glass furnace ∈ [0.95, 1.02] for all R∈{0.1,0.3,0.6,1.0},
+smooth glass unaffected (R≤0.03 stays ~0.97), no caustic/prism gate regressions,
+xfail removed (becomes a hard pass).
+
+---
+
+## Root cause (diagnosed 2026-05-31, instrumented)
+
+The current `plugins/materials/disney.cpp` rough-glass path is a **hybrid** of a
+single-scattering microfacet model plus a delta fallthrough, and it is NOT
+energy-conserving. Two opposing bugs partially cancel — they balance at high
+roughness and diverge at low roughness:
+
+1. **Single-scattering masking loss (under-count).** The rough microfacet
+   transmission/reflection use the single-scattering Smith G (separable
+   `G1(wo)·G1(wi)`). Like all single-scattering GGX, this loses the energy that
+   physically scatters via multiple microfacet bounces. The loss grows with
+   roughness. The reflection lobe already gets Kulla-Conty multi-scatter
+   compensation (`ggxCompensationFactor`, pkg60) but the **transmission lobe does
+   not**.
+
+2. **Delta-TIR over-count (gain).** When a VNDF-sampled rough reflection lands
+   below the surface (common for grazing exit/TIR rays — PBRT discards these),
+   the code **falls through to the smooth delta path**. Instrumentation (env
+   `DISNEY_DBG=1`, see the diag scripts) shows at R=0.05 **~1.3M fallthroughs**
+   vs 330K successful rough refractions. The delta-reflect branch then assigns a
+   forced-TIR reflection `f=1, pdf=Fresnel·transmission` → throughput **≈21×**
+   (= 1/Fresnel) instead of the physically-correct **1.0** for a deterministic
+   total reflection.
+
+At high roughness the over-count (2) roughly cancels the masking loss (1) → ~0.96.
+At low roughness there are fewer grazing-TIR fallthroughs, so (2) under-compensates
+(1) and the furnace sags to 0.77. The fix is to make BOTH terms correct, not to
+keep relying on their accidental cancellation.
+
+### Evidence (instrumented furnace, R=0.05)
+```
+rough-reflect      count=359        avg_throughput=0.19
+rough-refract      count=330210     avg_throughput=0.50
+delta-reflect      count=581425     avg_throughput=21.27   <-- forced-TIR over-count
+delta-refract      count=719513     avg_throughput=1.81
+rough-fallthrough  count=1300938                            <-- dominant at low R
+```
+- Loss saturates by path depth 4 (per-transmission-event leak, not truncation).
+- `rec.normal` is already face-forwarded to `wo` by the integrator (a faceforward
+  of the VNDF sampling frame was verified a no-op — do NOT re-attempt that).
+- The GPU furnace test passes because `set_use_gpu(True)` routes to the spectral
+  multiwavelength closure path, NOT `gpu_disney_sample`; the bespoke RGB
+  `disney_sample` BSDF has the same defect on both backends.
+
+Diag scripts (keep): `scripts/diag_rough_glass_furnace.py`,
+`scripts/diag_rough_glass_depth.py`,
+`scripts/prototypes/rough_glass_albedo_probe.py`.
+
+---
+
+## Fix plan (cite — no inventions, CLAUDE.md §6)
+
+Two correct, independently-verifiable changes:
+
+### A. Correct the forced-TIR delta throughput (small, unblocks the gain bug)
+In the delta reflect branch, when `cannotRefract` (TIR) forced the reflection,
+the selection probability is 1 (deterministic), so `pdf = transmission_`
+(NOT `Fresnel·transmission_`). Only the *Fresnel-selected* reflection keeps
+`pdf = Fresnel·transmission_`. This removes the non-physical ~21× firefly.
+Mirror in `gpu_materials.h`. **Cite:** PBRT-v4 §9.5 specular dielectric
+(`Sample_f` reflection branch sets `pdf = pr/(pr+pt)`; for TIR `pt=0` ⇒ `pdf=1`).
+
+### B. Multiple-scattering energy compensation for the rough dielectric
+After (A) the furnace will read the true single-scattering albedo (below 1, sagging
+with roughness). Compensate the missing multi-scatter energy:
+- Precompute the rough-dielectric directional albedo table
+  `E_glass(alpha, mu, eta)` by MC-integrating the single-scattering rough-dielectric
+  BSDF (reuse the numpy BSDF in the prototype script; generate per-IOR slices or a
+  3D table keyed on the common IOR set). Store alongside the existing
+  `DisneyEnergyCompensationTables`.
+- Apply the Kulla-Conty multi-scatter factor `1 + F_avg·(1-E)/E` to the rough
+  transmission+reflection throughput, exactly as `ggxCompensationFactor` already
+  does for the opaque GGX reflection lobe.
+- **Cite:** Kulla & Conty 2017 "Revisiting Physically Based Shading at Imageworks"
+  (SIGGRAPH course); Heitz et al. 2016 "Multiple-Scattering Microfacet BSDFs with
+  the Smith Model" (the stochastic alternative if a table is undesirable); Cycles
+  `intern/cycles/kernel/closure/bsdf_microfacet.h` `microfacet_ggx_preserve_energy`
+  (Apache-2.0) — the reference the reflection lobe already mirrors.
+
+Verification: rebuild, run `scripts/diag_rough_glass_furnace.py`; the CPU column
+must read ∈[0.95,1.02] for R∈{0.1,0.3,0.6,1.0}. Then remove the xfail. Re-run the
+prism/glass-sphere caustic gates (`test_glass_sphere_caustic.py`, the prism
+hue/coverage gates) to confirm no regression.
+
+---
+
+## Acceptance criteria
+- [ ] `test_disney_rough_glass_furnace_energy_cpu` passes (xfail removed).
+- [ ] Smooth glass furnace unchanged (R≤0.03 ~0.97).
+- [ ] No regression: prism hue/coverage gates, `test_glass_sphere_caustic.py`,
+      `test_dielectric_glass_furnace.py`, `test_disney_reflection_not_black.py`.
+- [ ] CPU and GPU `disney_sample` kept in lockstep (mirror both changes).
+- [ ] Research note: `E_glass` table generation method + Kulla-Conty citation in
+      `.astroray_plan/docs/vndf-microfacet-dielectric-research.md`.
+
+## Non-goals
+- The GPU spectral closure path (already energy-conserving) — untouched.
+- pkg64-gpu SMS caustics (frozen/legacy per owner 2026-05-30).
+- A full Heitz-2016 stochastic multi-scatter rewrite (table approach preferred;
+  the stochastic path is the documented fallback if the table proves insufficient).
+
+## Filed by
+Claude (Opus 4.8), 2026-05-31, after a full instrumented root-cause pass on
+NEXT_STAGE_REPORT §2 open item 1. Supersedes the "low-alpha residual" framing —
+the real defect is missing multi-scatter compensation + a forced-TIR over-count.

--- a/scripts/diag_rough_glass_depth.py
+++ b/scripts/diag_rough_glass_depth.py
@@ -1,0 +1,33 @@
+"""Localize the CPU rough-glass loss: furnace vs path depth (CPU only).
+
+If the furnace value DROPS as depth increases, the loss compounds per internal
+bounce (a per-interaction BSDF energy leak). If it is flat vs depth, a single
+dominant event (e.g. first enter or the rough->delta boundary) is responsible.
+"""
+import sys
+import numpy as np
+
+sys.path.insert(0, "tests")
+from runtime_setup import configure_test_imports  # noqa: E402
+configure_test_imports()
+import astroray  # noqa: E402
+
+
+def furnace(roughness, depth, spp=256):
+    r = astroray.Renderer()
+    r.set_background_color([1.0, 1.0, 1.0])
+    g = r.create_material("disney", [1.0, 1.0, 1.0],
+                          {"transmission": 1.0, "ior": 1.5, "roughness": roughness, "metallic": 0.0})
+    r.add_sphere([0.0, 0.0, 0.0], 1.0, g)
+    r.set_integrator("path_tracer")
+    r.setup_camera([0, 0, 4], [0, 0, 0], [0, 1, 0], 40.0, 1.0, 0.0, 4.0, 80, 80)
+    r.set_seed(7)
+    img = np.asarray(r.render(spp, depth, None, True), dtype=np.float32).reshape(80, 80, 3)
+    return float(img[28:52, 28:52].mean())
+
+
+print(f"{'R':>6} | " + " ".join(f"d={d:<2}" for d in [1, 2, 4, 8, 16, 32]))
+print("-" * 60)
+for R in [0.03, 0.05, 0.1, 0.3, 1.0]:
+    vals = [furnace(R, d) for d in [1, 2, 4, 8, 16, 32]]
+    print(f"{R:>6.2f} | " + " ".join(f"{v:>5.3f}" for v in vals))

--- a/scripts/diag_rough_glass_furnace.py
+++ b/scripts/diag_rough_glass_furnace.py
@@ -1,0 +1,44 @@
+"""Phase-1 evidence: current CPU vs GPU Disney rough-glass white-furnace values.
+
+Measures the same furnace as tests/test_disney_rough_glass_furnace.py across a
+roughness sweep, CPU and GPU, so we can see exactly where the CPU residual lives.
+"""
+from __future__ import annotations
+
+import sys
+import numpy as np
+
+sys.path.insert(0, "tests")
+from runtime_setup import configure_test_imports  # noqa: E402
+
+configure_test_imports()
+import astroray  # noqa: E402
+
+print("module:", astroray.__file__)
+print("features:", astroray.__features__)
+
+
+def furnace(roughness: float, *, use_gpu: bool, spp: int = 256, depth: int = 32) -> float:
+    r = astroray.Renderer()
+    r.set_background_color([1.0, 1.0, 1.0])
+    g = r.create_material("disney", [1.0, 1.0, 1.0],
+                          {"transmission": 1.0, "ior": 1.5, "roughness": roughness, "metallic": 0.0})
+    r.add_sphere([0.0, 0.0, 0.0], 1.0, g)
+    r.set_integrator("path_tracer")
+    if use_gpu:
+        r.set_use_gpu(True)
+    r.setup_camera([0, 0, 4], [0, 0, 0], [0, 1, 0], 40.0, 1.0, 0.0, 4.0, 80, 80)
+    r.set_seed(7)
+    img = np.asarray(r.render(spp, depth, None, True), dtype=np.float32).reshape(80, 80, 3)
+    return float(img[28:52, 28:52].mean())
+
+
+ROUGH = [0.05, 0.1, 0.3, 0.6, 1.0]
+gpu_ok = astroray.Renderer().gpu_available
+print(f"\nGPU available: {gpu_ok}")
+print(f"{'R':>6} | {'CPU@256':>9} | {'GPU@256':>9} | {'delta':>7}")
+print("-" * 40)
+for R in ROUGH:
+    cpu = furnace(R, use_gpu=False)
+    gpu = furnace(R, use_gpu=True) if gpu_ok else float("nan")
+    print(f"{R:>6.2f} | {cpu:>9.4f} | {gpu:>9.4f} | {cpu-gpu:>+7.4f}")

--- a/scripts/prototypes/rough_glass_albedo_probe.py
+++ b/scripts/prototypes/rough_glass_albedo_probe.py
@@ -1,0 +1,152 @@
+"""Numpy replication of disney.cpp glass BSDF (metallic=0, transmission=1, ior=1.5)
+to localize the CPU rough-glass furnace energy loss WITHOUT C++ rebuilds.
+
+Two independent measurements for a fixed wo:
+  (A) Directional albedo by BRUTE-FORCE sphere integration of the actual
+      BRDF/BTDF (PBRT f, NOT pre-multiplied by cos):  A = sum f * |cosI| * dOmega.
+      A ~= 1  => BSDF is physically lossless; loss is in sampling/convention.
+      A  < 1  => the eval itself loses energy.
+  (B) MC estimator using the EXACT sample()/integrator convention the C++ uses
+      (throughput = s.f / s.pdf).  If (A)~1 but (B)<1, the bug is the convention.
+
+Mirrors plugins/materials/disney.cpp lines ~95-540 exactly.
+"""
+import numpy as np
+
+IOR = 1.5
+EPS = 1e-10
+
+
+def normalize(v):
+    n = np.linalg.norm(v)
+    return v / n if n > 0 else v
+
+
+def fresnel_dielectric(cosThetaI, etaI, etaT):
+    cosThetaI = np.clip(cosThetaI, -1.0, 1.0)
+    if cosThetaI <= 0.0:
+        etaI, etaT = etaT, etaI
+        cosThetaI = abs(cosThetaI)
+    sinI = np.sqrt(max(0.0, 1 - cosThetaI**2))
+    sinT = etaI / etaT * sinI
+    if sinT >= 1.0:
+        return 1.0
+    cosT = np.sqrt(max(0.0, 1 - sinT**2))
+    rPar = (etaT*cosThetaI - etaI*cosT) / (etaT*cosThetaI + etaI*cosT + 1e-6)
+    rPer = (etaI*cosThetaI - etaT*cosT) / (etaI*cosThetaI + etaT*cosT + 1e-6)
+    return float(np.clip(0.5*(rPar**2 + rPer**2), 0.0, 1.0))
+
+
+def fresnel_schlick(cosTheta, F0, scale=0.8):
+    c = np.clip(1 - cosTheta, 0.0, 1.0)
+    return F0 + (1 - F0) * c**5 * scale
+
+
+def D_GTR2(NdotH, a):
+    a2 = a*a
+    t = 1 + (a2 - 1) * NdotH*NdotH
+    return a2 / (np.pi * t*t + 0.001)
+
+
+def smithG_GGX(NdotV, a):       # combined visibility form (eval reflection)
+    aa = a*a
+    b = NdotV*NdotV
+    return 1.0 / (NdotV + np.sqrt(aa + b - aa*b) + 0.001)
+
+
+def smithG1_GGX(NdotV, a):      # true Smith G1 (transmission)
+    aa = a*a
+    b = NdotV*NdotV
+    return 2.0*NdotV / (NdotV + np.sqrt(aa + b - aa*b) + 0.001)
+
+
+def alpha_of(rough):
+    return max(rough*rough, 0.0064)
+
+
+# ---- reflection BRDF (glass: metallic=0, transmission=1) -> eval() spec*NdotL ----
+def eval_reflection_fcos(N, wo, wi, rough):
+    """Returns spec*NdotL  == f_r * cosI  (the C++ eval() convention)."""
+    NdotL = N @ wi
+    NdotV = N @ wo
+    if NdotL <= 0 or NdotV <= 0:
+        return 0.0
+    H = normalize(wi + wo)
+    NdotH = N @ H
+    LdotH = wi @ H
+    F0 = 0.5 * 0.08  # specular_=0.5 default -> Cspec0 = 0.04
+    a = alpha_of(rough)
+    Ds = D_GTR2(NdotH, a)
+    F = fresnel_schlick(LdotH, F0, 0.8)
+    Gs = smithG_GGX(NdotL, a) * smithG_GGX(NdotV, a)
+    spec = Ds * F * Gs
+    return spec * NdotL
+
+
+# ---- transmission BTDF -> roughTransmissionEval (NO cosI) ----
+def eval_transmission_f(N, wo, wi, rough):
+    cosO = N @ wo
+    cosI = N @ wi
+    if cosO == 0 or cosI == 0 or cosO*cosI >= 0:
+        return 0.0
+    entering = cosO > 0
+    etaI = 1.0 if entering else IOR
+    etaT = IOR if entering else 1.0
+    etap = IOR if entering else 1.0/IOR
+    wm = normalize(wi*etap + wo)
+    if (N @ wm) < 0:
+        wm = -wm
+    if (wm @ wi)*cosI < 0 or (wm @ wo)*cosO < 0:
+        return 0.0
+    a = alpha_of(rough)
+    D = D_GTR2(abs(N @ wm), a)
+    G = smithG1_GGX(abs(cosO), a) * smithG1_GGX(abs(cosI), a)
+    F = fresnel_dielectric(abs(wo @ wm), etaI, etaT)
+    denom = (wi @ wm) + (wo @ wm)/etap
+    denom = denom*denom * cosI * cosO
+    ft = D * (1-F) * G * abs((wi @ wm)*(wo @ wm) / (denom + EPS))
+    ft /= etap*etap
+    return ft  # baseColor=1
+
+
+def directional_albedo_bruteforce(wo, rough, ntheta=400, nphi=400):
+    """A(wo) = integral over full sphere of [f_r*|cosI| + f_t*|cosI|] dOmega.
+    f_r here = eval_reflection_fcos / cosI (strip the cos), then * |cosI| again
+    => just eval_reflection_fcos.  For transmission f_t * |cosI|."""
+    N = np.array([0.0, 0.0, 1.0])
+    A_refl = 0.0
+    A_tran = 0.0
+    thetas = (np.arange(ntheta) + 0.5) * np.pi / ntheta      # 0..pi full sphere
+    phis = (np.arange(nphi) + 0.5) * 2*np.pi / nphi
+    dtheta = np.pi/ntheta
+    dphi = 2*np.pi/nphi
+    for th in thetas:
+        st, ct = np.sin(th), np.cos(th)
+        dOmega = st * dtheta * dphi
+        for ph in phis:
+            wi = np.array([st*np.cos(ph), st*np.sin(ph), ct])
+            cosI = N @ wi
+            if cosI > 0:    # reflection hemisphere
+                A_refl += eval_reflection_fcos(N, wo, wi, rough) * dOmega
+            elif cosI < 0:  # transmission hemisphere
+                A_tran += eval_transmission_f(N, wo, wi, rough) * abs(cosI) * dOmega
+    return A_refl, A_tran
+
+
+def main():
+    N = np.array([0.0, 0.0, 1.0])
+    print(f"ior={IOR}  brute-force directional albedo (A_refl + A_tran should = 1)")
+    print(f"{'rough':>6} {'incid':>6} | {'A_refl':>8} {'A_tran':>8} {'total':>8}")
+    print("-"*50)
+    for rough in [0.05, 0.1, 0.3, 0.6, 1.0]:
+        for cosO in [0.95, 0.7, 0.4, 0.15]:
+            sinO = np.sqrt(1 - cosO**2)
+            wo = np.array([sinO, 0.0, cosO])
+            Ar, At = directional_albedo_bruteforce(wo, rough, 300, 300)
+            ang = np.degrees(np.arccos(cosO))
+            print(f"{rough:>6.2f} {ang:>5.0f}d | {Ar:>8.4f} {At:>8.4f} {Ar+At:>8.4f}")
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_disney_rough_glass_furnace.py
+++ b/tests/test_disney_rough_glass_furnace.py
@@ -90,8 +90,12 @@ def test_disney_rough_glass_furnace_energy_gpu():
     assert not bad, f"GPU rough disney glass furnace not energy-conserving at roughness {bad}; all={vals}"
 
 
-@pytest.mark.xfail(reason="CPU rough transmission lags GPU + low-alpha (R~0.05-0.1) boundary loss; "
-                          "see vndf-microfacet-dielectric-research.md",
+@pytest.mark.xfail(reason="CPU rough dielectric lacks multiple-scattering energy "
+                          "compensation; single-scatter masking loss is only partly "
+                          "offset by a forced-TIR delta over-count, so the furnace sags "
+                          "at low roughness (R=0.1: 0.81, R=0.3: 0.92). Root-caused + "
+                          "fix plan in packages/pkg118-rough-dielectric-multiscatter-energy.md "
+                          "(Kulla-Conty 2017 / Heitz 2016).",
                    strict=False)
 def test_disney_rough_glass_furnace_energy_cpu():
     vals = {R: _furnace(R, spp=256) for R in _ROUGH}


### PR DESCRIPTION
## Summary

Documents the full instrumented root-cause of the xfail'd `test_disney_rough_glass_furnace_energy_cpu` (NEXT_STAGE_REPORT §2 open item 1) and files the scoped follow-up package **pkg118**.

The residual is **not** a VNDF/low-alpha bug — the VNDF rewrite is correct. It is **missing multiple-scattering energy compensation** for the rough dielectric: the single-scattering Smith-G masking loss (the transmission lobe lacks the Kulla-Conty compensation the reflection lobe already has) is only partly offset by a **forced-TIR delta-path over-count** (throughput ~21× = 1/Fresnel instead of 1.0). They balance at high roughness (~0.96) and diverge at low roughness (0.77/0.81). A faceforward of the VNDF sampling frame to `wo` was tried and is a **verified no-op** (`rec.normal` is already faceforwarded by the integrator).

## Changes (docs + diag, no behavior change)
- `packages/pkg118-rough-dielectric-multiscatter-energy.md` — new spec with the root cause, instrumented evidence, and the cited fix plan (PBRT-v4 TIR pdf; Kulla-Conty 2017 / Heitz 2016 multi-scatter; Cycles `microfacet_ggx_preserve_energy`).
- `vndf-microfacet-dielectric-research.md` — UPDATE 3 with the finding.
- `test_disney_rough_glass_furnace.py` — sharpened the (still non-strict) xfail reason to point at pkg118.
- `scripts/diag_rough_glass_*.py`, `scripts/prototypes/rough_glass_albedo_probe.py` — the diagnostic harness used (kept for the pkg118 implementer).

## Test
Doc + string change only; `test_disney_rough_glass_furnace.py` still collects and xfails as before. No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)