### PR TITLE
feat(pkg113): GPU photon emission + bounce → deposit — phase 2 [RTX-verified 3/3]

### DIFF
--- a/.astroray_plan/docs/pkg113-phase2-photon-emission-research.md
+++ b/.astroray_plan/docs/pkg113-phase2-photon-emission-research.md
@@ -1,0 +1,112 @@
+# pkg113 Phase 2 — GPU photon EMISSION + BOUNCE → deposit (research note)
+
+Scope: a device kernel that forward-traces a batch of collimated-sun photons
+through flagged caustic-caster glass (general deterministic-refraction path) and
+deposits the surviving per-λ CIE flux as `GPhoton`s onto the receiver. This is the
+GPU port of the GENERAL path of `plugins/integrators/light_tracer_caustic.cpp`
+(NOT the integrator gather — that is Phase 3). Built on the Phase-1 store branch
+`feat/pkg113-gpu-photon-store` (the `GPhoton` struct + hash grid it ingests).
+
+## What is being ported (math, file:line in the CPU source)
+
+`plugins/integrators/light_tracer_caustic.cpp`, the GENERAL branch (lines 276-326):
+
+| Step | CPU source | Device mirror |
+|---|---|---|
+| collimated-sun aperture seeding around `sunDir`, disc of radius `crad` | l.219-249, 282-287 | `kEmitPhotons` ONB + uniform-disc sample (curand) |
+| per-photon wavelength `λ = lmin + (lmax-lmin)·u01` | l.283 | `curand_uniform` over [380,720] |
+| per-λ IOR `iorAt(λ)` (Sellmeier) | l.295 | `gpu_sellmeier_ior` (pkg64-gpu, `gpu_dispersion.cuh`) |
+| enter/exit from geometric-normal sign | l.297-300 | `d.dot(ng) < 0 ? entering : exiting` |
+| Snell refraction `refract(d, nf, eta)` | l.183-189, 302 | device `pe_refract` (identical formula) |
+| TIR → mirror reflect | l.303 | device reflect branch |
+| Schlick-Fresnel transmittance accumulate `tr *= fresnelT` | l.190-194, 302 | device `pe_fresnelT` (identical formula) |
+| deposit on first diffuse receiver on an L S+ D path | l.313-323 | receiver-plane hit, `passedCaster && n.y>0.7` |
+| per-λ CIE deposit `cmf = cieCmf1964_10deg(λ); power = cmf·tr` | l.314-318 | device CMF lookup (same `data/spectra/cie_cmf.inc` table) |
+
+The refraction/Fresnel formulae are *identical* to the CPU `refract()` /
+`fresnelT()` private statics — these are the standard Snell vector form and the
+Schlick approximation, the same ones already on the GPU in
+`sms_attempt_device.cuh:283-307`. No new algorithm.
+
+## Citations (CLAUDE.md §6)
+
+- **Arvo, "Backward Ray Tracing", SIGGRAPH 1986 Course Notes** — forward light
+  transport (light particles) for caustics. (CPU header citation, carried.)
+- **Jensen, "Global Illumination using Photon Maps", EGWR 1996** (DOI
+  10.1007/978-3-7091-7484-5_3) — diffuse-surface photon deposition. The Phase-1
+  store ingests the `GPhoton`s this phase produces.
+- **Schlick, "An Inexpensive BRDF Model for Physically-based Rendering",
+  Eurographics 1994** — the Fresnel reflectance approximation `F0 + (1-F0)(1-cosθ)^5`.
+  (Undergraduate-textbook tier per CLAUDE.md §6, but cited for provenance; the
+  exact CPU form is mirrored, not re-derived.)
+- **Sellmeier 1871**, Annalen der Physik 219(11):272-282 (public domain) — `n(λ)`.
+  REUSED via `gpu_sellmeier_ior` (`include/astroray/gpu_dispersion.cuh`,
+  pkg64-gpu Sellmeier upload). Dispersion is NOT re-derived here.
+- **CIE 1964 10° standard observer CMF** — `data/spectra/cie_cmf.inc` (the same
+  1 nm table `src/spectrum.cpp::cieCmf1964_10deg` reads, also mirrored to GPU
+  constant memory by pkg54b in `multiwavelength_kernel.cu`). The deposit color is
+  the bit-identical host table, linearly interpolated, so the GPU per-λ deposit
+  weight matches the CPU one to float precision.
+
+## Reuse points (audited, this branch, file:line)
+
+| What | Where | Note |
+|---|---|---|
+| `GPhoton` struct (deposit target) | `include/astroray/gpu_photon_store.h:41` | Phase-1 store ingests it |
+| `gpu_sellmeier_ior(GDispersion, λ)` | `include/astroray/gpu_dispersion.cuh:19` | per-λ IOR (pkg64-gpu) |
+| `gpu_buildONB` | `include/astroray/gpu_materials.h` | aperture frame around sunDir |
+| ray-sphere `gpu_sphere_hit` math | `include/astroray/gpu_bvh.h:62` | single-sphere trace (self-contained) |
+| GHitRecord frontFace/normal sign | `gpu_bvh.h:50-51,84-85` | geometric enter/exit decision |
+| CMF table `data/spectra/cie_cmf.inc` | included like `multiwavelength_kernel.cu:164` | per-λ CIE deposit |
+| host-callable + pybind pattern | `photon_store.cu` / `blender_module.cpp:2464` | Phase-1 mirror |
+
+## Flat-prism decision: STAYS CPU (general loop goes on GPU)
+
+The flat-prism explicit 2-face path is NOT ported in Phase 2. Reasons:
+1. The general deterministic BVH refraction loop already covers the glass SPHERE
+   (the spec's primary GPU caustic target) and any solid/curved caster — it is the
+   load-bearing GPU path.
+2. The 2-face path depends on host-side geometry classification
+   (`gatherTriangleCasters` / `countDistinctCasterPlanes` / `CausticTri`,
+   `light_tracer_caustic.cpp:152-181, 234-275`) that is not uploaded to the GPU.
+   Porting it would require uploading the per-triangle caster set + plane-grouping
+   classifier — scope the spec explicitly leaves optional ("or decide it stays
+   CPU — the prism is a flat special case") and which the general loop subsumes for
+   the parity scene.
+3. Memory `[[general-photon-loop-needs-solid-glass]]`: the 2-face deposit is a
+   brittle CPU geometric special case; the general loop on a flat 2-quad caster
+   scatters into chromatic noise (CPU header l.20-23). So the clean prism deposit
+   stays the CPU special path; the GPU does the general loop, validated on the
+   glass sphere.
+
+Phase-2 GPU port = the GENERAL deterministic-refraction loop only. The flat-prism
+clean-deposit path remains CPU-only (`light_tracer_caustic.cpp`).
+
+## Parity-test design (aggregate bounds, NOT bit-exact)
+
+`tests/test_gpu_photon_emission.py` (CUDA-gated, mirrors `test_gpu_photon_store.py`
+skip pattern). A single BK7 glass sphere + a flat receiver plane below it + a
+collimated sun straight down. The GPU entry `_gpu_photon_emit_sphere` forward-traces
+N photons and returns the deposit set (positions + XYZ power). A numpy float64
+ORACLE runs the IDENTICAL closed-form math (analytic ray-sphere entry/exit, Snell,
+Schlick, Sellmeier, CMF) on the SAME stratified aperture samples (no RNG: the
+aperture is a deterministic jittered grid passed to both sides) and compares by
+AGGREGATE bounds:
+  - total deposited Y-energy: GPU/oracle ratio within ±5 %;
+  - deposit centroid (x,z): within a small fraction of the sphere radius;
+  - deposit radial extent (RMS spread): within ±15 %.
+Per memory `[[general-photon-loop-needs-solid-glass]]`, the caustic numeric gates
+pass on salt-and-pepper noise, so the test asserts energy AND position bounds, not
+a deposit count alone. To remove RNG as a variable for the parity comparison the
+aperture sampling is a fixed deterministic jittered lattice (the same lattice fed
+to the oracle), isolating the refraction math from Monte-Carlo noise — the same
+"inject the same samples both sides" tactic `sms_attempt_device.cuh` uses for its
+Phase-1 unit test.
+
+## Files
+
+- `include/astroray/gpu_photon_emit.h` — host-callable entry decl + result struct.
+- `src/gpu/photon_emission.cu` — the device kernel + host launcher.
+- `module/blender_module.cpp` — `_gpu_photon_emit_sphere` pybind (CUDA-gated).
+- `tests/test_gpu_photon_emission.py` — the parity test.
+- `CMakeLists.txt` — add `src/gpu/photon_emission.cu` to the CUDA sources.

--- a/.astroray_plan/packages/pkg113-gpu-photon-map-caustics.md
+++ b/.astroray_plan/packages/pkg113-gpu-photon-map-caustics.md
@@ -78,6 +78,17 @@ algorithm invented.
   core, or the gates can't run.
 
 ### Phase 2 — GPU photon emission + bounce
+**Status: implemented (branch `feat/pkg113-gpu-photon-emission`, 2026-06-08 — awaiting
+RTX `/verify`).** Device kernel `kEmitPhotons` (`src/gpu/photon_emission.cu`) +
+host-callable `cuda_photon_emit_sphere` (`include/astroray/gpu_photon_emit.h`) +
+`_gpu_photon_emit_sphere` pybind. Parity test `tests/test_gpu_photon_emission.py`
+(CUDA-gated) compares the GPU deposit set to a numpy float64 oracle of the identical
+math (same jittered aperture lattice, Sellmeier IOR, Schlick transmittance, CIE-CMF
+table) by aggregate bounds: total Y-energy ±5 %, Y-weighted centroid < 0.05·radius,
+radial RMS extent ±15 %. **Flat-prism decision: stays CPU** (the general loop covers
+the glass sphere + any solid/curved caster; the 2-face path needs host-side geometry
+classification not uploaded to GPU and scatters into chromatic noise on a flat caster
+— research note + `gpu_photon_emit.h` header). NOTE: not yet RTX-built/verified.
 - Port the deterministic refraction loop (`light_tracer_caustic.cpp` general path) to
   a device kernel: Snell + Schlick-Fresnel, enter/exit from the geometric-normal sign,
   per-λ `iorAt` (reuse pkg64-gpu Sellmeier upload), TIR; deposit per-λ CIE flux into

--- a/.astroray_plan/packages/pkg113-gpu-photon-map-caustics.md
+++ b/.astroray_plan/packages/pkg113-gpu-photon-map-caustics.md
@@ -2,13 +2,16 @@
 
 **Pillar:** 3 (light transport) + 5 (GPU)
 **Track:** A
-**Status:** **Phase 1 DONE** (2026-06-08 — GPU uniform spatial hash-grid photon
-STORE + device fixed-radius query; CUDA-gated unit test vs numpy brute-force oracle
-**4/4 PASS verified on RTX**: neighbor-set match, Jensen Eq.8 irradiance rel-err
-<1e-3, areal-density convergence, empty-region dark). Phases 2 (GPU emission/bounce
-→ deposit into this store) + 3 (integrator gather wiring + SSIM/energy acceptance
-gates vs the CPU photon map) remain. **GPU-gated: do NOT pick up in a CI-only run —
-correctness must be RTX-`/verify`-ed; CI has no GPU and CI-green ≠ correct.**
+**Status:** **Phases 1 + 2 DONE** (2026-06-08/09, both RTX-verified). Phase 1: GPU
+uniform hash-grid photon STORE + device query (4/4 PASS vs numpy oracle). Phase 2: GPU
+photon EMISSION + bounce → deposit (forward Snell/Schlick/per-λ Sellmeier/TIR port of
+`light_tracer_caustic.cpp` general path; flat-prism 2-face stays CPU) — **3/3 PASS on
+RTX** vs a numpy float64 oracle (energy ±5%, centroid <0.05·r, RMS ±15%, dispersion
+band >100nm). **Phase 3 remains:** wire the device `photonGridGather` into the GPU
+integrator at receiver hits (mirror pkg111), drive emission from the uploaded scene,
+re-run the prism + glass-sphere acceptance scenes on GPU with the **visual PNG check**
++ the GPU-vs-CPU SSIM≥0.97 / energy parity gate. **GPU-gated: do NOT pick up in a
+CI-only run — correctness must be RTX-`/verify`-ed; CI has no GPU and CI-green ≠ correct.**
 **Estimated effort:** L (~3–4 weeks, multiple RTX sessions)
 **Depends on:** pkg109 (photon-map kd-tree, done), pkg110 (BSDF photon bounce, done),
 **pkg111** (CPU k-NN gather into the default path — do FIRST). The caustics-fork is

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -473,6 +473,7 @@ if(ASTRORAY_CUDA_FOUND)
         src/gpu/scene_upload.cu
         src/gpu/pkg64_sms_probe.cu
         src/gpu/photon_store.cu
+        src/gpu/photon_emission.cu
     )
     if(ASTRORAY_WAVEFRONT_CUDA_N3)
         list(APPEND ASTRORAY_CUDA_SOURCES

--- a/include/astroray/gpu_photon_emit.h
+++ b/include/astroray/gpu_photon_emit.h
@@ -1,0 +1,88 @@
+#pragma once
+// pkg113 Phase 2 — GPU photon EMISSION + BOUNCE → deposit.
+//
+// The GPU port of the GENERAL deterministic-refraction path of the CPU forward
+// light tracer (plugins/integrators/light_tracer_caustic.cpp, lines 276-326): a
+// batch of collimated-sun photons is traced through a flagged glass caster
+// (Snell refraction + Schlick-Fresnel reflect/transmit + enter/exit from the
+// geometric-normal sign + per-λ Sellmeier iorAt + TIR) and the surviving per-λ
+// CIE flux is deposited as GPhoton records on the receiver. The Phase-1 store
+// (gpu_photon_store.h) then ingests these GPhotons. EMISSION + BOUNCE only — NO
+// integrator gather wiring (Phase 3).
+//
+// Flat-prism decision (pkg113 Phase 2, see
+// .astroray_plan/docs/pkg113-phase2-photon-emission-research.md): the flat-prism
+// explicit 2-face path STAYS CPU-only. The general deterministic loop ported
+// here covers the glass SPHERE (the spec's primary GPU caustic target) and any
+// solid/curved caster; the 2-face path depends on host-side geometry
+// classification not uploaded to the GPU, and the general loop on a flat 2-quad
+// caster scatters into chromatic noise (CPU header l.20-23, memory
+// [[general-photon-loop-needs-solid-glass]]).
+//
+// Citations (CLAUDE.md §6; see the research note above):
+//   Arvo 1986 (forward light transport); Jensen 1996 (diffuse photon deposit);
+//   Schlick 1994 (Fresnel approximation); Sellmeier 1871 (n(λ), REUSED via
+//   gpu_dispersion.cuh's gpu_sellmeier_ior, pkg64-gpu upload); CIE 1964 10° CMF
+//   (data/spectra/cie_cmf.inc, the same table src/spectrum.cpp uses).
+//
+// Mirrors the Phase-1 host-callable pattern (cuda_photon_store_query): a
+// host-callable entry the pybind binding reaches under #ifdef
+// ASTRORAY_CUDA_ENABLED, used by tests/test_gpu_photon_emission.py to gate the
+// GPU deposit set against a numpy float64 oracle (aggregate energy/position
+// bounds — NOT bit-exact, the trace is a stochastic forward trace).
+
+#include "astroray/gpu_photon_store.h"   // GPhoton (deposit target)
+#include "astroray/gpu_types.h"          // GVec3, GDispersion
+
+#include <vector>
+
+namespace astroray {
+namespace photon {
+namespace gpu {
+
+// A single-glass-sphere forward-trace scene description for the Phase-2 parity
+// harness. Deliberately minimal (one sphere + one flat receiver plane + a
+// collimated sun): the parity test isolates the refraction/deposit MATH, not the
+// full scene-upload path (that is exercised separately by the integrator wiring
+// in Phase 3). The aperture is a deterministic jittered lattice (NOT curand) so
+// the oracle can feed the SAME entry samples and the comparison isolates the
+// math from Monte-Carlo noise — the same "inject the same samples both sides"
+// tactic sms_attempt_device.cuh uses for its Phase-1 unit test.
+struct PhotonEmitSphereScene {
+    GVec3       sphereCenter;
+    float       sphereRadius;
+    GDispersion dispersion;    // Sellmeier coefficients (pkg64-gpu); B*=C*=0 => flat IOR
+    float       flatIor;       // used when dispersion is all-zero (non-dispersive glass)
+    bool        isDispersive;  // true => use gpu_sellmeier_ior, false => flatIor
+
+    GVec3       sunDir;        // collimated propagation direction (unit, toward the sphere)
+    GVec3       apertureCenter;// center of the entry aperture disc (in front of the sphere)
+    float       apertureRadius;// disc radius spanning the sphere's projected extent
+
+    float       receiverY;     // y of the horizontal diffuse receiver plane (normal +y)
+
+    int         apertureN;     // sqrt of the photon count: photons = apertureN*apertureN
+    float       lambdaMin;     // emission band lower bound (nm), e.g. 380
+    float       lambdaMax;     // emission band upper bound (nm), e.g. 720
+    int         maxDepth;      // max refraction bounces through the glass (CPU maxDepth_)
+};
+
+// One deposited photon read back to the host (the GPU deposit set).
+struct PhotonEmitDeposit {
+    GVec3 position;   // world-space deposit point on the receiver
+    GVec3 power;      // CIE XYZ flux (cmf(λ) * accumulated transmittance)
+    float lambda;     // sampled wavelength (nm)
+};
+
+// Forward-trace apertureN*apertureN photons through the single glass sphere onto
+// the receiver plane and return the surviving deposit set. The aperture is a
+// deterministic apertureN*apertureN jittered lattice (stratified jitter from a
+// fixed hash, NOT curand) so the parity oracle can reproduce the exact entry
+// samples. Photons that miss the sphere, TIR out, or never reach the receiver
+// are dropped (deposit set is the survivors, like the CPU `photons` vector).
+std::vector<PhotonEmitDeposit> cuda_photon_emit_sphere(
+    const PhotonEmitSphereScene& scene);
+
+}  // namespace gpu
+}  // namespace photon
+}  // namespace astroray

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -45,6 +45,7 @@
 #ifdef ASTRORAY_CUDA_ENABLED
 #  include "astroray/gpu_renderer.h"
 #  include "astroray/gpu_photon_store.h"   // pkg113 Phase 1 — GPU photon store query
+#  include "astroray/gpu_photon_emit.h"    // pkg113 Phase 2 — GPU photon emission/bounce
 #  ifdef ASTRORAY_WAVEFRONT_CUDA_N3
 #    include "../src/gpu/wavefront/gpu_wavefront_snapshot.h"
 #  endif
@@ -2502,6 +2503,60 @@ PYBIND11_MODULE(astroray, m) {
           "max_neighbors"_a = 256,
           "pkg113 Phase 1: build the GPU photon hash grid and gather at each "
           "query. Returns [(irradiance(3), neighbor_indices, found_count), ...].");
+
+    // pkg113 Phase 2 — GPU photon EMISSION + BOUNCE parity binding. Forward-
+    // traces a batch of collimated-sun photons through a single glass sphere
+    // (Snell + Schlick-Fresnel + enter/exit from the geometric-normal sign +
+    // per-λ Sellmeier iorAt + TIR) and returns the surviving per-λ CIE-weighted
+    // deposit set — the GPhotons Phase 1's store ingests. Validated against a
+    // numpy float64 oracle (identical math, same jittered aperture lattice) by
+    // tests/test_gpu_photon_emission.py with AGGREGATE energy/position bounds
+    // (the flat-prism 2-face path stays CPU — see gpu_photon_emit.h).
+    m.def("_gpu_photon_emit_sphere",
+          [](const std::array<float, 3>& center, float radius,
+             const std::array<float, 6>& sellmeier, float flat_ior,
+             bool is_dispersive,
+             const std::array<float, 3>& sun_dir,
+             const std::array<float, 3>& aperture_center, float aperture_radius,
+             float receiver_y, int aperture_n,
+             float lambda_min, float lambda_max, int max_depth) {
+              namespace pe = astroray::photon::gpu;
+              pe::PhotonEmitSphereScene sc;
+              sc.sphereCenter   = GVec3(center[0], center[1], center[2]);
+              sc.sphereRadius   = radius;
+              sc.dispersion     = GDispersion{sellmeier[0], sellmeier[1],
+                                              sellmeier[2], sellmeier[3],
+                                              sellmeier[4], sellmeier[5]};
+              sc.flatIor        = flat_ior;
+              sc.isDispersive   = is_dispersive;
+              sc.sunDir         = GVec3(sun_dir[0], sun_dir[1], sun_dir[2]);
+              sc.apertureCenter = GVec3(aperture_center[0], aperture_center[1],
+                                        aperture_center[2]);
+              sc.apertureRadius = aperture_radius;
+              sc.receiverY      = receiver_y;
+              sc.apertureN      = aperture_n;
+              sc.lambdaMin      = lambda_min;
+              sc.lambdaMax      = lambda_max;
+              sc.maxDepth       = max_depth;
+
+              auto deposits = pe::cuda_photon_emit_sphere(sc);
+              // Return one tuple per surviving deposit:
+              //   (position[3], power_xyz[3], lambda)
+              py::list out;
+              for (const auto& dpt : deposits) {
+                  out.append(py::make_tuple(
+                      py::make_tuple(dpt.position.x, dpt.position.y, dpt.position.z),
+                      py::make_tuple(dpt.power.x, dpt.power.y, dpt.power.z),
+                      dpt.lambda));
+              }
+              return out;
+          },
+          "center"_a, "radius"_a, "sellmeier"_a, "flat_ior"_a,
+          "is_dispersive"_a, "sun_dir"_a, "aperture_center"_a,
+          "aperture_radius"_a, "receiver_y"_a, "aperture_n"_a,
+          "lambda_min"_a = 380.f, "lambda_max"_a = 720.f, "max_depth"_a = 12,
+          "pkg113 Phase 2: forward-trace photons through a glass sphere and "
+          "return the GPhoton deposit set [(position(3), power_xyz(3), lambda), ...].");
 #endif
 
     m.def("synchrotron_thermal_emissivity",

--- a/src/gpu/photon_emission.cu
+++ b/src/gpu/photon_emission.cu
@@ -1,0 +1,289 @@
+// photon_emission.cu — pkg113 Phase 2 — GPU photon EMISSION + BOUNCE → deposit.
+//
+// Device port of the GENERAL deterministic-refraction path of the CPU forward
+// light tracer (plugins/integrators/light_tracer_caustic.cpp, lines 276-326):
+// trace collimated-sun photons through a glass caster (Snell + Schlick-Fresnel +
+// enter/exit from the geometric-normal sign + per-λ Sellmeier iorAt + TIR) and
+// deposit the surviving per-λ CIE flux as GPhoton records on the receiver plane.
+// The Phase-1 store (gpu_photon_store.h) ingests these GPhotons. EMISSION +
+// BOUNCE only — no integrator gather (Phase 3). Flat-prism stays CPU (see
+// gpu_photon_emit.h header / the research note).
+//
+// Self-contained single-glass-sphere trace (no full BVH) — the parity harness
+// isolates the refraction/deposit MATH against a numpy float64 oracle; the
+// integrator scene-upload path is exercised in Phase 3. The aperture is a
+// deterministic jittered lattice (NOT curand) so the oracle reproduces the exact
+// entry samples and the comparison isolates the math from Monte-Carlo noise.
+//
+// Citations (CLAUDE.md §6; .astroray_plan/docs/pkg113-phase2-photon-emission-research.md):
+//   Arvo 1986 (forward light transport); Jensen 1996 (diffuse photon deposit);
+//   Schlick 1994 (Fresnel approx); Sellmeier 1871 (n(λ) — reused via
+//   gpu_dispersion.cuh); CIE 1964 10° CMF (data/spectra/cie_cmf.inc).
+
+#include "astroray/gpu_photon_emit.h"
+#include "astroray/gpu_photon_store.h"
+#include "astroray/gpu_types.h"
+#include "astroray/gpu_dispersion.cuh"   // gpu_sellmeier_ior (pkg64-gpu Sellmeier)
+
+#include <cuda_runtime.h>
+
+#include <cstdio>
+#include <stdexcept>
+#include <vector>
+
+#define APE_CUDA_CHECK(call) do {                                           \
+    cudaError_t _e = (call);                                                \
+    if (_e != cudaSuccess) {                                                \
+        std::fprintf(stderr, "CUDA error at %s:%d: %s\n",                  \
+                __FILE__, __LINE__, cudaGetErrorString(_e));                \
+        throw std::runtime_error(cudaGetErrorString(_e));                   \
+    }                                                                       \
+} while(0)
+
+namespace astroray {
+namespace photon {
+namespace gpu {
+
+namespace {
+
+// --- CIE 1964 10° CMF table (same data the CPU cieCmf1964_10deg reads) -------
+// Mirrors multiwavelength_kernel.cu:163-165; the .inc declares
+// `static constexpr float kCieCmfX[471] = {...}` plus the range constants. We
+// keep the table in a translation-unit-local namespace and copy it to constant
+// memory once. The device lookup linearly interpolates the 1 nm grid exactly
+// like src/spectrum.cpp::sampleTable, so the GPU per-λ deposit weight matches
+// the CPU one to float precision.
+namespace cmf_baked {
+#include "data/spectra/cie_cmf.inc"
+}  // namespace cmf_baked
+
+__constant__ float g_emitCmfX[cmf_baked::kCieCmfCount];
+__constant__ float g_emitCmfY[cmf_baked::kCieCmfCount];
+__constant__ float g_emitCmfZ[cmf_baked::kCieCmfCount];
+
+void uploadEmitCmf() {
+    static bool uploaded = false;
+    if (uploaded) return;
+    APE_CUDA_CHECK(cudaMemcpyToSymbol(g_emitCmfX, cmf_baked::kCieCmfX,
+                                      sizeof(cmf_baked::kCieCmfX)));
+    APE_CUDA_CHECK(cudaMemcpyToSymbol(g_emitCmfY, cmf_baked::kCieCmfY,
+                                      sizeof(cmf_baked::kCieCmfY)));
+    APE_CUDA_CHECK(cudaMemcpyToSymbol(g_emitCmfZ, cmf_baked::kCieCmfZ,
+                                      sizeof(cmf_baked::kCieCmfZ)));
+    uploaded = true;
+}
+
+// Device CMF lookup: 1 nm linear interpolation over [360,830] nm, clamped at the
+// ends. Exact port of src/spectrum.cpp::sampleTable (l.40-46).
+__device__ inline GVec3 pe_cieCmf(float lambda) {
+    const float lmin = 360.0f, step = 1.0f;
+    const int count = 471;
+    float idx = (lambda - lmin) / step;
+    int i = static_cast<int>(idx);
+    if (i < 0) {   // below the table -> first sample (CPU clamps via i=0,t=0)
+        return GVec3(g_emitCmfX[0], g_emitCmfY[0], g_emitCmfZ[0]);
+    }
+    if (i >= count - 1) {
+        return GVec3(g_emitCmfX[count - 1], g_emitCmfY[count - 1], g_emitCmfZ[count - 1]);
+    }
+    float t = idx - static_cast<float>(i);
+    return GVec3(g_emitCmfX[i] * (1.0f - t) + g_emitCmfX[i + 1] * t,
+                 g_emitCmfY[i] * (1.0f - t) + g_emitCmfY[i + 1] * t,
+                 g_emitCmfZ[i] * (1.0f - t) + g_emitCmfZ[i + 1] * t);
+}
+
+// --- Refraction / Fresnel (identical to light_tracer_caustic.cpp:183-194) ----
+
+// Snell refraction (vector form). d is the unit incident direction, n the
+// surface normal oriented against d, eta the relative IOR (n_from/n_to). Returns
+// false on total internal reflection. CPU: light_tracer_caustic.cpp:183-189.
+__device__ inline bool pe_refract(const GVec3& d, const GVec3& n, float eta, GVec3& out) {
+    float cosi = -d.dot(n);
+    float s2 = eta * eta * (1.0f - cosi * cosi);
+    if (s2 >= 1.0f) return false;          // TIR
+    out = (d * eta + n * (eta * cosi - sqrtf(1.0f - s2))).normalized();
+    return true;
+}
+
+// Schlick-Fresnel TRANSMITTANCE 1 - F. CPU: light_tracer_caustic.cpp:190-194.
+__device__ inline float pe_fresnelT(float cosi, float ior) {
+    float f0 = (1.0f - ior) / (1.0f + ior); f0 *= f0;
+    float fr = f0 + (1.0f - f0) * powf(fmaxf(0.0f, 1.0f - fabsf(cosi)), 5.0f);
+    return 1.0f - fr;
+}
+
+// --- Single-sphere intersection ----------------------------------------------
+// Nearest forward (t > tMin) intersection of (o,d) with the glass sphere. Fills
+// the GEOMETRIC outward normal (point - center)/radius (NOT oriented against d —
+// the bounce decides enter/exit from d.dot(ng), exactly like the CPU general
+// loop uses rec.normal = the geometric outward normal, l.297). Returns t or -1.
+__device__ inline float pe_sphereHit(const GVec3& center, float radius,
+                                     const GVec3& o, const GVec3& d, float tMin,
+                                     GVec3& ngOut) {
+    GVec3 oc = o - center;
+    float a = d.length2();
+    float hb = oc.dot(d);
+    float c = oc.length2() - radius * radius;
+    float disc = hb * hb - a * c;
+    if (disc < 0.0f) return -1.0f;
+    float sq = sqrtf(disc);
+    float root = (-hb - sq) / a;
+    if (root < tMin) {
+        root = (-hb + sq) / a;
+        if (root < tMin) return -1.0f;
+    }
+    GVec3 p = o + d * root;
+    ngOut = (p - center) * (1.0f / radius);   // geometric outward normal
+    return root;
+}
+
+// --- Deterministic jittered aperture lattice ---------------------------------
+// A van-der-Corput-free, dependency-free stratified jitter from a small integer
+// hash, so the host oracle reproduces the SAME entry sample for cell (i,j). This
+// replaces the CPU's std::mt19937 u01() draws with a fixed per-cell jitter; the
+// parity test passes the IDENTICAL lattice to the numpy oracle (the same tactic
+// sms_attempt_device.cuh uses: inject the same samples both sides).
+__device__ inline float pe_jitter(unsigned int cell, unsigned int salt) {
+    unsigned int h = cell * 0x9E3779B1u + salt * 0x85EBCA77u;
+    h ^= h >> 15; h *= 0x2C1B3C6Du; h ^= h >> 12; h *= 0x297A2D39u; h ^= h >> 15;
+    return (h & 0x00FFFFFFu) * (1.0f / 16777216.0f);   // [0,1)
+}
+
+// --- Emission + bounce kernel ------------------------------------------------
+// One thread per aperture cell (apertureN x apertureN). Mirrors the CPU general
+// loop (light_tracer_caustic.cpp:282-326): sample a wavelength, seed a photon at
+// the aperture, march it through the sphere refracting (or reflecting on TIR)
+// accumulating the Schlick transmittance, and deposit on the receiver plane.
+// A cell that misses / TIRs out / never reaches the receiver writes a power of 0
+// (the host compacts the survivors, mirroring the CPU `photons` vector).
+__global__ void kEmitPhotons(GVec3 center, float radius, GDispersion disp,
+                             float flatIor, int isDispersive,
+                             GVec3 sunDir, GVec3 apOrigin, GVec3 apU, GVec3 apV,
+                             float apRadius, float receiverY,
+                             int apertureN, float lambdaMin, float lambdaMax,
+                             int maxDepth, PhotonEmitDeposit* out) {
+    int gx = blockIdx.x * blockDim.x + threadIdx.x;
+    int gy = blockIdx.y * blockDim.y + threadIdx.y;
+    if (gx >= apertureN || gy >= apertureN) return;
+    int cell = gy * apertureN + gx;
+    out[cell].power = GVec3(0.f);   // default: dropped
+    out[cell].position = GVec3(0.f);
+    out[cell].lambda = 0.f;
+
+    // Wavelength: an independent per-cell uniform draw (CPU: λ = lmin +
+    // (lmax-lmin)*u01, an independent uniform per photon). pe_jitter is a
+    // deterministic per-cell hash so the host oracle reproduces the SAME λ; it
+    // is decorrelated from the aperture-position jitters (different salt), so
+    // wavelength does not track entry position.
+    float uLam = pe_jitter(cell, 101u);
+    float lambda = lambdaMin + (lambdaMax - lambdaMin) * uLam;
+
+    float ior = isDispersive ? gpu_sellmeier_ior(disp, lambda) : flatIor;
+    if (ior <= 1.0f) ior = 1.5f;   // CPU general loop fallback (l.296)
+
+    // Jittered lattice point on the aperture disc -> a collimated entry ray.
+    float jx = (gx + pe_jitter(cell, 1u)) / float(apertureN);   // [0,1)
+    float jy = (gy + pe_jitter(cell, 2u)) / float(apertureN);
+    float a2 = (jx * 2.0f - 1.0f) * apRadius;
+    float b2 = (jy * 2.0f - 1.0f) * apRadius;
+    GVec3 o = apOrigin + apU * a2 + apV * b2;
+    GVec3 d = sunDir;
+
+    float tr = 1.0f;
+    bool passedCaster = false;
+    const float eps = 1e-3f;
+
+    for (int bounce = 0; bounce < maxDepth; ++bounce) {
+        GVec3 ng;
+        float t = pe_sphereHit(center, radius, o, d, eps, ng);
+        if (t < 0.0f) {
+            // Missed the glass. If we already passed through it, test the
+            // receiver plane; else this photon never interacts -> dropped.
+            if (!passedCaster) return;
+            break;
+        }
+        // Hit point along the CURRENT (pre-bounce) direction (CPU rec.point).
+        GVec3 hitPoint = o + d * t;
+        // Transmissive hit: enter/exit from the geometric-normal sign
+        // (CPU l.297-303). d.dot(ng) < 0 => entering (eta = 1/ior), else exiting.
+        GVec3 nf; float eta;
+        if (d.dot(ng) < 0.0f) { nf = ng;        eta = 1.0f / ior; }
+        else                  { nf = ng * -1.0f; eta = ior; }
+        GVec3 nd;
+        if (pe_refract(d, nf, eta, nd)) {
+            tr *= pe_fresnelT(d.dot(nf), ior);
+            d = nd;
+        } else {
+            // TIR -> mirror reflect (CPU l.303).
+            d = (d - nf * (2.0f * d.dot(nf))).normalized();
+        }
+        passedCaster = true;
+        // Advance from the hit point along the NEW direction (CPU l.310:
+        // o = rec.point + d*eps).
+        o = hitPoint + d * eps;
+    }
+
+    // The structural CPU loop computes the receiver deposit when, after passing
+    // the caster, the next BVH hit is a diffuse upward-facing surface. Here the
+    // only non-glass surface is the receiver plane (normal +y); intersect it.
+    if (!passedCaster || tr <= 0.0f) return;
+    if (d.y >= -1e-6f) return;                   // not heading down toward the receiver
+    float tPlane = (receiverY - o.y) / d.y;
+    if (tPlane <= eps) return;
+    GVec3 hit = o + d * tPlane;
+
+    GVec3 cmf = pe_cieCmf(lambda);
+    out[cell].position = hit;
+    out[cell].power = GVec3(cmf.x * tr, cmf.y * tr, cmf.z * tr);
+    out[cell].lambda = lambda;
+}
+
+}  // namespace
+
+std::vector<PhotonEmitDeposit> cuda_photon_emit_sphere(
+    const PhotonEmitSphereScene& scene) {
+
+    const int n = scene.apertureN * scene.apertureN;
+    std::vector<PhotonEmitDeposit> result;
+    if (scene.apertureN <= 0 || scene.sphereRadius <= 0.f) return result;
+
+    uploadEmitCmf();
+
+    // Aperture frame around the sun direction (CPU l.219-222).
+    GVec3 sunDir = scene.sunDir.normalized();
+    GVec3 a = (fabsf(sunDir.x) < 0.9f) ? GVec3(1, 0, 0) : GVec3(0, 1, 0);
+    GVec3 apU = (a - sunDir * a.dot(sunDir)).normalized();
+    GVec3 apV = sunDir.cross(apU);
+
+    PhotonEmitDeposit* d_out = nullptr;
+    APE_CUDA_CHECK(cudaMalloc(&d_out, (size_t)n * sizeof(PhotonEmitDeposit)));
+
+    dim3 block(16, 16);
+    dim3 grid((scene.apertureN + block.x - 1) / block.x,
+              (scene.apertureN + block.y - 1) / block.y);
+    kEmitPhotons<<<grid, block>>>(
+        scene.sphereCenter, scene.sphereRadius, scene.dispersion,
+        scene.flatIor, scene.isDispersive ? 1 : 0,
+        sunDir, scene.apertureCenter, apU, apV,
+        scene.apertureRadius, scene.receiverY,
+        scene.apertureN, scene.lambdaMin, scene.lambdaMax,
+        scene.maxDepth, d_out);
+    APE_CUDA_CHECK(cudaGetLastError());
+    APE_CUDA_CHECK(cudaDeviceSynchronize());
+
+    std::vector<PhotonEmitDeposit> host(n);
+    APE_CUDA_CHECK(cudaMemcpy(host.data(), d_out,
+                              (size_t)n * sizeof(PhotonEmitDeposit),
+                              cudaMemcpyDeviceToHost));
+    cudaFree(d_out);
+
+    // Compact survivors (power.y > 0), mirroring the CPU `photons` vector.
+    result.reserve(n);
+    for (const auto& dpt : host)
+        if (dpt.power.y > 0.f) result.push_back(dpt);
+    return result;
+}
+
+}  // namespace gpu
+}  // namespace photon
+}  // namespace astroray

--- a/tests/test_gpu_photon_emission.py
+++ b/tests/test_gpu_photon_emission.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python
+"""pkg113 Phase 2 — GPU photon EMISSION + BOUNCE vs a numpy float64 oracle.
+
+The GPU device kernel (src/gpu/photon_emission.cu) forward-traces a batch of
+collimated-sun photons through a single glass sphere (Snell refraction +
+Schlick-Fresnel reflect/transmit + enter/exit from the geometric-normal sign +
+per-λ Sellmeier iorAt + TIR) and deposits the surviving per-λ CIE flux as
+GPhotons on a flat receiver plane. This is the GPU port of the GENERAL
+deterministic-refraction path of plugins/integrators/light_tracer_caustic.cpp
+(lines 276-326). The flat-prism explicit 2-face path STAYS CPU (see
+include/astroray/gpu_photon_emit.h).
+
+Parity is by AGGREGATE bounds, NOT bit-exact — the forward trace is a stochastic
+light-particle deposit (memory [[general-photon-loop-needs-solid-glass]]: the
+caustic numeric gates pass on salt-and-pepper noise, so assert energy AND
+position, never a count alone). The oracle runs the IDENTICAL closed-form math
+(same pe_jitter aperture lattice, same Sellmeier IOR via the GPU's GDispersion
+coefficients, same Schlick transmittance, same CIE-CMF table via the
+`cie_cmf_1964_10deg` binding) fed the SAME deterministic entry samples — the
+"inject the same samples both sides" tactic sms_attempt_device.cuh uses for its
+Phase-1 unit test — so the comparison isolates the device math from RNG noise.
+
+GPU-gated: skips gracefully when CUDA is absent (CI has no GPU); /verify runs
+this on the RTX box. Mirrors the skip pattern of tests/test_gpu_photon_store.py.
+
+References: Arvo 1986 (forward light transport); Jensen 1996 (diffuse photon
+deposit); Schlick 1994 (Fresnel); Sellmeier 1871 (n(λ), reused via pkg64-gpu
+gpu_dispersion.cuh); CIE 1964 10° CMF (data/spectra/cie_cmf.inc). See
+.astroray_plan/docs/pkg113-phase2-photon-emission-research.md.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+try:
+    import astroray  # noqa: E402
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray not built")
+
+if AVAILABLE and not astroray.__features__.get("cuda", False):
+    pytest.skip(
+        "CUDA feature not in this build — pkg113 Phase 2 GPU photon emission "
+        "needs CUDA; /verify runs this on the RTX box.",
+        allow_module_level=True,
+    )
+
+if AVAILABLE and not hasattr(astroray, "_gpu_photon_emit_sphere"):
+    pytest.skip(
+        "GPU photon-emission binding not present — rebuild astroray.pyd (pkg113).",
+        allow_module_level=True,
+    )
+
+
+# --- BK7 Sellmeier coefficients (Schott BK7, the prism/sphere glass) ----------
+# n²(λ) = 1 + B1λ²/(λ²−C1) + B2λ²/(λ²−C2) + B3λ²/(λ²−C3), λ in μm.
+BK7_B = (1.03961212, 0.231792344, 1.01046945)
+BK7_C = (0.00600069867, 0.0200179144, 103.560653)
+BK7_SELLMEIER = list(BK7_B) + list(BK7_C)
+
+
+# --- Oracle: bit-faithful re-implementation of the device kernel math ---------
+_M32 = 0xFFFFFFFF
+
+
+def _pe_jitter(cell, salt):
+    """Exact uint32 reproduction of pe_jitter() in photon_emission.cu. CUDA's
+    unsigned arithmetic wraps mod 2^32; we mask Python ints to 32 bits to match
+    bit-for-bit, then do the final float multiply in float32 like the device."""
+    h = (cell * 0x9E3779B1 + salt * 0x85EBCA77) & _M32
+    h ^= h >> 15
+    h = (h * 0x2C1B3C6D) & _M32
+    h ^= h >> 12
+    h = (h * 0x297A2D39) & _M32
+    h ^= h >> 15
+    return float(np.float32((h & 0x00FFFFFF) * np.float32(1.0 / 16777216.0)))
+
+
+def _sellmeier_ior(lam_nm, B, C):
+    lam_um = lam_nm * 1e-3
+    l2 = lam_um * lam_um
+    n2 = 1.0
+    n2 += B[0] * l2 / (l2 - C[0])
+    n2 += B[1] * l2 / (l2 - C[1])
+    n2 += B[2] * l2 / (l2 - C[2])
+    return float(np.sqrt(max(1.0, n2)))
+
+
+def _refract(d, n, eta):
+    cosi = -float(np.dot(d, n))
+    s2 = eta * eta * (1.0 - cosi * cosi)
+    if s2 >= 1.0:
+        return None
+    out = d * eta + n * (eta * cosi - np.sqrt(1.0 - s2))
+    return out / np.linalg.norm(out)
+
+
+def _fresnel_t(cosi, ior):
+    f0 = (1.0 - ior) / (1.0 + ior)
+    f0 *= f0
+    fr = f0 + (1.0 - f0) * max(0.0, 1.0 - abs(cosi)) ** 5
+    return 1.0 - fr
+
+
+def _sphere_hit(center, radius, o, d, t_min):
+    oc = o - center
+    a = float(np.dot(d, d))
+    hb = float(np.dot(oc, d))
+    c = float(np.dot(oc, oc)) - radius * radius
+    disc = hb * hb - a * c
+    if disc < 0.0:
+        return None
+    sq = np.sqrt(disc)
+    root = (-hb - sq) / a
+    if root < t_min:
+        root = (-hb + sq) / a
+        if root < t_min:
+            return None
+    p = o + d * root
+    ng = (p - center) / radius
+    return root, ng
+
+
+def _oracle_emit(center, radius, B, C, sun_dir, ap_origin, ap_u, ap_v,
+                 ap_radius, receiver_y, aperture_n, lam_min, lam_max, max_depth,
+                 ior_fn=_sellmeier_ior):
+    eps = 1e-3
+    deposits = []
+    for gy in range(aperture_n):
+        for gx in range(aperture_n):
+            cell = gy * aperture_n + gx
+            u_lam = float(_pe_jitter(cell, 101))
+            lam = lam_min + (lam_max - lam_min) * u_lam
+            ior = ior_fn(lam, B, C)
+            if ior <= 1.0:
+                ior = 1.5
+
+            jx = (gx + float(_pe_jitter(cell, 1))) / aperture_n
+            jy = (gy + float(_pe_jitter(cell, 2))) / aperture_n
+            a2 = (jx * 2.0 - 1.0) * ap_radius
+            b2 = (jy * 2.0 - 1.0) * ap_radius
+            o = ap_origin + ap_u * a2 + ap_v * b2
+            d = sun_dir.copy()
+
+            tr = 1.0
+            passed = False
+            for _ in range(max_depth):
+                hit = _sphere_hit(center, radius, o, d, eps)
+                if hit is None:
+                    if not passed:
+                        o = None
+                    break
+                t, ng = hit
+                hit_point = o + d * t
+                if float(np.dot(d, ng)) < 0.0:
+                    nf, eta = ng, 1.0 / ior
+                else:
+                    nf, eta = -ng, ior
+                nd = _refract(d, nf, eta)
+                if nd is not None:
+                    tr *= _fresnel_t(float(np.dot(d, nf)), ior)
+                    d = nd
+                else:
+                    d = d - nf * (2.0 * float(np.dot(d, nf)))
+                    d = d / np.linalg.norm(d)
+                passed = True
+                o = hit_point + d * eps
+
+            if o is None or not passed or tr <= 0.0:
+                continue
+            if d[1] >= -1e-6:
+                continue
+            t_plane = (receiver_y - o[1]) / d[1]
+            if t_plane <= eps:
+                continue
+            hit = o + d * t_plane
+            cmf = astroray.cie_cmf_1964_10deg(lam)  # exact CPU CMF table (XYZ struct)
+            power = np.array([cmf.X * tr, cmf.Y * tr, cmf.Z * tr])
+            deposits.append((hit, power, lam))
+    return deposits
+
+
+def _scene():
+    center = np.array([0.0, 1.0, 0.0])
+    radius = 0.5
+    sun_dir = np.array([0.0, -1.0, 0.0])      # straight down
+    # Aperture disc above the sphere, spanning the inner projected extent.
+    # ap_radius=0.35 (< radius) keeps every ray clear of the grazing/TIR rim, so
+    # the deterministic lattice survives 100% on BOTH sides — no float32-vs-float64
+    # boundary flips — giving a clean, focused-caustic parity scene.
+    ap_origin = np.array([0.0, 3.0, 0.0])
+    ap_radius = 0.35
+    receiver_y = -1.0
+    aperture_n = 96                           # 9216 photons
+    lam_min, lam_max = 380.0, 720.0
+    max_depth = 12
+    # Device-side aperture frame around sun_dir (matches the .cu launcher).
+    a = np.array([1.0, 0.0, 0.0]) if abs(sun_dir[0]) < 0.9 else np.array([0.0, 1.0, 0.0])
+    ap_u = a - sun_dir * float(np.dot(a, sun_dir))
+    ap_u = ap_u / np.linalg.norm(ap_u)
+    ap_v = np.cross(sun_dir, ap_u)
+    return dict(center=center, radius=radius, sun_dir=sun_dir, ap_origin=ap_origin,
+                ap_u=ap_u, ap_v=ap_v, ap_radius=ap_radius, receiver_y=receiver_y,
+                aperture_n=aperture_n, lam_min=lam_min, lam_max=lam_max,
+                max_depth=max_depth)
+
+
+def _run_gpu(s):
+    return astroray._gpu_photon_emit_sphere(
+        center=s["center"].tolist(), radius=s["radius"],
+        sellmeier=BK7_SELLMEIER, flat_ior=1.5, is_dispersive=True,
+        sun_dir=s["sun_dir"].tolist(),
+        aperture_center=s["ap_origin"].tolist(),
+        aperture_radius=s["ap_radius"], receiver_y=s["receiver_y"],
+        aperture_n=s["aperture_n"], lambda_min=s["lam_min"],
+        lambda_max=s["lam_max"], max_depth=s["max_depth"],
+    )
+
+
+def _aggregate(positions, powers):
+    pos = np.asarray(positions, dtype=np.float64)
+    pw = np.asarray(powers, dtype=np.float64)
+    total_y = float(pw[:, 1].sum())
+    # Y-weighted centroid in the receiver plane (x, z).
+    w = pw[:, 1]
+    wsum = max(w.sum(), 1e-12)
+    cx = float((pos[:, 0] * w).sum() / wsum)
+    cz = float((pos[:, 2] * w).sum() / wsum)
+    # Y-weighted radial RMS extent about the centroid.
+    rr = (pos[:, 0] - cx) ** 2 + (pos[:, 2] - cz) ** 2
+    rms = float(np.sqrt((rr * w).sum() / wsum))
+    return total_y, (cx, cz), rms
+
+
+def test_gpu_deposit_set_matches_oracle_aggregate():
+    """GPU deposit set vs numpy float64 oracle (identical math, same lattice):
+    total Y-energy within ±5 %, Y-weighted centroid within 0.05·radius, radial
+    RMS extent within ±15 %. Aggregate bounds, not bit-exact (stochastic
+    forward trace; memory [[general-photon-loop-needs-solid-glass]])."""
+    s = _scene()
+
+    gpu = _run_gpu(s)
+    assert len(gpu) > 100, f"GPU deposited only {len(gpu)} photons (expected many)"
+    g_pos = [d[0] for d in gpu]
+    g_pw = [d[1] for d in gpu]
+
+    oracle = _oracle_emit(
+        s["center"], s["radius"], BK7_B, BK7_C, s["sun_dir"], s["ap_origin"],
+        s["ap_u"], s["ap_v"], s["ap_radius"], s["receiver_y"], s["aperture_n"],
+        s["lam_min"], s["lam_max"], s["max_depth"],
+    )
+    assert len(oracle) > 100, f"oracle deposited only {len(oracle)} (math/scene bug)"
+    o_pos = [d[0] for d in oracle]
+    o_pw = [d[1] for d in oracle]
+
+    # Survivor count: same deterministic lattice -> nearly identical survivor set
+    # (float32 vs float64 may flip a handful at the TIR / grazing boundary).
+    assert abs(len(gpu) - len(oracle)) <= 0.02 * len(oracle) + 5, (
+        f"survivor count GPU {len(gpu)} vs oracle {len(oracle)} diverges"
+    )
+
+    g_total, g_cent, g_rms = _aggregate(g_pos, g_pw)
+    o_total, o_cent, o_rms = _aggregate(o_pos, o_pw)
+
+    energy_ratio = g_total / max(o_total, 1e-12)
+    assert 0.95 <= energy_ratio <= 1.05, (
+        f"deposited Y-energy ratio {energy_ratio:.4f} outside ±5% "
+        f"(GPU {g_total:.4g}, oracle {o_total:.4g})"
+    )
+
+    cent_err = np.hypot(g_cent[0] - o_cent[0], g_cent[1] - o_cent[1])
+    assert cent_err < 0.05 * s["radius"], (
+        f"deposit centroid off by {cent_err:.4g} > 0.05·radius "
+        f"(GPU {g_cent}, oracle {o_cent})"
+    )
+
+    rms_ratio = g_rms / max(o_rms, 1e-9)
+    assert 0.85 <= rms_ratio <= 1.15, (
+        f"deposit radial RMS extent ratio {rms_ratio:.4f} outside ±15% "
+        f"(GPU {g_rms:.4g}, oracle {o_rms:.4g})"
+    )
+
+
+def test_gpu_deposit_is_dispersed_not_a_point():
+    """A dispersive glass sphere focuses a caustic with finite extent and a
+    spread of wavelengths — guards against a degenerate all-at-one-point or
+    all-one-λ deposit (the salt-and-pepper failure mode)."""
+    s = _scene()
+    gpu = _run_gpu(s)
+    assert len(gpu) > 100
+    lambdas = np.array([d[2] for d in gpu])
+    pos = np.asarray([d[0] for d in gpu], dtype=np.float64)
+    # Wavelengths span a real band (dispersion is active), not collapsed.
+    assert lambdas.max() - lambdas.min() > 100.0, "deposit λ band collapsed"
+    # The caustic has finite spatial extent (not a single degenerate point).
+    extent = np.hypot(pos[:, 0].std(), pos[:, 2].std())
+    assert extent > 1e-3, "deposit collapsed to a point (geometry/refraction bug)"
+
+
+def test_non_dispersive_glass_also_deposits():
+    """A flat-IOR (non-dispersive) glass sphere still focuses a caustic — the
+    is_dispersive=False path (flat_ior, no Sellmeier) must deposit, with energy
+    matching the oracle within ±5 %."""
+    s = _scene()
+    gpu = astroray._gpu_photon_emit_sphere(
+        center=s["center"].tolist(), radius=s["radius"],
+        sellmeier=[0.0] * 6, flat_ior=1.5, is_dispersive=False,
+        sun_dir=s["sun_dir"].tolist(),
+        aperture_center=s["ap_origin"].tolist(),
+        aperture_radius=s["ap_radius"], receiver_y=s["receiver_y"],
+        aperture_n=s["aperture_n"], lambda_min=s["lam_min"],
+        lambda_max=s["lam_max"], max_depth=s["max_depth"],
+    )
+    assert len(gpu) > 100, f"non-dispersive glass deposited only {len(gpu)}"
+
+    # Oracle with a constant IOR = 1.5 (Sellmeier bypassed), matching the
+    # device's is_dispersive=False path (flat_ior=1.5).
+    def const_ior(_lam, _B, _C):
+        return 1.5
+
+    oracle = _oracle_emit(
+        s["center"], s["radius"], (0.0, 0.0, 0.0), (1.0, 1.0, 1.0), s["sun_dir"],
+        s["ap_origin"], s["ap_u"], s["ap_v"], s["ap_radius"],
+        s["receiver_y"], s["aperture_n"], s["lam_min"], s["lam_max"],
+        s["max_depth"], ior_fn=const_ior,
+    )
+
+    g_total, _, _ = _aggregate([d[0] for d in gpu], [d[1] for d in gpu])
+    o_total, _, _ = _aggregate([d[0] for d in oracle], [d[1] for d in oracle])
+    ratio = g_total / max(o_total, 1e-12)
+    assert 0.95 <= ratio <= 1.05, f"non-dispersive energy ratio {ratio:.4f} outside ±5%"


### PR DESCRIPTION
**pkg113 phase 2** — GPU forward photon emission/bounce, stacked on the merged phase-1 store. Implemented by a package-implementer agent, **built + RTX-verified by me**.

## What landed
A device kernel + host-callable that forward-traces collimated-sun photons through a glass sphere and deposits per-λ CIE flux — the GPU port of the GENERAL deterministic-refraction path of `light_tracer_caustic.cpp` (Snell + Schlick-Fresnel + enter/exit from the geometric-normal sign + per-λ Sellmeier `iorAt` reusing pkg64-gpu's dispersion + TIR):
- `include/astroray/gpu_photon_emit.h`, `src/gpu/photon_emission.cu` — kernel + `cuda_photon_emit_sphere`.
- `tests/test_gpu_photon_emission.py` — CUDA-gated parity test vs a numpy float64 oracle running the identical math on the same deterministic aperture lattice ("inject the same samples both sides").
- `module/blender_module.cpp` binding + CMakeLists entry + research note.

**Flat-prism decision:** the explicit 2-face path **stays CPU** (it needs host-side caster-plane classification not on the GPU; the general loop covers the sphere + any solid caster — spec-authorized fork).

## Verification (RTX)
`pytest tests/test_gpu_photon_emission.py` → **3 passed**: deposit energy ratio within ±5%, Y-weighted centroid within 0.05·radius, radial RMS within ±15%, dispersion band >100 nm (non-degenerate). Phase-1 store gate still 4/4. Additive (new files + guarded binding).

**Phase 3 next:** wire the device `photonGridGather` into the GPU integrator at receiver hits, drive emission from the uploaded scene, and re-run the prism/glass-sphere acceptance scenes on GPU with the visual + SSIM≥0.97 parity gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)