### PR TITLE
feat(pkg114): exporter transform-only dispatch → TLAS refit (inc 3d integration)

### DIFF
--- a/.astroray_plan/packages/pkg114-two-level-bvh-tlas-blas.md
+++ b/.astroray_plan/packages/pkg114-two-level-bvh-tlas-blas.md
@@ -8,13 +8,14 @@
 inc 3d #468). GPU two-level BVH: instanced renders pixel-match flattened, share
 one BLAS (Blender test 325→5 flat objects), mixed instanced+flat scenes work, the
 addon instances collection/particle duplis, and a transform-only edit refits the
-TLAS at **19.5%** of a full geometry upload (≤50% budget). **GPU-gated.** The one
-remaining INTEGRATION (not an acceptance gate): wire the exporter
-`Change.TRANSFORMS` viewport path to call `update_instance_transform` +
-`upload_instance_transforms` + `render(skip_upload=True)` for instanced objects —
-best done alongside the in-flux viewport-interactivity work (pkg81/pkg116) rather
-than against a moving target. Follow-up acceleration-structure package explicitly
-deferred by pkg56 §4.1.
+TLAS at **19.5%** of a full geometry upload (≤50% budget). **GPU-gated.** The
+remaining exporter INTEGRATION is now **done (PR #TBD, 2026-07-18)**: the viewport
+`Change.TRANSFORMS` path dispatches the inc-3d fast path
+(`update_instance_transform` per dupli + `upload_instance_transforms` +
+`render(skip_upload=True)`) for a pure transform-only batch whose changed objects
+are all instanced sources or eligible instancer empties — headless Blender 5.1
+refit render is **byte-identical** to a full re-sync (mad 0.00000 < 0.02). Follow-up
+acceleration-structure package explicitly deferred by pkg56 §4.1.
 
 ### Increment log
 - **Inc 1 (PR #430, merged):** device structs (`GMat4`/`GBLAS`/`GInstance`/
@@ -69,8 +70,20 @@ deferred by pkg56 §4.1.
   skip-upload render == a from-scratch build at the new transform (mad < 0.02,
   with a negative control proving `skip_upload` reads device state); refit upload
   cost **19.5%** of a full `upload_geometry` (≤50% budget met). `test_tlas_refit.py`.
-  Wiring the exporter's `Change.TRANSFORMS` branch to call these for instanced
-  objects (instance-id map) is the small remaining integration.
+- **Inc 3d exporter wiring (landed — PR #TBD, 2026-07-18):** `convert_objects`
+  records `_renderer_instance_id_map` {source name: [instance_id…] in dupli order}
+  and `_renderer_instancer_eligible` {instancer name: bool}. The viewport
+  `Change.TRANSFORMS` branch takes the TLAS-only fast path
+  (`refit_instance_transforms` re-walks `depsgraph.object_instances` and re-derives
+  EACH dupli's fresh `matrix_world` → `update_instance_transform` per instance →
+  `upload_instance_transforms()` → `render(skip_upload=True)`) iff the batch is
+  pure-transform and every changed object is an instanced source or an eligible
+  instancer empty. Pure-Python dispatch tests
+  (`test_pkg114_exporter_transform_dispatch.py`, 7) + headless Blender 5.1
+  (`scripts/verify_pkg114_refit_blender.py`): moving an instancer empty and
+  refitting is **byte-identical** to a full re-sync (mad 0.00000 < 0.02; moved-image
+  Δ 0.092 non-vacuous; negative control 0.092 proving `skip_upload` reads device
+  state).
 
   **Decisions (inc 3c):** (1) addon instancing is **GPU-only**; CPU has no
   two-level traversal (renders solely via the scene-only `bvh`), so CPU keeps
@@ -82,6 +95,21 @@ deferred by pkg56 §4.1.
   package. Multi-instance EMISSIVE-light NEE, instanced caustic casters, and
   deformation-motion-on-instances remain deferred. SAH TLAS stays an explicit
   non-goal. See memory `pkg114-instancing-engine-facts`.
+
+  **Decisions (inc 3d exporter wiring, 2026-07-18):** (1) The refit never writes
+  one `obj.matrix_world` onto a dupli group — since inc-3c only instances duplis
+  (≥2 per name), each with its own composed `instancer ∘ prop_local` matrix, the
+  fast path re-walks `depsgraph.object_instances` and re-derives each instance's
+  fresh transform. It refreshes ALL mapped instances (not just the changed one):
+  `upload_instance_transforms` rebuilds the whole TLAS from current transforms
+  regardless, so this is free and immune to per-object change-attribution. (2)
+  **Trigger semantics:** a moved instancer EMPTY takes the fast path when it is
+  refit-eligible — recorded at registration as "not nested AND every dupli it
+  generated went through the shared BLAS." Any poisoned instancer (a flattened
+  member: count-1 linked dupe, emissive/caustic/volume, non-MESH), a nested
+  instancer, a mixed flat+instanced transform batch, a transform batch mixed with
+  another domain, or a CPU render (instance maps empty) all fall back to the
+  existing full sync — a partial refit can't keep flat-scene geometry consistent.
 **Depends on:** pkg56 (done — provides the `_renderer_object_id_map` placeholder
 and transform-only dispatch hook). Complementary to pkg112.
 **Estimated effort:** L (~3–4 weeks, multiple RTX sessions)

--- a/.astroray_plan/packages/pkg114-two-level-bvh-tlas-blas.md
+++ b/.astroray_plan/packages/pkg114-two-level-bvh-tlas-blas.md
@@ -9,7 +9,7 @@ inc 3d #468). GPU two-level BVH: instanced renders pixel-match flattened, share
 one BLAS (Blender test 325→5 flat objects), mixed instanced+flat scenes work, the
 addon instances collection/particle duplis, and a transform-only edit refits the
 TLAS at **19.5%** of a full geometry upload (≤50% budget). **GPU-gated.** The
-remaining exporter INTEGRATION is now **done (PR #TBD, 2026-07-18)**: the viewport
+remaining exporter INTEGRATION is now **done (PR #479, 2026-07-18)**: the viewport
 `Change.TRANSFORMS` path dispatches the inc-3d fast path
 (`update_instance_transform` per dupli + `upload_instance_transforms` +
 `render(skip_upload=True)`) for a pure transform-only batch whose changed objects
@@ -70,7 +70,7 @@ acceleration-structure package explicitly deferred by pkg56 §4.1.
   skip-upload render == a from-scratch build at the new transform (mad < 0.02,
   with a negative control proving `skip_upload` reads device state); refit upload
   cost **19.5%** of a full `upload_geometry` (≤50% budget met). `test_tlas_refit.py`.
-- **Inc 3d exporter wiring (landed — PR #TBD, 2026-07-18):** `convert_objects`
+- **Inc 3d exporter wiring (landed — PR #479, 2026-07-18):** `convert_objects`
   records `_renderer_instance_id_map` {source name: [instance_id…] in dupli order}
   and `_renderer_instancer_eligible` {instancer name: bool}. The viewport
   `Change.TRANSFORMS` branch takes the TLAS-only fast path

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -3424,7 +3424,20 @@ class CustomRaytracerRenderEngine(RenderEngine):
         Grouping key is (mesh datablock, obj.name): duplis of one source share the
         name → one shared BLAS + one Cryptomatte matte (matches the flatten path);
         linked duplicates have distinct names → distinct count-1 groups → they
-        flatten (no regression). Only groups with >= 2 instances are worth it."""
+        flatten (no regression). Only groups with >= 2 instances are worth it.
+
+        pkg114 inc 3d wiring: also records `_renderer_instance_id_map`
+        {source obj.name: [instance_id, ...] in dupli-enumeration order} so a
+        later transform-only viewport edit can refit the TLAS instead of a full
+        geometry re-upload, and `_renderer_instancer_eligible` {instancer obj.name:
+        bool} so a moved instancer EMPTY can also refit. An instancer is eligible
+        only when EVERY dupli it generated went through the shared BLAS (none
+        flattened) and it is not itself nested — otherwise moving it also moves
+        flat-scene geometry the refit wouldn't touch, so it must full-sync. Both
+        maps are reset here so a full re-sync always rebuilds them (empty ⇒ nothing
+        instanced ⇒ the transform path stays on full sync)."""
+        self._renderer_instance_id_map = {}
+        self._renderer_instancer_eligible = {}
         if not (hasattr(renderer, "register_mesh_bulk") and hasattr(renderer, "add_instance")):
             return set()
         settings = getattr(depsgraph.scene, "custom_raytracer", None)
@@ -3433,8 +3446,11 @@ class CustomRaytracerRenderEngine(RenderEngine):
         if not BULK_GEOMETRY_UPLOAD:
             return set()
 
-        # Pass A — collect eligible instances grouped by (datablock, name).
+        # Pass A — collect eligible instances grouped by (datablock, name), and
+        # track each instancer's generated duplis for the inc-3d empty-move guard.
         groups = {}      # key -> list of (enum_index, obj, matrix_world.copy())
+        instancer_members = {}   # instancer name -> [member source obj.name, ...]
+        instancer_nested = set()  # instancer names that generate a nested instancer
         for i, inst in enumerate(depsgraph.object_instances):
             obj = inst.object
             if obj is None:
@@ -3444,12 +3460,24 @@ class CustomRaytracerRenderEngine(RenderEngine):
                     continue
             elif getattr(obj, 'hide_viewport', False):
                 continue
+            # Record which instancer produced this (visible) dupli BEFORE the
+            # instanceable filter — a flattened member still poisons its instancer.
+            if getattr(inst, 'is_instance', False):
+                parent = getattr(inst, 'parent', None)
+                pname = getattr(parent, 'name', None) if parent is not None else None
+                if pname is not None:
+                    instancer_members.setdefault(pname, []).append(obj.name)
+                    # A dupli whose source is itself an instancer ⇒ nested; refit
+                    # of the outer empty can't reason about the inner TLAS → poison.
+                    if getattr(obj, 'instance_type', 'NONE') not in ('NONE', None, ''):
+                        instancer_nested.add(pname)
             if not self._object_instanceable(obj):
                 continue
             key = (obj.data, obj.name)
             groups.setdefault(key, []).append((i, obj, inst.matrix_world.copy()))
 
         skip = set()
+        instanced_names = set()  # source names that made it into a shared BLAS
         identity4 = mathutils.Matrix.Identity(4)
         identity3 = mathutils.Matrix.Identity(3)
         for (data, name), entries in groups.items():
@@ -3487,12 +3515,67 @@ class CustomRaytracerRenderEngine(RenderEngine):
                 int(getattr(src_obj, "pass_index", 0)), uvs, uv_names, normals,
                 name)
             for enum_i, _obj, mw in entries:
-                renderer.add_instance(mesh_id, [v for row in mw for v in row])
+                iid = renderer.add_instance(mesh_id, [v for row in mw for v in row])
                 skip.add(enum_i)
+                # pkg114 inc 3d: dupli-enumeration-ordered id list per source name,
+                # keyed so the transform-only path can look the instances up by name
+                # and refit them (matches the add_instance order used at refit time).
+                self._renderer_instance_id_map.setdefault(name, []).append(iid)
+            instanced_names.add(name)
+
+        # pkg114 inc 3d: an instancer EMPTY is refit-eligible only if it is not
+        # nested and EVERY dupli it generated went through the shared BLAS. If any
+        # member flattened (count-1 linked dupe, emissive/caustic/volume, non-MESH),
+        # moving the empty also moves flat-scene geometry a TLAS refit won't touch,
+        # so that instancer must full-sync.
+        for pname, member_names in instancer_members.items():
+            self._renderer_instancer_eligible[pname] = (
+                pname not in instancer_nested
+                and all(m in instanced_names for m in member_names))
         if skip:
             print(f"Astroray: instanced {len(skip)} objects across "
                   f"{sum(1 for e in groups.values() if len(e) >= 2)} shared meshes (two-level BVH)")
         return skip
+
+    def refit_instance_transforms(self, depsgraph, renderer):
+        """pkg114 inc 3d — TLAS-only refit for a transform-only viewport edit.
+
+        Re-walks `depsgraph.object_instances` in the SAME dupli-enumeration order
+        `_register_instanced_groups` used, and pushes each registered instance's
+        fresh `inst.matrix_world` onto its recorded instance id via
+        `update_instance_transform` (CPU, in place). The caller then does one
+        `upload_instance_transforms()` (re-push d_instances + d_tlas only) and
+        renders with `skip_upload=True`. No BLAS geometry is touched.
+
+        Every mapped instance is refreshed, not only the moved one — the whole TLAS
+        is rebuilt from current transforms on upload regardless, so refreshing all
+        is free and immune to per-object change-attribution subtleties (team-lead
+        decision, 2026-07-17). The visibility filter mirrors registration so the
+        per-name id cursor stays aligned for an unchanged topology."""
+        id_map = getattr(self, '_renderer_instance_id_map', None)
+        if not id_map:
+            return
+        is_render = getattr(depsgraph, 'mode', 'VIEWPORT') == 'RENDER'
+        cursor = {name: 0 for name in id_map}
+        for inst in depsgraph.object_instances:
+            obj = inst.object
+            if obj is None:
+                continue
+            if is_render:
+                if getattr(obj, 'hide_render', False):
+                    continue
+            elif getattr(obj, 'hide_viewport', False):
+                continue
+            ids = id_map.get(obj.name)
+            if not ids:
+                continue
+            k = cursor[obj.name]
+            if k >= len(ids):
+                continue  # topology drifted since registration — skip (full sync
+                          # would have been taken for a genuine geometry change).
+            mw = inst.matrix_world
+            renderer.update_instance_transform(ids[k], [v for row in mw for v in row])
+            cursor[obj.name] = k + 1
 
     def convert_objects(self, depsgraph, renderer, material_map):
         tri_count = 0

--- a/blender_addon/exporter.py
+++ b/blender_addon/exporter.py
@@ -88,18 +88,27 @@ class ObjectsCache:
         self._last_ids = set()
 
     def diff(self, depsgraph):
-        """Check if objects/geometry changed. Returns (geometry_changed: bool,
-        has_transforms: bool, transforms: list[(obj_id, mat16)]).
+        """Check if objects/geometry changed. Returns
+        (geometry: bool, flat_transforms: list[(obj_id, mat16)], xform_names: list[str]).
+
+          - geometry: a real is_updated_geometry edit occurred.
+          - flat_transforms: transform-only edits resolved via the flat
+            renderer-object-id map (the update_object_transform path).
+          - xform_names: names of transform-only edits with NO flat-map entry —
+            candidates for the pkg114 inc-3d instanced-refit fast path or (if not
+            instanced) a geometry promote. That decision needs the instance maps,
+            which live on the engine, so the dispatcher classifies these.
 
         Note: is_updated_geometry subsumes is_updated_transform — rebuilding
         geometry already covers a moved object. Only transform-only edits
         route to the transform path."""
         updates = getattr(depsgraph, 'updates', None)
         if updates is None:
-            return False, False, []
+            return False, [], []
 
         geometry = False
-        transforms = []
+        flat_transforms = []
+        xform_names = []
 
         for upd in updates:
             upd_id = getattr(upd, 'id', None)
@@ -116,19 +125,23 @@ class ObjectsCache:
                 # Transform-only edit
                 obj_id = self._renderer_object_id_for_fn(upd_id)
                 if obj_id is None:
-                    # No id mapping cached — promote to geometry rebuild
-                    geometry = True
+                    # No flat-map entry — hand the name to the dispatcher, which
+                    # decides instanced-refit vs geometry-rebuild promote.
+                    nm = getattr(upd_id, 'name', None)
+                    if nm is not None:
+                        xform_names.append(nm)
+                    else:
+                        geometry = True  # can't identify → safe full rebuild
                 else:
                     try:
                         m = list(upd_id.matrix_world)
                         if m and hasattr(m[0], '__iter__'):
                             m = [float(x) for row in m for x in row]
-                        transforms.append((obj_id, m))
+                        flat_transforms.append((obj_id, m))
                     except Exception:
                         geometry = True
 
-        has_transforms = bool(transforms)
-        return geometry, has_transforms, transforms
+        return geometry, flat_transforms, xform_names
 
 
 class MaterialsCache:
@@ -266,6 +279,9 @@ class Exporter:
         self._viewport_target_spp = 0
         self._viewport_accum_key = None
         self._viewport_prewarmed_for_mode = None  # pkg84: CUDA kernel pre-warm state
+        self._viewport_skip_upload_next = False  # pkg114 inc 3d: next render is a
+        # TLAS-only refit → render(skip_upload=True); set by apply_depsgraph_updates,
+        # consumed by view_update.
 
         # Per-domain caches
         self._camera_cache = CameraCache(bpy_module)
@@ -327,10 +343,28 @@ class Exporter:
             changes |= Change.MATERIALS
         if self._lights_cache.diff(depsgraph):
             changes |= Change.LIGHTS
-        geometry, has_transforms, transforms = self._objects_cache.diff(depsgraph)
+        geometry, flat_transforms, xform_names = self._objects_cache.diff(depsgraph)
+        # pkg114 inc 3d: classify unresolved transform-only edits against the
+        # engine's instance maps (populated by convert_objects on GPU only; empty
+        # otherwise, so CPU / non-instanced scenes fall through unchanged).
+        instance_map = getattr(self.engine, '_renderer_instance_id_map', None) or {}
+        instancer_elig = getattr(self.engine, '_renderer_instancer_eligible', None) or {}
+
+        def _fast_ok(nm):
+            # Refit-able in place: an instanced source (duplis in the id map) or an
+            # eligible instancer empty (all its duplis went through the shared BLAS).
+            return (nm in instance_map) or (instancer_elig.get(nm) is True)
+
+        def _related(nm):
+            # Touches instancing at all — including a poisoned/nested instancer — so
+            # a partial update would leave the scene inconsistent (→ full sync).
+            return (nm in instance_map) or (nm in instancer_elig)
+
+        instancing_related = any(_related(nm) for nm in xform_names)
+
         if geometry:
             changes |= Change.GEOMETRY
-        if has_transforms:
+        if flat_transforms or xform_names:
             changes |= Change.TRANSFORMS
         backend_config, accumulation_only = self._config_cache.diff(depsgraph)
         if accumulation_only:
@@ -366,6 +400,21 @@ class Exporter:
                 self._reset_viewport_accumulation()
             return 'idle'
 
+        # pkg114 inc 3d — instanced transform-only dispatch decision. A PURE
+        # transform batch (no other image-changing domain) where every changed
+        # object is refit-able takes the TLAS-only fast path. A batch that touches
+        # instancing any OTHER way (mixed flat+instanced, poisoned/nested instancer,
+        # or transform + another domain) can't be kept consistent by a partial
+        # update, so it full-syncs. Non-instanced transform-only edits keep the
+        # pre-pkg114 behaviour: promote to a geometry rebuild.
+        transform_only = (changes & ~(Change.TRANSFORMS | Change.ACCUMULATION_ONLY)) == 0
+        do_refit = (transform_only and bool(xform_names) and not flat_transforms
+                    and all(_fast_ok(nm) for nm in xform_names))
+        if not do_refit and instancing_related:
+            return 'fallback'
+        if not do_refit and any(not _fast_ok(nm) for nm in xform_names):
+            changes |= Change.GEOMETRY
+
         # pkg96 P2: reconcile-then-upload contract. Each domain re-derives
         # its state from Blender before pushing device buffers.
         if changes & Change.BACKEND_CONFIG:
@@ -386,8 +435,15 @@ class Exporter:
             renderer.upload_lights()
         if changes & Change.GEOMETRY:
             renderer.upload_geometry()
+        elif do_refit:
+            # pkg114 inc 3d: TLAS-only refit — push each instance's fresh
+            # matrix_world in place, re-upload ONLY d_instances + d_tlas, then
+            # signal the caller to render(skip_upload=True) from device state.
+            self.engine.refit_instance_transforms(depsgraph, renderer)
+            renderer.upload_instance_transforms()
+            self._viewport_skip_upload_next = True
         elif changes & Change.TRANSFORMS:
-            for obj_id, mat16 in transforms:
+            for obj_id, mat16 in flat_transforms:
                 try:
                     renderer.update_object_transform(obj_id, mat16)
                 except (RuntimeError, AttributeError, TypeError):
@@ -446,8 +502,13 @@ class Exporter:
         self._viewport_full_synced = True
 
     def render_viewport_frame(self, renderer, context, settings, region,
-                             reset_accumulation, engine_methods):
-        """Set up camera, run render, update cached GPU texture."""
+                             reset_accumulation, engine_methods, skip_upload=False):
+        """Set up camera, run render, update cached GPU texture.
+
+        skip_upload (pkg114 inc 3d): render from the CURRENT device state without a
+        full geometry re-upload — used after a TLAS-only instance-transform refit
+        (update_instance_transform + upload_instance_transforms), so a transform-only
+        edit of instanced objects pays only the cheap instance/TLAS re-push."""
         width = max(1, region.width)
         height = max(1, region.height)
         render_key = engine_methods['viewport_render_key'](context, settings, region)
@@ -507,7 +568,8 @@ class Exporter:
             min(settings.glossy_bounces, depth),
             min(settings.transmission_bounces, depth),
             min(settings.volume_bounces, depth),
-            min(settings.transparent_bounces, depth)
+            min(settings.transparent_bounces, depth),
+            skip_upload
         )
         if pixels is None:
             return
@@ -583,10 +645,16 @@ class Exporter:
                 self._viewport_camera_substantive_hash = camera_substantive_state_hash_fn(context, region)
                 return
 
+            # pkg114 inc 3d: consume the refit flag apply_depsgraph_updates may have
+            # set this call — render from device state without a geometry re-upload.
+            skip_upload = self._viewport_skip_upload_next
+            self._viewport_skip_upload_next = False
+
             t0 = time.perf_counter()
             self.render_viewport_frame(renderer, context, settings, region,
                                       reset_accumulation=True,
-                                      engine_methods=engine_methods)
+                                      engine_methods=engine_methods,
+                                      skip_upload=skip_upload)
             viewport_perf_record_fn("render", t0)
             viewport_perf_frame_complete_fn()
 

--- a/scripts/verify_pkg114_refit_blender.py
+++ b/scripts/verify_pkg114_refit_blender.py
@@ -1,0 +1,229 @@
+"""pkg114 inc 3d — real-Blender end-to-end verification of the TLAS-only REFIT.
+
+Run headless:
+    "C:/Program Files/Blender Foundation/Blender 5.1/blender.exe" --background \
+        --factory-startup --python scripts/verify_pkg114_refit_blender.py
+
+Builds the same collection-instanced scene as verify_pkg114_instancing_blender.py
+(one "Prop" datablock instanced by several empties + a static floor), full-syncs it
+through the addon's `convert_objects` on a REAL GPU renderer at transform state A,
+then MOVES an instancer empty and exercises the exporter's transform-only fast path
+directly:
+
+    engine.refit_instance_transforms(depsgraph_B, r)   # re-derive each dupli xform
+    r.upload_instance_transforms()                      # TLAS-only re-push
+    img_refit = r.render(..., skip_upload=True)         # render from device state
+
+and compares that to a from-scratch full re-sync at B (fresh renderer,
+`convert_objects` at the new transforms, normal render). Mirrors test_tlas_refit.py:
+
+  * CORRECTNESS: mean-abs-diff(refit, full-resync @ B) < 0.02.
+  * NON-VACUOUS: A and B renders differ (the empty really moved the image).
+  * NEGATIVE CONTROL: render(skip_upload=True) WITHOUT the refit keeps device @ A,
+    so it differs from the oracle @ B (proves skip_upload reads device state).
+
+Prints PKG114_REFIT_RESULT PASS / FAIL.
+"""
+import os
+import sys
+import importlib.util
+
+import bpy
+import numpy as np
+
+ROOT = os.environ.get(
+    "ASTRORAY_ROOT",
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "tests"))
+import runtime_setup
+runtime_setup.configure_test_imports()
+sys.path.insert(0, os.path.join(ROOT, "blender_addon"))
+import astroray
+
+_spec = importlib.util.spec_from_file_location(
+    "astroray_addon", os.path.join(ROOT, "blender_addon", "__init__.py"))
+addon = importlib.util.module_from_spec(_spec)
+sys.modules["astroray_addon"] = addon
+_spec.loader.exec_module(addon)
+try:
+    addon.register()
+except Exception as exc:
+    print(f"addon.register() warning: {exc}")
+Engine = addon.CustomRaytracerRenderEngine
+
+
+def _make_engine_standin():
+    class _Standin:
+        def report(self, *a, **k):
+            pass
+    for name, fn in Engine.__dict__.items():
+        if callable(fn) and not name.startswith("__"):
+            setattr(_Standin, name, fn)
+    return _Standin()
+
+
+W = H = 80
+SAMPLES = 16
+MAX_DEPTH = 3
+SEED = 13
+
+
+def _build_scene():
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+    scene = bpy.context.scene
+
+    bpy.ops.mesh.primitive_ico_sphere_add(subdivisions=2, radius=0.5)
+    prop = bpy.context.active_object
+    prop.name = "Prop"
+    prop.scale = (1.0, 0.6, 1.3)
+    me = prop.data
+    for nm, col in (("PropA", (0.85, 0.25, 0.2)), ("PropB", (0.2, 0.4, 0.85))):
+        m = bpy.data.materials.new(nm)
+        m.use_nodes = True
+        bsdf = m.node_tree.nodes.get("Principled BSDF")
+        if bsdf is not None:
+            bsdf.inputs["Base Color"].default_value = (*col, 1.0)
+            es = bsdf.inputs.get("Emission Strength")
+            if es is not None:
+                es.default_value = 0.0
+        me.materials.append(m)
+    for i, poly in enumerate(me.polygons):
+        poly.material_index = i % 2
+        poly.use_smooth = True
+    if not me.uv_layers:
+        me.uv_layers.new(name="UVMap")
+
+    col = bpy.data.collections.new("PropCol")
+    scene.collection.children.link(col)
+    col.objects.link(prop)
+    scene.collection.objects.unlink(prop)
+
+    placements = [
+        ((-1.6, 0.0, 0.0), 0.0),
+        ((0.0, 0.0, 0.0), 35.0),
+        ((1.6, 0.0, 0.0), -20.0),
+    ]
+    empties = []
+    for k, (loc, rot_deg) in enumerate(placements):
+        e = bpy.data.objects.new(f"Inst{k}", None)
+        e.instance_type = 'COLLECTION'
+        e.instance_collection = col
+        e.location = loc
+        e.rotation_euler = (0.0, np.radians(rot_deg), 0.0)
+        scene.collection.objects.link(e)
+        empties.append(e)
+
+    bpy.ops.mesh.primitive_plane_add(size=12.0, location=(0.0, -1.0, 0.0))
+    floor = bpy.context.active_object
+    floor.name = "Floor"
+    fm = bpy.data.materials.new("FloorMat")
+    fm.use_nodes = True
+    fb = fm.node_tree.nodes.get("Principled BSDF")
+    if fb is not None:
+        fb.inputs["Base Color"].default_value = (0.3, 0.55, 0.3, 1.0)
+    floor.data.materials.append(fm)
+
+    bpy.context.view_layer.update()
+    return scene, empties
+
+
+def _setup_common(r):
+    r.set_background_color([0.5, 0.6, 0.8])
+    r.set_integrator("path_tracer")
+    r.set_use_gpu(True)
+    r.setup_camera([0.0, 2.0, 8.0], [0.0, -0.1, 0.0], [0.0, 1.0, 0.0],
+                   42.0, W / H, 0.0, 8.0, W, H)
+    r.add_sun_light_dedicated([0.3, -0.7, -0.5], 0.02,
+                              {"mode": "rgb", "color": [1.0, 1.0, 1.0]}, 3.0)
+    r.set_seed(SEED)
+
+
+def _render(r, skip_upload=False):
+    img = np.asarray(
+        r.render(SAMPLES, MAX_DEPTH, None, False, -1, -1, -1, -1, -1, skip_upload),
+        dtype=np.float32)
+    return img.reshape(H, W, 3) if img.ndim == 1 else img
+
+
+def _full_sync(eng, depsgraph):
+    """Fresh renderer, full convert at the depsgraph's current transforms."""
+    r = astroray.Renderer()
+    if not r.gpu_available:
+        raise SystemExit("PKG114_REFIT_RESULT SKIP (no CUDA GPU)")
+    material_map = eng.convert_materials(depsgraph, r)
+    _setup_common(r)
+    eng.convert_objects(depsgraph, r, material_map)
+    return r
+
+
+def main():
+    scene, empties = _build_scene()
+    eng = _make_engine_standin()
+
+    # NB: bpy.context.evaluated_depsgraph_get() returns the scene's single depsgraph,
+    # re-evaluated IN PLACE by view_layer.update(). So we capture the state-A images
+    # (and the negative control) BEFORE moving, then reuse the same depsgraph handle
+    # for the refit/oracle after the move.
+    depsgraph = bpy.context.evaluated_depsgraph_get()
+
+    # --- State A: full sync + prime device. ---
+    r = _full_sync(eng, depsgraph)
+    id_map = dict(getattr(eng, "_renderer_instance_id_map", {}))
+    elig = dict(getattr(eng, "_renderer_instancer_eligible", {}))
+    img_a = _render(r)                          # normal (full upload) render @ A
+
+    # --- Negative control: skip_upload WITHOUT a refit reads the device state,
+    #     which is still A. Captured before the move; must differ from the B oracle.
+    img_stale = _render(r, skip_upload=True)
+
+    # --- Move (and scale) an instancer empty dramatically → state B. Big enough that
+    #     its dupli clearly relocates on the 80x80 frame (non-vacuous move); scaling
+    #     the empty also exercises composed (empty ∘ prop_local) matrices in refit.
+    empties[1].location = (0.0, 1.3, 3.4)
+    empties[1].scale = (2.4, 2.4, 2.4)
+    empties[1].rotation_euler = (0.0, np.radians(70.0), 0.0)
+    bpy.context.view_layer.update()
+
+    # --- REFIT path (the exporter fast path, driven directly): re-derive every mapped
+    #     instance's fresh matrix_world, TLAS-only re-push, render from device state.
+    eng.refit_instance_transforms(depsgraph, r)
+    r.upload_instance_transforms()
+    img_refit = _render(r, skip_upload=True)
+
+    # --- Oracle: from-scratch full re-sync at B. ---
+    r_oracle = _full_sync(eng, depsgraph)
+    img_oracle = _render(r_oracle)
+
+    mad_refit = float(np.abs(img_refit - img_oracle).mean())
+    mad_moved = float(np.abs(img_a - img_oracle).mean())
+    mad_stale = float(np.abs(img_stale - img_oracle).mean())
+
+    print(f"PKG114_REFIT instancer_eligible={elig} "
+          f"instanced_names={list(id_map.keys())} "
+          f"n_instances={sum(len(v) for v in id_map.values())}")
+    print(f"PKG114_REFIT mad_refit_vs_oracle={mad_refit:.5f} "
+          f"mad_A_vs_oracle(moved)={mad_moved:.5f} "
+          f"mad_stale_vs_oracle(neg_ctrl)={mad_stale:.5f} "
+          f"mean_refit={float(img_refit.mean()):.4f}")
+
+    ok = True
+    if not any(elig.values()):
+        print("FAIL: no instancer was refit-eligible (empty-move path never armed)")
+        ok = False
+    if not (img_refit.mean() > 0.05):
+        print("FAIL: refit render looks empty"); ok = False
+    if mad_refit > 0.02:
+        print(f"FAIL: refit != full re-sync @ B (mad={mad_refit:.4g} > 0.02)"); ok = False
+    if not (mad_moved > 0.02):
+        print(f"FAIL: moving the empty did not change the image (mad={mad_moved:.4g}) "
+              f"— test is vacuous"); ok = False
+    if not (mad_stale > 0.02):
+        print(f"FAIL: skip_upload without refit matched the oracle (mad={mad_stale:.4g}) "
+              f"— skip_upload not reading device state"); ok = False
+
+    print("PKG114_REFIT_RESULT " + ("PASS" if ok else "FAIL"))
+    if not ok:
+        raise SystemExit(1)
+
+
+main()

--- a/tests/test_pkg114_exporter_transform_dispatch.py
+++ b/tests/test_pkg114_exporter_transform_dispatch.py
@@ -1,0 +1,384 @@
+"""pkg114 inc 3d — exporter transform-only → TLAS-refit dispatch tests.
+
+A transform-only viewport edit of an INSTANCED object (or an eligible instancer
+empty) must take the cheap TLAS-only refit path — update_instance_transform per
+dupli + upload_instance_transforms once + render(skip_upload=True) — and must NOT
+re-upload geometry. Anything that instancing can't keep consistent with a partial
+update (mixed flat+instanced batch, a poisoned/nested instancer, a non-GPU scene
+with no instance map) falls back to the existing full-sync / geometry path.
+
+These mirror the pkg56 Phase-C dispatch tests: a spy renderer records which
+uploader entry points fire, driven through the REAL addon engine (so the real
+refit_instance_transforms re-walk runs) with a stubbed bpy.
+
+The refit re-derives EACH dupli's fresh matrix_world by re-walking
+depsgraph.object_instances (pkg114 inc 3d) — a single obj.matrix_world is never
+written onto a whole dupli group (that would collapse them).
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+
+# --------------------------------------------------------------------------- #
+# stub bpy with the bpy.types.* hierarchy the dispatcher classifies on
+# --------------------------------------------------------------------------- #
+
+class _BpyId:
+    def __init__(self, name="x"):
+        self.name = name
+
+
+class World(_BpyId): pass
+class Light(_BpyId): pass
+class Material(_BpyId): pass
+class NodeTree(_BpyId): pass
+class Image(_BpyId): pass
+class Scene(_BpyId): pass
+
+
+class Object(_BpyId):
+    def __init__(self, name="obj", matrix_world=None):
+        super().__init__(name)
+        self.matrix_world = matrix_world or [
+            [1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]
+        ]
+
+
+class _DepsgraphUpdate:
+    def __init__(self, id, *, geometry=False, transform=False, shading=False):
+        self.id = id
+        self.is_updated_geometry = geometry
+        self.is_updated_transform = transform
+        self.is_updated_shading = shading
+
+
+def _load_addon(monkeypatch, renderer_cls):
+    bpy_module = types.ModuleType("bpy")
+    bpy_types_module = types.ModuleType("bpy.types")
+    bpy_props_module = types.ModuleType("bpy.props")
+
+    class _Base: pass
+
+    class _RenderEngineBase:
+        def report(self, *_a, **_k): return None
+        def update_progress(self, *_a, **_k): return None
+        def update_stats(self, *_a, **_k): return None
+        def test_break(self): return False
+        def tag_redraw(self): pass
+
+    bpy_types_module.Panel = _Base
+    bpy_types_module.Operator = _Base
+    bpy_types_module.AddonPreferences = _Base
+    bpy_types_module.PropertyGroup = _Base
+    bpy_types_module.RenderEngine = _RenderEngineBase
+    bpy_types_module.World = World
+    bpy_types_module.Light = Light
+    bpy_types_module.Material = Material
+    bpy_types_module.NodeTree = NodeTree
+    bpy_types_module.ShaderNodeTree = NodeTree
+    bpy_types_module.Image = Image
+    bpy_types_module.Object = Object
+    bpy_types_module.Scene = Scene
+    bpy_module.types = bpy_types_module
+
+    for name in ("BoolProperty", "IntProperty", "FloatProperty",
+                 "StringProperty", "PointerProperty", "FloatVectorProperty",
+                 "EnumProperty"):
+        setattr(bpy_props_module, name, lambda **_kw: None)
+    bpy_module.props = bpy_props_module
+    bpy_module.path = types.SimpleNamespace(abspath=lambda p: p)
+
+    shader_blending_module = types.ModuleType("shader_blending")
+    shader_blending_module.blend_shader_specs = {}
+    shader_blending_module.add_shader_specs = {}
+    mathutils_module = types.ModuleType("mathutils")
+    mathutils_module.Vector = lambda values: values
+    mathutils_module.Matrix = types.SimpleNamespace(
+        Identity=lambda n: [[1 if i == j else 0 for j in range(n)] for i in range(n)])
+
+    astroray_module = types.ModuleType("astroray")
+    astroray_module.__version__ = "test"
+    astroray_module.__features__ = {"cuda": False, "spectral": False}
+    astroray_module.__file__ = "/fake/astroray.pyd"
+    astroray_module.Renderer = renderer_cls
+    astroray_module.integrator_registry_names = lambda: ["path_tracer"]
+    astroray_module.material_registry_names = lambda: ["lambertian"]
+    astroray_module.pass_registry_names = lambda: []
+
+    monkeypatch.setitem(sys.modules, "bpy", bpy_module)
+    monkeypatch.setitem(sys.modules, "bpy.types", bpy_types_module)
+    monkeypatch.setitem(sys.modules, "bpy.props", bpy_props_module)
+    monkeypatch.setitem(sys.modules, "shader_blending", shader_blending_module)
+    monkeypatch.setitem(sys.modules, "mathutils", mathutils_module)
+    monkeypatch.setitem(sys.modules, "astroray", astroray_module)
+
+    module_path = Path(__file__).parent.parent / "blender_addon" / "__init__.py"
+    spec = importlib.util.spec_from_file_location(
+        "astroray_blender_addon_pkg114_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+# --------------------------------------------------------------------------- #
+# Spy renderer — records every uploader / refit entry point hit
+# --------------------------------------------------------------------------- #
+
+class _SpyRenderer:
+    def __init__(self):
+        self.calls = []
+
+    def _rec(self, name, *args):
+        self.calls.append((name,) + args)
+
+    def upload_geometry(self):    self._rec("upload_geometry")
+    def upload_materials(self):   self._rec("upload_materials")
+    def upload_lights(self):      self._rec("upload_lights")
+    def upload_environment(self): self._rec("upload_environment")
+
+    def update_object_transform(self, obj_id, mat16):
+        self._rec("update_object_transform", obj_id, tuple(mat16))
+
+    # pkg114 inc 3d surface
+    def update_instance_transform(self, iid, mat16):
+        self._rec("update_instance_transform", iid, tuple(float(x) for x in mat16))
+
+    def upload_instance_transforms(self):
+        self._rec("upload_instance_transforms")
+
+    def clear(self):                           self._rec("clear")
+    def set_adaptive_sampling(self, *_):       pass
+    def set_clamp_direct(self, *_):            pass
+    def set_clamp_indirect(self, *_):          pass
+    def set_filter_glossy(self, *_):           pass
+    def set_use_reflective_caustics(self, *_): pass
+    def set_use_refractive_caustics(self, *_): pass
+
+    def names(self):
+        return [c[0] for c in self.calls]
+
+
+def _engine(monkeypatch):
+    addon = _load_addon(monkeypatch, _SpyRenderer)
+    eng = addon.CustomRaytracerRenderEngine()
+    eng._viewport_renderer = _SpyRenderer()
+    eng._viewport_full_synced = True
+    return addon, eng, eng._viewport_renderer
+
+
+def _mat(tx=0.0):
+    return [[1, 0, 0, tx], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]
+
+
+def _inst(name, matrix, *, is_instance=True, parent_name=None, instance_type='NONE'):
+    obj = types.SimpleNamespace(name=name, instance_type=instance_type)
+    parent = types.SimpleNamespace(name=parent_name) if parent_name is not None else None
+    return types.SimpleNamespace(object=obj, matrix_world=matrix,
+                                 is_instance=is_instance, parent=parent)
+
+
+def _depsgraph(updates, object_instances=None, scene=None):
+    return types.SimpleNamespace(
+        updates=list(updates),
+        object_instances=list(object_instances or []),
+        scene=scene,
+        mode='VIEWPORT')
+
+
+# --------------------------------------------------------------------------- #
+# 1. instanced SOURCE object transform-only → TLAS refit, no geometry upload
+# --------------------------------------------------------------------------- #
+
+def test_instanced_source_transform_refits(monkeypatch):
+    _addon, eng, spy = _engine(monkeypatch)
+    # Two duplis of "Prop" registered as instances 10 and 11.
+    eng._renderer_instance_id_map = {"Prop": [10, 11]}
+    eng._renderer_instancer_eligible = {}
+    depsgraph = _depsgraph(
+        [_DepsgraphUpdate(Object("Prop"), transform=True)],
+        object_instances=[_inst("Prop", _mat(-1.6)), _inst("Prop", _mat(1.6))])
+
+    res = eng._apply_depsgraph_updates(spy, depsgraph, settings=None)
+
+    assert res == "dispatched"
+    names = spy.names()
+    assert names.count("update_instance_transform") == 2
+    assert names.count("upload_instance_transforms") == 1
+    assert "upload_geometry" not in names
+    assert "update_object_transform" not in names
+    # skip_upload flag was set on the exporter for the caller's render.
+    assert eng._get_exporter()._viewport_skip_upload_next is True
+
+
+# --------------------------------------------------------------------------- #
+# 2. re-derive correctness — each dupli gets its OWN fresh matrix (FINDING 1)
+# --------------------------------------------------------------------------- #
+
+def test_refit_rederives_per_dupli_matrix(monkeypatch):
+    _addon, eng, spy = _engine(monkeypatch)
+    eng._renderer_instance_id_map = {"Prop": [10, 11]}
+    eng._renderer_instancer_eligible = {}
+    depsgraph = _depsgraph(
+        [_DepsgraphUpdate(Object("Prop"), transform=True)],
+        object_instances=[_inst("Prop", _mat(-1.6)), _inst("Prop", _mat(1.6))])
+
+    eng._apply_depsgraph_updates(spy, depsgraph, settings=None)
+
+    updates = [c for c in spy.calls if c[0] == "update_instance_transform"]
+    by_id = {c[1]: c[2] for c in updates}
+    # instance 10 gets dupli-0's matrix (tx=-1.6), instance 11 gets dupli-1's (tx=1.6);
+    # a naive "obj.matrix_world onto the whole group" would give both the SAME matrix.
+    assert by_id[10][3] == pytest.approx(-1.6)
+    assert by_id[11][3] == pytest.approx(1.6)
+    assert by_id[10] != by_id[11]
+
+
+# --------------------------------------------------------------------------- #
+# 3. eligible instancer EMPTY move → refit (empty not in id map, but eligible)
+# --------------------------------------------------------------------------- #
+
+def test_eligible_instancer_empty_move_refits(monkeypatch):
+    _addon, eng, spy = _engine(monkeypatch)
+    eng._renderer_instance_id_map = {"Prop": [10, 11]}
+    eng._renderer_instancer_eligible = {"Coll": True}
+    depsgraph = _depsgraph(
+        [_DepsgraphUpdate(Object("Coll"), transform=True)],
+        object_instances=[_inst("Prop", _mat(-1.6), parent_name="Coll"),
+                          _inst("Prop", _mat(1.6), parent_name="Coll")])
+
+    res = eng._apply_depsgraph_updates(spy, depsgraph, settings=None)
+
+    assert res == "dispatched"
+    names = spy.names()
+    assert names.count("update_instance_transform") == 2
+    assert names.count("upload_instance_transforms") == 1
+    assert "upload_geometry" not in names
+    assert eng._get_exporter()._viewport_skip_upload_next is True
+
+
+# --------------------------------------------------------------------------- #
+# 4. poisoned instancer (a flattened member) → full sync, no refit
+# --------------------------------------------------------------------------- #
+
+def test_poisoned_instancer_falls_back(monkeypatch):
+    _addon, eng, spy = _engine(monkeypatch)
+    eng._renderer_instance_id_map = {"Prop": [10, 11]}
+    eng._renderer_instancer_eligible = {"Coll": False}  # has a flattened member
+    depsgraph = _depsgraph(
+        [_DepsgraphUpdate(Object("Coll"), transform=True)],
+        object_instances=[_inst("Prop", _mat(-1.6), parent_name="Coll")])
+
+    res = eng._apply_depsgraph_updates(spy, depsgraph, settings=None)
+
+    assert res == "fallback"  # caller runs a full re-sync
+    names = spy.names()
+    assert "update_instance_transform" not in names
+    assert "upload_instance_transforms" not in names
+    assert eng._get_exporter()._viewport_skip_upload_next is False
+
+
+# --------------------------------------------------------------------------- #
+# 5. mixed batch (one flat object + one instanced source) → full sync
+# --------------------------------------------------------------------------- #
+
+def test_mixed_flat_and_instanced_falls_back(monkeypatch):
+    _addon, eng, spy = _engine(monkeypatch)
+    eng._renderer_instance_id_map = {"Prop": [10, 11]}
+    eng._renderer_instancer_eligible = {}
+    depsgraph = _depsgraph(
+        [_DepsgraphUpdate(Object("Prop"), transform=True),
+         _DepsgraphUpdate(Object("Floor"), transform=True)],  # flat, not in any map
+        object_instances=[_inst("Prop", _mat(-1.6)), _inst("Prop", _mat(1.6))])
+
+    res = eng._apply_depsgraph_updates(spy, depsgraph, settings=None)
+
+    assert res == "fallback"
+    names = spy.names()
+    assert "update_instance_transform" not in names
+    assert "upload_geometry" not in names  # fallback, not a partial upload
+
+
+# --------------------------------------------------------------------------- #
+# 6. CPU / non-instanced scene (empty maps) → geometry promote, never a refit
+# --------------------------------------------------------------------------- #
+
+def test_cpu_empty_maps_promotes_to_geometry(monkeypatch):
+    _addon, eng, spy = _engine(monkeypatch)
+    # convert_objects on CPU leaves both maps empty (instancing is GPU-only).
+    eng._renderer_instance_id_map = {}
+    eng._renderer_instancer_eligible = {}
+    depsgraph = _depsgraph(
+        [_DepsgraphUpdate(Object("Cube"), transform=True)],
+        object_instances=[_inst("Cube", _mat(2.0), is_instance=False)])
+
+    res = eng._apply_depsgraph_updates(spy, depsgraph, settings=None)
+
+    assert res == "dispatched"
+    names = spy.names()
+    assert "upload_geometry" in names
+    assert "update_instance_transform" not in names
+    assert "upload_instance_transforms" not in names
+    assert eng._get_exporter()._viewport_skip_upload_next is False
+
+
+# --------------------------------------------------------------------------- #
+# 7. render_viewport_frame forwards skip_upload as render()'s last positional arg
+# --------------------------------------------------------------------------- #
+
+class _RenderSpy(_SpyRenderer):
+    def __init__(self):
+        super().__init__()
+        self.render_args = None
+
+    def set_wavelength_range(self, *_):  pass
+    def set_output_mode(self, *_):       pass
+    def set_integrator(self, *_):        pass
+    def clear_passes(self):              pass
+    def add_pass(self, *_):              pass
+
+    def render(self, *args):
+        self.render_args = args
+        return np.zeros(2 * 2 * 3, dtype=np.float32)
+
+
+def _render_engine_methods():
+    return {
+        'viewport_render_key': lambda *a: "k",
+        'viewport_target_samples': lambda s: 8,
+        'viewport_chunk_samples': lambda s, cur: 4,
+        'setup_viewport_camera': lambda *a: None,
+        'wavelength_range_from_settings': lambda s: (380.0, 780.0),
+        'effective_integrator_name': lambda s: "path_tracer",
+        'resolve_denoiser_pass': lambda s: None,
+        'check_gpu_limitations_and_report': lambda *a, **k: None,
+        'update_viewport_texture': lambda *a: None,
+        'update_viewport_status': lambda *a: None,
+    }
+
+
+def test_render_viewport_frame_forwards_skip_upload(monkeypatch):
+    _addon, eng, _spy = _engine(monkeypatch)
+    exporter = eng._get_exporter()
+    renderer = _RenderSpy()
+    settings = types.SimpleNamespace(
+        max_bounces=6, diffuse_bounces=4, glossy_bounces=4, transmission_bounces=4,
+        volume_bounces=0, transparent_bounces=8,
+        viewport_display_pass="combined", viewport_oidn=False)
+    region = types.SimpleNamespace(width=2, height=2)
+
+    exporter.render_viewport_frame(renderer, context=None, settings=settings,
+                                   region=region, reset_accumulation=True,
+                                   engine_methods=_render_engine_methods(),
+                                   skip_upload=True)
+
+    assert renderer.render_args is not None
+    # render(spp, depth, cb, gamma, d, g, t, v, tp, skip_upload) — 10 positionals.
+    assert len(renderer.render_args) == 10
+    assert renderer.render_args[9] is True

--- a/tests/test_pkg116_exporter_caches.py
+++ b/tests/test_pkg116_exporter_caches.py
@@ -178,12 +178,14 @@ def test_objects_cache_diff_returns_geometry_flag_on_geometry_update():
 
     cache = exp.ObjectsCache(bpy, no_id_map)
 
-    # Object.is_updated_geometry → geometry=True
+    # Object.is_updated_geometry → geometry=True. pkg114 inc 3d changed diff's
+    # return to (geometry, flat_transforms, xform_names); a pure geometry edit
+    # leaves both transform lists empty.
     dg = _stub_depsgraph([_DepsgraphUpdate(Object("O"), geometry=True)])
-    geom, has_xforms, xforms = cache.diff(dg)
-    assert geom is True
-    assert has_xforms is False
-    assert xforms == []
+    geometry, flat_transforms, xform_names = cache.diff(dg)
+    assert geometry is True
+    assert flat_transforms == []
+    assert xform_names == []
 
 
 def test_objects_cache_diff_returns_transforms_on_transform_only_with_id_map():
@@ -195,15 +197,32 @@ def test_objects_cache_diff_returns_transforms_on_transform_only_with_id_map():
 
     cache = exp.ObjectsCache(bpy, id_map)
 
-    # Object.is_updated_transform (no geometry) → transforms list
+    # Object.is_updated_transform (no geometry), flat-map resolves the id →
+    # flat_transforms carries (obj_id, mat16); xform_names stays empty (pkg114
+    # inc 3d: only unresolved transform names land in xform_names).
     obj = Object("O")
     dg = _stub_depsgraph([_DepsgraphUpdate(obj, transform=True)])
-    geom, has_xforms, xforms = cache.diff(dg)
-    assert geom is False
-    assert has_xforms is True
-    assert len(xforms) == 1
-    assert xforms[0][0] == 42  # obj_id
-    assert len(xforms[0][1]) == 16  # mat16
+    geometry, flat_transforms, xform_names = cache.diff(dg)
+    assert geometry is False
+    assert len(flat_transforms) == 1
+    assert flat_transforms[0][0] == 42  # obj_id
+    assert len(flat_transforms[0][1]) == 16  # mat16
+    assert xform_names == []
+
+
+def test_objects_cache_diff_unresolved_transform_goes_to_xform_names():
+    # pkg114 inc 3d: a transform-only edit with NO flat-map id is handed to the
+    # dispatcher by name (which classifies it as an instanced refit or a geometry
+    # promote) rather than being force-promoted to geometry inside diff.
+    exp = _load_exporter_module()
+    bpy = _stub_bpy()
+
+    cache = exp.ObjectsCache(bpy, lambda obj: None)
+    dg = _stub_depsgraph([_DepsgraphUpdate(Object("Prop"), transform=True)])
+    geometry, flat_transforms, xform_names = cache.diff(dg)
+    assert geometry is False
+    assert flat_transforms == []
+    assert xform_names == ["Prop"]
 
 
 def test_config_cache_diff_fires_on_scene():


### PR DESCRIPTION
## What

Wires the Blender addon exporter's `Change.TRANSFORMS` viewport path to the pkg114 **inc-3d TLAS-only refit**, the last remaining pkg114 integration. A transform-only viewport edit of instanced objects now refits the TLAS instead of re-uploading all geometry.

**No C++/CUDA changes.** The bindings (`update_instance_transform`, `upload_instance_transforms`, `render(skip_upload=...)`) landed in #468. This PR is pure Python (addon + tests + spec).

## How

- `convert_objects` (`_register_instanced_groups`) records two maps, reset each full sync:
  - `_renderer_instance_id_map` = `{source obj.name: [instance_id, …] in dupli-enumeration order}`
  - `_renderer_instancer_eligible` = `{instancer obj.name: bool}` — eligible iff **not nested** and **every dupli it generated went through the shared BLAS** (a flattened member ⇒ poisoned ⇒ ineligible).
- New `refit_instance_transforms(depsgraph, renderer)` re-walks `depsgraph.object_instances` in registration order and pushes **each dupli's freshly re-derived `matrix_world`** to its recorded instance id. It never writes one `obj.matrix_world` onto a whole dupli group (that would collapse them — inc-3c only ever instances duplis, ≥2 per name, each with its own `instancer ∘ prop_local` matrix).
- `apply_depsgraph_updates` takes the fast path — `refit_instance_transforms` → `upload_instance_transforms()` → `render(skip_upload=True)` — iff the batch is **pure transform-only** and every changed object is an instanced source or an eligible instancer empty. Otherwise unchanged: mixed flat+instanced, poisoned/nested instancer, multi-domain batches, and CPU renders (maps empty) all full-sync.
- `render_viewport_frame` gains a `skip_upload` param threaded from a per-call exporter flag consumed in `view_update`.

## Trigger-semantics decision (per team-lead)

Both a moved **instanced source object** and a moved **eligible instancer empty** hit the refit. Refreshing ALL mapped instances (not just the changed one) is deliberate — `upload_instance_transforms` rebuilds the whole TLAS from current transforms regardless, so it is free and immune to per-object change attribution. Poisoned/nested instancers and mixed/multi-domain/CPU batches conservatively full-sync (a partial refit can't keep flat-scene geometry consistent).

Confirmed the real depsgraph: moving an instancer empty emits exactly one recognized update — `('Object','Inst1', transform-only)` — no Collection/unrecognised id, so real empty-moves route to the fast path end-to-end.

## Verification (measured)

Headless Blender 5.1 (`scripts/verify_pkg114_refit_blender.py`, collection-instanced Prop × 4 + static floor, GPU / RTX 3000 Ada), move+scale an instancer empty:

```
PKG114_REFIT instancer_eligible={'Inst0': True, 'Inst1': True, 'Inst2': True} instanced_names=['Prop'] n_instances=4
PKG114_REFIT mad_refit_vs_oracle=0.00000 mad_A_vs_oracle(moved)=0.09203 mad_stale_vs_oracle(neg_ctrl)=0.09203 mean_refit=0.4318
PKG114_REFIT_RESULT PASS
```

- **refit vs full re-sync @ B: mad 0.00000** (< 0.02 gate — byte-identical).
- moved-image Δ **0.092** (non-vacuous move), negative control **0.092** (proves `skip_upload` reads device state, no re-upload).

Tests:
- `tests/test_pkg114_exporter_transform_dispatch.py` — **7 new** (source refit, per-dupli re-derive correctness, eligible-empty refit, poisoned-instancer fallback, mixed fallback, CPU promote, `render_viewport_frame` skip_upload forwarding).
- `tests/test_pkg116_exporter_caches.py` — updated to the new `diff` contract `(geometry, flat_transforms, xform_names)` + 1 new case; **13 pass**.
- Regression: pkg56 dispatch (15) + addon/blender mock subset (80) + GPU TLAS suite (`test_tlas_refit` etc., 5) all green against the main `build_cuda` build.

## Acceptance criteria

This wiring was explicitly **not an acceptance gate** (the inc-3d budget/parity gates were already met in #468). The integration is now complete; spec status line + decision list updated.

- [x] Transform-only instanced edit refits the TLAS (no geometry re-upload) — dispatch tests + headless byte-identical.
- [x] Mixed / poisoned / nested / CPU → full sync — dispatch tests.
- [x] pkg56 `idle`/`fallback`/`dispatched` contract preserved — pkg56 + pkg116 suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)