### PR TITLE
docs(pkg115): visual-gate diagnosis — 4 root causes + harness fixes

### DIFF
--- a/.astroray_plan/docs/blender-procedural-parity-research.md
+++ b/.astroray_plan/docs/blender-procedural-parity-research.md
@@ -558,14 +558,18 @@ plus a paired-still RTX check at the end.
 9. **Voronoi** — largest port: metrics + F1/F2/SmoothF1/DistToEdge/NSphere +
    fractal wrapper + normalize + multi-output mapping. ✅ **DONE 2026-06-11 (chunk 4, PR #445)**
 10. **Addon translator + duplication removal + standalone CI example**
-    (Stage 3/4 of the package spec). 🔶 **PARTIAL 2026-06-11 (chunk 5):** addon
-    `ShaderNodeTexVoronoi` translation updated to the new feature enum
-    (0=F1,1=SmoothF1,2=F2,3=DistToEdge,4=NSphere) + full detail/roughness/
-    lacunarity/exponent/normalize wiring; `create_procedural_texture("voronoi", …)`
-    factory extended to forward the trailing params (backward-compatible);
-    standalone CI example added. REMAINING: addon-side private texture-definition
-    duplication removal (Approach step 4) and the Blender-vs-Cycles paired-still
-    visual (RTX `/verify`).
+    (Stage 3/4 of the package spec). ✅ **DONE 2026-06-12 (chunks 5-6):** addon
+    `load_procedural_texture` now routes all Blender procedural texture nodes
+    (Noise, Voronoi, Wave, Brick, Checker, Gradient, Magic, Musgrave) through
+    the engine's `create_procedural_texture` factory with Cycles-parity param
+    vectors. Duplication removed — addon carries no private texture evaluators.
+    C++ factory extended to accept full param vectors for Noise (Perlin-based,
+    chunk 2), Wave (16 params: wave_type, bands/rings directions, phase_offset,
+    detail_scale), and Brick (19 params: color1/color2 per-brick variation,
+    mortar_smooth, bias, offset/squash frequencies). Tests added in
+    `test_pkg115_addon_texture_translation.py` asserting param mappings match
+    engine expectations. REMAINING: Blender-vs-Cycles paired-still visual
+    (RTX `/verify`).
 
 ---
 

--- a/.astroray_plan/packages/pkg115-adopt-blender-shader-node-textures.md
+++ b/.astroray_plan/packages/pkg115-adopt-blender-shader-node-textures.md
@@ -4,6 +4,14 @@
 **Track:** A
 **Codex-paste-ready:** no (large, staged; RTX visual verify)
 **Status:** Stage 2 chunks 1-6 done (PR #439 coord defaults, #441 hash+Perlin+fBM, #442 Wave+Brick, #445 Voronoi, #446 addon ShaderNodeTexVoronoi wiring, chunk 6 addon dedup — 2026-06-12). REMAINING: Blender-vs-Cycles RTX visual verify. **Visual-verify status (2026-06-12 03:15, RTX): OPEN FINDING — the paired-stills harness (scripts/verify_pkg115_textures_blender.py, headless Blender 5.1 factory-startup, 8-sphere texture grid) renders correctly under CYCLES but the CUSTOM_RAYTRACER leg produces uniformly dark, untextured spheres regardless of area-light energy (300W vs 9000W identical) — an end-to-end F12 export gap (lighting and/or material-texture translation not reaching the renderer for this scene construction), DISTINCT from the dedup chunk's translation layer whose unit tests pass. The visual acceptance gate stays OPEN pending diagnosis of the addon F12 export path on factory-startup scenes.**
+
+**FULL DIAGNOSIS (2026-06-12 morning, RTX + Blender 5.1 headless) — four separated root causes:**
+1. **GPU leg dark: dedicated lights are not uploaded to the GPU** (`[CUDA] Scene uploaded: ... 0 lights`). The addon exports AREA lights as pkg89 dedicated AreaLights (`add_area_light_dedicated`), which the GPU scene upload does not carry (the pkg86-B "dedicated lights -> power-CDF fallback" deferral). Affects ANY dedicated-light scene on GPU, independent of pkg115.
+2. **CPU leg HANGS: OpenMP deadlock inside Blender** — the standard MSVC .pyd deadlocks Blender 5.1's F12 CPU render (~zero CPU use); rebuilding with `-DASTRORAY_DISABLE_OPENMP=ON` fixes it (render 0.1-18 s). This GENERALIZES the MinGW-only memory (mingw_openmp_blender_deadlock) to MSVC/vcomp: ALL addon-use builds need the flag.
+3. **Harness bug (fixed): the F12 sample count property is `samples`** (default 2) — `preview_samples` is viewport-only; early stills were 2 spp regardless of --spp.
+4. **THE REMAINING pkg115 ITEM — procedural-texture coordinate space:** at 128 spp the CPU leg renders textures cleanly but in UV space (checker = fine concentric rings on the sphere) where Cycles defaults unconnected-Vector procedural textures to GENERATED (object-local 3D) coordinates (checker = large 3D blocks). The addon/eval path must default to generated coordinates (the audit's Mapping/TexCoord item; chunk 1's CoordMode infrastructure is the hook). Also the dedicated area light contributes far less than Cycles at equal wattage on CPU (energy-scale audit needed, pkg89 follow-up).
+
+Paired stills: wt test_results/pkg115_final/ (cycles.png vs custom_raytracer.png).
 **Depends on:** pkg57 (done — established the additive custom-node pattern and
 the `convert_node_material` traversal). Benefits from pkg112.
 **Estimated effort:** L (multi-week, staged)

--- a/.astroray_plan/packages/pkg115-adopt-blender-shader-node-textures.md
+++ b/.astroray_plan/packages/pkg115-adopt-blender-shader-node-textures.md
@@ -3,7 +3,7 @@
 **Pillar:** 5 (addon) + 2 (materials/textures)
 **Track:** A
 **Codex-paste-ready:** no (large, staged; RTX visual verify)
-**Status:** Stage 2 chunks 1-5 done (PR #439 coord defaults, #441 hash+Perlin+fBM, #442 Wave+Brick, #445 Voronoi, #446 addon ShaderNodeTexVoronoi wiring — 2026-06-11). REMAINING: addon-side private texture-definition duplication removal (Approach step 4) + Blender-vs-Cycles RTX visual verify.
+**Status:** Stage 2 chunks 1-6 done (PR #439 coord defaults, #441 hash+Perlin+fBM, #442 Wave+Brick, #445 Voronoi, #446 addon ShaderNodeTexVoronoi wiring, chunk 6 addon dedup — 2026-06-12). REMAINING: Blender-vs-Cycles RTX visual verify.
 **Depends on:** pkg57 (done — established the additive custom-node pattern and
 the `convert_node_material` traversal). Benefits from pkg112.
 **Estimated effort:** L (multi-week, staged)

--- a/.astroray_plan/packages/pkg115-adopt-blender-shader-node-textures.md
+++ b/.astroray_plan/packages/pkg115-adopt-blender-shader-node-textures.md
@@ -3,7 +3,7 @@
 **Pillar:** 5 (addon) + 2 (materials/textures)
 **Track:** A
 **Codex-paste-ready:** no (large, staged; RTX visual verify)
-**Status:** Stage 2 chunks 1-6 done (PR #439 coord defaults, #441 hash+Perlin+fBM, #442 Wave+Brick, #445 Voronoi, #446 addon ShaderNodeTexVoronoi wiring, chunk 6 addon dedup — 2026-06-12). REMAINING: Blender-vs-Cycles RTX visual verify.
+**Status:** Stage 2 chunks 1-6 done (PR #439 coord defaults, #441 hash+Perlin+fBM, #442 Wave+Brick, #445 Voronoi, #446 addon ShaderNodeTexVoronoi wiring, chunk 6 addon dedup — 2026-06-12). REMAINING: Blender-vs-Cycles RTX visual verify. **Visual-verify status (2026-06-12 03:15, RTX): OPEN FINDING — the paired-stills harness (scripts/verify_pkg115_textures_blender.py, headless Blender 5.1 factory-startup, 8-sphere texture grid) renders correctly under CYCLES but the CUSTOM_RAYTRACER leg produces uniformly dark, untextured spheres regardless of area-light energy (300W vs 9000W identical) — an end-to-end F12 export gap (lighting and/or material-texture translation not reaching the renderer for this scene construction), DISTINCT from the dedup chunk's translation layer whose unit tests pass. The visual acceptance gate stays OPEN pending diagnosis of the addon F12 export path on factory-startup scenes.**
 **Depends on:** pkg57 (done — established the additive custom-node pattern and
 the `convert_node_material` traversal). Benefits from pkg112.
 **Estimated effort:** L (multi-week, staged)

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -2742,10 +2742,12 @@ class CustomRaytracerRenderEngine(RenderEngine):
                 noise_dist = _nsock('Distortion', 0.0)
                 # Blender Noise Texture noise_dimensions: '3D' is the only one the engine supports (node has 1D/2D/3D/4D).
                 # noise_type: Blender enum FBM/MULTIFRACTAL/RIGID_MULTIFRACTAL/HYBRID_MULTIFRACTAL/HETERO_TERRAIN
-                # maps to fractal_noise.h 0=fBM, 1=multifractal, 2=ridged, 3=hybrid, 4=hetero per audit §6 item 6.
+                # maps to the ENGINE ordering (advanced_features.h noise_select):
+                # 0=fBM, 1=multifractal, 2=HYBRID, 3=RIDGED, 4=hetero.
+                # (pkg98 chunk-6 review B1: an earlier draft swapped 2/3.)
                 noise_type_map = {
-                    'FBM': 0.0, 'MULTIFRACTAL': 1.0, 'RIDGED_MULTIFRACTAL': 2.0,
-                    'HYBRID_MULTIFRACTAL': 3.0, 'HETERO_TERRAIN': 4.0
+                    'FBM': 0.0, 'MULTIFRACTAL': 1.0, 'HYBRID_MULTIFRACTAL': 2.0,
+                    'RIDGED_MULTIFRACTAL': 3.0, 'HETERO_TERRAIN': 4.0
                 }
                 nt = noise_type_map.get(getattr(node, 'noise_type', 'FBM'), 0.0)
                 noise_norm = 1.0 if getattr(node, 'normalize', True) else 0.0

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -2741,7 +2741,7 @@ class CustomRaytracerRenderEngine(RenderEngine):
                 noise_gain = _nsock('Gain', 1.0)
                 noise_dist = _nsock('Distortion', 0.0)
                 # Blender Noise Texture noise_dimensions: '3D' is the only one the engine supports (node has 1D/2D/3D/4D).
-                # noise_type: Blender enum FBM/MULTIFRACTAL/RIGID_MULTIFRACTAL/HYBRID_MULTIFRACTAL/HETERO_TERRAIN
+                # noise_type: Blender enum FBM/MULTIFRACTAL/RIDGED_MULTIFRACTAL/HYBRID_MULTIFRACTAL/HETERO_TERRAIN
                 # maps to the ENGINE ordering (advanced_features.h noise_select):
                 # 0=fBM, 1=multifractal, 2=HYBRID, 3=RIDGED, 4=hetero.
                 # (pkg98 chunk-6 review B1: an earlier draft swapped 2/3.)

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -2728,9 +2728,30 @@ class CustomRaytracerRenderEngine(RenderEngine):
         tex_name = None
         try:
             if ntype == 'TEX_NOISE':
-                scale = float(node.inputs['Scale'].default_value) if node.inputs.get('Scale') else 5.0
+                # pkg115 chunk 2: ShaderNodeTexNoise → NoiseTextureCycles (Perlin + fractal).
+                # Params: [scale, detail, roughness, lacunarity, offset, gain, distortion, noise_type, normalize]
+                def _nsock(name, fallback):
+                    s = node.inputs.get(name)
+                    return float(s.default_value) if s is not None else fallback
+                noise_scale = _nsock('Scale', 5.0)
+                noise_detail = _nsock('Detail', 2.0)
+                noise_rough = _nsock('Roughness', 0.5)
+                noise_lac = _nsock('Lacunarity', 2.0)
+                noise_offset = _nsock('Offset', 0.0)
+                noise_gain = _nsock('Gain', 1.0)
+                noise_dist = _nsock('Distortion', 0.0)
+                # Blender Noise Texture noise_dimensions: '3D' is the only one the engine supports (node has 1D/2D/3D/4D).
+                # noise_type: Blender enum FBM/MULTIFRACTAL/RIGID_MULTIFRACTAL/HYBRID_MULTIFRACTAL/HETERO_TERRAIN
+                # maps to fractal_noise.h 0=fBM, 1=multifractal, 2=ridged, 3=hybrid, 4=hetero per audit §6 item 6.
+                noise_type_map = {
+                    'FBM': 0.0, 'MULTIFRACTAL': 1.0, 'RIDGED_MULTIFRACTAL': 2.0,
+                    'HYBRID_MULTIFRACTAL': 3.0, 'HETERO_TERRAIN': 4.0
+                }
+                nt = noise_type_map.get(getattr(node, 'noise_type', 'FBM'), 0.0)
+                noise_norm = 1.0 if getattr(node, 'normalize', True) else 0.0
                 tex_name = f"_proc_noise_{node_id}"
-                renderer.create_procedural_texture(tex_name, 'noise', [scale])
+                renderer.create_procedural_texture(tex_name, 'noise_perlin',
+                    [noise_scale, noise_detail, noise_rough, noise_lac, noise_offset, noise_gain, noise_dist, nt, noise_norm])
             elif ntype == 'TEX_CHECKER':
                 scale = float(node.inputs['Scale'].default_value) if node.inputs.get('Scale') else 5.0
                 c1 = list(node.inputs['Color1'].default_value[:3]) if node.inputs.get('Color1') else [1,1,1]
@@ -2767,18 +2788,30 @@ class CustomRaytracerRenderEngine(RenderEngine):
                      0, 0, 0, 1, 1, 1,
                      detail, roughness, lacunarity, exponent, normalize])
             elif ntype == 'TEX_WAVE':
+                # pkg115 chunk 3 + chunk 6 (addon dedup): full Cycles-parity Wave.
+                # Params: [wave_type, bands_direction, rings_direction, profile, scale, distortion,
+                #          detail, detail_scale, detail_roughness, phase_offset, r1,g1,b1, r2,g2,b2]
                 scale = float(node.inputs['Scale'].default_value) if node.inputs.get('Scale') else 5.0
                 dist = float(node.inputs['Distortion'].default_value) if node.inputs.get('Distortion') else 0.0
                 detail = float(node.inputs['Detail'].default_value) if node.inputs.get('Detail') else 2.0
-                rough = float(node.inputs['Detail Roughness'].default_value or node.inputs.get('Roughness', type(0)).default_value) \
-                    if node.inputs.get('Detail Roughness') else 0.5
-                lac = float(node.inputs['Detail Scale'].default_value) if node.inputs.get('Detail Scale') else 2.0
-                bd = 1 if getattr(node, 'wave_type', 'BANDS') == 'RINGS' else 0
-                profile_map = {'SINE': 0, 'SAW': 1, 'TRIANGLE': 2}
-                prof = profile_map.get(getattr(node, 'bands_direction', 'SINE'), 0)
+                dscale = float(node.inputs['Detail Scale'].default_value) if node.inputs.get('Detail Scale') else 1.0
+                drough = float(node.inputs['Detail Roughness'].default_value) if node.inputs.get('Detail Roughness') else 0.5
+                phase = float(node.inputs['Phase Offset'].default_value) if node.inputs.get('Phase Offset') else 0.0
+                # wave_type: BANDS=0, RINGS=1
+                wt = 1 if getattr(node, 'wave_type', 'BANDS') == 'RINGS' else 0
+                # bands_direction: X=0, Y=1, Z=2, DIAGONAL=3; Blender property 'bands_direction'
+                bands_dir_map = {'X': 0, 'Y': 1, 'Z': 2, 'DIAGONAL': 3}
+                bd = bands_dir_map.get(getattr(node, 'bands_direction', 'X'), 0)
+                # rings_direction: X=0, Y=1, Z=2, SPHERICAL=3; Blender property 'rings_direction'
+                rings_dir_map = {'X': 0, 'Y': 1, 'Z': 2, 'SPHERICAL': 3}
+                rd = rings_dir_map.get(getattr(node, 'rings_direction', 'X'), 0)
+                # wave_profile: SINE=0, SAW=1, TRIANGLE=2; Blender property 'wave_profile'
+                profile_map = {'SIN': 0, 'SAW': 1, 'TRI': 2}
+                prof = profile_map.get(getattr(node, 'wave_profile', 'SIN'), 0)
                 tex_name = f"_proc_wave_{node_id}"
                 renderer.create_procedural_texture(tex_name, 'wave',
-                    [float(bd), float(prof), scale, dist, detail, rough, lac, 0,0,0, 1,1,1])
+                    [float(wt), float(bd), float(rd), float(prof), scale, dist, detail, dscale, drough, phase,
+                     0,0,0, 1,1,1])
             elif ntype == 'TEX_MAGIC':
                 depth = int(node.turbulence_depth) if hasattr(node, 'turbulence_depth') else 2
                 scale = float(node.inputs['Scale'].default_value) if node.inputs.get('Scale') else 5.0
@@ -2787,16 +2820,26 @@ class CustomRaytracerRenderEngine(RenderEngine):
                 renderer.create_procedural_texture(tex_name, 'magic',
                     [float(depth), scale, dist, 0,0,0, 1,1,1])
             elif ntype == 'TEX_BRICK':
+                # pkg115 chunk 3 + chunk 6 (addon dedup): full Cycles-parity Brick.
+                # Params: [brick1_r,g,b, brick2_r,g,b, mortar_r,g,b, scale, mortar_size, mortar_smooth,
+                #          bias, brick_width, row_height, offset_amount, offset_freq, squash, squash_freq]
+                c1 = list(node.inputs['Color1'].default_value[:3]) if node.inputs.get('Color1') else [0.8, 0.8, 0.8]
+                c2 = list(node.inputs['Color2'].default_value[:3]) if node.inputs.get('Color2') else [0.2, 0.2, 0.2]
+                c_mortar = list(node.inputs['Color3'].default_value[:3]) if node.inputs.get('Color3') else [0.0, 0.0, 0.0]
                 scale = float(node.inputs['Scale'].default_value) if node.inputs.get('Scale') else 5.0
-                mortar = float(node.inputs['Mortar Size'].default_value) if node.inputs.get('Mortar Size') else 0.02
-                offset = float(node.inputs['Offset'].default_value) if node.inputs.get('Offset') else 0.5
-                c_brick = list(node.inputs['Color1'].default_value[:3]) if node.inputs.get('Color1') else [0.7, 0.35, 0.2]
-                c_mortar = list(node.inputs['Color3'].default_value[:3]) if node.inputs.get('Color3') else [0.9, 0.9, 0.9]
+                mort_size = float(node.inputs['Mortar Size'].default_value) if node.inputs.get('Mortar Size') else 0.02
+                mort_smooth = float(node.inputs['Mortar Smooth'].default_value) if node.inputs.get('Mortar Smooth') else 0.1
+                bias = float(node.inputs['Bias'].default_value) if node.inputs.get('Bias') else 0.0
                 bw = float(node.inputs['Brick Width'].default_value) if node.inputs.get('Brick Width') else 0.5
-                bh = float(node.inputs['Row Height'].default_value) if node.inputs.get('Row Height') else 0.25
+                rh = float(node.inputs['Row Height'].default_value) if node.inputs.get('Row Height') else 0.25
+                # Blender Brick properties: offset, offset_frequency, squash, squash_frequency
+                offamt = float(node.inputs['Offset'].default_value) if node.inputs.get('Offset') else 0.5
+                offfreq = float(getattr(node, 'offset_frequency', 2))
+                sq = float(getattr(node, 'squash', 1.0))
+                sqfreq = float(getattr(node, 'squash_frequency', 2))
                 tex_name = f"_proc_brick_{node_id}"
                 renderer.create_procedural_texture(tex_name, 'brick',
-                    c_brick + c_mortar + [bw, bh, mortar, offset, scale])
+                    c1 + c2 + c_mortar + [scale, mort_size, mort_smooth, bias, bw, rh, offamt, offfreq, sq, sqfreq])
             elif ntype == 'TEX_GRADIENT':
                 grad_map = {'LINEAR': 0, 'QUADRATIC': 1, 'EASING': 2, 'DIAGONAL': 3,
                             'SPHERICAL': 4, 'QUADRATIC_SPHERE': 5, 'RADIAL': 6}

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -198,6 +198,20 @@ public:
             proceduralTextures[name] = std::make_shared<CheckerTexture>(c1, c2, scale);
         } else if (type == "noise") {
             proceduralTextures[name] = std::make_shared<NoiseTexture>(params.size() > 0 ? params[0] : 1.0f);
+        } else if (type == "noise_perlin") {
+            // pkg115 chunk 2 + chunk 6 (addon dedup): ShaderNodeTexNoise → NoiseTextureCycles.
+            // Params: [scale, detail, roughness, lacunarity, offset, gain, distortion, noise_type, normalize]
+            float scale = params.size() > 0 ? params[0] : 5.0f;
+            float detail = params.size() > 1 ? params[1] : 2.0f;
+            float roughness = params.size() > 2 ? params[2] : 0.5f;
+            float lacunarity = params.size() > 3 ? params[3] : 2.0f;
+            float offset = params.size() > 4 ? params[4] : 0.0f;
+            float gain = params.size() > 5 ? params[5] : 1.0f;
+            float distortion = params.size() > 6 ? params[6] : 0.0f;
+            int noise_type = params.size() > 7 ? (int)params[7] : 0;
+            bool normalize = params.size() > 8 ? (params[8] != 0.0f) : true;
+            proceduralTextures[name] = std::make_shared<NoiseTextureCycles>(
+                scale, detail, roughness, lacunarity, offset, gain, distortion, noise_type, normalize);
         } else if (type == "marble") {
             proceduralTextures[name] = std::make_shared<MarbleTexture>(params.size() > 0 ? params[0] : 1.0f);
         } else if (type == "wood") {
@@ -210,22 +224,26 @@ public:
             Vec3 c2 = params.size() > 7 ? Vec3(params[5], params[6], params[7]) : Vec3(1);
             proceduralTextures[name] = std::make_shared<GradientTexture>(gt, c1, c2, sc);
         } else if (type == "wave") {
-            // Legacy positional params: [band_dir, profile, scale, distortion,
-            // detail, roughness, lacunarity, r1,g1,b1, r2,g2,b2]. pkg115 chunk 3:
-            // mapped onto the Cycles-parity ctor (wave_type=bands; the legacy
-            // lacunarity slot is accepted but unused - the Cycles Wave node has
-            // no lacunarity socket, its fBM detail uses the svm/wave.h scheme).
-            int bd = params.size() > 0 ? (int)params[0] : 0;
-            int pf = params.size() > 1 ? (int)params[1] : 0;
-            float sc = params.size() > 2 ? params[2] : 5.0f;
-            float dist = params.size() > 3 ? params[3] : 0.0f;
-            float det = params.size() > 4 ? params[4] : 2.0f;
-            float rough = params.size() > 5 ? params[5] : 0.5f;
-            Vec3 c1 = params.size() > 9 ? Vec3(params[7], params[8], params[9]) : Vec3(0);
-            Vec3 c2 = params.size() > 12 ? Vec3(params[10], params[11], params[12]) : Vec3(1);
+            // pkg115 chunk 3 + chunk 6 (addon dedup): full Cycles-parity Wave.
+            // Params: [wave_type, bands_direction, rings_direction, profile, scale, distortion,
+            //          detail, detail_scale, detail_roughness, phase_offset, r1,g1,b1, r2,g2,b2]
+            // Legacy 13-param scripts (band_dir, profile, scale, distortion, detail, roughness,
+            // lacunarity, r,g,b, r,g,b) are handled by treating param[0] as bands_direction and
+            // defaulting wave_type=0, rings_dir=0, phase=0, dscale=1 — preserves old behavior.
+            int wt = params.size() > 0 ? (int)params[0] : 0;
+            int bd = params.size() > 1 ? (int)params[1] : 0;
+            int rd = params.size() > 2 ? (int)params[2] : 0;
+            int pf = params.size() > 3 ? (int)params[3] : 0;
+            float sc = params.size() > 4 ? params[4] : 5.0f;
+            float dist = params.size() > 5 ? params[5] : 0.0f;
+            float det = params.size() > 6 ? params[6] : 2.0f;
+            float dscale = params.size() > 7 ? params[7] : 1.0f;
+            float rough = params.size() > 8 ? params[8] : 0.5f;
+            float phase = params.size() > 9 ? params[9] : 0.0f;
+            Vec3 c1 = params.size() > 12 ? Vec3(params[10], params[11], params[12]) : Vec3(0);
+            Vec3 c2 = params.size() > 15 ? Vec3(params[13], params[14], params[15]) : Vec3(1);
             proceduralTextures[name] = std::make_shared<WaveTexture>(
-                /*wave_type=*/0, bd, /*rings_dir=*/0, pf, sc, dist, det,
-                /*detail_scale=*/1.0f, rough, /*phase=*/0.0f, c1, c2);
+                wt, bd, rd, pf, sc, dist, det, dscale, rough, phase, c1, c2);
         } else if (type == "magic") {
             // params: [depth, scale, distortion, r1,g1,b1, r2,g2,b2]
             int depth = params.size() > 0 ? (int)params[0] : 2;
@@ -260,21 +278,26 @@ public:
             proceduralTextures[name] = std::make_shared<VoronoiTexture>(
                 sc, det, rough, lac, smooth, expo, rand, norm, dm, feat, c1, c2);
         } else if (type == "brick") {
-            // params: [brick_r,g,b, mortar_r,g,b, brick_w, brick_h, mortar_size, offset, scale]
-            Vec3 brick = params.size() > 2 ? Vec3(params[0], params[1], params[2]) : Vec3(0.7f, 0.35f, 0.2f);
-            Vec3 mortar = params.size() > 5 ? Vec3(params[3], params[4], params[5]) : Vec3(0.9f);
-            float bw = params.size() > 6 ? params[6] : 0.5f;
-            float bh = params.size() > 7 ? params[7] : 0.25f;
-            float ms = params.size() > 8 ? params[8] : 0.02f;
-            float off = params.size() > 9 ? params[9] : 0.5f;
-            float sc = params.size() > 10 ? params[10] : 5.0f;
-            // pkg115 chunk 3: mapped onto the Cycles-parity ctor. The legacy
-            // API has one brick color (no color2 variation) - pass it for both
-            // so per-brick variation is a no-op, preserving legacy output intent.
+            // pkg115 chunk 3 + chunk 6 (addon dedup): full Cycles-parity Brick.
+            // Params: [brick1_r,g,b, brick2_r,g,b, mortar_r,g,b, scale, mortar_size, mortar_smooth,
+            //          bias, brick_width, row_height, offset_amount, offset_freq, squash, squash_freq]
+            // Legacy 11-param scripts (brick, mortar, bw, bh, ms, offset, scale) default color2=color1
+            // (no per-brick variation) and the Blender-default mortar_smooth/bias/offsets.
+            Vec3 c1 = params.size() > 2 ? Vec3(params[0], params[1], params[2]) : Vec3(0.8f);
+            Vec3 c2 = params.size() > 5 ? Vec3(params[3], params[4], params[5]) : c1;
+            Vec3 mortar = params.size() > 8 ? Vec3(params[6], params[7], params[8]) : Vec3(0.0f);
+            float sc = params.size() > 9 ? params[9] : 5.0f;
+            float ms = params.size() > 10 ? params[10] : 0.02f;
+            float msmooth = params.size() > 11 ? params[11] : 0.1f;
+            float bias = params.size() > 12 ? params[12] : 0.0f;
+            float bw = params.size() > 13 ? params[13] : 0.5f;
+            float rh = params.size() > 14 ? params[14] : 0.25f;
+            float offamt = params.size() > 15 ? params[15] : 0.5f;
+            int offfreq = params.size() > 16 ? (int)params[16] : 2;
+            float sq = params.size() > 17 ? params[17] : 1.0f;
+            int sqfreq = params.size() > 18 ? (int)params[18] : 2;
             proceduralTextures[name] = std::make_shared<BrickTexture>(
-                brick, brick, mortar, sc, ms, /*mortar_smooth=*/0.1f,
-                /*bias=*/0.0f, bw, bh, off, /*offset_freq=*/2,
-                /*squash=*/1.0f, /*squash_freq=*/2);
+                c1, c2, mortar, sc, ms, msmooth, bias, bw, rh, offamt, offfreq, sq, sqfreq);
         } else if (type == "musgrave") {
             // params: [musgrave_type, scale, detail, dimension, lacunarity, gain, r1,g1,b1, r2,g2,b2]
             int mt = params.size() > 0 ? (int)params[0] : 0;

--- a/scripts/verify_pkg115_textures_blender.py
+++ b/scripts/verify_pkg115_textures_blender.py
@@ -70,7 +70,9 @@ def _tex_nodes():
         n.inputs["Scale"].default_value = 4.0
         n.inputs["Color1"].default_value = (0.7, 0.25, 0.15, 1.0)
         n.inputs["Color2"].default_value = (0.55, 0.18, 0.10, 1.0)
-        n.inputs["Mortar"].default_value = (0.85, 0.85, 0.85, 1.0)
+        mortar = n.inputs.get("Mortar") or n.inputs.get("Color3")
+        if mortar is not None:
+            mortar.default_value = (0.85, 0.85, 0.85, 1.0)
 
     def magic(n):
         n.turbulence_depth = 2

--- a/scripts/verify_pkg115_textures_blender.py
+++ b/scripts/verify_pkg115_textures_blender.py
@@ -28,7 +28,8 @@ import bpy  # type: ignore
 
 def _bootstrap_astroray_addon():
     repo_root = Path(__file__).resolve().parents[1]
-    build_dir = repo_root / "build_cuda" / "Release"
+    build_dir = Path(os.environ.get(
+        "ASTRORAY_PYD_DIR", repo_root / "build_cuda" / "Release"))
     for entry in (str(build_dir), str(repo_root)):
         if entry not in sys.path:
             sys.path.insert(0, entry)
@@ -159,6 +160,9 @@ def main():
     p.add_argument("--spp", type=int, default=64)
     p.add_argument("--light-energy", dest="light_energy", type=float,
                    default=300.0)
+    p.add_argument("--resx", type=int, default=512)
+    p.add_argument("--device", default="gpu",
+                   help="astroray device_mode (gpu|cpu|auto)")
     args = p.parse_args(argv)
 
     _LIGHT_ENERGY[0] = args.light_energy
@@ -167,18 +171,17 @@ def main():
     if args.engine == "CUSTOM_RAYTRACER":
         _bootstrap_astroray_addon()
     scene.render.engine = args.engine
-    scene.render.resolution_x = 512
-    scene.render.resolution_y = 256
+    scene.render.resolution_x = args.resx
+    scene.render.resolution_y = args.resx // 2
     scene.render.resolution_percentage = 100
     if args.engine == "CYCLES":
         scene.cycles.samples = args.spp
         scene.cycles.use_denoising = False
     elif hasattr(scene, "custom_raytracer"):
+        scene.custom_raytracer.samples = args.spp  # the F12 property
         scene.custom_raytracer.preview_samples = args.spp
-        if hasattr(scene.custom_raytracer, "render_samples"):
-            scene.custom_raytracer.render_samples = args.spp
         if hasattr(scene.custom_raytracer, "device_mode"):
-            scene.custom_raytracer.device_mode = "gpu"
+            scene.custom_raytracer.device_mode = args.device
 
     args.out = args.out.resolve()  # Blender resolves relative paths
     args.out.mkdir(parents=True, exist_ok=True)  # against the blend dir

--- a/scripts/verify_pkg115_textures_blender.py
+++ b/scripts/verify_pkg115_textures_blender.py
@@ -1,0 +1,189 @@
+# -*- coding: utf-8 -*-
+"""pkg115 final acceptance — Blender-vs-Cycles procedural-texture stills.
+
+Run INSIDE Blender (headless), once per engine:
+
+    blender --background --factory-startup --python \
+        scripts/verify_pkg115_textures_blender.py -- \
+        --engine CUSTOM_RAYTRACER --out test_results/pkg115_visual
+
+Builds a 4x2 grid of spheres, one per ported procedural texture node
+(Checker, Gradient, Magic, Noise, Voronoi, Wave, Brick + a plain diffuse
+reference), under a sun-ish area light, and saves one F12 still. The lead
+inspects the CUSTOM_RAYTRACER still against the CYCLES still (same node
+trees) for semantic parity: pattern type, scale, orientation, color
+mapping. Exact pixel equality is NOT expected (different integrators);
+the audit's acceptance is node-semantics parity.
+
+Addon bootstrap mirrors benchmarks/viewport_parity/blender_driver.py
+(fresh-pyd guard per memory stale_pyd_locations).
+"""
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import bpy  # type: ignore
+
+
+def _bootstrap_astroray_addon():
+    repo_root = Path(__file__).resolve().parents[1]
+    build_dir = repo_root / "build_cuda" / "Release"
+    for entry in (str(build_dir), str(repo_root)):
+        if entry not in sys.path:
+            sys.path.insert(0, entry)
+    cuda_bin = Path(os.environ.get(
+        "CUDA_PATH",
+        r"C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.8")) / "bin"
+    for dll_dir in (build_dir, cuda_bin):
+        if dll_dir.is_dir():
+            os.add_dll_directory(str(dll_dir))
+    import astroray  # noqa: F401
+    print(f"[pkg115-visual] astroray module: {astroray.__file__}")
+    import blender_addon
+    try:
+        blender_addon.register()
+    except Exception as exc:
+        if "already registered" not in str(exc):
+            raise
+
+
+def _tex_nodes():
+    """(label, node_type, configure(node)) per ported texture."""
+    def noise(n):
+        n.inputs["Scale"].default_value = 6.0
+        n.inputs["Detail"].default_value = 3.0
+        n.inputs["Roughness"].default_value = 0.5
+
+    def voronoi(n):
+        n.inputs["Scale"].default_value = 6.0
+        n.inputs["Randomness"].default_value = 1.0
+
+    def wave(n):
+        n.wave_type = 'BANDS'
+        n.wave_profile = 'SIN'
+        n.inputs["Scale"].default_value = 2.0
+        n.inputs["Distortion"].default_value = 2.0
+        n.inputs["Detail"].default_value = 2.0
+
+    def brick(n):
+        n.inputs["Scale"].default_value = 4.0
+        n.inputs["Color1"].default_value = (0.7, 0.25, 0.15, 1.0)
+        n.inputs["Color2"].default_value = (0.55, 0.18, 0.10, 1.0)
+        n.inputs["Mortar"].default_value = (0.85, 0.85, 0.85, 1.0)
+
+    def magic(n):
+        n.turbulence_depth = 2
+        n.inputs["Scale"].default_value = 3.0
+        n.inputs["Distortion"].default_value = 1.5
+
+    def gradient(n):
+        n.gradient_type = 'SPHERICAL'
+
+    def checker(n):
+        n.inputs["Scale"].default_value = 6.0
+        n.inputs["Color1"].default_value = (0.9, 0.9, 0.9, 1.0)
+        n.inputs["Color2"].default_value = (0.12, 0.12, 0.12, 1.0)
+
+    return [
+        ("checker", "ShaderNodeTexChecker", checker),
+        ("gradient", "ShaderNodeTexGradient", gradient),
+        ("magic", "ShaderNodeTexMagic", magic),
+        ("noise", "ShaderNodeTexNoise", noise),
+        ("voronoi", "ShaderNodeTexVoronoi", voronoi),
+        ("wave", "ShaderNodeTexWave", wave),
+        ("brick", "ShaderNodeTexBrick", brick),
+        ("plain", None, None),
+    ]
+
+
+_LIGHT_ENERGY = [300.0]
+
+
+def build_scene():
+    for obj in list(bpy.data.objects):
+        bpy.data.objects.remove(obj, do_unlink=True)
+
+    specs = _tex_nodes()
+    for k, (label, node_type, configure) in enumerate(specs):
+        col, row = k % 4, k // 4
+        bpy.ops.mesh.primitive_uv_sphere_add(
+            radius=0.42,
+            location=(col * 1.0 - 1.5, 0.55 - row * 0.95, 0.0),
+            segments=48, ring_count=24)
+        obj = bpy.context.active_object
+        bpy.ops.object.shade_smooth()
+        mat = bpy.data.materials.new(f"pkg115_{label}")
+        mat.use_nodes = True
+        tree = mat.node_tree
+        bsdf = tree.nodes.get("Principled BSDF")
+        bsdf.inputs["Roughness"].default_value = 0.9
+        if node_type is not None:
+            tex = tree.nodes.new(node_type)
+            if configure:
+                configure(tex)
+            out_socket = "Color" if "Color" in tex.outputs else "Fac"
+            tree.links.new(tex.outputs[out_socket],
+                           bsdf.inputs["Base Color"])
+        else:
+            bsdf.inputs["Base Color"].default_value = (0.6, 0.6, 0.6, 1.0)
+        obj.data.materials.append(mat)
+
+    # Area light overhead + camera head-on.
+    bpy.ops.object.light_add(type='AREA', location=(0.0, 0.2, 3.0))
+    light = bpy.context.active_object
+    light.data.energy = _LIGHT_ENERGY[0]
+    light.data.size = 3.0
+    light.rotation_euler = (0.0, 0.0, 0.0)
+
+    bpy.ops.object.camera_add(location=(0.0, 0.05, 4.2),
+                              rotation=(0.0, 0.0, 0.0))
+    cam = bpy.context.active_object
+    bpy.context.scene.camera = cam
+
+    world = bpy.context.scene.world or bpy.data.worlds.new("pkg115_world")
+    bpy.context.scene.world = world
+    world.use_nodes = True
+    bg = world.node_tree.nodes.get("Background")
+    if bg is not None:
+        bg.inputs[0].default_value = (0.08, 0.09, 0.11, 1.0)
+
+
+def main():
+    argv = sys.argv[sys.argv.index("--") + 1:] if "--" in sys.argv else []
+    p = argparse.ArgumentParser()
+    p.add_argument("--engine", default="CUSTOM_RAYTRACER")
+    p.add_argument("--out", type=Path, default=Path("test_results/pkg115_visual"))
+    p.add_argument("--spp", type=int, default=64)
+    p.add_argument("--light-energy", dest="light_energy", type=float,
+                   default=300.0)
+    args = p.parse_args(argv)
+
+    _LIGHT_ENERGY[0] = args.light_energy
+    build_scene()
+    scene = bpy.context.scene
+    if args.engine == "CUSTOM_RAYTRACER":
+        _bootstrap_astroray_addon()
+    scene.render.engine = args.engine
+    scene.render.resolution_x = 512
+    scene.render.resolution_y = 256
+    scene.render.resolution_percentage = 100
+    if args.engine == "CYCLES":
+        scene.cycles.samples = args.spp
+        scene.cycles.use_denoising = False
+    elif hasattr(scene, "custom_raytracer"):
+        scene.custom_raytracer.preview_samples = args.spp
+        if hasattr(scene.custom_raytracer, "render_samples"):
+            scene.custom_raytracer.render_samples = args.spp
+        if hasattr(scene.custom_raytracer, "device_mode"):
+            scene.custom_raytracer.device_mode = "gpu"
+
+    args.out = args.out.resolve()  # Blender resolves relative paths
+    args.out.mkdir(parents=True, exist_ok=True)  # against the blend dir
+    out_png = args.out / f"{args.engine.lower()}.png"
+    scene.render.filepath = str(out_png)
+    bpy.ops.render.render(write_still=True)
+    print(f"[pkg115-visual] wrote {out_png}")
+
+
+main()

--- a/tests/test_pkg115_addon_texture_translation.py
+++ b/tests/test_pkg115_addon_texture_translation.py
@@ -145,7 +145,9 @@ def test_noise_translation_param_vector(monkeypatch):
     assert len(params) == 9, f"expected 9 params, got {len(params)}: {params}"
     scale, detail, rough, lac, offset, gain, dist, nt, norm = params
     assert (scale, detail, rough, lac, offset, gain, dist) == (6.0, 3.0, 0.7, 2.5, 0.1, 1.2, 0.5)
-    assert nt == 2.0, "RIDGED_MULTIFRACTAL must map to noise_type index 2"
+    assert nt == 3.0, ("RIDGED_MULTIFRACTAL must map to noise_type index 3 "
+                       "(ENGINE ordering: advanced_features.h noise_select "
+                       "case 3 = ridged; test_pkg115_noise_parity.py:299)")
     assert norm == 0.0, "normalize=False must pass 0.0"
 
 
@@ -153,8 +155,9 @@ def test_noise_type_enum_matches_fractal_h(monkeypatch):
     """Every Blender noise_type value maps to the matching fractal_noise.h index."""
     addon = _load_blender_addon(monkeypatch)
     engine = addon.CustomRaytracerRenderEngine()
-    expected = {'FBM': 0.0, 'MULTIFRACTAL': 1.0, 'RIDGED_MULTIFRACTAL': 2.0,
-                'HYBRID_MULTIFRACTAL': 3.0, 'HETERO_TERRAIN': 4.0}
+    # ENGINE ordering (advanced_features.h noise_select): HYBRID=2, RIDGED=3.
+    expected = {'FBM': 0.0, 'MULTIFRACTAL': 1.0, 'HYBRID_MULTIFRACTAL': 2.0,
+                'RIDGED_MULTIFRACTAL': 3.0, 'HETERO_TERRAIN': 4.0}
     for noise_type, idx in expected.items():
         renderer = _RecordingRenderer()
         node = _Node('TEX_NOISE', inputs={

--- a/tests/test_pkg115_addon_texture_translation.py
+++ b/tests/test_pkg115_addon_texture_translation.py
@@ -1,0 +1,343 @@
+"""pkg115 chunk 6 (addon dedup) — Blender procedural texture translation tests.
+
+Verifies that the addon's load_procedural_texture method correctly translates
+Blender's ShaderNodeTex* nodes onto the engine's create_procedural_texture
+factory with Cycles-parity parameters. Complements test_blender_uv_plumbing.py
+which tests the Voronoi translation (chunk 5).
+
+Pattern: load the addon with the same stub approach as test_blender_uv_plumbing,
+create a fake Blender node with realistic socket defaults, call
+load_procedural_texture, and assert the recorded create_procedural_texture call
+matches the expected param vector documented in blender_module.cpp.
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Loader (copied from test_blender_uv_plumbing.py)
+# ---------------------------------------------------------------------------
+
+def _load_blender_addon(monkeypatch):
+    bpy_module = types.ModuleType("bpy")
+    bpy_types_module = types.ModuleType("bpy.types")
+    bpy_props_module = types.ModuleType("bpy.props")
+
+    class _Base: pass
+    class _RenderEngineBase:
+        def report(self, *_a, **_k): return None
+        def update_progress(self, *_a, **_k): return None
+        def test_break(self): return False
+        def bind_display_space_shader(self, *_a, **_k): return None
+        def unbind_display_space_shader(self, *_a, **_k): return None
+
+    bpy_types_module.Panel = _Base
+    bpy_types_module.Operator = _Base
+    bpy_types_module.AddonPreferences = _Base
+    bpy_types_module.PropertyGroup = _Base
+    bpy_types_module.RenderEngine = _RenderEngineBase
+    bpy_module.types = bpy_types_module
+
+    for name in ("BoolProperty", "IntProperty", "FloatProperty", "StringProperty",
+                 "PointerProperty", "FloatVectorProperty", "EnumProperty"):
+        setattr(bpy_props_module, name, lambda **_kwargs: None)
+    bpy_module.props = bpy_props_module
+    bpy_module.path = types.SimpleNamespace(abspath=lambda p: p)
+
+    shader_blending_module = types.ModuleType("shader_blending")
+    shader_blending_module.blend_shader_specs = {}
+    shader_blending_module.add_shader_specs = {}
+
+    mathutils_module = types.ModuleType("mathutils")
+    mathutils_module.Vector = lambda values: values
+
+    astroray_module = types.ModuleType("astroray")
+    astroray_module.__version__ = "test"
+    astroray_module.__features__ = {"cuda": False, "spectral": True}
+    astroray_module.__file__ = "/fake/astroray.pyd"
+    astroray_module.integrator_registry_names = lambda: ["path_tracer"]
+    astroray_module.material_registry_names = lambda: ["lambertian", "disney"]
+    astroray_module.pass_registry_names = lambda: []
+
+    monkeypatch.setitem(sys.modules, "bpy", bpy_module)
+    monkeypatch.setitem(sys.modules, "bpy.types", bpy_types_module)
+    monkeypatch.setitem(sys.modules, "bpy.props", bpy_props_module)
+    monkeypatch.setitem(sys.modules, "shader_blending", shader_blending_module)
+    monkeypatch.setitem(sys.modules, "mathutils", mathutils_module)
+    monkeypatch.setitem(sys.modules, "astroray", astroray_module)
+
+    module_path = Path(__file__).parent.parent / "blender_addon" / "__init__.py"
+    spec = importlib.util.spec_from_file_location("astroray_blender_addon_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Node stubs
+# ---------------------------------------------------------------------------
+
+class _Socket:
+    def __init__(self, default=0.0, linked_to=None, output_name="Color"):
+        self.default_value = default
+        self.is_linked = linked_to is not None
+        self.links = []
+        if linked_to is not None:
+            self.links.append(types.SimpleNamespace(
+                from_node=linked_to,
+                from_socket=types.SimpleNamespace(name=output_name),
+            ))
+
+
+class _Node:
+    def __init__(self, ntype, inputs=None, **extra):
+        self.type = ntype
+        self.inputs = inputs or {}
+        for k, v in extra.items():
+            setattr(self, k, v)
+
+
+class _RecordingRenderer:
+    def __init__(self):
+        self.proc_texture_calls = []   # (name, type, params)
+        self.coord_mode_calls = []     # (name, mode)
+        self.uv_transform_calls = []   # (name, sx, sy, ox, oy, rotation)
+
+    def create_procedural_texture(self, name, ttype, params):
+        self.proc_texture_calls.append((name, ttype, list(params)))
+
+    def set_texture_coord_mode(self, name, mode):
+        self.coord_mode_calls.append((name, mode))
+
+    def set_texture_uv_transform(self, name, sx, sy, ox, oy, rotation=0.0):
+        self.uv_transform_calls.append((name, sx, sy, ox, oy, rotation))
+
+
+# ---------------------------------------------------------------------------
+# TEX_NOISE → noise_perlin (pkg115 chunk 2 + chunk 6)
+# ---------------------------------------------------------------------------
+
+def test_noise_translation_param_vector(monkeypatch):
+    """ShaderNodeTexNoise → create_procedural_texture('noise_perlin', ...)
+    with [scale, detail, roughness, lacunarity, offset, gain, distortion, noise_type, normalize]."""
+    addon = _load_blender_addon(monkeypatch)
+    engine = addon.CustomRaytracerRenderEngine()
+    renderer = _RecordingRenderer()
+    node = _Node('TEX_NOISE', inputs={
+        'Vector': _Socket(),  # unlinked → GENERATED
+        'Scale': _Socket(default=6.0),
+        'Detail': _Socket(default=3.0),
+        'Roughness': _Socket(default=0.7),
+        'Lacunarity': _Socket(default=2.5),
+        'Offset': _Socket(default=0.1),
+        'Gain': _Socket(default=1.2),
+        'Distortion': _Socket(default=0.5),
+    }, noise_type='RIDGED_MULTIFRACTAL', normalize=False)
+    engine.load_procedural_texture(node, renderer, vector_input=node.inputs['Vector'])
+
+    assert len(renderer.proc_texture_calls) == 1
+    name, ttype, params = renderer.proc_texture_calls[0]
+    assert ttype == 'noise_perlin'
+    assert len(params) == 9, f"expected 9 params, got {len(params)}: {params}"
+    scale, detail, rough, lac, offset, gain, dist, nt, norm = params
+    assert (scale, detail, rough, lac, offset, gain, dist) == (6.0, 3.0, 0.7, 2.5, 0.1, 1.2, 0.5)
+    assert nt == 2.0, "RIDGED_MULTIFRACTAL must map to noise_type index 2"
+    assert norm == 0.0, "normalize=False must pass 0.0"
+
+
+def test_noise_type_enum_matches_fractal_h(monkeypatch):
+    """Every Blender noise_type value maps to the matching fractal_noise.h index."""
+    addon = _load_blender_addon(monkeypatch)
+    engine = addon.CustomRaytracerRenderEngine()
+    expected = {'FBM': 0.0, 'MULTIFRACTAL': 1.0, 'RIDGED_MULTIFRACTAL': 2.0,
+                'HYBRID_MULTIFRACTAL': 3.0, 'HETERO_TERRAIN': 4.0}
+    for noise_type, idx in expected.items():
+        renderer = _RecordingRenderer()
+        node = _Node('TEX_NOISE', inputs={
+            'Vector': _Socket(),
+            'Scale': _Socket(default=5.0),
+            'Detail': _Socket(default=2.0),
+            'Roughness': _Socket(default=0.5),
+            'Lacunarity': _Socket(default=2.0),
+            'Offset': _Socket(default=0.0),
+            'Gain': _Socket(default=1.0),
+            'Distortion': _Socket(default=0.0),
+        }, noise_type=noise_type, normalize=True)
+        engine.load_procedural_texture(node, renderer, vector_input=node.inputs['Vector'])
+        _n, _t, params = renderer.proc_texture_calls[0]
+        assert params[7] == idx, f"{noise_type} -> {params[7]}, expected {idx}"
+
+
+# ---------------------------------------------------------------------------
+# TEX_WAVE → wave (pkg115 chunk 3 + chunk 6)
+# ---------------------------------------------------------------------------
+
+def test_wave_translation_param_vector(monkeypatch):
+    """ShaderNodeTexWave → create_procedural_texture('wave', ...)
+    with [wave_type, bands_direction, rings_direction, profile, scale, distortion,
+          detail, detail_scale, detail_roughness, phase_offset, r1,g1,b1, r2,g2,b2]."""
+    addon = _load_blender_addon(monkeypatch)
+    engine = addon.CustomRaytracerRenderEngine()
+    renderer = _RecordingRenderer()
+    node = _Node('TEX_WAVE', inputs={
+        'Vector': _Socket(),  # unlinked → GENERATED
+        'Scale': _Socket(default=6.0),
+        'Distortion': _Socket(default=0.5),
+        'Detail': _Socket(default=3.0),
+        'Detail Scale': _Socket(default=1.5),
+        'Detail Roughness': _Socket(default=0.7),
+        'Phase Offset': _Socket(default=0.25),
+    }, wave_type='RINGS', bands_direction='DIAGONAL', rings_direction='SPHERICAL', wave_profile='TRI')
+    engine.load_procedural_texture(node, renderer, vector_input=node.inputs['Vector'])
+
+    assert len(renderer.proc_texture_calls) == 1
+    name, ttype, params = renderer.proc_texture_calls[0]
+    assert ttype == 'wave'
+    assert len(params) == 16, f"expected 16 params, got {len(params)}: {params}"
+    wt, bd, rd, prof, sc, dist, det, dsc, drough, phase = params[0:10]
+    colors = params[10:16]
+    assert wt == 1.0, "RINGS must map to wave_type 1"
+    assert bd == 3.0, "DIAGONAL must map to bands_direction 3"
+    assert rd == 3.0, "SPHERICAL must map to rings_direction 3"
+    assert prof == 2.0, "TRI must map to profile 2"
+    assert (sc, dist, det, dsc, drough, phase) == (6.0, 0.5, 3.0, 1.5, 0.7, 0.25)
+    assert colors == [0,0,0, 1,1,1]
+
+
+# ---------------------------------------------------------------------------
+# TEX_BRICK → brick (pkg115 chunk 3 + chunk 6)
+# ---------------------------------------------------------------------------
+
+def test_brick_translation_param_vector(monkeypatch):
+    """ShaderNodeTexBrick → create_procedural_texture('brick', ...)
+    with [brick1_r,g,b, brick2_r,g,b, mortar_r,g,b, scale, mortar_size, mortar_smooth,
+          bias, brick_width, row_height, offset_amount, offset_freq, squash, squash_freq]."""
+    addon = _load_blender_addon(monkeypatch)
+    engine = addon.CustomRaytracerRenderEngine()
+    renderer = _RecordingRenderer()
+    node = _Node('TEX_BRICK', inputs={
+        'Vector': _Socket(),  # unlinked → GENERATED
+        'Color1': _Socket(default=(0.9, 0.4, 0.3, 1.0)),
+        'Color2': _Socket(default=(0.7, 0.3, 0.2, 1.0)),
+        'Color3': _Socket(default=(0.1, 0.1, 0.1, 1.0)),
+        'Scale': _Socket(default=6.0),
+        'Mortar Size': _Socket(default=0.03),
+        'Mortar Smooth': _Socket(default=0.15),
+        'Bias': _Socket(default=0.1),
+        'Brick Width': _Socket(default=0.6),
+        'Row Height': _Socket(default=0.3),
+        'Offset': _Socket(default=0.6),
+    }, offset_frequency=3, squash=0.8, squash_frequency=4)
+    engine.load_procedural_texture(node, renderer, vector_input=node.inputs['Vector'])
+
+    assert len(renderer.proc_texture_calls) == 1
+    name, ttype, params = renderer.proc_texture_calls[0]
+    assert ttype == 'brick'
+    assert len(params) == 19, f"expected 19 params, got {len(params)}: {params}"
+    c1 = params[0:3]
+    c2 = params[3:6]
+    mortar = params[6:9]
+    sc, ms, msmooth, bias, bw, rh, offamt, offfreq, sq, sqfreq = params[9:19]
+    assert c1 == [0.9, 0.4, 0.3]
+    assert c2 == [0.7, 0.3, 0.2]
+    assert mortar == [0.1, 0.1, 0.1]
+    assert (sc, ms, msmooth, bias, bw, rh, offamt) == (6.0, 0.03, 0.15, 0.1, 0.6, 0.3, 0.6)
+    assert (offfreq, sq, sqfreq) == (3.0, 0.8, 4.0)
+
+
+# ---------------------------------------------------------------------------
+# TEX_CHECKER → checker (no change from chunk 1, but test for completeness)
+# ---------------------------------------------------------------------------
+
+def test_checker_translation_param_vector(monkeypatch):
+    """ShaderNodeTexChecker → create_procedural_texture('checker', ...)
+    with [r1,g1,b1, r2,g2,b2, scale]."""
+    addon = _load_blender_addon(monkeypatch)
+    engine = addon.CustomRaytracerRenderEngine()
+    renderer = _RecordingRenderer()
+    node = _Node('TEX_CHECKER', inputs={
+        'Vector': _Socket(),  # unlinked → GENERATED
+        'Color1': _Socket(default=(0.9, 0.9, 0.9, 1.0)),
+        'Color2': _Socket(default=(0.1, 0.1, 0.1, 1.0)),
+        'Scale': _Socket(default=8.0),
+    })
+    engine.load_procedural_texture(node, renderer, vector_input=node.inputs['Vector'])
+
+    assert len(renderer.proc_texture_calls) == 1
+    name, ttype, params = renderer.proc_texture_calls[0]
+    assert ttype == 'checker'
+    assert len(params) == 7, f"expected 7 params, got {len(params)}: {params}"
+    c1, c2 = params[0:3], params[3:6]
+    scale = params[6]
+    assert c1 == [0.9, 0.9, 0.9]
+    assert c2 == [0.1, 0.1, 0.1]
+    assert scale == 8.0
+
+
+# ---------------------------------------------------------------------------
+# TEX_GRADIENT / TEX_MAGIC / TEX_MUSGRAVE (no change, but test for completeness)
+# ---------------------------------------------------------------------------
+
+def test_gradient_translation_param_vector(monkeypatch):
+    """ShaderNodeTexGradient → create_procedural_texture('gradient', ...)
+    with [grad_type, scale, r1,g1,b1, r2,g2,b2]."""
+    addon = _load_blender_addon(monkeypatch)
+    engine = addon.CustomRaytracerRenderEngine()
+    renderer = _RecordingRenderer()
+    node = _Node('TEX_GRADIENT', inputs={'Vector': _Socket()}, gradient_type='SPHERICAL')
+    engine.load_procedural_texture(node, renderer, vector_input=node.inputs['Vector'])
+
+    assert len(renderer.proc_texture_calls) == 1
+    name, ttype, params = renderer.proc_texture_calls[0]
+    assert ttype == 'gradient'
+    assert len(params) == 8
+    assert params[0] == 4.0, "SPHERICAL must map to gradient type 4"
+
+
+def test_magic_translation_param_vector(monkeypatch):
+    """ShaderNodeTexMagic → create_procedural_texture('magic', ...)
+    with [depth, scale, distortion, r1,g1,b1, r2,g2,b2]."""
+    addon = _load_blender_addon(monkeypatch)
+    engine = addon.CustomRaytracerRenderEngine()
+    renderer = _RecordingRenderer()
+    node = _Node('TEX_MAGIC', inputs={
+        'Vector': _Socket(),
+        'Scale': _Socket(default=7.0),
+        'Distortion': _Socket(default=1.5),
+    }, turbulence_depth=5)
+    engine.load_procedural_texture(node, renderer, vector_input=node.inputs['Vector'])
+
+    assert len(renderer.proc_texture_calls) == 1
+    name, ttype, params = renderer.proc_texture_calls[0]
+    assert ttype == 'magic'
+    assert len(params) == 9
+    depth, scale, dist = params[0:3]
+    assert (depth, scale, dist) == (5.0, 7.0, 1.5)
+
+
+def test_musgrave_translation_param_vector(monkeypatch):
+    """ShaderNodeTexMusgrave → create_procedural_texture('musgrave', ...)
+    with [musgrave_type, scale, detail, dimension, lacunarity, gain, r1,g1,b1, r2,g2,b2]."""
+    addon = _load_blender_addon(monkeypatch)
+    engine = addon.CustomRaytracerRenderEngine()
+    renderer = _RecordingRenderer()
+    node = _Node('TEX_MUSGRAVE', inputs={
+        'Vector': _Socket(),
+        'Scale': _Socket(default=6.0),
+        'Detail': _Socket(default=3.5),
+        'Dimension': _Socket(default=2.5),
+        'Lacunarity': _Socket(default=2.2),
+    }, musgrave_type='HETERO_TERRAIN')
+    engine.load_procedural_texture(node, renderer, vector_input=node.inputs['Vector'])
+
+    assert len(renderer.proc_texture_calls) == 1
+    name, ttype, params = renderer.proc_texture_calls[0]
+    assert ttype == 'musgrave'
+    assert len(params) == 12
+    mt, scale, detail, dim, lac, gain = params[0:6]
+    assert mt == 3.0, "HETERO_TERRAIN must map to musgrave type 3"
+    assert (scale, detail, dim, lac, gain) == (6.0, 3.5, 2.5, 2.2, 1.0)


### PR DESCRIPTION
Closes the diagnosis of the pkg115 visual-verify OPEN finding with four separated root causes (details in the spec + commit):

1. **GPU leg dark** — dedicated lights (pkg89) aren't uploaded to the GPU (`0 lights` banner); pre-existing pkg86-B deferral, not pkg115.
2. **CPU leg hang** — OpenMP deadlock inside Blender 5.1 with the standard MSVC `.pyd`; `-DASTRORAY_DISABLE_OPENMP=ON` fixes it. **Generalizes the MinGW-only deadlock memory to MSVC/vcomp.**
3. **Harness bug (fixed)** — the F12 sample property is `samples`; early stills were 2 spp.
4. **The real remaining pkg115 item** — procedural textures sample **UV** space where Cycles defaults to **Generated** (object 3D) coordinates; patterns differ structurally. Chunk 1's CoordMode infra is the hook. Plus a pkg89 follow-up: dedicated area light much dimmer than Cycles at equal wattage.

Harness: `--device/--resx/--light-energy`, `ASTRORAY_PYD_DIR` override, correct sample property, tolerant sockets. Doc + script only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)