### PR TITLE
feat(pkg115): chunk 5 — ShaderNodeTexVoronoi addon translation + factory full-param wiring

### DIFF
--- a/.astroray_plan/docs/blender-procedural-parity-research.md
+++ b/.astroray_plan/docs/blender-procedural-parity-research.md
@@ -556,9 +556,16 @@ plus a paired-still RTX check at the end.
    factory params (directions, phase, dscale). ✅ **DONE 2026-06-11 (chunk 3)**
 8. **Brick** — port `svm_brick` + `brick_noise`; 3D input; new params. ✅ **DONE 2026-06-11 (chunk 3)**
 9. **Voronoi** — largest port: metrics + F1/F2/SmoothF1/DistToEdge/NSphere +
-   fractal wrapper + normalize + multi-output mapping.
+   fractal wrapper + normalize + multi-output mapping. ✅ **DONE 2026-06-11 (chunk 4, PR #445)**
 10. **Addon translator + duplication removal + standalone CI example**
-    (Stage 3/4 of the package spec).
+    (Stage 3/4 of the package spec). 🔶 **PARTIAL 2026-06-11 (chunk 5):** addon
+    `ShaderNodeTexVoronoi` translation updated to the new feature enum
+    (0=F1,1=SmoothF1,2=F2,3=DistToEdge,4=NSphere) + full detail/roughness/
+    lacunarity/exponent/normalize wiring; `create_procedural_texture("voronoi", …)`
+    factory extended to forward the trailing params (backward-compatible);
+    standalone CI example added. REMAINING: addon-side private texture-definition
+    duplication removal (Approach step 4) and the Blender-vs-Cycles paired-still
+    visual (RTX `/verify`).
 
 ---
 

--- a/.astroray_plan/packages/pkg115-adopt-blender-shader-node-textures.md
+++ b/.astroray_plan/packages/pkg115-adopt-blender-shader-node-textures.md
@@ -3,7 +3,7 @@
 **Pillar:** 5 (addon) + 2 (materials/textures)
 **Track:** A
 **Codex-paste-ready:** no (large, staged; RTX visual verify)
-**Status:** Stage 2 chunk 3 done (2026-06-11 — Wave + Brick parity). Chunks 1-2 merged (PR #439 coord defaults, PR #441 hash+Perlin+fBM). REMAINING: Voronoi (audit §6.9), addon translator dedup + standalone CI example + RTX visual verify vs Cycles.
+**Status:** Stage 2 chunk 4 done (2026-06-11 — full Cycles-parity Voronoi, PR #445). Chunk 5 (2026-06-11): addon `ShaderNodeTexVoronoi` translation + factory full-param wiring + standalone CI example. Chunks 1-3 merged (PR #439 coord defaults, PR #441 hash+Perlin+fBM, PR #442 Wave+Brick). REMAINING: addon-side private texture-definition duplication removal (Approach step 4) + Blender-vs-Cycles RTX visual verify.
 **Depends on:** pkg57 (done — established the additive custom-node pattern and
 the `convert_node_material` traversal). Benefits from pkg112.
 **Estimated effort:** L (multi-week, staged)

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -2739,16 +2739,33 @@ class CustomRaytracerRenderEngine(RenderEngine):
                 renderer.create_procedural_texture(tex_name, 'checker',
                     c1 + c2 + [scale])
             elif ntype == 'TEX_VORONOI':
-                scale = float(node.inputs['Scale'].default_value) if node.inputs.get('Scale') else 5.0
-                randomness = float(node.inputs['Randomness'].default_value) if node.inputs.get('Randomness') else 1.0
-                smoothness = float(node.inputs.get('Smoothness', type(None) or type(0)).default_value) if node.inputs.get('Smoothness') else 1.0
+                def _vsock(name, fallback):
+                    s = node.inputs.get(name)
+                    return float(s.default_value) if s is not None else fallback
+                scale = _vsock('Scale', 5.0)
+                randomness = _vsock('Randomness', 1.0)
+                smoothness = _vsock('Smoothness', 1.0)
+                detail = _vsock('Detail', 0.0)
+                roughness = _vsock('Roughness', 0.5)
+                lacunarity = _vsock('Lacunarity', 2.0)
+                exponent = _vsock('Exponent', 0.5)
                 dist_map = {'EUCLIDEAN': 0, 'MANHATTAN': 1, 'CHEBYCHEV': 2, 'MINKOWSKI': 3}
-                feat_map = {'F1': 0, 'F2': 1, 'F1_F2': 2, 'SMOOTH_F1': 4, 'DISTANCE_TO_EDGE': 3}
+                # Feature enum MUST match the C++ VoronoiTexture order (pkg115 chunk 4,
+                # advanced_features.h): 0=F1, 1=Smooth F1, 2=F2, 3=Distance to Edge,
+                # 4=N-Sphere Radius. (Older Blender 'F1_F2' has no Cycles socket anymore.)
+                feat_map = {'F1': 0, 'SMOOTH_F1': 1, 'F2': 2,
+                            'DISTANCE_TO_EDGE': 3, 'N_SPHERE_RADIUS': 4}
                 dm = dist_map.get(getattr(node, 'distance', 'EUCLIDEAN'), 0)
                 feat = feat_map.get(getattr(node, 'feature', 'F1'), 0)
+                normalize = 1.0 if getattr(node, 'normalize', False) else 0.0
                 tex_name = f"_proc_voronoi_{node_id}"
+                # Full Cycles-parity param vector (see TextureManager::createProceduralTexture
+                # "voronoi" in module/blender_module.cpp): trailing detail/roughness/lacunarity/
+                # exponent/normalize drive the fractal wrapper + Minkowski exponent + normalize.
                 renderer.create_procedural_texture(tex_name, 'voronoi',
-                    [scale, randomness, float(dm), float(feat), smoothness, 0,0,0, 1,1,1])
+                    [scale, randomness, float(dm), float(feat), smoothness,
+                     0, 0, 0, 1, 1, 1,
+                     detail, roughness, lacunarity, exponent, normalize])
             elif ntype == 'TEX_WAVE':
                 scale = float(node.inputs['Scale'].default_value) if node.inputs.get('Scale') else 5.0
                 dist = float(node.inputs['Distortion'].default_value) if node.inputs.get('Distortion') else 0.0

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -235,9 +235,14 @@ public:
             Vec3 c2 = params.size() > 8 ? Vec3(params[6], params[7], params[8]) : Vec3(1);
             proceduralTextures[name] = std::make_shared<MagicTexture>(depth, sc, dist, c1, c2);
         } else if (type == "voronoi") {
-            // Legacy params: [scale, randomness, dist_metric, feature, smoothness, r1,g1,b1, r2,g2,b2]
-            // pkg115 chunk 4: extended Cycles-parity ctor adds detail, roughness, lacunarity,
-            // exponent, normalize. Legacy API maps to the new ctor with defaults for new params.
+            // Params (positional, backward-compatible):
+            //   [0..4]  scale, randomness, dist_metric, feature, smoothness
+            //   [5..10] r1,g1,b1, r2,g2,b2            (color_low, color_high)
+            //   [11..15] detail, roughness, lacunarity, exponent, normalize   (pkg115 item 10)
+            // Legacy 5-param + colour scripts (size <= 11) keep working: the trailing
+            // Cycles-parity params (detail/roughness/lacunarity/exponent/normalize) default
+            // off, so a non-fractal, non-normalised F1 matches the old behaviour. The addon
+            // translator passes all 16 to drive full ShaderNodeTexVoronoi parity.
             float sc = params.size() > 0 ? params[0] : 5.0f;
             float rand = params.size() > 1 ? params[1] : 1.0f;
             int dm = params.size() > 2 ? (int)params[2] : 0;
@@ -245,12 +250,15 @@ public:
             float smooth = params.size() > 4 ? params[4] : 1.0f;
             Vec3 c1 = params.size() > 7 ? Vec3(params[5], params[6], params[7]) : Vec3(0);
             Vec3 c2 = params.size() > 10 ? Vec3(params[8], params[9], params[10]) : Vec3(1);
+            float det = params.size() > 11 ? params[11] : 0.0f;
+            float rough = params.size() > 12 ? params[12] : 0.5f;
+            float lac = params.size() > 13 ? params[13] : 2.0f;
+            float expo = params.size() > 14 ? params[14] : 0.5f;
+            bool norm = params.size() > 15 ? (params[15] != 0.0f) : false;
             // New ctor: (scale, detail, roughness, lacunarity, smoothness, exponent, randomness,
             //            normalize, dist_metric, feature, color_low, color_high).
-            // Legacy order had randomness before dist_metric; new ctor has randomness after exponent.
             proceduralTextures[name] = std::make_shared<VoronoiTexture>(
-                sc, /*detail=*/0.0f, /*roughness=*/0.5f, /*lacunarity=*/2.0f, smooth,
-                /*exponent=*/0.5f, rand, /*normalize=*/false, dm, feat, c1, c2);
+                sc, det, rough, lac, smooth, expo, rand, norm, dm, feat, c1, c2);
         } else if (type == "brick") {
             // params: [brick_r,g,b, mortar_r,g,b, brick_w, brick_h, mortar_size, offset, scale]
             Vec3 brick = params.size() > 2 ? Vec3(params[0], params[1], params[2]) : Vec3(0.7f, 0.35f, 0.2f);

--- a/tests/test_blender_uv_plumbing.py
+++ b/tests/test_blender_uv_plumbing.py
@@ -435,3 +435,65 @@ def test_apply_texture_transform_skips_identity_with_zero_rotation(monkeypatch):
     )
     assert renderer.uv_transform_calls == []
     assert renderer.coord_mode_calls == []
+
+
+# ---------------------------------------------------------------------------
+# pkg115 item 10 — ShaderNodeTexVoronoi translation
+#
+# The C++ VoronoiTexture feature enum changed in pkg115 chunk 4 (PR #445):
+#   0=F1, 1=Smooth F1, 2=F2, 3=Distance to Edge, 4=N-Sphere Radius.
+# These tests pin the addon's feature/metric/normalize mapping and the full
+# Cycles-parity param vector so the stale-enum class of regression (which CI
+# cannot catch -- no Blender in CI) fails loudly here instead.
+# ---------------------------------------------------------------------------
+
+def _voronoi_node(feature='F1', distance='EUCLIDEAN', normalize=False):
+    return _Node('TEX_VORONOI', inputs={
+        'Vector':     _Socket(),  # unlinked -> GENERATED
+        'Scale':      _Socket(default=6.0),
+        'Detail':     _Socket(default=3.0),
+        'Roughness':  _Socket(default=0.7),
+        'Lacunarity': _Socket(default=2.5),
+        'Smoothness': _Socket(default=0.8),
+        'Exponent':   _Socket(default=1.5),
+        'Randomness': _Socket(default=0.9),
+    }, feature=feature, distance=distance, normalize=normalize)
+
+
+def test_voronoi_translation_param_vector(monkeypatch):
+    """Full 16-float Cycles-parity vector in the documented order:
+       [scale, randomness, dist_metric, feature, smoothness,
+        r1,g1,b1, r2,g2,b2, detail, roughness, lacunarity, exponent, normalize]."""
+    addon = _load_blender_addon(monkeypatch)
+    engine = addon.CustomRaytracerRenderEngine()
+    renderer = _RecordingRenderer()
+    node = _voronoi_node(feature='F2', distance='MINKOWSKI', normalize=True)
+    engine.load_procedural_texture(node, renderer, vector_input=node.inputs['Vector'])
+
+    assert len(renderer.proc_texture_calls) == 1
+    name, ttype, params = renderer.proc_texture_calls[0]
+    assert ttype == 'voronoi'
+    assert len(params) == 16, f"expected 16 params, got {len(params)}: {params}"
+    scale, rand, dm, feat, smooth = params[0:5]
+    colors = params[5:11]
+    detail, rough, lac, expo, norm = params[11:16]
+    assert (scale, rand, smooth) == (6.0, 0.9, 0.8)
+    assert dm == 3.0, "MINKOWSKI must map to metric index 3"
+    assert feat == 2.0, "F2 must map to feature index 2 (new enum), not the legacy 1"
+    assert colors == [0, 0, 0, 1, 1, 1]
+    assert (detail, rough, lac, expo) == (3.0, 0.7, 2.5, 1.5)
+    assert norm == 1.0, "normalize=True must pass 1.0"
+
+
+def test_voronoi_feature_enum_matches_cpp(monkeypatch):
+    """Every Blender feature value maps to the matching C++ VoronoiTexture index."""
+    addon = _load_blender_addon(monkeypatch)
+    engine = addon.CustomRaytracerRenderEngine()
+    expected = {'F1': 0.0, 'SMOOTH_F1': 1.0, 'F2': 2.0,
+                'DISTANCE_TO_EDGE': 3.0, 'N_SPHERE_RADIUS': 4.0}
+    for feature, idx in expected.items():
+        renderer = _RecordingRenderer()
+        node = _voronoi_node(feature=feature)
+        engine.load_procedural_texture(node, renderer, vector_input=node.inputs['Vector'])
+        _n, _t, params = renderer.proc_texture_calls[0]
+        assert params[3] == idx, f"{feature} -> {params[3]}, expected {idx}"

--- a/tests/test_pkg115_voronoi_standalone.py
+++ b/tests/test_pkg115_voronoi_standalone.py
@@ -1,0 +1,71 @@
+"""pkg115 item 10 - standalone Voronoi factory example (no Blender required).
+
+Demonstrates building a Voronoi-textured material through the public
+`create_procedural_texture` factory API and verifies the factory forwards the
+full Cycles-parity parameter vector (the same path the Blender addon translator
+uses). The parameter layout (module/blender_module.cpp, "voronoi"):
+
+    [scale, randomness, dist_metric, feature, smoothness,
+     r1,g1,b1, r2,g2,b2,                       # color_low, color_high
+     detail, roughness, lacunarity, exponent, normalize]   # pkg115 item 10
+
+Legacy 5-param + colour scripts (<= 11 values) keep working unchanged; the
+trailing detail/roughness/lacunarity/exponent/normalize default off, so a bare
+voronoi stays a non-fractal F1.
+"""
+import os
+import numpy as np
+
+from base_helpers import (
+    create_renderer, setup_camera, render_image, assert_valid_image,
+    save_image, get_output_dir,
+)
+
+OUTPUT_DIR = get_output_dir()
+
+
+def _render_voronoi(params, seed=7, w=72, h=54):
+    """Build a single Voronoi-textured sphere via the factory and render it."""
+    r = create_renderer()
+    r.set_seed(seed)
+    r.set_adaptive_sampling(False)
+    r.set_background_color([0.0, 0.0, 0.0])
+    r.create_procedural_texture("vor", "voronoi", params, "GENERATED")
+    mat = r.create_material('lambertian', [1, 1, 1], {'texture': 'vor'})
+    light = r.create_material('light', [1, 1, 1], {'intensity': 7.0})
+    r.add_sphere([0, 0, 0], 1.0, mat)
+    r.add_sphere([0, 4, 2], 0.6, light)
+    setup_camera(r, look_from=[0, 0, 4], look_at=[0, 0, 0], vfov=40, width=w, height=h)
+    return render_image(r, samples=12)
+
+
+def test_voronoi_factory_standalone_renders():
+    """The factory builds a textured material without Blender and renders it."""
+    img = _render_voronoi([6.0, 1.0, 0.0, 0.0, 1.0, 0, 0, 0, 1, 1, 1])
+    assert_valid_image(img, 54, 72, min_mean=0.01, label='voronoi_standalone')
+    save_image(img, os.path.join(OUTPUT_DIR, 'test_pkg115_voronoi_standalone.png'))
+
+
+def test_voronoi_factory_forwards_trailing_params():
+    """The trailing params (params[11:16]) must reach VoronoiTexture. They are
+    read as one block, so proving any one is forwarded proves the tail is.
+    `normalize` (params[15]) rescales the whole distance field by ~1/sqrt(3),
+    a large albedo change, giving an unambiguous signal through the render."""
+    base = [6.0, 1.0, 0.0, 0.0, 1.0, 0, 0, 0, 1, 1, 1]
+    img_plain = _render_voronoi(base, seed=7)
+    # Control: identical params + same seed -> fully deterministic render, so the
+    # per-pixel floor is ~0. Anything clearly above it is a genuine texture change.
+    img_plain2 = _render_voronoi(base, seed=7)
+    floor = float(np.mean(np.abs(img_plain2 - img_plain)))
+    assert floor < 1e-5, f"render not deterministic at fixed seed (floor={floor:.2e})"
+    # Only difference vs base: normalize=1 (params[15]); detail stays 0.
+    img_norm = _render_voronoi(base + [0.0, 0.5, 2.0, 0.5, 1.0], seed=7)
+    assert_valid_image(img_norm, 54, 72, min_mean=0.01, label='voronoi_normalized')
+    mad = float(np.mean(np.abs(img_norm - img_plain)))
+    # Lambertian shading damps texture contrast, so the absolute MAD is modest,
+    # but it is hundreds of times the deterministic floor -- proof the trailing
+    # params reach VoronoiTexture (the factory does not drop params[11:16]).
+    assert mad > 0.003, (
+        f"normalize param had no effect: per-pixel MAD={mad:.4f} (floor={floor:.2e}) "
+        f"-- factory may be dropping params[11:16]"
+    )


### PR DESCRIPTION
## Summary

pkg115 item 10 (partial — the Blender-side wiring). PR #445 changed the C++ `VoronoiTexture` feature enum but left the addon translator's feature map stale; CI cannot catch that (no Blender in CI). This wires `ShaderNodeTexVoronoi` to the new parameterization and verifies it with pure-Python addon tests + a standalone factory example.

## The latent regression this fixes

PR #445 set the C++ feature enum to `0=F1, 1=Smooth F1, 2=F2, 3=Distance to Edge, 4=N-Sphere Radius`. The addon's `feat_map` still mapped `F2→1, SMOOTH_F1→4, F1_F2→2`, so a Blender Voronoi node set to **F2** would have rendered **Smooth F1**, and **Smooth F1** would have rendered **N-Sphere Radius**. This is the [[gr-emission-model-wiring-checklist]] class — green CI, broken render.

## Changes

**`blender_addon/__init__.py` (`TEX_VORONOI`):**
- `feat_map` → `{F1:0, SMOOTH_F1:1, F2:2, DISTANCE_TO_EDGE:3, N_SPHERE_RADIUS:4}` (matches `advanced_features.h`; drops the obsolete `F1_F2`).
- Wire the full Cycles sockets — Detail, Roughness, Lacunarity, Exponent, and the `normalize` property — into a 16-float param vector.

**`module/blender_module.cpp` (`create_procedural_texture` "voronoi"):**
- Read trailing `params[11:15]` = detail, roughness, lacunarity, exponent, normalize. **Backward-compatible**: legacy 5-param + colour scripts (≤11 values) keep working unchanged (new params default off → non-fractal F1).

**Tests:**
- `tests/test_blender_uv_plumbing.py` — 2 pure-Python addon tests (mocked `bpy`, `_RecordingRenderer`) assert the emitted param vector and **every** feature-enum mapping. The stale-enum class now fails here loudly, not silently in Blender.
- `tests/test_pkg115_voronoi_standalone.py` — standalone factory example (no Blender): renders a Voronoi-textured material and proves the factory forwards `params[11:16]` (`normalize` per-pixel MAD vs a deterministic-floor control).

## Verification
- Addon tests: 18/18 (`test_blender_uv_plumbing.py`). Standalone: 2/2.
- **Full local suite: 1271 passed, 0 failed.**
- No signature changes → no stale call sites (factory reads more of the existing vector; addon method signature unchanged).

## Deferred (remaining item 10)
- Addon-side private texture-definition duplication removal (Approach step 4).
- Blender-vs-Cycles paired-still RTX visual (`/verify`).
Both are tracked in the updated audit (§6 item 10 PARTIAL) and pkg115 spec status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)