### PR TITLE
docs(pkg118): precise localization of the rough-glass furnace leak

### DIFF
--- a/.astroray_plan/docs/pkg118-multiscatter-energy-research.md
+++ b/.astroray_plan/docs/pkg118-multiscatter-energy-research.md
@@ -78,3 +78,45 @@ against the closure path.
   is removed from scope. Keep the `test_disney_rough_glass_furnace_energy_cpu` xfail.
 - Only `disney` rough glass is affected; the prism / glass-sphere / dielectric-furnace
   scenes use the separate `dielectric` plugin and are untouched by any of this.
+
+## PRECISE LOCALIZATION (2026-06-08, instrumented — the actionable lead)
+
+Added DISNEY_DBG per-event instrumentation to `disney.cpp::sample()` (gated by env
+`DISNEY_DBG`, near-zero cost off) + `scripts/diag_disney_dbg.py` (single-roughness
+furnace + depth sweep). Findings at R=0.05 (furnace 0.771, ior 1.5, 256 spp):
+
+```
+rough_refl  count=359       avg_tp=0.19
+rough_refr  count=330210    avg_tp=0.50
+delta_refl  count=581425    avg_tp=2.24
+delta_refr  count=719513    avg_tp=1.81
+fallthrough count=1300938                 (= delta_refl + delta_refr)
+```
+
+1. **Not truncation.** Depth sweep R=0.05: furnace = 0.749 / 0.759 / 0.755 / 0.768 at
+   depth 4 / 16 / 64 / 256. The loss saturates by depth ~4 — a genuine per-bounce leak,
+   not rays trapped inside the sphere.
+2. **alpha is CLAMPED at 0.0064 for R≤0.08** (`alpha = max(R², 0.0064)`), so the rough
+   microfacets at R=0.05 are *near-flat* — yet the rough path furnaces 0.77 while the
+   smooth-delta path (R=0.03) furnaces 0.97. So the rough VNDF path itself leaks ~20% vs
+   the delta path at essentially-identical (near-flat) microfacet geometry.
+3. **The leak is the rough→delta fallthrough mis-weighting.** 80% of rough samples fall
+   through (1.3M of 1.63M). The dominant fallthrough trigger is the **rough-reflection
+   side-check** (`disney.cpp` `if (s.wi.dot(rec.normal) * wo.dot(rec.normal) > 0)`): on
+   the curved sphere, grazing/TIR microfacet reflections land *below* the macro surface,
+   the check rejects them, and they fall through to the **macro-delta path** (geometric-
+   normal reflection with `pdf = fresnel·transmission`). That macro-delta is sampled
+   AFTER the VNDF + R/(R+T) randoms were already drawn, so its pdf does not account for
+   the VNDF sampling that preceded it → energy mis-weighted (the delta avg_tp 1.8–2.2
+   are η²-amplified exit events whose contribution does not balance the entering side).
+
+**The fix (next attempt):** replace the bespoke VNDF-rough + smooth-delta hybrid +
+fallthrough with a clean **PBRT-v4 `DielectricBxDF::Sample_f`** (BSD-3-Clause): sample
+wm via VNDF, `pr=F, pt=1−F`, reflect or transmit *within the microfacet framework* with
+matching `f` and `pdf` (`f_reflect = D·F·G/(4|cosO||cosI|)`, `pdf_reflect =
+VNDF·pr/(4|wo·wm|)`; transmit via the existing `roughTransmissionEval/Pdf` scaled by
+`pt`). NO macro-delta fallthrough for rough glass — invalid micro-samples return f=0
+(unbiased VNDF). Validate: furnace ∈[0.95,1.02] for R∈{0.1,0.3,0.6,1.0} AND no
+regression to `test_glass_sphere_caustic`, the prism gates, and the disney-sweep SSIM
+(disney glass is in that scene). The GPU `gpu_disney_sample` mirror must be updated in
+lockstep. Mirror Cycles `bsdf_microfacet.h` (Apache-2.0) for cross-check.

--- a/scripts/diag_disney_dbg.py
+++ b/scripts/diag_disney_dbg.py
@@ -1,0 +1,31 @@
+"""pkg118: single-roughness CPU disney-glass furnace + depth sweep.
+
+  python scripts/diag_disney_dbg.py 0.05            # one roughness, depth 32
+  python scripts/diag_disney_dbg.py 0.05 4,16,64    # depth sweep (truncation test)
+
+The per-event DISNEY_DBG instrumentation used to localize the leak (rough_refl /
+rough_refr / delta_refl / delta_refr counts + avg throughput + fallthrough count) is
+described in .astroray_plan/docs/pkg118-multiscatter-energy-research.md ("PRECISE
+LOCALIZATION"). Re-add it to disney.cpp::sample() for the next fix attempt.
+"""
+import sys
+import numpy as np
+
+sys.path.insert(0, "tests")
+from runtime_setup import configure_test_imports  # noqa: E402
+configure_test_imports()
+import astroray  # noqa: E402
+
+R = float(sys.argv[1]) if len(sys.argv) > 1 else 0.05
+depths = [int(x) for x in sys.argv[2].split(",")] if len(sys.argv) > 2 else [32]
+for depth in depths:
+    r = astroray.Renderer()
+    r.set_background_color([1.0, 1.0, 1.0])
+    g = r.create_material("disney", [1.0, 1.0, 1.0],
+                          {"transmission": 1.0, "ior": 1.5, "roughness": R, "metallic": 0.0})
+    r.add_sphere([0.0, 0.0, 0.0], 1.0, g)
+    r.set_integrator("path_tracer")
+    r.setup_camera([0, 0, 4], [0, 0, 0], [0, 1, 0], 40.0, 1.0, 0.0, 4.0, 80, 80)
+    r.set_seed(7)
+    img = np.asarray(r.render(256, depth, None, True), dtype=np.float32).reshape(80, 80, 3)
+    print("R=%.3f depth=%-4d furnace=%.4f" % (R, depth, float(img[28:52, 28:52].mean())))


### PR DESCRIPTION
Instrumented diagnosis (DISNEY_DBG per-event + depth sweep) localized the rough-glass furnace deficit precisely — a real advance over the rejected multi-scatter framing.

**Findings (R=0.05, furnace 0.771):**
- **Not truncation** — furnace ~0.75–0.77 across depth 4→256 (per-bounce leak, saturates by depth ~4).
- **α is clamped at 0.0064 for R≤0.08**, so R=0.05 microfacets are near-flat, yet the rough path furnaces 0.77 vs the smooth-delta path's 0.97.
- **The leak is the rough→delta fallthrough mis-weighting**: 80% of rough samples fall through (grazing/TIR microfacet reflections rejected by the side-check) to the macro-delta path, whose pdf doesn't account for the VNDF + R/(R+T) randoms already drawn.

**Fix plan (next attempt):** replace the bespoke VNDF-rough + smooth-delta hybrid + fallthrough with a clean PBRT-v4 `DielectricBxDF::Sample_f` (no macro-delta fallthrough for rough glass). Adds `scripts/diag_disney_dbg.py`. `disney.cpp` unchanged (instrumentation reverted — production stays zero-cost). xfail kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)