### PR TITLE
feat(pkg115): Stage 2 chunk 3 — Wave + Brick Cycles parity

### DIFF
--- a/.astroray_plan/docs/blender-procedural-parity-research.md
+++ b/.astroray_plan/docs/blender-procedural-parity-research.md
@@ -553,8 +553,8 @@ plus a paired-still RTX check at the end.
    (distortion, color channels, normalize). Re-map factory `"musgrave"` with
    the 4.1 conversion (§5.8). ✅ **DONE 2026-06-11 (chunk 2)** — musgrave remap deferred to Stage 3 addon wiring
 7. **Wave** — port `svm_wave` (depends on `noise_fbm` from step 6); extend
-   factory params (directions, phase, dscale).
-8. **Brick** — port `svm_brick` + `brick_noise`; 3D input; new params.
+   factory params (directions, phase, dscale). ✅ **DONE 2026-06-11 (chunk 3)**
+8. **Brick** — port `svm_brick` + `brick_noise`; 3D input; new params. ✅ **DONE 2026-06-11 (chunk 3)**
 9. **Voronoi** — largest port: metrics + F1/F2/SmoothF1/DistToEdge/NSphere +
    fractal wrapper + normalize + multi-output mapping.
 10. **Addon translator + duplication removal + standalone CI example**

--- a/.astroray_plan/packages/pkg115-adopt-blender-shader-node-textures.md
+++ b/.astroray_plan/packages/pkg115-adopt-blender-shader-node-textures.md
@@ -3,7 +3,7 @@
 **Pillar:** 5 (addon) + 2 (materials/textures)
 **Track:** A
 **Codex-paste-ready:** no (large, staged; RTX visual verify)
-**Status:** Stage 2 chunk 1 done (PR #439, 2026-06-11 — GENERATED coord default for procedural nodes, signed Normal coord, (u,v,0) UV 3D point, Checker floor-parity, Gradient 4 formula fixes, Magic verbatim port, eval_texture_at_3d debug binding). REMAINING chunks (audit §6 order 5–10): util/hash + White Noise, Perlin + fractal stack + Noise node, Wave, Brick, Voronoi, addon translator dedup + standalone CI example + RTX visual verify vs Cycles.
+**Status:** Stage 2 chunk 3 done (2026-06-11 — Wave + Brick parity). Chunks 1-2 merged (PR #439 coord defaults, PR #441 hash+Perlin+fBM). REMAINING: Voronoi (audit §6.9), addon translator dedup + standalone CI example + RTX visual verify vs Cycles.
 **Depends on:** pkg57 (done — established the additive custom-node pattern and
 the `convert_node_material` traversal). Benefits from pkg112.
 **Estimated effort:** L (multi-week, staged)
@@ -181,8 +181,51 @@ Implementation of research-doc items 1-4 (coordinate/mapping wiring, Checker, Gr
   - `tests/test_pkg115_noise_parity.py`: 11 parity tests for hash, white noise, perlin,
     fractal stack properties.
 
-**Next chunk (items 7-9):** Wave, Brick, Voronoi — require real fBM for Wave distortion
-(now available), Brick integer hash, Voronoi cell search + fractal wrapper.
+**Chunk 3 progress (items 7-8, DONE 2026-06-11):**
+
+7. **Wave** (audit §5.4):
+   - [x] Rewrite in place: verbatim port of Cycles `intern/cycles/kernel/svm/wave.h::svm_wave`
+         (Apache-2.0). Replaces old turbulence (unsigned sin-hash) with SIGNED fBM distortion
+         via `fractal_noise::noise_fbm`.
+   - [x] Phase factor 20.0 (was π — ~6.4x denser, audit-documented bug).
+   - [x] Bands directions: X/Y/Z/Diagonal (0/1/2/3). Old had only X.
+   - [x] Rings directions: X/Y/Z/Spherical (0/1/2/3, axis-zeroing per direction). Old had only
+         spherical (full radius).
+   - [x] Profiles: Sine `0.5+0.5·sin(n−π/2)`, Saw ascending `frac(n/2π)` (was descending),
+         Triangle `abs(frac−floor(frac+0.5))·2`.
+   - [x] New params: `wave_type` (0=bands, 1=rings), `bands_direction`, `rings_direction`,
+         `phase_offset`, `detail_scale` (dscale). Lacunarity fixed at 2.0 per Cycles.
+   - [x] Plugin `wave.cpp` updated to new signature (11 params).
+   - [x] Tests: `test_pkg115_wave_brick_parity.py`: phase factor 20.0, diagonal, rings
+         spherical vs X, saw/triangle profiles, distortion via fBM, phase offset.
+
+8. **Brick** (audit §5.7):
+   - [x] Rewrite in place: port of Cycles `intern/cycles/kernel/svm/brick.h::svm_brick` +
+         `brick_noise` hash (Apache-2.0). 3D input (uses p.x, p.y; old was 2D uv-only).
+   - [x] Per-brick color variation: `tint = saturate(brick_noise((rownum<<16)+(bricknum&0xFFFF)) + bias)`
+         mixing Color1→Color2. Old had uniform brick color.
+   - [x] New params: `color1`/`color2` (was `color_brick`), `mortar_smooth` (smoothstep
+         transition), `bias`, `offset_amount`/`offset_frequency`, `squash_amount`/`squash_frequency`,
+         `row_height` (was `brick_height`). Mortar gap semantics: total gap = 2·mortar_size
+         per side (old: mortarSize/2).
+   - [x] Plugin `brick.cpp` updated to new signature (13 params).
+   - [x] Tests: cell classification, mortar_size=0 edge, bias shifts tint, per-brick variation,
+         mortar_smooth smoothstep.
+
+**License compliance:**
+  - Apache-2.0 Blender Foundation SPDX headers retained at Wave and Brick port sites.
+
+**Files changed:**
+  - `include/advanced_features.h`: WaveTexture class rewritten (lines 340-429), BrickTexture
+    class rewritten (lines 531-610).
+  - `plugins/textures/wave.cpp`: parameter list updated.
+  - `plugins/textures/brick.cpp`: parameter list updated.
+  - `tests/test_pkg115_wave_brick_parity.py`: 13 parity tests for Wave (bands/rings,
+    directions, profiles, distortion, phase) and Brick (cell classification, mortar, bias,
+    per-brick variation, smoothstep).
+
+**Next chunk (item 9):** Voronoi — largest port (metrics, features F1/F2/SmoothF1/DistToEdge/
+NSphere, fractal wrapper, normalize, multi-output mapping).
 
 ---
 

--- a/include/advanced_features.h
+++ b/include/advanced_features.h
@@ -347,314 +347,9 @@ public:
 // bands_direction: 0=X, 1=Y, 2=Z, 3=Diagonal
 // rings_direction: 0=X, 1=Y, 2=Z, 3=Spherical
 // profile: 0=Sine, 1=Saw, 2=Triangle
-class WaveTexture : public Texture {
-    int waveType;           // 0=bands, 1=rings
-    int bandsDirection;     // 0=X, 1=Y, 2=Z, 3=Diagonal
-    int ringsDirection;     // 0=X, 1=Y, 2=Z, 3=Spherical
-    int profile;            // 0=sine, 1=saw, 2=triangle
-    float scale, distortion, detail, detailScale, detailRoughness, phaseOffset;
-    Vec3 colorLow, colorHigh;
-public:
-    WaveTexture(int wt = 0, int bd = 0, int rd = 0, int prof = 0,
-                float sc = 5.0f, float dist = 0.0f, float det = 2.0f,
-                float dscale = 1.0f, float drough = 0.5f, float phase = 0.0f,
-                const Vec3& c1 = Vec3(0), const Vec3& c2 = Vec3(1))
-        : waveType(wt), bandsDirection(bd), ringsDirection(rd), profile(prof),
-          scale(sc), distortion(dist), detail(det), detailScale(dscale),
-          detailRoughness(drough), phaseOffset(phase), colorLow(c1), colorHigh(c2) {}
-
-    Vec3 value(const Vec2&, const Vec3& p) const override {
-        // Cycles intern/cycles/kernel/svm/wave.h::svm_wave (Apache-2.0).
-        // Precision guard per Cycles.
-        Vec3 pp = (p + Vec3(0.000001f)) * 0.999999f;
-        pp = pp * scale;
-
-        float n = 0.0f;
-        if (waveType == 0) {
-            // Bands
-            switch (bandsDirection) {
-                case 0: n = pp.x * 20.0f; break;  // X
-                case 1: n = pp.y * 20.0f; break;  // Y
-                case 2: n = pp.z * 20.0f; break;  // Z
-                case 3: n = (pp.x + pp.y + pp.z) * 10.0f; break;  // Diagonal
-            }
-        } else {
-            // Rings: zero one axis then len * 20
-            Vec3 rp = pp;
-            switch (ringsDirection) {
-                case 0: rp.x = 0.0f; break;  // X
-                case 1: rp.y = 0.0f; break;  // Y
-                case 2: rp.z = 0.0f; break;  // Z
-                case 3: break;  // Spherical (no zeroing)
-            }
-            float r = std::sqrt(rp.x*rp.x + rp.y*rp.y + rp.z*rp.z);
-            n = r * 20.0f;
-        }
-
-        n += phaseOffset;
-
-        if (distortion != 0.0f) {
-            // Distortion via SIGNED fBM (lacunarity fixed 2.0, normalized).
-            float distort = fractal_noise::noise_fbm(pp * detailScale, detail,
-                                                     detailRoughness, 2.0f, true);
-            n += distortion * (distort * 2.0f - 1.0f);
-        }
-
-        float t;
-        const float pi = 3.14159265358979323846f;
-        const float two_pi = 2.0f * pi;
-        switch (profile) {
-            case 1: {  // Saw
-                float frac = n / two_pi;
-                t = frac - std::floor(frac);
-                break;
-            }
-            case 2: {  // Triangle
-                float frac = n / two_pi;
-                t = std::abs(frac - std::floor(frac + 0.5f)) * 2.0f;
-                break;
-            }
-            default: {  // Sine
-                t = 0.5f + 0.5f * std::sin(n - pi / 2.0f);
-                break;
-            }
-        }
-
-        return colorLow * (1.0f - t) + colorHigh * t;
-    }
-};
-
-// --- Magic texture ---
-class MagicTexture : public Texture {
-    int turbDepth;
-    float scale, distortion;
-    Vec3 color1, color2;
-public:
-    MagicTexture(int depth = 2, float sc = 5.0f, float dist = 1.0f,
-                 const Vec3& c1 = Vec3(0), const Vec3& c2 = Vec3(1))
-        : turbDepth(depth), scale(sc), distortion(dist), color1(c1), color2(c2) {}
-    Vec3 value(const Vec2&, const Vec3& p) const override {
-        // pkg115 parity fix: verbatim port of Cycles intern/cycles/kernel/svm/magic.h::svm_magic (Apache-2.0).
-        // Key differences from old engine math: fmod(p·scale, 2π) then ·5 (not scale·π),
-        // *= distortion per branch + final /= (2·distortion), depth ≤ 10 (was 5),
-        // output is true RGB (0.5-x, 0.5-y, 0.5-z), not a scalar 2-color lerp.
-        // Keep color1/color2 params for backward compat with standalone factory calls;
-        // addon passes (0,0,0)/(1,1,1) so this becomes a tint.
-        float px = std::fmod(p.x * scale, 2.0f * float(M_PI));
-        float py = std::fmod(p.y * scale, 2.0f * float(M_PI));
-        float pz = std::fmod(p.z * scale, 2.0f * float(M_PI));
-        float x = std::sin((px + py + pz) * 5.0f);
-        float y = std::cos((-px + py - pz) * 5.0f);
-        float z = -std::cos((-px - py + pz) * 5.0f);
-        int n = turbDepth;
-        float dist = distortion;
-        if (n > 0) {
-            x *= dist; y *= dist; z *= dist;
-            y = -std::cos(x - y + z);
-            y *= dist;
-            if (n > 1) {
-                x = std::cos(x - y - z);
-                x *= dist;
-                if (n > 2) {
-                    z = std::sin(-x - y - z);
-                    z *= dist;
-                    if (n > 3) {
-                        x = -std::cos(-x + y - z);
-                        x *= dist;
-                        if (n > 4) {
-                            y = -std::sin(-x + y + z);
-                            y *= dist;
-                            if (n > 5) {
-                                y = -std::cos(-x + y + z);
-                                y *= dist;
-                                if (n > 6) {
-                                    x = std::cos(x + y + z);
-                                    x *= dist;
-                                    if (n > 7) {
-                                        z = std::sin(x + y - z);
-                                        z *= dist;
-                                        if (n > 8) {
-                                            x = -std::cos(-x - y + z);
-                                            x *= dist;
-                                            if (n > 9) {
-                                                y = -std::sin(x - y + z);
-                                                y *= dist;
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        if (dist != 0.0f) {
-            dist *= 2.0f;
-            x /= dist;
-            y /= dist;
-            z /= dist;
-        }
-        // Blender outputs true RGB: (0.5-x, 0.5-y, 0.5-z). For standalone factory
-        // backward compat, apply color1/color2 as a lerp tint using the average.
-        Vec3 rgb(0.5f - x, 0.5f - y, 0.5f - z);
-        float fac = (rgb.x + rgb.y + rgb.z) / 3.0f;
-        return color1 * (1.0f - fac) + color2 * fac;
-    }
-};
-
-// --- Voronoi texture ---
-// distMetric: 0=Euclidean, 1=Manhattan, 2=Chebychev, 3=Minkowski(p=2.5)
-// feature: 0=F1, 1=F2, 2=F1+F2, 3=F2-F1, 4=smooth_F1
-class VoronoiTexture : public Texture {
-    float scale, randomness, smoothness;
-    int distMetric, feature;
-    Vec3 colorLow, colorHigh;
-public:
-    VoronoiTexture(float sc = 5.0f, float rand = 1.0f, int dm = 0, int feat = 0,
-                   float smooth = 1.0f, const Vec3& c1 = Vec3(0), const Vec3& c2 = Vec3(1))
-        : scale(sc), randomness(rand), smoothness(smooth), distMetric(dm), feature(feat),
-          colorLow(c1), colorHigh(c2) {}
-
-    static float hash1(float n) {
-        float x = std::sin(n) * 43758.5453f;
-        return x - std::floor(x);
-    }
-    static Vec3 hash3(Vec3 p) {
-        Vec3 q(p.dot(Vec3(127.1f, 311.7f, 74.7f)),
-               p.dot(Vec3(269.5f, 183.3f, 246.1f)),
-               p.dot(Vec3(113.5f, 271.9f, 124.6f)));
-        return Vec3(hash1(q.x), hash1(q.y), hash1(q.z));
-    }
-    float dist(const Vec3& a, const Vec3& b) const {
-        Vec3 d = a - b;
-        switch (distMetric) {
-            case 1: return std::abs(d.x) + std::abs(d.y) + std::abs(d.z);
-            case 2: return std::max({std::abs(d.x), std::abs(d.y), std::abs(d.z)});
-            case 3: { float p = 2.5f; return std::pow(std::pow(std::abs(d.x),p)+std::pow(std::abs(d.y),p)+std::pow(std::abs(d.z),p), 1.0f/p); }
-            default: return std::sqrt(d.dot(d));
-        }
-    }
-    Vec3 value(const Vec2&, const Vec3& p) const override {
-        Vec3 sp = p * scale;
-        Vec3 ip(std::floor(sp.x), std::floor(sp.y), std::floor(sp.z));
-        float f1 = 1e9f, f2 = 1e9f;
-        float smoothF1 = 0.0f;
-        for (int dz = -1; dz <= 1; ++dz)
-        for (int dy = -1; dy <= 1; ++dy)
-        for (int dx = -1; dx <= 1; ++dx) {
-            Vec3 nb(ip.x+dx, ip.y+dy, ip.z+dz);
-            Vec3 r = nb + hash3(nb) * randomness;
-            float d = dist(sp, r);
-            if (d < f1) { f2 = f1; f1 = d; }
-            else if (d < f2) { f2 = d; }
-            if (smoothness > 0.0f && smoothness < 1e9f) {
-                float h = std::max(smoothness - d, 0.0f) / smoothness;
-                smoothF1 += h * h * h;
-            }
-        }
-        float val;
-        switch (feature) {
-            case 1: val = f2; break;
-            case 2: val = (f1 + f2) * 0.5f; break;
-            case 3: val = f2 - f1; break;
-            case 4: val = smoothness > 0.0f ? -std::log(smoothF1) / 3.0f : f1; break;
-            default: val = f1; break;
-        }
-        float t = std::clamp(val, 0.0f, 1.0f);
-        return colorLow * (1.0f - t) + colorHigh * t;
-    }
-};
-
-// --- Brick texture ---
-// Ported from Blender intern/cycles/kernel/svm/brick.h (Apache-2.0).
-// SPDX-FileCopyrightText: 2011-2022 Blender Foundation
-// SPDX-License-Identifier: Apache-2.0
-//
-// pkg115 chunk 3: full parity with Blender/Cycles Brick node.
-// 3D input (p.x, p.y), mortar_smooth, bias, per-brick color variation,
-// offset_frequency, squash/squash_frequency.
-class BrickTexture : public Texture {
-    Vec3 color1, color2, colorMortar;
-    float scale, mortarSize, mortarSmooth, bias, brickWidth, rowHeight;
-    float offsetAmount, squashAmount;
-    int offsetFrequency, squashFrequency;
-
-    static inline uint32_t brick_noise(uint32_t n) {
-        // Cycles intern/cycles/kernel/svm/brick.h:14-21 (Apache-2.0).
-        // Integer hash for per-brick color variation.
-        uint32_t nn = (n + 1013u) & 0x7fffffffu;
-        nn = (nn >> 13u) ^ nn;
-        uint32_t nnn = (nn * (nn * nn * 60493u + 19990303u) + 1376312589u) & 0x7fffffffu;
-        return nnn;
-    }
-
-public:
-    BrickTexture(const Vec3& c1 = Vec3(0.8f),
-                 const Vec3& c2 = Vec3(0.2f),
-                 const Vec3& mortar = Vec3(0.0f),
-                 float sc = 5.0f, float mort = 0.02f, float msmooth = 0.1f,
-                 float b = 0.0f, float bw = 0.5f, float rh = 0.25f,
-                 float off = 0.5f, int offfreq = 2, float sq = 1.0f, int sqfreq = 2)
-        : color1(c1), color2(c2), colorMortar(mortar),
-          scale(sc), mortarSize(mort), mortarSmooth(msmooth), bias(b),
-          brickWidth(bw), rowHeight(rh), offsetAmount(off), squashAmount(sq),
-          offsetFrequency(offfreq), squashFrequency(sqfreq) {}
-
-    Vec3 value(const Vec2&, const Vec3& p) const override {
-        // Cycles intern/cycles/kernel/svm/brick.h::svm_brick (Apache-2.0).
-        // 3D input: uses p.x, p.y (ignores p.z per Cycles).
-        Vec3 coord = p * scale;
-
-        int rownum = static_cast<int>(std::floor(coord.y / rowHeight));
-
-        float brick_w = brickWidth;
-        float offset = 0.0f;
-        if (offsetFrequency != 0 && squashFrequency != 0) {
-            brick_w *= (rownum % squashFrequency) ? 1.0f : squashAmount;
-            offset = (rownum % offsetFrequency) ? 0.0f : brick_w * offsetAmount;
-        }
-
-        int bricknum = static_cast<int>(std::floor((coord.x + offset) / brick_w));
-
-        float x = (coord.x + offset) - brick_w * bricknum;
-        float y = coord.y - rowHeight * rownum;
-
-        // Per-brick random tint: mix color1 -> color2 by (hash + bias).
-        uint32_t hash_in = (static_cast<uint32_t>(rownum) << 16) + (static_cast<uint32_t>(bricknum) & 0xFFFFu);
-        float tint_raw = static_cast<float>(brick_noise(hash_in)) / 2147483647.0f;
-        float tint = std::clamp(tint_raw + bias, 0.0f, 1.0f);
-        Vec3 brick_color = color1 * (1.0f - tint) + color2 * tint;
-
-        // Mortar test: minimum distance to brick edge.
-        float min_dist = std::min({x, y, brick_w - x, rowHeight - y});
-        float mortar;
-        if (min_dist >= mortarSize) {
-            mortar = 0.0f;
-        } else if (mortarSmooth == 0.0f) {
-            mortar = 1.0f;
-        } else {
-            // Cycles smoothstep inversion: (1 - min_dist / mortar_size) / mortar_smooth.
-            float t = (1.0f - min_dist / mortarSize) / mortarSmooth;
-            t = std::clamp(t, 0.0f, 1.0f);
-            mortar = t * t * (3.0f - 2.0f * t);
-        }
-
-        return brick_color * (1.0f - mortar) + colorMortar * mortar;
-    }
-};
-
-// --- Musgrave (fBm) texture ---
-// ============================================================================
-// HASH FAMILY (pkg115 chunk 2)
-// ============================================================================
-// Ported from Blender intern/cycles/util/hash.h (Apache-2.0).
-// SPDX-FileCopyrightText: 2011-2022 Blender Foundation
-// SPDX-License-Identifier: Apache-2.0
-//
-// Jenkins Lookup3 hash core. Required by Perlin, Voronoi, White Noise, and
-// the Noise node's random offsets. Bit-identical to Cycles for parity.
-
+// NOTE (pkg115 chunk 3): the hash/perlin/fractal namespaces are defined
+// ABOVE WaveTexture because the Cycles Wave port consumes
+// fractal_noise::noise_fbm for its detail distortion.
 namespace cycles_hash {
 
 inline uint32_t rot(uint32_t x, int k) {
@@ -1011,6 +706,315 @@ inline float noise_ridged_multi_fractal(Vec3 p, float detail, float roughness,
 // ============================================================================
 // WHITE NOISE TEXTURE (pkg115 chunk 2)
 // ============================================================================
+
+class WaveTexture : public Texture {
+    int waveType;           // 0=bands, 1=rings
+    int bandsDirection;     // 0=X, 1=Y, 2=Z, 3=Diagonal
+    int ringsDirection;     // 0=X, 1=Y, 2=Z, 3=Spherical
+    int profile;            // 0=sine, 1=saw, 2=triangle
+    float scale, distortion, detail, detailScale, detailRoughness, phaseOffset;
+    Vec3 colorLow, colorHigh;
+public:
+    WaveTexture(int wt = 0, int bd = 0, int rd = 0, int prof = 0,
+                float sc = 5.0f, float dist = 0.0f, float det = 2.0f,
+                float dscale = 1.0f, float drough = 0.5f, float phase = 0.0f,
+                const Vec3& c1 = Vec3(0), const Vec3& c2 = Vec3(1))
+        : waveType(wt), bandsDirection(bd), ringsDirection(rd), profile(prof),
+          scale(sc), distortion(dist), detail(det), detailScale(dscale),
+          detailRoughness(drough), phaseOffset(phase), colorLow(c1), colorHigh(c2) {}
+
+    Vec3 value(const Vec2&, const Vec3& p) const override {
+        // Cycles intern/cycles/kernel/svm/wave.h::svm_wave (Apache-2.0).
+        // Precision guard per Cycles.
+        Vec3 pp = (p + Vec3(0.000001f)) * 0.999999f;
+        pp = pp * scale;
+
+        float n = 0.0f;
+        if (waveType == 0) {
+            // Bands
+            switch (bandsDirection) {
+                case 0: n = pp.x * 20.0f; break;  // X
+                case 1: n = pp.y * 20.0f; break;  // Y
+                case 2: n = pp.z * 20.0f; break;  // Z
+                case 3: n = (pp.x + pp.y + pp.z) * 10.0f; break;  // Diagonal
+            }
+        } else {
+            // Rings: zero one axis then len * 20
+            Vec3 rp = pp;
+            switch (ringsDirection) {
+                case 0: rp.x = 0.0f; break;  // X
+                case 1: rp.y = 0.0f; break;  // Y
+                case 2: rp.z = 0.0f; break;  // Z
+                case 3: break;  // Spherical (no zeroing)
+            }
+            float r = std::sqrt(rp.x*rp.x + rp.y*rp.y + rp.z*rp.z);
+            n = r * 20.0f;
+        }
+
+        n += phaseOffset;
+
+        if (distortion != 0.0f) {
+            // Distortion via SIGNED fBM (lacunarity fixed 2.0, normalized).
+            float distort = fractal_noise::noise_fbm(pp * detailScale, detail,
+                                                     detailRoughness, 2.0f, true);
+            n += distortion * (distort * 2.0f - 1.0f);
+        }
+
+        float t;
+        const float pi = 3.14159265358979323846f;
+        const float two_pi = 2.0f * pi;
+        switch (profile) {
+            case 1: {  // Saw
+                float frac = n / two_pi;
+                t = frac - std::floor(frac);
+                break;
+            }
+            case 2: {  // Triangle
+                float frac = n / two_pi;
+                t = std::abs(frac - std::floor(frac + 0.5f)) * 2.0f;
+                break;
+            }
+            default: {  // Sine
+                t = 0.5f + 0.5f * std::sin(n - pi / 2.0f);
+                break;
+            }
+        }
+
+        return colorLow * (1.0f - t) + colorHigh * t;
+    }
+};
+
+// --- Magic texture ---
+class MagicTexture : public Texture {
+    int turbDepth;
+    float scale, distortion;
+    Vec3 color1, color2;
+public:
+    MagicTexture(int depth = 2, float sc = 5.0f, float dist = 1.0f,
+                 const Vec3& c1 = Vec3(0), const Vec3& c2 = Vec3(1))
+        : turbDepth(depth), scale(sc), distortion(dist), color1(c1), color2(c2) {}
+    Vec3 value(const Vec2&, const Vec3& p) const override {
+        // pkg115 parity fix: verbatim port of Cycles intern/cycles/kernel/svm/magic.h::svm_magic (Apache-2.0).
+        // Key differences from old engine math: fmod(p·scale, 2π) then ·5 (not scale·π),
+        // *= distortion per branch + final /= (2·distortion), depth ≤ 10 (was 5),
+        // output is true RGB (0.5-x, 0.5-y, 0.5-z), not a scalar 2-color lerp.
+        // Keep color1/color2 params for backward compat with standalone factory calls;
+        // addon passes (0,0,0)/(1,1,1) so this becomes a tint.
+        float px = std::fmod(p.x * scale, 2.0f * float(M_PI));
+        float py = std::fmod(p.y * scale, 2.0f * float(M_PI));
+        float pz = std::fmod(p.z * scale, 2.0f * float(M_PI));
+        float x = std::sin((px + py + pz) * 5.0f);
+        float y = std::cos((-px + py - pz) * 5.0f);
+        float z = -std::cos((-px - py + pz) * 5.0f);
+        int n = turbDepth;
+        float dist = distortion;
+        if (n > 0) {
+            x *= dist; y *= dist; z *= dist;
+            y = -std::cos(x - y + z);
+            y *= dist;
+            if (n > 1) {
+                x = std::cos(x - y - z);
+                x *= dist;
+                if (n > 2) {
+                    z = std::sin(-x - y - z);
+                    z *= dist;
+                    if (n > 3) {
+                        x = -std::cos(-x + y - z);
+                        x *= dist;
+                        if (n > 4) {
+                            y = -std::sin(-x + y + z);
+                            y *= dist;
+                            if (n > 5) {
+                                y = -std::cos(-x + y + z);
+                                y *= dist;
+                                if (n > 6) {
+                                    x = std::cos(x + y + z);
+                                    x *= dist;
+                                    if (n > 7) {
+                                        z = std::sin(x + y - z);
+                                        z *= dist;
+                                        if (n > 8) {
+                                            x = -std::cos(-x - y + z);
+                                            x *= dist;
+                                            if (n > 9) {
+                                                y = -std::sin(x - y + z);
+                                                y *= dist;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if (dist != 0.0f) {
+            dist *= 2.0f;
+            x /= dist;
+            y /= dist;
+            z /= dist;
+        }
+        // Blender outputs true RGB: (0.5-x, 0.5-y, 0.5-z). For standalone factory
+        // backward compat, apply color1/color2 as a lerp tint using the average.
+        Vec3 rgb(0.5f - x, 0.5f - y, 0.5f - z);
+        float fac = (rgb.x + rgb.y + rgb.z) / 3.0f;
+        return color1 * (1.0f - fac) + color2 * fac;
+    }
+};
+
+// --- Voronoi texture ---
+// distMetric: 0=Euclidean, 1=Manhattan, 2=Chebychev, 3=Minkowski(p=2.5)
+// feature: 0=F1, 1=F2, 2=F1+F2, 3=F2-F1, 4=smooth_F1
+class VoronoiTexture : public Texture {
+    float scale, randomness, smoothness;
+    int distMetric, feature;
+    Vec3 colorLow, colorHigh;
+public:
+    VoronoiTexture(float sc = 5.0f, float rand = 1.0f, int dm = 0, int feat = 0,
+                   float smooth = 1.0f, const Vec3& c1 = Vec3(0), const Vec3& c2 = Vec3(1))
+        : scale(sc), randomness(rand), smoothness(smooth), distMetric(dm), feature(feat),
+          colorLow(c1), colorHigh(c2) {}
+
+    static float hash1(float n) {
+        float x = std::sin(n) * 43758.5453f;
+        return x - std::floor(x);
+    }
+    static Vec3 hash3(Vec3 p) {
+        Vec3 q(p.dot(Vec3(127.1f, 311.7f, 74.7f)),
+               p.dot(Vec3(269.5f, 183.3f, 246.1f)),
+               p.dot(Vec3(113.5f, 271.9f, 124.6f)));
+        return Vec3(hash1(q.x), hash1(q.y), hash1(q.z));
+    }
+    float dist(const Vec3& a, const Vec3& b) const {
+        Vec3 d = a - b;
+        switch (distMetric) {
+            case 1: return std::abs(d.x) + std::abs(d.y) + std::abs(d.z);
+            case 2: return std::max({std::abs(d.x), std::abs(d.y), std::abs(d.z)});
+            case 3: { float p = 2.5f; return std::pow(std::pow(std::abs(d.x),p)+std::pow(std::abs(d.y),p)+std::pow(std::abs(d.z),p), 1.0f/p); }
+            default: return std::sqrt(d.dot(d));
+        }
+    }
+    Vec3 value(const Vec2&, const Vec3& p) const override {
+        Vec3 sp = p * scale;
+        Vec3 ip(std::floor(sp.x), std::floor(sp.y), std::floor(sp.z));
+        float f1 = 1e9f, f2 = 1e9f;
+        float smoothF1 = 0.0f;
+        for (int dz = -1; dz <= 1; ++dz)
+        for (int dy = -1; dy <= 1; ++dy)
+        for (int dx = -1; dx <= 1; ++dx) {
+            Vec3 nb(ip.x+dx, ip.y+dy, ip.z+dz);
+            Vec3 r = nb + hash3(nb) * randomness;
+            float d = dist(sp, r);
+            if (d < f1) { f2 = f1; f1 = d; }
+            else if (d < f2) { f2 = d; }
+            if (smoothness > 0.0f && smoothness < 1e9f) {
+                float h = std::max(smoothness - d, 0.0f) / smoothness;
+                smoothF1 += h * h * h;
+            }
+        }
+        float val;
+        switch (feature) {
+            case 1: val = f2; break;
+            case 2: val = (f1 + f2) * 0.5f; break;
+            case 3: val = f2 - f1; break;
+            case 4: val = smoothness > 0.0f ? -std::log(smoothF1) / 3.0f : f1; break;
+            default: val = f1; break;
+        }
+        float t = std::clamp(val, 0.0f, 1.0f);
+        return colorLow * (1.0f - t) + colorHigh * t;
+    }
+};
+
+// --- Brick texture ---
+// Ported from Blender intern/cycles/kernel/svm/brick.h (Apache-2.0).
+// SPDX-FileCopyrightText: 2011-2022 Blender Foundation
+// SPDX-License-Identifier: Apache-2.0
+//
+// pkg115 chunk 3: full parity with Blender/Cycles Brick node.
+// 3D input (p.x, p.y), mortar_smooth, bias, per-brick color variation,
+// offset_frequency, squash/squash_frequency.
+class BrickTexture : public Texture {
+    Vec3 color1, color2, colorMortar;
+    float scale, mortarSize, mortarSmooth, bias, brickWidth, rowHeight;
+    float offsetAmount, squashAmount;
+    int offsetFrequency, squashFrequency;
+
+    static inline uint32_t brick_noise(uint32_t n) {
+        // Cycles intern/cycles/kernel/svm/brick.h:14-21 (Apache-2.0).
+        // Integer hash for per-brick color variation.
+        uint32_t nn = (n + 1013u) & 0x7fffffffu;
+        nn = (nn >> 13u) ^ nn;
+        uint32_t nnn = (nn * (nn * nn * 60493u + 19990303u) + 1376312589u) & 0x7fffffffu;
+        return nnn;
+    }
+
+public:
+    BrickTexture(const Vec3& c1 = Vec3(0.8f),
+                 const Vec3& c2 = Vec3(0.2f),
+                 const Vec3& mortar = Vec3(0.0f),
+                 float sc = 5.0f, float mort = 0.02f, float msmooth = 0.1f,
+                 float b = 0.0f, float bw = 0.5f, float rh = 0.25f,
+                 float off = 0.5f, int offfreq = 2, float sq = 1.0f, int sqfreq = 2)
+        : color1(c1), color2(c2), colorMortar(mortar),
+          scale(sc), mortarSize(mort), mortarSmooth(msmooth), bias(b),
+          brickWidth(bw), rowHeight(rh), offsetAmount(off), squashAmount(sq),
+          offsetFrequency(offfreq), squashFrequency(sqfreq) {}
+
+    Vec3 value(const Vec2&, const Vec3& p) const override {
+        // Cycles intern/cycles/kernel/svm/brick.h::svm_brick (Apache-2.0).
+        // 3D input: uses p.x, p.y (ignores p.z per Cycles).
+        Vec3 coord = p * scale;
+
+        int rownum = static_cast<int>(std::floor(coord.y / rowHeight));
+
+        float brick_w = brickWidth;
+        float offset = 0.0f;
+        if (offsetFrequency != 0 && squashFrequency != 0) {
+            brick_w *= (rownum % squashFrequency) ? 1.0f : squashAmount;
+            offset = (rownum % offsetFrequency) ? 0.0f : brick_w * offsetAmount;
+        }
+
+        int bricknum = static_cast<int>(std::floor((coord.x + offset) / brick_w));
+
+        float x = (coord.x + offset) - brick_w * bricknum;
+        float y = coord.y - rowHeight * rownum;
+
+        // Per-brick random tint: mix color1 -> color2 by (hash + bias).
+        uint32_t hash_in = (static_cast<uint32_t>(rownum) << 16) + (static_cast<uint32_t>(bricknum) & 0xFFFFu);
+        float tint_raw = static_cast<float>(brick_noise(hash_in)) / 2147483647.0f;
+        float tint = std::clamp(tint_raw + bias, 0.0f, 1.0f);
+        Vec3 brick_color = color1 * (1.0f - tint) + color2 * tint;
+
+        // Mortar test: minimum distance to brick edge.
+        float min_dist = std::min({x, y, brick_w - x, rowHeight - y});
+        float mortar;
+        if (min_dist >= mortarSize) {
+            mortar = 0.0f;
+        } else if (mortarSmooth == 0.0f) {
+            mortar = 1.0f;
+        } else {
+            // Cycles smoothstep inversion: (1 - min_dist / mortar_size) / mortar_smooth.
+            float t = (1.0f - min_dist / mortarSize) / mortarSmooth;
+            t = std::clamp(t, 0.0f, 1.0f);
+            mortar = t * t * (3.0f - 2.0f * t);
+        }
+
+        return brick_color * (1.0f - mortar) + colorMortar * mortar;
+    }
+};
+
+// --- Musgrave (fBm) texture ---
+// ============================================================================
+// HASH FAMILY (pkg115 chunk 2)
+// ============================================================================
+// Ported from Blender intern/cycles/util/hash.h (Apache-2.0).
+// SPDX-FileCopyrightText: 2011-2022 Blender Foundation
+// SPDX-License-Identifier: Apache-2.0
+//
+// Jenkins Lookup3 hash core. Required by Perlin, Voronoi, White Noise, and
+// the Noise node's random offsets. Bit-identical to Cycles for parity.
+
 class WhiteNoiseTexture : public Texture {
 public:
     WhiteNoiseTexture() = default;

--- a/include/advanced_features.h
+++ b/include/advanced_features.h
@@ -338,50 +338,88 @@ public:
 };
 
 // --- Wave texture ---
-// bandDir: 0=bands, 1=rings; profile: 0=sine, 1=saw, 2=triangle
+// Ported from Blender intern/cycles/kernel/svm/wave.h (Apache-2.0).
+// SPDX-FileCopyrightText: 2011-2022 Blender Foundation
+// SPDX-License-Identifier: Apache-2.0
+//
+// pkg115 chunk 3: full parity with Blender/Cycles Wave node.
+// wave_type: 0=Bands, 1=Rings
+// bands_direction: 0=X, 1=Y, 2=Z, 3=Diagonal
+// rings_direction: 0=X, 1=Y, 2=Z, 3=Spherical
+// profile: 0=Sine, 1=Saw, 2=Triangle
 class WaveTexture : public Texture {
-    int bandDir;   // 0=bands (X), 1=rings (radial)
-    int profile;   // 0=sine, 1=saw, 2=triangle
-    float scale, distortion, detail, roughness, lacunarity;
+    int waveType;           // 0=bands, 1=rings
+    int bandsDirection;     // 0=X, 1=Y, 2=Z, 3=Diagonal
+    int ringsDirection;     // 0=X, 1=Y, 2=Z, 3=Spherical
+    int profile;            // 0=sine, 1=saw, 2=triangle
+    float scale, distortion, detail, detailScale, detailRoughness, phaseOffset;
     Vec3 colorLow, colorHigh;
 public:
-    WaveTexture(int bd = 0, int prof = 0, float sc = 5.0f, float dist = 0.0f,
-                float det = 2.0f, float rough = 0.5f, float lac = 2.0f,
+    WaveTexture(int wt = 0, int bd = 0, int rd = 0, int prof = 0,
+                float sc = 5.0f, float dist = 0.0f, float det = 2.0f,
+                float dscale = 1.0f, float drough = 0.5f, float phase = 0.0f,
                 const Vec3& c1 = Vec3(0), const Vec3& c2 = Vec3(1))
-        : bandDir(bd), profile(prof), scale(sc), distortion(dist),
-          detail(det), roughness(rough), lacunarity(lac), colorLow(c1), colorHigh(c2) {}
-
-    static float turbulence(const Vec3& p, float det, float rough, float lac) {
-        float accum = 0, w = 1.0f;
-        Vec3 pp = p;
-        int steps = std::max(1, (int)det);
-        for (int i = 0; i < steps; ++i) {
-            accum += w * NoiseTexture::noise(pp);
-            w *= rough;
-            pp = pp * lac;
-        }
-        return accum;
-    }
+        : waveType(wt), bandsDirection(bd), ringsDirection(rd), profile(prof),
+          scale(sc), distortion(dist), detail(det), detailScale(dscale),
+          detailRoughness(drough), phaseOffset(phase), colorLow(c1), colorHigh(c2) {}
 
     Vec3 value(const Vec2&, const Vec3& p) const override {
-        Vec3 sp = p * scale;
-        float d = distortion > 0.0f ? distortion * turbulence(sp, detail, roughness, lacunarity) : 0.0f;
-        float phase;
-        if (bandDir == 1) {
-            float r = std::sqrt(sp.x*sp.x + sp.y*sp.y + sp.z*sp.z);
-            phase = (r + d) * float(M_PI);
+        // Cycles intern/cycles/kernel/svm/wave.h::svm_wave (Apache-2.0).
+        // Precision guard per Cycles.
+        Vec3 pp = (p + Vec3(0.000001f)) * 0.999999f;
+        pp = pp * scale;
+
+        float n = 0.0f;
+        if (waveType == 0) {
+            // Bands
+            switch (bandsDirection) {
+                case 0: n = pp.x * 20.0f; break;  // X
+                case 1: n = pp.y * 20.0f; break;  // Y
+                case 2: n = pp.z * 20.0f; break;  // Z
+                case 3: n = (pp.x + pp.y + pp.z) * 10.0f; break;  // Diagonal
+            }
         } else {
-            phase = (sp.x + d) * float(M_PI);
+            // Rings: zero one axis then len * 20
+            Vec3 rp = pp;
+            switch (ringsDirection) {
+                case 0: rp.x = 0.0f; break;  // X
+                case 1: rp.y = 0.0f; break;  // Y
+                case 2: rp.z = 0.0f; break;  // Z
+                case 3: break;  // Spherical (no zeroing)
+            }
+            float r = std::sqrt(rp.x*rp.x + rp.y*rp.y + rp.z*rp.z);
+            n = r * 20.0f;
         }
+
+        n += phaseOffset;
+
+        if (distortion != 0.0f) {
+            // Distortion via SIGNED fBM (lacunarity fixed 2.0, normalized).
+            float distort = fractal_noise::noise_fbm(pp * detailScale, detail,
+                                                     detailRoughness, 2.0f, true);
+            n += distortion * (distort * 2.0f - 1.0f);
+        }
+
         float t;
-        if (profile == 1) { // saw
-            t = 1.0f - std::fmod(phase / float(M_PI), 1.0f);
-        } else if (profile == 2) { // triangle
-            float x = std::fmod(phase / float(M_PI), 1.0f);
-            t = x < 0.5f ? 2.0f * x : 2.0f - 2.0f * x;
-        } else { // sine
-            t = 0.5f + 0.5f * std::sin(phase);
+        const float pi = 3.14159265358979323846f;
+        const float two_pi = 2.0f * pi;
+        switch (profile) {
+            case 1: {  // Saw
+                float frac = n / two_pi;
+                t = frac - std::floor(frac);
+                break;
+            }
+            case 2: {  // Triangle
+                float frac = n / two_pi;
+                t = std::abs(frac - std::floor(frac + 0.5f)) * 2.0f;
+                break;
+            }
+            default: {  // Sine
+                t = 0.5f + 0.5f * std::sin(n - pi / 2.0f);
+                break;
+            }
         }
+
         return colorLow * (1.0f - t) + colorHigh * t;
     }
 };
@@ -529,29 +567,80 @@ public:
 };
 
 // --- Brick texture ---
+// Ported from Blender intern/cycles/kernel/svm/brick.h (Apache-2.0).
+// SPDX-FileCopyrightText: 2011-2022 Blender Foundation
+// SPDX-License-Identifier: Apache-2.0
+//
+// pkg115 chunk 3: full parity with Blender/Cycles Brick node.
+// 3D input (p.x, p.y), mortar_smooth, bias, per-brick color variation,
+// offset_frequency, squash/squash_frequency.
 class BrickTexture : public Texture {
-    Vec3 colorBrick, colorMortar;
-    float brickWidth, brickHeight, mortarSize, offset, scale;
+    Vec3 color1, color2, colorMortar;
+    float scale, mortarSize, mortarSmooth, bias, brickWidth, rowHeight;
+    float offsetAmount, squashAmount;
+    int offsetFrequency, squashFrequency;
+
+    static inline uint32_t brick_noise(uint32_t n) {
+        // Cycles intern/cycles/kernel/svm/brick.h:14-21 (Apache-2.0).
+        // Integer hash for per-brick color variation.
+        uint32_t nn = (n + 1013u) & 0x7fffffffu;
+        nn = (nn >> 13u) ^ nn;
+        uint32_t nnn = (nn * (nn * nn * 60493u + 19990303u) + 1376312589u) & 0x7fffffffu;
+        return nnn;
+    }
+
 public:
-    BrickTexture(const Vec3& brick = Vec3(0.7f, 0.35f, 0.2f),
-                 const Vec3& mortar = Vec3(0.9f),
-                 float bw = 0.5f, float bh = 0.25f, float mort = 0.02f,
-                 float off = 0.5f, float sc = 5.0f)
-        : colorBrick(brick), colorMortar(mortar),
-          brickWidth(std::max(0.001f, bw)), brickHeight(std::max(0.001f, bh)),
-          mortarSize(mort), offset(off), scale(sc) {}
-    Vec3 value(const Vec2& uv, const Vec3&) const override {
-        float u = uv.u * scale;
-        float v = uv.v * scale;
-        int row = (int)std::floor(v / brickHeight);
-        float rowOffset = (row % 2 == 0) ? 0.0f : offset * brickWidth;
-        float uu = std::fmod(u - rowOffset, brickWidth);
-        if (uu < 0) uu += brickWidth;
-        float vv = std::fmod(v, brickHeight);
-        float half = mortarSize * 0.5f;
-        if (uu < half || uu > brickWidth - half || vv < half || vv > brickHeight - half)
-            return colorMortar;
-        return colorBrick;
+    BrickTexture(const Vec3& c1 = Vec3(0.8f),
+                 const Vec3& c2 = Vec3(0.2f),
+                 const Vec3& mortar = Vec3(0.0f),
+                 float sc = 5.0f, float mort = 0.02f, float msmooth = 0.1f,
+                 float b = 0.0f, float bw = 0.5f, float rh = 0.25f,
+                 float off = 0.5f, int offfreq = 2, float sq = 1.0f, int sqfreq = 2)
+        : color1(c1), color2(c2), colorMortar(mortar),
+          scale(sc), mortarSize(mort), mortarSmooth(msmooth), bias(b),
+          brickWidth(bw), rowHeight(rh), offsetAmount(off), squashAmount(sq),
+          offsetFrequency(offfreq), squashFrequency(sqfreq) {}
+
+    Vec3 value(const Vec2&, const Vec3& p) const override {
+        // Cycles intern/cycles/kernel/svm/brick.h::svm_brick (Apache-2.0).
+        // 3D input: uses p.x, p.y (ignores p.z per Cycles).
+        Vec3 coord = p * scale;
+
+        int rownum = static_cast<int>(std::floor(coord.y / rowHeight));
+
+        float brick_w = brickWidth;
+        float offset = 0.0f;
+        if (offsetFrequency != 0 && squashFrequency != 0) {
+            brick_w *= (rownum % squashFrequency) ? 1.0f : squashAmount;
+            offset = (rownum % offsetFrequency) ? 0.0f : brick_w * offsetAmount;
+        }
+
+        int bricknum = static_cast<int>(std::floor((coord.x + offset) / brick_w));
+
+        float x = (coord.x + offset) - brick_w * bricknum;
+        float y = coord.y - rowHeight * rownum;
+
+        // Per-brick random tint: mix color1 -> color2 by (hash + bias).
+        uint32_t hash_in = (static_cast<uint32_t>(rownum) << 16) + (static_cast<uint32_t>(bricknum) & 0xFFFFu);
+        float tint_raw = static_cast<float>(brick_noise(hash_in)) / 2147483647.0f;
+        float tint = std::clamp(tint_raw + bias, 0.0f, 1.0f);
+        Vec3 brick_color = color1 * (1.0f - tint) + color2 * tint;
+
+        // Mortar test: minimum distance to brick edge.
+        float min_dist = std::min({x, y, brick_w - x, rowHeight - y});
+        float mortar;
+        if (min_dist >= mortarSize) {
+            mortar = 0.0f;
+        } else if (mortarSmooth == 0.0f) {
+            mortar = 1.0f;
+        } else {
+            // Cycles smoothstep inversion: (1 - min_dist / mortar_size) / mortar_smooth.
+            float t = (1.0f - min_dist / mortarSize) / mortarSmooth;
+            t = std::clamp(t, 0.0f, 1.0f);
+            mortar = t * t * (3.0f - 2.0f * t);
+        }
+
+        return brick_color * (1.0f - mortar) + colorMortar * mortar;
     }
 };
 

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -210,17 +210,22 @@ public:
             Vec3 c2 = params.size() > 7 ? Vec3(params[5], params[6], params[7]) : Vec3(1);
             proceduralTextures[name] = std::make_shared<GradientTexture>(gt, c1, c2, sc);
         } else if (type == "wave") {
-            // params: [band_dir, profile, scale, distortion, detail, roughness, lacunarity, r1,g1,b1, r2,g2,b2]
+            // Legacy positional params: [band_dir, profile, scale, distortion,
+            // detail, roughness, lacunarity, r1,g1,b1, r2,g2,b2]. pkg115 chunk 3:
+            // mapped onto the Cycles-parity ctor (wave_type=bands; the legacy
+            // lacunarity slot is accepted but unused - the Cycles Wave node has
+            // no lacunarity socket, its fBM detail uses the svm/wave.h scheme).
             int bd = params.size() > 0 ? (int)params[0] : 0;
             int pf = params.size() > 1 ? (int)params[1] : 0;
             float sc = params.size() > 2 ? params[2] : 5.0f;
             float dist = params.size() > 3 ? params[3] : 0.0f;
             float det = params.size() > 4 ? params[4] : 2.0f;
             float rough = params.size() > 5 ? params[5] : 0.5f;
-            float lac = params.size() > 6 ? params[6] : 2.0f;
             Vec3 c1 = params.size() > 9 ? Vec3(params[7], params[8], params[9]) : Vec3(0);
             Vec3 c2 = params.size() > 12 ? Vec3(params[10], params[11], params[12]) : Vec3(1);
-            proceduralTextures[name] = std::make_shared<WaveTexture>(bd, pf, sc, dist, det, rough, lac, c1, c2);
+            proceduralTextures[name] = std::make_shared<WaveTexture>(
+                /*wave_type=*/0, bd, /*rings_dir=*/0, pf, sc, dist, det,
+                /*detail_scale=*/1.0f, rough, /*phase=*/0.0f, c1, c2);
         } else if (type == "magic") {
             // params: [depth, scale, distortion, r1,g1,b1, r2,g2,b2]
             int depth = params.size() > 0 ? (int)params[0] : 2;
@@ -248,7 +253,13 @@ public:
             float ms = params.size() > 8 ? params[8] : 0.02f;
             float off = params.size() > 9 ? params[9] : 0.5f;
             float sc = params.size() > 10 ? params[10] : 5.0f;
-            proceduralTextures[name] = std::make_shared<BrickTexture>(brick, mortar, bw, bh, ms, off, sc);
+            // pkg115 chunk 3: mapped onto the Cycles-parity ctor. The legacy
+            // API has one brick color (no color2 variation) - pass it for both
+            // so per-brick variation is a no-op, preserving legacy output intent.
+            proceduralTextures[name] = std::make_shared<BrickTexture>(
+                brick, brick, mortar, sc, ms, /*mortar_smooth=*/0.1f,
+                /*bias=*/0.0f, bw, bh, off, /*offset_freq=*/2,
+                /*squash=*/1.0f, /*squash_freq=*/2);
         } else if (type == "musgrave") {
             // params: [musgrave_type, scale, detail, dimension, lacunarity, gain, r1,g1,b1, r2,g2,b2]
             int mt = params.size() > 0 ? (int)params[0] : 0;

--- a/plugins/textures/brick.cpp
+++ b/plugins/textures/brick.cpp
@@ -5,13 +5,19 @@ class BrickPlugin : public BrickTexture {
 public:
     explicit BrickPlugin(const astroray::ParamDict& p)
         : BrickTexture(
-            p.getVec3("color_brick", Vec3(0.7f, 0.35f, 0.2f)),
-            p.getVec3("color_mortar", Vec3(0.9f)),
-            p.getFloat("brick_width", 0.5f),
-            p.getFloat("brick_height", 0.25f),
+            p.getVec3("color1", Vec3(0.8f)),
+            p.getVec3("color2", Vec3(0.2f)),
+            p.getVec3("color_mortar", Vec3(0.0f)),
+            p.getFloat("scale", 5.0f),
             p.getFloat("mortar_size", 0.02f),
-            p.getFloat("offset", 0.5f),
-            p.getFloat("scale", 5.0f)) {}
+            p.getFloat("mortar_smooth", 0.1f),
+            p.getFloat("bias", 0.0f),
+            p.getFloat("brick_width", 0.5f),
+            p.getFloat("row_height", 0.25f),
+            p.getFloat("offset_amount", 0.5f),
+            static_cast<int>(p.getFloat("offset_frequency", 2.0f)),
+            p.getFloat("squash_amount", 1.0f),
+            static_cast<int>(p.getFloat("squash_frequency", 2.0f))) {}
     astroray::SampledSpectrum sampleSpectral(
             const Vec2& uv, const Vec3& p,
             const astroray::SampledWavelengths& lambdas) const override {

--- a/plugins/textures/wave.cpp
+++ b/plugins/textures/wave.cpp
@@ -5,13 +5,16 @@ class WavePlugin : public WaveTexture {
 public:
     explicit WavePlugin(const astroray::ParamDict& p)
         : WaveTexture(
-            static_cast<int>(p.getFloat("band_dir", 0.0f)),
+            static_cast<int>(p.getFloat("wave_type", 0.0f)),
+            static_cast<int>(p.getFloat("bands_direction", 0.0f)),
+            static_cast<int>(p.getFloat("rings_direction", 0.0f)),
             static_cast<int>(p.getFloat("profile", 0.0f)),
             p.getFloat("scale", 5.0f),
             p.getFloat("distortion", 0.0f),
             p.getFloat("detail", 2.0f),
-            p.getFloat("roughness", 0.5f),
-            p.getFloat("lacunarity", 2.0f),
+            p.getFloat("detail_scale", 1.0f),
+            p.getFloat("detail_roughness", 0.5f),
+            p.getFloat("phase_offset", 0.0f),
             p.getVec3("color_low", Vec3(0.0f)),
             p.getVec3("color_high", Vec3(1.0f))) {}
     astroray::SampledSpectrum sampleSpectral(

--- a/tests/test_pkg115_wave_brick_parity.py
+++ b/tests/test_pkg115_wave_brick_parity.py
@@ -1,0 +1,476 @@
+"""
+pkg115 Stage 2 chunk 3 parity tests: Wave + Brick (audit items 7-8).
+
+Wave texture ported from Blender intern/cycles/kernel/svm/wave.h (Apache-2.0).
+Brick texture ported from Blender intern/cycles/kernel/svm/brick.h (Apache-2.0).
+
+Per CLAUDE.md section 6, all formulas cited to exact Cycles files + licenses.
+"""
+import pytest
+import math
+
+
+def test_wave_bands_x_sine_phase_factor():
+    """Wave bands-X sine: phase factor 20.0 (not pi).
+
+    Cycles intern/cycles/kernel/svm/wave.h (Apache-2.0):
+      bands-X: n = p.x * 20.0
+      sine profile: t = 0.5 + 0.5 * sin(n - pi/2)
+
+    At x=0.1, scale=1, phase_offset=0:
+      n = 0.1 * 20 = 2.0
+      t = 0.5 + 0.5 * sin(2.0 - pi/2) = 0.5 + 0.5 * sin(2.0 - 1.5708)
+        = 0.5 + 0.5 * sin(0.4292) = 0.5 + 0.5 * 0.4161 = 0.7080
+
+    Output color = c1*(1-t) + c2*t.
+    For c1=(0,0,0), c2=(1,1,1): output = (0.7080, 0.7080, 0.7080).
+    """
+    import astroray
+    r = astroray.Renderer()
+
+    params = {
+        "wave_type": 0,         # Bands
+        "bands_direction": 0,   # X
+        "profile": 0,           # Sine
+        "scale": 1.0,
+        "distortion": 0.0,
+        "phase_offset": 0.0,
+        "color_low": [0.0, 0.0, 0.0],
+        "color_high": [1.0, 1.0, 1.0]
+    }
+    val = r.eval_texture_at_3d("wave", params, 0.1, 0.0, 0.0)
+    expected = 0.5 + 0.5 * math.sin(2.0 - math.pi / 2.0)
+    assert abs(val[0] - expected) < 0.01, f"Wave bands-X sine at x=0.1: expected {expected}, got {val[0]}"
+
+
+def test_wave_bands_diagonal():
+    """Wave bands diagonal: n = (x + y + z) * 10.0.
+
+    At (0.1, 0.1, 0.1), scale=1, sine profile:
+      n = (0.1 + 0.1 + 0.1) * 10 = 3.0
+      t = 0.5 + 0.5 * sin(3.0 - pi/2) = 0.5 + 0.5 * sin(1.4292) = 0.5 + 0.5 * 0.9900 = 0.9950
+    """
+    import astroray
+    r = astroray.Renderer()
+
+    params = {
+        "wave_type": 0,
+        "bands_direction": 3,  # Diagonal
+        "profile": 0,
+        "scale": 1.0,
+        "distortion": 0.0,
+        "phase_offset": 0.0,
+        "color_low": [0.0, 0.0, 0.0],
+        "color_high": [1.0, 1.0, 1.0]
+    }
+    val = r.eval_texture_at_3d("wave", params, 0.1, 0.1, 0.1)
+    expected = 0.5 + 0.5 * math.sin(3.0 - math.pi / 2.0)
+    assert abs(val[0] - expected) < 0.01, f"Wave diagonal: expected {expected:.4f}, got {val[0]:.4f}"
+
+
+def test_wave_rings_spherical():
+    """Wave rings spherical: no axis zeroing, n = len(p) * 20.
+
+    At (0.05, 0.0, 0.0), rings spherical, scale=1, sine:
+      len = 0.05, n = 0.05 * 20 = 1.0
+      t = 0.5 + 0.5 * sin(1.0 - pi/2) = 0.5 + 0.5 * sin(-0.5708) = 0.5 + 0.5 * (-0.5403) = 0.2298
+
+    Compare rings-X (zero x axis): at (0.05, 0.0, 0.0), len((0, 0, 0)) = 0 -> n=0.
+      t = 0.5 + 0.5 * sin(-pi/2) = 0.5 + 0.5 * (-1) = 0.0
+    These must differ.
+    """
+    import astroray
+    r = astroray.Renderer()
+
+    params_sph = {
+        "wave_type": 1,         # Rings
+        "rings_direction": 3,   # Spherical
+        "profile": 0,
+        "scale": 1.0,
+        "distortion": 0.0,
+        "phase_offset": 0.0,
+        "color_low": [0.0, 0.0, 0.0],
+        "color_high": [1.0, 1.0, 1.0]
+    }
+    val_sph = r.eval_texture_at_3d("wave", params_sph, 0.05, 0.0, 0.0)
+    expected_sph = 0.5 + 0.5 * math.sin(1.0 - math.pi / 2.0)
+    assert abs(val_sph[0] - expected_sph) < 0.01, f"Rings spherical: expected {expected_sph:.4f}, got {val_sph[0]:.4f}"
+
+    params_x = {
+        "wave_type": 1,
+        "rings_direction": 0,  # X (zero x)
+        "profile": 0,
+        "scale": 1.0,
+        "distortion": 0.0,
+        "phase_offset": 0.0,
+        "color_low": [0.0, 0.0, 0.0],
+        "color_high": [1.0, 1.0, 1.0]
+    }
+    val_x = r.eval_texture_at_3d("wave", params_x, 0.05, 0.0, 0.0)
+    expected_x = 0.5 + 0.5 * math.sin(0.0 - math.pi / 2.0)
+    assert abs(val_x[0] - expected_x) < 0.01, f"Rings-X: expected {expected_x:.4f}, got {val_x[0]:.4f}"
+    assert abs(val_sph[0] - val_x[0]) > 0.1, "Rings spherical vs X must differ at same point"
+
+
+def test_wave_profile_saw():
+    """Wave saw profile: ascending sawtooth period 2pi.
+
+    Cycles svm/wave.h: saw: frac = n / (2*pi); return frac - floor(frac);
+    At n=1.0: frac = 1.0 / 6.283 = 0.1592, t = 0.1592.
+    At n=6.0: frac = 6.0 / 6.283 = 0.9549, t = 0.9549.
+    """
+    import astroray
+    r = astroray.Renderer()
+
+    params = {
+        "wave_type": 0,
+        "bands_direction": 0,  # X
+        "profile": 1,          # Saw
+        "scale": 1.0,
+        "distortion": 0.0,
+        "phase_offset": 0.0,
+        "color_low": [0.0, 0.0, 0.0],
+        "color_high": [1.0, 1.0, 1.0]
+    }
+    # x=0.05 -> n=0.05*20=1.0
+    val1 = r.eval_texture_at_3d("wave", params, 0.05, 0.0, 0.0)
+    expected1 = 1.0 / (2.0 * math.pi)
+    assert abs(val1[0] - expected1) < 0.01, f"Saw at n=1.0: expected {expected1:.4f}, got {val1[0]:.4f}"
+
+    # x=0.3 -> n=0.3*20=6.0
+    val2 = r.eval_texture_at_3d("wave", params, 0.3, 0.0, 0.0)
+    expected2 = 6.0 / (2.0 * math.pi) - math.floor(6.0 / (2.0 * math.pi))
+    assert abs(val2[0] - expected2) < 0.01, f"Saw at n=6.0: expected {expected2:.4f}, got {val2[0]:.4f}"
+
+
+def test_wave_profile_triangle():
+    """Wave triangle: period 2pi, symmetric.
+
+    Cycles svm/wave.h: frac = n / (2*pi); return abs(frac - floor(frac + 0.5)) * 2.
+    At n=pi/2 (quarter period): frac=0.25, frac-floor(0.75)=0.25-0=0.25, abs*2 = 0.5.
+    At n=pi: frac=0.5, frac-floor(1.0)=0.5-1=-0.5, abs*2 = 1.0 (peak).
+    """
+    import astroray
+    r = astroray.Renderer()
+
+    params = {
+        "wave_type": 0,
+        "bands_direction": 0,
+        "profile": 2,  # Triangle
+        "scale": 1.0,
+        "distortion": 0.0,
+        "phase_offset": 0.0,
+        "color_low": [0.0, 0.0, 0.0],
+        "color_high": [1.0, 1.0, 1.0]
+    }
+    # n = pi -> x = pi/20
+    x_peak = math.pi / 20.0
+    val_peak = r.eval_texture_at_3d("wave", params, x_peak, 0.0, 0.0)
+    assert abs(val_peak[0] - 1.0) < 0.01, f"Triangle peak: expected 1.0, got {val_peak[0]:.4f}"
+
+    # n = pi/2 -> x = pi/40
+    x_mid = math.pi / 40.0
+    val_mid = r.eval_texture_at_3d("wave", params, x_mid, 0.0, 0.0)
+    assert abs(val_mid[0] - 0.5) < 0.01, f"Triangle quarter: expected 0.5, got {val_mid[0]:.4f}"
+
+
+def test_wave_detail_changes_output():
+    """Wave distortion uses real fBM: detail>0 changes output.
+
+    Cycles svm/wave.h: distortion != 0 adds noise_fbm(p*dscale, detail, drough, 2.0, true)*2-1.
+    At distortion=0 vs distortion>0 with detail>0, outputs differ.
+    """
+    import astroray
+    r = astroray.Renderer()
+
+    params_no_dist = {
+        "wave_type": 0,
+        "bands_direction": 0,
+        "profile": 0,
+        "scale": 1.0,
+        "distortion": 0.0,
+        "detail": 2.0,
+        "detail_scale": 1.0,
+        "detail_roughness": 0.5,
+        "phase_offset": 0.0,
+        "color_low": [0.0, 0.0, 0.0],
+        "color_high": [1.0, 1.0, 1.0]
+    }
+    # Avoid integer lattice (snoise=0); use offset coordinates.
+    val_no = r.eval_texture_at_3d("wave", params_no_dist, 0.37, 0.0, 0.0)
+
+    params_with_dist = dict(params_no_dist)
+    params_with_dist["distortion"] = 1.0
+    val_with = r.eval_texture_at_3d("wave", params_with_dist, 0.37, 0.0, 0.0)
+
+    assert abs(val_no[0] - val_with[0]) > 0.01, f"Distortion>0 must change output: no={val_no[0]:.4f}, with={val_with[0]:.4f}"
+
+
+def test_wave_phase_offset():
+    """Wave phase_offset shifts the pattern.
+
+    At phase_offset=pi, sine output shifts by a half-period.
+    """
+    import astroray
+    r = astroray.Renderer()
+
+    params_zero = {
+        "wave_type": 0,
+        "bands_direction": 0,
+        "profile": 0,
+        "scale": 1.0,
+        "distortion": 0.0,
+        "phase_offset": 0.0,
+        "color_low": [0.0, 0.0, 0.0],
+        "color_high": [1.0, 1.0, 1.0]
+    }
+    val_zero = r.eval_texture_at_3d("wave", params_zero, 0.1, 0.0, 0.0)
+
+    params_offset = dict(params_zero)
+    params_offset["phase_offset"] = math.pi
+    val_offset = r.eval_texture_at_3d("wave", params_offset, 0.1, 0.0, 0.0)
+
+    assert abs(val_zero[0] - val_offset[0]) > 0.1, f"Phase offset pi must shift output: zero={val_zero[0]:.4f}, offset={val_offset[0]:.4f}"
+
+
+def test_brick_cell_classification():
+    """Brick cell classification: known coords map to brick vs mortar.
+
+    Cycles intern/cycles/kernel/svm/brick.h (Apache-2.0):
+      rownum = floor(coord.y / row_height)
+      bricknum = floor((coord.x + offset) / brick_width)
+      min_dist = min(x, y, brick_w - x, row_h - y)
+      mortar = (min_dist >= mortar_size) ? 0 : ...
+
+    Default: brick_width=0.5, row_height=0.25, mortar_size=0.02, scale=5.
+    At p=(0.1, 0.1, 0.0), scale=1 (not 5): coord=(0.1, 0.1).
+      rownum = floor(0.1 / 0.25) = 0.
+      offset = (0 % 2) ? 0 : offset_amount*brick_width = 0.5*0.5 = 0.25 (offset_frequency=2).
+      bricknum = floor((0.1 + 0.25) / 0.5) = floor(0.7) = 1.
+      x = 0.35 - 0.5*1 = -0.15 (negative wrap issue? NO: Cycles computes (coord.x+offset) - brick_w*bricknum = 0.35 - 0.5 = -0.15... Actually coord.x=0.1, offset=0.25, sum=0.35, bricknum=floor(0.35/0.5)=0, x=0.35-0=0.35).
+
+    Recompute: rownum=0, offset=0.25, bricknum=floor((0.1+0.25)/0.5)=floor(0.7)=1, x=0.35-0.5*1=-0.15.
+    Wait, that's negative. Cycles code: x = (coord.x + offset) - brick_width * bricknum.
+    (0.1+0.25) = 0.35, brick_width=0.5, bricknum=floor(0.35/0.5)=0, x=0.35-0=0.35.
+
+    Actually at row=0 with offset_frequency=2: (rownum % offset_frequency) = 0%2=0, so offset = brick_w*offset_amount = 0.5*0.5=0.25.
+    bricknum = floor((0.1+0.25)/0.5) = floor(0.7) = 1.
+    x = 0.35 - 0.5*1 = -0.15. Negative x is a wrap issue in the engine port.
+
+    Actually the Cycles code line 37-38:
+      x = (coord.x + offset) - brick_width * bricknum
+    This can be negative if the modulo wasn't handled. Engine should match verbatim.
+
+    Instead of hand-computing wraparound edge cases, test a known INTERIOR brick point:
+    p=(0.3, 0.13, 0.0), scale=1, row_height=0.25, brick_width=0.5, mortar_size=0.02.
+      rownum=floor(0.13/0.25)=0, offset=0.25 (row 0 even).
+      bricknum=floor((0.3+0.25)/0.5)=floor(1.1)=2.
+      x=(0.55 - 0.5*2)=0.55-1.0=-0.45. Negative again.
+
+    The issue is my mental offset logic. Let me re-read Cycles brick.h lines 28-32:
+      if (offset_frequency && squash_frequency) {
+        brick_width *= (rownum % squash_frequency) ? 1 : squash_amount;
+        offset = (rownum % offset_frequency) ? 0 : brick_width * offset_amount;
+      }
+    For row=0, offset_frequency=2: rownum%2=0 -> offset = brick_width*offset_amount.
+    For row=1, rownum%2=1 -> offset=0.
+
+    At row=0, offset=0.25. At row=1, offset=0. So a clean brick center in row 1:
+    p=(0.25, 0.38, 0) -> rownum=floor(0.38/0.25)=1, offset=0.
+      bricknum=floor(0.25/0.5)=0, x=0.25-0=0.25, y=0.38-0.25*1=0.13.
+      min_dist = min(0.25, 0.13, 0.5-0.25=0.25, 0.25-0.13=0.12) = 0.12.
+      0.12 >= 0.02 -> brick interior.
+
+    Color1=(0.8,0.8,0.8), Color2=(0.2,0.2,0.2), bias=0.
+      hash((1<<16) + (0&0xFFFF)) = hash(65536).
+      Without computing the exact hash, output = color1*(1-tint) + color2*tint, tint in [0,1].
+      Output should be in [0.2, 0.8] per channel, NOT the mortar color (0,0,0 default).
+    """
+    import astroray
+    r = astroray.Renderer()
+
+    params = {
+        "color1": [0.8, 0.8, 0.8],
+        "color2": [0.2, 0.2, 0.2],
+        "color_mortar": [0.0, 0.0, 0.0],
+        "scale": 1.0,
+        "mortar_size": 0.02,
+        "mortar_smooth": 0.0,
+        "bias": 0.0,
+        "brick_width": 0.5,
+        "row_height": 0.25,
+        "offset_amount": 0.5,
+        "offset_frequency": 2,
+        "squash_amount": 1.0,
+        "squash_frequency": 2
+    }
+    # Brick interior point (row 1, no offset, centered).
+    val_brick = r.eval_texture_at_3d("brick", params, 0.25, 0.38, 0.0)
+    assert 0.15 < val_brick[0] < 0.85, f"Brick interior: expected [0.2,0.8], got {val_brick[0]:.4f}"
+    assert abs(val_brick[0]) > 0.01, f"Brick interior must not be mortar (0,0,0), got {val_brick[0]:.4f}"
+
+    # Mortar point: edge of brick at x near 0.
+    val_mortar = r.eval_texture_at_3d("brick", params, 0.01, 0.38, 0.0)
+    assert abs(val_mortar[0]) < 0.01, f"Mortar edge: expected 0.0, got {val_mortar[0]:.4f}"
+
+
+def test_brick_mortar_size_zero():
+    """Brick mortar_size=0: no mortar, all brick.
+
+    At mortar_size=0, min_dist >= 0 always -> mortar=0 -> pure brick color.
+    """
+    import astroray
+    r = astroray.Renderer()
+
+    params = {
+        "color1": [1.0, 0.0, 0.0],
+        "color2": [0.0, 1.0, 0.0],
+        "color_mortar": [0.0, 0.0, 1.0],
+        "scale": 1.0,
+        "mortar_size": 0.0,
+        "mortar_smooth": 0.0,
+        "bias": 0.0,
+        "brick_width": 0.5,
+        "row_height": 0.25,
+        "offset_amount": 0.5,
+        "offset_frequency": 2,
+        "squash_amount": 1.0,
+        "squash_frequency": 2
+    }
+    val = r.eval_texture_at_3d("brick", params, 0.0, 0.0, 0.0)
+    # mortar_size=0 -> min_dist always >= 0 -> mortar=0 -> output = brick_color.
+    # brick_color = color1*(1-tint) + color2*tint. tint from hash is non-zero.
+    # Blue component (mortar) must be 0.
+    assert abs(val[2]) < 0.01, f"Mortar_size=0: blue (mortar) channel must be 0, got {val[2]:.4f}"
+    assert (val[0] > 0.1 or val[1] > 0.1), f"Mortar_size=0: must show brick colors (R or G), got {val}"
+
+
+def test_brick_bias_shifts_tint():
+    """Brick bias shifts the per-brick color tint.
+
+    tint = clamp(hash_result + bias, 0, 1).
+    At bias=-0.5, hash outputs near 0.5 shift down; at bias=+0.5, shift up.
+    We verify that changing bias changes the output color.
+    """
+    import astroray
+    r = astroray.Renderer()
+
+    params_zero = {
+        "color1": [1.0, 1.0, 1.0],
+        "color2": [0.0, 0.0, 0.0],
+        "color_mortar": [0.5, 0.5, 0.5],
+        "scale": 1.0,
+        "mortar_size": 0.0,  # No mortar
+        "mortar_smooth": 0.0,
+        "bias": 0.0,
+        "brick_width": 0.5,
+        "row_height": 0.25,
+        "offset_amount": 0.5,
+        "offset_frequency": 2,
+        "squash_amount": 1.0,
+        "squash_frequency": 2
+    }
+    val_zero = r.eval_texture_at_3d("brick", params_zero, 0.25, 0.38, 0.0)
+
+    params_plus = dict(params_zero)
+    params_plus["bias"] = 0.3
+    val_plus = r.eval_texture_at_3d("brick", params_plus, 0.25, 0.38, 0.0)
+
+    params_minus = dict(params_zero)
+    params_minus["bias"] = -0.3
+    val_minus = r.eval_texture_at_3d("brick", params_minus, 0.25, 0.38, 0.0)
+
+    # Bias shifts tint -> shifts color1/color2 mix. At least one of +/- must differ from zero.
+    assert (abs(val_plus[0] - val_zero[0]) > 0.05 or abs(val_minus[0] - val_zero[0]) > 0.05), \
+        f"Bias must shift tint: zero={val_zero[0]:.4f}, +bias={val_plus[0]:.4f}, -bias={val_minus[0]:.4f}"
+
+
+def test_brick_per_brick_variation():
+    """Brick per-brick color variation: different bricks have different colors.
+
+    hash((rownum<<16) + (bricknum&0xFFFF)) produces different tints for different cells.
+    Sample two brick interiors in different cells; colors must differ.
+    """
+    import astroray
+    r = astroray.Renderer()
+
+    params = {
+        "color1": [1.0, 1.0, 1.0],
+        "color2": [0.0, 0.0, 0.0],
+        "color_mortar": [0.5, 0.5, 0.5],
+        "scale": 1.0,
+        "mortar_size": 0.0,
+        "mortar_smooth": 0.0,
+        "bias": 0.0,
+        "brick_width": 0.5,
+        "row_height": 0.25,
+        "offset_amount": 0.5,
+        "offset_frequency": 2,
+        "squash_amount": 1.0,
+        "squash_frequency": 2
+    }
+    # Brick 1: row=1, brick=0 (center at x=0.25, y=0.38).
+    val1 = r.eval_texture_at_3d("brick", params, 0.25, 0.38, 0.0)
+
+    # Brick 2: row=1, brick=1 (center at x=0.75, y=0.38).
+    val2 = r.eval_texture_at_3d("brick", params, 0.75, 0.38, 0.0)
+
+    # Different bricks -> different hash -> (usually) different tint.
+    # Hash is deterministic but pseudo-random; highly likely to differ.
+    assert abs(val1[0] - val2[0]) > 0.01, f"Different bricks must (usually) differ: brick1={val1[0]:.4f}, brick2={val2[0]:.4f}"
+
+    # Same brick, different points within -> same color.
+    val1_dup = r.eval_texture_at_3d("brick", params, 0.26, 0.38, 0.0)
+    assert abs(val1[0] - val1_dup[0]) < 0.001, f"Same brick interior must have same color: {val1[0]:.4f} vs {val1_dup[0]:.4f}"
+
+
+def test_brick_mortar_smooth():
+    """Brick mortar_smooth: smoothstep transition at mortar edge.
+
+    With mortar_smooth=0, mortar is a hard binary step.
+    With mortar_smooth>0, Cycles applies a smoothstep on (1 - min_dist/mortar_size)/mortar_smooth.
+    At a point just inside mortar_size, smooth>0 gives a gradient; smooth=0 gives full mortar.
+    """
+    import astroray
+    r = astroray.Renderer()
+
+    params_hard = {
+        "color1": [1.0, 1.0, 1.0],
+        "color2": [1.0, 1.0, 1.0],
+        "color_mortar": [0.0, 0.0, 0.0],
+        "scale": 1.0,
+        "mortar_size": 0.05,
+        "mortar_smooth": 0.0,  # Hard edge
+        "bias": 0.0,
+        "brick_width": 0.5,
+        "row_height": 0.25,
+        "offset_amount": 0.5,
+        "offset_frequency": 2,
+        "squash_amount": 1.0,
+        "squash_frequency": 2
+    }
+    # Point near edge: x=0.04 (min_dist from x=0 is 0.04, less than 0.05 -> mortar).
+    val_hard = r.eval_texture_at_3d("brick", params_hard, 0.04, 0.38, 0.0)
+    assert abs(val_hard[0]) < 0.01, f"Hard mortar edge: expected 0.0, got {val_hard[0]:.4f}"
+
+    params_smooth = dict(params_hard)
+    params_smooth["mortar_smooth"] = 0.1
+    val_smooth = r.eval_texture_at_3d("brick", params_smooth, 0.04, 0.38, 0.0)
+    # With smoothstep, the edge is not pure 0 or 1, but a blend.
+    # At min_dist=0.04, mortar_size=0.05, t=(1-0.04/0.05)/0.1 = (1-0.8)/0.1 = 2.0, clamped to 1.
+    # smoothstep(1) = 1 -> full mortar. Actually that's still mortar.
+    # Try a point slightly farther: x=0.045, min_dist=0.045.
+    val_smooth2 = r.eval_texture_at_3d("brick", params_smooth, 0.045, 0.38, 0.0)
+    # t=(1-0.045/0.05)/0.1 = (1-0.9)/0.1 = 1.0, smoothstep(1)=1.
+    # Still full mortar. The smoothstep transition happens near min_dist ~ mortar_size.
+    # At min_dist=0.04, t=(1-0.8)/0.1=2, clamped to 1 -> smoothstep(1)=1 -> full mortar.
+    # At min_dist=0.049, t=(1-0.98)/0.1=0.2, smoothstep(0.2)=0.2^2*(3-2*0.2)=0.04*2.6=0.104.
+    val_smooth3 = r.eval_texture_at_3d("brick", params_smooth, 0.049, 0.38, 0.0)
+    # mortar = 0.104 -> output = brick*(1-0.104) + mortar*0.104 = 1.0*0.896 + 0.0*0.104 = 0.896.
+    # This is a partial blend, not pure brick or pure mortar.
+    # Just verify that smooth>0 produces a different value than smooth=0 at this edge.
+    val_hard3 = r.eval_texture_at_3d("brick", params_hard, 0.049, 0.38, 0.0)
+    # Hard: min_dist=0.049 < 0.05 -> mortar=1 -> pure mortar (0).
+    # Smooth: mortar ~ 0.1 -> output ~ 0.9.
+    assert abs(val_hard3[0]) < 0.01, f"Hard mortar at 0.049: expected 0.0, got {val_hard3[0]:.4f}"
+    assert val_smooth3[0] > 0.5, f"Smooth mortar at 0.049: expected partial blend ~0.9, got {val_smooth3[0]:.4f}"


### PR DESCRIPTION
Chunk 3 of pkg115 Stage 2 (audit items 7–8): Wave and Brick rewritten in place per the audit.

## What
- **Wave** (cite `svm/wave.h`, Apache-2.0): fixes the documented ~6.4× density bug (phase factor 20.0, was π); real signed-fBM detail distortion via chunk 2's `fractal_noise::noise_fbm` (replaces the old unsigned sine-hash turbulence); band/ring direction enums (X/Y/Z/diagonal, X/Y/Z/spherical); sine/saw/triangle profiles exact; `phase_offset` param.
- **Brick** (cite `svm/brick.h`, Apache-2.0): 3D input, `brick_noise` integer hash bit-identical, row offset/squash with frequencies, mortar_smooth smoothstep, bias, per-brick color variation; Cycles socket param names.
- Legacy string-factory call sites mapped onto the new ctors (wave: wave_type=bands, legacy lacunarity slot accepted-but-unused — no Cycles socket; brick: legacy single color → color1==color2 so variation is a no-op, preserving legacy intent).
- Noise namespaces hoisted above WaveTexture (pure move, consumer ordering).

## Verification
- **51/51** wave/brick/noise/procedural/spectral-texture tests on a fresh Release build (RTX box).
- Independent review (pkg98): **SIGN-OFF** — line-by-line comparison against canonical `svm/wave.h`/`svm/brick.h` fetched from projects.blender.org; hand-computed test assertions re-derived; call-site sweep clean; namespace hoist verified pure-move.

Remaining chunks: Voronoi (largest; needs the signed-shift PCG3D already fixed in chunk 2) → addon translator + dedup + standalone CI example + RTX visual verify vs Cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)