### PR TITLE
fix(pkg118): forced-TIR delta pdf over-count (CPU+GPU) + corrected root-cause

### DIFF
--- a/.astroray_plan/docs/pkg118-multiscatter-energy-research.md
+++ b/.astroray_plan/docs/pkg118-multiscatter-energy-research.md
@@ -1,0 +1,80 @@
+# pkg118 — rough-dielectric energy: forced-TIR pdf fix + corrected root-cause
+
+**Date:** 2026-06-08
+**Author:** Claude (Opus 4.8)
+**Spec:** `packages/pkg118-rough-dielectric-multiscatter-energy.md`
+**Outcome:** Part A (forced-TIR pdf) landed; **Part B (Kulla-Conty compensation table)
+is a DEAD-END — the spec's diagnosis is incomplete.** pkg118 stays OPEN, re-scoped.
+
+## Baseline (256 spp, ior 1.5, reproduced 2026-06-08)
+
+| R | 0.05 | 0.10 | 0.30 | 0.60 | 1.00 |
+|---|------|------|------|------|------|
+| CPU furnace | 0.771 | 0.815 | 0.921 | 0.967 | 0.962 |
+| GPU furnace | 0.905 | 0.956 | 1.000 | 1.000 | 1.000 |
+
+Gate (`test_disney_rough_glass_furnace_energy_cpu`, xfail) wants ∈[0.95,1.02] for
+R∈{0.1,0.3,0.6,1.0}. The deficit is **worst at LOW roughness** — the OPPOSITE of
+single-scatter GGX masking (which worsens with roughness).
+
+## Part A — forced-TIR delta pdf (CPU + GPU) — LANDED, correct, gate-neutral
+
+`disney.cpp` sample() (and the GPU `gpu_disney_sample` mirror) set the forced-TIR
+delta-reflect `pdf = fresnel * transmission_`. When `cannotRefract` (TIR) forces the
+reflection, its selection probability is 1, so `pdf = transmission_`; only a
+Fresnel-roulette-selected reflection keeps the `fresnel` factor. Just past the
+critical angle the geometric Schlick `fresnel` ≈ 0.04–0.07 while the true reflectance
+→ 1, so the old pdf over-counted forced-TIR throughput by ~1/fresnel (~14–24× firefly).
+**Cite:** PBRT-v4 §9.5 `DielectricBxDF::Sample_f` (pdf = pr/(pr+pt); TIR ⇒ pt=0 ⇒ 1).
+
+**Measured: this is a no-op on the furnace centre-patch gate** (0.815→0.815): the
+forced-TIR events fire near the critical angle on *exit* and scatter to edge pixels,
+not the centre patch the gate samples. It IS a correct firefly/variance fix and is
+kept. It does NOT close the gate on its own.
+
+## Part B — Kulla-Conty multi-scatter table — REJECTED (does not address the deficit)
+
+The spec prescribes a precomputed `E_glass(alpha,mu,eta)` table and a
+`1 + Fms(1-E)/E` factor on the rough-transmission throughput, mirroring the opaque
+GGX lobe's `ggxCompensationFactor`. This was implemented and tested; it does NOT work:
+
+1. **The deficit is not single-scatter masking.** Masking loss worsens with
+   roughness; the furnace deficit is worst at LOW roughness (R=0.05: 0.77). A
+   Kulla-Conty masking compensation (`1/E[G1]`) compensates MORE at high roughness —
+   the wrong direction.
+2. **Two albedo-table estimators both fail.** Brute-force sphere integration of
+   `f·cosI` underflows at low alpha (the sharp transmission lobe is missed → E≈0). An
+   importance-sampled MC of the renderer's `sample()` throughput returns the RADIANCE
+   expectation (incl. the `1/η²` radiance factor and the `1/fresnel` firefly), which
+   is >1 and is not an energy albedo to invert.
+3. **Even compensating the right code path barely moves the gate.** A furnace-calibrated
+   table (`E=F0^0.5` ⇒ `C=F0^−0.5` per bounce) applied to `roughTransmissionEval`
+   moved R=0.1 by **+0.003**. Adding the same factor to the rough→delta **fallthrough**
+   refract (which carries ~80% of low-R transmission energy — at R=0.05 the spec's own
+   instrumentation shows ~1.3M fallthroughs vs 330K rough refractions) moved R=0.1 only
+   **0.815 → 0.823**. The transmission throughput is simply not where the energy leaks.
+
+## Corrected root cause (the real lead for the next attempt)
+
+The decisive datum: at R=0.1 the **GPU spectral closure-graph path is already
+energy-conserving (0.956)** while the **CPU bespoke RGB `disney_sample` is 0.823**.
+The closure path uses `makeDielectricTransmissionClosure` (a proper energy-conserving
+microfacet dielectric); the CPU RGB Disney glass is a hand-rolled VNDF-rough +
+smooth-delta **hybrid** whose fallthrough/threshold handling at low alpha loses ~13%
+that the closure formulation does not.
+
+**So pkg118 is not a multi-scatter-table problem — it is a CPU-RGB-path formulation
+problem.** The fix is to make the CPU rough Disney glass match the energy behaviour of
+the GPU closure path (or route disney glass through the same dielectric closure on
+CPU), not to bolt a compensation table onto a leaky hybrid. The leak must be localized
+with per-event energy instrumentation (rough-reflect / rough-refract / delta-reflect /
+delta-refract / fallthrough), comparing each event's expected vs realized throughput
+against the closure path.
+
+## Recommendation
+
+- Keep Part A (correct).
+- Re-scope pkg118 around the CPU-RGB-vs-closure-path divergence; the Kulla-Conty table
+  is removed from scope. Keep the `test_disney_rough_glass_furnace_energy_cpu` xfail.
+- Only `disney` rough glass is affected; the prism / glass-sphere / dielectric-furnace
+  scenes use the separate `dielectric` plugin and are untouched by any of this.

--- a/.astroray_plan/packages/pkg118-rough-dielectric-multiscatter-energy.md
+++ b/.astroray_plan/packages/pkg118-rough-dielectric-multiscatter-energy.md
@@ -3,7 +3,16 @@
 **Pillar:** 2 (materials / BSDF correctness)
 **Track:** A (CPU-gated; furnace test runs on CI — no GPU needed)
 **Codex-paste-ready:** no (numerical precompute + furnace verification)
-**Status:** open — proposed 2026-05-31. Root cause fully diagnosed (this spec).
+**Status:** open — RE-SCOPED 2026-06-08. Part A (forced-TIR pdf) landed (correct,
+gate-neutral). **Part B (Kulla-Conty compensation table) REJECTED — the diagnosis
+below is incomplete:** the furnace deficit is worst at LOW roughness (not single-scatter
+masking), and compensating the rough-transmission lobe AND the rough→delta fallthrough
+moves R=0.1 only 0.815→0.823. The real defect is the **CPU bespoke RGB `disney_sample`
+diverging from the energy-conserving GPU spectral closure path** (GPU furnace R=0.1 =
+0.956 vs CPU 0.823). Re-scope: match the CPU rough Disney glass to the closure-path
+dielectric formulation, NOT a compensation table. Full analysis:
+[`pkg118-multiscatter-energy-research.md`](../docs/pkg118-multiscatter-energy-research.md).
+Keep the `test_disney_rough_glass_furnace_energy_cpu` xfail.
 **Depends on:** none. Extends the existing `DisneyEnergyCompensationTables` (pkg60).
 **Estimated effort:** M (a precompute pass + apply + furnace re-gate)
 

--- a/include/astroray/gpu_materials.h
+++ b/include/astroray/gpu_materials.h
@@ -742,7 +742,10 @@ __device__ inline GBSDFSample gpu_disney_sample(
         if (cannotRef || curand_uniform(rng) < fresnel) {
             s.wi  = n * (2.f * wo.dot(n)) - wo;
             s.f   = GVec3(1.f);
-            s.pdf = fresnel * mat.transmission;
+            // pkg118 Part A: forced-TIR reflection is deterministic (selection prob 1),
+            // so pdf = transmission (not fresnel*transmission). PBRT-v4 §9.5. Mirrors CPU
+            // disney.cpp forced-TIR fix; keeps the bespoke RGB GPU path in lockstep.
+            s.pdf = cannotRef ? mat.transmission : (fresnel * mat.transmission);
         } else {
             GVec3 perp = (wo - n*cosTheta) * (-eta);
             GVec3 para = n * (-sqrtf(fabsf(1.f - perp.length2())));

--- a/plugins/materials/disney.cpp
+++ b/plugins/materials/disney.cpp
@@ -462,7 +462,13 @@ public:
             if (cannotRefract || dist(gen) < fresnel) {
                 s.wi = n * (2 * wo.dot(n)) - wo;
                 s.f = Vec3(1);
-                s.pdf = fresnel * transmission_;
+                // pkg118 Part A: a forced-TIR reflection is deterministic (selection
+                // probability 1), so pdf = transmission_; only a Fresnel-roulette-selected
+                // reflection keeps the `fresnel` factor. PBRT-v4 §9.5 DielectricBxDF::Sample_f:
+                // reflection pdf = pr/(pr+pt); for TIR pt=0 => pdf=1. The old
+                // `fresnel * transmission_` over-counted forced-TIR throughput by ~1/fresnel
+                // (~21x firefly that masked the single-scatter masking loss).
+                s.pdf = (cannotRefract ? transmission_ : fresnel * transmission_);
             } else {
                 Vec3 perp = (wo - n * cosTheta) * (-eta);
                 Vec3 para = n * (-std::sqrt(std::abs(1 - perp.length2())));


### PR DESCRIPTION
## Part A (correct, kept)
The forced-TIR delta-reflect branch in `disney.cpp::sample()` and the GPU `gpu_disney_sample` mirror set `pdf = fresnel * transmission_`. When `cannotRefract` (TIR) forces the reflection its selection probability is 1, so `pdf = transmission_`; only a Fresnel-roulette-selected reflection keeps the `fresnel` factor. Just past the critical angle Schlick `fresnel`≈0.04–0.07 while true F→1, so the old pdf over-counted forced-TIR throughput by ~1/fresnel (~14–24× firefly). **Cite:** PBRT-v4 §9.5 `DielectricBxDF` (pdf = pr/(pr+pt); TIR ⇒ pt=0 ⇒ 1).

## Root-cause finding (re-scopes the spec)
The spec's **Part B (Kulla-Conty compensation table) is a dead-end**:
- The furnace deficit is worst at **low** roughness (R=0.05→0.77) — the opposite of single-scatter masking.
- Compensating the rough-transmission lobe **and** the rough→delta fallthrough moved R=0.1 only **0.815→0.823** — the transmission throughput is not where the energy leaks.
- Decisive datum: the **GPU spectral closure-graph path is already energy-conserving** (R=0.1 = 0.956) while the **CPU bespoke RGB `disney_sample` is 0.823**. The real defect is the CPU hybrid (VNDF-rough + smooth-delta) diverging from the closure-path dielectric. Re-scope: match CPU to the closure formulation, not a table.

Full analysis: `.astroray_plan/docs/pkg118-multiscatter-energy-research.md`. Spec status re-scoped; `test_disney_rough_glass_furnace_energy_cpu` xfail intentionally kept.

## Verification
Local (RTX): `8 passed, 1 xfailed` across `test_disney_rough_glass_furnace.py`, `test_disney_reflection_not_black.py`, `test_dielectric_glass_furnace.py`. Gate-neutral (Part A removes fireflies, not centre-patch energy). Only `disney` rough glass is touched; prism/glass-sphere/dielectric scenes use the separate `dielectric` plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)