### PR TITLE
feat(pkg114): two-level BVH inc 1 — structs + gpu_tlas_hit + identity parity (RTX-verified)

### DIFF
--- a/.astroray_plan/docs/external-references.md
+++ b/.astroray_plan/docs/external-references.md
@@ -146,6 +146,12 @@ own because a dependency for 40 lines of code is ridiculous.
   Tracing" (SIGGRAPH 1986) + Jensen photon maps (EGWR 1996); MNEE transfer-matrix
   geometry term ported from Cycles `mnee.h` (Apache-2.0). Notes:
   `pkg106-forward-lighttracing-research.md`.
+- **Two-level BVH / TLAS-over-BLAS instancing (pkg114)** — PBRT-v4
+  `TransformedPrimitive` (Apache-2.0 — v4 is Apache, *not* v3's BSD-3-Clause),
+  Cycles `bvh2.cpp` / `bvh_instance_push` (Apache-2.0), Embree (Wald 2014,
+  DOI 10.1145/2601097.2601199) + OptiX IAS/GAS. Ray→object with an
+  un-normalized direction (shared `tMax`), normals via inverse-transpose.
+  Notes: `two-level-bvh-research.md`.
 
 Astroray targets MIT (or Apache 2.0). Compatible:
 - Apache 2.0, BSD-2/3, MIT, ISC — link freely.

--- a/.astroray_plan/docs/pkg114-cycles-twolevel-bvh-research.md
+++ b/.astroray_plan/docs/pkg114-cycles-twolevel-bvh-research.md
@@ -1,0 +1,198 @@
+# pkg114 — Cycles Two-Level BVH (TLAS over BLAS) Research
+
+Research note per CLAUDE.md §6. Source: Blender Cycles, **Apache-2.0**
+(SPDX-License-Identifier: Apache-2.0, SPDX-FileCopyrightText: 2011-2022
+Blender Foundation; traversal also carries 2009-2010 NVIDIA Corp /
+2009-2012 Intel Corp headers — all Apache-2.0 compatible).
+
+GitHub mirror: `blender/cycles` (src/), main checkout: `blender/blender`
+(intern/cycles/). Both kept in sync.
+
+## Files mirrored
+
+| Concept | File (cycles src/ path) | blender/ path |
+|---|---|---|
+| BVH2 build + two-level pack | `src/bvh/bvh2.cpp`, `src/bvh/bvh2.h` | `intern/cycles/bvh/bvh2.cpp` |
+| Device traversal loop | `src/kernel/bvh/traversal.h` | `intern/cycles/kernel/bvh/traversal.h` |
+| Dispatcher / scene_intersect | `src/kernel/bvh/bvh.h` | `intern/cycles/kernel/bvh/bvh.h` |
+| Instance push/pop + dir helpers | `src/kernel/bvh/util.h` (clamp/inverse dir); push/pop in `src/kernel/geom/object.h` on main | — |
+| object_fetch_transform | `src/kernel/geom/object.h` | — |
+| Transform math | `src/util/transform.h` | `intern/cycles/util/transform.h` |
+
+## 1. Build / data layout (bvh2.cpp)
+
+`Transform` = 4x3 affine matrix, 3 rows of float4:
+```c
+struct Transform { float4 x, y, z; };   // util/transform.h
+```
+Each `KernelObject` (objects array) stores `.tfm` (object→world) and
+`.itfm` (world→object inverse).
+
+Two-level merge in `BVH2::pack_instances(nodes_size, leaf_nodes_size)`:
+comment — *"Adjust primitive index to point to the triangle in the global
+array, for geometry with transform applied and already in the top level
+BVH."* It concatenates every per-mesh (BLAS) BVH's node array + prim arrays
+into ONE global flat array, offsetting child pointers, and records where
+each object's BLAS root lives:
+
+```cpp
+if (bvh->pack.root_index == -1)          // BLAS root is a single leaf
+  pack.object_node[object_offset++] = -noffset_leaf - 1;
+else
+  pack.object_node[object_offset++] = noffset;   // node-array offset
+```
+
+Global parallel arrays produced:
+- `pack.prim_index`  — geometry-local primitive id (or -1 for the
+  instance-marker leaf), adjusted by `geom->prim_offset`.
+- `pack.prim_type`   — encodes triangle/curve/point + segment.
+- `pack.prim_object` — object index; for an instance leaf this is what the
+  traversal reads to know which object to descend into.
+- `pack.prim_visibility` — `ob->visibility_for_tracing()`.
+- `pack.object_node[object]` — node address of object's BLAS root.
+
+`pack_leaf()`: for a single-triangle object with prim_index -1 it negates
+the entry to mark an **object/instance leaf** (vs primitive leaf).
+`refit_nodes()`/`refit_primitives()` allow refit instead of full rebuild
+when transforms/objects change (the stated reason for two-level: lower mem,
+fast rebuild, at a small tree-quality cost).
+
+## 2. Device traversal (traversal.h)  — entry `BVH_FUNCTION_FULL_NAME(BVH)`
+
+Top of function:
+```c
+int traversal_stack[BVH_STACK_SIZE];
+traversal_stack[0] = ENTRYPOINT_SENTINEL;
+int object = OBJECT_NONE;            // (classic: int object = ~0;)
+isect->t = ray->tmax;
+float3 P = ray->P, dir = bvh_clamp_direction(ray->D), idir = bvh_inverse_direction(dir);
+```
+
+Node discrimination by SIGN:
+- `node_addr >= 0` → inner node (push children).
+- `node_addr < 0`  → leaf; fetch leaf, `prim_addr = leaf.x`.
+  - `prim_addr >= 0` → primitive leaf (triangle/curve/point intersect).
+  - `prim_addr < 0`  → **object/instance leaf** → push into object space.
+
+Instance push branch (main):
+```c
+object = kernel_data_fetch(prim_object, -prim_addr - 1);
+#if BVH_FEATURE(BVH_MOTION)
+  bvh_instance_motion_push(kg, object, ray, &P, &dir, &idir);
+#else
+  bvh_instance_push(kg, object, ray, &P, &dir, &idir);
+#endif
+++stack_ptr;
+traversal_stack[stack_ptr] = ENTRYPOINT_SENTINEL;   // sentinel = "pop back to world"
+node_addr = kernel_data_fetch(object_node, object); // jump to BLAS root
+```
+
+Instance pop (when node_addr hits ENTRYPOINT_SENTINEL with stack non-empty):
+```c
+if (stack_ptr >= 0) {
+  kernel_assert(object != OBJECT_NONE);
+  bvh_instance_pop(ray, &P, &dir, &idir);
+  object = OBJECT_NONE;
+  node_addr = traversal_stack[stack_ptr];
+  --stack_ptr;
+}
+```
+One unified `traversal_stack`; the ENTRYPOINT_SENTINEL pushed at instance
+entry is what triggers the pop. Only ONE level of instancing (no recursive
+nesting) — `object` is a single scalar, not a stack.
+
+## 3. Instance push/pop transforms — THE tMax / len(dir) TRICK
+
+### Modern (main, kernel/geom/object.h) — implicit scaling, no `t` param
+```c
+ccl_device_inline void bvh_instance_push(KernelGlobals kg, int object,
+    const Ray *ray, float3 *P, float3 *dir, float3 *idir) {
+  const Transform tfm = object_fetch_transform(kg, object, OBJECT_INVERSE_TRANSFORM);
+  *P   = transform_point(&tfm, ray->P);
+  *dir = bvh_clamp_direction(transform_direction(&tfm, ray->D));  // NOT renormalized
+  *idir = bvh_inverse_direction(*dir);
+}
+ccl_device_inline void bvh_instance_pop(const Ray *ray, float3 *P, float3 *dir, float3 *idir) {
+  *P = ray->P; *dir = bvh_clamp_direction(ray->D); *idir = bvh_inverse_direction(*dir);
+}
+```
+Key: `transform_direction` does **not** normalize. The object-space ray
+direction has length `s = |M_inv · D|`. Because intersection routines use
+this same un-normalized `dir`, the parametric `t` they compute is already in
+**world units** — t measures world distance along the un-normalized object
+dir, so `isect->t` (= ray->tmax world distance) stays directly comparable
+across world and object space with NO extra scaling. Pop just restores the
+saved world P/dir/idir. This is why modern push/pop take no `t` argument.
+
+### Classic (kernel_bvh.h, ≤2.7x) — explicit `*t *= len` scaling
+```c
+// push:
+Transform tfm = object_fetch_transform(kg, object, OBJECT_INVERSE_TRANSFORM);
+*P = transform_point(&tfm, ray->P);
+float3 dir = transform_direction(&tfm, ray->D);
+float len; dir = normalize_len(dir, &len);   // HERE it normalizes...
+*idir = bvh_inverse_direction(dir);
+if (*t != FLT_MAX) *t *= len;                 // ...so t must be scaled into object space
+// pop:
+if (*t != FLT_MAX) {
+  Transform tfm = object_fetch_transform(kg, object, OBJECT_TRANSFORM);
+  *t *= len(transform_direction(&tfm, 1.0f/(*idir)));   // scale back to world
+}
+*P = ray->P; *idir = bvh_inverse_direction(ray->D);
+```
+Classic traversal passed t by ref: `bvh_instance_push(kg, object, ray, &P,
+&idir, &isect->t, tmax);`. The two formulations are mathematically
+equivalent — modern avoids the normalize+rescale by keeping dir un-normalized.
+
+**Astroray decision point:** pick ONE convention. The modern un-normalized
+approach is simpler (no len() per push/pop, no FLT_MAX guards) but requires
+the triangle/AABB intersectors to consume the same un-normalized dir/idir.
+
+### object_fetch_transform
+```c
+ccl_device_inline Transform object_fetch_transform(KernelGlobals kg, int object, ObjectTransform type) {
+  if (type == OBJECT_INVERSE_TRANSFORM) return kernel_data_fetch(objects, object).itfm;
+  return kernel_data_fetch(objects, object).tfm;
+}
+```
+Motion variant `object_fetch_transform_motion_test` interpolates tfm at
+`ray->time` and inverts when `SD_OBJECT_MOTION` set.
+
+## 4. Transform math (util/transform.h)
+- `struct Transform { float4 x, y, z; };` (4x3 affine).
+- `transform_point(t, p)` — full affine (dot rows incl. translation .w).
+- `transform_direction(t, a)` — rotation/scale only (ignores translation),
+  does NOT normalize.
+- `transform_direction_transposed(t, a)` — applies transposed 3x3; used for
+  transforming NORMALS by the INVERSE transform (i.e. `N_world =
+  normalize(transform_direction_transposed(&itfm, N_object))`), the standard
+  inverse-transpose normal rule.
+- `transform_inverse(tfm)` — adjoint/determinant, AVX2 fast path.
+
+## Normal transform rule (for shading after hit)
+Cycles transforms the geometric normal back to world with the
+inverse-transpose: it applies `transform_direction_transposed(&itfm, Ng)`
+(itfm = world→object, so its transpose acts as the inverse-transpose of the
+object→world matrix), then normalizes. Astroray must do the same or
+non-uniform-scaled instances get wrong normals.
+
+## Pitfalls
+1. Single-level instancing only: `object` is scalar, not a stack — no nested
+   instances in this loop.
+2. tMax convention is load-bearing: classic scales `*t`, modern keeps dir
+   un-normalized; mixing them double-scales or unscales t. The intersectors
+   MUST match whichever push convention you choose.
+3. `ENTRYPOINT_SENTINEL` on the traversal stack is the pop trigger — must be
+   pushed exactly once at instance entry.
+4. object_node offset can be a negated "leaf root" (`-noffset_leaf-1`) for
+   single-leaf BLAS — handle both inner-node and leaf-root object roots.
+5. Normals need inverse-transpose (`transform_direction_transposed` with
+   itfm), not the forward tfm, or non-uniform scale breaks shading.
+6. prim_object for an instance-marker leaf is set 0 / unused; the real object
+   id for descent comes from `prim_object[-prim_addr-1]`.
+
+## References
+- Aila & Laine, "Understanding the Efficiency of Ray Traversal on GPUs"
+  (HPG 2009) — basis of the Cycles GPU traversal stack loop (cited in
+  traversal.h NVIDIA header).
+- Cycles source, Apache-2.0, files listed above.

--- a/.astroray_plan/docs/two-level-bvh-research.md
+++ b/.astroray_plan/docs/two-level-bvh-research.md
@@ -1,0 +1,185 @@
+# Two-level BVH (TLAS over per-mesh BLAS) — Research (pkg114)
+
+CLAUDE.md §6 gate for pkg114. Cite-first; this note precedes code.
+Cross-verified against PBRT-v4, Cycles, and Embree/OptiX (research workflow
+`wf_52dd8c37-b5a`, 2026-06-10).
+
+## Paper / canonical references
+
+1. **PBRT-v4 (object instancing).** Pharr, Jakob, Humphreys, *Physically Based
+   Rendering: From Theory to Implementation*, 4th ed. (2023), Ch.7 §7.1.2
+   (`TransformedPrimitive` / `AnimatedPrimitive`) and §6.1.4 (ray-`t` invariance
+   under a transform). Online: https://pbr-book.org/4ed/Primitives_and_Intersection_Acceleration/Primitive_Interface_and_Geometric_Primitives
+2. **Embree.** Wald, Woop, Benthin, Johnson, Ernst, "Embree: A Kernel Framework
+   for Efficient CPU Ray Tracing", *ACM TOG* 33(4):143 (SIGGRAPH 2014).
+   DOI: 10.1145/2601097.2601199. Two-level instanced BVH; `rtcSetGeometryTransform`
+   takes a 3×4 local→world per instance.
+3. **NVIDIA OptiX Programming Guide** — `OptixInstance` (object→world 3×4
+   row-major), IAS-over-GAS (instance accel over geometry accel),
+   `optixTransformNormalFromObjectToWorldSpace` (inverse-transpose).
+4. **GPU traversal basis.** Aila & Laine, "Understanding the Efficiency of Ray
+   Traversal on GPUs", HPG 2009 (the stack-loop our `gpu_bvh_hit` already mirrors).
+
+## Reference implementations (all license-clean for MIT)
+
+| Source | License | Files we mirror |
+|---|---|---|
+| **pbrt-v4** `github.com/mmp/pbrt-v4` | **Apache-2.0** (SPDX per-file; `LICENSE.txt`) | `src/pbrt/cpu/primitive.cpp` `TransformedPrimitive::Intersect/IntersectP/Bounds`; `src/pbrt/util/transform.h` `Transform::ApplyInverse(const Ray&, Float*)` + `operator()` for Point/Vector/Normal; `src/pbrt/cpu/aggregates.cpp` `LinearBVHNode` + `flattenBVH` |
+| **Cycles** `github.com/blender/cycles` | **Apache-2.0** | `src/bvh/bvh2.cpp` `pack_instances`; `src/kernel/bvh/bvh.h` + `traversal.h` (`bvh_instance_push`/`pop`); `src/kernel/geom/object.h` `object_fetch_transform(OBJECT_INVERSE_TRANSFORM)`; `src/util/transform.h` `transform_point`/`transform_direction`/`transform_direction_transposed` |
+| **Embree / OptiX** | **Apache-2.0** (Embree) / NVIDIA docs (OptiX) | the IAS/GAS + 3×4-instance + inverse-transpose-normal concept |
+
+> **Cycles deep-dive appendix.** A detailed Cycles-specific porting reference
+> (exact `bvh2.cpp::pack_instances` concatenation/offset logic, the
+> `object_node` BLAS-root encoding, `bvh_instance_push`/`pop`,
+> `object_fetch_transform`, the `Transform` 4×3 layout) lives in
+> `pkg114-cycles-twolevel-bvh-research.md` — consult it when implementing
+> increment 2's real multi-instance traversal.
+
+> **License correction.** The pkg114 spec assumed pbrt is BSD-3-Clause. That was
+> true for **pbrt-v3**; **pbrt-v4 is Apache-2.0**. Apache-2.0 is on CLAUDE.md §6's
+> allow-list and is compatible with Astroray's MIT. Apache obligations when
+> porting: preserve copyright/attribution, state the changes made. Cycles is also
+> Apache-2.0. Both are fine; cite as Apache-2.0.
+
+## What we reproduce
+
+A two-level acceleration structure:
+
+- **BLAS** (bottom level): one BVH per unique mesh datablock, built once over the
+  mesh's **object-local** triangles. Reuses Astroray's existing `BVHAccel`
+  (`include/raytracer.h:1114`) and the GPU `GBVHNode` layout (`gpu_types.h:221`),
+  which is byte-for-byte PBRT-v4's `alignas(32) LinearBVHNode` (24 B bounds +
+  union offset + `uint16 nPrimitives` + `uint8 axis` + pad = 32 B).
+- **TLAS** (top level): a BVH over per-instance **world-space AABBs**, whose
+  leaves index an instance list. The TLAS reuses the **same** `GBVHNode` layout
+  (PBRT: "the TLAS is just another BVH"). `GTLASNode = GBVHNode`.
+- **`GInstance`**: a `(BLAS ref, 4×4 worldFromObject M, 4×4 objectFromWorld Minv,
+  instanceId)` record. Both M and Minv are precomputed **host-side** (pbrt's
+  `ApplyInverse` and Cycles' `object_fetch_transform` both read a precomputed
+  inverse — never invert per-ray on device).
+
+### The core device math (identical across all three references)
+
+At a TLAS instance node, transform the **world** ray into **BLAS-local** space:
+
+```
+o_local = Minv · o_world          (point: full 4×4 + homogeneous w-divide, incl. translation)
+d_local = Minv_3x3 · d_world       (vector: upper 3×3, NO translation, *** NOT renormalized ***)
+```
+
+Because `o_world + t·d_world = M·(o_local + t·d_local)`, the **same `t`** satisfies
+both spaces ⇒ **local `t` == world `t`**. Therefore:
+
+- The global `tMax` is seeded into every BLAS traversal **unchanged** and shrinks
+  on each closer hit — one shared cutoff across both levels (Cycles "modern push";
+  PBRT copies `tMax` back by reference). The returned `tHit` is **never rescaled**.
+- This only holds if `d_local` is **not renormalized**. The classic alternative
+  (normalize `d_local`, then scale `t` by `len(Minv·d_world)` on push/pop) is
+  mathematically equivalent but adds a multiply per push/pop and is the documented
+  #1 instancing footgun — we reject it.
+
+On a hit, transform the local interaction **back to world**:
+
+```
+point_world  = M · point_local                  (or exactly o_world + tHit·d_world)
+normal_world = normalize( (Minv_3x3)^T · normal_local )   *** inverse-transpose, renormalize ***
+tangent_world= normalize( M_3x3 · tangent_local )         (vectors use M, not Minv^T)
+frontFace    = dot(d_world, normal_world) < 0              (recomputed in WORLD space)
+```
+
+- **Inverse-transpose for normals** is load-bearing: under non-uniform scale, a
+  normal transformed by M shears off the surface. (pbrt `Transform::operator()(Normal3)`
+  reads `mInv` transposed; OptiX `optixTransformNormalFromObjectToWorldSpace`.)
+- **frontFace recomputed in world space** (not copied from local winding) so a
+  negative-determinant (mirror) instance, which flips winding, gets the correct
+  front/back — this is the same bug class as Astroray's prior refraction
+  frontFace bug (memory `refraction-frontface-bug`).
+
+### Per-instance world AABB (TLAS build)
+Transform the **8 corners** of the BLAS root AABB by M and take their bound
+(Embree/OptiX convention).
+
+### Complexity / the win
+N instances of an M-triangle mesh: **build** O(M log M + N log N), **memory**
+O(M + N) — vs flattened O(N·M). (PBRT Moana: ~4 GB instanced vs ~516 GB flattened;
+vertices never copied per instance.)
+
+## Astroray-specific decisions (differences from the references)
+
+1. **`GRay` ctor renormalizes (`gpu_types.h:193`).** None of the references have
+   this. The local ray must carry the **un-normalized** `d_local`, so we
+   **default-construct `GRay` and field-assign** `origin`/`direction` — exactly
+   the in-repo precedent the wavefront stages already use and document
+   (`src/gpu/wavefront/stage_intersect.cu:58`). This touches **none** of
+   `gpu_bvh_hit` / `GAABB::hit` / `gpu_triangle_hit` — they already treat
+   `ray.direction` as the vector `t` is measured against, with no unit assumption
+   (Möller–Trumbore `t` is in units of `|d|`; the slab test uses `1/d` and is
+   scale-consistent).
+2. **BLAS-local node offsets.** `gpu_bvh_hit` uses `curr+1` / `secondChildOffset`
+   as indices into the array **base** it is handed. So each BLAS is flattened
+   **independently starting at node 0** (its `secondChildOffset`s are BLAS-local),
+   and the TLAS traversal hands `gpu_bvh_hit` the pointer `blasNodes + blas.nodeOffset`
+   as the base. Invariant: never feed `gpu_bvh_hit` a concatenated multi-BLAS node
+   array with global offsets. (Asserted host-side.)
+3. **`primId` remap keeps a single global `prims[]` index space.** Inside a BLAS,
+   `gpu_bvh_hit` sets `lrec.primId = leafOffset + i` (BLAS-local); the TLAS wrapper
+   rewrites `rec.primId = blas.primOffset + lrec.primId` into the shared global
+   `prims[]`. Cryptomatte's `prims[rec.primId]` and NEE's `prims[l.primitiveIndex]`
+   keep working unchanged. `GPRIM_SKIP` index-alignment (`scene_upload.cu:343`) is
+   preserved **within** each BLAS.
+4. **Per-instance object identity** (two instances of one mesh need distinct
+   Cryptomatte IDs) needs `int instanceId` added to `GHitRecord`; resolved via
+   `instances[rec.instanceId].objectHash`. **Deferred to increment 2** (increment
+   1 has a single identity instance whose prim hashes equal today's, so it stays
+   identical with **no** `GHitRecord`/Cryptomatte change).
+5. **PBRT's sub-epsilon `dt` origin nudge** (`ApplyInverse` float-error bound) is
+   dropped for the first cut; non-degenerate transforms don't need it.
+
+## What we deliberately do NOT take
+- Cycles' negated-leaf node-sign encoding and `ENTRYPOINT_SENTINEL` stack scheme —
+  Astroray's `gpu_bvh_hit` already has a clean `nPrimitives>0`-leaf + explicit
+  `stack[64]` loop; we keep it and add a sibling `gpu_tlas_hit`.
+- The classic normalize-and-scale-`t` push/pop (rejected above).
+- Motion-blur / `AnimatedPrimitive` time interpolation (out of scope; pkg88).
+- An any-hit/shadow fast path (`gpu_tlas_any_hit`) — Astroray reuses closest-hit
+  for shadow rays today; matching that keeps the diff minimal. Perf follow-up.
+
+## Integration plan in Astroray (incremental, RTX-verified per increment)
+
+- **Increment 1 — structs + `gpu_tlas_hit` + identity-passthrough parity probe.**
+  Add `GMat4`, `GBLAS`, `GInstance`, `GTLASNode` alias (`gpu_types.h`); add
+  `gpu_tlas_hit` (`include/astroray/gpu_bvh.h`); a host helper that synthesizes a
+  single identity BLAS+instance+TLAS from a `SceneUploadResult`; a **device dual-trace
+  parity probe** (mirrors `src/gpu/wavefront/intersect_parity.cu`) that asserts
+  `gpu_tlas_hit`(identity) ≡ `gpu_bvh_hit` over the camera rays of a real scene
+  (fp-exact on `t`/`primId`/`materialId`/`frontFace`/`point`; ≤1e-6 on `normal`,
+  since identity inverse-transpose + renormalize can drift ≤1 ulp). **Touches no
+  production kernel** ⇒ zero render risk. Test: `tests/test_tlas_blas_parity.py`.
+  Verify on RTX.
+- **Increment 2 — multi-instance + real transforms.** Host mesh/instance API
+  (`register_mesh` → BLAS once; `add_instance(meshId, 4×4)`), add `GHitRecord.instanceId`,
+  route the production megakernel(s) through `gpu_tlas_hit`, host unit-test
+  `GMat4` xform helpers vs a numpy reference, **full-render pixel parity** of N
+  transformed instances vs the flattened/baked-world-space scene (per-channel
+  mean-ratio gate, per memory `ssim-wrong-gate-for-independent-rng`), and a visual
+  check of a rotated + **non-uniform-scaled** + a **mirror-scaled** instance
+  (proves inverse-transpose + frontFace-recompute). RTX `/verify`.
+- **Increment 3 — memory/build win + depsgraph refit.** BLAS cache across frames;
+  Blender transform-only edit → **TLAS-only** rebuild (pkg56 §4.1 deferral; the
+  `_renderer_object_id_map` + `update_object_transform` hook,
+  `module/blender_module.cpp`); measure device geometry ≈ 1× mesh for N instances.
+
+## Deferred / follow-up (fundamental fork surfaced to owner)
+- **Multi-instance emissive/area-light NEE.** `GLight.primitiveIndex`
+  (`scene_upload.cu:366`) and `GAreaLight` world-baked verts assume one global prim
+  list with world-space emitters; they are not instancing-aware. Increments 1–3
+  keep the single-instance/identity emitter path pixel-identical; **instanced
+  *emissive* geometry is a separate package** (per-instance emitter power,
+  transformed area, MIS re-keying to an (instance,prim) join). File a follow-up
+  before shipping instanced emitters. (Owner-flagged; non-blocking for pkg114's
+  acceptance, which is about instanced *geometry* + transform-edit budget +
+  pixel parity.)
+
+## Open questions
+- None blocking. The above emissive-instancing fork is deferred by design, not a
+  prerequisite.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -475,6 +475,7 @@ if(ASTRORAY_CUDA_FOUND)
         src/gpu/photon_store.cu
         src/gpu/photon_emission.cu
         src/gpu/photon_caustic.cu
+        src/gpu/tlas_parity.cu
     )
     if(ASTRORAY_WAVEFRONT_CUDA_N3)
         list(APPEND ASTRORAY_CUDA_SOURCES

--- a/include/astroray/gpu_bvh.h
+++ b/include/astroray/gpu_bvh.h
@@ -159,6 +159,124 @@ __device__ inline bool gpu_bvh_hit(
 }
 
 // ---------------------------------------------------------------------------
+// pkg114 — Two-level traversal: a TLAS (BVH over instance world-AABBs) whose
+// leaves are GInstance records, each referencing a BLAS (the per-mesh BVH this
+// file's gpu_bvh_hit traverses) plus a 4x4 object<->world transform pair.
+//
+// Source: pbrt-v4 (Apache-2.0), Pharr/Jakob/Humphreys —
+//   src/pbrt/cpu/primitive.cpp TransformedPrimitive::Intersect;
+//   src/pbrt/util/transform.h  Transform::ApplyInverse(const Ray&, Float*).
+// Source: Cycles (Apache-2.0), Blender Foundation —
+//   src/kernel/bvh/bvh.h bvh_instance_push; src/util/transform.h
+//   transform_point / transform_direction (un-normalized) /
+//   transform_direction_transposed (normal by inverse-transpose).
+// See .astroray_plan/docs/two-level-bvh-research.md.
+//
+// Invariants (load-bearing):
+//  - The world ray is transformed into BLAS-local space with the instance's
+//    objectFromWorld (Minv); the local direction is NOT renormalized, so local
+//    t == world t and the global tMax is one shared cutoff across both levels.
+//    We bypass the GRay(o,d) ctor (which renormalizes) by default-construct +
+//    field-assign — the same precedent as src/gpu/wavefront/stage_intersect.cu.
+//  - The local hit's GEOMETRIC outward normal is recovered (frontFace ? n : -n),
+//    transformed by (Minv)^T, renormalized; frontFace is RECOMPUTED in world
+//    space vs the world ray (recomputing from the already-oriented normal would
+//    always read "front" since the oriented normal always points against the
+//    ray, and it would mis-handle mirror/negative-det transforms). The world
+//    ONB is rebuilt from the world normal so the shading frame matches a
+//    flattened-world-space reference.
+//  - rec.primId is remapped BLAS-local -> global (blas.primOffset + localPrimId)
+//    so prims[rec.primId] (Cryptomatte / NEE) keeps working unchanged.
+// ---------------------------------------------------------------------------
+__device__ inline bool gpu_tlas_hit(
+    const GTLASNode*  tlas,
+    const GInstance*  instances,
+    const GBLAS*      blas,
+    const GBVHNode*   blasNodes,
+    const GPrimitive* prims,
+    const GTriangle*  tris,
+    const GSphere*    spheres,
+    const GRay&       ray,
+    float tMin, float tMax,
+    GHitRecord&       rec)
+{
+    // No TLAS uploaded -> behave exactly like the single-level path. (Lets a
+    // caller route unconditionally through gpu_tlas_hit before instances exist.)
+    if (!tlas || !instances || !blas) {
+        return gpu_bvh_hit(blasNodes, prims, tris, spheres, ray, tMin, tMax, rec);
+    }
+
+    bool  hit    = false;
+    GVec3 invDir(1.f/ray.direction.x,
+                 1.f/ray.direction.y,
+                 1.f/ray.direction.z);
+    int   dirIsNeg[3] = { invDir.x < 0, invDir.y < 0, invDir.z < 0 };
+    int   toVisit = 0, curr = 0;
+    int   stack[64];
+
+    while (true) {
+        const GTLASNode& n = tlas[curr];
+
+        if (n.bounds.hit(ray, tMin, tMax)) {        // TLAS AABB: world space, world ray
+            if (n.nPrimitives > 0) {
+                // Leaf: a list of instances.
+                for (int i = 0; i < n.nPrimitives; ++i) {
+                    const GInstance& inst = instances[n.primitivesOffset + i];
+                    const GBLAS&     b    = blas[inst.blasIndex];
+
+                    // World ray -> BLAS-local space. Bypass the GRay ctor so the
+                    // local direction stays un-normalized (tMax comparability).
+                    GRay local;
+                    local.origin    = inst.objectFromWorld.xformPoint(ray.origin);
+                    local.direction = inst.objectFromWorld.xformDir(ray.direction);
+
+                    GHitRecord lrec;
+                    lrec.primId = -1;
+                    // Shared, un-scaled tMax: lrec.t comes back in world units.
+                    bool ih = gpu_bvh_hit(blasNodes + b.nodeOffset, prims, tris, spheres,
+                                          local, tMin, tMax, lrec);
+                    if (ih && lrec.t < tMax) {
+                        hit  = true;
+                        tMax = lrec.t;              // tighten the shared cutoff
+
+                        // Recover local geometric outward normal, transform to
+                        // world by inverse-transpose, recompute frontFace.
+                        GVec3 geomOut_l = lrec.frontFace ? lrec.normal : (lrec.normal * -1.f);
+                        GVec3 geomOut_w = inst.objectFromWorld
+                                              .xformNormalByInvTranspose(geomOut_l)
+                                              .normalized();
+                        bool ff = ray.direction.dot(geomOut_w) < 0.f;
+
+                        rec            = lrec;       // t, materialId, isDelta carry over
+                        rec.t          = lrec.t;     // world units, unchanged
+                        rec.point      = inst.worldFromObject.xformPoint(lrec.point);
+                        rec.frontFace  = ff;
+                        rec.normal     = ff ? geomOut_w : (geomOut_w * -1.f);
+                        gpu_buildONB(rec.normal, rec.tangent, rec.bitangent);
+                        rec.primId     = b.primOffset + lrec.primId;
+                    }
+                }
+                if (toVisit == 0) break;
+                curr = stack[--toVisit];
+            } else {
+                // Interior: same near/far ordering as gpu_bvh_hit.
+                if (dirIsNeg[n.axis]) {
+                    stack[toVisit++] = curr + 1;
+                    curr = n.secondChildOffset;
+                } else {
+                    stack[toVisit++] = n.secondChildOffset;
+                    curr = curr + 1;
+                }
+            }
+        } else {
+            if (toVisit == 0) break;
+            curr = stack[--toVisit];
+        }
+    }
+    return hit;
+}
+
+// ---------------------------------------------------------------------------
 // Environment map sampling helpers (device-side)
 // ---------------------------------------------------------------------------
 

--- a/include/astroray/gpu_tlas_parity.h
+++ b/include/astroray/gpu_tlas_parity.h
@@ -1,0 +1,37 @@
+#pragma once
+// gpu_tlas_parity.h — pkg114 increment 1 test hook (pure C++; NO CUDA headers).
+//
+// Declares the host entry point for the two-level-BVH identity-passthrough
+// parity probe. Included by the pybind translation unit (blender_module.cpp)
+// which nvcc never compiles; the implementation lives in src/gpu/tlas_parity.cu.
+//
+// The probe builds a single IDENTITY instance (one BLAS = the whole uploaded
+// scene, identity transform, a 1-leaf TLAS) and, for every primary camera ray,
+// compares gpu_tlas_hit(identity) against the single-level gpu_bvh_hit. If the
+// two-level plumbing is correct, the only permitted difference is a sub-ulp
+// normal drift from the (no-op) inverse-transpose renormalize.
+
+class Renderer;
+class Camera;
+
+namespace astroray {
+namespace twolevel {
+
+struct TlasParityResult {
+    int   totalRays      = 0;   // width*height
+    int   hitDisagree    = 0;   // rays where one path hit and the other missed
+    int   fieldMismatch  = 0;   // both hit but t / primId / materialId / frontFace differ
+    float maxTDelta      = 0.f; // max |t_tlas - t_ref| over agreeing hits
+    float maxPointDelta  = 0.f; // max |point_tlas - point_ref|
+    float maxNormalDelta = 0.f; // max |normal_tlas - normal_ref|
+};
+
+// Requires the CPU Renderer to have a built BVH (call Renderer::buildAcceleration()
+// — or render once — first). Uploads the scene, runs the dual-trace probe over a
+// width*height grid of primary camera rays, frees device memory, returns stats.
+// Throws std::runtime_error on any CUDA failure.
+TlasParityResult cuda_tlas_identity_parity(
+    const Renderer& cpu, const Camera& cam, int width, int height);
+
+}  // namespace twolevel
+}  // namespace astroray

--- a/include/astroray/gpu_types.h
+++ b/include/astroray/gpu_types.h
@@ -272,6 +272,74 @@ struct GSphere {
 };
 
 // ---------------------------------------------------------------------------
+// pkg114 — Two-level BVH (TLAS over per-mesh BLAS + instance transforms).
+//
+// Ported from pbrt-v4 (Apache-2.0) Transform::ApplyInverse / operator() and
+// Cycles (Apache-2.0) transform_point/transform_direction. See
+// .astroray_plan/docs/two-level-bvh-research.md. Row-major affine; we store
+// BOTH M (object->world) and Minv (world->object) so the device never inverts
+// a matrix per ray (pbrt/Cycles both precompute the inverse).
+// ---------------------------------------------------------------------------
+struct GMat4 {
+    float m[16];   // row-major: m[row*4 + col]
+
+    HD static GMat4 identity() {
+        GMat4 r;
+        for (int i = 0; i < 16; ++i) r.m[i] = 0.f;
+        r.m[0] = r.m[5] = r.m[10] = r.m[15] = 1.f;
+        return r;
+    }
+
+    // Point transform: full 4x4 incl. translation + homogeneous w-divide.
+    HD GVec3 xformPoint(const GVec3& p) const {
+        float x = m[0]*p.x + m[1]*p.y + m[2]*p.z + m[3];
+        float y = m[4]*p.x + m[5]*p.y + m[6]*p.z + m[7];
+        float z = m[8]*p.x + m[9]*p.y + m[10]*p.z + m[11];
+        float w = m[12]*p.x + m[13]*p.y + m[14]*p.z + m[15];
+        float inv = (w != 0.f) ? 1.f/w : 1.f;
+        return GVec3(x*inv, y*inv, z*inv);
+    }
+    // Vector transform: upper 3x3, NO translation, *** NOT renormalized ***
+    // (so a ray direction keeps the object-space scale and local t == world t;
+    //  pbrt §6.1.4 / Cycles transform_direction).
+    HD GVec3 xformDir(const GVec3& d) const {
+        return GVec3(m[0]*d.x + m[1]*d.y + m[2]*d.z,
+                     m[4]*d.x + m[5]*d.y + m[6]*d.z,
+                     m[8]*d.x + m[9]*d.y + m[10]*d.z);
+    }
+    // Normal transform by the inverse-transpose: 'this' MUST be Minv
+    // (world<-object), and we read it transposed (multiply by columns) to get
+    // (Minv)^T * n_local = world normal direction. Caller renormalizes.
+    HD GVec3 xformNormalByInvTranspose(const GVec3& n) const {
+        return GVec3(m[0]*n.x + m[4]*n.y + m[8]*n.z,
+                     m[1]*n.x + m[5]*n.y + m[9]*n.z,
+                     m[2]*n.x + m[6]*n.y + m[10]*n.z);
+    }
+};
+
+// One BLAS = one unique mesh BVH. Slices into the shared global node/prim
+// arrays. Each BLAS is flattened INDEPENDENTLY starting at node 0, so its
+// GBVHNode.secondChildOffset values are BLAS-local; only the root pointer
+// (blasNodes + nodeOffset) is offset at traversal time.
+struct GBLAS {
+    int nodeOffset;   // first GBVHNode of this BLAS in the global blas-node array
+    int primOffset;   // added to a BLAS-local leaf primId to land in global prims[]
+};
+
+// One instance. A TLAS leaf points at a list of these.
+struct GInstance {
+    GMat4 worldFromObject;   // M    — hit point + tangents back to world
+    GMat4 objectFromWorld;   // Minv — ray into local space + normal inverse-transpose
+    int   blasIndex;         // index into the GBLAS array
+    int   instanceId;        // stable id (Cryptomatte/NEE join handle; used in inc 2)
+};
+
+// The TLAS reuses the 32-byte GBVHNode layout verbatim ("the TLAS is just
+// another BVH", pbrt-v4). A TLAS leaf's primitivesOffset/nPrimitives index the
+// instance list instead of prims[].
+using GTLASNode = GBVHNode;
+
+// ---------------------------------------------------------------------------
 // Material
 // ---------------------------------------------------------------------------
 // Sellmeier dispersion coefficients (Sellmeier 1871, public domain).

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -46,6 +46,7 @@
 #  include "astroray/gpu_renderer.h"
 #  include "astroray/gpu_photon_store.h"   // pkg113 Phase 1 — GPU photon store query
 #  include "astroray/gpu_photon_emit.h"    // pkg113 Phase 2 — GPU photon emission/bounce
+#  include "astroray/gpu_tlas_parity.h"    // pkg114 inc 1 — two-level BVH identity parity probe
 #  ifdef ASTRORAY_WAVEFRONT_CUDA_N3
 #    include "../src/gpu/wavefront/gpu_wavefront_snapshot.h"
 #  endif
@@ -2590,6 +2591,37 @@ PYBIND11_MODULE(astroray, m) {
           "max_neighbors"_a = 256,
           "pkg113 Phase 1: build the GPU photon hash grid and gather at each "
           "query. Returns [(irradiance(3), neighbor_indices, found_count), ...].");
+
+    // pkg114 increment 1 — two-level BVH (TLAS-over-BLAS) identity-passthrough
+    // parity probe. Builds a single identity instance (one BLAS = the whole
+    // uploaded scene, M = Minv = I, a 1-leaf TLAS) and, for every primary camera
+    // ray, dual-traces gpu_tlas_hit(identity) against the single-level
+    // gpu_bvh_hit. The identity case must reduce EXACTLY to single-level on
+    // t / primId / materialId / frontFace / point, with at most a sub-ulp normal
+    // drift (the no-op inverse-transpose renormalize). Touches no production
+    // kernel. Validated by tests/test_tlas_blas_parity.py. See
+    // .astroray_plan/docs/two-level-bvh-research.md.
+    m.def("_gpu_tlas_identity_parity",
+          [](PyRenderer& r, int width, int height) {
+              auto cam = r.getCamera();
+              if (!cam)
+                  throw std::runtime_error("Camera not set up. Call setup_camera() first.");
+              r.getRenderer().buildAcceleration();
+              auto res = astroray::twolevel::cuda_tlas_identity_parity(
+                  r.getRenderer(), *cam, width, height);
+              py::dict d;
+              d["total_rays"]       = res.totalRays;
+              d["hit_disagree"]     = res.hitDisagree;
+              d["field_mismatch"]   = res.fieldMismatch;
+              d["max_t_delta"]      = res.maxTDelta;
+              d["max_point_delta"]  = res.maxPointDelta;
+              d["max_normal_delta"] = res.maxNormalDelta;
+              return d;
+          },
+          "renderer"_a, "width"_a, "height"_a,
+          "pkg114 inc 1: two-level BVH identity-passthrough parity probe. Returns "
+          "dict(total_rays, hit_disagree, field_mismatch, max_t_delta, "
+          "max_point_delta, max_normal_delta).");
 
     // pkg113 Phase 2 — GPU photon EMISSION + BOUNCE parity binding. Forward-
     // traces a batch of collimated-sun photons through a single glass sphere

--- a/src/gpu/tlas_parity.cu
+++ b/src/gpu/tlas_parity.cu
@@ -1,0 +1,211 @@
+// tlas_parity.cu — pkg114 increment 1.
+//
+// Identity-passthrough parity probe for the two-level (TLAS-over-BLAS)
+// traversal. Builds ONE identity instance (a single BLAS = the whole uploaded
+// scene, M = Minv = I, a 1-leaf TLAS) and, for every primary camera ray,
+// dual-traces gpu_tlas_hit(identity) against the single-level gpu_bvh_hit.
+//
+// If the two-level plumbing (struct upload, leaf/instance indirection, BLAS
+// root-pointer offset, primId remap, ray field-assign, back-transform) is
+// correct, the identity case must reduce EXACTLY to the single-level result on
+// t / primId / materialId / frontFace / point, with at most a sub-ulp normal
+// drift from the (no-op) inverse-transpose renormalize.
+//
+// Mirrors the dual-trace pattern of src/gpu/wavefront/intersect_parity.cu.
+// Touches NO production kernel (zero render risk for increment 1).
+//
+// References (Apache-2.0; see .astroray_plan/docs/two-level-bvh-research.md):
+//   pbrt-v4 src/pbrt/cpu/primitive.cpp TransformedPrimitive::Intersect;
+//   Cycles  src/kernel/bvh/bvh.h bvh_instance_push.
+
+#include "astroray/gpu_tlas_parity.h"
+#include "astroray/gpu_types.h"
+#include "astroray/gpu_bvh.h"
+#include "astroray/gpu_materials.h"     // gpu_generateCameraRay
+#include "astroray/gpu_scene_upload.h"  // SceneUploadResult, buildSceneArrays
+#include "raytracer.h"                  // Renderer, Camera
+
+#include <cuda_runtime.h>
+#include <curand_kernel.h>
+#include <vector>
+#include <cstdio>
+#include <stdexcept>
+#include <algorithm>
+
+namespace astroray {
+namespace twolevel {
+
+namespace {
+
+#define TLAS_CUDA_CHECK(call) do {                                          \
+    cudaError_t _e = (call);                                                \
+    if (_e != cudaSuccess) {                                                \
+        std::fprintf(stderr, "[tlas-parity] CUDA error %s:%d: %s\n",        \
+                     __FILE__, __LINE__, cudaGetErrorString(_e));           \
+        throw std::runtime_error(cudaGetErrorString(_e));                   \
+    }                                                                       \
+} while (0)
+
+template <typename T>
+T* devUpload(const std::vector<T>& host) {
+    if (host.empty()) return nullptr;
+    T* d = nullptr;
+    TLAS_CUDA_CHECK(cudaMalloc(reinterpret_cast<void**>(&d), host.size() * sizeof(T)));
+    TLAS_CUDA_CHECK(cudaMemcpy(d, host.data(), host.size() * sizeof(T),
+                               cudaMemcpyHostToDevice));
+    return d;
+}
+
+__global__ void tlasParityKernel(
+    GCameraParams     cam, int width, int height,
+    const GBVHNode*   nodes,
+    const GPrimitive* prims,
+    const GTriangle*  tris,
+    const GSphere*    spheres,
+    const GTLASNode*  tlas,
+    const GInstance*  instances,
+    const GBLAS*      blas,
+    int*   out_disagree,
+    int*   out_fieldmm,
+    float* out_td,
+    float* out_pd,
+    float* out_nd)
+{
+    int idx   = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = width * height;
+    if (idx >= total) return;
+
+    int px = idx % width;
+    int py = idx / width;
+
+    // One camera ray, generated once and fed to BOTH traversals so the only
+    // variable under test is single-level vs two-level traversal.
+    curandState rng;
+    curand_init(0ULL, idx, 0, &rng);
+    GRay ray = gpu_generateCameraRay(cam, px, py, &rng);
+
+    GHitRecord refRec; refRec.primId = -1;
+    bool refHit = gpu_bvh_hit(nodes, prims, tris, spheres,
+                              ray, 0.001f, 1e30f, refRec);
+
+    GHitRecord tRec; tRec.primId = -1;
+    bool tHit = gpu_tlas_hit(tlas, instances, blas, nodes, prims, tris, spheres,
+                             ray, 0.001f, 1e30f, tRec);
+
+    out_disagree[idx] = 0;
+    out_fieldmm[idx]  = 0;
+    out_td[idx] = 0.f;
+    out_pd[idx] = 0.f;
+    out_nd[idx] = 0.f;
+
+    if (refHit != tHit) { out_disagree[idx] = 1; return; }
+    if (!refHit) return;  // both missed — agreement
+
+    bool fmm = (refRec.t          != tRec.t) ||
+               (refRec.primId     != tRec.primId) ||
+               (refRec.materialId != tRec.materialId) ||
+               (refRec.frontFace  != tRec.frontFace);
+    out_fieldmm[idx] = fmm ? 1 : 0;
+    out_td[idx] = fabsf(tRec.t - refRec.t);
+    out_pd[idx] = (tRec.point  - refRec.point ).length();
+    out_nd[idx] = (tRec.normal - refRec.normal).length();
+}
+
+}  // namespace
+
+TlasParityResult cuda_tlas_identity_parity(
+    const Renderer& cpu, const Camera& cam, int width, int height)
+{
+    TlasParityResult res;
+    res.totalRays = width * height;
+    if (res.totalRays <= 0) return res;
+
+    // Host-side flat scene arrays (requires a built CPU BVH).
+    SceneUploadResult s = buildSceneArrays(cpu, &cam);
+    if (s.nodes.empty())
+        throw std::runtime_error("[tlas-parity] empty BVH — build the scene first");
+
+    // The kernel maps pixels via cam.width/height; keep the probe grid matched.
+    s.camera.width  = width;
+    s.camera.height = height;
+
+    // --- Synthesize the identity two-level structure ---
+    // One BLAS = the whole uploaded scene (its leaf prim offsets are already
+    // global, so primOffset = 0; its node array starts at 0, so nodeOffset = 0).
+    std::vector<GBLAS> blas = { GBLAS{ /*nodeOffset*/0, /*primOffset*/0 } };
+    GInstance inst;
+    inst.worldFromObject = GMat4::identity();
+    inst.objectFromWorld = GMat4::identity();
+    inst.blasIndex       = 0;
+    inst.instanceId      = 0;
+    std::vector<GInstance> instances = { inst };
+    // 1-leaf TLAS whose bounds equal the scene root AABB; points at instance 0.
+    GTLASNode tnode = s.nodes[0];        // copy scene-root bounds
+    tnode.primitivesOffset = 0;          // into instances[]
+    tnode.nPrimitives      = 1;
+    tnode.axis             = 0;
+    tnode.pad              = 0;
+    std::vector<GTLASNode> tlas = { tnode };
+
+    // --- Upload everything ---
+    GBVHNode*   d_nodes     = devUpload(s.nodes);
+    GPrimitive* d_prims     = devUpload(s.prims);
+    GTriangle*  d_tris      = devUpload(s.triangles);
+    GSphere*    d_spheres   = devUpload(s.spheres);
+    GTLASNode*  d_tlas      = devUpload(tlas);
+    GInstance*  d_instances = devUpload(instances);
+    GBLAS*      d_blas      = devUpload(blas);
+
+    int total = res.totalRays;
+    int   *d_disagree = nullptr, *d_fieldmm = nullptr;
+    float *d_td = nullptr, *d_pd = nullptr, *d_nd = nullptr;
+    TLAS_CUDA_CHECK(cudaMalloc(&d_disagree, total * sizeof(int)));
+    TLAS_CUDA_CHECK(cudaMalloc(&d_fieldmm,  total * sizeof(int)));
+    TLAS_CUDA_CHECK(cudaMalloc(&d_td, total * sizeof(float)));
+    TLAS_CUDA_CHECK(cudaMalloc(&d_pd, total * sizeof(float)));
+    TLAS_CUDA_CHECK(cudaMalloc(&d_nd, total * sizeof(float)));
+
+    int threads = 256;
+    int blocks  = (total + threads - 1) / threads;
+    tlasParityKernel<<<blocks, threads>>>(
+        s.camera, width, height,
+        d_nodes, d_prims, d_tris, d_spheres,
+        d_tlas, d_instances, d_blas,
+        d_disagree, d_fieldmm, d_td, d_pd, d_nd);
+    cudaError_t launchErr = cudaGetLastError();
+    if (launchErr == cudaSuccess) launchErr = cudaDeviceSynchronize();
+
+    // Download (even on success path) then free.
+    std::vector<int>   h_disagree(total), h_fieldmm(total);
+    std::vector<float> h_td(total), h_pd(total), h_nd(total);
+    cudaError_t cpyErr = launchErr;
+    if (cpyErr == cudaSuccess) cpyErr = cudaMemcpy(h_disagree.data(), d_disagree, total*sizeof(int), cudaMemcpyDeviceToHost);
+    if (cpyErr == cudaSuccess) cpyErr = cudaMemcpy(h_fieldmm.data(),  d_fieldmm,  total*sizeof(int), cudaMemcpyDeviceToHost);
+    if (cpyErr == cudaSuccess) cpyErr = cudaMemcpy(h_td.data(), d_td, total*sizeof(float), cudaMemcpyDeviceToHost);
+    if (cpyErr == cudaSuccess) cpyErr = cudaMemcpy(h_pd.data(), d_pd, total*sizeof(float), cudaMemcpyDeviceToHost);
+    if (cpyErr == cudaSuccess) cpyErr = cudaMemcpy(h_nd.data(), d_nd, total*sizeof(float), cudaMemcpyDeviceToHost);
+
+    cudaFree(d_disagree); cudaFree(d_fieldmm);
+    cudaFree(d_td); cudaFree(d_pd); cudaFree(d_nd);
+    cudaFree(d_nodes); cudaFree(d_prims); cudaFree(d_tris); cudaFree(d_spheres);
+    cudaFree(d_tlas); cudaFree(d_instances); cudaFree(d_blas);
+    cudaGetLastError();  // swallow any cleanup error
+
+    if (cpyErr != cudaSuccess) {
+        std::fprintf(stderr, "[tlas-parity] kernel/copy error: %s\n",
+                     cudaGetErrorString(cpyErr));
+        throw std::runtime_error(cudaGetErrorString(cpyErr));
+    }
+
+    for (int i = 0; i < total; ++i) {
+        res.hitDisagree   += h_disagree[i];
+        res.fieldMismatch += h_fieldmm[i];
+        res.maxTDelta      = std::max(res.maxTDelta,      h_td[i]);
+        res.maxPointDelta  = std::max(res.maxPointDelta,  h_pd[i]);
+        res.maxNormalDelta = std::max(res.maxNormalDelta, h_nd[i]);
+    }
+    return res;
+}
+
+}  // namespace twolevel
+}  // namespace astroray

--- a/tests/test_tlas_blas_parity.py
+++ b/tests/test_tlas_blas_parity.py
@@ -1,0 +1,77 @@
+"""pkg114 increment 1 — two-level BVH (TLAS-over-BLAS) identity-passthrough gate.
+
+Validates that the new device two-level traversal `gpu_tlas_hit`, fed a single
+IDENTITY instance (one BLAS = the whole uploaded scene, M = Minv = I, a 1-leaf
+TLAS), reduces EXACTLY to the single-level `gpu_bvh_hit` over every primary
+camera ray of the Cornell scene.
+
+The comparison runs device-side (see src/gpu/tlas_parity.cu): for each ray the
+probe generates ONE camera ray and dual-traces it through both entry points,
+then returns aggregate stats. For an identity instance:
+
+  * t / primId / materialId / frontFace / point must match bit-for-bit, and
+  * the surface normal may differ by at most a sub-ulp (the no-op
+    inverse-transpose + renormalize on the way back to world space).
+
+This is the regression guard for the two-level plumbing — struct upload, the
+leaf/instance indirection, the BLAS root-pointer offset, the primId remap, the
+GRay field-assign (un-normalized local direction), and the back-transform —
+BEFORE any production kernel is routed through it (increment 2).
+
+Skipped when the astroray module lacks CUDA or no GPU is present.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "tests"))
+sys.path.insert(0, str(ROOT))
+
+import runtime_setup  # noqa: E402
+
+runtime_setup.configure_test_imports()
+
+import astroray  # noqa: E402
+
+_RES = 64  # 64x64 = 4096 primary rays
+
+
+def _build_cornell(res: int):
+    from importlib import import_module
+
+    mod = import_module("benchmarks.showcase.scenes.convergence_grid")
+    r = astroray.Renderer()
+    mod.build_cornell(r, res, res)
+    return r
+
+
+@pytest.mark.skipif(
+    not getattr(astroray, "__features__", {}).get("cuda", False),
+    reason="astroray built without CUDA",
+)
+def test_tlas_identity_passthrough_matches_single_level():
+    r = _build_cornell(_RES)
+    if not getattr(r, "gpu_available", False):
+        pytest.skip("CUDA GPU not available")
+
+    stats = astroray._gpu_tlas_identity_parity(r, _RES, _RES)
+
+    assert stats["total_rays"] == _RES * _RES, stats
+    # Hit/miss agreement and the exact integer/float fields must be bit-identical.
+    assert stats["hit_disagree"] == 0, (
+        f"{stats['hit_disagree']} rays where TLAS and single-level disagreed on "
+        f"hit/miss: {stats}")
+    assert stats["field_mismatch"] == 0, (
+        f"{stats['field_mismatch']} rays where t/primId/materialId/frontFace "
+        f"differed under the identity instance: {stats}")
+    assert stats["max_t_delta"] == 0.0, stats
+    assert stats["max_point_delta"] == 0.0, stats
+    # The only permitted drift: a sub-ulp normal change from the (no-op) inverse-
+    # transpose renormalize on an already-unit normal.
+    assert stats["max_normal_delta"] < 1e-5, (
+        f"identity instance perturbed the surface normal by "
+        f"{stats['max_normal_delta']:.3e} (> 1e-5): {stats}")


### PR DESCRIPTION
## pkg114 — Two-level BVH (TLAS over per-mesh BLAS), increment 1

First landable increment of the GPU instancing acceleration structure (the follow-up to pkg112's batched upload). **§6 research is now signed off** and this increment lands the device data structures + traversal + a regression guard, **without touching any production kernel** (zero render risk).

### §6 research (CLAUDE.md gate)
`.astroray_plan/docs/two-level-bvh-research.md` (+ a Cycles deep-dive appendix `pkg114-cycles-twolevel-bvh-research.md`), cross-verified against **PBRT-v4** `TransformedPrimitive`, **Cycles** `bvh2.cpp`/`bvh_instance_push`, and **Embree/OptiX** IAS-over-GAS — all **Apache-2.0** (compatible with Astroray's MIT). Notable correction: **pbrt-v4 is Apache-2.0**, not BSD-3-Clause (BSD applied to pbrt-*v3*; the spec assumed wrong).

### What lands
- **`gpu_types.h`** — `GMat4` (row-major affine: `xformPoint`, **un-normalized** `xformDir`, `xformNormalByInvTranspose`), `GBLAS{nodeOffset,primOffset}`, `GInstance` (M + Minv + blasIndex + instanceId), `GTLASNode = GBVHNode`.
- **`gpu_bvh.h`** — `gpu_tlas_hit`: TLAS-over-BLAS traversal. Ray→BLAS-local via `Minv` with the direction **not renormalized** (so local `t` == world `t` and the global `tMax` is one shared cutoff; the `GRay` ctor's renormalize is bypassed by field-assign — the `stage_intersect.cu` precedent). Back-transform recovers the **geometric outward** normal, applies `(Minv)^T`, renormalizes, **recomputes `frontFace` in world space** (correct under mirror/negative-det), rebuilds the world ONB; `primId` remapped BLAS-local→global.
- **`src/gpu/tlas_parity.cu`** + `gpu_tlas_parity.h` + `_gpu_tlas_identity_parity` binding — a device dual-trace probe that builds **one identity instance** and asserts `gpu_tlas_hit(identity)` ≡ single-level `gpu_bvh_hit` over every primary ray.

### RTX verification (this machine — CI has no GPU)
Cornell, 64×64 = **4096 primary rays**:
```
hit_disagree=0  field_mismatch=0  (t / primId / materialId / frontFace bit-exact)
max_t_delta=0   max_point_delta=0   max_normal_delta=3.24e-06  (sub-ulp; no-op inverse-transpose renormalize)
```
- `tests/test_tlas_blas_parity.py` — **PASSED**
- GPU regression smoke (glass furnace / multiwavelength / smooth-shade / disney-reflection): **11 passed, 1 xfailed** (pre-existing low-α residual).
- Build: Ninja+MSVC `build_cuda`, `.pyd` mtime postdates HEAD; module loads from canonical `build_cuda/`.

> CI has no GPU, so the meaningful verification is the RTX numbers above. CI's build-and-test is a compile check only.

### Next (increment 2)
Host `register_mesh`/`add_instance` API, route the megakernel through `gpu_tlas_hit`, multi-instance real transforms, full-render pixel parity vs the flattened scene + a non-uniform/mirror-scale visual. Multi-instance **emissive** NEE is deferred to a follow-up (owner-flagged fork; non-blocking for pkg114 acceptance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)