### PR TITLE
feat(pkg113): GPU photon store (uniform hash grid) — phase 1 [RTX-verified 4/4]

### DIFF
--- a/.astroray_plan/docs/pkg113-gpu-photon-store-research.md
+++ b/.astroray_plan/docs/pkg113-gpu-photon-store-research.md
@@ -1,0 +1,125 @@
+# pkg113 Phase 1 — GPU photon-store research (uniform spatial hash grid)
+
+Research notes for the GPU port of the photon-map caustic STORE + query
+(pkg113 Phase 1). Satisfies CLAUDE.md §6: paper + license-compatible reference
+impl cited before code; the CUDA cites file:line back to these sources.
+
+## Store decision (already made by owner, not re-litigated here)
+
+`packages/pkg113-gpu-photon-map-caustics.md` Decisions §2 and
+`.astroray_plan/docs/cpu-gpu-parity-status.md` Decisions §2 (owner, 2026-05-30):
+
+> Build the GPU store as a **uniform spatial hash grid** (pbrt SPPM style —
+> far friendlier to GPU parallelism than the CPU balanced kd-tree) and gate on
+> SSIM/energy vs the CPU result. Do **not** port the kd-tree for bit-exact
+> parity.
+
+Phase 1 therefore implements the hash-grid build + a device radius/k-NN query
+that mirrors the **density-estimate semantics** of the CPU
+`photon_map.h::estimateIrradiance` (Jensen 2000 §3.1 Eq. 8) — NOT bit-exact
+kd-tree parity. The hash grid returns the *same neighbor set within a fixed
+radius* as a brute-force radius search, so a radius query is exactly verifiable
+against a numpy oracle; the irradiance estimate then matches the CPU disk-area
+density factor within float tolerance.
+
+## Papers
+
+- **Jensen, "Global Illumination using Photon Maps", EGWR 1996**, DOI
+  `10.1007/978-3-7091-7484-5_3` — the photon map: diffuse-surface deposition +
+  k-NN density-estimate radiance.
+- **Jensen, "A Practical Guide to Global Illumination using Photon Maps",
+  SIGGRAPH 2000 Course 8**, §3.1 Eq. 8 (radiance/irradiance estimate). The CPU
+  `photon_map.h` mirrors this; the GPU store reproduces the same Eq. 8 estimate
+  over the radius-gathered neighbor set.
+
+## Reference implementation (license-clean)
+
+- **pbrt-v3** `src/integrators/sppm.cpp` (SPDX **BSD-2-Clause**, MIT-compatible).
+  The canonical uniform spatial-hash-grid build for SPPM. We mirror three
+  functions verbatim (math identical; adapted to GVec3 / device code):
+
+  - **`ToGrid`** — map a world point inside the grid AABB to integer grid
+    coords:
+    ```cpp
+    static bool ToGrid(const Point3f &p, const Bounds3f &bounds,
+                       const int gridRes[3], Point3i *pi) {
+        bool inBounds = true;
+        Vector3f pg = bounds.Offset(p);               // (p-min)/(max-min)
+        for (int i = 0; i < 3; ++i) {
+            (*pi)[i] = (int)(gridRes[i] * pg[i]);
+            inBounds &= ((*pi)[i] >= 0 && (*pi)[i] < gridRes[i]);
+            (*pi)[i] = Clamp((*pi)[i], 0, gridRes[i] - 1);
+        }
+        return inBounds;
+    }
+    ```
+  - **`hash`** — integer grid coords → bucket index, with the three large
+    primes (Teschner et al. 2003 "Optimized Spatial Hashing", reused by pbrt):
+    ```cpp
+    inline unsigned int hash(const Point3i &p, int hashSize) {
+        return (unsigned int)((p.x * 73856093) ^ (p.y * 19349663) ^
+                              (p.z * 83492791)) % hashSize;
+    }
+    ```
+    Primes: **73856093, 19349663, 83492791**.
+  - **grid resolution** from the AABB diagonal and the search radius:
+    ```cpp
+    Vector3f diag = gridBounds.Diagonal();
+    Float maxDiag = MaxComponent(diag);
+    int baseGridRes = (int)(maxDiag / maxRadius);
+    for (int i = 0; i < 3; ++i)
+        gridRes[i] = max((int)(baseGridRes * diag[i] / maxDiag), 1);
+    ```
+
+  We DROP pbrt's progressive radius reduction (γ / rNew = r√…) and per-pixel
+  visible points — Phase 1 is a fixed-radius single-pass store (same
+  non-progressive simplification the CPU chain already takes; pkg109 research
+  note §"Reference implementation"). pbrt stores *visible points* in the grid
+  and shoots photons against them; we store *photons* in the grid and query at
+  receiver points — the data structure and hash are identical, only the roles of
+  "stored" vs "queried" swap. That is the standard photon-map↔SPPM duality.
+
+## Density estimate (mirrors CPU `photon_map.h`)
+
+Within a fixed radius `r`, the Jensen 2000 §3.1 Eq. 8 irradiance estimate is
+
+    E(x) = (1 / (π r²)) · Σ_{p : |x−x_p| < r} ΔΦ_p
+
+The CPU `estimateIrradiance` additionally applies the §3.2.1 cone filter using
+the k-th nearest distance as `r`. For the **Phase-1 parity harness** we compare
+the simpler fixed-radius density (no cone filter) on both sides so the oracle is
+unambiguous; the cone-filtered/k-NN form is a Phase-2/3 concern (it needs the
+emission pipeline to produce realistic photon distributions anyway). The device
+query returns BOTH:
+  1. the neighbor index set within `radius` (exact set-match vs numpy oracle),
+  2. the fixed-radius irradiance estimate `E` (float-tolerance vs numpy oracle).
+
+## Astroray reuse points (audited)
+
+| What | Where | Note |
+|---|---|---|
+| `GVec3` device vec3 | `include/astroray/gpu_types.h:20` | photon position / query point |
+| `XYZ` CPU struct | `include/astroray/spectrum.h:29` | photon power on host side |
+| host→device upload helper pattern | `src/gpu/scene_upload.cu:39` | `cudaMalloc`+`cudaMemcpy` |
+| `CUDA_CHECK` macro | `src/gpu/scene_upload.cu:26` | error wrapping |
+| host-callable CUDA fn → pybind | `src/gpu/wavefront/gpu_wavefront_snapshot.{h,cu}` + `module/blender_module.cpp:3257` | the exact binding pattern Phase-1 mirrors |
+| GPU test skip pattern | `tests/test_pkg64_gpu_cpu_parity.py:41-46` | skip when `__features__["cuda"]` false |
+| CPU kd-tree oracle test | `tests/test_photon_map.py` | numpy float64 brute-force pattern to mirror |
+
+## Phase-1 deliverables (scope guard)
+
+STORE + query only. NOT emission/bounce (Phase 2), NOT integrator gather wiring
+(Phase 3). A single new `.cu` (`src/gpu/photon_store.cu`) + its header
+(`include/astroray/gpu_photon_store.h`) + a pybind test binding
+(`_gpu_photon_store_query`) + a CUDA-gated unit test
+(`tests/test_gpu_photon_store.py`).
+
+## Integration risks (carried forward to the parent build/verify)
+
+- **CI has no GPU** (memory `ci_has_no_gpu_runtime_blindspot`): the unit test
+  skips on CI; correctness must be RTX-`/verify`-ed.
+- **Stale .pyd** (memory `stale_pyd_locations`): rebuild + check
+  `astroray.__file__` before trusting the test.
+- The CUDA frontend syntax-check CI job (`cuda-syntax-check`) compiles every
+  `.cu` via `nvcc -c`; it will catch frontend errors at PR time but is a
+  backstop — parent must run the full local CUDA build.

--- a/.astroray_plan/packages/pkg113-gpu-photon-map-caustics.md
+++ b/.astroray_plan/packages/pkg113-gpu-photon-map-caustics.md
@@ -2,9 +2,11 @@
 
 **Pillar:** 3 (light transport) + 5 (GPU)
 **Track:** A
-**Status:** open — proposed 2026-05-30 (the GPU-equivalence follow-up for the
-general-caustics chain pkg109/110/111). **GPU-gated: do NOT pick up in a CI-only
-run — correctness must be RTX-`/verify`-ed; CI has no GPU and CI-green ≠ correct.**
+**Status:** Phase 1 in progress (PR #TBD, 2026-06-08 — GPU uniform spatial
+hash-grid photon STORE + device fixed-radius query landed; CUDA-gated unit test
+vs numpy brute-force oracle. Phases 2 (emission/bounce) + 3 (integrator gather +
+acceptance gates) remain). **GPU-gated: do NOT pick up in a CI-only run —
+correctness must be RTX-`/verify`-ed; CI has no GPU and CI-green ≠ correct.**
 **Estimated effort:** L (~3–4 weeks, multiple RTX sessions)
 **Depends on:** pkg109 (photon-map kd-tree, done), pkg110 (BSDF photon bounce, done),
 **pkg111** (CPU k-NN gather into the default path — do FIRST). The caustics-fork is

--- a/.astroray_plan/packages/pkg113-gpu-photon-map-caustics.md
+++ b/.astroray_plan/packages/pkg113-gpu-photon-map-caustics.md
@@ -2,10 +2,12 @@
 
 **Pillar:** 3 (light transport) + 5 (GPU)
 **Track:** A
-**Status:** Phase 1 in progress (PR #TBD, 2026-06-08 — GPU uniform spatial
-hash-grid photon STORE + device fixed-radius query landed; CUDA-gated unit test
-vs numpy brute-force oracle. Phases 2 (emission/bounce) + 3 (integrator gather +
-acceptance gates) remain). **GPU-gated: do NOT pick up in a CI-only run —
+**Status:** **Phase 1 DONE** (2026-06-08 — GPU uniform spatial hash-grid photon
+STORE + device fixed-radius query; CUDA-gated unit test vs numpy brute-force oracle
+**4/4 PASS verified on RTX**: neighbor-set match, Jensen Eq.8 irradiance rel-err
+<1e-3, areal-density convergence, empty-region dark). Phases 2 (GPU emission/bounce
+→ deposit into this store) + 3 (integrator gather wiring + SSIM/energy acceptance
+gates vs the CPU photon map) remain. **GPU-gated: do NOT pick up in a CI-only run —
 correctness must be RTX-`/verify`-ed; CI has no GPU and CI-green ≠ correct.**
 **Estimated effort:** L (~3–4 weeks, multiple RTX sessions)
 **Depends on:** pkg109 (photon-map kd-tree, done), pkg110 (BSDF photon bounce, done),

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -472,6 +472,7 @@ if(ASTRORAY_CUDA_FOUND)
         src/gpu/multiwavelength_kernel.cu
         src/gpu/scene_upload.cu
         src/gpu/pkg64_sms_probe.cu
+        src/gpu/photon_store.cu
     )
     if(ASTRORAY_WAVEFRONT_CUDA_N3)
         list(APPEND ASTRORAY_CUDA_SOURCES

--- a/include/astroray/gpu_photon_store.h
+++ b/include/astroray/gpu_photon_store.h
@@ -1,0 +1,212 @@
+#pragma once
+// pkg113 Phase 1 — GPU photon STORE + query (uniform spatial hash grid).
+//
+// The GPU counterpart of the CPU world-space photon store in
+// include/astroray/photon/photon_map.h. Phase 1 implements STORAGE + QUERY only
+// (NOT GPU emission/bounce — Phase 2 — NOT integrator gather wiring — Phase 3).
+//
+// Store decision (owner 2026-05-30; packages/pkg113-gpu-photon-map-caustics.md
+// Decisions §2, cpu-gpu-parity-status.md Decisions §2): a **uniform spatial hash
+// grid** (pbrt SPPM style), NOT a CUDA kd-tree. The hash grid is far friendlier
+// to GPU parallelism than the CPU balanced kd-tree, and the photon-map gate is
+// SSIM/energy parity (stochastic), not bit-exact.
+//
+// Citations (CLAUDE.md §6; see .astroray_plan/docs/pkg113-gpu-photon-store-research.md):
+//   Jensen, "A Practical Guide to Global Illumination using Photon Maps",
+//     SIGGRAPH 2000 Course 8 — §3.1 Eq. 8 irradiance density estimate.
+//   pbrt-v3 src/integrators/sppm.cpp (BSD-2-Clause) — ToGrid / hash /
+//     gridRes-from-diagonal; we mirror the hash-grid build math verbatim and
+//     drop the progressive radius reduction (fixed radius, single pass — the
+//     same non-progressive simplification the CPU chain already takes).
+//   Teschner et al. 2003, "Optimized Spatial Hashing for Collision Detection of
+//     Deformable Objects" — the three large primes used by pbrt's hash().
+//
+// This header is included by both .cu files (nvcc) and pure C++ translation
+// units (the pybind binding in blender_module.cpp). The device-side query is in
+// an `#ifdef __CUDACC__` block so the kernel-callable helpers only compile under
+// nvcc; the host-callable build/query entry point is declared unconditionally.
+
+#include "astroray/gpu_types.h"   // GVec3, GAABB
+
+#include <cstdint>
+#include <vector>
+
+namespace astroray {
+namespace photon {
+namespace gpu {
+
+// Device photon record. Mirrors astroray::photon::Photon (photon_map.h:39):
+// world-space position, CIE-weighted flux (power), incoming direction, and the
+// sampled wavelength. 44 bytes; POD so it cudaMemcpy's directly.
+struct GPhoton {
+    GVec3 position;      // world-space deposit point
+    GVec3 power;         // CIE-weighted flux (XYZ packed into GVec3.x/y/z)
+    GVec3 incidentDir;   // unit dir the photon arrived along (Phase-2 BSDF eval)
+    float lambda;        // sampled wavelength (nm) — diagnostics
+};
+
+// Device-resident uniform hash grid over the uploaded photons. Built by
+// buildPhotonGrid (host launches the build); read by the device query helpers.
+// The grid stores photon INDICES bucketed by a CSR layout so a query touches
+// only the photons in the 3x3x3 cell neighborhood of the query point.
+//
+// Layout (all device pointers):
+//   cellStart[h], cellCount[h]  — CSR offsets into photonIndex[] for bucket h
+//   photonIndex[]               — photon indices grouped by bucket
+//   photonCellId[]              — the flattened cell id of each photonIndex[]
+//                                 entry, parallel to it (see the de-dup note in
+//                                 photonGridGather)
+//   photons[]                   — the uploaded GPhoton array
+struct GPhotonGrid {
+    const GPhoton* photons;       // device ptr, numPhotons entries
+    const int*     cellStart;     // device ptr, hashSize entries
+    const int*     cellCount;     // device ptr, hashSize entries
+    const int*     photonIndex;   // device ptr, numPhotons entries
+    const int*     photonCellId;  // device ptr, numPhotons entries (parallel)
+    GAABB          bounds;        // grid AABB (photon extent, padded by radius)
+    int            gridRes[3];    // per-axis cell counts
+    int            hashSize;      // number of hash buckets
+    int            numPhotons;
+    float          radius;        // fixed gather radius the grid was built for
+};
+
+// Flatten a 3-int grid cell to a single id, used to disambiguate hash
+// collisions in the gather (two distinct cells can hash to the same bucket).
+#ifdef __CUDACC__
+__host__ __device__
+#endif
+inline int photonCellFlatten(int cx, int cy, int cz, const int gridRes[3]) {
+    return (cz * gridRes[1] + cy) * gridRes[0] + cx;
+}
+
+// ---------------------------------------------------------------------------
+// pbrt-v3 sppm.cpp hash-grid math (host+device). The host build and the device
+// query MUST agree bit-for-bit on bucket assignment, so these are shared
+// inline helpers in gpu_types.h-style HD form.
+// ---------------------------------------------------------------------------
+#ifdef __CUDACC__
+#  define APH_HD __host__ __device__
+#else
+#  define APH_HD
+#endif
+
+// pbrt-v3 sppm.cpp ToGrid(): world point -> integer grid cell (clamped to the
+// grid). Returns false (and still clamps) when p is outside the grid AABB.
+APH_HD inline bool photonToGrid(const GVec3& p, const GAABB& b,
+                                const int gridRes[3], int outCell[3]) {
+    bool inBounds = true;
+    GVec3 ext = b.max - b.min;
+    for (int i = 0; i < 3; ++i) {
+        float e = ext[i];
+        float pg = (e > 0.f) ? (p[i] - b.min[i]) / e : 0.f;  // Bounds3::Offset
+        int c = static_cast<int>(gridRes[i] * pg);
+        inBounds = inBounds && (c >= 0 && c < gridRes[i]);
+        if (c < 0) c = 0;
+        if (c > gridRes[i] - 1) c = gridRes[i] - 1;
+        outCell[i] = c;
+    }
+    return inBounds;
+}
+
+// pbrt-v3 sppm.cpp hash(): integer grid cell -> bucket index. Primes from
+// Teschner 2003 (the same constants pbrt uses). The (unsigned) cast + %hashSize
+// matches pbrt; negative coords cannot occur after photonToGrid clamps to
+// [0, gridRes-1].
+APH_HD inline unsigned int photonHash(int x, int y, int z, int hashSize) {
+    return static_cast<unsigned int>(
+               (x * 73856093) ^ (y * 19349663) ^ (z * 83492791)) %
+           static_cast<unsigned int>(hashSize);
+}
+
+#ifdef __CUDACC__
+// Device-side fixed-radius gather, callable from any kernel. Iterates the
+// 3x3x3 cell neighborhood of q, accumulates the Jensen 2000 §3.1 Eq. 8
+// fixed-radius irradiance estimate E = (1/(pi r^2)) * sum power, and optionally
+// records the in-radius photon indices (up to maxOut) so a parity harness can
+// assert the exact neighbor set. Returns the number of photons within radius.
+//
+// outIdx may be nullptr (estimate-only). foundCount is the true in-radius count
+// (may exceed maxOut; outIdx is then truncated, but E uses all of them).
+__device__ inline int photonGridGather(const GPhotonGrid& g, const GVec3& q,
+                                        GVec3& outE,
+                                        int* outIdx, int maxOut,
+                                        int& foundCount) {
+    outE = GVec3(0.f);
+    foundCount = 0;
+    int written = 0;
+    const float r2 = g.radius * g.radius;
+    int base[3];
+    photonToGrid(q, g.bounds, g.gridRes, base);
+    for (int dz = -1; dz <= 1; ++dz)
+    for (int dy = -1; dy <= 1; ++dy)
+    for (int dx = -1; dx <= 1; ++dx) {
+        int cx = base[0] + dx, cy = base[1] + dy, cz = base[2] + dz;
+        if (cx < 0 || cy < 0 || cz < 0 ||
+            cx >= g.gridRes[0] || cy >= g.gridRes[1] || cz >= g.gridRes[2])
+            continue;
+        // Hash collisions: two distinct cells can map to the same bucket, and
+        // the 27-cell sweep can visit two such cells. Gate each photon on its
+        // OWN flattened cell id matching the cell we are currently visiting —
+        // this both rejects collided foreign photons AND guarantees a photon is
+        // counted at most once (it is only accepted when we visit its true
+        // cell, and each of the 27 cells is visited exactly once).
+        int wantCell = photonCellFlatten(cx, cy, cz, g.gridRes);
+        unsigned int h = photonHash(cx, cy, cz, g.hashSize);
+        int start = g.cellStart[h];
+        int count = g.cellCount[h];
+        for (int s = 0; s < count; ++s) {
+            if (g.photonCellId[start + s] != wantCell) continue;
+            int pi = g.photonIndex[start + s];
+            const GPhoton& ph = g.photons[pi];
+            GVec3 d = ph.position - q;
+            if (d.length2() >= r2) continue;
+            foundCount++;
+            outE += ph.power;
+            if (outIdx && written < maxOut) outIdx[written++] = pi;
+        }
+    }
+    // Jensen 2000 §3.1 Eq. 8 disk-area density factor (fixed radius, no cone
+    // filter for the Phase-1 parity harness; matches the numpy oracle exactly).
+    if (g.radius > 0.f) {
+        float norm = 3.14159265358979323846f * r2;
+        outE = outE / norm;
+    }
+    return written;
+}
+#endif  // __CUDACC__
+
+#undef APH_HD
+
+// ---------------------------------------------------------------------------
+// Host-callable Phase-1 parity entry point (defined in src/gpu/photon_store.cu).
+// Mirrors the cuda_wavefront_snapshot_* host-callable pattern
+// (src/gpu/wavefront/gpu_wavefront_snapshot.h) so the pybind binding in
+// blender_module.cpp can reach it under #ifdef ASTRORAY_CUDA_ENABLED.
+//
+// Uploads `photons`, builds the hash grid on the GPU for `radius`, runs a
+// fixed-radius gather at each query point, and downloads the per-query density
+// estimate + in-radius neighbor index sets. Used ONLY by
+// tests/test_gpu_photon_store.py to gate the store against a numpy oracle.
+// ---------------------------------------------------------------------------
+
+// One query result. neighborIdx holds the in-radius photon indices (sorted
+// ascending by the host so the test can set-compare against numpy), foundCount
+// is the true in-radius count (== neighborIdx.size() unless truncated).
+struct PhotonStoreQueryResult {
+    GVec3            irradiance;   // Jensen Eq. 8 fixed-radius estimate
+    std::vector<int> neighborIdx; // in-radius photon indices, sorted ascending
+    int              foundCount;
+};
+
+// Build the grid on the GPU and gather at each query point. radius is the fixed
+// gather radius; maxNeighborsPerQuery caps the index readback per query (the
+// estimate always uses ALL in-radius photons). Returns one result per query.
+std::vector<PhotonStoreQueryResult> cuda_photon_store_query(
+    const std::vector<GPhoton>& photons,
+    const std::vector<GVec3>&   queries,
+    float                       radius,
+    int                         maxNeighborsPerQuery);
+
+}  // namespace gpu
+}  // namespace photon
+}  // namespace astroray

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -44,6 +44,7 @@
 #include "astroray/lights/area_light.h"
 #ifdef ASTRORAY_CUDA_ENABLED
 #  include "astroray/gpu_renderer.h"
+#  include "astroray/gpu_photon_store.h"   // pkg113 Phase 1 — GPU photon store query
 #  ifdef ASTRORAY_WAVEFRONT_CUDA_N3
 #    include "../src/gpu/wavefront/gpu_wavefront_snapshot.h"
 #  endif
@@ -2451,6 +2452,57 @@ PYBIND11_MODULE(astroray, m) {
               return py::make_tuple(E.X, E.Y, E.Z);
           },
           "points"_a, "powers"_a, "query"_a, "k"_a, "max_radius"_a);
+
+#ifdef ASTRORAY_CUDA_ENABLED
+    // pkg113 Phase 1 — GPU photon STORE + query parity binding. Builds the
+    // uniform spatial hash grid on the GPU from a fixed photon set, runs a
+    // fixed-radius gather at each query point, and returns the per-query
+    // (irradiance estimate, in-radius neighbor index set, in-radius count).
+    // Validated against a numpy float64 brute-force oracle in
+    // tests/test_gpu_photon_store.py (mirrors tests/test_photon_map.py for the
+    // CPU kd-tree). STORE+QUERY only — no emission/bounce, no integrator wiring.
+    m.def("_gpu_photon_store_query",
+          [](const std::vector<std::array<float, 3>>& pts,
+             const std::vector<std::array<float, 3>>& powers,
+             const std::vector<std::array<float, 3>>& queries,
+             float radius, int max_neighbors) {
+              namespace pg = astroray::photon::gpu;
+              std::vector<pg::GPhoton> photons;
+              photons.reserve(pts.size());
+              for (std::size_t i = 0; i < pts.size(); ++i) {
+                  pg::GPhoton ph;
+                  ph.position = GVec3(pts[i][0], pts[i][1], pts[i][2]);
+                  if (i < powers.size())
+                      ph.power = GVec3(powers[i][0], powers[i][1], powers[i][2]);
+                  else
+                      ph.power = GVec3(0.f);
+                  ph.incidentDir = GVec3(0.f);
+                  ph.lambda = 0.f;
+                  photons.push_back(ph);
+              }
+              std::vector<GVec3> qs;
+              qs.reserve(queries.size());
+              for (const auto& q : queries) qs.push_back(GVec3(q[0], q[1], q[2]));
+
+              auto res = pg::cuda_photon_store_query(photons, qs, radius,
+                                                     max_neighbors);
+              // Return one tuple per query:
+              //   (irradiance[3], neighbor_indices[list], found_count)
+              py::list out;
+              for (const auto& r : res) {
+                  py::list idx;
+                  for (int v : r.neighborIdx) idx.append(v);
+                  out.append(py::make_tuple(
+                      py::make_tuple(r.irradiance.x, r.irradiance.y, r.irradiance.z),
+                      idx, r.foundCount));
+              }
+              return out;
+          },
+          "points"_a, "powers"_a, "queries"_a, "radius"_a,
+          "max_neighbors"_a = 256,
+          "pkg113 Phase 1: build the GPU photon hash grid and gather at each "
+          "query. Returns [(irradiance(3), neighbor_indices, found_count), ...].");
+#endif
 
     m.def("synchrotron_thermal_emissivity",
           &astroray::synchrotron::jnuThermalI,

--- a/src/gpu/photon_store.cu
+++ b/src/gpu/photon_store.cu
@@ -1,0 +1,248 @@
+// photon_store.cu — pkg113 Phase 1 — GPU photon STORE + query.
+//
+// Uniform spatial hash grid over photons (pbrt-v3 sppm.cpp, BSD-2-Clause) with a
+// device-side fixed-radius gather (Jensen 2000 §3.1 Eq. 8). STORE + QUERY only —
+// no emission/bounce (Phase 2), no integrator gather wiring (Phase 3).
+//
+// See include/astroray/gpu_photon_store.h for the store decision + citations and
+// .astroray_plan/docs/pkg113-gpu-photon-store-research.md for the reference math.
+//
+// The grid is BUILT ON THE GPU: a counting pass (atomicAdd into per-bucket
+// counts) + a prefix sum (host scan of the small hashSize array) + a scatter
+// pass (atomic cursor per bucket) produce the CSR layout. This mirrors the
+// standard parallel uniform-grid build (pbrt-v4 wavefront SPPM does the same
+// count/scan/scatter); for Phase 1 the prefix scan over the hashSize-length
+// array runs on the host (hashSize ~ numPhotons, trivially small for the
+// parity-harness sizes).
+
+#include "astroray/gpu_photon_store.h"
+#include "astroray/gpu_types.h"
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <stdexcept>
+#include <vector>
+
+#define APH_CUDA_CHECK(call) do {                                           \
+    cudaError_t _e = (call);                                                \
+    if (_e != cudaSuccess) {                                                \
+        std::fprintf(stderr, "CUDA error at %s:%d: %s\n",                  \
+                __FILE__, __LINE__, cudaGetErrorString(_e));                \
+        throw std::runtime_error(cudaGetErrorString(_e));                   \
+    }                                                                       \
+} while(0)
+
+namespace astroray {
+namespace photon {
+namespace gpu {
+
+namespace {
+
+// Counting pass: each photon hashes its cell and atomically bumps the bucket
+// count. pbrt-v3 sppm.cpp does the equivalent under its grid mutex; on the GPU
+// we use atomicAdd (the canonical parallel counting-sort histogram).
+__global__ void kCountPhotons(const GPhoton* photons, int numPhotons,
+                              GAABB bounds, int gridX, int gridY, int gridZ,
+                              int hashSize, int* cellCount) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numPhotons) return;
+    int res[3] = {gridX, gridY, gridZ};
+    int cell[3];
+    photonToGrid(photons[i].position, bounds, res, cell);
+    unsigned int h = photonHash(cell[0], cell[1], cell[2], hashSize);
+    atomicAdd(&cellCount[h], 1);
+}
+
+// Scatter pass: each photon writes its index into photonIndex[] at the bucket's
+// running cursor (cellStart[h] + atomic offset), and the parallel
+// photonCellId[] entry records its flattened cell id (so the gather can reject
+// hash-collided foreign photons). Counting-sort scatter.
+__global__ void kScatterPhotons(const GPhoton* photons, int numPhotons,
+                                GAABB bounds, int gridX, int gridY, int gridZ,
+                                int hashSize, const int* cellStart,
+                                int* cellCursor, int* photonIndex,
+                                int* photonCellId) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numPhotons) return;
+    int res[3] = {gridX, gridY, gridZ};
+    int cell[3];
+    photonToGrid(photons[i].position, bounds, res, cell);
+    unsigned int h = photonHash(cell[0], cell[1], cell[2], hashSize);
+    int slot = atomicAdd(&cellCursor[h], 1);
+    int dst = cellStart[h] + slot;
+    photonIndex[dst] = i;
+    photonCellId[dst] = photonCellFlatten(cell[0], cell[1], cell[2], res);
+}
+
+// Query kernel: one thread per query point. Calls the shared device gather
+// helper (the same code a Phase-3 integrator kernel will call) and writes the
+// density estimate + neighbor indices + count back to global memory.
+__global__ void kQuery(GPhotonGrid grid, const GVec3* queries, int numQueries,
+                       int maxNeighbors, GVec3* outE, int* outIdx,
+                       int* outFound, int* outWritten) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numQueries) return;
+    GVec3 e;
+    int found = 0;
+    int written = photonGridGather(grid, queries[i], e,
+                                   outIdx + (size_t)i * maxNeighbors,
+                                   maxNeighbors, found);
+    outE[i] = e;
+    outFound[i] = found;
+    outWritten[i] = written;
+}
+
+}  // namespace
+
+std::vector<PhotonStoreQueryResult> cuda_photon_store_query(
+    const std::vector<GPhoton>& photons,
+    const std::vector<GVec3>&   queries,
+    float                       radius,
+    int                         maxNeighborsPerQuery) {
+
+    const int n = static_cast<int>(photons.size());
+    const int nq = static_cast<int>(queries.size());
+    std::vector<PhotonStoreQueryResult> results(nq);
+    if (n == 0 || nq == 0 || radius <= 0.f) {
+        for (auto& r : results) { r.irradiance = GVec3(0.f); r.foundCount = 0; }
+        return results;
+    }
+    const int maxOut = std::max(1, maxNeighborsPerQuery);
+
+    // --- Grid AABB: photon extent padded by one radius so the 3x3x3 neighbor
+    // sweep around any query point inside the padded box stays in range. pbrt
+    // pads the visible-point grid bounds by maxRadius the same way. ---
+    GVec3 mn = photons[0].position, mx = photons[0].position;
+    for (int i = 1; i < n; ++i) {
+        mn = gvec3_min(mn, photons[i].position);
+        mx = gvec3_max(mx, photons[i].position);
+    }
+    GVec3 pad(radius);
+    GAABB bounds; bounds.min = mn - pad; bounds.max = mx + pad;
+
+    // --- gridRes from the AABB diagonal and radius (pbrt-v3 sppm.cpp). ---
+    GVec3 diag = bounds.max - bounds.min;
+    float maxDiag = diag.maxComponent();
+    int baseGridRes = std::max(1, static_cast<int>(maxDiag / radius));
+    int gridRes[3];
+    for (int i = 0; i < 3; ++i)
+        gridRes[i] = std::max(static_cast<int>(baseGridRes * diag[i] / maxDiag), 1);
+    const int hashSize = n;  // pbrt uses hashSize = number of items in the grid
+
+    // --- Upload photons + queries. ---
+    GPhoton* d_photons = nullptr;
+    GVec3*   d_queries = nullptr;
+    APH_CUDA_CHECK(cudaMalloc(&d_photons, (size_t)n * sizeof(GPhoton)));
+    APH_CUDA_CHECK(cudaMemcpy(d_photons, photons.data(),
+                              (size_t)n * sizeof(GPhoton), cudaMemcpyHostToDevice));
+    APH_CUDA_CHECK(cudaMalloc(&d_queries, (size_t)nq * sizeof(GVec3)));
+    APH_CUDA_CHECK(cudaMemcpy(d_queries, queries.data(),
+                              (size_t)nq * sizeof(GVec3), cudaMemcpyHostToDevice));
+
+    // --- Grid CSR buffers. ---
+    int* d_cellCount  = nullptr;
+    int* d_cellStart  = nullptr;
+    int* d_cellCursor = nullptr;
+    int* d_photonIndex = nullptr;
+    int* d_photonCellId = nullptr;
+    APH_CUDA_CHECK(cudaMalloc(&d_cellCount,  (size_t)hashSize * sizeof(int)));
+    APH_CUDA_CHECK(cudaMalloc(&d_cellStart,  (size_t)hashSize * sizeof(int)));
+    APH_CUDA_CHECK(cudaMalloc(&d_cellCursor, (size_t)hashSize * sizeof(int)));
+    APH_CUDA_CHECK(cudaMalloc(&d_photonIndex, (size_t)n * sizeof(int)));
+    APH_CUDA_CHECK(cudaMalloc(&d_photonCellId, (size_t)n * sizeof(int)));
+    APH_CUDA_CHECK(cudaMemset(d_cellCount, 0, (size_t)hashSize * sizeof(int)));
+
+    const int TPB = 256;
+    const int photonBlocks = (n + TPB - 1) / TPB;
+
+    // --- Count pass. ---
+    kCountPhotons<<<photonBlocks, TPB>>>(d_photons, n, bounds,
+                                         gridRes[0], gridRes[1], gridRes[2],
+                                         hashSize, d_cellCount);
+    APH_CUDA_CHECK(cudaGetLastError());
+
+    // --- Exclusive prefix sum over the hashSize counts (host scan — hashSize
+    // is tiny for the harness; a device scan is a Phase-3 perf concern). ---
+    std::vector<int> h_count(hashSize);
+    APH_CUDA_CHECK(cudaMemcpy(h_count.data(), d_cellCount,
+                              (size_t)hashSize * sizeof(int), cudaMemcpyDeviceToHost));
+    std::vector<int> h_start(hashSize);
+    int acc = 0;
+    for (int i = 0; i < hashSize; ++i) { h_start[i] = acc; acc += h_count[i]; }
+    APH_CUDA_CHECK(cudaMemcpy(d_cellStart, h_start.data(),
+                              (size_t)hashSize * sizeof(int), cudaMemcpyHostToDevice));
+    APH_CUDA_CHECK(cudaMemset(d_cellCursor, 0, (size_t)hashSize * sizeof(int)));
+
+    // --- Scatter pass. ---
+    kScatterPhotons<<<photonBlocks, TPB>>>(d_photons, n, bounds,
+                                           gridRes[0], gridRes[1], gridRes[2],
+                                           hashSize, d_cellStart, d_cellCursor,
+                                           d_photonIndex, d_photonCellId);
+    APH_CUDA_CHECK(cudaGetLastError());
+
+    // --- Assemble the device grid view + query buffers. ---
+    GPhotonGrid grid;
+    grid.photons      = d_photons;
+    grid.cellStart    = d_cellStart;
+    grid.cellCount    = d_cellCount;
+    grid.photonIndex  = d_photonIndex;
+    grid.photonCellId = d_photonCellId;
+    grid.bounds       = bounds;
+    grid.gridRes[0] = gridRes[0]; grid.gridRes[1] = gridRes[1]; grid.gridRes[2] = gridRes[2];
+    grid.hashSize    = hashSize;
+    grid.numPhotons  = n;
+    grid.radius      = radius;
+
+    GVec3* d_outE = nullptr;
+    int* d_outIdx = nullptr;
+    int* d_outFound = nullptr;
+    int* d_outWritten = nullptr;
+    APH_CUDA_CHECK(cudaMalloc(&d_outE, (size_t)nq * sizeof(GVec3)));
+    APH_CUDA_CHECK(cudaMalloc(&d_outIdx, (size_t)nq * maxOut * sizeof(int)));
+    APH_CUDA_CHECK(cudaMalloc(&d_outFound, (size_t)nq * sizeof(int)));
+    APH_CUDA_CHECK(cudaMalloc(&d_outWritten, (size_t)nq * sizeof(int)));
+
+    const int queryBlocks = (nq + TPB - 1) / TPB;
+    kQuery<<<queryBlocks, TPB>>>(grid, d_queries, nq, maxOut,
+                                 d_outE, d_outIdx, d_outFound, d_outWritten);
+    APH_CUDA_CHECK(cudaGetLastError());
+    APH_CUDA_CHECK(cudaDeviceSynchronize());
+
+    // --- Download results. ---
+    std::vector<GVec3> h_outE(nq);
+    std::vector<int>   h_outIdx((size_t)nq * maxOut);
+    std::vector<int>   h_outFound(nq);
+    std::vector<int>   h_outWritten(nq);
+    APH_CUDA_CHECK(cudaMemcpy(h_outE.data(), d_outE,
+                              (size_t)nq * sizeof(GVec3), cudaMemcpyDeviceToHost));
+    APH_CUDA_CHECK(cudaMemcpy(h_outIdx.data(), d_outIdx,
+                              (size_t)nq * maxOut * sizeof(int), cudaMemcpyDeviceToHost));
+    APH_CUDA_CHECK(cudaMemcpy(h_outFound.data(), d_outFound,
+                              (size_t)nq * sizeof(int), cudaMemcpyDeviceToHost));
+    APH_CUDA_CHECK(cudaMemcpy(h_outWritten.data(), d_outWritten,
+                              (size_t)nq * sizeof(int), cudaMemcpyDeviceToHost));
+
+    for (int i = 0; i < nq; ++i) {
+        PhotonStoreQueryResult& r = results[i];
+        r.irradiance = h_outE[i];
+        r.foundCount = h_outFound[i];
+        int w = h_outWritten[i];
+        r.neighborIdx.assign(h_outIdx.begin() + (size_t)i * maxOut,
+                             h_outIdx.begin() + (size_t)i * maxOut + w);
+        std::sort(r.neighborIdx.begin(), r.neighborIdx.end());
+    }
+
+    // --- Cleanup. ---
+    cudaFree(d_photons); cudaFree(d_queries);
+    cudaFree(d_cellCount); cudaFree(d_cellStart); cudaFree(d_cellCursor);
+    cudaFree(d_photonIndex); cudaFree(d_photonCellId);
+    cudaFree(d_outE); cudaFree(d_outIdx); cudaFree(d_outFound); cudaFree(d_outWritten);
+
+    return results;
+}
+
+}  // namespace gpu
+}  // namespace photon
+}  // namespace astroray

--- a/tests/test_gpu_photon_store.py
+++ b/tests/test_gpu_photon_store.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python
+"""pkg113 Phase 1 — GPU photon STORE + query vs a numpy float64 brute-force oracle.
+
+Validates the GPU uniform spatial hash grid (pbrt-v3 sppm.cpp ToGrid/hash, plus
+the Jensen 2000 §3.1 Eq. 8 fixed-radius irradiance estimate) through the
+`_gpu_photon_store_query` binding against the SAME brute-force reference used by
+tests/test_photon_map.py for the CPU kd-tree.
+
+Store decision: uniform spatial hash grid, NOT a CUDA kd-tree
+(packages/pkg113-gpu-photon-map-caustics.md Decisions §2; owner 2026-05-30).
+
+The hash grid returns the EXACT in-radius neighbor SET (set-match, deterministic)
+and a density estimate matching the numpy oracle to single precision. This is the
+Phase-1 acceptance: "GPU store gather vs CPU (Phase 1) — aggregate energy bound".
+
+GPU-gated: skips gracefully when CUDA is absent (CI has no GPU); /verify runs this
+on the RTX box. Mirrors the skip pattern of tests/test_pkg64_gpu_cpu_parity.py:41-46.
+
+References: Jensen 2000 Course 8 §3.1 Eq. 8; pbrt-v3 src/integrators/sppm.cpp
+(BSD-2-Clause). See .astroray_plan/docs/pkg113-gpu-photon-store-research.md.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+try:
+    import astroray  # noqa: E402
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray not built")
+
+if AVAILABLE and not astroray.__features__.get("cuda", False):
+    pytest.skip(
+        "CUDA feature not in this build — pkg113 Phase 1 GPU photon store needs "
+        "CUDA; /verify runs this on the RTX box.",
+        allow_module_level=True,
+    )
+
+if AVAILABLE and not hasattr(astroray, "_gpu_photon_store_query"):
+    pytest.skip(
+        "GPU photon-store binding not present — rebuild astroray.pyd (pkg113).",
+        allow_module_level=True,
+    )
+
+
+# float32 (GPU) vs float64 (oracle) can disagree on a photon sitting within an
+# ULP-thin shell of the radius boundary — that is a precision tie, not a store
+# bug. We compare the set EXACTLY for photons clearly inside/outside the radius
+# and tolerate disagreement only inside a narrow boundary shell. Same idea as
+# test_photon_map.py comparing squared distances to a 1e-3 tolerance.
+_BOUNDARY_REL = 1e-4  # shell half-width as a fraction of radius^2
+
+
+def _brute_in_radius_sets(points, q, radius):
+    """Return (definitely_in, ambiguous): index sets that are unambiguously
+    inside the radius vs within the float-precision boundary shell."""
+    d2 = np.sum((points - q) ** 2, axis=1)
+    r2 = radius * radius
+    shell = _BOUNDARY_REL * r2
+    definitely_in = set(np.where(d2 < r2 - shell)[0].tolist())
+    ambiguous = set(np.where(np.abs(d2 - r2) <= shell)[0].tolist())
+    return definitely_in, ambiguous
+
+
+def test_radius_neighbor_set_matches_brute_force():
+    """The GPU hash-grid in-radius neighbor set must match a numpy brute-force
+    radius search for every photon outside the float-precision boundary shell,
+    over many random queries (deterministic set away from the boundary)."""
+    rng = np.random.default_rng(20260530)
+    n = 4000
+    points = rng.uniform(-5.0, 5.0, size=(n, 3))
+    powers = np.ones((n, 3))
+    radius = 0.6
+
+    queries = rng.uniform(-5.0, 5.0, size=(64, 3))
+    results = astroray._gpu_photon_store_query(
+        points.tolist(), powers.tolist(), queries.tolist(), radius, 4096
+    )
+    assert len(results) == len(queries)
+
+    mismatches = 0
+    for qi, (_E, gpu_idx, found) in enumerate(results):
+        gpu_set = set(int(v) for v in gpu_idx)
+        # No duplicates in the returned set (the cell-id de-dup must hold).
+        assert len(gpu_set) == len(list(gpu_idx)), (
+            f"query {qi}: duplicate indices returned"
+        )
+        definitely_in, ambiguous = _brute_in_radius_sets(points, queries[qi], radius)
+        # Every clearly-inside photon must be present.
+        missing = definitely_in - gpu_set
+        # Every returned photon must be either clearly-inside or boundary-ambiguous.
+        extra = gpu_set - definitely_in - ambiguous
+        if missing or extra:
+            mismatches += 1
+    assert mismatches == 0, f"{mismatches}/{len(queries)} neighbor-set mismatches"
+
+
+def test_irradiance_matches_disk_area_density():
+    """Jensen Eq. 8 fixed-radius estimate on the GPU must match the numpy
+    oracle E = (1/(pi r^2)) * sum(power within r) to single precision."""
+    rng = np.random.default_rng(7)
+    n = 3000
+    points = rng.uniform(-4.0, 4.0, size=(n, 3))
+    powers = rng.uniform(0.1, 2.0, size=(n, 3))
+    radius = 0.8
+
+    queries = rng.uniform(-4.0, 4.0, size=(48, 3))
+    results = astroray._gpu_photon_store_query(
+        points.tolist(), powers.tolist(), queries.tolist(), radius, 4096
+    )
+
+    norm = np.pi * radius * radius
+    max_rel = 0.0
+    for qi, (E, _idx, _found) in enumerate(results):
+        d2 = np.sum((points - queries[qi]) ** 2, axis=1)
+        mask = d2 < radius * radius
+        bf_E = powers[mask].sum(axis=0) / norm  # XYZ
+        E = np.asarray(E, dtype=np.float64)
+        denom = np.maximum(np.abs(bf_E), 1e-6)
+        max_rel = max(max_rel, float(np.max(np.abs(E - bf_E) / denom)))
+    assert max_rel < 1e-3, f"irradiance rel-err {max_rel:.3e} exceeds 1e-3"
+
+
+def test_irradiance_converges_to_areal_density():
+    """Unit-power photons on a dense plane recover the true areal flux density
+    N/A within the fixed-radius footprint — same convergence check as the CPU
+    test_photon_map.py::test_irradiance_converges_to_areal_density."""
+    rng = np.random.default_rng(20260530)
+    side, npl = 4.0, 40000
+    plane = np.zeros((npl, 3))
+    plane[:, 0] = rng.uniform(-side / 2, side / 2, size=npl)
+    plane[:, 2] = rng.uniform(-side / 2, side / 2, size=npl)
+    powers = np.ones((npl, 3))
+    true_density = npl / (side * side)
+    radius = 0.25  # small vs the plane so the disk lies inside it
+
+    queries = np.array([[-1.0, 0.0, 0.0], [0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+    results = astroray._gpu_photon_store_query(
+        plane.tolist(), powers.tolist(), queries.tolist(), radius, 65536
+    )
+    ests = [E[1] for (E, _idx, _found) in results]  # Y channel
+    rel_err = abs(np.mean(ests) - true_density) / true_density
+    assert rel_err < 0.10, f"density estimate rel_err {rel_err:.3%} (true {true_density})"
+
+
+def test_empty_region_is_dark():
+    """A query far from any photon (beyond radius) returns zero irradiance and
+    an empty neighbor set — keeps the receiver dark outside the caustic band."""
+    points = [[0.0, 0.0, 0.0], [0.1, 0.0, 0.0], [0.0, 0.0, 0.1]]
+    powers = [[1.0, 1.0, 1.0]] * 3
+    results = astroray._gpu_photon_store_query(
+        points, powers, [[100.0, 0.0, 0.0]], 1.0, 16
+    )
+    E, idx, found = results[0]
+    assert found == 0
+    assert list(idx) == []
+    assert tuple(E) == (0.0, 0.0, 0.0)


### PR DESCRIPTION
**pkg113 phase 1** — the GPU foundation of the photon-map caustics port. Implemented by a package-implementer agent, **built + RTX-verified by me**.

## What landed
A **uniform spatial hash-grid GPU photon store** (the owner-decided structure, not a CUDA kd-tree — `cpu-gpu-parity-status.md` §2) + a device fixed-radius gather (`photonGridGather`, reusable from a Phase-3 integrator kernel):
- `include/astroray/gpu_photon_store.h` — `GPhoton`/`GPhotonGrid` POD + host/device pbrt-v3 `ToGrid`/`hash` (Teschner 2003 primes) + the device gather (Jensen 2000 §3.1 Eq.8).
- `src/gpu/photon_store.cu` — GPU count/scan/scatter CSR build + query kernel + the host-callable `cuda_photon_store_query`.
- `tests/test_gpu_photon_store.py` — CUDA-gated unit test vs a numpy float64 brute-force oracle (skips on CI/no-GPU).
- `module/blender_module.cpp` — `_gpu_photon_store_query` pybind binding (`#ifdef ASTRORAY_CUDA_ENABLED`).
- Research note + CMakeLists entry.

## Verification (RTX, this machine)
Build clean (Ninja). `pytest tests/test_gpu_photon_store.py` → **4 passed**: neighbor-set matches brute-force (no dups, boundary-shell tolerance), Jensen Eq.8 irradiance rel-err <1e-3, areal-density convergence <10%, empty-region dark.

Purely **additive** (new files + a guarded binding); existing render paths untouched. Phases 2 (GPU emission/bounce) + 3 (integrator gather + acceptance gates) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)