### PR TITLE
fix(pkg55): root-cause megakernel env 1.85x divergence + worldMaxBounces env gate

### DIFF
--- a/.astroray_plan/packages/pkg55-wavefront-soa-refactor.md
+++ b/.astroray_plan/packages/pkg55-wavefront-soa-refactor.md
@@ -560,3 +560,54 @@ Phase C:
 - Both sides now capture the SAME logical moment: the shading point where NEE/RR occurred, not the next-bounce ray origin.
 - Empty PostRR snapshot at bounce 0 remains expected (RR depth threshold not reached on session_n1_envmap_cornell at max_depth=8, 1 spp).
 - Measured PostLightSample p99.9 = 2.211559e-06 is the gate value; threshold conservatively set at 1.5× (3.5e-06) to allow for minor numerical drift on future hardware/driver updates while catching real regressions.
+
+### Megakernel open-env "~1.85x divergence" root-caused 2026-06-11
+
+**Scope:** Follow-up to the Session N+6 MAJOR FINDING (feature branch
+`feat/pkg55-B-wavefront-shade-kernels` spec entry): "the MEGAKERNEL diverges
+~1.85x from CPU on the open-top env scene" (per-channel MK/CPU mean ratio
+[1.86, 1.81, 1.85] on `session_n1_envmap_cornell`, 64x64, 64 spp, seed
+424242, max_depth 8).
+
+**Root cause: measurement artifact, not a kernel bug.** The megakernel leg
+of the N+6 measurement was `r.render(64, 8, None, True)` — the 4th
+positional argument of `PyRenderer::render` is `applyGamma=True` (clamp to
+[0,1] + pow 1/2.2, `module/blender_module.cpp`), while the CPU oracle
+`reference_pt_wavefront_render` returns LINEAR sRGB. For a dim scene
+(channel means ~0.23-0.27 linear), v^(1/2.2)/v is a stable, seed- and
+spp-independent ~1.8-2x — exactly the textbook "stable per-channel ratio"
+deterministic-bug signature, which is why it looked like an accumulation
+bug. Measured on RTX 5070 Ti (2026-06-11):
+
+- MK applyGamma=True vs CPU linear: **[1.856, 1.813, 1.853]** (reproduces N+6)
+- MK applyGamma=False vs CPU linear: **[1.091, 0.993, 1.050]** — same
+  residual class as the GPU wavefront's [1.089, 0.991, 1.045] (inherited
+  megakernel-BSDF <-> CPU-plugin divergences; no env-specific divergence).
+
+The suspect list from the N+6 entry was checked and cleared: env is NOT
+double-counted with NEE (`sampleDirectSpectralMW` samples geometry lights
+only), and the `wasSpecular` emissive gating matches the CPU
+(`bounce == 0 || wasSpecular`).
+
+**One real latent divergence found and fixed:** `tracePathMW` ignored
+`worldMaxBounces` — CPU production (`raytracer.h:2412`), CPU wavefront
+(`path_kernel.cpp:192`) and the GPU wavefront all gate env accumulation on
+miss by `bounce <= worldMaxBounces`; the megakernel accumulated env at ALL
+bounces. A no-op at the default (1024), but real whenever a scene sets
+world max bounces below max_depth (the Blender addon wires
+`world.max_bounces` through `set_world_max_bounces`). Measured at
+`world_max_bounces=0`: MK/CPU = [1.277, 1.218, 1.364] before the fix,
+[1.085, 0.999, 1.035] after plumbing the gate through
+`renderMultiwavelength` -> `launchMultiwavelengthKernel` -> `tracePathMW`.
+
+**Regression gate added:** `tests/wavefront_diff/test_pkg55_megakernel_env_open_scene.py`
+- gates the megakernel against the CPU linear oracle on the open env scene
+  (both sides `applyGamma=False`), per-channel mean-ratio tol 0.12 (mirrors
+  the N+6 wavefront gate; measured max |ratio-1| = 0.091), and
+- gates the `world_max_bounces=0` behavior so the env gate cannot silently
+  regress. Mean-ratio, not SSIM: independent RNG streams.
+
+**Lesson:** any CPU-vs-GPU comparison must state the color encoding of both
+legs. `render()`'s positional `applyGamma` defaults to True and reads as a
+mystery boolean at call sites; comparisons against linear oracles must pass
+`False` explicitly.

--- a/src/gpu/cuda_renderer.cu
+++ b/src/gpu/cuda_renderer.cu
@@ -90,6 +90,7 @@ void launchPkg64SmsProbe(
 void launchMultiwavelengthKernel(
     float* d_framebuffer, int width, int height,
     int samplesPerPixel, int maxDepth,
+    int worldMaxBounces,  // pkg55-B' N+6 follow-up: env gate, raytracer.h:2412
     float lambdaMin, float lambdaMax, bool useLuminanceOutput,
     bool enableNEE,
     bool useCaustics,  // pkg64-gpu Phase 2
@@ -937,8 +938,16 @@ void CUDARenderer::renderMultiwavelength(
     // attempt; disable SMS when the photon grid is active (no double-count).
     if (caustic.ready) useCaustics = false;
 
+    // pkg55-B' N+6 follow-up: plumb the world/env max-bounces gate (CPU
+    // raytracer.h:2412, wavefront path_kernel.cpp:192). Previously the MW
+    // megakernel accumulated env radiance on miss at ALL bounces, diverging
+    // from the CPU whenever a scene sets world max bounces < max_depth.
+    int worldMaxBounces = impl->hostRenderer
+        ? impl->hostRenderer->getWorldMaxBounces() : 1024;
+
     launchMultiwavelengthKernel(
         impl->d_framebuffer, width, height, samplesPerPixel, maxDepth,
+        worldMaxBounces,
         lambdaMin, lambdaMax, useLuminanceOutput, enableNEE, useCaustics,
         impl->d_tlas, impl->d_instances, impl->d_blas,  // pkg114
         impl->d_bvhNodes, impl->d_prims, impl->d_triangles, impl->d_spheres,

--- a/src/gpu/multiwavelength_kernel.cu
+++ b/src/gpu/multiwavelength_kernel.cu
@@ -587,6 +587,7 @@ __device__ GSampledSpectrum sampleDirectSpectralMW(
 // ---------------------------------------------------------------------------
 __device__ GSampledSpectrum tracePathMW(
     GRay ray, int maxDepth,
+    int worldMaxBounces,  // pkg55-B' N+6 follow-up: env gate, raytracer.h:2412
     GSampledWavelengths& lambdas,
     bool useLuminanceOutput,
     bool enableNEE,
@@ -623,6 +624,12 @@ __device__ GSampledSpectrum tracePathMW(
             // pkg55-B' Session N+6) so the wavefront stage_advance shares ONE
             // implementation; the luminance-band Rayleigh fallback stays here
             // (needs this TU's rayleighScale, no CPU-wavefront twin).
+            //
+            // Gated by worldMaxBounces (pkg55-B' N+6 follow-up): mirrors CPU
+            // pathTraceSpectral (raytracer.h:2412) and the CPU/GPU wavefront
+            // (path_kernel.cpp:192) — the path dies on miss either way; env
+            // radiance is only accumulated for bounce <= gate.
+            if (bounce > worldMaxBounces) break;
             GSampledSpectrum envSpec(0.f);
             GVec3 dir = ray.direction.normalized();
             if (useLuminanceOutput && !hasBackgroundColor && !envMap.loaded) {
@@ -843,6 +850,7 @@ __device__ inline float gpu_mw_haltonBase2(int index) {
 __global__ void multiwavelengthKernel(
     float* framebuffer, int width, int height,
     int samplesPerPixel, int maxDepth,
+    int worldMaxBounces,  // pkg55-B' N+6 follow-up: env gate, raytracer.h:2412
     float lambdaMin, float lambdaMax,
     bool  useLuminanceOutput,
     bool  enableNEE,
@@ -907,7 +915,8 @@ __global__ void multiwavelengthKernel(
             gpu_sampleBandWavelengths(&localRng, lambdaMin, lambdaMax);
 
         GSampledSpectrum rad = tracePathMW(
-            ray, maxDepth, lambdas, useLuminanceOutput, enableNEE, useCaustics,
+            ray, maxDepth, worldMaxBounces,
+            lambdas, useLuminanceOutput, enableNEE, useCaustics,
             tlas, instances, blas,  // pkg114
             bvhNodes, prims, tris, spheres, materials,
             lights, numLights, totalLightPower,
@@ -991,6 +1000,7 @@ __global__ void multiwavelengthKernel(
 void launchMultiwavelengthKernel(
     float* d_framebuffer, int width, int height,
     int samplesPerPixel, int maxDepth,
+    int worldMaxBounces,  // pkg55-B' N+6 follow-up: env gate, raytracer.h:2412
     float lambdaMin, float lambdaMax, bool useLuminanceOutput,
     bool enableNEE,
     bool useCaustics,  // pkg64-gpu Phase 2
@@ -1021,6 +1031,7 @@ void launchMultiwavelengthKernel(
             (const void*)multiwavelengthKernel, blocks, threadsPerBlock);
         multiwavelengthKernel<<<blocks, threadsPerBlock>>>(
             d_framebuffer, width, height, samplesPerPixel, maxDepth,
+            worldMaxBounces,
             lambdaMin, lambdaMax, useLuminanceOutput, enableNEE, useCaustics,
             d_tlas, d_instances, d_blas,  // pkg114
             d_bvhNodes, d_prims, d_tris, d_spheres, d_materials,

--- a/tests/wavefront_diff/test_pkg55_megakernel_env_open_scene.py
+++ b/tests/wavefront_diff/test_pkg55_megakernel_env_open_scene.py
@@ -1,0 +1,158 @@
+"""pkg55-B' Session N+6 follow-up — megakernel open-env-scene mean-ratio gate.
+
+Session N+6 reported the spectral megakernel ~1.85x BRIGHTER than the CPU
+oracle on the open-top env Cornell scene (per-channel mean ratio
+[1.86, 1.81, 1.85]). Root cause (2026-06-11 follow-up investigation): a
+MEASUREMENT ARTIFACT, not a kernel bug. The megakernel leg of that
+measurement was `r.render(64, 8, None, True)` — the 4th positional arg of
+PyRenderer::render is `applyGamma=True` (clamp to [0,1] + pow 1/2.2,
+blender_module.cpp), while the CPU oracle reference_pt_wavefront_render
+returns LINEAR sRGB. For a dim scene, v^(1/2.2)/v gives a stable,
+seed-independent ~1.8-2x "brightness" ratio. Measured linear-vs-linear on
+the same scene/params, the megakernel sits at [1.091, 0.993, 1.050] — the
+same residual class as the GPU wavefront ([1.089, 0.991, 1.045], inherited
+megakernel-BSDF <-> CPU-plugin divergences, spec N+6 entry).
+
+This gate renders BOTH sides linear (applyGamma=False) so the comparison
+can never silently mix color encodings again, and pins per-channel mean
+ratios. Mean-ratio, NOT SSIM: megakernel and oracle use independent RNG
+streams, and windowed SSIM is unreachable for independent MC streams at
+modest spp (see pkg55 spec / SSIM gate rationale).
+
+Second test: the one REAL env-accumulation divergence found during the
+investigation — tracePathMW ignored worldMaxBounces (CPU gates env on miss
+by bounce <= worldMaxBounces, raytracer.h:2412 / path_kernel.cpp:192; the
+Blender addon wires world.max_bounces through set_world_max_bounces).
+Before the fix, MK/CPU at world_max_bounces=0 measured [1.277, 1.218,
+1.364] on this scene; with the gate plumbed it returns to the normal
+residual class.
+"""
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+# Add tests/scenes to path (same pattern as test_pkg55_cuda_threshold_gate.py)
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scenes"))
+import session_n1_envmap_cornell
+
+# Lazy import to avoid import-time failures if astroray not built
+astroray = None
+
+
+def _lazy_import_astroray():
+    global astroray
+    if astroray is None:
+        import astroray as ar
+        astroray = ar
+    return astroray
+
+
+WIDTH, HEIGHT = 64, 64
+SPP = 64
+MAX_DEPTH = 8
+SEED = 424242
+
+# Same tolerance class as the N+6 GPU-wavefront final-image gate (<=0.12):
+# the megakernel shares its BSDF device code with the wavefront, so it
+# inherits the same documented divergences (e.g. missing
+# diffuseFurnaceScale/Kulla-Conty on GPU disney). Measured 2026-06-11
+# (RTX 5070 Ti, 64x64, 64spp, seed 424242): ratios [1.091, 0.993, 1.050]
+# default / [1.085, 0.999, 1.035] wmb=0 => max |ratio-1| = 0.091.
+# Tightening to <=0.05 is the per-material parity work.
+MEAN_RATIO_TOL = 0.12
+
+
+def _build_renderer(world_max_bounces=None):
+    """Session N+1 env-map Cornell scene (7 materials + env-miss paths)."""
+    ar = _lazy_import_astroray()
+    r = ar.Renderer()
+    session_n1_envmap_cornell.build_scene(r)
+    session_n1_envmap_cornell.setup_camera(r, width=WIDTH, height=HEIGHT)
+    r.set_seed(SEED)
+    r.set_integrator_param("max_depth", MAX_DEPTH)
+    r.set_integrator("path_tracer")
+    if world_max_bounces is not None:
+        r.set_world_max_bounces(world_max_bounces)
+    # Warmup render to trigger BVH build
+    _ = r.render(1, 1, None, False)
+    return r
+
+
+def _require_gpu():
+    ar = _lazy_import_astroray()
+    if not ar.Renderer().gpu_available:
+        pytest.skip("No CUDA GPU available — megakernel gate is hardware-only")
+
+
+def _per_channel_mean_ratio(world_max_bounces=None):
+    """Render CPU oracle and GPU megakernel, both LINEAR, return mean ratios."""
+    ar = _lazy_import_astroray()
+
+    r_cpu = _build_renderer(world_max_bounces)
+    cpu = np.asarray(
+        ar.reference_pt_wavefront_render(r_cpu, SPP, MAX_DEPTH, SEED, False),
+        dtype=np.float64).reshape(-1, 3)
+
+    r_gpu = _build_renderer(world_max_bounces)
+    r_gpu.set_use_gpu(True)
+    # applyGamma=False — LINEAR output. The 4th positional arg of render()
+    # is applyGamma; passing True here is exactly the N+6 measurement
+    # artifact this gate exists to prevent.
+    mk = np.asarray(r_gpu.render(SPP, MAX_DEPTH, None, False),
+                    dtype=np.float64).reshape(-1, 3)
+
+    return mk.mean(axis=0) / cpu.mean(axis=0)
+
+
+def test_megakernel_open_env_scene_mean_ratio():
+    """GPU spectral megakernel vs CPU linear oracle on the OPEN env scene.
+
+    All pre-existing megakernel SSIM gates use CLOSED scenes (pkg54 parity
+    set), so env-miss accumulation was never gated. This is the first gate
+    that exercises megakernel env-miss paths against the CPU.
+    """
+    _require_gpu()
+    ratios = _per_channel_mean_ratio()
+    deviation = np.abs(ratios - 1.0)
+    assert np.all(deviation <= MEAN_RATIO_TOL), (
+        f"Megakernel/CPU per-channel mean ratio {ratios.round(3).tolist()} "
+        f"deviates more than {MEAN_RATIO_TOL} from 1.0 on the open env "
+        f"scene. If the ratio is ~1.8-2x across all channels, check the "
+        f"comparison protocol FIRST: render(..., applyGamma=True) output is "
+        f"gamma-encoded while the CPU oracle is linear (the Session N+6 "
+        f"false alarm). A genuine env-accumulation regression (e.g. env "
+        f"double-count with NEE, missing worldMaxBounces gate) also lands "
+        f"here."
+    )
+    print(f"\n[pkg55 megakernel open-env gate] PASS: "
+          f"MK/CPU mean ratios = {ratios.round(3).tolist()} (tol {MEAN_RATIO_TOL})")
+
+
+def test_megakernel_world_max_bounces_env_gate():
+    """world_max_bounces=0: env radiance reaches camera rays only.
+
+    Gates the worldMaxBounces plumbing into tracePathMW (the one real
+    env-accumulation divergence found in the N+6 follow-up). Without the
+    gate the megakernel accumulates env on miss at ALL bounces and measured
+    [1.277, 1.218, 1.364] vs CPU on this scene.
+    """
+    _require_gpu()
+    ratios = _per_channel_mean_ratio(world_max_bounces=0)
+    deviation = np.abs(ratios - 1.0)
+    assert np.all(deviation <= MEAN_RATIO_TOL), (
+        f"Megakernel/CPU per-channel mean ratio {ratios.round(3).tolist()} "
+        f"deviates more than {MEAN_RATIO_TOL} from 1.0 with "
+        f"world_max_bounces=0. The megakernel is likely ignoring the "
+        f"worldMaxBounces env gate (CPU: raytracer.h:2412; MW kernel: "
+        f"tracePathMW miss branch)."
+    )
+    print(f"\n[pkg55 megakernel wmb=0 env gate] PASS: "
+          f"MK/CPU mean ratios = {ratios.round(3).tolist()} (tol {MEAN_RATIO_TOL})")
+
+
+if __name__ == "__main__":
+    test_megakernel_open_env_scene_mean_ratio()
+    test_megakernel_world_max_bounces_env_gate()


### PR DESCRIPTION
## Summary

Root-causes the pkg55-B' Session N+6 "MAJOR FINDING" that the GPU spectral megakernel renders ~1.85x brighter than the CPU on the open-top env-map Cornell scene (`session_n1_envmap_cornell`, 64x64, 64spp, seed 424242, depth 8, MK/CPU mean ratio [1.86, 1.81, 1.85]).

**Root cause: measurement artifact, not a kernel bug.** The megakernel leg of the N+6 measurement was `r.render(64, 8, None, True)` — the 4th positional arg of `PyRenderer::render` is `applyGamma=True` (clamp to [0,1] + pow 1/2.2), while the CPU oracle `reference_pt_wavefront_render` returns **linear** sRGB. For this dim scene (channel means ~0.23–0.27 linear), `v^(1/2.2)/v` produces a stable, seed/spp-independent ~1.8–2x ratio — which mimics the deterministic-bug signature.

Measured on RTX 5070 Ti (2026-06-11):

| comparison | per-channel mean ratio |
|---|---|
| MK `applyGamma=True` vs CPU linear | **[1.856, 1.813, 1.853]** (reproduces N+6) |
| MK `applyGamma=False` vs CPU linear | **[1.091, 0.993, 1.050]** |

The linear-vs-linear residual is the same class as the GPU wavefront's [1.089, 0.991, 1.045] (inherited megakernel-BSDF↔CPU-plugin divergences) — there is no env-specific accumulation bug. The N+6 suspect list was checked and cleared: no env/NEE double-count (`sampleDirectSpectralMW` samples geometry lights only), and `wasSpecular` emissive gating matches the CPU.

**One real latent divergence found and fixed:** `tracePathMW` ignored `worldMaxBounces`. CPU production (`raytracer.h:2412`), CPU wavefront (`path_kernel.cpp:192`), and the GPU wavefront all gate env accumulation on miss by `bounce <= worldMaxBounces`; the megakernel accumulated env at ALL bounces. No-op at the default (1024) but real whenever a scene sets world max bounces below max_depth (Blender addon wires `world.max_bounces` → `set_world_max_bounces`). Measured at `world_max_bounces=0`: MK/CPU = [1.277, 1.218, 1.364] before → **[1.085, 0.999, 1.035]** after.

## Changes

- `src/gpu/multiwavelength_kernel.cu` — plumb `worldMaxBounces` into `tracePathMW` and gate the env-miss accumulation (`if (bounce > worldMaxBounces) break;`, mirroring CPU semantics: path dies on miss either way).
- `src/gpu/cuda_renderer.cu` — read `getWorldMaxBounces()` from the host renderer in `renderMultiwavelength` and pass it through the launcher (public API unchanged).
- `tests/wavefront_diff/test_pkg55_megakernel_env_open_scene.py` — NEW regression gate: megakernel vs CPU linear oracle on the open env scene, per-channel **mean-ratio** gate (not SSIM — independent RNG streams), both legs `applyGamma=False`; second test pins the `world_max_bounces=0` behavior. Skips when no CUDA GPU (CI-safe).
- `.astroray_plan/packages/pkg55-wavefront-soa-refactor.md` — Lessons entry documenting the root cause, the fix, and the measured numbers. Note for the merge of `feat/pkg55-B-wavefront-shade-kernels`: the N+6 "MAJOR FINDING" entry on that branch should be read with this correction.

## Verification

- RTX 5070 Ti: new gate tests pass (ratios above; tol 0.12, measured max |ratio−1| = 0.091).
- Default-scene ratios unchanged by the fix (gate is a no-op at worldMaxBounces=1024), confirming no regression on closed/parity scenes.
- Full local suite: 1246 passed, 22 skipped, 21 xfailed, 2 xpassed (the only failures in the first pass were 6 pkg92 RNG tests missing the separately-built `astroray_test_helpers` target; after building it they pass — unrelated to this change).
- Call-site sweep: `tracePathMW` / `multiwavelengthKernel` / `launchMultiwavelengthKernel` referenced only within the two edited files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
