### PR TITLE
feat(pkg88-C.0): deformation motion blur — per-vertex motion, union-AABB BVH, CPU+GPU

### DIFF
--- a/.astroray_plan/packages/pkg88-motion-blur.md
+++ b/.astroray_plan/packages/pkg88-motion-blur.md
@@ -64,6 +64,24 @@ Key cross-references from that note:
 Recommended landing order: A → C.0 → C.1 (only if measured) → B
 (addon-only finish) → D.
 
+**Phase progress:**
+- **A done** (PR #284 + pkg103b addon wiring PR #372).
+- **C.0 implemented** (branch `feat/pkg88-c0-deformation-mb`, 2026-06-10 — PR
+  pending): per-triangle motion vertex buffer (`add_triangles_bulk_motion`
+  bulk binding, K=2 pre/post-shutter steps, linear blend per Cycles
+  `motion_triangle.h` Apache-2.0), time-aware `Triangle::hit` +
+  `gpu_triangle_hit_motion`, union-AABB `boundingBox`, `GRay::time` +
+  end-to-end time threading (primary/bounce/shadow rays, BOTH kernels —
+  the MW megakernel samples per-spp Halton time; its camera remains
+  non-interpolated, a known Phase-A gap), `d_motionVertices` upload.
+  `Camera::getRay`'s zero-shutter path now carries the sampled time (the
+  shutter flag gates CAMERA interpolation only; A3 holds — static scenes
+  have no time consumers, verified bit-identical). RTX-verified: no-op
+  bit-identity, CPU+GPU streak gates, union-AABB extremes, cross-backend
+  motion/static energy-shift parity. Deformation motion on INSTANCED meshes
+  (pkg114 TLAS) is out of scope v1; the wavefront/photon/SMS paths stay
+  static (documented nullptr).
+
 ---
 
 ## Non-goals

--- a/include/astroray/gpu_bvh.h
+++ b/include/astroray/gpu_bvh.h
@@ -7,7 +7,82 @@
 #include "gpu_materials.h"  // for gpu_buildONB
 
 // ---------------------------------------------------------------------------
+// pkg88-C.0 GPU — verify on RTX. Motion-aware triangle hit: interpolate vertices
+// at ray.time before Möller-Trumbore. Per Cycles motion_triangle.h (Apache-2.0):
+// linear blend between bracketing time steps. If motionOffset < 0, falls back to static.
+// ---------------------------------------------------------------------------
+__device__ inline bool gpu_triangle_hit_motion(
+    const GTriangle& tri, const GRay& ray, float tMin, float tMax,
+    GHitRecord& rec, const GVec3* d_motionVertices)
+{
+    const float EPS = 1e-6f;
+    // Interpolate vertices at ray.time if motion data exists
+    GVec3 p0 = tri.v0, p1 = tri.v1, p2 = tri.v2;
+    if (tri.motionOffset >= 0 && tri.motionSteps > 1) {
+        float time = ray.time;  // Phase A already samples and carries time in GRay
+        int maxStep = tri.motionSteps - 1;
+        int step = min(static_cast<int>(time * maxStep), maxStep - 1);
+        float t = time * maxStep - step;
+        // Center step (step=0) uses tri.v0/v1/v2; additional steps read d_motionVertices.
+        // Buffer layout: [v0_step1, v1_step1, v2_step1, v0_step2, ...]
+        if (step == 0) {
+            // Blend between center and first motion step
+            const GVec3* nextVerts = d_motionVertices + tri.motionOffset;
+            p0 = tri.v0 * (1.0f - t) + nextVerts[0] * t;
+            p1 = tri.v1 * (1.0f - t) + nextVerts[1] * t;
+            p2 = tri.v2 * (1.0f - t) + nextVerts[2] * t;
+        } else {
+            // Blend between two motion steps
+            const GVec3* currVerts = d_motionVertices + tri.motionOffset + (step - 1) * 3;
+            const GVec3* nextVerts = d_motionVertices + tri.motionOffset + step * 3;
+            p0 = currVerts[0] * (1.0f - t) + nextVerts[0] * t;
+            p1 = currVerts[1] * (1.0f - t) + nextVerts[1] * t;
+            p2 = currVerts[2] * (1.0f - t) + nextVerts[2] * t;
+        }
+    }
+    GVec3 e1 = p1 - p0;
+    GVec3 e2 = p2 - p0;
+    GVec3 h  = ray.direction.cross(e2);
+    float a  = e1.dot(h);
+    if (fabsf(a) < EPS) return false;
+
+    float f  = 1.f / a;
+    GVec3 s  = ray.origin - p0;
+    float u  = f * s.dot(h);
+    if (u < 0.f || u > 1.f) return false;
+
+    GVec3 q = s.cross(e1);
+    float v = f * ray.direction.dot(q);
+    if (v < 0.f || u + v > 1.f) return false;
+
+    float t_hit = f * e2.dot(q);
+    if (t_hit < tMin || t_hit > tMax) return false;
+
+    rec.t     = t_hit;
+    rec.point = ray.at(t_hit);
+
+    // pkg55-followup: skip redundant interpolation for flat-shaded triangles
+    GVec3 outwardNormal;
+    if (tri.flat_shaded) {
+        outwardNormal = tri.n0;
+    } else {
+        float w = 1.f - u - v;
+        outwardNormal = (tri.n0 * w + tri.n1 * u + tri.n2 * v).normalized();
+    }
+
+    rec.frontFace = ray.direction.dot(outwardNormal) < 0.f;
+    rec.normal    = rec.frontFace ? outwardNormal : -outwardNormal;
+    gpu_buildONB(rec.normal, rec.tangent, rec.bitangent);
+
+    rec.materialId = tri.materialId;
+    rec.isDelta    = false;
+    return true;
+}
+
+// ---------------------------------------------------------------------------
 // Ray-triangle intersection: Möller–Trumbore (exact port from raytracer.h)
+// STATIC VARIANT — no motion. Kept for backward compatibility and zero-overhead
+// when motion is disabled.
 // ---------------------------------------------------------------------------
 __device__ inline bool gpu_triangle_hit(
     const GTriangle& tri, const GRay& ray, float tMin, float tMax,

--- a/include/astroray/gpu_bvh.h
+++ b/include/astroray/gpu_bvh.h
@@ -176,7 +176,11 @@ __device__ inline bool gpu_bvh_hit(
     const GSphere*    spheres,
     const GRay&       ray,
     float tMin, float tMax,
-    GHitRecord&       rec)
+    GHitRecord&       rec,
+    // pkg88-C.0: device motion-vertex buffer. nullptr = no deformation motion
+    // anywhere in the scene (default keeps motion-agnostic callers — photon
+    // pre-pass, TLAS parity probe, wavefront — unchanged).
+    const GVec3*     motionVerts = nullptr)
 {
     if (!nodes) return false;
 
@@ -199,7 +203,14 @@ __device__ inline bool gpu_bvh_hit(
                     GHitRecord tmpRec;
                     bool isHit = false;
                     if (p.type == GPRIM_TRIANGLE) {
-                        isHit = gpu_triangle_hit(tris[p.index], ray, tMin, tMax, tmpRec);
+                        // pkg88-C.0: motion-aware leaf dispatch (union-AABB BVH;
+                        // the node bounds already enclose all time steps).
+                        const GTriangle& tri = tris[p.index];
+                        if (motionVerts != nullptr && tri.motionOffset >= 0) {
+                            isHit = gpu_triangle_hit_motion(tri, ray, tMin, tMax, tmpRec, motionVerts);
+                        } else {
+                            isHit = gpu_triangle_hit(tri, ray, tMin, tMax, tmpRec);
+                        }
                     } else if (p.type == GPRIM_SPHERE) {
                         isHit = gpu_sphere_hit(spheres[p.index], ray, tMin, tMax, tmpRec);
                     } else {
@@ -273,12 +284,16 @@ __device__ inline bool gpu_tlas_hit(
     const GSphere*    spheres,
     const GRay&       ray,
     float tMin, float tMax,
-    GHitRecord&       rec)
+    GHitRecord&       rec,
+    // pkg88-C.0: motion verts apply to the classic single-level path only.
+    // Deformation motion on INSTANCED meshes is out of scope v1 (the BLAS
+    // walk below intentionally does not receive the buffer).
+    const GVec3*      motionVerts = nullptr)
 {
     // No TLAS uploaded -> behave exactly like the single-level path. (Lets a
     // caller route unconditionally through gpu_tlas_hit before instances exist.)
     if (!tlas || !instances || !blas) {
-        return gpu_bvh_hit(blasNodes, prims, tris, spheres, ray, tMin, tMax, rec);
+        return gpu_bvh_hit(blasNodes, prims, tris, spheres, ray, tMin, tMax, rec, motionVerts);
     }
 
     bool  hit    = false;

--- a/include/astroray/gpu_scene_upload.h
+++ b/include/astroray/gpu_scene_upload.h
@@ -38,6 +38,11 @@ struct SceneUploadResult {
     // pkg64-gpu Phase 2: caustic-caster spheres (flagged + transmissive + IOR > 1)
     std::vector<astroray::manifold::device::GSMSCaster> smsCasters;
 
+    // pkg88-C.0 GPU — verify on RTX. Scene-wide motion vertex buffer for deformation
+    // motion blur. Per Cycles: center step reuses triangles[].v0/v1/v2; additional
+    // steps stored here. Each triangle's motionOffset indexes into this array.
+    std::vector<GVec3> motionVertices;
+
     // Camera
     GCameraParams camera{};
 

--- a/include/astroray/gpu_types.h
+++ b/include/astroray/gpu_types.h
@@ -254,6 +254,11 @@ struct GTriangle {
     // pkg55-followup — flat-shaded flag: true when n0==n1==n2 (no per-vertex normals),
     // allows gpu_triangle_hit to skip the redundant interpolate+normalize chain.
     bool flat_shaded;
+    // pkg88-C.0 GPU — verify on RTX. Motion blur: offset into d_motionVertices device array.
+    // If motionOffset >= 0, triangle has motion; read [offset, offset+1, offset+2] for end verts.
+    // motionSteps=2 → one additional step. Linear blend per Cycles motion_triangle.h (Apache-2.0).
+    int motionOffset = -1;    // -1 = no motion (static)
+    int motionSteps = 1;      // 1 = static, 2 = pre+post shutter
 };
 
 struct GSphere {

--- a/include/astroray/gpu_types.h
+++ b/include/astroray/gpu_types.h
@@ -189,8 +189,13 @@ HD inline GSampledSpectrum operator*(float s, const GSampledSpectrum& x) { retur
 // ---------------------------------------------------------------------------
 struct GRay {
     GVec3 origin, direction;
+    // pkg88-C.0: shutter time in [0,1]. Default 0 = shutter open; static
+    // geometry ignores it. Mirrors CPU Ray::time (raytracer.h).
+    float time = 0.f;
     HD GRay() {}
     HD GRay(const GVec3& o, const GVec3& d) : origin(o), direction(d.normalized()) {}
+    HD GRay(const GVec3& o, const GVec3& d, float t)
+        : origin(o), direction(d.normalized()), time(t) {}
     HD GVec3 at(float t) const { return origin + direction * t; }
 };
 

--- a/include/astroray/shapes.h
+++ b/include/astroray/shapes.h
@@ -94,6 +94,12 @@ class Triangle : public Hittable {
     bool emissive;
     Vec3 vn0, vn1, vn2;
     bool hasVertexNormals = false;
+    // pkg88-C.0 — deformation motion blur. Per Cycles motion_triangle.h (Apache-2.0):
+    // motionVertexBuffer is a pointer into the Renderer's motionVertices_ array.
+    // If non-null, contains (K-1) additional time steps per vertex (center step = v0/v1/v2).
+    // motionSteps=2 → 1 extra step at shutter close. Linear interpolation only (K ≤ 3 typical).
+    const Vec3* motionVertexBuffer = nullptr;  // points to [v0_end, v1_end, v2_end, ...] for each step
+    int motionSteps = 1;  // 1 = no motion (static), 2 = pre+post shutter, 3+ = keyframes
 public:
     Triangle(const Vec3& a, const Vec3& b, const Vec3& c, std::shared_ptr<Material> m)
         : v0(a), v1(b), v2(c), material(m), uv0(0,0), uv1(1,0), uv2(0,1),
@@ -142,12 +148,37 @@ public:
 
     bool hit(const Ray& r, float tMin, float tMax, HitRecord& rec) const override {
         const float EPS = 1e-6f;
-        Vec3 e1 = v1 - v0, e2 = v2 - v0;
+        // pkg88-C.0 — time-aware vertex interpolation. Per Cycles motion_triangle.h (Apache-2.0):
+        // bracket ray.time into [step, step+1], then linear blend: v = (1-t)*v[step] + t*v[step+1].
+        Vec3 p0 = v0, p1 = v1, p2 = v2;
+        if (motionVertexBuffer != nullptr && motionSteps > 1) {
+            float time = r.time;  // Phase A already samples and carries time in Ray
+            int maxStep = motionSteps - 1;
+            int step = std::min(static_cast<int>(time * maxStep), maxStep - 1);
+            float t = time * maxStep - step;
+            // Center step (step=0) uses v0/v1/v2; additional steps read motionVertexBuffer.
+            // Buffer layout: [v0_step1, v1_step1, v2_step1, v0_step2, v1_step2, v2_step2, ...]
+            if (step == 0) {
+                // Blend between center (v0/v1/v2) and first motion step
+                const Vec3* nextVerts = motionVertexBuffer;  // step 1 starts at offset 0
+                p0 = v0 * (1.0f - t) + nextVerts[0] * t;
+                p1 = v1 * (1.0f - t) + nextVerts[1] * t;
+                p2 = v2 * (1.0f - t) + nextVerts[2] * t;
+            } else {
+                // Blend between two motion steps
+                const Vec3* currVerts = motionVertexBuffer + (step - 1) * 3;
+                const Vec3* nextVerts = motionVertexBuffer + step * 3;
+                p0 = currVerts[0] * (1.0f - t) + nextVerts[0] * t;
+                p1 = currVerts[1] * (1.0f - t) + nextVerts[1] * t;
+                p2 = currVerts[2] * (1.0f - t) + nextVerts[2] * t;
+            }
+        }
+        Vec3 e1 = p1 - p0, e2 = p2 - p0;
         Vec3 h = r.direction.cross(e2);
         float a = e1.dot(h);
         if (std::fabs(a) < EPS) return false;
         float f = 1.0f / a;
-        Vec3 s = r.origin - v0;
+        Vec3 s = r.origin - p0;
         float u = f * s.dot(h);
         if (u < 0 || u > 1) return false;
         Vec3 q = s.cross(e1);
@@ -177,8 +208,17 @@ public:
     }
 
     bool boundingBox(AABB& box) const override {
+        // pkg88-C.0 — union-AABB static BVH. If motion exists, compute AABB union across all time steps.
         Vec3 minP = Vec3::min(Vec3::min(v0, v1), v2);
         Vec3 maxP = Vec3::max(Vec3::max(v0, v1), v2);
+        if (motionVertexBuffer != nullptr && motionSteps > 1) {
+            // Expand to include all motion steps
+            for (int step = 1; step < motionSteps; ++step) {
+                const Vec3* stepVerts = motionVertexBuffer + (step - 1) * 3;
+                minP = Vec3::min(minP, Vec3::min(Vec3::min(stepVerts[0], stepVerts[1]), stepVerts[2]));
+                maxP = Vec3::max(maxP, Vec3::max(Vec3::max(stepVerts[0], stepVerts[1]), stepVerts[2]));
+            }
+        }
         box = AABB(minP - Vec3(0.0001f), maxP + Vec3(0.0001f));
         return true;
     }
@@ -216,6 +256,16 @@ public:
         v0 = a; v1 = b; v2 = c;
         normal = (v1 - v0).cross(v2 - v0).normalized();
     }
+    // pkg88-C.0 — attach motion data to this triangle. The buffer pointer must
+    // remain valid for the triangle's lifetime (typically points into Renderer::motionVertices_).
+    // steps = 2 means buffer has 3 Vec3s [v0_end, v1_end, v2_end] for shutter close.
+    void setMotionData(const Vec3* buffer, int steps) {
+        motionVertexBuffer = buffer;
+        motionSteps = steps;
+    }
+    // pkg88-C.0 — accessor for GPU scene upload to read motion data.
+    const Vec3* getMotionVertexBuffer() const { return motionVertexBuffer; }
+    int getMotionSteps() const { return motionSteps; }
 };
 
 // ============================================================================

--- a/include/raytracer.h
+++ b/include/raytracer.h
@@ -2099,6 +2099,10 @@ class Renderer {
     std::vector<std::vector<std::shared_ptr<Hittable>>> meshPrims_;  // local-space prims per mesh
     std::vector<std::shared_ptr<BVHAccel>> meshBlas_;                 // per-mesh BLAS
     std::vector<InstanceRecord> instances_;
+    // pkg88-C.0 — scene-wide motion vertex buffer for deformation motion blur.
+    // Per Cycles motion_triangle.h (Apache-2.0): center step reuses static
+    // vertices; additional steps stored here. Linear blend only (K ≤ 3 typical).
+    std::vector<Vec3> motionVertices_;  // additional time-step vertex positions
     LightList lights;
     std::shared_ptr<EnvironmentMap> envMap;
     Vec3 backgroundColor = Vec3(-1);  // negative = use default sky gradient
@@ -2823,6 +2827,17 @@ public:
     const std::vector<std::shared_ptr<BVHAccel>>& getMeshBlas() const { return meshBlas_; }
     const std::vector<std::vector<std::shared_ptr<Hittable>>>& getMeshPrims() const { return meshPrims_; }
     const std::vector<InstanceRecord>& getInstances() const { return instances_; }
+
+    // pkg88-C.0 — motion blur API. Append motion vertices to the scene-wide buffer
+    // and return the offset. Caller then passes this offset to Triangle::setMotionData.
+    // Per Cycles: center step reuses static verts; additional steps stored here.
+    // motionVerts layout: [v0_end, v1_end, v2_end] for 2 steps, or [..., v0_step2, ...] for 3.
+    size_t appendMotionVertices(const std::vector<Vec3>& motionVerts) {
+        size_t offset = motionVertices_.size();
+        motionVertices_.insert(motionVertices_.end(), motionVerts.begin(), motionVerts.end());
+        return offset;
+    }
+    const std::vector<Vec3>& getMotionVertices() const { return motionVertices_; }
 
     // Accessors for CUDARenderer (scene_upload.cu reads these to upload scene to GPU)
     const std::vector<std::shared_ptr<Hittable>>& getScene() const { return scene; }

--- a/include/raytracer.h
+++ b/include/raytracer.h
@@ -1918,10 +1918,14 @@ public:
     Ray getRay(float s, float t, float time, std::mt19937& gen) const {
         // pkg88-A: if shutter is off, use current camera basis (pre-pkg88 path).
         // This gates acceptance criterion A3 (zero-shutter regression).
+        // pkg88-C.0: the sampled time still rides on the ray — the shutter
+        // flag gates CAMERA interpolation only. Deformation motion (geometry
+        // with motion data) blurs whenever motion steps exist, mirroring the
+        // GPU kernels; static scenes have no time consumers so A3 holds.
         if (shutter <= 0.0f) {
             Vec3 rd = Vec3::randomInUnitDisk(gen) * lensRadius;
             Vec3 offset = u * rd.x + v * rd.y;
-            Ray ray(origin + offset, lowerLeft + horizontal * s + vertical * t - origin - offset, 0.0f, s, t);
+            Ray ray(origin + offset, lowerLeft + horizontal * s + vertical * t - origin - offset, time, s, t);
             ray.hasCameraFrame = true;
             ray.cameraOrigin = origin;
             ray.cameraU = u;
@@ -2469,7 +2473,9 @@ public:
                 if (ls.pdf > 0) {
                     Vec3 wi = (ls.position - rec.point).normalized();
                     HitRecord shadow;
-                    bool hitOccluder = bvh->hit(Ray(rec.point, wi), 0.001f, ls.distance - 0.001f, shadow);
+                    // pkg88-C.0: shadow rays carry the path's shutter time so
+                    // moving geometry occludes at the sampled instant.
+                    bool hitOccluder = bvh->hit(Ray(rec.point, wi, ray.time), 0.001f, ls.distance - 0.001f, shadow);
                     bool occluded = hitOccluder && !(shadow.hitObject && shadow.hitObject->isInfiniteLight());
                     if (!occluded) {
                         astroray::SampledSpectrum f_spec =
@@ -2652,7 +2658,9 @@ public:
                 if (ls.pdf > 0) {
                     Vec3 wi = (ls.position - rec.point).normalized();
                     HitRecord shadow;
-                    bool hitOccluder = bvh->hit(Ray(rec.point, wi), 0.001f, ls.distance - 0.001f, shadow);
+                    // pkg88-C.0: shadow rays carry the path's shutter time so
+                    // moving geometry occludes at the sampled instant.
+                    bool hitOccluder = bvh->hit(Ray(rec.point, wi, ray.time), 0.001f, ls.distance - 0.001f, shadow);
                     bool occluded = hitOccluder && !(shadow.hitObject && shadow.hitObject->isInfiniteLight());
                     if (!occluded) {
                         astroray::SampledSpectrum f_spec =

--- a/include/raytracer.h
+++ b/include/raytracer.h
@@ -2,6 +2,7 @@
 
 #include <cmath>
 #include <vector>
+#include <deque>
 #include <memory>
 #include <random>
 #include <limits>
@@ -2103,10 +2104,15 @@ class Renderer {
     std::vector<std::vector<std::shared_ptr<Hittable>>> meshPrims_;  // local-space prims per mesh
     std::vector<std::shared_ptr<BVHAccel>> meshBlas_;                 // per-mesh BLAS
     std::vector<InstanceRecord> instances_;
-    // pkg88-C.0 — scene-wide motion vertex buffer for deformation motion blur.
+    // pkg88-C.0 — scene-wide motion vertex storage for deformation motion blur.
     // Per Cycles motion_triangle.h (Apache-2.0): center step reuses static
     // vertices; additional steps stored here. Linear blend only (K ≤ 3 typical).
-    std::vector<Vec3> motionVertices_;  // additional time-step vertex positions
+    // ONE inner vector per add_triangles_bulk_motion batch: deque growth never
+    // moves existing batches and each inner vector is immutable after append,
+    // so Triangle::motionVertexBuffer pointers stay valid for the renderer's
+    // lifetime. (pkg98 review: a prior single-vector design dangled every
+    // earlier batch's pointers when the next batch reallocated it.)
+    std::deque<std::vector<Vec3>> motionVertexBatches_;
     LightList lights;
     std::shared_ptr<EnvironmentMap> envMap;
     Vec3 backgroundColor = Vec3(-1);  // negative = use default sky gradient
@@ -2836,16 +2842,18 @@ public:
     const std::vector<std::vector<std::shared_ptr<Hittable>>>& getMeshPrims() const { return meshPrims_; }
     const std::vector<InstanceRecord>& getInstances() const { return instances_; }
 
-    // pkg88-C.0 — motion blur API. Append motion vertices to the scene-wide buffer
-    // and return the offset. Caller then passes this offset to Triangle::setMotionData.
-    // Per Cycles: center step reuses static verts; additional steps stored here.
-    // motionVerts layout: [v0_end, v1_end, v2_end] for 2 steps, or [..., v0_step2, ...] for 3.
-    size_t appendMotionVertices(const std::vector<Vec3>& motionVerts) {
-        size_t offset = motionVertices_.size();
-        motionVertices_.insert(motionVertices_.end(), motionVerts.begin(), motionVerts.end());
-        return offset;
+    // pkg88-C.0 — motion blur API. Stores one BATCH of motion vertices and
+    // returns a stable pointer to its first element (valid for the renderer's
+    // lifetime — see motionVertexBatches_). Triangles index into the batch
+    // with motionVertexBuffer + tri*3 arithmetic, so contiguity holds within
+    // a batch. Layout per batch: [v0_end, v1_end, v2_end, ...] for 2 steps.
+    const Vec3* appendMotionVertices(std::vector<Vec3> motionVerts) {
+        motionVertexBatches_.push_back(std::move(motionVerts));
+        return motionVertexBatches_.back().data();
     }
-    const std::vector<Vec3>& getMotionVertices() const { return motionVertices_; }
+    const std::deque<std::vector<Vec3>>& getMotionVertexBatches() const {
+        return motionVertexBatches_;
+    }
 
     // Accessors for CUDARenderer (scene_upload.cu reads these to upload scene to GPU)
     const std::vector<std::shared_ptr<Hittable>>& getScene() const { return scene; }

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -818,8 +818,10 @@ public:
             motionBatch.emplace_back(pos_end(t, 1, 0), pos_end(t, 1, 1), pos_end(t, 1, 2));
             motionBatch.emplace_back(pos_end(t, 2, 0), pos_end(t, 2, 1), pos_end(t, 2, 2));
         }
-        size_t baseOffset = renderer.appendMotionVertices(motionBatch);
-        const Vec3* motionBase = renderer.getMotionVertices().data() + baseOffset;
+        // pkg98 review fix: appendMotionVertices stores the batch in stable
+        // per-batch storage and returns a lifetime-stable pointer (a second
+        // bulk call can no longer dangle this batch's triangle pointers).
+        const Vec3* motionBase = renderer.appendMotionVertices(std::move(motionBatch));
 
         for (py::ssize_t t = 0; t < nt; ++t) {
             Vec3 p0(pos_start(t, 0, 0), pos_start(t, 0, 1), pos_start(t, 0, 2));

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -769,6 +769,92 @@ public:
         }
     }
 
+    // pkg88-C.0 — bulk motion triangle ingest. Per Cycles motion_triangle.h (Apache-2.0):
+    // positions_start (Nt,3,3) is the center step; positions_end (Nt,3,3) is the
+    // additional motion step at shutter close. motionSteps=2 → one additional step.
+    // Linear interpolation only (matches Cycles, suitable for ≤3 steps).
+    void addTrianglesBulkMotion(
+            py::array_t<float, py::array::c_style | py::array::forcecast> positions_start,
+            py::array_t<float, py::array::c_style | py::array::forcecast> positions_end,
+            py::array_t<int,   py::array::c_style | py::array::forcecast> materialIds,
+            py::array_t<int,   py::array::c_style | py::array::forcecast> materialPassIndices,
+            int objectPassIndex,
+            py::array_t<float, py::array::c_style | py::array::forcecast> uvs,
+            std::vector<std::string> uvLayerNames,
+            py::array_t<float, py::array::c_style | py::array::forcecast> normals) {
+        auto pos_start = positions_start.unchecked<3>();              // (Nt, 3, 3)
+        auto pos_end   = positions_end.unchecked<3>();                // (Nt, 3, 3)
+        const py::ssize_t nt = pos_start.shape(0);
+        if (pos_start.shape(1) != 3 || pos_start.shape(2) != 3)
+            throw std::runtime_error("add_triangles_bulk_motion: positions_start must be (N,3,3)");
+        if (pos_end.shape(0) != nt || pos_end.shape(1) != 3 || pos_end.shape(2) != 3)
+            throw std::runtime_error("add_triangles_bulk_motion: positions_end must match positions_start shape");
+        auto mid = materialIds.unchecked<1>();            // (Nt,)
+        auto mpi = materialPassIndices.unchecked<1>();    // (Nt,)
+        if (mid.shape(0) != nt || mpi.shape(0) != nt)
+            throw std::runtime_error("add_triangles_bulk_motion: material arrays must match triangle count");
+
+        const py::ssize_t nLayers = (uvs.size() > 0) ? uvs.shape(0) : 0;
+        const bool hasNormals = normals.size() > 0;
+        if (hasNormals && normals.shape(0) != nt)
+            throw std::runtime_error("add_triangles_bulk_motion: normals must be (N,3,3)");
+        std::vector<std::string> names;
+        for (py::ssize_t l = 0; l < nLayers; ++l) {
+            std::string nm = (l < (py::ssize_t)uvLayerNames.size()) ? uvLayerNames[l] : std::string();
+            names.push_back(nm.empty() ? (l == 0 ? "UVMap" : "UVMap" + std::to_string(l + 1)) : nm);
+        }
+        const float* uvPtr = (nLayers > 0) ? uvs.data() : nullptr;
+        const float* nPtr  = hasNormals ? normals.data() : nullptr;
+        auto uvAt = [&](py::ssize_t l, py::ssize_t t, int c) -> Vec2 {
+            const float* p = uvPtr + (((l * nt + t) * 3 + c) * 2);
+            return Vec2(p[0], p[1]);
+        };
+
+        // Append all motion vertices in one batch, then assign per-triangle offsets
+        std::vector<Vec3> motionBatch;
+        motionBatch.reserve(nt * 3);  // 3 verts per triangle at shutter close
+        for (py::ssize_t t = 0; t < nt; ++t) {
+            motionBatch.emplace_back(pos_end(t, 0, 0), pos_end(t, 0, 1), pos_end(t, 0, 2));
+            motionBatch.emplace_back(pos_end(t, 1, 0), pos_end(t, 1, 1), pos_end(t, 1, 2));
+            motionBatch.emplace_back(pos_end(t, 2, 0), pos_end(t, 2, 1), pos_end(t, 2, 2));
+        }
+        size_t baseOffset = renderer.appendMotionVertices(motionBatch);
+        const Vec3* motionBase = renderer.getMotionVertices().data() + baseOffset;
+
+        for (py::ssize_t t = 0; t < nt; ++t) {
+            Vec3 p0(pos_start(t, 0, 0), pos_start(t, 0, 1), pos_start(t, 0, 2));
+            Vec3 p1(pos_start(t, 1, 0), pos_start(t, 1, 1), pos_start(t, 1, 2));
+            Vec3 p2(pos_start(t, 2, 0), pos_start(t, 2, 1), pos_start(t, 2, 2));
+            int materialId = mid(t);
+            auto mat = materials.count(materialId) ? materials[materialId]
+                                                   : std::make_shared<Lambertian>(Vec3(0.5f));
+            std::shared_ptr<Triangle> tri;
+            if (nLayers == 0) {
+                tri = std::make_shared<Triangle>(p0, p1, p2, mat);
+            } else if (nLayers == 1) {
+                tri = std::make_shared<Triangle>(p0, p1, p2,
+                        uvAt(0, t, 0), uvAt(0, t, 1), uvAt(0, t, 2), mat);
+            } else {
+                std::vector<std::array<Vec2, 3>> layers;
+                layers.reserve(nLayers);
+                for (py::ssize_t l = 0; l < nLayers; ++l)
+                    layers.push_back({ uvAt(l, t, 0), uvAt(l, t, 1), uvAt(l, t, 2) });
+                tri = std::make_shared<Triangle>(p0, p1, p2, layers, names, mat);
+            }
+            if (hasNormals) {
+                const float* n = nPtr + (t * 9);
+                tri->setVertexNormals(Vec3(n[0], n[1], n[2]),
+                                      Vec3(n[3], n[4], n[5]),
+                                      Vec3(n[6], n[7], n[8]));
+            }
+            tri->setObjectPassIndex(objectPassIndex);
+            tri->setMaterialPassIndex(mpi(t));
+            // pkg88-C.0: attach motion data. motionSteps=2 means buffer has center+end.
+            tri->setMotionData(motionBase + t * 3, 2);
+            renderer.addObject(tri);
+        }
+    }
+
     void addMesh(const std::string& filename, int materialId, const std::vector<float>& position = {0,0,0},
                 const std::vector<float>& scale = {1,1,1}, float rotationY = 0, bool smoothNormals = false) {
         auto mat = materials.count(materialId) ? materials[materialId] : std::make_shared<Lambertian>(Vec3(0.5f));
@@ -2150,6 +2236,12 @@ PYBIND11_MODULE(astroray, m) {
              "pkg112: bulk triangle ingest from NumPy arrays (loops in C++ to cut per-tri "
              "pybind overhead). positions (N,3,3) world; uvs (nLayers,N,3,2) active-first; "
              "normals (N,3,3) or empty. Pixel-identical to add_triangle/add_triangle_layers.")
+        .def("add_triangles_bulk_motion", &PyRenderer::addTrianglesBulkMotion,
+             "positions_start"_a, "positions_end"_a, "material_ids"_a, "material_pass_indices"_a,
+             "object_pass_index"_a, "uvs"_a, "uv_layer_names"_a, "normals"_a,
+             "pkg88-C.0: bulk motion triangle ingest. positions_start (N,3,3) is center step, "
+             "positions_end (N,3,3) is shutter close. Linear interpolation per Cycles (Apache-2.0). "
+             "motionSteps=2 (pre+post). uvs/normals same as add_triangles_bulk.")
         .def("register_mesh_triangles", &PyRenderer::registerMeshTriangles,
              "triangles"_a, "material_id"_a,
              "pkg114: register a mesh's OBJECT-LOCAL flat-shaded triangles (list of "

--- a/src/gpu/cuda_renderer.cu
+++ b/src/gpu/cuda_renderer.cu
@@ -55,6 +55,7 @@ void launchPathTraceKernel(
     GVec3 backgroundColor, bool hasBackgroundColor,
     astroray::photon::gpu::GPhotonGrid photonGrid, bool hasPhotonGrid,  // pkg113 Phase 3
     float photonScale,                                                   // pkg113 Phase 3
+    const GVec3* d_motionVertices,  // pkg88-C.0
     curandState* d_rngStates,
     float* d_cryptoObjectBuffer = nullptr,      // pkg87b
     float* d_cryptoMaterialBuffer = nullptr,    // pkg87b
@@ -106,6 +107,7 @@ void launchMultiwavelengthKernel(
     GVec3 backgroundColor, bool hasBackgroundColor,
     astroray::photon::gpu::GPhotonGrid photonGrid, bool hasPhotonGrid,  // pkg113 Phase 3
     float photonScale,                                                   // pkg113 Phase 3
+    const GVec3* d_motionVertices,  // pkg88-C.0
     curandState* d_rngStates);
 
 // ---------------------------------------------------------------------------
@@ -141,6 +143,7 @@ struct CUDARenderer::Impl {
     GSphere*    d_spheres    = nullptr;
     GMaterial*  d_materials  = nullptr;
     GLight*     d_lights     = nullptr;
+    GVec3*      d_motionVertices = nullptr;  // pkg88-C.0 deformation motion buffer
     int         numLights    = 0;
     float       totalLightPower = 0.f;
 
@@ -231,6 +234,7 @@ struct CUDARenderer::Impl {
         if (d_spheres)    { cudaFree(d_spheres);     d_spheres    = nullptr; }
         if (d_materials)  { cudaFree(d_materials);   d_materials  = nullptr; }
         if (d_lights)     { cudaFree(d_lights);      d_lights     = nullptr; }
+        if (d_motionVertices) { cudaFree(d_motionVertices); d_motionVertices = nullptr; }  // pkg88-C.0
         if (d_lightTreeNodes)    { cudaFree(d_lightTreeNodes);    d_lightTreeNodes    = nullptr; }  // pkg86-B
         if (d_lightTreeEmitters) { cudaFree(d_lightTreeEmitters); d_lightTreeEmitters = nullptr; }  // pkg86-B
         if (d_lightToEmitter)    { cudaFree(d_lightToEmitter);    d_lightToEmitter    = nullptr; }  // pkg86-B
@@ -342,6 +346,7 @@ void CUDARenderer::uploadGeometry(const Renderer& cpuRenderer, const Camera& cam
     devUpload(r.prims,     &impl->d_prims);
     devUpload(r.triangles, &impl->d_triangles);
     devUpload(r.spheres,   &impl->d_spheres);
+    devUpload(r.motionVertices, &impl->d_motionVertices);  // pkg88-C.0
 
     // Camera + film + background piggyback on geometry uploads — they're
     // tiny scalars and any caller that just changed geometry almost always
@@ -530,6 +535,7 @@ void CUDARenderer::uploadScene(const Renderer& cpuRenderer, const Camera& cam) {
     devUpload(r.materials, &impl->d_materials);
     devUpload(r.lights,    &impl->d_lights);
     devUpload(r.smsCasters, &impl->d_smsCasters);  // pkg64-gpu Phase 2
+    devUpload(r.motionVertices, &impl->d_motionVertices);  // pkg88-C.0
     uploadLightTree(r);  // pkg86-B
 
     impl->numLights       = (int)r.lights.size();
@@ -849,6 +855,7 @@ void CUDARenderer::render(
         impl->filmExposure,
         impl->backgroundColor, impl->hasBackgroundColor,
         caustic.grid, caustic.ready, caustic.scale,  // pkg113 Phase 3
+        impl->d_motionVertices,  // pkg88-C.0
         impl->d_rngStates,
         impl->d_cryptoObjectBuffer, impl->d_cryptoMaterialBuffer,  // pkg87b
         impl->cryptoDepth, impl->cryptomatteEnabled);              // pkg87b
@@ -940,6 +947,7 @@ void CUDARenderer::renderMultiwavelength(
         impl->camera,
         impl->backgroundColor, impl->hasBackgroundColor,
         caustic.grid, caustic.ready, caustic.scale,  // pkg113 Phase 3
+        impl->d_motionVertices,  // pkg88-C.0
         impl->d_rngStates);
 
     astroray::photon::gpu::cuda_photon_caustic_free(caustic);  // pkg113 Phase 3

--- a/src/gpu/multiwavelength_kernel.cu
+++ b/src/gpu/multiwavelength_kernel.cu
@@ -467,6 +467,8 @@ __device__ GSampledSpectrum sampleDirectSpectralMW(
     const GMaterial*  materials,
     const GLight*     lights, int numLights, float totalLightPower,
     GLightTreeView    lightTree,  // pkg86-B
+    float             time,         // pkg88-C.0: path shutter time for shadow rays
+    const GVec3*      motionVerts,  // pkg88-C.0 (nullptr = static)
     curandState*      rng)
 {
     GSampledSpectrum direct(0.f);
@@ -521,7 +523,7 @@ __device__ GSampledSpectrum sampleDirectSpectralMW(
         lightMatId  = s.materialId;
         GHitRecord sh;
         if (!gpu_tlas_hit(tlas, instances, blas, bvhNodes, prims, tris, spheres,
-                         GRay(rec.point, wi), 0.001f, maxDist, sh) ||
+                         GRay(rec.point, wi, time), 0.001f, maxDist, sh, motionVerts) ||
             sh.materialId != lightMatId)
             return direct;
         lightFront = sh.frontFace;
@@ -543,7 +545,7 @@ __device__ GSampledSpectrum sampleDirectSpectralMW(
         lightFront = true;
         GHitRecord sh;
         if (gpu_tlas_hit(tlas, instances, blas, bvhNodes, prims, tris, spheres,
-                        GRay(rec.point, wi), 0.001f, maxDist, sh))
+                        GRay(rec.point, wi, time), 0.001f, maxDist, sh, motionVerts))
             return direct;          // occluded
     }
 
@@ -592,6 +594,7 @@ __device__ GSampledSpectrum tracePathMW(
     const GVec3&      backgroundColor,
     bool              hasBackgroundColor,
     GRay              primaryRay,  // pkg64-gpu Phase 2: needed for SMS wo_eye
+    const GVec3*      motionVerts,  // pkg88-C.0 (nullptr = static)
     curandState*      rng)
 {
     const int rrDepth = 3;
@@ -602,7 +605,7 @@ __device__ GSampledSpectrum tracePathMW(
     for (int bounce = 0; bounce < maxDepth; ++bounce) {
         GHitRecord rec;
         if (!gpu_tlas_hit(tlas, instances, blas, bvhNodes, prims, tris, spheres,
-                         ray, 0.001f, 1e30f, rec)) {
+                         ray, 0.001f, 1e30f, rec, motionVerts)) {
             // Environment / background contribution.
             GSampledSpectrum envSpec(0.f);
             GVec3 dir = ray.direction.normalized();
@@ -690,7 +693,9 @@ __device__ GSampledSpectrum tracePathMW(
         if (enableNEE && !rec.isDelta && numLights > 0) {
             color += throughput * sampleDirectSpectralMW(
                 rec, wo, lambdas, tlas, instances, blas, bvhNodes, prims, tris, spheres, materials,
-                lights, numLights, totalLightPower, lightTree, rng);
+                lights, numLights, totalLightPower, lightTree,
+                ray.time, motionVerts,  // pkg88-C.0
+                rng);
         }
 
         // pkg64-gpu Phase 2: SMS caustic attempt at non-delta vertices.
@@ -842,7 +847,8 @@ __device__ GSampledSpectrum tracePathMW(
         float maxC = throughput.maxValue();
         if (maxC > 10.f) throughput *= (10.f / maxC);
 
-        ray = GRay(rec.point, bs.wi);
+        // pkg88-C.0: bounce rays inherit the path's shutter time.
+        ray = GRay(rec.point, bs.wi, ray.time);
     }
 
     return color;
@@ -851,6 +857,22 @@ __device__ GSampledSpectrum tracePathMW(
 // ---------------------------------------------------------------------------
 // Multiwavelength megakernel
 // ---------------------------------------------------------------------------
+// pkg88-C.0: base-2 radical inverse for the per-spp shutter time. Same
+// sampler as the RGB megakernel's Phase-A camera time (path_trace_kernel.cu
+// haltonBase2) — TU-local copy because both kernels keep device helpers
+// file-static.
+__device__ inline float gpu_mw_haltonBase2(int index) {
+    float result = 0.0f;
+    float f = 1.0f;
+    int i = index;
+    while (i > 0) {
+        f = f / 2.0f;
+        result += f * (i % 2);
+        i = i / 2;
+    }
+    return result;
+}
+
 __global__ void multiwavelengthKernel(
     float* framebuffer, int width, int height,
     int samplesPerPixel, int maxDepth,
@@ -874,6 +896,7 @@ __global__ void multiwavelengthKernel(
     GVec3 backgroundColor, bool hasBackgroundColor,
     astroray::photon::gpu::GPhotonGrid photonGrid, bool hasPhotonGrid,  // pkg113 Phase 3
     float photonScale,                                                   // pkg113 Phase 3
+    const GVec3* d_motionVertices,  // pkg88-C.0 (nullptr = static scene)
     curandState* rngStates)
 {
     int pixelIdx = blockIdx.x * blockDim.x + threadIdx.x;
@@ -906,6 +929,12 @@ __global__ void multiwavelengthKernel(
         GVec3 dir    = cam.lowerLeft + cam.horizontal*u + cam.vertical*v
                        - cam.origin - offset;
         GRay ray(cam.origin + offset, dir);
+        // pkg88-C.0: per-spp shutter time for deformation motion (independent
+        // Halton base-2, same policy as the RGB megakernel / Phase A; spec
+        // Q-Owner-4: ONE consistent policy). NOTE: the MW kernel's camera is
+        // not shutter-interpolated (Phase-A camera MB lives in the RGB kernel
+        // only) — geometry motion works here, camera motion is a known gap.
+        ray.time = gpu_mw_haltonBase2(s + 1);
 
         GSampledWavelengths lambdas =
             gpu_sampleBandWavelengths(&localRng, lambdaMin, lambdaMax);
@@ -919,6 +948,7 @@ __global__ void multiwavelengthKernel(
             smsCasters, numSMSCasters,
             envMap, backgroundColor, hasBackgroundColor,
             ray,  // primaryRay for SMS wo_eye
+            d_motionVertices,  // pkg88-C.0
             &localRng);
 
         GVec3 sample;
@@ -940,8 +970,9 @@ __global__ void multiwavelengthKernel(
         // the Lambertian 1/π. Only meaningful for the visible-band (XYZ) output.
         if (hasPhotonGrid && !useLuminanceOutput && photonGrid.numPhotons > 0) {
             GHitRecord pr;
+            // pkg88-C.0: re-hit the primary at its shutter time (ray carries it).
             if (gpu_tlas_hit(tlas, instances, blas, bvhNodes, prims, tris, spheres,
-                            ray, 0.001f, 1e30f, pr)) {
+                            ray, 0.001f, 1e30f, pr, d_motionVertices)) {
                 const GMaterial& pmat = materials[pr.materialId];
                 if (pmat.emissionIntensity <= 0.0f) {
                     int found = 0;
@@ -1010,6 +1041,7 @@ void launchMultiwavelengthKernel(
     GVec3 backgroundColor, bool hasBackgroundColor,
     astroray::photon::gpu::GPhotonGrid photonGrid, bool hasPhotonGrid,  // pkg113 Phase 3
     float photonScale,                                                   // pkg113 Phase 3
+    const GVec3* d_motionVertices,  // pkg88-C.0
     curandState* d_rngStates)
 {
     int totalPixels    = width * height;
@@ -1030,6 +1062,7 @@ void launchMultiwavelengthKernel(
             d_smsCasters, numSMSCasters,
             envMap, cam, backgroundColor, hasBackgroundColor,
             photonGrid, hasPhotonGrid, photonScale,  // pkg113 Phase 3
+            d_motionVertices,  // pkg88-C.0
             d_rngStates);
 
         cudaError_t err = cudaGetLastError();

--- a/src/gpu/path_trace_kernel.cu
+++ b/src/gpu/path_trace_kernel.cu
@@ -206,6 +206,8 @@ __device__ GVec3 sampleDirectGPU(
     const GLight*     lights, int numLights, float totalLightPower,
     GLightTreeView    lightTree,  // pkg86-B
     const GEnvMap&    envMap,
+    float             time,         // pkg88-C.0: path shutter time for shadow/MIS rays
+    const GVec3*      motionVerts,  // pkg88-C.0: device motion buffer (nullptr = static)
     curandState*      rng)
 {
     const GMaterial& mat = materials[rec.materialId];
@@ -230,8 +232,8 @@ __device__ GVec3 sampleDirectGPU(
         if (es.pdf > 1e-8f) {
             GHitRecord shadow;
             bool occluded = gpu_tlas_hit(tlas, instances, blas, bvhNodes, prims, tris, spheres,
-                                        GRay(rec.point, es.direction),
-                                        0.001f, 1e30f, shadow);
+                                        GRay(rec.point, es.direction, time),
+                                        0.001f, 1e30f, shadow, motionVerts);
             if (!occluded) {
                 GVec3 f       = gpu_material_eval(mat, const_cast<GHitRecord&>(rec), wo, es.direction);
                 float bsdfPdf = gpu_material_pdf(mat, rec, wo, es.direction);
@@ -295,7 +297,7 @@ __device__ GVec3 sampleDirectGPU(
 
                 GHitRecord shadow;
                 if (!gpu_tlas_hit(tlas, instances, blas, bvhNodes, prims, tris, spheres,
-                                 GRay(rec.point, wi), 0.001f, 1e30f, shadow) ||
+                                 GRay(rec.point, wi, time), 0.001f, 1e30f, shadow, motionVerts) ||
                     shadow.materialId != spheres[lp.index].materialId)
                     goto bsdf_mis;
 
@@ -327,7 +329,7 @@ __device__ GVec3 sampleDirectGPU(
 
                 GHitRecord shadow;
                 bool occ = gpu_tlas_hit(tlas, instances, blas, bvhNodes, prims, tris, spheres,
-                                       GRay(rec.point, wi), 0.001f, dist - 0.001f, shadow);
+                                       GRay(rec.point, wi, time), 0.001f, dist - 0.001f, shadow, motionVerts);
                 if (occ) goto bsdf_mis;
 
                 const GMaterial& lm = materials[t.materialId];
@@ -352,7 +354,7 @@ bsdf_mis:
             GHitRecord bRec;
             bRec.primId = -1;
             if (gpu_tlas_hit(tlas, instances, blas, bvhNodes, prims, tris, spheres,
-                            GRay(rec.point, bs.wi), 0.001f, 1e30f, bRec)) {
+                            GRay(rec.point, bs.wi, time), 0.001f, 1e30f, bRec, motionVerts)) {
                 const GMaterial& lm = materials[bRec.materialId];
                 GVec3 Le = gpu_material_emitted(lm, bRec.frontFace);
                 if (Le != GVec3(0.f)) {
@@ -398,6 +400,7 @@ __device__ GVec3 tracePathGPU(
     GRay              primaryRay,  // pkg64-gpu Phase 2
     const astroray::photon::gpu::GPhotonGrid* photonGrid,  // pkg113 Phase 3 (null = off)
     float             photonScale,                          // pkg113 Phase 3
+    const GVec3*      motionVerts,  // pkg88-C.0 (nullptr = static scene)
     curandState*      rng,
     float*            cryptoObjectRanks = nullptr,    // pkg87b
     float*            cryptoMaterialRanks = nullptr,  // pkg87b
@@ -414,7 +417,7 @@ __device__ GVec3 tracePathGPU(
     for (int bounce = 0; bounce < maxDepth; ++bounce) {
         GHitRecord rec;
         if (!gpu_tlas_hit(tlas, instances, blas, bvhNodes, prims, tris, spheres,
-                         ray, 0.001f, 1e30f, rec)) {
+                         ray, 0.001f, 1e30f, rec, motionVerts)) {
             // Miss — environment / background
             GVec3 envColor(0.f);
             if (envMap.loaded) {
@@ -453,7 +456,7 @@ __device__ GVec3 tracePathGPU(
             color += throughput * sampleDirectGPU(
                 rec, wo, tlas, instances, blas, bvhNodes, prims, tris, spheres,
                 materials, lights, numLights, totalLightPower,
-                lightTree, envMap, rng);
+                lightTree, envMap, ray.time, motionVerts, rng);
         }
 
         // pkg113 Phase 3: photon-map caustic gather at the FIRST non-emissive hit
@@ -615,7 +618,9 @@ __device__ GVec3 tracePathGPU(
         float maxS = throughputSpectral.maxValue();
         if (maxS > 10.f) throughputSpectral *= 10.f / maxS;
 
-        ray = GRay(rec.point, bs.wi);
+        // pkg88-C.0: bounce rays inherit the path's shutter time (Cycles
+        // convention — one time sample per camera path).
+        ray = GRay(rec.point, bs.wi, ray.time);
     }
     return color;
 }
@@ -652,6 +657,7 @@ __global__ void pathTraceKernel(
     GVec3 backgroundColor, bool hasBackgroundColor,
     astroray::photon::gpu::GPhotonGrid photonGrid, bool hasPhotonGrid,  // pkg113 Phase 3
     float photonScale,                                                   // pkg113 Phase 3
+    const GVec3* d_motionVertices,  // pkg88-C.0 (nullptr = static scene)
     curandState* rngStates,
     float* cryptoObjectBuffer = nullptr,      // pkg87b
     float* cryptoMaterialBuffer = nullptr,    // pkg87b
@@ -717,6 +723,9 @@ __global__ void pathTraceKernel(
         GVec3 dir    = lowerLeft_cam + horizontal_cam*u + vertical_cam*v
                        - origin_cam - offset;
         GRay ray(origin_cam + offset, dir);
+        // pkg88-C.0: the Phase-A per-spp shutter time now also drives geometry
+        // (deformation motion); carried on the ray through the whole path.
+        ray.time = time;
 
         // pkg87b: compute per-pixel crypto buffer offset
         float* pixelCryptoObj = nullptr;
@@ -737,6 +746,7 @@ __global__ void pathTraceKernel(
             envMap, backgroundColor, hasBackgroundColor,
             ray,  // primaryRay for SMS
             hasPhotonGrid ? &photonGrid : nullptr, photonScale,  // pkg113 Phase 3
+            d_motionVertices,  // pkg88-C.0
             &localRng,
             pixelCryptoObj, pixelCryptoMat, cryptoDepth, cryptomatteEnabled);
 
@@ -783,6 +793,7 @@ void launchPathTraceKernel(
     GVec3 backgroundColor, bool hasBackgroundColor,
     astroray::photon::gpu::GPhotonGrid photonGrid, bool hasPhotonGrid,  // pkg113 Phase 3
     float photonScale,                                                   // pkg113 Phase 3
+    const GVec3* d_motionVertices,  // pkg88-C.0
     curandState* d_rngStates,
     float* d_cryptoObjectBuffer = nullptr,      // pkg87b
     float* d_cryptoMaterialBuffer = nullptr,    // pkg87b
@@ -806,6 +817,7 @@ void launchPathTraceKernel(
             d_smsCasters, numSMSCasters,
             envMap, cam, filmExposure, backgroundColor, hasBackgroundColor,
             photonGrid, hasPhotonGrid, photonScale,  // pkg113 Phase 3
+            d_motionVertices,  // pkg88-C.0
             d_rngStates, d_cryptoObjectBuffer, d_cryptoMaterialBuffer,
             cryptoDepth, cryptomatteEnabled);
 

--- a/src/gpu/scene_upload.cu
+++ b/src/gpu/scene_upload.cu
@@ -234,13 +234,23 @@ static void appendOnePrim(
             gt.flat_shaded = true;
         }
         gt.materialId = getOrAddMat(tri->getMaterial());
+        // pkg88-C.0 GPU — verify on RTX. Motion blur: append triangle's motion verts to buffer.
+        // tri->motionVertexBuffer is non-null iff triangle has motion data.
+        // WARNING: assumes appendOnePrim is called with triangles in the same order as
+        // Renderer::getScene() iteration (stable pointer into Renderer::motionVertices_).
+        // TODO BEFORE NEXT PICKUP: verify this pointer stability assumption holds on GPU.
+        gt.motionOffset = -1;
+        gt.motionSteps = 1;
+        // NOTE: CPU Triangle::motionVertexBuffer points into Renderer::motionVertices_.
+        // We'll upload the entire motionVertices_ buffer in buildSceneArrays; here we
+        // just compute the offset. Defer actual upload until we know all triangles.
+        r.triangles.push_back(gt);
         std::string objName = tri->getName();
-        if (objName.empty()) objName = "Unnamed_Triangle_" + std::to_string(r.triangles.size());
-        MurmurHash3_x86_32(objName.c_str(), static_cast<int>(objName.length()), 0, &gt.objectHash);
+        if (objName.empty()) objName = "Unnamed_Triangle_" + std::to_string(r.triangles.size() - 1);
+        MurmurHash3_x86_32(objName.c_str(), static_cast<int>(objName.length()), 0, &r.triangles.back().objectHash);
         std::string matName = tri->getMaterial()->getName();
         if (matName.empty()) matName = "Unnamed_Material_" + std::to_string(gt.materialId);
-        MurmurHash3_x86_32(matName.c_str(), static_cast<int>(matName.length()), 0, &gt.materialHash);
-        r.triangles.push_back(gt);
+        MurmurHash3_x86_32(matName.c_str(), static_cast<int>(matName.length()), 0, &r.triangles.back().materialHash);
     } else if (auto* sph = dynamic_cast<Sphere*>(hittable.get())) {
         gp.type  = GPRIM_SPHERE;
         gp.index = (int)r.spheres.size();
@@ -445,8 +455,28 @@ SceneUploadResult buildSceneArrays(const Renderer& cpu, const Camera* cam) {
         for (auto& n : cpuBvh->getNodes())
             r.nodes.push_back(convertNode(n));
         const auto& orderedPrims = cpuBvh->getPrimitives();
+        // pkg88-C.0: Build map of CPU Triangle* → Renderer::motionVertices_ offset
+        std::unordered_map<const Vec3*, size_t> motionPtrToOffset;
+        if (!cpu.getMotionVertices().empty()) {
+            const Vec3* basePtr = cpu.getMotionVertices().data();
+            // NOTE: assumes each triangle's motionVertexBuffer points into contiguous buffer
+            for (size_t i = 0; i < cpu.getMotionVertices().size(); ++i) {
+                motionPtrToOffset[basePtr + i] = i;
+            }
+        }
         for (auto& hittable : orderedPrims) {
             appendOnePrim(hittable, r, getOrAddMat);
+            // pkg88-C.0 GPU — verify on RTX. Populate motionOffset for motion triangles.
+            if (auto* tri = dynamic_cast<Triangle*>(hittable.get())) {
+                const Vec3* motionBuf = tri->getMotionVertexBuffer();
+                if (motionBuf != nullptr) {
+                    auto it = motionPtrToOffset.find(motionBuf);
+                    if (it != motionPtrToOffset.end()) {
+                        r.triangles.back().motionOffset = static_cast<int>(it->second);
+                        r.triangles.back().motionSteps = tri->getMotionSteps();
+                    }
+                }
+            }
             // pkg64-gpu Phase 2: gather caustic-caster spheres inline (single-level
             // only — SMS is not instancing-aware). primIdx preserves the prior
             // (orderedPrims.size()-1) convention to keep pkg64 acceptance stable.
@@ -650,6 +680,20 @@ SceneUploadResult buildSceneArrays(const Renderer& cpu, const Camera* cam) {
         }
         r.profileCount = (int)profIdx.size();
     }
+
+    // --- pkg88-C.0 GPU — verify on RTX. Motion vertices for deformation motion blur ---
+    // Convert the CPU Renderer's motionVertices_ buffer into GPU format. Each triangle
+    // that has motion points into this buffer via its motionOffset.
+    // NOTE: This copies the ENTIRE Renderer motion buffer. In a second pass (TODO after
+    // basic GPU verify), populate each GTriangle's motionOffset by walking the CPU
+    // Triangle's motionVertexBuffer pointer against the base of Renderer::motionVertices_.
+    const std::vector<Vec3>& cpuMotionVerts = cpu.getMotionVertices();
+    r.motionVertices.reserve(cpuMotionVerts.size());
+    for (const auto& v : cpuMotionVerts) {
+        r.motionVertices.push_back(GVec3(v.x, v.y, v.z));
+    }
+    // TODO pkg88-C.0: populate each GTriangle::motionOffset by scanning the CPU scene
+    // and matching Triangle::motionVertexBuffer pointers. Deferred to avoid double-pass.
 
     // --- Environment map ---
     auto& em = cpu.getEnvironmentMap();

--- a/src/gpu/scene_upload.cu
+++ b/src/gpu/scene_upload.cu
@@ -234,16 +234,11 @@ static void appendOnePrim(
             gt.flat_shaded = true;
         }
         gt.materialId = getOrAddMat(tri->getMaterial());
-        // pkg88-C.0 GPU — verify on RTX. Motion blur: append triangle's motion verts to buffer.
-        // tri->motionVertexBuffer is non-null iff triangle has motion data.
-        // WARNING: assumes appendOnePrim is called with triangles in the same order as
-        // Renderer::getScene() iteration (stable pointer into Renderer::motionVertices_).
-        // TODO BEFORE NEXT PICKUP: verify this pointer stability assumption holds on GPU.
+        // pkg88-C.0: defaults — the BVH primitive walk in buildSceneArrays
+        // resolves real offsets for motion triangles via motionPtrToOffset
+        // (per-batch stable pointers; see Renderer::motionVertexBatches_).
         gt.motionOffset = -1;
         gt.motionSteps = 1;
-        // NOTE: CPU Triangle::motionVertexBuffer points into Renderer::motionVertices_.
-        // We'll upload the entire motionVertices_ buffer in buildSceneArrays; here we
-        // just compute the offset. Defer actual upload until we know all triangles.
         r.triangles.push_back(gt);
         std::string objName = tri->getName();
         if (objName.empty()) objName = "Unnamed_Triangle_" + std::to_string(r.triangles.size() - 1);
@@ -455,13 +450,17 @@ SceneUploadResult buildSceneArrays(const Renderer& cpu, const Camera* cam) {
         for (auto& n : cpuBvh->getNodes())
             r.nodes.push_back(convertNode(n));
         const auto& orderedPrims = cpuBvh->getPrimitives();
-        // pkg88-C.0: Build map of CPU Triangle* → Renderer::motionVertices_ offset
+        // pkg88-C.0: map CPU Triangle motion pointers → offsets in the
+        // CONCATENATED GPU buffer. Batches are stored separately on the CPU
+        // (stable per-batch pointers — pkg98 review fix); the GPU buffer is
+        // their concatenation in batch order, so offset = batchBase + i.
         std::unordered_map<const Vec3*, size_t> motionPtrToOffset;
-        if (!cpu.getMotionVertices().empty()) {
-            const Vec3* basePtr = cpu.getMotionVertices().data();
-            // NOTE: assumes each triangle's motionVertexBuffer points into contiguous buffer
-            for (size_t i = 0; i < cpu.getMotionVertices().size(); ++i) {
-                motionPtrToOffset[basePtr + i] = i;
+        {
+            size_t batchBase = 0;
+            for (const auto& batch : cpu.getMotionVertexBatches()) {
+                for (size_t i = 0; i < batch.size(); ++i)
+                    motionPtrToOffset[batch.data() + i] = batchBase + i;
+                batchBase += batch.size();
             }
         }
         for (auto& hittable : orderedPrims) {
@@ -681,19 +680,14 @@ SceneUploadResult buildSceneArrays(const Renderer& cpu, const Camera* cam) {
         r.profileCount = (int)profIdx.size();
     }
 
-    // --- pkg88-C.0 GPU — verify on RTX. Motion vertices for deformation motion blur ---
-    // Convert the CPU Renderer's motionVertices_ buffer into GPU format. Each triangle
-    // that has motion points into this buffer via its motionOffset.
-    // NOTE: This copies the ENTIRE Renderer motion buffer. In a second pass (TODO after
-    // basic GPU verify), populate each GTriangle's motionOffset by walking the CPU
-    // Triangle's motionVertexBuffer pointer against the base of Renderer::motionVertices_.
-    const std::vector<Vec3>& cpuMotionVerts = cpu.getMotionVertices();
-    r.motionVertices.reserve(cpuMotionVerts.size());
-    for (const auto& v : cpuMotionVerts) {
-        r.motionVertices.push_back(GVec3(v.x, v.y, v.z));
+    // --- pkg88-C.0: motion vertices for deformation motion blur ---
+    // The GPU buffer is the concatenation of the CPU per-batch storage, in
+    // batch order — matching the motionPtrToOffset mapping built during the
+    // primitive walk above (each GTriangle::motionOffset indexes into this).
+    for (const auto& batch : cpu.getMotionVertexBatches()) {
+        for (const auto& v : batch)
+            r.motionVertices.push_back(GVec3(v.x, v.y, v.z));
     }
-    // TODO pkg88-C.0: populate each GTriangle::motionOffset by scanning the CPU scene
-    // and matching Triangle::motionVertexBuffer pointers. Deferred to avoid double-pass.
 
     // --- Environment map ---
     auto& em = cpu.getEnvironmentMap();

--- a/tests/test_pkg88_c0_deformation.py
+++ b/tests/test_pkg88_c0_deformation.py
@@ -1,172 +1,205 @@
-# test_pkg88_c0_deformation.py — pkg88 Phase C.0 (deformation motion blur) validation.
-# Mirrors the spec's gate structure: zero-shutter regression, translating-triangle streak,
-# BVH union-AABB correctness. GPU tests marked skipif-no-CUDA (verified by lead on RTX).
+"""pkg88 Phase C.0 — deformation motion blur validation gates.
 
-import pytest
+Gate structure per .astroray_plan/packages/pkg88-motion-blur.md:
+- A3-style regression: motion API with end == start must render BIT-IDENTICAL
+  to the static bulk API (the renderer interpolates over [0,1] always; shutter
+  scaling is the addon's Phase-B job — it bakes shutter-scaled deltas, so
+  shutter=0 means zero deltas, i.e. exactly this no-op case).
+- B/C1 streak: a translating emissive triangle's rendered footprint extends
+  well beyond its static silhouette.
+- BVH union-AABB: a fast mover is visible at BOTH time extremes (the grown
+  AABB keeps it traversable across the whole shutter).
+- GPU parity: the CUDA path (MW megakernel) blurs like the CPU (per-channel
+  mean ratio) — exercised on the RTX box, skipped on CI.
+"""
+
+from __future__ import annotations
+
 import numpy as np
-import astroray
+import pytest
+
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+
+try:
+    import astroray  # noqa: E402
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray not built")
+
+W = H = 96
+SPP = 64
+DEPTH = 3
+
+_EMPTY_UV = np.zeros((0, 0, 3, 2), dtype=np.float32)
+_EMPTY_N = np.zeros((0, 3, 3), dtype=np.float32)
 
 
-# Gate B/C3 — zero-shutter regression (CPU + GPU)
-# If shutter=0 or no motion data, renders must be bit-identical to a build without motion.
-def test_zero_shutter_regression_cpu():
-    """pkg88-C.0: CPU zero-shutter regression. Shutter=0 renders identical to static scene."""
-    import astroray
+def _make_renderer(use_gpu=False):
+    r = astroray.Renderer()
+    r.set_integrator("path_tracer")
+    r.set_background_color([0.0, 0.0, 0.0])
+    r.set_seed(42)
+    if use_gpu:
+        r.set_use_gpu(True)
+    r.setup_camera([0.5, 0.3, 3.0], [0.5, 0.3, 0.0], [0.0, 1.0, 0.0],
+                   45.0, W / H, 0.0, 3.0, W, H)
+    return r
 
-    # Build two renderers: one with motion data (but shutter=0), one static
-    eng_motion = astroray.Engine(width=64, height=64, device="cpu")
-    eng_static = astroray.Engine(width=64, height=64, device="cpu")
 
-    # Simple scene: one triangle
-    mat_id = eng_motion.add_lambertian_material([0.7, 0.7, 0.7])
-    mat_id_s = eng_static.add_lambertian_material([0.7, 0.7, 0.7])
+def _emissive_tri(r):
+    return r.create_material("light", [1.0, 1.0, 1.0], {"intensity": 4.0})
 
-    # Static triangle at center
-    pos_start = np.array([[[0, 0, -2], [1, 0, -2], [0.5, 1, -2]]], dtype=np.float32)
-    # Motion triangle: end position is translated +0.5 in X
-    pos_end = pos_start + np.array([0.5, 0, 0], dtype=np.float32)
 
-    mat_ids = np.array([mat_id], dtype=np.int32)
-    mat_pass = np.array([0], dtype=np.int32)
-    uvs = np.zeros((0, 1, 3, 2), dtype=np.float32)
-    normals = np.zeros((0, 3, 3), dtype=np.float32)
+def _tri_arrays(offset_x=0.0):
+    pos = np.array([[[0.0, 0.0, 0.0], [0.35, 0.0, 0.0], [0.175, 0.55, 0.0]]],
+                   dtype=np.float32)
+    pos[:, :, 0] += offset_x
+    mids = np.array([0], dtype=np.int32)   # patched by caller
+    mpass = np.array([0], dtype=np.int32)
+    return pos, mids, mpass
 
-    # Add motion triangle (shutter=0)
-    eng_motion.add_triangles_bulk_motion(pos_start, pos_end, mat_ids, mat_pass, 0, uvs, [], normals)
-    eng_motion.set_camera_motion_blur_shutter(0.0)  # zero shutter
 
-    # Add static triangle (same start position)
-    mat_ids_s = np.array([mat_id_s], dtype=np.int32)
-    eng_static.add_triangles_bulk(pos_start, mat_ids_s, mat_pass, 0, uvs, [], normals)
+def _render(r):
+    img = np.asarray(r.render(SPP, DEPTH, None, True), dtype=np.float32)
+    return img.reshape(H, W, 3) if img.ndim == 1 else img
 
-    # Build + render (fixed seed)
-    eng_motion.build_scene()
-    eng_static.build_scene()
 
-    img_motion = eng_motion.render(spp=64, seed=42)
-    img_static = eng_static.render(spp=64, seed=42)
+def _lit_columns(img, thresh=0.02):
+    return int(np.sum(np.any(np.mean(img, axis=2) > thresh, axis=0)))
 
-    # Zero-shutter → bit-identical
-    assert np.allclose(img_motion, img_static, atol=0.0), \
-        "Zero-shutter motion render should match static scene pixel-for-pixel"
+
+def test_motion_noop_is_bit_identical():
+    """end == start through the motion API must match the static bulk API
+    bit-for-bit (the interpolation collapses; no RNG stream change)."""
+    r_static = _make_renderer()
+    mat_s = _emissive_tri(r_static)
+    pos, mids, mpass = _tri_arrays()
+    mids[:] = mat_s
+    r_static.add_triangles_bulk(pos, mids, mpass, 0, _EMPTY_UV, [], _EMPTY_N)
+
+    r_motion = _make_renderer()
+    mat_m = _emissive_tri(r_motion)
+    pos2, mids2, mpass2 = _tri_arrays()
+    mids2[:] = mat_m
+    r_motion.add_triangles_bulk_motion(pos2, pos2.copy(), mids2, mpass2, 0,
+                                       _EMPTY_UV, [], _EMPTY_N)
+
+    img_s = _render(r_static)
+    img_m = _render(r_motion)
+    assert np.array_equal(img_s, img_m), (
+        "motion API with end == start must be bit-identical to the static API "
+        f"(max abs diff {np.max(np.abs(img_s - img_m)):.3g})"
+    )
 
 
 def test_translating_triangle_streak_cpu():
-    """pkg88-C.0 Gate B/C1: CPU translating-triangle streak test.
-    With motion blur on, the rendered streak should extend beyond static silhouette."""
-    import astroray
+    """Gate B/C1: a triangle translating +1.2 in X renders a footprint much
+    wider than its static silhouette."""
+    r_static = _make_renderer()
+    mat = _emissive_tri(r_static)
+    pos, mids, mpass = _tri_arrays()
+    mids[:] = mat
+    r_static.add_triangles_bulk(pos, mids, mpass, 0, _EMPTY_UV, [], _EMPTY_N)
+    static_cols = _lit_columns(_render(r_static))
 
-    eng = astroray.Engine(width=128, height=128, device="cpu")
-    mat_id = eng.add_lambertian_material([0.9, 0.9, 0.9])
+    r_motion = _make_renderer()
+    mat2 = _emissive_tri(r_motion)
+    pos2, mids2, mpass2 = _tri_arrays()
+    mids2[:] = mat2
+    pos_end = pos2.copy()
+    pos_end[:, :, 0] += 1.2
+    r_motion.add_triangles_bulk_motion(pos2, pos_end, mids2, mpass2, 0,
+                                       _EMPTY_UV, [], _EMPTY_N)
+    motion_cols = _lit_columns(_render(r_motion))
 
-    # Triangle moves from X=0 to X=1 during shutter
-    pos_start = np.array([[[0, 0, -3], [0.2, 0, -3], [0.1, 0.2, -3]]], dtype=np.float32)
-    pos_end = pos_start + np.array([1.0, 0, 0], dtype=np.float32)
-
-    mat_ids = np.array([mat_id], dtype=np.int32)
-    mat_pass = np.array([0], dtype=np.int32)
-    uvs = np.zeros((0, 1, 3, 2), dtype=np.float32)
-    normals = np.zeros((0, 3, 3), dtype=np.float32)
-
-    eng.add_triangles_bulk_motion(pos_start, pos_end, mat_ids, mat_pass, 0, uvs, [], normals)
-    eng.set_camera_motion_blur_shutter(0.5)  # half-frame shutter
-    eng.build_scene()
-
-    img = eng.render(spp=64, seed=123)
-
-    # Quantify streak: count non-black pixels in the horizontal extent
-    # Expect coverage wider than the static 0.2-unit triangle width
-    # (translate 1.0 unit at 0.5 shutter = 0.5 unit motion spread)
-    gray = np.mean(img, axis=2)
-    hit_pixels = gray > 0.01
-    hit_columns = np.any(hit_pixels, axis=0)
-    streak_width = np.sum(hit_columns)
-
-    # Static triangle would project ~10-15 px wide; with 1.0-unit translation
-    # over 0.5 shutter, expect ~50+ px streak (rough threshold)
-    assert streak_width > 20, \
-        f"Motion streak too narrow ({streak_width} px); expected >20 with motion blur"
-
-
-@pytest.mark.skipif(not astroray.__dict__.get("_cuda_available", False), reason="CUDA not available")
-def test_motion_blur_gpu_parity():
-    """pkg88-C.0 GPU — verify on RTX. GPU motion render should match CPU within per-channel mean ratio ≤1.05."""
-    import astroray
-
-    # Simple motion scene: translating cube
-    eng_cpu = astroray.Engine(width=64, height=64, device="cpu")
-    eng_gpu = astroray.Engine(width=64, height=64, device="cuda")
-
-    mat_id_c = eng_cpu.add_lambertian_material([0.7, 0.3, 0.3])
-    mat_id_g = eng_gpu.add_lambertian_material([0.7, 0.3, 0.3])
-
-    # Two triangles forming a quad, moving in X
-    pos_start = np.array([
-        [[0, 0, -2], [1, 0, -2], [0, 1, -2]],
-        [[1, 0, -2], [1, 1, -2], [0, 1, -2]]
-    ], dtype=np.float32)
-    pos_end = pos_start + np.array([0.8, 0, 0], dtype=np.float32)
-
-    mat_ids_c = np.array([mat_id_c, mat_id_c], dtype=np.int32)
-    mat_ids_g = np.array([mat_id_g, mat_id_g], dtype=np.int32)
-    mat_pass = np.array([0, 0], dtype=np.int32)
-    uvs = np.zeros((0, 2, 3, 2), dtype=np.float32)
-    normals = np.zeros((0, 3, 3), dtype=np.float32)
-
-    eng_cpu.add_triangles_bulk_motion(pos_start, pos_end, mat_ids_c, mat_pass, 0, uvs, [], normals)
-    eng_gpu.add_triangles_bulk_motion(pos_start, pos_end, mat_ids_g, mat_pass, 0, uvs, [], normals)
-
-    eng_cpu.set_camera_motion_blur_shutter(0.5)
-    eng_gpu.set_camera_motion_blur_shutter(0.5)
-
-    eng_cpu.build_scene()
-    eng_gpu.build_scene()
-
-    img_cpu = eng_cpu.render(spp=64, seed=999)
-    img_gpu = eng_gpu.render(spp=64, seed=999)
-
-    # Per-channel mean ratio (allow for MC variance)
-    mean_cpu = np.mean(img_cpu, axis=(0,1))
-    mean_gpu = np.mean(img_gpu, axis=(0,1))
-    ratio = np.maximum(mean_cpu, 1e-6) / np.maximum(mean_gpu, 1e-6)
-
-    assert np.all(ratio < 1.10) and np.all(ratio > 0.91), \
-        f"CPU/GPU motion blur parity failed: ratio={ratio}, expected ~1.0 per channel"
+    assert static_cols > 0, "static triangle not visible — scene/camera broken"
+    assert motion_cols > static_cols * 2, (
+        f"motion streak too narrow: {motion_cols} lit columns vs static "
+        f"{static_cols} (expected >2x)"
+    )
 
 
 def test_bvh_union_aabb_correctness():
-    """pkg88-C.0 BVH gate: motion triangle's union-AABB must catch ray at both t=0 and t=1 extremes."""
-    import astroray
+    """The union AABB must keep a fast mover traversable at BOTH extremes:
+    the streak must include the static (t=0) footprint AND columns near the
+    t=1 destination."""
+    r = _make_renderer()
+    mat = _emissive_tri(r)
+    pos, mids, mpass = _tri_arrays()
+    mids[:] = mat
+    pos_end = pos.copy()
+    pos_end[:, :, 0] += 1.2
+    r.add_triangles_bulk_motion(pos, pos_end, mids, mpass, 0,
+                                _EMPTY_UV, [], _EMPTY_N)
+    img = _render(r)
 
-    # Small fast-moving triangle; verify BVH union catches it at extremes
-    eng = astroray.Engine(width=128, height=128, device="cpu")
-    mat_id = eng.add_lambertian_material([1.0, 1.0, 1.0])
+    gray = np.mean(img, axis=2)
+    lit = np.any(gray > 0.02, axis=0)
+    lit_idx = np.nonzero(lit)[0]
+    assert lit_idx.size > 0, "moving triangle entirely invisible"
+    # Camera is centered at x=0.5 looking at the [0, 1.55] world span; the
+    # start silhouette lives in the left half, the end silhouette in the right.
+    assert lit_idx.min() < W // 2 - 5, (
+        f"t=0 extreme missing (leftmost lit column {lit_idx.min()})"
+    )
+    assert lit_idx.max() > W // 2 + 5, (
+        f"t=1 extreme missing (rightmost lit column {lit_idx.max()})"
+    )
 
-    # Triangle at t=0: X=0, at t=1: X=2 (fast motion)
-    pos_start = np.array([[[0, 0, -2], [0.1, 0, -2], [0.05, 0.1, -2]]], dtype=np.float32)
-    pos_end = pos_start + np.array([2.0, 0, 0], dtype=np.float32)
 
-    mat_ids = np.array([mat_id], dtype=np.int32)
-    mat_pass = np.array([0], dtype=np.int32)
-    uvs = np.zeros((0, 1, 3, 2), dtype=np.float32)
-    normals = np.zeros((0, 3, 3), dtype=np.float32)
+_NEEDS_CUDA = pytest.mark.skipif(
+    AVAILABLE and not astroray.__features__.get("cuda", False),
+    reason="CUDA feature not in this build — GPU half verified on the RTX box",
+)
 
-    eng.add_triangles_bulk_motion(pos_start, pos_end, mat_ids, mat_pass, 0, uvs, [], normals)
-    eng.set_camera_motion_blur_shutter(1.0)  # full range [0,1]
-    eng.build_scene()
 
-    # Render two crops: one at left (t=0 region), one at right (t=1 region)
-    # Both should show non-zero radiance (union AABB catches ray at both extremes)
-    img_full = eng.render(spp=128, seed=555)
+@_NEEDS_CUDA
+def test_motion_blur_gpu_streak_and_parity():
+    """GPU half: the CUDA path (MW megakernel) must blur — streak wider than
+    the GPU static silhouette — and motion must shift scene energy the SAME
+    way on both backends. The gate is a ratio-of-ratios (motion/static per
+    backend) so the pre-existing small CPU-vs-GPU pipeline energy offset
+    (independent RNG, spectral vs RGB upsampling) doesn't confound it
+    (memory: ssim-wrong-gate-for-independent-rng)."""
+    def static_scene(use_gpu):
+        r = _make_renderer(use_gpu=use_gpu)
+        m = _emissive_tri(r)
+        p, mi, mp = _tri_arrays()
+        mi[:] = m
+        r.add_triangles_bulk(p, mi, mp, 0, _EMPTY_UV, [], _EMPTY_N)
+        return _render(r)
 
-    # Extract left and right quarters
-    w = img_full.shape[1]
-    left_crop = img_full[:, :w//4, :]
-    right_crop = img_full[:, 3*w//4:, :]
+    def motion_scene(use_gpu):
+        r = _make_renderer(use_gpu=use_gpu)
+        m = _emissive_tri(r)
+        p, mi, mp = _tri_arrays()
+        mi[:] = m
+        p_end = p.copy()
+        p_end[:, :, 0] += 1.2
+        r.add_triangles_bulk_motion(p, p_end, mi, mp, 0, _EMPTY_UV, [], _EMPTY_N)
+        return _render(r)
 
-    left_mean = np.mean(left_crop)
-    right_mean = np.mean(right_crop)
+    img_gpu_static = static_scene(use_gpu=True)
+    img_gpu_motion = motion_scene(use_gpu=True)
+    img_cpu_static = static_scene(use_gpu=False)
+    img_cpu_motion = motion_scene(use_gpu=False)
 
-    # Both crops should have SOME radiance (union-AABB caught the triangle at both ends)
-    assert left_mean > 0.01, f"Left crop (t=0) too dark: {left_mean}, BVH may have missed triangle start"
-    assert right_mean > 0.01, f"Right crop (t=1) too dark: {right_mean}, BVH may have missed triangle end"
+    gpu_cols = _lit_columns(img_gpu_motion)
+    gpu_static_cols = _lit_columns(img_gpu_static)
+    assert gpu_cols > gpu_static_cols * 2, (
+        f"GPU motion streak too narrow: {gpu_cols} vs static {gpu_static_cols} "
+        "(d_motionVertices not reaching the kernel?)"
+    )
+
+    # Motion-induced energy change must match across backends.
+    gpu_shift = (img_gpu_motion.mean() + 1e-5) / (img_gpu_static.mean() + 1e-5)
+    cpu_shift = (img_cpu_motion.mean() + 1e-5) / (img_cpu_static.mean() + 1e-5)
+    rel = gpu_shift / cpu_shift
+    assert 0.93 < rel < 1.08, (
+        f"motion/static energy shift diverges across backends: GPU {gpu_shift:.4f} "
+        f"vs CPU {cpu_shift:.4f} (ratio {rel:.4f})"
+    )

--- a/tests/test_pkg88_c0_deformation.py
+++ b/tests/test_pkg88_c0_deformation.py
@@ -151,6 +151,43 @@ def test_bvh_union_aabb_correctness():
     )
 
 
+def test_two_motion_batches_no_dangling():
+    """pkg98 review regression: a SECOND add_triangles_bulk_motion call must
+    not invalidate the first batch's triangle motion pointers (the original
+    single-vector storage reallocated and dangled them — silent CPU heap
+    corruption). Two separately-batched movers must BOTH render correct
+    streaks, and the whole frame must be finite/sane."""
+    r = _make_renderer()
+    mat = _emissive_tri(r)
+
+    # Batch 1: left mover (pad with extra static-ish motion tris so a
+    # reallocation in a non-batched design would actually move memory).
+    p1, m1, mp1 = _tri_arrays(offset_x=-0.4)
+    m1[:] = mat
+    p1_end = p1.copy()
+    p1_end[:, :, 0] += 0.5
+    r.add_triangles_bulk_motion(p1, p1_end, m1, mp1, 0, _EMPTY_UV, [], _EMPTY_N)
+
+    # Batch 2: right mover — large batch to force any realloc.
+    n2 = 64
+    p2 = np.tile(_tri_arrays(offset_x=1.0)[0], (n2, 1, 1)).astype(np.float32)
+    p2[:, :, 2] -= np.linspace(0.0, 0.5, n2, dtype=np.float32)[:, None]
+    p2_end = p2.copy()
+    p2_end[:, :, 0] += 0.5
+    m2 = np.full(n2, mat, dtype=np.int32)
+    mp2 = np.zeros(n2, dtype=np.int32)
+    r.add_triangles_bulk_motion(p2, p2_end, m2, mp2, 0, _EMPTY_UV, [], _EMPTY_N)
+
+    img = _render(r)
+    assert np.all(np.isfinite(img)), "non-finite pixels — dangling motion pointers?"
+
+    gray = np.mean(img, axis=2)
+    lit = np.any(gray > 0.02, axis=0)
+    # Batch 1 streak spans the left half; batch 2 the right half.
+    assert lit[: W // 2].sum() > 5, "first batch's mover missing (dangled pointers)"
+    assert lit[W // 2 :].sum() > 5, "second batch's mover missing"
+
+
 _NEEDS_CUDA = pytest.mark.skipif(
     AVAILABLE and not astroray.__features__.get("cuda", False),
     reason="CUDA feature not in this build — GPU half verified on the RTX box",

--- a/tests/test_pkg88_c0_deformation.py
+++ b/tests/test_pkg88_c0_deformation.py
@@ -1,0 +1,172 @@
+# test_pkg88_c0_deformation.py — pkg88 Phase C.0 (deformation motion blur) validation.
+# Mirrors the spec's gate structure: zero-shutter regression, translating-triangle streak,
+# BVH union-AABB correctness. GPU tests marked skipif-no-CUDA (verified by lead on RTX).
+
+import pytest
+import numpy as np
+import astroray
+
+
+# Gate B/C3 — zero-shutter regression (CPU + GPU)
+# If shutter=0 or no motion data, renders must be bit-identical to a build without motion.
+def test_zero_shutter_regression_cpu():
+    """pkg88-C.0: CPU zero-shutter regression. Shutter=0 renders identical to static scene."""
+    import astroray
+
+    # Build two renderers: one with motion data (but shutter=0), one static
+    eng_motion = astroray.Engine(width=64, height=64, device="cpu")
+    eng_static = astroray.Engine(width=64, height=64, device="cpu")
+
+    # Simple scene: one triangle
+    mat_id = eng_motion.add_lambertian_material([0.7, 0.7, 0.7])
+    mat_id_s = eng_static.add_lambertian_material([0.7, 0.7, 0.7])
+
+    # Static triangle at center
+    pos_start = np.array([[[0, 0, -2], [1, 0, -2], [0.5, 1, -2]]], dtype=np.float32)
+    # Motion triangle: end position is translated +0.5 in X
+    pos_end = pos_start + np.array([0.5, 0, 0], dtype=np.float32)
+
+    mat_ids = np.array([mat_id], dtype=np.int32)
+    mat_pass = np.array([0], dtype=np.int32)
+    uvs = np.zeros((0, 1, 3, 2), dtype=np.float32)
+    normals = np.zeros((0, 3, 3), dtype=np.float32)
+
+    # Add motion triangle (shutter=0)
+    eng_motion.add_triangles_bulk_motion(pos_start, pos_end, mat_ids, mat_pass, 0, uvs, [], normals)
+    eng_motion.set_camera_motion_blur_shutter(0.0)  # zero shutter
+
+    # Add static triangle (same start position)
+    mat_ids_s = np.array([mat_id_s], dtype=np.int32)
+    eng_static.add_triangles_bulk(pos_start, mat_ids_s, mat_pass, 0, uvs, [], normals)
+
+    # Build + render (fixed seed)
+    eng_motion.build_scene()
+    eng_static.build_scene()
+
+    img_motion = eng_motion.render(spp=64, seed=42)
+    img_static = eng_static.render(spp=64, seed=42)
+
+    # Zero-shutter → bit-identical
+    assert np.allclose(img_motion, img_static, atol=0.0), \
+        "Zero-shutter motion render should match static scene pixel-for-pixel"
+
+
+def test_translating_triangle_streak_cpu():
+    """pkg88-C.0 Gate B/C1: CPU translating-triangle streak test.
+    With motion blur on, the rendered streak should extend beyond static silhouette."""
+    import astroray
+
+    eng = astroray.Engine(width=128, height=128, device="cpu")
+    mat_id = eng.add_lambertian_material([0.9, 0.9, 0.9])
+
+    # Triangle moves from X=0 to X=1 during shutter
+    pos_start = np.array([[[0, 0, -3], [0.2, 0, -3], [0.1, 0.2, -3]]], dtype=np.float32)
+    pos_end = pos_start + np.array([1.0, 0, 0], dtype=np.float32)
+
+    mat_ids = np.array([mat_id], dtype=np.int32)
+    mat_pass = np.array([0], dtype=np.int32)
+    uvs = np.zeros((0, 1, 3, 2), dtype=np.float32)
+    normals = np.zeros((0, 3, 3), dtype=np.float32)
+
+    eng.add_triangles_bulk_motion(pos_start, pos_end, mat_ids, mat_pass, 0, uvs, [], normals)
+    eng.set_camera_motion_blur_shutter(0.5)  # half-frame shutter
+    eng.build_scene()
+
+    img = eng.render(spp=64, seed=123)
+
+    # Quantify streak: count non-black pixels in the horizontal extent
+    # Expect coverage wider than the static 0.2-unit triangle width
+    # (translate 1.0 unit at 0.5 shutter = 0.5 unit motion spread)
+    gray = np.mean(img, axis=2)
+    hit_pixels = gray > 0.01
+    hit_columns = np.any(hit_pixels, axis=0)
+    streak_width = np.sum(hit_columns)
+
+    # Static triangle would project ~10-15 px wide; with 1.0-unit translation
+    # over 0.5 shutter, expect ~50+ px streak (rough threshold)
+    assert streak_width > 20, \
+        f"Motion streak too narrow ({streak_width} px); expected >20 with motion blur"
+
+
+@pytest.mark.skipif(not astroray.__dict__.get("_cuda_available", False), reason="CUDA not available")
+def test_motion_blur_gpu_parity():
+    """pkg88-C.0 GPU — verify on RTX. GPU motion render should match CPU within per-channel mean ratio ≤1.05."""
+    import astroray
+
+    # Simple motion scene: translating cube
+    eng_cpu = astroray.Engine(width=64, height=64, device="cpu")
+    eng_gpu = astroray.Engine(width=64, height=64, device="cuda")
+
+    mat_id_c = eng_cpu.add_lambertian_material([0.7, 0.3, 0.3])
+    mat_id_g = eng_gpu.add_lambertian_material([0.7, 0.3, 0.3])
+
+    # Two triangles forming a quad, moving in X
+    pos_start = np.array([
+        [[0, 0, -2], [1, 0, -2], [0, 1, -2]],
+        [[1, 0, -2], [1, 1, -2], [0, 1, -2]]
+    ], dtype=np.float32)
+    pos_end = pos_start + np.array([0.8, 0, 0], dtype=np.float32)
+
+    mat_ids_c = np.array([mat_id_c, mat_id_c], dtype=np.int32)
+    mat_ids_g = np.array([mat_id_g, mat_id_g], dtype=np.int32)
+    mat_pass = np.array([0, 0], dtype=np.int32)
+    uvs = np.zeros((0, 2, 3, 2), dtype=np.float32)
+    normals = np.zeros((0, 3, 3), dtype=np.float32)
+
+    eng_cpu.add_triangles_bulk_motion(pos_start, pos_end, mat_ids_c, mat_pass, 0, uvs, [], normals)
+    eng_gpu.add_triangles_bulk_motion(pos_start, pos_end, mat_ids_g, mat_pass, 0, uvs, [], normals)
+
+    eng_cpu.set_camera_motion_blur_shutter(0.5)
+    eng_gpu.set_camera_motion_blur_shutter(0.5)
+
+    eng_cpu.build_scene()
+    eng_gpu.build_scene()
+
+    img_cpu = eng_cpu.render(spp=64, seed=999)
+    img_gpu = eng_gpu.render(spp=64, seed=999)
+
+    # Per-channel mean ratio (allow for MC variance)
+    mean_cpu = np.mean(img_cpu, axis=(0,1))
+    mean_gpu = np.mean(img_gpu, axis=(0,1))
+    ratio = np.maximum(mean_cpu, 1e-6) / np.maximum(mean_gpu, 1e-6)
+
+    assert np.all(ratio < 1.10) and np.all(ratio > 0.91), \
+        f"CPU/GPU motion blur parity failed: ratio={ratio}, expected ~1.0 per channel"
+
+
+def test_bvh_union_aabb_correctness():
+    """pkg88-C.0 BVH gate: motion triangle's union-AABB must catch ray at both t=0 and t=1 extremes."""
+    import astroray
+
+    # Small fast-moving triangle; verify BVH union catches it at extremes
+    eng = astroray.Engine(width=128, height=128, device="cpu")
+    mat_id = eng.add_lambertian_material([1.0, 1.0, 1.0])
+
+    # Triangle at t=0: X=0, at t=1: X=2 (fast motion)
+    pos_start = np.array([[[0, 0, -2], [0.1, 0, -2], [0.05, 0.1, -2]]], dtype=np.float32)
+    pos_end = pos_start + np.array([2.0, 0, 0], dtype=np.float32)
+
+    mat_ids = np.array([mat_id], dtype=np.int32)
+    mat_pass = np.array([0], dtype=np.int32)
+    uvs = np.zeros((0, 1, 3, 2), dtype=np.float32)
+    normals = np.zeros((0, 3, 3), dtype=np.float32)
+
+    eng.add_triangles_bulk_motion(pos_start, pos_end, mat_ids, mat_pass, 0, uvs, [], normals)
+    eng.set_camera_motion_blur_shutter(1.0)  # full range [0,1]
+    eng.build_scene()
+
+    # Render two crops: one at left (t=0 region), one at right (t=1 region)
+    # Both should show non-zero radiance (union AABB catches ray at both extremes)
+    img_full = eng.render(spp=128, seed=555)
+
+    # Extract left and right quarters
+    w = img_full.shape[1]
+    left_crop = img_full[:, :w//4, :]
+    right_crop = img_full[:, 3*w//4:, :]
+
+    left_mean = np.mean(left_crop)
+    right_mean = np.mean(right_crop)
+
+    # Both crops should have SOME radiance (union-AABB caught the triangle at both ends)
+    assert left_mean > 0.01, f"Left crop (t=0) too dark: {left_mean}, BVH may have missed triangle start"
+    assert right_mean > 0.01, f"Right crop (t=1) too dark: {right_mean}, BVH may have missed triangle end"


### PR DESCRIPTION
pkg88 Phase C.0 (spec order A → **C.0** → C.1-gated → B → D). Per-vertex time-varying triangle positions with linear blend per Cycles `motion_triangle.h` (Apache-2.0); union-AABB static BVH (structure unchanged).

## What
- **API**: `add_triangles_bulk_motion(positions_start, positions_end, ...)` — bulk binding mirroring pkg112's, K=2 (pre/post shutter). Motion batches live in stable per-batch storage (`deque<vector<Vec3>>`) so triangle pointers survive subsequent batches (pkg98 review BLOCK, fixed + regression-tested).
- **CPU**: time-aware `Triangle::hit` (interpolate verts at `ray.time` before Möller–Trumbore), union-AABB `boundingBox`, NEE shadow rays carry the path time; `Camera::getRay`'s zero-shutter path now rides the sampled time on the ray (shutter gates CAMERA interpolation only — A3 bit-identity verified byte-equal).
- **GPU**: `GRay.time` threaded end-to-end in BOTH megakernels (primary/bounce/shadow/MIS rays); `gpu_triangle_hit_motion` leaf dispatch in `gpu_bvh_hit`/`gpu_tlas_hit`; `d_motionVertices` uploaded in uploadScene/uploadGeometry. The MW kernel samples per-spp Halton time (one consistent policy per spec Q-Owner-4); its camera stays non-interpolated (documented Phase-A gap).
- **Scoped out (documented)**: deformation motion on INSTANCED meshes (pkg114 TLAS), wavefront/photon/SMS paths (static, explicit nullptr), per-primitive time-split (C.1, perf-gated).

## Gates (RTX 5070 Ti)
| Gate | Result |
|---|---|
| No-op bit-identity (motion end==start vs static API) | byte-equal ✅ |
| CPU translating-triangle streak | >2× static silhouette ✅ |
| Union-AABB both extremes visible | ✅ |
| Two-batch dangling-pointer regression | ✅ |
| GPU streak + cross-backend motion/static energy-shift | ratio-of-ratios within [0.93,1.08] ✅ |

Full local suite: **1215 passed** (its only 3 failures were main's pkg86-B test-ordering bug, fixed in #436; suite rerun after rebase pending CI).
Visual check: clean motion streaks both backends (`test_results/pkg88_c0_streak_{cpu,gpu}.png`).
Independent review (pkg98): initial **BLOCK** (dangling motion pointers across batches) → fixed (stable per-batch storage + regression test) → **SIGN-OFF** on re-verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)