### PR TITLE
docs(pkg114): record GPU core landed (inc 1+2); scope inc 3

### DIFF
--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -1,6 +1,37 @@
 # Astroray Status
 
-**Last updated:** 2026-06-10 (pkg118 COMPLETE — PR #423; pkg113 COMPLETE — PR #425; pkg112 COMPLETE — PR #427).
+**Last updated:** 2026-06-10 (pkg114 GPU core landed — inc 1 PR #430, inc 2 PR #431; pkg118 COMPLETE — PR #423; pkg113 COMPLETE — PR #425; pkg112 COMPLETE — PR #427).
+
+## pkg114 — Two-level BVH (TLAS/BLAS) GPU core IN PROGRESS (2026-06-10, PRs #430 + #431)
+
+**The GPU instancing core is landed + RTX-verified.** A two-level acceleration
+structure: per-mesh **BLAS** (object-local BVH, built once, shared across
+instances) under a **TLAS** of `GInstance` records carrying a 4×4 object→world
+transform + its affine inverse. `gpu_tlas_hit` transforms the world ray into
+BLAS-local space (un-normalized direction → local `t` == world `t`, one shared
+`tMax`; the `GRay` ctor renormalize is bypassed by field-assign), and back-
+transforms the hit (point by `M`, normal by `(Minv)^T` + renormalize, frontFace
+recomputed in world space → correct under mirror/negative-det, ONB rebuilt).
+Both megakernels (path_trace + multiwavelength) route through it; for
+non-instanced scenes `d_tlas==nullptr` falls back to `gpu_bvh_hit` (byte-exact,
+zero behaviour change). Cited PBRT-v4 / Cycles / Embree (all Apache-2.0;
+**corrected: pbrt-v4 is Apache, not v3's BSD**) — `.astroray_plan/docs/two-level-bvh-research.md`.
+
+- **Inc 1 (#430):** structs + `gpu_tlas_hit` + device identity-passthrough probe.
+  RTX: 4096 Cornell rays byte-exact on t/primId/mat/frontFace/point, normal ≤3.2e-6.
+- **Inc 2 (#431):** `Renderer::registerMesh`/`addInstance` + bindings; two-level
+  `buildSceneArrays`; megakernel routing + `prims + blas.primOffset` BLAS-local
+  fix. RTX: 3 instances (rigid / **non-uniform scale** / **mirror**) vs baked
+  world-space — **mean ratio 1.00000, mean abs diff 8.1e-9**; BLAS sharing shown
+  (4 prims vs 12 baked). Visual `docs/renders/pkg114_instanced_tetrahedra.png`.
+  Full GPU regression sweep clean (only pre-existing xfails).
+- **Inc 3 (remaining):** Blender-addon `convert_objects` instancing
+  (register-mesh-once + `add_instance` per shared-datablock instance; needs a
+  `register_mesh_bulk` binding with UVs/normals/multi-material, object-local) +
+  the depsgraph transform-only → TLAS-only refit for the pkg56 ≤50%-baseline
+  budget. Headless-Blender-verified. Multi-instance EMISSIVE NEE deferred
+  (owner-flagged fork, non-blocking). SAH TLAS is an explicit non-goal.
+  **Next pickup:** pkg114 inc 3 (Blender path) or pkg55 wavefront continuation.
 
 ## pkg118 — rough-dielectric energy compensation COMPLETE (2026-06-08, PR #423)
 

--- a/.astroray_plan/packages/pkg114-two-level-bvh-tlas-blas.md
+++ b/.astroray_plan/packages/pkg114-two-level-bvh-tlas-blas.md
@@ -3,8 +3,37 @@
 **Pillar:** 5 (GPU) + 3 (light transport)
 **Track:** A
 **Codex-paste-ready:** no (core CUDA + CPU; large; multi-session RTX verify)
-**Status:** open — proposed 2026-05-30. **GPU-gated.** This is the follow-up
+**Status:** IN PROGRESS — GPU core landed + RTX-verified 2026-06-10
+(inc 1 PR #430, inc 2 PR #431). Remaining: Blender-addon instancing + the
+depsgraph transform-only refit (inc 3, below). **GPU-gated.** Follow-up
 acceleration-structure package explicitly deferred by pkg56 §4.1.
+
+### Increment log
+- **Inc 1 (PR #430, merged):** device structs (`GMat4`/`GBLAS`/`GInstance`/
+  `GTLASNode`), `gpu_tlas_hit` traversal (ray→BLAS-local, un-normalized dir →
+  shared `tMax`; normal via inverse-transpose; frontFace recomputed in world
+  space), and a device identity-passthrough parity probe. RTX: 4096 Cornell rays
+  byte-exact on t/primId/mat/frontFace/point, normal ≤3.2e-6. Research note
+  `.astroray_plan/docs/two-level-bvh-research.md` (PBRT-v4/Cycles/Embree, all
+  Apache-2.0; corrected pbrt-v4 = Apache not BSD).
+- **Inc 2 (PR #431, merged):** host `Renderer::registerMesh`/`addInstance` +
+  bindings; `buildSceneArrays` two-level branch (per-mesh BLAS concatenated in
+  object-local space, affine-inverse `Minv`, flat-leaf TLAS over instance
+  world-AABBs); both megakernels routed through `gpu_tlas_hit` (null-TLAS →
+  `gpu_bvh_hit` fallback, non-instanced scenes byte-unaffected). RTX: 3 instances
+  (rigid / non-uniform scale / mirror) vs baked world-space — mean ratio 1.00000,
+  mean abs diff 8.1e-9; BLAS sharing shown (4 prims vs 12 baked). Visual:
+  `docs/renders/pkg114_instanced_tetrahedra.png`.
+- **Inc 3 (remaining):** wire the Blender addon `convert_objects` to register a
+  mesh datablock once + `add_instance(matrix_world)` per shared-datablock
+  instance (collection/particle/linked-duplicate) — needs a `register_mesh_bulk`
+  binding (UVs/normals/multi-material, mirroring `add_triangles_bulk` but
+  object-local) and headless-Blender bit-identical + BLAS-sharing verification;
+  then the transform-only depsgraph refit (`_renderer_object_id_map` →
+  `update_instance_transform` → TLAS-only re-upload) for the pkg56 ≤50%-baseline
+  budget. Multi-instance EMISSIVE-light NEE stays a deferred follow-up
+  (owner-flagged fork; non-blocking). NOTE: a SAH TLAS is an explicit non-goal
+  (see Hard non-goals) — the flat-leaf TLAS is correct and sufficient.
 **Depends on:** pkg56 (done — provides the `_renderer_object_id_map` placeholder
 and transform-only dispatch hook). Complementary to pkg112.
 **Estimated effort:** L (~3–4 weeks, multiple RTX sessions)
@@ -63,12 +92,16 @@ to `.astroray_plan/docs/two-level-bvh-research.md` before coding.
 
 ## Acceptance criteria
 
-- [ ] Research note saved; references cited in code.
-- [ ] Instanced geometry (collection/particle instances) renders correctly and
-      shares one BLAS (memory/timing evidence).
-- [ ] Transform-only viewport edit ≤ **50%** of the pkg56 Phase-A baseline.
-- [ ] **Pixel parity** vs single-level BVH on static scenes (RTX `/verify`).
-- [ ] CPU/GPU parity gate green.
+- [x] Research note saved; references cited in code. *(inc 1)*
+- [~] Instanced geometry renders correctly and shares one BLAS (memory evidence).
+      *(inc 2: GPU API + `register_mesh`/`add_instance` shares one BLAS — 4 prims
+      vs 12 baked, pixel-parity 8.1e-9. The Blender collection/particle path is
+      inc 3.)*
+- [ ] Transform-only viewport edit ≤ **50%** of the pkg56 Phase-A baseline. *(inc 3)*
+- [x] **Pixel parity** vs single-level BVH on static scenes (RTX). *(inc 2:
+      mean ratio 1.00000, mean abs diff 8.1e-9; inc 1 identity probe byte-exact)*
+- [x] CPU/GPU parity gate green. *(routing is byte-safe for non-instanced scenes;
+      full RTX regression sweep clean, only pre-existing xfails)*
 
 ## Hard non-goals
 


### PR DESCRIPTION
Doc-only. Records pkg114 increments 1 (#430) and 2 (#431) as landed + RTX-verified in the spec and STATUS.md, updates acceptance checkboxes, and scopes the remaining increment 3 (Blender-addon instancing + depsgraph transform-only refit). No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)