### PR TITLE
docs: round closeout 2026-06-10

### DIFF
--- a/.astroray_plan/docs/NEXT_STAGE_REPORT.md
+++ b/.astroray_plan/docs/NEXT_STAGE_REPORT.md
@@ -1,49 +1,46 @@
 # Astroray Next Stage Report
 
-**Date:** 2026-05-31 (Round 15 Wave 6 closeout — pkg104 CPU+cross-engine acceptance closed, pkg118 rough-glass root-cause, pkg64-gpu HW-sweep evidence, pkg117 nonmesh geometry)
-**Prepared by:** Claude (Anthropic Code) — rewritten at the Wave 6 closeout (pkg104/pkg117 complete; pkg118 filed).
-**Scope:** post-Wave-6 next stage.
+**Date:** 2026-06-10 (Round closeout — pkg118 COMPLETE, pkg113 COMPLETE, pkg112 COMPLETE)
+**Prepared by:** Claude (Anthropic Code) — rewritten at the 2026-06-10 round closeout (pkg118/pkg113/pkg112 closed).
+**Scope:** post-2026-06-10 next stage.
 
 > Strategic gate: **RELEASED 2026-05-10** by pkg56 Phase C. Strategy in
 > [`ROADMAP.md`](ROADMAP.md), full status in [`STATUS.md`](STATUS.md) (the
 > Round 15 Wave 6 section is authoritative for the current state).
 
-> ⚠️ **UPDATE 2026-06-08:** pkg118 was attempted and **the multi-scatter-table
-> approach is a DEAD-END** (see STATUS.md 2026-06-08 + `pkg118-multiscatter-energy-research.md`).
-> Part A (forced-TIR pdf) landed (PR #415) but is gate-neutral; the furnace deficit is
-> NOT single-scatter masking (it is worst at LOW roughness) — it is the CPU bespoke RGB
-> `disney_sample` diverging from the energy-conserving GPU spectral closure path. pkg118
-> is OPEN, **re-scoped** to a CPU formulation fix and is **no longer a quick CPU win**.
-> The deployable set below (§2) treats pkg118 item 1 as superseded by this finding.
+> ⚠️ **UPDATE 2026-06-10:** **pkg118 SOLVED** (PR #423, 2026-06-08). The rough-glass
+> furnace deficit was the **η² albedo-LUT clamp** (the CPU twin of the #404 GPU glass-dark
+> bug): `Material::sampleSpectral` upsampled glass throughput through `RGBAlbedoSpectrum`,
+> whose Jakob-Hanika ALBEDO LUT clamps rgb>1 to 1, clipping the exit refraction's eta²=2.25
+> radiance recovery. Fix: factor the >1 magnitude out as a flat spectral scalar (mirrors
+> GPU #404), upsample only the normalized tint. CPU furnace 0.77/0.82/0.92/0.97/0.96 →
+> 0.89/0.94/1.00/1.00/1.00; `test_disney_rough_glass_furnace_energy_cpu` PASSES [0.92,1.03].
+> **pkg118 DONE.** Also closed: **pkg113** (GPU photon-map caustics, all 3 phases merged +
+> RTX-verified, PR #422/#424/#425) and **pkg112** (batched geometry upload, 31.7× speedup,
+> PR #427).
 >
-> The remaining lead pool is **pkg64-gpu gate resolution** (RTX owner adjudication) + the
-> standing GPU-gated work (pkg113 GPU photon-map, pkg116, pkg108, pkg115).
-> Clean CI-only CPU wins are largely exhausted; the next substantive work is GPU-gated
-> (do on this RTX with hardware verification) or the pkg118 CPU rough-glass rewrite.
+> The next autonomous lead pool is **pkg114** (two-level BVH, TLAS/BLAS) → **pkg55**
+> (wavefront SoA refactor) → **pkg64** (spectral caustics). All GPU-gated + RTX-verifiable.
+> Clean CI-only CPU wins are exhausted; the next substantive work is GPU-gated (do on this
+> RTX with hardware verification).
 >
-> **Owner directives (2026-06-08):** (1) **Pillar 4 (pkg45/46/48/49/50/51) is ON PAUSE**
-> until the rest is working/stable/sufficiently progressed — do not pick it up. (2) The
-> broken old-Blender benchmark scenes (Classroom/BMW27/Junkshop/UDIM_monster) were
-> **removed**; **pkg76 Classroom/BMW27/Junkshop fidelity is dropped** from the pool
-> (item 9 below is void). cornell is the only remaining Cycles-parity scene.
+> **Owner directives (2026-06-08):** (1) **Pillar 4 (pkg45/46/48/49/50/51 + pkg107) is ON
+> PAUSE** until the rest is working/stable/sufficiently progressed — do not pick it up.
+> (2) The broken old-Blender benchmark scenes (Classroom/BMW27/Junkshop/UDIM_monster) were
+> **removed**; **pkg76 Classroom/BMW27/Junkshop fidelity is dropped** from the pool.
+> cornell is the only remaining Cycles-parity scene.
 
 ---
 
 ## 1. Current state (one screen)
 
-- **pkg104 + pkg117 COMPLETE.** pkg104 (visual reference bank) closed CPU + cross-engine
-  acceptance: PR #407 added 3 tests (`test_reference_bank_smoke.py`) on the REAL
-  references (broken-render gate-fails; prism hue_spread 0.753 ≥ 0.7; Schwarzschild
-  dark_disk 0.053 ≥ 0.03); PR #410 re-rendered the disney-sweep Cycles reference via
-  Blender 5.1 with the FOV fix → SSIM 0.7611 ≥ 0.65. pkg117 (nonmesh geometry) routes
-  CURVE/SURFACE/FONT/META via `to_mesh()` + `to_mesh_clear()` (PR #411, 4 tests + 10
-  existing pass; Blender 5.1 headless check confirms 288/58/170 polys).
-- **pkg118 filed — rough-dielectric multi-scatter energy compensation.** The xfail'd
-  `test_disney_rough_glass_furnace_energy_cpu` residual is **NOT** VNDF/low-alpha — it
-  is **missing Kulla-Conty multi-scatter** (single-scatter masking loss + forced-TIR
-  delta over-count partially cancel at high roughness, diverge at low). PR #408 documented
-  the root cause + filed `packages/pkg118-rough-dielectric-multiscatter-energy.md` with
-  the fix plan (dielectric E precompute table + PBRT-v4 TIR pdf correction).
+- **pkg118 + pkg113 + pkg112 COMPLETE (2026-06-08→10).** pkg118 (rough-glass energy) SOLVED
+  (PR #423): the η² albedo-LUT clamp (CPU twin of #404 GPU glass-dark bug) — fix = factor
+  >1 magnitude out as flat spectral scalar; CPU furnace 0.77→0.89+, test PASSES [0.92,1.03].
+  pkg113 (GPU photon-map caustics) all 3 phases merged + RTX-verified (PR #422/#424/#425):
+  store, emission, gather; the phase-3 follow-up resolved (CPU exit-refraction sign bug,
+  not GPU). pkg112 (batched geometry upload) 31.7× speedup (PR #427): one
+  `add_triangles_bulk` pybind call per mesh, bit-identical render + real-Blender end-to-end.
 - **pkg64-gpu SMS gates drift documented (GPU improved, frozen gates measure vs stale
   baselines).** PR #409 confirmed on RTX: parity SSIM 0.8352 < 0.85, Phase-3 prism PSNR
   −0.59 dB < −0.5. Cause: Wave-5 glass fix (PR #404) legitimately improved GPU; the
@@ -53,69 +50,73 @@
 - **Blender 5.1 is installed on this machine.** Agents CAN now re-bless cross-engine
   Cycles references (was "owner Blender re-render"; PR #410 did it).
 - **No open PRs.** The PR queue is empty.
-- **Blocked / not-overnight:** pkg113 (GPU photon-map port), pkg64-gpu gate resolution
-  (owner adjudication), pkg55-B' CUDA sessions, pkg86-B GPU light tree — all need RTX
-  hardware-verified gates (CI has NO GPU).
+- **Next autonomous work: GPU-gated + RTX-verifiable.** pkg114 (two-level BVH TLAS/BLAS) →
+  pkg55 (wavefront SoA refactor) → pkg64 (spectral caustics). pkg108/pkg88 owner-blocked
+  (reproduction scenes / open questions). Pillar 4 (pkg45/46/48/49/50/51 + pkg107) ON PAUSE
+  per owner directive 2026-06-08.
 
 ---
 
 ## 2. Deployable set (prioritized)
 
-Ordered by value × overnight-shippability. CI is **Linux/CPU only** — pick CPU
-work whose correctness can be gated without a GPU.
+Ordered by value × overnight-shippability. **pkg118, pkg113, pkg112 are DONE** (closed
+this round). CI is **Linux/CPU only** — pick CPU work whose correctness can be gated
+without a GPU.
 
-**Top priority (CPU-shippable):**
+**Top priority (autonomous, GPU-gated — do on RTX):**
 
-1. **pkg118 — CPU rough-dielectric multi-scatter energy compensation** (M, CPU-gated).
-   The xfail'd `test_disney_rough_glass_furnace_energy_cpu` now has a root-cause
-   (PR #408 / `packages/pkg118-rough-dielectric-multiscatter-energy.md`): missing
-   Kulla-Conty multi-scatter on the rough dielectric transmission lobe. Single-scatter
-   masking loss + forced-TIR delta over-count partially cancel at high roughness (~0.96),
-   diverge at low (0.77/0.81). Fix: (A) correct the forced-TIR delta throughput (PBRT-v4
-   §9.5 TIR pdf = 1, not Fresnel×transmission), (B) precompute `E_glass(alpha, mu, eta)`
-   table (MC integration of the single-scatter rough dielectric BSDF, Heitz 2016 + Kulla-
-   Conty 2017 multi-scatter factor), apply to rough transmission like the reflection
-   lobe already does. Furnace gate wants [0.95, 1.02] for R∈{0.1,0.3,0.6,1.0}. **Cite:**
-   PBRT-v4 `DielectricBxDF`, Cycles `bsdf_microfacet.h` energy-conserving dielectric,
-   Kulla-Conty 2017, Heitz 2016. Sources already in `vndf-microfacet-dielectric-research.md`
-   UPDATE 3.
+1. **pkg114 — two-level BVH (TLAS/BLAS)** (GPU, RTX-verifiable, AUTONOMOUS). Enables
+   instancing; natural follow-up to pkg112 (batched geometry upload). Large/multi-session;
+   needs §6 research (cite Cycles `bvh2.cpp` TLAS/BLAS, PBRT-v4 ch.7 BVH construction,
+   NVIDIA OptiX Programming Guide TLAS/BLAS split). **Start with a research pass** —
+   locate canonical refs, save to `.astroray_plan/docs/pkg114-tlas-blas-research.md`,
+   then implement.
+2. **pkg55 — wavefront SoA refactor** (GPU, large, research already signed off per its
+   spec). Laine 2013 per-material shade kernels; the pkg81-measured viewport-parity
+   blocker (CUDA 104 ms vs CPU 58 ms — megakernel register pressure). Multi-session.
+3. **pkg64 — spectral caustics** (huge, ~3–4 wk). The SMS CPU spectral caustic path.
 
-**Standing CPU-shippable pool:**
+**GPU-gated pool (OWNER-BLOCKED or owner-reserved):**
 
-2. **pkg101 / pkg102 / pkg100** (S each, no research) — addon viewport vfov, HDRI/DOF
-   aperture units, .blend importer camera intrinsics. Branches exist on origin;
-   re-verify vs current main (Wave-4 check found pkg100/101/102 already landed — may be
-   no work needed). Independent — parallelizable.
-3. **pkg76 Classroom Gap 2 continuation** (M, partial) — Gap 2 landed the non-Principled
-   shader-graph walk (PR #394), but the Classroom SSIM ≥0.85 gate is GPU-gated and was
-   deferred. Land any remaining importer-side code + bpy-free unit tests on CI; defer the
-   GPU SSIM gate to the next HW sweep.
-
-**GPU-gated (NOT overnight — do on RTX):**
-
-4. **pkg64-gpu gate resolution** (owner adjudication needed). PR #409 HW-sweep evidence
-   doc `pkg64-gpu-hw-sweep-2026-05-31.md` confirms both SMS gates drifted: parity SSIM
+4. **pkg108 — addon residual triage** (owner questions: BUG-09/BUG-14 need the owner's
+   reproduction scene; only BUG-16 subsurface is a candidate autonomous fix). Blender
+   integration parity spec.
+5. **pkg88 — motion blur** (4 owner questions remain in the spec). Blender integration
+   parity spec.
+6. **pkg64-gpu SMS gate resolution** (owner-reserved). PR #409 HW-sweep evidence doc
+   `pkg64-gpu-hw-sweep-2026-05-31.md` confirms both SMS gates drifted: parity SSIM
    0.8352 < 0.85, Phase-3 prism PSNR −0.59 dB < −0.5. Root cause: Wave-5 glass fix
    (PR #404) legitimately improved GPU; the frozen SMS-GPU gates measure vs stale
-   baselines. The two gates need different fixes: (a) PSNR gate = re-bless the stored
-   high-spp reference (clean reference update); (b) SSIM parity gate = owner picks
-   xfail-as-legacy (recommended; SMS-GPU frozen, pkg113 photon-map is canonical) OR
-   recalibrate the floor. Owner action required — do NOT silently lower a floor.
-5. **pkg113 — GPU photon-map caustics + CPU/GPU parity** (L, multi-session, GPU-verifiable
-   on RTX). The GPU port of the now-CPU-complete chain (pkg109→pkg110→pkg111). Caustic
-   photon map is the canonical path on CPU+GPU; SMS-GPU (pkg64-gpu) is frozen/legacy per
-   owner decision 2026-05-30. Full CPU↔GPU-equivalence picture + caustics fork in
-   `cpu-gpu-parity-status.md`.
-6. **pkg116 — exporter cache refactor** (M, addon). Blender integration parity spec.
-7. **pkg108 — addon residual triage**. Blender integration parity spec.
+   baselines. Owner action required — do NOT silently lower a floor.
+7. **pkg116 — exporter cache refactor** (M, addon). Blender integration parity spec.
 8. **pkg115 — shader-node textures**. Blender integration parity spec.
 9. **pkg76 Classroom fidelity** — GPU investigation (SSIM ≥0.85 gate deferred from Gap 2).
+   NOTE: the broken old-Blender benchmark scenes (Classroom/BMW27/Junkshop/UDIM_monster)
+   were removed per owner directive 2026-06-08; pkg76 Classroom/BMW27/Junkshop fidelity
+   is DROPPED from the pool. cornell is the only remaining Cycles-parity scene.
 10. **pkg55-B' CUDA sessions** (wavefront port continuation), **pkg86-B GPU light tree**,
     **SPPM-progressive + VCM** (owner decision). All GPU-gated; CI has no GPU.
 
+**Pillar 4 (PAUSED per owner directive 2026-06-08):**
+
+- **pkg45/46/48/49/50/51 + pkg107** — all ON PAUSE until core rendering is
+  working/stable/sufficiently progressed. **Do NOT pick up Pillar-4 specs.**
+
+**Standing CPU-shippable pool (low priority or already verified stale):**
+
+- **pkg101 / pkg102 / pkg100** (S each, no research) — addon viewport vfov, HDRI/DOF
+  aperture units, .blend importer camera intrinsics. Branches exist on origin;
+  re-verify vs current main (Wave-4 check found pkg100/101/102 already landed — may be
+  no work needed). Independent — parallelizable.
+- **pkg76 Classroom Gap 2 continuation** (M, partial) — Gap 2 landed the non-Principled
+  shader-graph walk (PR #394), but the Classroom SSIM ≥0.85 gate is GPU-gated and was
+  deferred. Land any remaining importer-side code + bpy-free unit tests on CI; defer the
+  GPU SSIM gate to the next HW sweep. **OBSOLETED** by the 2026-06-08 owner directive
+  (Classroom scene removed).
+
 **Note on test suite:** The full local test suite has **ONE expected failure**: the
 pkg64-gpu parity SSIM gate (`test_pkg64_gpu_cpu_parity_ssim`) — this is the legitimate
-owner-reserved drift (item 4 above), NOT a regression. Do not mis-diagnose it.
+owner-reserved drift (item 6 above), NOT a regression. Do not mis-diagnose it.
 
 ---
 

--- a/.astroray_plan/docs/ROADMAP.md
+++ b/.astroray_plan/docs/ROADMAP.md
@@ -178,6 +178,32 @@ fix:
   to pkg55 Phase B per the spec's escape clause; smaller H2/H5
   follow-ups split out as **pkg83** + **pkg84**.
 
+**Round closeout (2026-06-10): pkg118 + pkg113 + pkg112 COMPLETE.**
+**pkg118 SOLVED** (PR #423, 2026-06-08) — the rough-glass furnace energy deficit was the **η²
+albedo-LUT clamp** (the CPU twin of the #404 GPU glass-dark bug): `Material::sampleSpectral`
+upsampled glass throughput through `RGBAlbedoSpectrum`, whose Jakob-Hanika ALBEDO LUT clamps
+rgb>1 to 1, clipping the exit refraction's eta²=2.25 radiance recovery. Fix: factor the >1
+magnitude out as a flat spectral scalar (mirrors GPU #404), upsample only the normalized tint.
+CPU furnace 0.77/0.82/0.92/0.97/0.96 → 0.89/0.94/1.00/1.00/1.00; `test_disney_rough_glass_furnace_energy_cpu`
+PASSES [0.92,1.03]; no regressions. The spec's Part B (Kulla-Conty multi-scatter table) was a
+dead-end (the deficit was NOT single-scatter masking). Full diagnosis:
+`.astroray_plan/docs/pkg118-multiscatter-energy-research.md`. **pkg113 DONE** (all 3 phases merged +
+RTX-verified, PR #422 store, #424 emission, #425 gather) — GPU photon-map caustics: uniform hash-grid
+store, GPU photon emission + bounce → deposit, adaptive k-NN cone gather wired into both GPU
+integrators. Phase-3 follow-up resolved: the "GPU caustic 5.6x more spread" was REAL but the diagnosis
+was INVERTED — the GPU was correct; the **CPU reference carried an exit-refraction sign bug** (both CPU
+caustic loops keyed enter/exit off the ray-ORIENTED `rec.normal`, always taking the "entering" branch;
+fix = recover geometric outward normal `ng = frontFace ? rec.normal : -rec.normal`). RTX-verified:
+glass-sphere parity ROI ratio 1.09x, SSIM 0.962, peak 0.409; pkg110 conc 32.4; 26 caustic/GPU tests
+pass, 0 regressions. Detail: `pkg113-phase3-gather-wiring-research.md` RESOLUTION section. **pkg112
+DONE** (PR #427) — batched geometry upload: one `add_triangles_bulk` pybind call per mesh (looping in
+C++), replacing the per-triangle `add_triangle` round-trip. Addon fills arrays with Blender's C-speed
+`foreach_get`; **31.7× upload speedup** on 100,352 tris (692.7ms→21.9ms). Verified at four layers:
+binding pixel-identity (bit-identical CPU render), extraction-parity unit test (non-uniform-scale +
+inverse-transpose normals + multi-UV order), and a **real-Blender end-to-end bit-identical render**
+(headless Blender 5.1). **Next pickup:** pkg114 (two-level BVH TLAS/BLAS) → pkg55 (wavefront SoA) →
+pkg64 (spectral caustics) — all GPU-gated + RTX-verifiable.
+
 **Round 15 Waves 3–5 (2026-05-29→30): forward-light-tracer prism rainbow → general caustics → GPU glass energy + showcase.**
 **pkg106 FINISHED** (PR #393) — a triangulated BK7 prism throws a clean continuous rainbow caustic
 (hue_spread 0.754 ≥0.7, bright_coverage 0.88) via a NEW forward light-tracer integrator
@@ -194,10 +220,10 @@ energy bug (delta refraction eta^2 was albedo-clamped to [0,1] by the JH upsampl
 0.705 → 0.991 flat @ ior 1.5) and lands a **Heitz-2018 VNDF microfacet-dielectric rough-transmission
 rewrite** (PBRT-v4 `DielectricBxDF`, BSD-3-Clause — GPU rough glass now energy-conserving for R≥0.1);
 **PR #405** re-authors 6 reference-bank showcase scenes (≥512², gate-green on RTX). The forward
-photon-map caustics are CPU-only by design; the GPU port is specced as **pkg113** (GPU-gated). The
-glass-energy fix legitimately moved GPU output, so **two pkg64-gpu HW gates need re-baselining with
-written justification** (parity SSIM 0.835 < 0.85; Phase-3 prism PSNR delta −0.59 < −0.5 dB) — these
-do not run on CI (no GPU); flagged for the next HW sweep.
+photon-map caustics were CPU-only by design; **pkg113** (the GPU port) is now DONE (2026-06-10, see
+closeout section above). The glass-energy fix legitimately moved GPU output, so **two pkg64-gpu HW
+gates need re-baselining with written justification** (parity SSIM 0.835 < 0.85; Phase-3 prism PSNR
+delta −0.59 < −0.5 dB) — these do not run on CI (no GPU); flagged for the next HW sweep.
 
 **Round 15 Wave 2 (2026-05-28, 3 PRs merged): pkg106 Chunks B/C/D-seed — MNEE foundation complete.**
 **pkg106 MNEE foundation COMPLETE** (PRs #389/#390/#391) — Chunks B/C/D-seed shipped: surface (u,v) partials (`manifold/surface_partials.h`), analytic Newton solver (`newton_iterate.h::solveAnalytic`), multi-vertex manifold chain (`manifold/manifold_chain.h` — block-tridiagonal Jacobian + damped Newton), mesh seed-ray + chain convergence on triangulated prism (`manifold/mesh_caustic.h`). All CPU-only header math + unit tests, validated to ~1e-11 vs finite-difference / analytic Snell. **Remaining: Chunk D-radiance** (wire multi-vertex MNEE into live integrator — transfer-matrix geometry term + finite prism faces + in-triangle validity + visibility; currently renders chromatic noise on wip/pkg106-chunk-d-radiance) + **Chunk E** (prism scene + hue_spread ≥0.7).

--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -1,6 +1,23 @@
 # Astroray Status
 
-**Last updated:** 2026-06-10 (pkg112 batched geometry upload COMPLETE — PR #427; pkg113 COMPLETE — #425).
+**Last updated:** 2026-06-10 (pkg118 COMPLETE — PR #423; pkg113 COMPLETE — PR #425; pkg112 COMPLETE — PR #427).
+
+## pkg118 — rough-dielectric energy compensation COMPLETE (2026-06-08, PR #423)
+
+**SOLVED**: the rough-glass furnace energy deficit was the **η² albedo-LUT clamp** (the CPU
+twin of the #404 GPU glass-dark bug). `raytracer.h` `Material::sampleSpectral` upsampled
+the glass throughput through `RGBAlbedoSpectrum`, whose Jakob-Hanika ALBEDO LUT clamps
+rgb>1 to 1, clipping the exit refraction's **eta²=2.25** radiance recovery at the glass→air
+exit. Fix (PR #423): factor the >1 magnitude out as a flat spectral scalar (mirrors the GPU
+#404 fix), upsample only the normalized tint. CPU furnace 0.77/0.82/0.92/0.97/0.96 →
+0.89/0.94/1.00/1.00/1.00; `test_disney_rough_glass_furnace_energy_cpu` now **PASSES**
+[0.92,1.03]; no regressions. Part A (forced-TIR pdf correction, PR #415) also landed but
+was gate-neutral. The spec's Part B (Kulla-Conty multi-scatter compensation table) was a
+**dead-end** — the deficit was NOT single-scatter masking (it was worst at LOW roughness,
+not high). Full diagnosis (5 ruled-out approaches → per-bounce ray trace):
+`.astroray_plan/docs/pkg118-multiscatter-energy-research.md`. **Next pickup:** the general
+pool (pkg114 two-level BVH, pkg55 wavefront SoA, pkg64 spectral caustics — all GPU-gated +
+autonomous).
 
 ## pkg112 — batched geometry upload COMPLETE (2026-06-10, PR #427)
 
@@ -50,16 +67,20 @@ geometry upload, GPU-gated, RTX-verifiable).
   from the uncommitted gallery stash that predated the cleanup; main had the pre-fix
   dark-glass renders. `gallery_prism_caustics.png` left as main's (the stash version is
   a broken black render).
-- **pkg118 — forced-TIR pdf fix + Kulla-Conty table REJECTED (PR #415).** Part A: the
-  forced-TIR delta-reflect pdf was `fresnel*transmission_`; corrected to `transmission_`
-  for deterministic TIR (PBRT-v4 §9.5), CPU + GPU. Correct firefly fix but **gate-neutral**.
-  **Key finding: the spec's Part B (multi-scatter compensation table) is a dead-end.**
-  The furnace deficit is worst at LOW roughness (not single-scatter masking), and
-  compensating the rough-transmission lobe AND the rough→delta fallthrough moves R=0.1
-  only 0.815→0.823. The real defect is the **CPU bespoke RGB `disney_sample` diverging
-  from the energy-conserving GPU spectral closure path** (GPU furnace R=0.1 = 0.956 vs
-  CPU 0.823). pkg118 stays OPEN, re-scoped to a CPU-RGB-vs-closure-path formulation fix;
-  `test_disney_rough_glass_furnace_energy_cpu` xfail kept. Analysis:
+- **pkg118 — forced-TIR pdf fix + root-cause diagnosis (PR #415, PR #423).** Part A
+  (PR #415): the forced-TIR delta-reflect pdf was `fresnel*transmission_`; corrected to
+  `transmission_` for deterministic TIR (PBRT-v4 §9.5), CPU + GPU. Correct firefly fix
+  but **gate-neutral**. **Key finding: the spec's Part B (multi-scatter compensation
+  table) is a dead-end.** The furnace deficit is worst at LOW roughness (not single-
+  scatter masking), and compensating the rough-transmission lobe AND the rough→delta
+  fallthrough moves R=0.1 only 0.815→0.823. The real defect was the **η² albedo-LUT
+  clamp** (the CPU twin of the #404 GPU glass-dark bug): `Material::sampleSpectral`
+  upsampled the glass throughput through `RGBAlbedoSpectrum`, whose Jakob-Hanika ALBEDO
+  LUT clamps rgb>1 to 1, clipping the exit refraction's eta²=2.25 radiance recovery. Fix
+  (PR #423): factor the >1 magnitude out as a flat spectral scalar (mirrors GPU #404),
+  upsample only the normalized tint. CPU furnace 0.77/0.82/0.92/0.97/0.96 →
+  0.89/0.94/1.00/1.00/1.00; `test_disney_rough_glass_furnace_energy_cpu` now PASSES
+  [0.92,1.03]. **pkg118 DONE.** Analysis:
   `.astroray_plan/docs/pkg118-multiscatter-energy-research.md`.
 - **Removed broken old-Blender benchmark scenes (owner directive).** The Blender
   Foundation demo scenes (Classroom, BMW27, Junkshop, UDIM_monster) ship from old

--- a/.astroray_plan/packages/pkg118-rough-dielectric-multiscatter-energy.md
+++ b/.astroray_plan/packages/pkg118-rough-dielectric-multiscatter-energy.md
@@ -3,15 +3,14 @@
 **Pillar:** 2 (materials / BSDF correctness)
 **Track:** A (CPU-gated; furnace test runs on CI — no GPU needed)
 **Codex-paste-ready:** no (numerical precompute + furnace verification)
-**Status:** ✅ **DONE 2026-06-08.** The deficit was NOT missing multi-scatter (Part B
-Kulla-Conty correctly REJECTED) — it was the **CPU twin of the #404 GPU glass-dark bug**:
-`raytracer.h` `Material::sampleSpectral` upsampled the glass throughput through
-`RGBAlbedoSpectrum`, whose Jakob-Hanika ALBEDO LUT clamps rgb>1 to 1, clipping the exit
-refraction's **eta²=2.25** radiance recovery. Fix = factor the >1 magnitude out as a flat
-spectral scalar (same as PR #404 on GPU). CPU furnace 0.77/0.82/0.92/0.97/0.96 →
-0.89/0.94/1.00/1.00/1.00; `test_disney_rough_glass_furnace_energy_cpu` **un-xfailed and
-PASSES** [0.92,1.03]; no regressions. Part A (forced-TIR pdf) also landed. Full diagnosis
-(5 ruled-out approaches → per-bounce ray trace):
+**Status:** ✅ **DONE (PR #423, 2026-06-08 — CPU rough-glass furnace 0.77/0.82/0.92/0.97/0.96
+→ 0.89/0.94/1.00/1.00/1.00; test PASSES [0.92,1.03]).** The deficit was NOT missing
+multi-scatter (Part B Kulla-Conty correctly REJECTED) — it was the **CPU twin of the #404
+GPU glass-dark bug**: `raytracer.h` `Material::sampleSpectral` upsampled the glass
+throughput through `RGBAlbedoSpectrum`, whose Jakob-Hanika ALBEDO LUT clamps rgb>1 to 1,
+clipping the exit refraction's **eta²=2.25** radiance recovery. Fix = factor the >1
+magnitude out as a flat spectral scalar (same as PR #404 on GPU). Part A (forced-TIR pdf)
+also landed (PR #415). Full diagnosis (5 ruled-out approaches → per-bounce ray trace):
 [`pkg118-multiscatter-energy-research.md`](../docs/pkg118-multiscatter-energy-research.md).
 **Depends on:** none. Extends the existing `DisneyEnergyCompensationTables` (pkg60).
 **Estimated effort:** M (a precompute pass + apply + furnace re-gate)


### PR DESCRIPTION
## Summary

Round closeout documentation reconciliation for 2026-06-10. **Three packages closed this round:**

- **pkg118** (rough-dielectric energy, PR #423, 2026-06-08) — **SOLVED**: the η² albedo-LUT clamp (CPU twin of #404 GPU glass-dark bug). `Material::sampleSpectral` upsampled glass throughput through `RGBAlbedoSpectrum`, whose Jakob-Hanika ALBEDO LUT clamps rgb>1 to 1, clipping the exit refraction's eta²=2.25 radiance recovery. Fix: factor the >1 magnitude out as a flat spectral scalar (mirrors GPU #404), upsample only the normalized tint. CPU furnace 0.77/0.82/0.92/0.97/0.96 → 0.89/0.94/1.00/1.00/1.00; `test_disney_rough_glass_furnace_energy_cpu` PASSES [0.92,1.03]; no regressions.

- **pkg113** (GPU photon-map caustics, PR #422/#424/#425, 2026-06-08→10) — **ALL 3 PHASES MERGED + RTX-VERIFIED**: GPU photon store (uniform hash grid), GPU photon emission + bounce → deposit, adaptive k-NN cone gather wired into both GPU integrators. Phase-3 follow-up resolved: the "GPU caustic 5.6x more spread" was REAL but the diagnosis was INVERTED — the GPU was physically correct; the **CPU reference carried an exit-refraction sign bug** (both CPU caustic loops keyed enter/exit off the ray-ORIENTED `rec.normal`, always taking the "entering" branch). Fix: recover geometric outward normal `ng = frontFace ? rec.normal : -rec.normal` in `light_tracer_caustic.cpp` + `spectral_path_tracer.cpp::buildPhotonMap`. RTX-verified: glass-sphere parity ROI ratio 1.09x, SSIM 0.962, peak 0.409; pkg110 conc 32.4; 26 caustic/GPU tests pass, 0 regressions.

- **pkg112** (batched geometry upload, PR #427, 2026-06-10) — one `add_triangles_bulk` pybind call per mesh (looping in C++), replacing the per-triangle `add_triangle` round-trip. Addon fills arrays with Blender's C-speed `foreach_get`; **31.7× upload speedup** on 100,352 tris (692.7ms→21.9ms). Verified at four layers: binding pixel-identity (bit-identical CPU render), extraction-parity unit test (non-uniform-scale + inverse-transpose normals + multi-UV order), and a **real-Blender end-to-end bit-identical render** (headless Blender 5.1).

## Changes

- **pkg118 spec** (`packages/pkg118-rough-dielectric-multiscatter-energy.md`): Status → DONE (PR #423, 2026-06-08).
- **STATUS.md**: add pkg118 COMPLETE section (2026-06-08), fix stale 2026-06-08 maintenance prose (the "pkg118 stays OPEN, re-scoped" lines are now wrong — pkg118 is DONE).
- **NEXT_STAGE_REPORT.md**: rewrite §2 next-pickup queue (pkg114 two-level BVH → pkg55 wavefront SoA → pkg64 spectral caustics — all GPU-gated + autonomous); update §1 current state + UPDATE note (2026-06-10).
- **ROADMAP.md**: add 2026-06-10 closeout section.

## Next autonomous pickup

1. **pkg114** (two-level BVH, TLAS/BLAS) — GPU, RTX-verifiable, AUTONOMOUS; needs §6 research first.
2. **pkg55** (wavefront SoA refactor) — GPU, large, research already signed off.
3. **pkg64** (spectral caustics) — huge, ~3–4 wk.

All GPU-gated + RTX-verifiable (CI has no GPU).

## Process

Docs-only PR. Auto-merge eligible per pr-reviewer doc-only rule (CI green → merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)