### PR TITLE
feat(pkg114): inc 3b — mixed instanced + non-instanced GPU scenes

### DIFF
--- a/.astroray_plan/packages/pkg114-two-level-bvh-tlas-blas.md
+++ b/.astroray_plan/packages/pkg114-two-level-bvh-tlas-blas.md
@@ -3,9 +3,10 @@
 **Pillar:** 5 (GPU) + 3 (light transport)
 **Track:** A
 **Codex-paste-ready:** no (core CUDA + CPU; large; multi-session RTX verify)
-**Status:** IN PROGRESS — GPU core landed + RTX-verified 2026-06-10
-(inc 1 PR #430, inc 2 PR #431). Remaining: Blender-addon instancing + the
-depsgraph transform-only refit (inc 3, below). **GPU-gated.** Follow-up
+**Status:** IN PROGRESS — GPU core + bulk binding + MIXED scenes landed/in-review
+& RTX-verified (inc 1 #430, inc 2 #431, inc 3a #460, inc 3b #462 2026-06-12).
+Remaining: Blender-addon `convert_objects` instancing wiring + the depsgraph
+transform-only refit (inc 3c, below). **GPU-gated.** Follow-up
 acceleration-structure package explicitly deferred by pkg56 §4.1.
 
 ### Increment log
@@ -24,16 +25,43 @@ acceleration-structure package explicitly deferred by pkg56 §4.1.
   (rigid / non-uniform scale / mirror) vs baked world-space — mean ratio 1.00000,
   mean abs diff 8.1e-9; BLAS sharing shown (4 prims vs 12 baked). Visual:
   `docs/renders/pkg114_instanced_tetrahedra.png`.
-- **Inc 3 (remaining):** wire the Blender addon `convert_objects` to register a
+- **Inc 3a (PR #460, merged):** `register_mesh_bulk` binding — bulk twin of
+  `register_mesh_triangles` ingesting object-local UVs / smooth normals /
+  multi-material into a shared BLAS. RTX: 2 instances (smooth normals + 2 mats +
+  UV layer) vs baked match; BLAS sharing 8 prims vs 16.
+- **Inc 3b (PR #462):** **MIXED instanced + non-instanced scenes.** The two-level
+  upload was all-or-nothing — any instance dropped every non-instanced "flat"
+  object from the GPU. Fix: the flat scene (`cpu.getBVH()`) is uploaded first
+  (offset 0) and exposed as ONE identity-transform instance, so `gpu_tlas_hit`
+  traverses flat+instanced uniformly (no device change; inc-1 identity path is
+  byte-exact). Flat prims at offset 0 keep pkg64-SMS + light emitter→prim search
+  valid (flat-scene area lights now resolve in mixed scenes). Shared
+  `appendFlatScene()` for single-level + mixed. Also adds an optional
+  `object_name` to `register_mesh_bulk`/`register_mesh_triangles` → correct
+  Cryptomatte object id on the shared BLAS. RTX: floor + 3 instanced tetrahedra
+  (incl. mirror) == fully-baked; broad GPU regression sweep clean.
+- **Inc 3c (remaining):** wire the Blender addon `convert_objects` to register a
   mesh datablock once + `add_instance(matrix_world)` per shared-datablock
-  instance (collection/particle/linked-duplicate) — needs a `register_mesh_bulk`
-  binding (UVs/normals/multi-material, mirroring `add_triangles_bulk` but
-  object-local) and headless-Blender bit-identical + BLAS-sharing verification;
-  then the transform-only depsgraph refit (`_renderer_object_id_map` →
-  `update_instance_transform` → TLAS-only re-upload) for the pkg56 ≤50%-baseline
-  budget. Multi-instance EMISSIVE-light NEE stays a deferred follow-up
-  (owner-flagged fork; non-blocking). NOTE: a SAH TLAS is an explicit non-goal
-  (see Hard non-goals) — the flat-leaf TLAS is correct and sufficient.
+  instance. **GPU-gated** via a pure device pre-check (CPU keeps flattening — see
+  Decisions). Group `object_instances` by `(obj.data, obj.name [, eligibility])`,
+  instance groups with **count ≥ 2** (object-local via `mesh_to_bulk_arrays`
+  identity, `object_name=obj.name`), everything else flattens. Eligibility
+  EXCLUDES emissive / caustic-caster / volume / non-MESH objects (→ flatten).
+  Headless-Blender bit-identical + BLAS-sharing verification
+  (`scripts/verify_pkg112_bulk_blender.py` pattern). Then the transform-only
+  depsgraph refit (`_renderer_object_id_map` → `update_instance_transform` →
+  TLAS-only re-upload) for the pkg56 ≤50%-baseline budget.
+
+  **Decisions (inc 3c):** (1) addon instancing is **GPU-only**; CPU has no
+  two-level traversal (renders solely via the scene-only `bvh`), so CPU keeps
+  flattening — correct, no memory win. A CPU `InstanceHittable` decorator is a
+  possible later enhancement. (2) Per-instance Cryptomatte uses the shared-BLAS
+  `object_name` (duplis share the source name = one matte; linked duplicates
+  stay count-1 → flatten). (3) GPU Cryptomatte is currently CPU-only for the
+  `path_tracer` integrator (MW kernel has no crypto block) — orthogonal to this
+  package. Multi-instance EMISSIVE-light NEE, instanced caustic casters, and
+  deformation-motion-on-instances remain deferred. SAH TLAS stays an explicit
+  non-goal. See memory `pkg114-instancing-engine-facts`.
 **Depends on:** pkg56 (done — provides the `_renderer_object_id_map` placeholder
 and transform-only dispatch hook). Complementary to pkg112.
 **Estimated effort:** L (~3–4 weeks, multiple RTX sessions)

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -681,14 +681,17 @@ public:
     // addTriangle's material lookup + Triangle ctor. Flat-shaded (face normals)
     // so the instanced render and a baked-world-space reference agree exactly
     // (avoids interpolate-vs-transform normal-order drift).
-    int registerMeshTriangles(const std::vector<std::array<float, 9>>& tris, int materialId) {
+    int registerMeshTriangles(const std::vector<std::array<float, 9>>& tris, int materialId,
+                              const std::string& objectName = "") {
         auto mat = materials.count(materialId) ? materials[materialId]
                                                : std::make_shared<Lambertian>(Vec3(0.5f));
         std::vector<std::shared_ptr<Hittable>> prims;
         prims.reserve(tris.size());
         for (const auto& t : tris) {
             Vec3 p0(t[0], t[1], t[2]), p1(t[3], t[4], t[5]), p2(t[6], t[7], t[8]);
-            prims.push_back(std::make_shared<Triangle>(p0, p1, p2, mat));
+            auto tri = std::make_shared<Triangle>(p0, p1, p2, mat);
+            if (!objectName.empty()) tri->setName(objectName);
+            prims.push_back(tri);
         }
         return renderer.registerMesh(prims);
     }
@@ -829,7 +832,8 @@ public:
             int objectPassIndex,
             py::array_t<float, py::array::c_style | py::array::forcecast> uvs,
             std::vector<std::string> uvLayerNames,
-            py::array_t<float, py::array::c_style | py::array::forcecast> normals) {
+            py::array_t<float, py::array::c_style | py::array::forcecast> normals,
+            const std::string& objectName = "") {
         auto pos = positions.unchecked<3>();              // (Nt, 3, 3)
         const py::ssize_t nt = pos.shape(0);
         if (pos.shape(1) != 3 || pos.shape(2) != 3)
@@ -885,6 +889,11 @@ public:
             }
             tri->setObjectPassIndex(objectPassIndex);
             tri->setMaterialPassIndex(mpi(t));
+            // pkg114 inc 3b — name the BLAS triangles so scene_upload's
+            // appendOnePrim hashes the right Cryptomatte object id (the shared
+            // BLAS is reused by every instance; the dupli case wants one matte,
+            // distinct registrations get distinct names).
+            if (!objectName.empty()) tri->setName(objectName);
             prims.push_back(tri);
         }
         return renderer.registerMesh(prims);
@@ -2404,16 +2413,18 @@ PYBIND11_MODULE(astroray, m) {
              "positions_end (N,3,3) is shutter close. Linear interpolation per Cycles (Apache-2.0). "
              "motionSteps=2 (pre+post). uvs/normals same as add_triangles_bulk.")
         .def("register_mesh_triangles", &PyRenderer::registerMeshTriangles,
-             "triangles"_a, "material_id"_a,
+             "triangles"_a, "material_id"_a, "object_name"_a = "",
              "pkg114: register a mesh's OBJECT-LOCAL flat-shaded triangles (list of "
-             "(9,) [v0,v1,v2]) once; returns mesh_id for add_instance().")
+             "(9,) [v0,v1,v2]) once; returns mesh_id for add_instance(). object_name "
+             "(optional) sets the Cryptomatte object id baked into the shared BLAS.")
         .def("register_mesh_bulk", &PyRenderer::registerMeshBulk,
              "positions"_a, "material_ids"_a, "material_pass_indices"_a, "object_pass_index"_a,
-             "uvs"_a, "uv_layer_names"_a, "normals"_a,
+             "uvs"_a, "uv_layer_names"_a, "normals"_a, "object_name"_a = "",
              "pkg114: register a mesh's OBJECT-LOCAL geometry once (UVs/normals/multi-"
              "material) into a shared BLAS; returns mesh_id for add_instance(). Bulk twin "
              "of register_mesh_triangles. positions (N,3,3) object-space; arrays match "
-             "add_triangles_bulk.")
+             "add_triangles_bulk. object_name (optional) sets the Cryptomatte object id "
+             "baked into the shared BLAS triangles.")
         .def("add_instance", &PyRenderer::addInstance, "mesh_id"_a, "transform"_a,
              "pkg114: instance a registered mesh with a row-major 4x4 object->world "
              "transform (16 floats). Returns instance_id.")

--- a/src/gpu/scene_upload.cu
+++ b/src/gpu/scene_upload.cu
@@ -310,13 +310,109 @@ static bool affineInverse4x4(const float M[16], float Minv[16]) {
 // Instances carry M (object->world) + Minv; the TLAS is a single flat leaf over
 // all instances (a SAH TLAS is a later perf win — a flat leaf is correct).
 // ---------------------------------------------------------------------------
+// Append the non-instanced "flat" scene (cpu.getBVH()) into r.nodes/prims with
+// pkg88 motion-offset wiring + pkg64 SMS caster gather. Shared by the single-
+// level path and the pkg114 MIXED path (where the flat scene is wrapped as an
+// identity-transform BLAS so it coexists with instanced meshes). Callers append
+// it FIRST (node/prim offset 0) so the pkg64 SMS primIdx convention and the
+// light emitter→prim search (both keyed on the ordered-prim index) stay valid.
+// Returns the number of ordered prims appended (0 if the flat scene is empty).
+static size_t appendFlatScene(
+    const Renderer& cpu, const BVHAccel* cpuBvh, SceneUploadResult& r,
+    const std::function<int(const std::shared_ptr<Material>&)>& getOrAddMat)
+{
+    if (!cpuBvh) return 0;
+    for (auto& n : cpuBvh->getNodes())
+        r.nodes.push_back(convertNode(n));
+    const auto& orderedPrims = cpuBvh->getPrimitives();
+    // pkg88-C.0: map CPU Triangle motion pointers → offsets in the concatenated
+    // GPU buffer (stable per-batch pointers; pkg98 review fix).
+    std::unordered_map<const Vec3*, size_t> motionPtrToOffset;
+    {
+        size_t batchBase = 0;
+        for (const auto& batch : cpu.getMotionVertexBatches()) {
+            for (size_t i = 0; i < batch.size(); ++i)
+                motionPtrToOffset[batch.data() + i] = batchBase + i;
+            batchBase += batch.size();
+        }
+    }
+    for (auto& hittable : orderedPrims) {
+        appendOnePrim(hittable, r, getOrAddMat);
+        if (auto* tri = dynamic_cast<Triangle*>(hittable.get())) {
+            const Vec3* motionBuf = tri->getMotionVertexBuffer();
+            if (motionBuf != nullptr) {
+                auto it = motionPtrToOffset.find(motionBuf);
+                if (it != motionPtrToOffset.end()) {
+                    r.triangles.back().motionOffset = static_cast<int>(it->second);
+                    r.triangles.back().motionSteps = tri->getMotionSteps();
+                }
+            }
+        }
+        // pkg64-gpu Phase 2: gather caustic-caster spheres inline (single-level
+        // only — SMS is not instancing-aware). primIdx preserves the prior
+        // (orderedPrims.size()-1) convention to keep pkg64 acceptance stable.
+        if (auto* sph = dynamic_cast<Sphere*>(hittable.get())) {
+            const GSphere& gs = r.spheres.back();
+            if (gs.isCausticCaster) {
+                const auto& mat = sph->getMaterial();
+                if (mat && mat->isTransmissive()) {
+                    float ior = mat->getIOR();
+                    if (ior > 1.0f) {
+                        int primIdx = (int)orderedPrims.size() - 1;
+                        astroray::manifold::device::GSMSCaster gc;
+                        gc.center = gs.center;
+                        gc.radius = gs.radius;
+                        gc.primId = primIdx;
+                        r.smsCasters.push_back(gc);
+                    }
+                }
+            }
+        }
+    }
+    return orderedPrims.size();
+}
+
+// Merge an object-space AABB transformed by a row-major 4x4 into tlasBounds.
+static void mergeWorldAABB(const float* M, const AABB& lb,
+                           AABB& tlasBounds, bool& haveBounds) {
+    for (int cx = 0; cx < 2; ++cx)
+    for (int cy = 0; cy < 2; ++cy)
+    for (int cz = 0; cz < 2; ++cz) {
+        float x = cx ? lb.max.x : lb.min.x;
+        float y = cy ? lb.max.y : lb.min.y;
+        float z = cz ? lb.max.z : lb.min.z;
+        Vec3 w(M[0]*x + M[1]*y + M[2]*z + M[3],
+               M[4]*x + M[5]*y + M[6]*z + M[7],
+               M[8]*x + M[9]*y + M[10]*z + M[11]);
+        if (!haveBounds) { tlasBounds = AABB(w, w); haveBounds = true; }
+        else tlasBounds = tlasBounds.merge(AABB(w, w));
+    }
+}
+
 static void buildTwoLevelArrays(
-    const Renderer& cpu, SceneUploadResult& r,
+    const Renderer& cpu, const BVHAccel* cpuBvh, SceneUploadResult& r,
     const std::function<int(const std::shared_ptr<Material>&)>& getOrAddMat)
 {
     const auto& meshBlas  = cpu.getMeshBlas();
     const auto& instances = cpu.getInstances();
 
+    // pkg114 inc 3b — MIXED scenes: the non-instanced "flat" scene is uploaded
+    // FIRST (node/prim offset 0) and exposed to the device as ONE extra BLAS
+    // reached through an IDENTITY-transform instance. The flat scene is then
+    // "just another instance" and the existing gpu_tlas_hit traverses it
+    // alongside the real instanced meshes (the inc-1 identity-parity test proved
+    // the identity instance path is byte-exact). This is what lets a scene with
+    // a static floor + instanced props render correctly; without it, enabling
+    // any instance dropped all non-instanced geometry from the GPU upload.
+    AABB flatBounds; bool haveFlat = false;
+    int  flatBlasIndex = -1;
+    if (cpuBvh && !cpuBvh->getPrimitives().empty()) {
+        // nodeOffset/primOffset are 0 because the flat scene is appended first.
+        appendFlatScene(cpu, cpuBvh, r, getOrAddMat);
+        cpuBvh->boundingBox(flatBounds); haveFlat = true;
+    }
+
+    // Registered-mesh BLASes follow the flat scene; their offsets advance past it.
     std::vector<AABB> meshLocalBounds(meshBlas.size());
     r.blas.resize(meshBlas.size());
     for (size_t m = 0; m < meshBlas.size(); ++m) {
@@ -328,9 +424,16 @@ static void buildTwoLevelArrays(
         for (const auto& hittable : blasAccel->getPrimitives()) appendOnePrim(hittable, r, getOrAddMat);
         AABB b; blasAccel->boundingBox(b); meshLocalBounds[m] = b;
     }
+    // The flat scene's BLAS record (nodeOffset/primOffset 0) goes at the END so
+    // real instance.blasIndex == meshId stays a direct index into r.blas[0..M).
+    if (haveFlat) {
+        GBLAS fb; fb.nodeOffset = 0; fb.primOffset = 0;
+        flatBlasIndex = (int)r.blas.size();
+        r.blas.push_back(fb);
+    }
 
     AABB tlasBounds; bool haveBounds = false;
-    r.instances.reserve(instances.size());
+    r.instances.reserve(instances.size() + 1);
     for (size_t j = 0; j < instances.size(); ++j) {
         int meshId = instances[j].meshId;
         if (meshId < 0 || (size_t)meshId >= meshBlas.size()) continue;
@@ -346,20 +449,19 @@ static void buildTwoLevelArrays(
         gi.blasIndex  = meshId;
         gi.instanceId = (int)r.instances.size();
         r.instances.push_back(gi);
+        mergeWorldAABB(M, meshLocalBounds[meshId], tlasBounds, haveBounds);
+    }
 
-        const AABB& lb = meshLocalBounds[meshId];
-        for (int cx = 0; cx < 2; ++cx)
-        for (int cy = 0; cy < 2; ++cy)
-        for (int cz = 0; cz < 2; ++cz) {
-            float x = cx ? lb.max.x : lb.min.x;
-            float y = cy ? lb.max.y : lb.min.y;
-            float z = cz ? lb.max.z : lb.min.z;
-            Vec3 w(M[0]*x + M[1]*y + M[2]*z + M[3],
-                   M[4]*x + M[5]*y + M[6]*z + M[7],
-                   M[8]*x + M[9]*y + M[10]*z + M[11]);
-            if (!haveBounds) { tlasBounds = AABB(w, w); haveBounds = true; }
-            else tlasBounds = tlasBounds.merge(AABB(w, w));
-        }
+    // The flat scene as an identity-transform instance (world == object space).
+    if (haveFlat) {
+        static const float kIdentity[16] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
+        GInstance gi;
+        gi.worldFromObject = GMat4::identity();
+        gi.objectFromWorld = GMat4::identity();
+        gi.blasIndex  = flatBlasIndex;
+        gi.instanceId = (int)r.instances.size();
+        r.instances.push_back(gi);
+        mergeWorldAABB(kIdentity, flatBounds, tlasBounds, haveBounds);
     }
 
     if (!r.instances.empty()) {
@@ -444,59 +546,11 @@ SceneUploadResult buildSceneArrays(const Renderer& cpu, const Camera* cam) {
     // engages gpu_tlas_hit (otherwise it falls back to gpu_bvh_hit, unchanged). ---
     auto& cpuBvh = cpu.getBVH();
     if (cpu.hasInstances()) {
-        buildTwoLevelArrays(cpu, r, getOrAddMat);
+        // pkg114 inc 3b — mixed: flat scene (cpuBvh) folded in as an identity BLAS.
+        buildTwoLevelArrays(cpu, cpuBvh.get(), r, getOrAddMat);
     } else {
         if (!cpuBvh) throw std::runtime_error("BVH not built — call buildAcceleration() first");
-        for (auto& n : cpuBvh->getNodes())
-            r.nodes.push_back(convertNode(n));
-        const auto& orderedPrims = cpuBvh->getPrimitives();
-        // pkg88-C.0: map CPU Triangle motion pointers → offsets in the
-        // CONCATENATED GPU buffer. Batches are stored separately on the CPU
-        // (stable per-batch pointers — pkg98 review fix); the GPU buffer is
-        // their concatenation in batch order, so offset = batchBase + i.
-        std::unordered_map<const Vec3*, size_t> motionPtrToOffset;
-        {
-            size_t batchBase = 0;
-            for (const auto& batch : cpu.getMotionVertexBatches()) {
-                for (size_t i = 0; i < batch.size(); ++i)
-                    motionPtrToOffset[batch.data() + i] = batchBase + i;
-                batchBase += batch.size();
-            }
-        }
-        for (auto& hittable : orderedPrims) {
-            appendOnePrim(hittable, r, getOrAddMat);
-            // pkg88-C.0 GPU — verify on RTX. Populate motionOffset for motion triangles.
-            if (auto* tri = dynamic_cast<Triangle*>(hittable.get())) {
-                const Vec3* motionBuf = tri->getMotionVertexBuffer();
-                if (motionBuf != nullptr) {
-                    auto it = motionPtrToOffset.find(motionBuf);
-                    if (it != motionPtrToOffset.end()) {
-                        r.triangles.back().motionOffset = static_cast<int>(it->second);
-                        r.triangles.back().motionSteps = tri->getMotionSteps();
-                    }
-                }
-            }
-            // pkg64-gpu Phase 2: gather caustic-caster spheres inline (single-level
-            // only — SMS is not instancing-aware). primIdx preserves the prior
-            // (orderedPrims.size()-1) convention to keep pkg64 acceptance stable.
-            if (auto* sph = dynamic_cast<Sphere*>(hittable.get())) {
-                const GSphere& gs = r.spheres.back();
-                if (gs.isCausticCaster) {
-                    const auto& mat = sph->getMaterial();
-                    if (mat && mat->isTransmissive()) {
-                        float ior = mat->getIOR();
-                        if (ior > 1.0f) {
-                            int primIdx = (int)orderedPrims.size() - 1;
-                            astroray::manifold::device::GSMSCaster gc;
-                            gc.center = gs.center;
-                            gc.radius = gs.radius;
-                            gc.primId = primIdx;
-                            r.smsCasters.push_back(gc);
-                        }
-                    }
-                }
-            }
-        }
+        appendFlatScene(cpu, cpuBvh.get(), r, getOrAddMat);
     }
 
     // --- Lights ---
@@ -505,13 +559,14 @@ SceneUploadResult buildSceneArrays(const Renderer& cpu, const Camera* cam) {
     const auto& powerDist  = ll2.getPowerDist();
     r.totalLightPower      = ll2.getTotalPower();
 
-    // Emitter→prim search list. In the single-level case this is the BVH's
-    // ordered prims; pkg114 instanced emitters are deferred (a follow-up), so
-    // for an instanced scene we use an empty list (primIdx stays -1, GLight
-    // unwired) — the parity scene is background-lit with no area lights.
+    // Emitter→prim search list = the flat-scene ordered prims, which always
+    // occupy global prim offset 0 (single-level AND pkg114 mixed, where the flat
+    // scene is appended first). So flat-scene area lights resolve correctly even
+    // in a mixed scene. Emitters that live on an INSTANCED mesh are deferred (a
+    // follow-up): registered-mesh prims are not in this list, so their primIdx
+    // stays -1 (GLight unwired).
     static const std::vector<std::shared_ptr<Hittable>> kNoPrims;
-    const auto& orderedPrims =
-        (!cpu.hasInstances() && cpuBvh) ? cpuBvh->getPrimitives() : kNoPrims;
+    const auto& orderedPrims = cpuBvh ? cpuBvh->getPrimitives() : kNoPrims;
 
     // Find each light's primitive index in r.prims
     for (size_t i = 0; i < lightPtrs.size(); ++i) {

--- a/tests/test_tlas_mixed_scene_parity.py
+++ b/tests/test_tlas_mixed_scene_parity.py
@@ -1,0 +1,154 @@
+"""pkg114 increment 3b — MIXED instanced + non-instanced GPU pixel-parity gate.
+
+The previous two-level upload was all-or-nothing: the moment a scene contained
+ANY instance, every NON-instanced ("flat") object was dropped from the GPU
+upload. Real Blender scenes always mix a static floor / unique props with
+instanced duplis, so this is the blocker for using the addon instancing path.
+
+inc 3b folds the flat scene into the TLAS as ONE identity-transform instance
+(its BVH wrapped as a BLAS), so the existing gpu_tlas_hit traverses flat +
+instanced geometry uniformly. This test renders:
+
+  flat floor (add_triangle → single-level scene)  +  3 instanced tetrahedra
+                              vs
+  the SAME floor + tetrahedra ALL baked into world-space add_triangle calls.
+
+If the flat floor were still dropped (old behaviour) the two images would differ
+massively in the lower half of the frame. Same camera/seed/spp + flat
+background ⇒ they agree to float transform-order noise.
+
+Skipped when the astroray module lacks CUDA or no GPU is present.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+
+try:
+    import astroray  # noqa: E402
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray not built")
+
+_W = _H = 96
+_SPP = 24
+_DEPTH = 4
+
+_TET = np.array([
+    [1, 1, 1], [1, -1, -1], [-1, 1, -1], [-1, -1, 1],
+], dtype=np.float64) * 0.55
+_FACES = [(0, 1, 2), (0, 2, 3), (0, 3, 1), (1, 3, 2)]
+
+
+def _tet_local_triangles():
+    return [list(np.concatenate([_TET[a], _TET[b], _TET[c]]).astype(np.float32))
+            for (a, b, c) in _FACES]
+
+
+def _translate(x, y, z):
+    M = np.eye(4); M[0, 3], M[1, 3], M[2, 3] = x, y, z; return M
+
+
+def _scale(sx, sy, sz):
+    M = np.eye(4); M[0, 0], M[1, 1], M[2, 2] = sx, sy, sz; return M
+
+
+def _rot_y(deg):
+    a = np.radians(deg); c, s = np.cos(a), np.sin(a)
+    M = np.eye(4); M[0, 0], M[0, 2], M[2, 0], M[2, 2] = c, s, -s, c; return M
+
+
+_TRANSFORMS = [
+    _translate(-2.4, 0.4, 0) @ _rot_y(35),
+    _translate(0.0, 0.4, 0) @ _scale(1.5, 0.7, 1.0),
+    _translate(2.4, 0.4, 0) @ _scale(-1.0, 1.0, 1.0),   # mirror
+]
+
+# A large flat floor at y = -1.2 (two triangles), in the NON-instanced scene.
+_FLOOR = [
+    ([-6, -1.2, -6], [6, -1.2, -6], [6, -1.2, 6]),
+    ([-6, -1.2, -6], [6, -1.2, 6], [-6, -1.2, 6]),
+]
+
+
+def _common(r):
+    r.set_background_color([0.55, 0.65, 0.85])
+    r.set_integrator("path_tracer")
+    r.set_use_gpu(True)
+    r.setup_camera([0, 2.2, 9.0], [0, -0.2, 0], [0, 1, 0], 42.0, 1.0, 0.0, 9.0, _W, _H)
+    r.set_seed(7)
+
+
+def _render(r):
+    return np.asarray(r.render(_SPP, _DEPTH, None, False),
+                      dtype=np.float32).reshape(_H, _W, 3)
+
+
+def _add_floor(r, mat):
+    for (a, b, c) in _FLOOR:
+        r.add_triangle(list(map(float, a)), list(map(float, b)), list(map(float, c)), mat)
+
+
+def _mixed_image():
+    r = astroray.Renderer()
+    floor_mat = r.create_material("lambertian", [0.30, 0.55, 0.30], {})
+    tet_mat = r.create_material("lambertian", [0.82, 0.30, 0.30], {})
+    _add_floor(r, floor_mat)                       # → non-instanced flat scene
+    mesh = r.register_mesh_triangles(_tet_local_triangles(), tet_mat)  # → BLAS
+    for M in _TRANSFORMS:
+        r.add_instance(mesh, list(M.flatten().astype(np.float32)))
+    _common(r)
+    return _render(r)
+
+
+def _baked_image():
+    r = astroray.Renderer()
+    floor_mat = r.create_material("lambertian", [0.30, 0.55, 0.30], {})
+    tet_mat = r.create_material("lambertian", [0.82, 0.30, 0.30], {})
+    _add_floor(r, floor_mat)
+    for M in _TRANSFORMS:
+        R = M[:3, :3]; t = M[:3, 3]
+        for (a, b, c) in _FACES:
+            w = [(R @ _TET[i] + t).astype(np.float32).tolist() for i in (a, b, c)]
+            r.add_triangle(w[0], w[1], w[2], tet_mat)
+    _common(r)
+    return _render(r)
+
+
+@pytest.mark.skipif(
+    AVAILABLE and not astroray.__features__.get("cuda", False),
+    reason="CUDA feature not in this build")
+def test_mixed_instanced_and_flat_matches_fully_baked():
+    if not astroray.Renderer().gpu_available:
+        pytest.skip("CUDA GPU not available")
+
+    mixed = _mixed_image()
+    baked = _baked_image()
+
+    assert mixed.mean() > 0.05, f"mixed render looks empty (mean={mixed.mean():.4f})"
+
+    # The floor fills the lower rows of the frame. If the flat scene had been
+    # dropped (the bug this gate guards), the lower band would show only the
+    # blue background (high B, low R/G) instead of the green floor. Assert the
+    # floor band carries the floor's green energy in BOTH images.
+    band = slice(int(_H * 0.72), _H)
+    for img, tag in ((mixed, "mixed"), (baked, "baked")):
+        g = img[band, :, 1].mean(); b = img[band, :, 2].mean()
+        assert g > 0.10 and g > 0.6 * b, (
+            f"{tag} floor band missing green floor (G={g:.3f} B={b:.3f})")
+
+    # Whole-frame parity: same geometry, same seed ⇒ float transform-order noise.
+    for ch, name in enumerate("RGB"):
+        rm, rb = mixed[..., ch].mean(), baked[..., ch].mean()
+        ratio = rm / max(rb, 1e-6)
+        assert 0.97 <= ratio <= 1.03, (
+            f"{name} channel energy off: mixed={rm:.4f} baked={rb:.4f} ratio={ratio:.4f}")
+
+    mad = float(np.abs(mixed - baked).mean())
+    assert mad < 0.02, f"mean abs per-pixel diff {mad:.4f} too large (flat scene dropped?)"


### PR DESCRIPTION
## pkg114 increment 3b — mixed scenes

The two-level upload was **all-or-nothing**: any instance in a scene caused every non-instanced ("flat") object to be dropped from the GPU upload. Real Blender scenes always mix a static floor / unique props with instanced duplis, so this blocked the addon instancing path (inc 3c).

### Fix
The flat scene (`cpu.getBVH()`) is uploaded **first** (node/prim offset 0) and exposed to the device as **one extra BLAS reached through an identity-transform instance**. The flat scene becomes "just another instance" and the existing `gpu_tlas_hit` traverses flat + instanced geometry uniformly — **no device-side change, no new traversal path** (the inc-1 identity-parity test already proved the identity instance path is byte-exact).

Flat prims staying at global offset 0 keeps the pkg64 SMS `primIdx` convention and the light emitter→prim search valid; emitter search now also resolves **flat-scene area lights in a mixed scene**. The flat-scene append (pkg88 motion + pkg64 SMS wiring) is extracted into a shared `appendFlatScene()` used by both the single-level and mixed paths.

Also adds an optional `object_name` to `register_mesh_bulk`/`register_mesh_triangles` that names the shared BLAS triangles so `appendOnePrim` hashes the correct Cryptomatte object id (the addon passes `obj.name` in inc 3c).

### Verification (RTX, local)
- **NEW** `test_tlas_mixed_scene_parity.py`: flat green floor + 3 instanced tetrahedra (incl. a mirror) renders pixel-identical to the same floor + tetrahedra all baked into world-space `add_triangle` calls (floor-band green present, per-channel ratio in [0.97, 1.03], mean abs diff < 0.02). Fails if the flat scene is dropped.
- Existing TLAS parity (inc 1/2/3a) all pass.
- Broad GPU regression sweep (glass furnace, MW, shade-smooth, pkg64 phase2/3, light-tree, caustic-parity, spectral materials, glass-sphere caustic, motion, light-sampler, CPU cryptomatte) — all pass, only pre-existing xfails.

### Known v1 limitations (documented, deferred)
Emitters and caustic casters on an **instanced** mesh are not yet wired (flat-scene ones are); deformation motion blur is not applied to the flat scene when instances coexist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)