### PR TITLE
docs(pkg115): visual-gate diagnosis — 4 root causes + harness fixes

### DIFF
--- a/.astroray_plan/packages/pkg115-adopt-blender-shader-node-textures.md
+++ b/.astroray_plan/packages/pkg115-adopt-blender-shader-node-textures.md
@@ -4,6 +4,14 @@
 **Track:** A
 **Codex-paste-ready:** no (large, staged; RTX visual verify)
 **Status:** Stage 2 chunks 1-6 done (PR #439 coord defaults, #441 hash+Perlin+fBM, #442 Wave+Brick, #445 Voronoi, #446 addon ShaderNodeTexVoronoi wiring, chunk 6 addon dedup — 2026-06-12). REMAINING: Blender-vs-Cycles RTX visual verify. **Visual-verify status (2026-06-12 03:15, RTX): OPEN FINDING — the paired-stills harness (scripts/verify_pkg115_textures_blender.py, headless Blender 5.1 factory-startup, 8-sphere texture grid) renders correctly under CYCLES but the CUSTOM_RAYTRACER leg produces uniformly dark, untextured spheres regardless of area-light energy (300W vs 9000W identical) — an end-to-end F12 export gap (lighting and/or material-texture translation not reaching the renderer for this scene construction), DISTINCT from the dedup chunk's translation layer whose unit tests pass. The visual acceptance gate stays OPEN pending diagnosis of the addon F12 export path on factory-startup scenes.**
+
+**FULL DIAGNOSIS (2026-06-12 morning, RTX + Blender 5.1 headless) — four separated root causes:**
+1. **GPU leg dark: dedicated lights are not uploaded to the GPU** (`[CUDA] Scene uploaded: ... 0 lights`). The addon exports AREA lights as pkg89 dedicated AreaLights (`add_area_light_dedicated`), which the GPU scene upload does not carry (the pkg86-B "dedicated lights -> power-CDF fallback" deferral). Affects ANY dedicated-light scene on GPU, independent of pkg115.
+2. **CPU leg HANGS: OpenMP deadlock inside Blender** — the standard MSVC .pyd deadlocks Blender 5.1's F12 CPU render (~zero CPU use); rebuilding with `-DASTRORAY_DISABLE_OPENMP=ON` fixes it (render 0.1-18 s). This GENERALIZES the MinGW-only memory (mingw_openmp_blender_deadlock) to MSVC/vcomp: ALL addon-use builds need the flag.
+3. **Harness bug (fixed): the F12 sample count property is `samples`** (default 2) — `preview_samples` is viewport-only; early stills were 2 spp regardless of --spp.
+4. **THE REMAINING pkg115 ITEM — procedural-texture coordinate space:** at 128 spp the CPU leg renders textures cleanly but in UV space (checker = fine concentric rings on the sphere) where Cycles defaults unconnected-Vector procedural textures to GENERATED (object-local 3D) coordinates (checker = large 3D blocks). The addon/eval path must default to generated coordinates (the audit's Mapping/TexCoord item; chunk 1's CoordMode infrastructure is the hook). Also the dedicated area light contributes far less than Cycles at equal wattage on CPU (energy-scale audit needed, pkg89 follow-up).
+
+Paired stills: wt test_results/pkg115_final/ (cycles.png vs custom_raytracer.png).
 **Depends on:** pkg57 (done — established the additive custom-node pattern and
 the `convert_node_material` traversal). Benefits from pkg112.
 **Estimated effort:** L (multi-week, staged)

--- a/scripts/verify_pkg115_textures_blender.py
+++ b/scripts/verify_pkg115_textures_blender.py
@@ -28,7 +28,8 @@ import bpy  # type: ignore
 
 def _bootstrap_astroray_addon():
     repo_root = Path(__file__).resolve().parents[1]
-    build_dir = repo_root / "build_cuda" / "Release"
+    build_dir = Path(os.environ.get(
+        "ASTRORAY_PYD_DIR", repo_root / "build_cuda" / "Release"))
     for entry in (str(build_dir), str(repo_root)):
         if entry not in sys.path:
             sys.path.insert(0, entry)
@@ -159,6 +160,9 @@ def main():
     p.add_argument("--spp", type=int, default=64)
     p.add_argument("--light-energy", dest="light_energy", type=float,
                    default=300.0)
+    p.add_argument("--resx", type=int, default=512)
+    p.add_argument("--device", default="gpu",
+                   help="astroray device_mode (gpu|cpu|auto)")
     args = p.parse_args(argv)
 
     _LIGHT_ENERGY[0] = args.light_energy
@@ -167,18 +171,17 @@ def main():
     if args.engine == "CUSTOM_RAYTRACER":
         _bootstrap_astroray_addon()
     scene.render.engine = args.engine
-    scene.render.resolution_x = 512
-    scene.render.resolution_y = 256
+    scene.render.resolution_x = args.resx
+    scene.render.resolution_y = args.resx // 2
     scene.render.resolution_percentage = 100
     if args.engine == "CYCLES":
         scene.cycles.samples = args.spp
         scene.cycles.use_denoising = False
     elif hasattr(scene, "custom_raytracer"):
+        scene.custom_raytracer.samples = args.spp  # the F12 property
         scene.custom_raytracer.preview_samples = args.spp
-        if hasattr(scene.custom_raytracer, "render_samples"):
-            scene.custom_raytracer.render_samples = args.spp
         if hasattr(scene.custom_raytracer, "device_mode"):
-            scene.custom_raytracer.device_mode = "gpu"
+            scene.custom_raytracer.device_mode = args.device
 
     args.out = args.out.resolve()  # Blender resolves relative paths
     args.out.mkdir(parents=True, exist_ok=True)  # against the blend dir


### PR DESCRIPTION
Clean re-spin of #470. The four-root-cause diagnosis of the pkg115 visual gate:

1. **GPU leg dark** — dedicated lights (pkg89) aren't uploaded to the GPU (`0 lights` banner); pre-existing pkg86-B deferral.
2. **CPU leg hang** — OpenMP deadlock inside Blender 5.1 with the standard MSVC `.pyd`; `-DASTRORAY_DISABLE_OPENMP=ON` fixes it. **Generalizes the MinGW-only deadlock memory to MSVC/vcomp — all addon-use builds need the flag.**
3. **Harness bug (fixed)** — the F12 sample property is `samples`; early stills were 2 spp.
4. **The real remaining pkg115 item** — procedural textures sample **UV** space where Cycles defaults unconnected-Vector textures to **Generated** (object 3D) coordinates; patterns differ structurally (concentric UV rings vs 3D blocks at 128 spp). Chunk 1's CoordMode infra is the hook. Plus pkg89 follow-up: dedicated area light far dimmer than Cycles at equal wattage on CPU.

Harness gains: `--device/--resx/--light-energy`, `ASTRORAY_PYD_DIR` override, correct sample property, tolerant sockets. Doc + script only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)