### PR TITLE
fix(pkg115): stable texture cache keys + Magic RGB output — black gradient/magic spheres

### DIFF
--- a/.astroray_plan/docs/blender-procedural-parity-research.md
+++ b/.astroray_plan/docs/blender-procedural-parity-research.md
@@ -583,3 +583,57 @@ plus a paired-still RTX check at the end.
   Astroray vs Cycles, paired stills (RTX `/verify`), per the package spec.
 - Standalone: existing `create_procedural_texture` scripts must keep working
   (factory params stay backward-compatible; new params appended).
+
+---
+
+## 8. Residual diagnosis 2026-06-12 — black gradient/magic spheres (paired-stills gate)
+
+### Question investigated
+Why did the GRADIENT (spherical) and MAGIC spheres render black on the addon
+path while checker/voronoi/wave/brick were correct, and why did the earlier
+diagnosis describe Cycles' gradient sphere as "bright-grey"?
+
+### Cycles references (Blender 5.1 / main, projects.blender.org, Apache-2.0)
+- `intern/cycles/kernel/svm/gradient.h::svm_gradient` — spherical:
+  `r = max(0.999999 - len(p), 0)`. **Identical to our port** (advanced_features.h
+  GradientTexture case 4).
+- `intern/cycles/kernel/svm/magic.h::svm_magic` + `svm_node_tex_magic` — the
+  node's **Color socket carries the raw float3** `(0.5-x, 0.5-y, 0.5-z)`;
+  **Fac is `average(color)`**. Our MagicTexture collapsed the float3 to its
+  average (greyscale) — fixed to per-channel output with color1/color2 as a
+  per-channel tint (identity for the addon's black/white params).
+- `intern/cycles/blender/util.h::mesh_texture_space` +
+  `intern/cycles/blender/mesh.cpp` ATTR_STD_GENERATED loop —
+  `generated = co * (0.5/texspace_size) - (texspace_location*(0.5/size) - 0.5)`,
+  i.e. **bbox → [0,1]**. Confirmed empirically with an emission-shader probe
+  (`Emission = TexCoord.Generated`, top-down camera): visible-cap RGB =
+  `0.5 + 0.5*n̂` exactly. **Our per-object world-bbox bake matches the Cycles
+  convention; the "[-1,1] or unnormalized" hypothesis is refuted.**
+
+### Actual root cause (addon, not convention)
+`load_procedural_texture` keyed its dedupe cache and texture names on
+`id(node)`. `convert_node_material` iterates `bpy.data.materials` and works on
+a **temporary `inline_shader_nodes()` tree freed after each material**; CPython
+reuses the freed addresses, so a later material's texture node can carry the
+same `id()` as an earlier material's (freed) node → silent cache hit → the
+material binds the *previous* material's texture. Instrumented run (logged
+`id(node)` per material): magic→bound brick's texture, noise→checker's,
+wave→gradient's; only 4 textures created for 7 nodes. Victims shift run to run
+with the allocator — explains "gradient + noise" in one session, "gradient +
+magic" in another. A bound-but-foreign texture also gets the victim object's
+bbox baked over it (`_generated_textures_by_material` records the alias), which
+cross-contaminates the donor sphere's GENERATED frame — this is what erased the
+gradient sphere's bright crescent.
+
+Note: a *correct* spherical gradient on a [0,1]-generated sphere viewed from +z
+IS mostly black with a thin bright crescent toward the bbox-min corner — the
+fresh 64-spp Cycles still confirms this. "Bright-grey" came from the earlier
+broken (2-spp) reference still.
+
+### Fix
+- Addon: cache/texture keys = `material_name + node.name` (stable, unique per
+  conversion pass), `id()` fallback only for nameless unit-test stubs.
+- Engine: MagicTexture per-channel RGB output (Cycles Color-socket semantics).
+- Tests: `test_pkg115_addon_texture_translation.py::test_procedural_cache_key_identity_independent`,
+  strengthened `test_pkg115_procedural_parity.py::test_magic_rgb_output`
+  (hand-computed svm_magic reference at p=(0.3,0.4,0.5)).

--- a/.astroray_plan/docs/external-references.md
+++ b/.astroray_plan/docs/external-references.md
@@ -126,6 +126,12 @@ own because a dependency for 40 lines of code is ridiculous.
 - **Blender Python API** — viewport render needs
   `bpy.types.RenderEngine.view_draw`. Docs:
   https://docs.blender.org/api/current/
+- **Cycles SVM procedural textures + Generated/orco coordinates** —
+  https://projects.blender.org/blender/blender — Apache-2.0.
+  `intern/cycles/kernel/svm/{gradient,magic,checker,wave,brick,voronoi,noisetex}.h`,
+  `intern/cycles/blender/util.h::mesh_texture_space` (Generated = bbox→[0,1]).
+  Notes: `blender-procedural-parity-research.md` (§8 covers the 2026-06-12
+  black-sphere residual: id(node) cache aliasing + Magic Color-socket float3).
 
 ---
 

--- a/.astroray_plan/packages/pkg115-adopt-blender-shader-node-textures.md
+++ b/.astroray_plan/packages/pkg115-adopt-blender-shader-node-textures.md
@@ -3,7 +3,7 @@
 **Pillar:** 5 (addon) + 2 (materials/textures)
 **Track:** A
 **Codex-paste-ready:** no (large, staged; RTX visual verify)
-**Status:** done (PR #472, 2026-06-12 — 128-spp Blender stills: checker=3D blocks, brick=brickwork, wave=bands, voronoi patterned; semantic parity with Cycles; full suite 1289/0). Stage 2 chunks 1-6 done (PR #439 coord defaults, #441 hash+Perlin+fBM, #442 Wave+Brick, #445 Voronoi, #446 addon ShaderNodeTexVoronoi wiring, #467 chunk 6 addon dedup), GENERATED-coordinates MESH fix PR #472 (Texture::setGeneratedBBox + set_texture_generated_bbox binding + addon records GENERATED textures per material and bakes each user object's world bbox in convert_objects). REMAINING small follow-ups recorded in spec: gradient + noise spheres near-black on addon path; pkg89 dedicated-light energy audit; per-object texture instancing for shared materials.
+**Status:** done (PR #472, 2026-06-12 — 128-spp Blender stills: checker=3D blocks, brick=brickwork, wave=bands, voronoi patterned; semantic parity with Cycles; full suite 1289/0). Stage 2 chunks 1-6 done (PR #439 coord defaults, #441 hash+Perlin+fBM, #442 Wave+Brick, #445 Voronoi, #446 addon ShaderNodeTexVoronoi wiring, #467 chunk 6 addon dedup), GENERATED-coordinates MESH fix PR #472 (Texture::setGeneratedBBox + set_texture_generated_bbox binding + addon records GENERATED textures per material and bakes each user object's world bbox in convert_objects). RESOLVED 2026-06-12 (residual fix): gradient/magic/noise "near-black/wrong-texture spheres on addon path" was id(node) cache aliasing in `load_procedural_texture` — see finding 6 below. REMAINING follow-ups: pkg89 dedicated-light energy audit (uniform ~3x exposure gap vs Cycles across ALL spheres); per-object texture instancing for shared materials.
 
 **Visual-verify findings (2026-06-12, RTX + Blender 5.1 headless, a523a86 diagnosis commit):**
 1. **GPU leg dark: dedicated lights not uploaded to GPU** — pkg89/pkg86-B deferral; affects any dedicated-light GPU scene, NOT pkg115-specific.
@@ -11,6 +11,22 @@
 3. **Harness bug (fixed in a523a86): F12 samples property** is `samples`, not `preview_samples`; early stills were 2 spp.
 4. **FIXED (commit e418349): procedural-texture GENERATED coordinate space** — AreaLightShape::hit() was not setting rec.hitObject, causing the GENERATED path to fall back to UV (advanced_features.h:91). This produced concentric UV-ring artifact on spheres instead of 3D blocks. Fix: add `rec.hitObject = this;` after material assignment. Test: test_pkg115_generated_coords_fix.py (checker scanline flip count < 8).
 5. **pkg89 follow-up noted:** dedicated area light dimmer than Cycles at equal wattage on CPU (energy-scale audit).
+6. **FIXED (2026-06-12 residual): black gradient/magic spheres = id(node) cache aliasing.**
+   `load_procedural_texture` keyed its dedupe cache + texture names on `id(node)`;
+   each material's `inline_shader_nodes()` tree is freed after conversion and CPython
+   reuses the addresses, so a later material's texture node could alias an earlier
+   cache entry (instrumented: magic→brick's texture, noise→checker's, wave→gradient's;
+   victims shifted run to run). Fix: key on `material_name + node.name`. Also fixed
+   MagicTexture collapsing Cycles' Color-socket float3 to its average (greyscale).
+   NOT a coordinate-convention bug: Cycles Generated = bbox→[0,1] (verified against
+   `intern/cycles/blender/util.h::mesh_texture_space` + an Emission=Generated probe;
+   matches our world-bbox bake), and a spherical gradient on a [0,1]-generated sphere
+   viewed from +z is legitimately near-black with a thin bbox-min-corner crescent —
+   the fresh 64-spp Cycles still shows the same look (the old "bright-grey" reference
+   was the 2-spp harness-bug still). Post-fix parity: gradient brightest-quadrant
+   bottom-left in both engines; magic channel-spread 0.170 (ours) vs 0.183 (Cycles).
+   Research: blender-procedural-parity-research.md §8. Tests:
+   test_procedural_cache_key_identity_independent, test_magic_rgb_output (strengthened).
 **Depends on:** pkg57 (done — established the additive custom-node pattern and
 the `convert_node_material` traversal). Benefits from pkg112.
 **Estimated effort:** L (multi-week, staged)

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -2732,10 +2732,21 @@ class CustomRaytracerRenderEngine(RenderEngine):
         # pkg115 parity fix: procedural textures default to GENERATED when
         # Vector socket is unconnected (Blender standard behavior).
         coord_mode, uv_scale, offset, rotation, uv_layer_name = self._resolve_vector_input(vector_input, default_coord_mode="GENERATED")
-        cache_key = self._texture_variant_key(f"_proc_{id(node)}", coord_mode, uv_scale, offset, rotation, uv_layer_name)
+        # pkg115 residual fix (black gradient/magic spheres): id(node) is NOT a
+        # stable key — convert_node_material works on a temporary
+        # inline_shader_nodes() tree that is freed after each material, and
+        # CPython reuses the freed addresses, so a later material's texture
+        # node can alias an earlier cache entry (observed: the magic sphere
+        # silently bound the brick texture, the wave sphere the gradient one;
+        # which spheres went black shifted run to run). Key on material + node
+        # name instead — unique within a conversion pass and stable across the
+        # per-material tree lifetimes. Stub nodes in unit tests may lack
+        # .name; those fall back to id() (single-node test scope).
+        mat_name = getattr(self, "_current_material_name", "") or ""
+        node_id = f"{mat_name}.{getattr(node, 'name', '') or id(node)}"
+        cache_key = self._texture_variant_key(f"_proc_{node_id}", coord_mode, uv_scale, offset, rotation, uv_layer_name)
         if cache_key in cache:
             return cache[cache_key]
-        node_id = id(node)
 
         ntype = node.type
         tex_name = None

--- a/include/advanced_features.h
+++ b/include/advanced_features.h
@@ -888,11 +888,16 @@ public:
             y /= dist;
             z /= dist;
         }
-        // Blender outputs true RGB: (0.5-x, 0.5-y, 0.5-z). For standalone factory
-        // backward compat, apply color1/color2 as a lerp tint using the average.
+        // Cycles svm_node_tex_magic: the Color socket carries the raw float3
+        // (0.5-x, 0.5-y, 0.5-z); Fac is its average. Reproduce the float3 with
+        // color1/color2 as a PER-CHANNEL lerp tint for standalone factory
+        // callers (the addon passes black/white, making this the identity).
+        // pkg115 residual fix: the previous code collapsed the float3 to its
+        // average, rendering Magic greyscale instead of Cycles' colored swirls.
         Vec3 rgb(0.5f - x, 0.5f - y, 0.5f - z);
-        float fac = (rgb.x + rgb.y + rgb.z) / 3.0f;
-        return color1 * (1.0f - fac) + color2 * fac;
+        return Vec3(color1.x + (color2.x - color1.x) * rgb.x,
+                    color1.y + (color2.y - color1.y) * rgb.y,
+                    color1.z + (color2.z - color1.z) * rgb.z);
     }
 };
 

--- a/tests/test_pkg115_addon_texture_translation.py
+++ b/tests/test_pkg115_addon_texture_translation.py
@@ -344,3 +344,45 @@ def test_musgrave_translation_param_vector(monkeypatch):
     mt, scale, detail, dim, lac, gain = params[0:6]
     assert mt == 3.0, "HETERO_TERRAIN must map to musgrave type 3"
     assert (scale, detail, dim, lac, gain) == (6.0, 3.5, 2.5, 2.2, 1.0)
+
+
+# ---------------------------------------------------------------------------
+# pkg115 residual — texture cache keys must not depend on id(node)
+# ---------------------------------------------------------------------------
+
+def _named_magic_node():
+    return _Node('TEX_MAGIC', inputs={
+        'Vector': _Socket(),  # unlinked -> GENERATED
+        'Scale': _Socket(default=3.0),
+        'Distortion': _Socket(default=1.5),
+    }, turbulence_depth=2, name='1_Magic Texture')
+
+
+def test_procedural_cache_key_identity_independent(monkeypatch):
+    """Texture dedupe keys come from (material, node name), not id(node).
+
+    convert_node_material works on a temporary inline_shader_nodes() tree that
+    is freed after each material; CPython reuses the freed addresses, so with
+    id(node) keys a later material's texture node could silently alias an
+    earlier material's cache entry (pkg115 visual gate: the magic sphere bound
+    the brick texture, the wave sphere the gradient one — which spheres went
+    black shifted run to run with the allocator).
+    """
+    addon = _load_blender_addon(monkeypatch)
+    engine = addon.CustomRaytracerRenderEngine()
+    renderer = _RecordingRenderer()
+    engine._generated_textures_by_material = {}
+
+    engine._current_material_name = 'pkg115_magic'
+    n1 = _named_magic_node()
+    name1 = engine.load_procedural_texture(n1, renderer, vector_input=n1.inputs['Vector'])
+    n2 = _named_magic_node()  # same logical node, different Python object identity
+    name2 = engine.load_procedural_texture(n2, renderer, vector_input=n2.inputs['Vector'])
+    assert name1 == name2, "same material + node name must dedupe to one texture"
+    assert len(renderer.proc_texture_calls) == 1, "second call must be a cache hit"
+
+    engine._current_material_name = 'pkg115_other'
+    n3 = _named_magic_node()  # same node name in a DIFFERENT material
+    name3 = engine.load_procedural_texture(n3, renderer, vector_input=n3.inputs['Vector'])
+    assert name3 != name1, "different materials must get distinct texture entries"
+    assert len(renderer.proc_texture_calls) == 2

--- a/tests/test_pkg115_procedural_parity.py
+++ b/tests/test_pkg115_procedural_parity.py
@@ -159,19 +159,17 @@ def test_magic_depth_10():
 
 
 def test_magic_rgb_output():
-    """Magic outputs true RGB (0.5−x, 0.5−y, 0.5−z), not a scalar lerp.
+    """Magic outputs true RGB (0.5−x, 0.5−y, 0.5−z) per channel, not a scalar lerp.
 
-    When color1=(0,0,0) and color2=(1,1,1), the factory tint becomes `fac = (r+g+b)/3`,
-    so the output is still grayscale. To see true RGB, test with a non-identity tint
-    or check that the r,g,b channels differ before tinting.
+    Cycles svm_node_tex_magic (svm/magic.h, Apache-2.0): the Color socket
+    carries the raw float3 from svm_magic; Fac is average(color). With the
+    addon's identity tint (color1=black, color2=white) the engine must
+    reproduce the float3 — the pkg115 residual collapsed it to the average,
+    rendering magic greyscale (every channel = 0.535361 at this probe point).
     """
     import astroray
     r = astroray.Renderer()
 
-    # Sample at a point with non-zero xyz; the raw (0.5−x, 0.5−y, 0.5−z) should differ per channel.
-    # Since the factory applies a grayscale tint, we can't directly observe RGB. But the code change
-    # is verbatim from svm/magic.h, so the formula test is acceptance. Visual verification needs
-    # an addon-driven Blender comparison in Stage 3.
     val = r.eval_texture_at_3d("magic", {
         "turb_depth": 2,
         "scale": 5.0,
@@ -179,10 +177,14 @@ def test_magic_rgb_output():
         "color1": [0.0, 0.0, 0.0],
         "color2": [1.0, 1.0, 1.0]
     }, 0.3, 0.4, 0.5)
-    # Just check it doesn't crash and is in [0,1].
-    assert 0.0 <= val[0] <= 1.0
-    assert 0.0 <= val[1] <= 1.0
-    assert 0.0 <= val[2] <= 1.0
+    # Hand-computed from svm/magic.h at p=(0.3,0.4,0.5), scale=5, depth=2, dist=1:
+    #   px,py,pz = fmod(p*5, 2π) = (1.5, 2.0, 2.5)
+    #   x = sin(30) = -0.988032; y = cos(-10) = -0.839072; z = -cos(-5) = -0.283662
+    #   depth loop (dist=1): y = -cos(x-y+z) = -0.907873; x = cos(x-y-z) = 0.979354
+    #   final /= 2·dist → rgb = (0.5-x, 0.5-y, 0.5-z) = (0.010317, 0.953935, 0.641831)
+    expected = (0.010317, 0.953935, 0.641831)
+    for ch, (got, want) in enumerate(zip(val, expected)):
+        assert abs(got - want) < 1e-4, f"channel {ch}: got {got}, want {want}"
 
 
 # Coordinate-mode tests (items 1a, 1b, 1c from the audit) require a HitRecord or a full render setup.


### PR DESCRIPTION
## Summary

Closes the pkg115 paired-stills residual (gradient + magic spheres black on the addon path). The diagnosed-but-untested hypothesis (Cycles Generated-coordinate range convention) is **refuted with evidence**; the real root cause was found by instrumentation:

1. **`id(node)` cache aliasing in `load_procedural_texture`** — `convert_node_material` works on a temporary `inline_shader_nodes()` tree freed after each material; CPython reuses the freed addresses, so a later material''s texture node could silently alias an earlier cache entry. Instrumented run at HEAD: magic bound **brick''s** texture, noise bound **checker''s**, wave bound **gradient''s** (only 4 textures created for 7 nodes); victims shift run to run, which explains why earlier sessions blamed "gradient + noise" and later ones "gradient + magic". The aliased texture also got the victim object''s GENERATED bbox baked over it, erasing the donor sphere''s pattern (this killed gradient''s crescent). Fix: cache/texture keys = `material_name + node.name` (stable per conversion pass; `id()` fallback only for nameless unit-test stubs).

2. **`MagicTexture` collapsed Cycles'' Color-socket float3 to its average** — `svm_node_tex_magic` outputs the raw `(0.5-x, 0.5-y, 0.5-z)` on Color (Fac = average). Now per-channel, with `color1/color2` as a per-channel tint (identity for the addon''s black/white params).

## Convention verification (CLAUDE.md §6)

- `intern/cycles/blender/util.h::mesh_texture_space` + `mesh.cpp` ATTR_STD_GENERATED: **Generated = bbox→[0,1]**, exactly our per-object world-bbox bake. Confirmed empirically with an `Emission = TexCoord.Generated` probe (visible-cap RGB = `0.5 + 0.5·n̂`).
- `svm/gradient.h` spherical is identical to our port. A spherical gradient on a [0,1]-generated sphere viewed from +z is **legitimately near-black with a thin bbox-min-corner crescent** — the fresh 64-spp Cycles still shows the same look; the old "bright-grey" reference was the 2-spp harness-bug still.
- Research note: `.astroray_plan/docs/blender-procedural-parity-research.md` §8.

## Evidence

- Instrumented re-run post-fix: the id collision **fired again** (magic reused brick''s freed id) but keys ignored it — 7 distinct textures, 0 false cache hits.
- Paired stills (512×256, 64 spp, CPU, OpenMP-free build): magic = colored swirls, channel spread 0.170 vs Cycles 0.183; gradient = dark sphere with bottom-left crescent, brightest quadrant matching Cycles. Every sphere sits at the same ~0.28 global exposure factor vs Cycles (known pkg89 dedicated-light/view-transform follow-up), per-texture relative parity matches.

## Tests

- NEW `test_pkg115_addon_texture_translation.py::test_procedural_cache_key_identity_independent` — red on old code (id-based names), green now.
- STRENGTHENED `test_pkg115_procedural_parity.py::test_magic_rgb_output` — hand-computed svm_magic reference at p=(0.3,0.4,0.5); red on old pyd (all channels 0.535361), green now.
- Full local suite: 1266 passed, 0 failed (24 skipped, 18 xfailed, 4 xpassed) on fresh VS2022 OpenMP-free build.
- No function/class signatures changed; call-site sweeps for `load_procedural_texture`, `MagicTexture`, and `_proc_*` name consumers all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)