### PR TITLE
feat(pkg114): inc 3a — register_mesh_bulk binding (UV/normal/multi-material BLAS)

### DIFF
--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -815,6 +815,81 @@ public:
         }
     }
 
+    // pkg114 inc 3 — register a mesh's OBJECT-LOCAL geometry once (UVs / split
+    // normals / multi-material), returning its mesh id for add_instance(). This
+    // is the bulk twin of registerMeshTriangles: byte-for-byte the same Triangle
+    // construction as addTrianglesBulk, but the prims are collected and handed to
+    // renderer.registerMesh() (built into one shared BLAS) instead of pushed flat
+    // into the scene. Callers pass OBJECT-space corners (identity model matrix);
+    // the per-instance world transform is supplied later by add_instance().
+    int registerMeshBulk(
+            py::array_t<float, py::array::c_style | py::array::forcecast> positions,
+            py::array_t<int,   py::array::c_style | py::array::forcecast> materialIds,
+            py::array_t<int,   py::array::c_style | py::array::forcecast> materialPassIndices,
+            int objectPassIndex,
+            py::array_t<float, py::array::c_style | py::array::forcecast> uvs,
+            std::vector<std::string> uvLayerNames,
+            py::array_t<float, py::array::c_style | py::array::forcecast> normals) {
+        auto pos = positions.unchecked<3>();              // (Nt, 3, 3)
+        const py::ssize_t nt = pos.shape(0);
+        if (pos.shape(1) != 3 || pos.shape(2) != 3)
+            throw std::runtime_error("register_mesh_bulk: positions must be (N,3,3)");
+        auto mid = materialIds.unchecked<1>();            // (Nt,)
+        auto mpi = materialPassIndices.unchecked<1>();    // (Nt,)
+        if (mid.shape(0) != nt || mpi.shape(0) != nt)
+            throw std::runtime_error("register_mesh_bulk: material arrays must match triangle count");
+
+        const py::ssize_t nLayers = (uvs.size() > 0) ? uvs.shape(0) : 0;
+        const bool hasNormals = normals.size() > 0;
+        if (hasNormals && normals.shape(0) != nt)
+            throw std::runtime_error("register_mesh_bulk: normals must be (N,3,3)");
+        std::vector<std::string> names;
+        for (py::ssize_t l = 0; l < nLayers; ++l) {
+            std::string nm = (l < (py::ssize_t)uvLayerNames.size()) ? uvLayerNames[l] : std::string();
+            names.push_back(nm.empty() ? (l == 0 ? "UVMap" : "UVMap" + std::to_string(l + 1)) : nm);
+        }
+        const float* uvPtr = (nLayers > 0) ? uvs.data() : nullptr;   // (nLayers, nt, 3, 2)
+        const float* nPtr  = hasNormals ? normals.data() : nullptr;  // (nt, 3, 3)
+        auto uvAt = [&](py::ssize_t l, py::ssize_t t, int c) -> Vec2 {
+            const float* p = uvPtr + (((l * nt + t) * 3 + c) * 2);
+            return Vec2(p[0], p[1]);
+        };
+
+        std::vector<std::shared_ptr<Hittable>> prims;
+        prims.reserve(nt);
+        for (py::ssize_t t = 0; t < nt; ++t) {
+            Vec3 p0(pos(t, 0, 0), pos(t, 0, 1), pos(t, 0, 2));
+            Vec3 p1(pos(t, 1, 0), pos(t, 1, 1), pos(t, 1, 2));
+            Vec3 p2(pos(t, 2, 0), pos(t, 2, 1), pos(t, 2, 2));
+            int materialId = mid(t);
+            auto mat = materials.count(materialId) ? materials[materialId]
+                                                   : std::make_shared<Lambertian>(Vec3(0.5f));
+            std::shared_ptr<Triangle> tri;
+            if (nLayers == 0) {
+                tri = std::make_shared<Triangle>(p0, p1, p2, mat);
+            } else if (nLayers == 1) {
+                tri = std::make_shared<Triangle>(p0, p1, p2,
+                        uvAt(0, t, 0), uvAt(0, t, 1), uvAt(0, t, 2), mat);
+            } else {
+                std::vector<std::array<Vec2, 3>> layers;
+                layers.reserve(nLayers);
+                for (py::ssize_t l = 0; l < nLayers; ++l)
+                    layers.push_back({ uvAt(l, t, 0), uvAt(l, t, 1), uvAt(l, t, 2) });
+                tri = std::make_shared<Triangle>(p0, p1, p2, layers, names, mat);
+            }
+            if (hasNormals) {
+                const float* n = nPtr + (t * 9);
+                tri->setVertexNormals(Vec3(n[0], n[1], n[2]),
+                                      Vec3(n[3], n[4], n[5]),
+                                      Vec3(n[6], n[7], n[8]));
+            }
+            tri->setObjectPassIndex(objectPassIndex);
+            tri->setMaterialPassIndex(mpi(t));
+            prims.push_back(tri);
+        }
+        return renderer.registerMesh(prims);
+    }
+
     // pkg88-C.0 — bulk motion triangle ingest. Per Cycles motion_triangle.h (Apache-2.0):
     // positions_start (Nt,3,3) is the center step; positions_end (Nt,3,3) is the
     // additional motion step at shutter close. motionSteps=2 → one additional step.
@@ -2294,6 +2369,13 @@ PYBIND11_MODULE(astroray, m) {
              "triangles"_a, "material_id"_a,
              "pkg114: register a mesh's OBJECT-LOCAL flat-shaded triangles (list of "
              "(9,) [v0,v1,v2]) once; returns mesh_id for add_instance().")
+        .def("register_mesh_bulk", &PyRenderer::registerMeshBulk,
+             "positions"_a, "material_ids"_a, "material_pass_indices"_a, "object_pass_index"_a,
+             "uvs"_a, "uv_layer_names"_a, "normals"_a,
+             "pkg114: register a mesh's OBJECT-LOCAL geometry once (UVs/normals/multi-"
+             "material) into a shared BLAS; returns mesh_id for add_instance(). Bulk twin "
+             "of register_mesh_triangles. positions (N,3,3) object-space; arrays match "
+             "add_triangles_bulk.")
         .def("add_instance", &PyRenderer::addInstance, "mesh_id"_a, "transform"_a,
              "pkg114: instance a registered mesh with a row-major 4x4 object->world "
              "transform (16 floats). Returns instance_id.")

--- a/tests/test_tlas_bulk_register_parity.py
+++ b/tests/test_tlas_bulk_register_parity.py
@@ -1,0 +1,177 @@
+"""pkg114 increment 3a — register_mesh_bulk GPU pixel-parity gate.
+
+register_mesh_bulk() is the bulk twin of register_mesh_triangles: it ingests a
+mesh's OBJECT-LOCAL geometry *with* UV layers, per-vertex (smooth) normals and
+per-triangle multi-material into one shared BLAS. This test exercises exactly the
+features the flat-shaded register_mesh_triangles path cannot:
+
+  * SMOOTH per-vertex normals (the inverse-transpose normal transform must be
+    applied per instance, so shading depends on the registered normals), and
+  * MULTI-MATERIAL (per-triangle material ids), and
+  * a UV layer present during ingest (must not corrupt the geometry).
+
+The instanced-via-bulk render is compared against the SAME instances baked into
+world-space triangles via add_triangle (carrying the inverse-transpose-transformed
+corner normals and per-face material). Same camera/seed/spp + flat background
+(no area lights) ⇒ the two images agree to float transform-order noise.
+
+Skipped when the astroray module lacks CUDA or no GPU is present.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+
+try:
+    import astroray  # noqa: E402
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray not built")
+
+_W = _H = 96
+_SPP = 24
+_DEPTH = 4
+
+# Unit octahedron — vertices are already unit length, so each one doubles as its
+# own smooth vertex normal. Object-local geometry is scaled by 0.7.
+_V = np.array([
+    [1, 0, 0], [-1, 0, 0],
+    [0, 1, 0], [0, -1, 0],
+    [0, 0, 1], [0, 0, -1],
+], dtype=np.float64)
+_SCALE = 0.7
+_FACES = [
+    (0, 2, 4), (2, 1, 4), (1, 3, 4), (3, 0, 4),   # top (+z) fan
+    (2, 0, 5), (1, 2, 5), (3, 1, 5), (0, 3, 5),   # bottom (-z) fan
+]
+# Per-corner UVs (constant per face — UVs don't affect a plain lambertian, this
+# just proves the layer survives ingest without corrupting positions/normals).
+_UV3 = np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]], dtype=np.float32)
+
+
+def _translate(x, y, z):
+    M = np.eye(4)
+    M[0, 3], M[1, 3], M[2, 3] = x, y, z
+    return M
+
+
+def _scale(sx, sy, sz):
+    M = np.eye(4)
+    M[0, 0], M[1, 1], M[2, 2] = sx, sy, sz
+    return M
+
+
+def _rot_y(deg):
+    a = np.radians(deg)
+    c, s = np.cos(a), np.sin(a)
+    M = np.eye(4)
+    M[0, 0], M[0, 2], M[2, 0], M[2, 2] = c, s, -s, c
+    return M
+
+
+# Rigid rotate+translate, and a NON-UNIFORM scale (validates the inverse-
+# transpose normal transform on the registered smooth normals).
+_TRANSFORMS = [
+    _translate(-1.7, 0, 0) @ _rot_y(35),
+    _translate(1.7, 0, 0) @ _scale(1.5, 0.6, 1.0),
+]
+
+
+def _bulk_arrays():
+    """OBJECT-local (positions, material_ids, mat_pass, uvs, normals) for the octahedron."""
+    nt = len(_FACES)
+    positions = np.empty((nt, 3, 3), dtype=np.float32)
+    normals = np.empty((nt, 3, 3), dtype=np.float32)
+    for t, (a, b, c) in enumerate(_FACES):
+        for k, vi in enumerate((a, b, c)):
+            positions[t, k] = (_V[vi] * _SCALE).astype(np.float32)
+            normals[t, k] = _V[vi].astype(np.float32)   # already unit
+    uvs = np.broadcast_to(_UV3, (1, nt, 3, 2)).astype(np.float32).copy()
+    return positions, normals, uvs
+
+
+def _common(r):
+    r.set_background_color([0.55, 0.65, 0.85])
+    r.set_integrator("path_tracer")
+    r.set_use_gpu(True)
+    r.setup_camera([0, 1.4, 6.5], [0, 0, 0], [0, 1, 0], 40.0, 1.0, 0.0, 6.5, _W, _H)
+    r.set_seed(7)
+
+
+def _render(r):
+    return np.asarray(r.render(_SPP, _DEPTH, None, False),
+                      dtype=np.float32).reshape(_H, _W, 3)
+
+
+def _mats(r):
+    a = r.create_material("lambertian", [0.85, 0.30, 0.25], {})
+    b = r.create_material("lambertian", [0.25, 0.45, 0.85], {})
+    return a, b
+
+
+def _instanced_image():
+    r = astroray.Renderer()
+    matA, matB = _mats(r)
+    positions, normals, uvs = _bulk_arrays()
+    material_ids = np.array([matA if t % 2 == 0 else matB
+                             for t in range(len(_FACES))], dtype=np.int32)
+    mat_pass = np.array([t % 2 for t in range(len(_FACES))], dtype=np.int32)
+    mesh = r.register_mesh_bulk(positions, material_ids, mat_pass, 0,
+                                uvs, ["UVMap"], normals)
+    for M in _TRANSFORMS:
+        r.add_instance(mesh, list(M.flatten().astype(np.float32)))
+    _common(r)
+    return _render(r)
+
+
+def _baked_image():
+    r = astroray.Renderer()
+    matA, matB = _mats(r)
+    positions, normals, _uvs = _bulk_arrays()
+    for M in _TRANSFORMS:
+        R = M[:3, :3]
+        t = M[:3, 3]
+        Ninv = np.linalg.inv(R).T
+        for tri, (a, b, c) in enumerate(_FACES):
+            mat_id = matA if tri % 2 == 0 else matB
+            w = [(R @ positions[tri, k] + t).astype(np.float32).tolist()
+                 for k in range(3)]
+            nw = []
+            for k in range(3):
+                n = Ninv @ normals[tri, k]
+                n = n / max(np.linalg.norm(n), 1e-9)
+                nw.append(n.astype(np.float32).tolist())
+            r.add_triangle(w[0], w[1], w[2], mat_id, [], [], [],
+                           nw[0], nw[1], nw[2], 0, int(tri % 2))
+    _common(r)
+    return _render(r)
+
+
+@pytest.mark.skipif(
+    AVAILABLE and not astroray.__features__.get("cuda", False),
+    reason="CUDA feature not in this build")
+def test_bulk_registered_instances_match_baked():
+    if not astroray.Renderer().gpu_available:
+        pytest.skip("CUDA GPU not available")
+
+    inst = _instanced_image()
+    baked = _baked_image()
+
+    assert inst.mean() > 0.05, f"instanced render looks empty (mean={inst.mean():.4f})"
+    assert baked.mean() > 0.05, f"baked render looks empty (mean={baked.mean():.4f})"
+
+    for ch, name in enumerate("RGB"):
+        ri, rb = inst[..., ch].mean(), baked[..., ch].mean()
+        ratio = ri / max(rb, 1e-6)
+        assert 0.97 <= ratio <= 1.03, (
+            f"{name} channel energy off: instanced={ri:.4f} baked={rb:.4f} "
+            f"ratio={ratio:.4f}")
+
+    mad = float(np.abs(inst - baked).mean())
+    assert mad < 0.02, f"mean abs per-pixel diff {mad:.4f} too large (bulk-BLAS≠baked)"


### PR DESCRIPTION
## pkg114 increment 3a

Adds `register_mesh_bulk` — the bulk twin of `register_mesh_triangles`. It ingests a mesh's **object-local** geometry with UV layers, per-vertex (smooth) normals and per-triangle multi-material into one shared BLAS, returning a `mesh_id` for `add_instance()`. The Triangle construction is byte-for-byte identical to `add_triangles_bulk`; only the destination differs (`renderer.registerMesh()` → shared BLAS, vs flat scene push).

This is the binding the Blender addon instancing path (inc 3c) will register shared mesh datablocks through.

### Verification (RTX, local)
`tests/test_tlas_bulk_register_parity.py`: 2 instances of an octahedron registered via `register_mesh_bulk` (smooth normals + 2 materials + a UV layer) render **identical** to the same instances baked into world-space `add_triangle` calls — per-channel mean ratio in [0.97, 1.03], mean abs per-pixel diff < 0.02. Upload log confirms BLAS sharing: instanced = **8 prims**, baked = **16**.

Existing inc-1/inc-2 TLAS parity tests still pass (no signature changes; additive binding only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)