### PR TITLE
fix(pkg108): BUG-14 GPU glass tint + BUG-16 GPU subsurface; BUG-09 live-Blender verified

### DIFF
--- a/.astroray_plan/packages/pkg108-addon-residual-bug-triage.md
+++ b/.astroray_plan/packages/pkg108-addon-residual-bug-triage.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 5 (Production polish)
 **Track:** A (small targeted fixes) + investigation
-**Status:** open
+**Status:** done (PR pending, 2026-06-10 — BUG-09 verified non-reproducing in live Blender 5.1; BUG-14 root cause was the GPU delta-dielectric dropping the tint (`s.f = eta²` without baseColor), fixed CPU-parity (`baseColor * eta²`); BUG-16 GPU half fixed — closure-graph diffuse + GMAT_DISNEY both now apply the Burley §5.3 HK subsurface mix; 6 regression tests incl. GPU variants + headless-Blender routing verify)
 **Estimated effort:** 2–4 days (one bug per ½–1 day)
 **Depends on:** none
 
@@ -112,9 +112,38 @@ param, C++ ignores it) or a missing material-implementation branch.
 ## Progress
 
 - [x] BUG-08 closed (pkg104 sensor-width fallback fix).
-- [ ] BUG-09 investigation.
-- [ ] BUG-14 investigation.
-- [ ] BUG-16 investigation.
+- [x] BUG-09 closed (2026-06-10): live-Blender verification done headlessly
+      (`scripts/verify_pkg108_bug09_bug14_blender.py`, Blender 5.1
+      `--background --factory-startup`). A REAL `AstrorayOutputNode` →
+      `AstrorayShaderNodeSellmeierGlass` tree (with a decoy Cycles
+      OUTPUT_MATERIAL + Principled) routes to `dielectric`/`sellmeier_preset
+      ='bk7'` through the full engine render path, including the real
+      `inline_shader_nodes()` flattening pass. Does not reproduce; the P3-c
+      probe + `convert_astroray_output` handler work as designed.
+- [x] BUG-14 closed (2026-06-10): the report WAS real — on the **CUDA
+      backend only**. `gpu_dielectric_sample` / `gpu_dielectric_sample_spectral`
+      set the refraction throughput to `eta²` with no baseColor, so tinted
+      glass rendered clear on GPU at any roughness ≤0.03 (the delta regime —
+      exactly "tint invisible at low roughness"). The closure-graph lowering
+      (disney glass AND plain dielectric both lower to GMAT_CLOSURE_GRAPH →
+      GMAT_DIELECTRIC at low roughness) carried the tint into `baseColor` but
+      the sampler ignored it. Fix mirrors CPU `dielectric.cpp` (`s.f = tint_
+      * eta²`): refraction now multiplies `mat.baseColor`. Reflection stays
+      untinted (CPU parity). Direct dispersive-dielectric uploads use white
+      baseColor → Sellmeier/BK7 paths bit-identical. Regression tests:
+      dielectric + disney-routed (addon config) × CPU + GPU in
+      `tests/test_pkg108_glass_color_lowroughness.py`. Addon-side plumbing
+      separately verified in the live-Blender script (red tint +
+      transmission=1.0 reach `create_material('disney', ...)`).
+- [x] BUG-16 closed (2026-06-10): CPU half was fixed in PR #375; the GPU half
+      remained — `subsurface` was uploaded but never read. TWO GPU paths fixed:
+      (a) `gpu_disney_eval` (direct GMAT_DISNEY) now applies the Burley 2012
+      §5.3 Hanrahan-Krueger mix mirroring the CPU fix; (b) the closure-graph
+      path (what the Disney plugin actually lowers to: GCLOSURE_DIFFUSE →
+      GMAT_LAMBERTIAN) now carries `subsurface` + parent roughness through
+      `convertMaterial` → `gpu_closure_as_material` → gated HK mix in
+      `gpu_lambertian_eval` (subsurface==0 renders bit-identical).
+      GPU regression test added (`test_subsurface_weight_changes_rendered_output_gpu`).
 
 ---
 

--- a/include/astroray/gpu_materials.h
+++ b/include/astroray/gpu_materials.h
@@ -123,10 +123,32 @@ __device__ inline GRay gpu_generateCameraRay(
 // ===========================================================================
 
 __device__ inline GVec3 gpu_lambertian_eval(
-    const GMaterial& mat, const GHitRecord& rec, const GVec3& /*wo*/, const GVec3& wi)
+    const GMaterial& mat, const GHitRecord& rec, const GVec3& wo, const GVec3& wi)
 {
     float NdotL = rec.normal.dot(wi);
     if (NdotL <= 0.f) return GVec3(0.f);
+    // pkg108 BUG-16 (closure path): Disney materials lower their diffuse lobe
+    // to GCLOSURE_DIFFUSE which shades here, so subsurface_weight was a silent
+    // no-op on the CUDA backend. Apply the Burley 2012 "Physically-Based
+    // Shading at Disney" §5.3 Hanrahan-Krueger mix, mirroring the CPU fix in
+    // plugins/materials/disney.cpp::eval (PR #375). Gated on subsurface > 0:
+    // plain Lambertian renders stay bit-identical.
+    if (mat.subsurface > 0.f) {
+        float NdotV = rec.normal.dot(wo);
+        if (NdotV > 0.f) {
+            GVec3 H = (wi + wo).normalized();
+            float LdotH = wi.dot(H);
+            float FL = powf(1.f - NdotL, 5.f);
+            float FV = powf(1.f - NdotV, 5.f);
+            float Fd90 = 0.5f + 2.f * LdotH*LdotH * mat.roughness;
+            float Fd = (1.f + (Fd90-1.f)*FL) * (1.f + (Fd90-1.f)*FV);
+            float Fss90 = LdotH*LdotH * mat.roughness;
+            float Fss = (1.f + (Fss90-1.f)*FL) * (1.f + (Fss90-1.f)*FV);
+            float ss = 1.25f * (Fss * (1.f / fmaxf(NdotL + NdotV, 1e-4f) - 0.5f) + 0.5f);
+            float FdMixed = (1.f - mat.subsurface) * Fd + mat.subsurface * ss;
+            return mat.baseColor * (1.f / M_PI_F) * FdMixed * NdotL;
+        }
+    }
     return mat.baseColor * (1.f / M_PI_F) * NdotL;
 }
 
@@ -294,7 +316,12 @@ __device__ inline GBSDFSample gpu_dielectric_sample(
         GVec3 wt_perp   = (wo - n*cosTheta) * (-eta);
         GVec3 wt_para   = n * (-sqrtf(fabsf(1.f - wt_perp.length2())));
         s.wi  = (wt_perp + wt_para).normalized();
-        s.f   = GVec3(eta * eta);
+        // pkg108 BUG-14 (GPU half): refraction carries the glass tint.
+        // Mirrors CPU DielectricPlugin::sample (dielectric.cpp: s.f =
+        // tint_ * eta^2) and the GPU disney delta branch. baseColor is the
+        // closure color when this material was lowered from a closure graph,
+        // so tinted glass was rendering clear on the CUDA backend only.
+        s.f   = mat.baseColor * (eta * eta);
         s.pdf = 1.f;
     }
     return s;
@@ -347,7 +374,8 @@ __device__ inline GBSDFSample gpu_dielectric_sample_spectral(
         GVec3 wt_perp   = (wo - n*cosTheta) * (-eta);
         GVec3 wt_para   = n * (-sqrtf(fabsf(1.f - wt_perp.length2())));
         s.wi  = (wt_perp + wt_para).normalized();
-        s.f   = GVec3(eta * eta);
+        // pkg108 BUG-14 (GPU half): tinted refraction — see gpu_dielectric_sample.
+        s.f   = mat.baseColor * (eta * eta);
         s.pdf = 1.f;
         // Dispersive refraction: only the hero wavelength follows this bend.
         // Mirror CPU dielectric.cpp:188 — terminate the secondary wavelengths.
@@ -648,7 +676,16 @@ __device__ inline GVec3 gpu_disney_eval(
     float FV  = powf(1.f - NdotV, 5.f);
     float Fd90 = 0.5f + 2.f * LdotH*LdotH * mat.roughness;
     float Fd  = (1.f + (Fd90-1.f)*FL) * (1.f + (Fd90-1.f)*FV);
-    GVec3 diffuse = (1.f / M_PI_F) * Cdlin * Fd;
+    // pkg108 BUG-16 (GPU half): Burley 2012 "Physically-Based Shading at
+    // Disney" §5.3 Hanrahan-Krueger subsurface approximation. Mirrors the
+    // CPU fix in plugins/materials/disney.cpp::eval (PR #375); without this
+    // mix mat.subsurface was uploaded but never read, so subsurface_weight
+    // was a silent no-op on the CUDA backend only.
+    float Fss90 = LdotH*LdotH * mat.roughness;
+    float Fss = (1.f + (Fss90-1.f)*FL) * (1.f + (Fss90-1.f)*FV);
+    float ss = 1.25f * (Fss * (1.f / fmaxf(NdotL + NdotV, 1e-4f) - 0.5f) + 0.5f);
+    float FdMixed = (1.f - mat.subsurface) * Fd + mat.subsurface * ss;
+    GVec3 diffuse = (1.f / M_PI_F) * Cdlin * FdMixed;
 
     // Specular — min alpha 0.0064 (roughness 0.08) to prevent numerical collapse
     float a  = fmaxf(mat.roughness*mat.roughness, 0.0064f);
@@ -855,6 +892,12 @@ __device__ inline GMaterial gpu_closure_as_material(const GMaterial& parent, con
     switch (closure.type) {
         case GCLOSURE_DIFFUSE:
             tmp.type = GMAT_LAMBERTIAN;
+            // pkg108 BUG-16 (closure path): the Disney plugin lowers its
+            // diffuse lobe to GCLOSURE_DIFFUSE, so the subsurface mix must
+            // ride along. The HK formula needs the Disney roughness, which
+            // lives on the parent (the diffuse closure's own roughness is 0).
+            tmp.subsurface = parent.subsurface;
+            tmp.roughness  = parent.roughness;
             break;
         case GCLOSURE_GGX_CONDUCTOR:
             tmp.type = GMAT_METAL;

--- a/scripts/verify_pkg108_bug09_bug14_blender.py
+++ b/scripts/verify_pkg108_bug09_bug14_blender.py
@@ -1,0 +1,169 @@
+"""pkg108 BUG-09 + BUG-14 — real-Blender 5.1 verification of addon material routing.
+
+Run headless:
+    "C:/Program Files/Blender Foundation/Blender 5.1/blender.exe" --background \
+        --factory-startup --python scripts/verify_pkg108_bug09_bug14_blender.py
+
+BUG-09 (Astroray Output node): the original report said an AstrorayOutputNode
+in a material's node tree was detected but its output "isn't picked up" — the
+material fell through to standard Principled translation. The stub-Blender
+test (tests/test_blender_native_nodes.py) passes; what remained per the spec
+was verification "on a live Blender scene with an actual AstrorayOutputNode
+wired up". This script IS that verification: it registers the real addon in
+real Blender, builds a material whose tree contains a REAL AstrorayOutputNode
+→ AstrorayShaderNodeSellmeierGlass (plus a decoy Cycles OUTPUT_MATERIAL +
+Principled), runs a full engine render (which exercises the real
+inline_shader_nodes() flattening pass), and asserts the C++ material created
+for it is a 'dielectric' with sellmeier_preset='bk7' — NOT a principled/disney
+fallback.
+
+BUG-14 (glass tint at low roughness): the addon-routed half. A second object
+gets a real Principled BSDF with Transmission=1.0, Roughness=0.02 and a strong
+red Base Color; we assert the conversion emits a 'disney' material carrying
+both the transmission and the red tint (the core-renderer tint response at low
+roughness is covered by tests/test_pkg108_glass_color_lowroughness.py).
+"""
+import os
+import sys
+
+import bpy
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "tests"))
+import runtime_setup
+runtime_setup.configure_test_imports()
+sys.path.insert(0, ROOT)
+
+import astroray as _real_astroray
+import blender_addon
+
+
+class _SpyRenderer:
+    """Wraps a real astroray.Renderer, recording create_material calls."""
+
+    calls = []  # class-level: shared across every renderer the addon creates
+
+    def __init__(self, *args, **kwargs):
+        object.__setattr__(self, "_r", _real_astroray.Renderer(*args, **kwargs))
+
+    def create_material(self, kind, color, params):
+        mat_id = self._r.create_material(kind, color, params)
+        _SpyRenderer.calls.append((kind, list(color), dict(params), mat_id))
+        return mat_id
+
+    def __getattr__(self, name):
+        return getattr(object.__getattribute__(self, "_r"), name)
+
+
+class _SpyModule:
+    """Module proxy: astroray.* passthrough, but Renderer is the spy."""
+
+    Renderer = _SpyRenderer
+
+    def __getattr__(self, name):
+        return getattr(_real_astroray, name)
+
+
+def main():
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+    blender_addon.register()
+    blender_addon.astroray = _SpyModule()
+
+    scene = bpy.context.scene
+    scene.render.engine = "CUSTOM_RAYTRACER"
+    scene.render.resolution_x = 64
+    scene.render.resolution_y = 64
+    scene.render.resolution_percentage = 100
+    scene.custom_raytracer.samples = 2
+
+    # Camera + light so the engine has a complete scene.
+    cam_data = bpy.data.cameras.new("Cam")
+    cam = bpy.data.objects.new("Cam", cam_data)
+    cam.location = (0.0, -4.0, 1.0)
+    cam.rotation_euler = (1.35, 0.0, 0.0)
+    bpy.context.collection.objects.link(cam)
+    scene.camera = cam
+
+    light_data = bpy.data.lights.new("Sun", type="SUN")
+    light = bpy.data.objects.new("Sun", light_data)
+    light.location = (1.0, -1.0, 3.0)
+    bpy.context.collection.objects.link(light)
+
+    # --- Object 1: BUG-09 — AstrorayOutputNode → Sellmeier glass -------------
+    bpy.ops.mesh.primitive_uv_sphere_add(radius=0.7, location=(-1.0, 0.0, 0.7))
+    sphere = bpy.context.active_object
+    mat09 = bpy.data.materials.new("Bug09SellmeierGlass")
+    mat09.use_nodes = True
+    tree = mat09.node_tree
+    # Keep the default Principled + OUTPUT_MATERIAL as the decoy Cycles path;
+    # the AstrorayOutputNode must take precedence over it.
+    sellmeier = tree.nodes.new("AstrorayShaderNodeSellmeierGlass")
+    sellmeier.use_preset = True
+    sellmeier.preset = "bk7"
+    astro_out = tree.nodes.new("AstrorayOutputNode")
+    tree.links.new(sellmeier.outputs["BSDF"], astro_out.inputs["Surface"])
+    sphere.data.materials.append(mat09)
+
+    # --- Object 2: BUG-14 — Principled glass, red tint, near-zero roughness --
+    bpy.ops.mesh.primitive_cube_add(size=1.0, location=(1.0, 0.0, 0.5))
+    cube = bpy.context.active_object
+    mat14 = bpy.data.materials.new("Bug14TintedGlass")
+    mat14.use_nodes = True
+    principled = next(
+        n for n in mat14.node_tree.nodes if n.type == "BSDF_PRINCIPLED")
+    principled.inputs["Base Color"].default_value = (0.9, 0.05, 0.05, 1.0)
+    principled.inputs["Roughness"].default_value = 0.02
+    principled.inputs["Transmission Weight"].default_value = 1.0
+    principled.inputs["IOR"].default_value = 1.5
+    cube.data.materials.append(mat14)
+
+    bpy.context.view_layer.update()
+    bpy.ops.render.render(write_still=False)
+
+    calls = _SpyRenderer.calls
+    print(f"[pkg108-verify] {len(calls)} create_material calls recorded:")
+    for kind, color, params, mat_id in calls:
+        print(f"[pkg108-verify]   id={mat_id} kind={kind!r} color={color} params={params}")
+
+    failures = []
+
+    # BUG-09: the AstrorayOutputNode material must have routed to a Sellmeier
+    # dielectric, not fallen through to disney/principled.
+    bug09 = [c for c in calls
+             if c[0] == "dielectric" and c[2].get("sellmeier_preset") == "bk7"]
+    if not bug09:
+        failures.append(
+            "BUG-09 REPRODUCED: no dielectric material with "
+            "sellmeier_preset='bk7' was created — AstrorayOutputNode output "
+            "was not picked up by the live conversion path.")
+
+    # BUG-14 (addon half): the Principled glass must reach C++ as a disney
+    # material carrying transmission=1 and the red tint.
+    def _is_red(color):
+        return color[0] > 0.5 and color[1] < 0.2 and color[2] < 0.2
+
+    bug14 = [c for c in calls
+             if c[0] == "disney"
+             and c[2].get("transmission", 0.0) >= 0.99
+             and _is_red(c[1])]
+    if not bug14:
+        failures.append(
+            "BUG-14 (addon route) REPRODUCED: no disney material with "
+            "transmission=1.0 and red base color was created — the Principled "
+            "glass tint/transmission did not survive conversion.")
+
+    if failures:
+        for f in failures:
+            print(f"[pkg108-verify] {f}")
+        print("PKG108_BLENDER_RESULT FAIL")
+        raise SystemExit(1)
+
+    print("[pkg108-verify] BUG-09: AstrorayOutputNode routed to "
+          f"dielectric/bk7 (mat id {bug09[0][3]}) — does not reproduce.")
+    print("[pkg108-verify] BUG-14: Principled glass routed to disney with "
+          f"transmission=1.0, red tint (mat id {bug14[0][3]}) — addon tint "
+          "plumbing intact.")
+    print("PKG108_BLENDER_RESULT PASS")
+
+
+main()

--- a/src/gpu/scene_upload.cu
+++ b/src/gpu/scene_upload.cu
@@ -111,6 +111,9 @@ static GMaterial convertMaterial(const std::shared_ptr<Material>& mat) {
         g.roughness = mat->getRoughness();
         g.ior = mat->getIOR();
         g.transmission = mat->getTransmission();
+        // pkg108 BUG-16: the diffuse closure applies the Hanrahan-Krueger
+        // subsurface mix (gpu_lambertian_eval); carry the weight across.
+        g.subsurface = mat->getSubsurface();
         g.closureCount = static_cast<uint8_t>(
             std::min(graph.count(), G_MAX_MATERIAL_CLOSURES));
 

--- a/tests/test_pkg108_glass_color_lowroughness.py
+++ b/tests/test_pkg108_glass_color_lowroughness.py
@@ -40,17 +40,25 @@ SAMPLES = 64
 MAX_DEPTH = 8
 
 
-def _render_through_glass(tint_rgb):
+def _render_through_glass(tint_rgb, material_kind="dielectric", use_gpu=False):
     """Render a scene with a glass slab tinted with the given RGB.
 
     Layout: light above, glass slab in middle of frame, white floor below.
     Camera looks down at the floor through the glass. Tinted transmission
     should colour the rectangle under the slab.
+
+    ``material_kind`` selects the BSDF route:
+    - "dielectric": the direct glass material (original probe).
+    - "disney": transmission=1.0 Disney — this is what the Blender addon's
+      ``_principled_shader_spec`` emits for a Principled-BSDF glass, i.e. the
+      addon-routed path the BUG-14 report suspected of dropping the tint.
     """
     r = astroray.Renderer()
     r.set_integrator("path_tracer")
     r.set_background_color([0.0, 0.0, 0.0])
     r.set_seed(31)
+    if use_gpu:
+        r.set_use_gpu(True)
 
     # White floor.
     white = r.create_material("lambertian", [0.92, 0.92, 0.92], {})
@@ -64,7 +72,12 @@ def _render_through_glass(tint_rgb):
 
     # Tinted glass slab — VERY LOW roughness, just covering the central area.
     # 0.02 roughness = near-mirror smoothness; this is the regime BUG-14 reports.
-    glass = r.create_material("dielectric", tint_rgb, {"ior": 1.5, "roughness": 0.02})
+    if material_kind == "disney":
+        glass = r.create_material(
+            "disney", tint_rgb,
+            {"ior": 1.5, "roughness": 0.02, "transmission": 1.0, "metallic": 0.0})
+    else:
+        glass = r.create_material("dielectric", tint_rgb, {"ior": 1.5, "roughness": 0.02})
     # Thin horizontal glass slab at y=1.2, 1.0 wide × 1.0 deep, ~0.1 thick.
     y_top, y_bot = 1.25, 1.15
     # Top face
@@ -86,10 +99,11 @@ def _render_through_glass(tint_rgb):
     return np.asarray(r.render(SAMPLES, MAX_DEPTH, None, True), dtype=np.float32)
 
 
-def test_red_vs_blue_glass_tints_floor_differently():
-    """Glass with red tint should produce a redder transmission than blue tint."""
-    red_img = _render_through_glass([0.95, 0.05, 0.05])
-    blue_img = _render_through_glass([0.05, 0.05, 0.95])
+def _assert_red_vs_blue_tints_differ(material_kind, use_gpu):
+    red_img = _render_through_glass(
+        [0.95, 0.05, 0.05], material_kind=material_kind, use_gpu=use_gpu)
+    blue_img = _render_through_glass(
+        [0.05, 0.05, 0.95], material_kind=material_kind, use_gpu=use_gpu)
 
     # Sample the floor area under the slab — bottom half of frame, center.
     h, w, _ = red_img.shape
@@ -105,13 +119,43 @@ def test_red_vs_blue_glass_tints_floor_differently():
     r_ratio = (red_means[0] + 1e-4) / (blue_means[0] + 1e-4)
     b_ratio = (red_means[2] + 1e-4) / (blue_means[2] + 1e-4)
 
+    label = f"{material_kind}/{'GPU' if use_gpu else 'CPU'}"
     assert r_ratio > 1.3, (
-        f"Red tint did not produce visibly redder floor than blue tint. "
+        f"[{label}] Red tint did not produce visibly redder floor than blue tint. "
         f"Red-tint R={red_means[0]:.4f}, blue-tint R={blue_means[0]:.4f}, "
         f"ratio={r_ratio:.2f} (want >1.3)"
     )
     assert b_ratio < 0.77, (
-        f"Red tint did not produce visibly bluer-less floor than blue tint. "
+        f"[{label}] Red tint did not produce visibly bluer-less floor than blue tint. "
         f"Red-tint B={red_means[2]:.4f}, blue-tint B={blue_means[2]:.4f}, "
         f"ratio={b_ratio:.2f} (want <0.77)"
     )
+
+
+def test_red_vs_blue_glass_tints_floor_differently():
+    """Glass with red tint should produce a redder transmission than blue tint."""
+    _assert_red_vs_blue_tints_differ("dielectric", use_gpu=False)
+
+
+def test_red_vs_blue_disney_glass_tints_floor_differently():
+    """BUG-14 addon-routed path: the Blender addon converts a Principled glass
+    to a Disney material with transmission=1.0 (``_principled_shader_spec``),
+    not to the direct dielectric. This probes the tint through that route at
+    near-zero roughness — the configuration the original report suspected."""
+    _assert_red_vs_blue_tints_differ("disney", use_gpu=False)
+
+
+_NEEDS_CUDA = pytest.mark.skipif(
+    AVAILABLE and not astroray.__features__.get("cuda", False),
+    reason="CUDA feature not in this build — GPU probe runs on the RTX box",
+)
+
+
+@_NEEDS_CUDA
+def test_red_vs_blue_glass_tints_floor_differently_gpu():
+    _assert_red_vs_blue_tints_differ("dielectric", use_gpu=True)
+
+
+@_NEEDS_CUDA
+def test_red_vs_blue_disney_glass_tints_floor_differently_gpu():
+    _assert_red_vs_blue_tints_differ("disney", use_gpu=True)

--- a/tests/test_pkg108_subsurface_weight_response.py
+++ b/tests/test_pkg108_subsurface_weight_response.py
@@ -42,12 +42,14 @@ SAMPLES = 64
 MAX_DEPTH = 6
 
 
-def _render_with_subsurface(subsurface_weight, subsurface_radius=None):
+def _render_with_subsurface(subsurface_weight, subsurface_radius=None, use_gpu=False):
     """Render a thick translucent sphere with the given subsurface params."""
     r = astroray.Renderer()
     r.set_integrator("path_tracer")
     r.set_background_color([0.0, 0.0, 0.0])
     r.set_seed(31)
+    if use_gpu:
+        r.set_use_gpu(True)
 
     # Bright back-light so light has to travel through the sphere to reach the camera.
     # This is the geometry that makes subsurface scattering visible: light enters
@@ -84,11 +86,11 @@ def _render_with_subsurface(subsurface_weight, subsurface_radius=None):
     return np.asarray(r.render(SAMPLES, MAX_DEPTH, None, True), dtype=np.float32)
 
 
-def test_subsurface_weight_changes_rendered_output():
-    """subsurface_weight=0 vs 1 with non-zero radius must differ measurably."""
-    no_sss = _render_with_subsurface(subsurface_weight=0.0)
+def _assert_subsurface_responds(use_gpu):
+    no_sss = _render_with_subsurface(subsurface_weight=0.0, use_gpu=use_gpu)
     with_sss = _render_with_subsurface(
-        subsurface_weight=1.0, subsurface_radius=[0.3, 0.3, 0.3])
+        subsurface_weight=1.0, subsurface_radius=[0.3, 0.3, 0.3],
+        use_gpu=use_gpu)
 
     # Sample the sphere region (centre half of frame).
     h, w, _ = no_sss.shape
@@ -105,11 +107,29 @@ def test_subsurface_weight_changes_rendered_output():
     rel_diff = diff / (no_sss_mean + 1e-4)
 
     max_rel_diff = float(rel_diff.max())
+    backend = "GPU" if use_gpu else "CPU"
     assert max_rel_diff > 0.01, (
-        f"subsurface_weight=0 vs 1 produces identical (<1% diff) renders.\n"
+        f"[{backend}] subsurface_weight=0 vs 1 produces identical (<1% diff) renders.\n"
         f"  no_sss mean per channel:   {no_sss_mean}\n"
         f"  with_sss mean per channel: {with_sss_mean}\n"
         f"  max relative diff:         {max_rel_diff:.4f}\n"
         f"This confirms BUG-16: subsurface_weight is plumbed but ignored "
         f"by the renderer."
     )
+
+
+def test_subsurface_weight_changes_rendered_output():
+    """subsurface_weight=0 vs 1 with non-zero radius must differ measurably."""
+    _assert_subsurface_responds(use_gpu=False)
+
+
+@pytest.mark.skipif(
+    AVAILABLE and not astroray.__features__.get("cuda", False),
+    reason="CUDA feature not in this build — GPU half of BUG-16 needs the RTX box",
+)
+def test_subsurface_weight_changes_rendered_output_gpu():
+    """GPU half of BUG-16: gpu_disney_eval previously never read mat.subsurface,
+    so subsurface_weight was a silent no-op on the CUDA backend while the CPU
+    responded (CPU fix: PR #375). This is the regression gate for the GPU mirror
+    of the Burley 2012 §5.3 Hanrahan-Krueger mix."""
+    _assert_subsurface_responds(use_gpu=True)


### PR DESCRIPTION
Closes pkg108 (addon residual bug triage). All three residual bugs adjudicated with evidence:

## BUG-14 — glass tint invisible at low roughness: REAL, GPU-only
`gpu_dielectric_sample` / `gpu_dielectric_sample_spectral` set refraction throughput to `eta²` with **no baseColor**, so tinted glass rendered clear on the CUDA backend in the delta regime (roughness ≤ 0.03 — both disney glass and plain dielectric lower to `GMAT_CLOSURE_GRAPH → GMAT_DIELECTRIC` there; the closure carried the tint into `baseColor` but the sampler ignored it). Fix mirrors CPU `dielectric.cpp::sample` (`s.f = tint * eta²`); reflection stays untinted (CPU parity). Direct dispersive uploads use white baseColor → Sellmeier/BK7 renders bit-identical.

## BUG-16 — subsurface no-op: GPU half fixed
CPU was fixed in PR #375; on GPU `subsurface` was uploaded but never read. Fixed in **both** GPU shading paths: (a) `gpu_disney_eval` (direct `GMAT_DISNEY`) applies the Burley 2012 §5.3 Hanrahan-Krueger mix mirroring the CPU fix; (b) the closure path the Disney plugin actually lowers to (`GCLOSURE_DIFFUSE → GMAT_LAMBERTIAN`) carries `subsurface` + parent roughness through `convertMaterial → gpu_closure_as_material` into a **gated** HK mix in `gpu_lambertian_eval` (subsurface == 0 renders bit-identical).

## BUG-09 — Astroray Output node: does NOT reproduce in live Blender 5.1
New headless verification script (`scripts/verify_pkg108_bug09_bug14_blender.py`) registers the real addon, wires a real `AstrorayOutputNode → AstrorayShaderNodeSellmeierGlass` tree behind a decoy Cycles output, runs a full engine render (real `inline_shader_nodes()` flattening), and asserts routing to `dielectric / sellmeier_preset=bk7`. **PASS**. Same script confirms BUG-14's addon-side plumbing (red tint + transmission=1.0 reach `create_material('disney', ...)`).

## Verification (RTX 5070 Ti)
- 6 pkg108 regression tests pass (4 new GPU variants; CPU variants kept). GPU tests skip cleanly on CI (no GPU).
- Full local suite: **1196 passed, 22 skipped, 22 xfailed, 0 regressions**.
- Visual check: GPU tinted-glass renders show clean red vs blue transmission footprints (saved under `test_results/`).
- Independent review (pkg98 gate): **SIGN-OFF** (different-model review; noted pre-existing GPU disney `diffuseFurnaceScale` divergence as out-of-scope follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)