### PR TITLE
docs(pkg127-129): material + caustics specs from 2026-07 PBR sweep

### DIFF
--- a/.astroray_plan/packages/pkg127-specular-polynomials-sms.md
+++ b/.astroray_plan/packages/pkg127-specular-polynomials-sms.md
@@ -1,0 +1,231 @@
+# pkg127 — Specular Polynomials for SMS seed finding (deterministic, Newton-free seeds)
+
+**Pillar:** 3 (light transport / caustics) + 2 (spectral core)
+**Track:** A (CPU-first seed-stage upgrade with numerical caustic-quality gates; the GPU/wavefront SMS mirror is RTX-verified against the CPU result)
+**Codex-paste-ready:** no (research-grade algorithm port with a license-verification gate, a math re-derivation from the paper, and a caustic-quality acceptance bar — needs judgment at each step, not a mechanical patch)
+**Status:** open — the highest-value bounded caustics-quality upgrade on the roadmap (per `.astroray_plan/docs/2026-07-pbr-advances-research.md` headline finding 1)
+**Estimated effort:** L (single-bounce polynomial solver + integration into the existing seed stage, then the two-bounce extension; a license phase-0, a paper re-derivation, and a before/after seed-failure measurement)
+**Depends on:** **pkg64** (SMS folded into the default spectral path — DONE; this package upgrades its seed stage) and **pkg106** (multi-vertex MNEE/manifold-chain foundation — the two-bounce leg builds on `include/astroray/manifold/manifold_chain.h`). No hard blocker: this is a drop-in upgrade to landed code, gated behind a flag so the current Newton seeding stays the fallback.
+
+---
+
+## Goal
+
+**Before:** Astroray's caustics come from Specular Manifold Sampling (SMS, Zeltner
+2020) folded into the default spectral path tracer (pkg64). Seed finding is a
+**stochastic-seed + Newton-solve** loop: `runSMSAttempt`
+(`include/astroray/manifold/sms_attempt.h:107-148`) draws a **uniform-on-sphere**
+seed on the caster (`nSeed`, lines 111-118, Zeltner 2020 §4.4), then runs
+Newton iteration to convergence
+(`include/astroray/manifold/newton_iterate.h::solve`, called at
+`sms_attempt.h:148`). A seed that does not converge is simply dropped —
+`if (!R.converged) return false;` (`sms_attempt.h:149`). This has the two failure
+modes the Specular Polynomials paper was written to kill:
+
+1. **Divergence from a bad seed.** Newton has a finite convergence basin; a seed
+   outside it diverges or stalls (`newton_iterate.h:106-107` bails on a singular
+   Jacobian, `:82` on non-convergence within `maxIterations`). On triangulated
+   casters the basin shrinks further because ±h finite-difference steps cross
+   triangle edges into neighbours with different normals (the pkg106
+   SMS-fails-on-triangles failure, documented at `newton_iterate.h:121-131`); the
+   analytic-Jacobian path (`solveAnalytic`, `newton_iterate.h:151`) mitigates but
+   does not eliminate the basin problem.
+2. **One solution per seed.** Each seed can reach at most one manifold vertex.
+   Admissible specular paths whose vertices sit in a different basin are missed
+   unless a *different* seed happens to land near them — so multi-solution
+   configurations (a glass sphere focusing several caustic branches to one
+   receiver point, an SF11 prism with strong dispersion) need many seeds and still
+   under-sample, showing up as seed-failure waste and residual caustic noise.
+
+**After:** The SMS seed stage finds specular-chain solutions by **deterministic
+polynomial root-finding** (Specular Polynomials, Fan et al. SIGGRAPH 2024) instead
+of a stochastic-seed Newton search. For the **single-bounce** case the reflection/
+refraction constraint is reformulated as a univariate polynomial whose **real roots
+enumerate every admissible manifold vertex exactly** — no seed, no divergence,
+every solution branch found in one solve. For **two bounces** a bivariate system is
+reduced by the hidden-variable resultant to univariate root-finding, robust where
+Newton's basin fails (the paper reports the two-bounce GPU solver is ~10× the cost
+of a single Newton step but far more robust). Newton is retained only as an optional
+refinement/fallback behind a flag. Caustic quality on the refbank glass/prism scenes
+is **equal-or-better at equal spp**, and the measured **seed-failure rate drops**.
+
+---
+
+## Context — why this is the top caustics upgrade
+
+The 2026-07-17 PBR sweep ranked four independent 2023–2026 lines of specular/caustic
+transport work and put Specular Polynomials first for Astroray specifically:
+*"a targeted drop-in upgrade for the SMS seed-finding stage (pkg64/pkg106
+lineage)"* and, in the adoption recommendation, *"the highest-value bounded upgrade
+to what we already have"*
+(`.astroray_plan/docs/2026-07-pbr-advances-research.md` finding 1 + §"Adoption
+recommendation"). It is bounded because it replaces exactly one stage — seed finding
+— inside an integrator that already ships, rather than adding a new subsystem
+(unlike ReSTIR-PT, path guiding, or the Gaussian photon guiding on the horizon
+list). The visual payoff is directly on the owner's showcase scenes: the prism
+rainbow (`prism-bk7-collimated`, `prism-sf11-collimated`) and the glass-sphere
+caustic (`sms-refractive-glass-sphere`), which are the journal article's caustic
+figures. Deterministic root-finding is also the natural fit for the wavefront GPU
+kernel: no per-seed rejection divergence.
+
+---
+
+## Fix plan (cite — no inventions, CLAUDE.md §6)
+
+### Phase 0 — license verification (blocking, do first)
+
+The reference implementation is **github.com/mollnn/spoly**. The research doc lists
+its license as **"MIT-style" but explicitly UNVERIFIED**
+(`2026-07-pbr-advances-research.md` finding 1: *"MIT-style — VERIFY"*). Before any
+code is written or any source line is read for porting:
+
+- [ ] Fetch the actual `LICENSE` file from `github.com/mollnn/spoly` and record the
+      exact license text + SPDX identifier in the research note.
+- [ ] Confirm compatibility with Astroray's MIT license (MIT/BSD-3/Apache-2.0/
+      MPL-2.0/public-domain are fine; GPL is **not** — mirror the pkg64 decision that
+      kept Cycles' GPL MNEE at arm's length and re-derived from the paper instead).
+- [ ] If the license is incompatible or absent, **stop and re-derive from the paper
+      alone** (arXiv:2405.13409 carries the full math), exactly as pkg64 did for the
+      Hanika spectral extension. Do not copy source under an unverified license.
+
+**Cite:** Fan, Wang, Dong, Wang, Hašan, Yan et al., "Specular Polynomials",
+SIGGRAPH 2024, ACM ToG, **DOI 10.1145/3658132**, **arXiv:2405.13409**. Reference
+impl **github.com/mollnn/spoly** (license per phase 0).
+
+### Phase 1 — single-bounce polynomial seed finding (CPU first)
+
+- Reformulate the single-vertex specular constraint currently solved by Newton
+  (`sms_attempt.h::constraint`, the Hanika half-vector residual
+  `h(λ) = ω_i + η(λ)·ω_o` at `sms_attempt.h:124-128`) as the paper's polynomial
+  system: rational coordinate mapping of the caster surface parameterisation →
+  univariate polynomial whose real roots are the admissible manifold vertices
+  (Specular Polynomials §4, single-bounce case). Solve for **all** real roots
+  (robust companion-matrix / Sturm-sequence root isolation), then map each root back
+  to a surface vertex and validate it (in-surface, correct refraction side, not
+  TIR) with the existing checks (`sms_attempt.h:159-181`).
+- Wire this behind a new integrator flag (mirror the pkg64 `spectral_newton` toggle
+  convention, read via `getInt(...) != 0` per the pkg64 Phase-2 lesson) so the
+  current uniform-seed Newton path stays the default fallback until the gates prove
+  the replacement. Keep the per-wavelength η dispatch: the polynomial coefficients
+  depend on `η(λ_hero)` exactly as the residual does today, so the hero-wavelength
+  decoupling (pkg64 Phase-2 lesson) carries over unchanged — one solve per ray at
+  `λ_hero`, contribution written to the hero spectral channel.
+- Retain Newton as an **optional refinement** of each polynomial root (one or two
+  steps of the existing `newton_iterate.h::solveAnalytic`) to polish floating-point
+  root error to the existing `tolerance` — the paper notes root-finding gives the
+  basin, a Newton polish gives the last digits.
+
+### Phase 2 — two-bounce (build on the pkg106 manifold chain)
+
+- Extend to the two-vertex chain (`include/astroray/manifold/manifold_chain.h`,
+  pkg106) using the paper's **hidden-variable resultant**: eliminate one vertex
+  parameter to reduce the bivariate constraint system to univariate root-finding
+  (Specular Polynomials §5, multi-bounce). This is where the robustness win over
+  Newton is largest (multi-solution glass-sphere and double-refraction prism paths).
+- Budget accordingly: the paper measures the two-bounce GPU solver at ~10× a single
+  Newton step but far more robust. Gate on **quality-at-equal-spp and
+  seed-failure-rate**, not raw solver walltime — the point is fewer wasted samples
+  and lower caustic variance per spp.
+
+### Phase 3 — GPU/wavefront mirror
+
+- Mirror the single-bounce solver into the device SMS path
+  (`include/astroray/manifold/sms_attempt_device.cuh`) and RTX-verify against the
+  CPU result via the existing caustic parity harness
+  (`tests/test_gpu_caustic_parity.py`, `tests/test_pkg64_gpu_sms_attempt_unit.py`).
+  Deterministic root-finding removes the per-seed rejection divergence that hurts
+  wavefront occupancy, so this is a natural GPU fit — but keep the port CPU-gated
+  first; GPU parity is verification, not the primary gate.
+
+---
+
+## Acceptance criteria
+
+- [ ] **Phase 0 license recorded:** `github.com/mollnn/spoly` license fetched,
+      SPDX identifier + compatibility decision written into
+      `.astroray_plan/docs/specular-polynomials-research.md`; if incompatible, the
+      note records the paper-only re-derivation path taken instead (no source
+      copied under an unverified license).
+- [ ] **Single-bounce exact:** the polynomial solver enumerates all admissible
+      single-bounce manifold vertices on the analytic glass-sphere caster; a unit
+      test confirms it finds solutions Newton-from-uniform-seed misses on a
+      multi-solution configuration.
+- [ ] **Caustic-quality gates equal-or-better at equal spp:** `prism-bk7-collimated`,
+      `prism-sf11-collimated`, and `sms-refractive-glass-sphere` reference-bank gates
+      (`benchmarks/reference_bank/scenes/*/gates.toml`) hold or improve their metrics
+      (prism `hue_spread`/`bright_coverage`; glass-sphere receiver energy / SSIM) at
+      the same spp as the current Newton seeding — no regression on
+      `sms-reflective-metal-sphere` (single-bounce reflective).
+- [ ] **Seed-failure rate measured before/after:** instrument the fraction of SMS
+      attempts that reach a valid path (the current `return false` drop rate at
+      `sms_attempt.h:149`) on the glass-sphere and SF11 scenes; report the Newton
+      baseline and the polynomial rate. The polynomial rate must be **lower**
+      (fewer wasted attempts per valid path) — this is the headline quantitative gate.
+- [ ] **Two-bounce lands second:** the hidden-variable resultant two-bounce solver
+      passes a double-refraction convergence unit test where Newton stalls; gated as
+      a distinct phase so single-bounce can ship first.
+- [ ] **No regression with the flag off:** default integrator (flag off) is bit-equal
+      to the pre-pkg127 SMS path — `tests/test_sms_caustic_validation.py`,
+      `tests/test_sms_caustic_spectral.py`, `tests/test_glass_sphere_caustic.py`,
+      `tests/test_prism_caustic_rainbow.py` unchanged.
+- [ ] **GPU parity:** wavefront single-bounce solver matches the CPU result on
+      `tests/test_gpu_caustic_parity.py`; RTX-verified.
+- [ ] **Citations in code:** every polynomial-solver call site cites
+      "Fan et al. 2024 (Specular Polynomials) §4/§5, DOI 10.1145/3658132" and the
+      license-verified provenance of any borrowed structure, per CLAUDE.md §6.
+
+---
+
+## Non-goals
+
+- **Not a replacement for SMS as a whole.** This upgrades the **seed-finding stage**
+  only. The refraction, Fresnel, visibility, and MIS-composition chain
+  (`sms_attempt.h:159-201`) is untouched; Newton stays as an optional root-polish and
+  a flagged fallback.
+- **Not the forward light-tracing prism path.** pkg106 ships the triangulated-prism
+  rainbow via `light_tracer_caustic`; that integrator is out of scope. This package
+  targets the camera-side SMS seed stage (`runSMSAttempt`).
+- **Not three-plus bounces.** Single-bounce first, two-bounce second, as the paper
+  and the research doc scope it. Higher-order chains are a follow-up if the
+  resultant approach proves tractable at that order.
+- **Not ReSTIR / partitioned SMS.** The Hong et al. 2025 Partitioned-SMS+ReSTIR line
+  (research finding 2) presupposes ReSTIR reservoir infrastructure from pkg55
+  Phase C; it is a separate, later package.
+- **Not glint rendering.** SMS supports rough normal-mapped glints; out of scope
+  here, as in pkg64.
+- **No new caustic algorithm.** CLAUDE.md §6: port the published method, cite it,
+  verify its license — do not invent a root-finder.
+
+---
+
+## Provenance
+
+Filed from the **2026-07-17 PBR-advances research sweep**
+(`.astroray_plan/docs/2026-07-pbr-advances-research.md`, finding 1, verified 3-0),
+which ranked Specular Polynomials the top directly-adoptable caustics upgrade for
+Astroray's existing SMS pipeline and flagged the mollnn/spoly license as needing
+verification at port. Grounded against the live SMS seed stage
+(`include/astroray/manifold/sms_attempt.h` + `newton_iterate.h`) delivered by pkg64
+(SMS in the default path) and pkg106 (multi-vertex manifold chain). Owner context:
+the prism rainbow and glass-sphere caustic are journal-article caustic figures and
+spectral-showcase scenes — deterministic, exact seed finding is what makes them
+clean at production spp.
+
+---
+
+## Progress
+
+- [ ] Phase 0 — mollnn/spoly license fetched + recorded; compatibility decided.
+- [ ] Phase 1 — single-bounce univariate polynomial solver, CPU, behind a flag;
+      Newton retained as root-polish/fallback.
+- [ ] Phase 2 — two-bounce hidden-variable resultant on the pkg106 manifold chain.
+- [ ] Phase 3 — GPU/wavefront mirror; caustic parity RTX-verified.
+- [ ] Seed-failure-rate before/after measured on glass-sphere + SF11.
+- [ ] Research note `.astroray_plan/docs/specular-polynomials-research.md` written
+      (paper + DOI/arXiv, license decision, the exact math reproduced).
+
+---
+
+## Lessons
+
+*(Fill in after the package is done.)*

--- a/.astroray_plan/packages/pkg128-thin-film-iridescence.md
+++ b/.astroray_plan/packages/pkg128-thin-film-iridescence.md
@@ -1,0 +1,207 @@
+# pkg128 — Thin-film iridescence (Belcour-Barla), evaluated per-wavelength on the spectral core
+
+**Pillar:** 2 (materials / BSDF) + 5 (spectral showcase)
+**Track:** A (CPU-first spectral BSDF layer with numerical + visual gates; GPU spectral-closure mirror RTX-verified; Blender addon parity cells closed)
+**Codex-paste-ready:** no (a physically-based interference model re-derived from the paper, applied across three closures + the GPU mirror, plus a spectral-showcase visual bar and addon socket wiring — needs judgment, not a mechanical patch)
+**Status:** open — self-contained material feature; the recommended "good medium package after Phase C" in the research adoption plan
+**Estimated effort:** M–L (a self-contained interference term is moderate, but it attaches to metal/dielectric/Disney Fresnel on both CPU and GPU, needs a spectral-native evaluation the RGB references don't, and closes three DROPPED-SILENT addon parity cells with a visual showcase gate)
+**Depends on:** none hard. Composes with the spectral material path (pkg30/pkg35 spectral BSDF interface) and the Fresnel evaluation in `plugins/materials/{metal,dielectric,disney}.cpp` + `include/astroray/gpu_materials.h`. Best sequenced after pkg55 Phase C so the GPU mirror lands in the single surviving wavefront closure rather than the doomed megakernel.
+
+---
+
+## Goal
+
+**Before:** Astroray has no thin-film interference. A microfacet surface's Fresnel
+term (`metal.cpp`/`dielectric.cpp`/`disney.cpp` and the GPU spectral closure in
+`gpu_materials.h`) is the bare conductor/dielectric Fresnel — no wavelength-dependent
+phase interference, so soap bubbles, oil slicks, anodised metal, and coated glass
+render as flat, non-iridescent surfaces. The Blender Principled/Glass/Metallic nodes
+expose **Thin Film Thickness** and **Thin Film IOR** sockets, and the addon parity
+audit records all six of them as **DROPPED-SILENT**: a user who wires thin-film in
+Blender gets a silently non-iridescent render
+(`docs/blender_parity/report.md:570-571` glass, `:610-611` metallic, `:643-644`
+principled; same rows in `docs/blender_parity/coverage_matrix.json`).
+
+**After:** A thin-film interference layer modulates the specular Fresnel term of the
+microfacet closures per the Belcour-Barla 2017 model, controlled by a film thickness
+and film IOR. Because Astroray's core is **spectral**, the interference is evaluated
+**per wavelength directly** — the airy/phase term is computed at each sampled
+wavelength with no RGB spectral-sensitivity fit (the step that dominates the RGB
+references' complexity is simply absent for us). Soap bubbles and oil slicks show
+physically-correct, view- and thickness-dependent iridescence in the spectral
+showcase. The Blender **Thin Film Thickness** / **Thin Film IOR** sockets on
+Principled, Glass, and Metallic are honoured end-to-end, flipping those six parity
+cells from DROPPED-SILENT to SUPPORTED.
+
+---
+
+## Context — the spectral renderer's showpiece material
+
+The 2026-07 PBR sweep flagged thin-film as *"a self-contained, showcase-friendly
+material feature — good medium package after Phase C"*
+(`.astroray_plan/docs/2026-07-pbr-advances-research.md` finding 6 + adoption plan),
+and the follow-up pass confirmed **OpenPBR's recommended thin-film model is
+Belcour-Barla** (`2026-07-pbr-advances-research-pass2.md` Axis C).
+
+The differentiator worth foregrounding: iridescence **is** a spectral phenomenon —
+the colour comes from wavelength-dependent constructive/destructive interference in
+a film a few hundred nanometres thick. Every RGB renderer (Belcour-Barla's own
+reference, Cycles) must approximate the spectral integral by fitting the interference
+response to three RGB spectral-sensitivity curves — the paper's central engineering
+compromise. Astroray already carries a bundle of real wavelengths through each path
+(the spectral core), so it evaluates the interference term at the **actual sampled
+wavelengths** and needs no RGB fit. That makes soap bubbles and oil slicks the
+natural hero images for the spectral showcase and the journal article's
+"why spectral" argument — a genuine capability the RGB engines only approximate.
+
+---
+
+## Fix plan (cite — no inventions, CLAUDE.md §6)
+
+### A. Port the Belcour-Barla interference term (CPU first, spectral-native)
+
+- Implement the thin-film Fresnel modulation from **Belcour & Barla 2017,
+  "A Practical Extension to Microfacet Theory for the Modeling of Varying
+  Iridescence", ACM ToG / SIGGRAPH 2017** (project page + supplemental code, and the
+  OpenPBR reference). The model replaces the interface Fresnel `F(cosθ)` with an
+  interference-modulated reflectance that depends on film thickness `d`, film IOR
+  `η₁`, the bounding media IORs, and wavelength `λ` via the optical path difference
+  and the polarised phase shifts.
+- **Evaluate per wavelength, not via the RGB sensitivity fit.** For each wavelength
+  in the current `SampledWavelengths` bundle, compute the airy-summation reflectance
+  at that `λ` directly. This is the spectral simplification: skip Belcour §4's
+  projection onto RGB sensitivity curves entirely. Document at the call site that the
+  RGB-fit step is intentionally omitted because the renderer is spectral.
+- Attach as a **layer on the existing microfacet Fresnel**, not a new closure: in the
+  specular-reflection Fresnel of `plugins/materials/metal.cpp` (conductor),
+  `plugins/materials/dielectric.cpp` (dielectric), and `plugins/materials/disney.cpp`
+  (the metallic/specular lobe `F0` path near `disney.cpp:381-385`). Two new material
+  params `thinFilmThickness` (nm) and `thinFilmIOR`, default thickness 0 ⇒ term is a
+  no-op (bit-equal to today).
+- **Cite:** Belcour & Barla 2017 (DOI / project page in the research note); the
+  OpenPBR specification's thin-film section, **Apache-2.0**, arXiv:2512.23696, as the
+  parameterisation reference; and Cycles' implementation as the production
+  cross-check (see B). Re-derive the polarised Fresnel phase math from the paper — do
+  not copy GPL Cycles source (mirror the pkg64 SMS discipline).
+
+### B. Cross-check against Cycles' thin-film kernel
+
+- Cycles implements the same Belcour-Barla model in
+  **`src/kernel/closure/bsdf_microfacet.h`** — a `FresnelThinFilm` struct feeding
+  `fresnel_dielectric_polarized` / `fresnel_conductor_polarized` with phase shifts
+  matched to the paper's figures (Blender PR **#118477**, Principled dielectric
+  thin-film; PR **#141131**, thin-film for metals). Cycles is **Apache-2.0**, so it
+  is a license-clean *reference for behaviour and the RGB cross-check*, but Astroray's
+  evaluation stays spectral-native per A. Use a Cycles A/B on a soap-bubble scene as a
+  qualitative parity check, accepting that Cycles' RGB fit and Astroray's spectral
+  evaluation will differ slightly in hue by construction (record the expected
+  divergence).
+
+### C. GPU spectral-closure mirror
+
+- Mirror the per-wavelength interference term into the GPU spectral closure
+  (`include/astroray/gpu_materials.h` and the wavefront metal/dielectric shade,
+  `src/gpu/wavefront/stage_shade_metal.cu`). Keep CPU and GPU in lockstep (same phase
+  math, same per-λ evaluation); RTX-verify against the CPU render. Sequence after
+  pkg55 Phase C so this lands in the single surviving wavefront closure, not the
+  megakernel that Phase C deletes.
+
+### D. Blender addon wiring — close the DROPPED-SILENT parity cells
+
+- Read the **Thin Film Thickness** and **Thin Film IOR** sockets in the addon
+  material conversion (`blender_addon/__init__.py::convert_materials`, the
+  `BSDF_PRINCIPLED` / `BSDF_GLASS` / `BSDF_METALLIC` branches — the Principled path is
+  around `__init__.py:3054` and `:3387`) and pass them to the renderer material as the
+  new `thinFilmThickness` / `thinFilmIOR` params.
+- Regenerate `docs/blender_parity/report.md` + `coverage_matrix.json` and confirm the
+  six cells now read **SUPPORTED**: `BSDF_GLASS`/`BSDF_METALLIC`/`BSDF_PRINCIPLED` ×
+  {Thin Film Thickness, Thin Film IOR}.
+
+### E. Showcase + gates
+
+- **Numerical gate:** an energy/furnace check that the thin-film term does not add
+  energy — at thickness 0 the closure is bit-equal to today; at non-zero thickness the
+  directional-hemispherical reflectance stays ≤ 1 (interference redistributes energy
+  across wavelengths, it does not create it). Reuse the pkg60/pkg118 furnace
+  harness pattern.
+- **Spectral-showcase visual gate:** a soap-bubble and an oil-slick scene rendered on
+  the spectral path showing thickness- and view-angle-dependent iridescent banding;
+  saved as reference PNGs with an SSIM floor, in the spirit of the pkg64 caustic
+  visual gate. These are the journal-article / showcase hero images.
+
+---
+
+## Acceptance criteria
+
+- [ ] Thin-film interference term implemented in `metal.cpp` (conductor),
+      `dielectric.cpp`, and the `disney.cpp` specular lobe, evaluated **per
+      wavelength** on the spectral path with **no RGB sensitivity fit**; `thickness=0`
+      is bit-equal to the pre-pkg128 closures.
+- [ ] GPU spectral closure mirrors the CPU term; CPU↔GPU lockstep RTX-verified on a
+      thin-film scene.
+- [ ] Blender **Thin Film Thickness** + **Thin Film IOR** sockets honoured for
+      Principled, Glass, and Metallic; the six `docs/blender_parity` cells flip
+      DROPPED-SILENT → SUPPORTED (report + coverage_matrix regenerated).
+- [ ] Energy gate: directional-hemispherical reflectance ≤ 1 across a
+      (thickness, film-IOR, roughness, view-angle) grid — no glow.
+- [ ] Spectral-showcase visual gate: soap-bubble + oil-slick reference renders show
+      physically-correct thickness/view-angle iridescence; SSIM floor vs saved
+      references; qualitative Cycles A/B recorded (expected hue divergence from
+      Cycles' RGB fit documented, not treated as a failure).
+- [ ] Research note `.astroray_plan/docs/thin-film-iridescence-research.md`: Belcour-
+      Barla 2017 citation + DOI, OpenPBR (Apache-2.0) parameterisation, Cycles
+      `bsdf_microfacet.h::FresnelThinFilm` (PR #118477/#141131) as the cross-check
+      reference, the polarised-phase math reproduced, and the spectral-vs-RGB-fit
+      rationale.
+- [ ] CLAUDE.md §6 citations at every thin-film call site.
+
+---
+
+## Non-goals
+
+- **Not a general layered-BSDF framework.** This is the single thin-film interference
+  layer on the microfacet Fresnel — not position-free Monte Carlo layered BSDFs
+  (research finding 5, a separate horizon package).
+- **Not coat or fuzz.** OpenPBR documents coat (with darkening) and fuzz as distinct
+  layers (finding 6); those are separate packages. This is thin-film only.
+- **Not the RGB sensitivity-curve fit.** Deliberately omitted — the spectral core
+  evaluates interference at real wavelengths. We do **not** port Belcour §4's RGB
+  projection.
+- **Not multiscatter energy compensation.** Reflection multiscatter is pkg129;
+  thin-film redistributes energy spectrally but this package does not add the
+  Turquin/Kulla-Conty compensation term.
+- **No new procedural thickness textures beyond the socket value.** Honour the
+  Blender socket (constant or texture-driven if the addon already resolves it); do
+  not invent new thickness authoring UX.
+
+---
+
+## Provenance
+
+Filed from the **2026-07-17 PBR-advances research sweep** (finding 6, verified 3-0,
+`.astroray_plan/docs/2026-07-pbr-advances-research.md`) and its **follow-up pass**
+(`2026-07-pbr-advances-research-pass2.md` Axis C, which confirmed OpenPBR's
+recommended thin-film model is Belcour-Barla). The research adoption plan named
+thin-film the showcase-friendly medium package after Phase C. The DROPPED-SILENT
+parity cells are from the live addon parity audit (`docs/blender_parity/report.md`).
+Owner context: iridescent soap bubbles / oil slicks are the spectral renderer's
+showpiece — a capability RGB engines can only approximate via an RGB fit, and a
+"why spectral" figure for the journal article.
+
+---
+
+## Progress
+
+- [ ] A — Belcour-Barla per-wavelength interference term in metal/dielectric/disney
+      Fresnel (CPU); thickness-0 no-op verified.
+- [ ] B — Cycles `bsdf_microfacet.h` cross-check A/B recorded.
+- [ ] C — GPU spectral-closure mirror; CPU↔GPU lockstep RTX-verified.
+- [ ] D — addon socket wiring; six parity cells → SUPPORTED.
+- [ ] E — energy gate + soap-bubble/oil-slick showcase visual gate.
+- [ ] Research note written.
+
+---
+
+## Lessons
+
+*(Fill in after the package is done.)*

--- a/.astroray_plan/packages/pkg129-turquin-multiscatter-luts.md
+++ b/.astroray_plan/packages/pkg129-turquin-multiscatter-luts.md
@@ -1,0 +1,212 @@
+# pkg129 — Reflection multiscatter energy compensation via Turquin albedo-scaling LUTs (CPU+GPU parity)
+
+**Pillar:** 2 (materials / BSDF energy correctness)
+**Track:** A (CPU-gated rough-metal furnace + chi² gates on CI; GPU spectral-closure leg RTX-verified against the CPU result, with a live-Cycles A/B on rough metals)
+**Codex-paste-ready:** no (a LUT port that must be reconciled against two existing compensation implementations of different heritage, replace a GPU placeholder, and hold chi² gates that depend on a sibling pdf adjudication — needs judgment, not a mechanical patch)
+**Status:** open — closes the *reflection* multiscatter gap (the counterpart to pkg118's transmission fix), and gives the GPU spectral path its first physically-based reflection multiscatter term
+**Estimated effort:** M (port 7 verified LUTs with a CUDA backend + apply on both paths + reconcile with the existing CPU compensation + re-gate furnace/chi²; the LUTs are pre-baked and license-clean, so the work is integration and validation, not derivation)
+**Depends on:** **pkg123** (Disney spec-lobe sample/pdf adjudication — the residual finding from pkg121). The multiscatter factor **multiplies the single-scatter GGX lobe throughput**; if the underlying lobe's `sample()`/`pdf()` shape is still mismatched (pkg121 localised a spec-lobe shape bug that fails chi² on every metallic config), the furnace and chi² interpretation of this compensation is confounded. pkg123 must land the corrected single-scatter baseline first so pkg129 is measured against, and gated by, a correct lobe. **Composes with** pkg60 (CPU Kulla-Conty GGX reflection compensation, DONE) and pkg118 (rough-*dielectric*/transmission multiscatter, DONE) — see Root cause for how the three relate.
+
+---
+
+## Goal
+
+**Before:** Reflection multiscatter energy compensation is **inconsistent across the
+two backends and of mixed heritage**:
+
+- **CPU** Disney reflection uses **Kulla-Conty** albedo compensation
+  (`ggxCompensationFactor`, `plugins/materials/disney.cpp:43-51`, applied at
+  `:381-385`) off the pkg60 `ggxE` LUT
+  (`include/astroray/energy_compensation.h`) — a working, physically-based term.
+- **GPU** wavefront metal shade has **no working reflection multiscatter**:
+  `ggxMultiScatterCompensation` in `src/gpu/wavefront/stage_shade_metal.cu:114-116`
+  is a **placeholder that returns 0** (comment: *"Simplified placeholder: return 0
+  for now"*), and the actual multiscatter energy is a hand-tuned, non-physical hack
+  `albedo · (Fms · roughness·(2-roughness) · 1.3)` (`stage_shade_metal.cu:211-214`).
+  So GPU rough metals lose (or mis-add) energy at high roughness with no LUT behind it.
+
+Modern Cycles has moved past both: Blender commit `888bdc1` **deleted** its
+Heitz-2016 stochastic multiscatter GGX and replaced it with **Turquin-style
+albedo scaling of the single-scatter lobe via precomputed LUTs** (PR
+blender/blender#107958), on the rationale that *"having the exact correct
+directional distribution is not that important as long as the overall albedo is
+correct."*
+
+**After:** Reflection multiscatter compensation is a **single Turquin-style
+albedo-scaling LUT set, ported once and applied identically on CPU and GPU**. The
+GPU placeholder/hack is replaced by a real device-side LUT lookup; the CPU path is
+reconciled onto the same tables (or a documented equivalence between Kulla-Conty and
+Turquin scaling is recorded). Rough-metal white-furnace at high roughness moves
+**toward unity on both backends**, the chi² sampler gates stay green (compensation
+scales throughput, not the sampling distribution), and a live-Cycles A/B on rough
+metals confirms parity with the reference that made the same Turquin switch.
+
+---
+
+## Root cause / relationship to pkg60, pkg118, pkg123
+
+The pass-2 research answered this axis directly
+(`.astroray_plan/docs/2026-07-pbr-advances-research-pass2.md` Axis B, two claims
+✅-VERIFIED by direct fetch):
+
+- Cycles' current (4.x-era) energy conservation **is** Turquin albedo scaling, not
+  Heitz stochastic multiscatter and not the Kulla-Conty second lobe — commit
+  `888bdc1`, PR #107958. Generator `intern/cycles/app/cycles_precompute.cpp`, tables
+  in `intern/cycles/scene/shader.tables`.
+- **`adobe/openpbr-bsdf` is Apache-2.0** and ships **7 precomputed multiscatter
+  energy LUTs** (ideal/opaque dielectrics, ideal metals) + an LTC fuzz table,
+  portable across **C++/GLSL/CUDA/MSL/Slang** with LUTs embeddable as arrays or GPU
+  textures — a directly portable CUDA-compatible reference. This is the port pair.
+
+How this sits with the shipped energy work:
+
+- **pkg60** added Kulla-Conty reflection compensation **on CPU only** (its non-goal:
+  *"Do not port to GPU"*). pkg129 is the deferred GPU counterpart the pkg60 Lessons
+  explicitly flagged (*"GPU compensation is the obvious follow-up… port the same LUTs
+  to a device-side texture lookup"*) — but done with the **Turquin LUTs that modern
+  Cycles actually uses**, and with the CPU path reconciled so both backends share one
+  table set instead of the current Kulla-Conty(CPU)/placeholder(GPU) split.
+- **pkg118** fixed *transmission* (rough-glass) multiscatter energy. Its research
+  note is explicit that this axis is the **reflection** counterpart at high roughness
+  (`2026-07-pbr-advances-research-pass2.md`: *"pkg118 fixed transmission energy — this
+  axis is reflection multiscatter at high roughness"*).
+- **pkg123** (dependency) fixes the Disney spec-lobe sample/pdf shape mismatch. Since
+  Turquin scaling multiplies the single-scatter lobe, a wrong lobe underneath would
+  make both the furnace ratio and the chi² gate un-interpretable. Land pkg123 first.
+
+---
+
+## Fix plan (cite — no inventions, CLAUDE.md §6)
+
+### A. Port the Turquin multiscatter LUTs (the port pair)
+
+- Port the multiscatter energy LUTs from **`adobe/openpbr-bsdf` (Apache-2.0)** — the
+  metal/dielectric reflection tables — using its **CUDA backend** so the same table
+  data serves the GPU path directly (embed as device arrays or textures, as the
+  reference supports). Store alongside the existing pkg60 tables
+  (`data/disney_compensation/`, loaded via
+  `include/astroray/energy_compensation.h`); extend
+  `DisneyEnergyCompensationTables` rather than adding a parallel loader.
+- Apply **Turquin albedo scaling**: scale the single-scatter GGX reflection lobe so
+  the total directional albedo integrates to the multiscatter-complete value
+  `ρ_ms = F_ms · k_ms · ρ_ss` (Turquin's `E`-scaling form). This trades exact
+  reciprocity for energy preservation — the documented Turquin tradeoff, and the one
+  Cycles accepted in #107958.
+- **Cite:** Turquin 2019, "Practical multiple scattering compensation for microfacet
+  models" (blog.selfshadow.com/publications/turquin/ms_comp_final.pdf);
+  `adobe/openpbr-bsdf` (Apache-2.0) as the LUT + CUDA-backend source; Cycles
+  `intern/cycles/app/cycles_precompute.cpp` + `intern/cycles/scene/shader.tables`
+  (Apache-2.0, PR #107958, commit `888bdc1`) as the production cross-check.
+
+### B. Replace the GPU placeholder with the real lookup
+
+- Delete the `stage_shade_metal.cu:114-116` return-0 placeholder and the
+  `:211-214` ad-hoc `roughness·(2-roughness)·1.3` hack; apply the ported LUT-based
+  Turquin scaling to the GPU single-scatter metal lobe. This is the concrete
+  correctness win — the GPU had **no** physically-based reflection multiscatter
+  before.
+
+### C. Reconcile the CPU path onto the same tables
+
+- Either (i) switch the CPU `ggxCompensationFactor`
+  (`disney.cpp:43-51`, `:381-385`) to the Turquin LUTs so CPU and GPU are bit-for-bit
+  the same scaling, or (ii) keep pkg60's Kulla-Conty on CPU **only if** a documented
+  furnace-equivalence to Turquin scaling is established within tolerance. Prefer (i)
+  for single-source-of-truth; the research recommendation is Turquin as the target
+  model. Record the choice and its furnace evidence in the research note. Note the
+  `metal.cpp` lobe currently references an Fdez-Agüera fit
+  (`stage_shade_metal.cu:111` comment "Mirrors metal.cpp ggxMultiScatterCompensation")
+  — fold that onto the same tables too, so no third heritage survives.
+
+### D. Furnace + chi² + Cycles A/B gates
+
+- **Rough-metal white-furnace:** high-roughness rough-metal furnace ratio moves
+  **toward unity** on **both** CPU and GPU (reuse the pkg60/pkg118 furnace harness;
+  gate e.g. ∈ [0.97, 1.03] at R ∈ {0.6, 0.8, 1.0} for metallic=1). Assert the GPU
+  column matches the CPU column (the placeholder made them diverge).
+- **chi² gates stay green:** compensation multiplies throughput, not the sampling
+  pdf, so `tests/statistical/test_chi2_bsdf.py` metal configs must not regress —
+  **this is why pkg123 is a dependency**: the chi² gate is only meaningful once the
+  spec-lobe shape is adjudicated. Un-xfail nothing here that pkg123 owns; just prove
+  no regression.
+- **Live-Cycles A/B on rough metals:** render a rough-metal sweep in headless Cycles
+  (which uses the same Turquin LUTs) and confirm image-plane radiance parity within
+  tolerance — the strongest external check, since we are matching the exact model
+  Cycles ships.
+
+---
+
+## Acceptance criteria
+
+- [ ] Turquin multiscatter LUTs ported from `adobe/openpbr-bsdf` (Apache-2.0) with
+      its CUDA backend; tables loaded via `DisneyEnergyCompensationTables`
+      (`energy_compensation.h`), one table set for both backends.
+- [ ] GPU placeholder (`stage_shade_metal.cu:114-116`) and ad-hoc hack
+      (`:211-214`) removed and replaced by the real LUT-based Turquin scaling; GPU
+      rough-metal furnace has physically-based compensation for the first time.
+- [ ] CPU path reconciled onto the same tables (option i preferred), or a documented
+      furnace-equivalence recorded (option ii); no third compensation heritage left.
+- [ ] Rough-metal furnace ∈ tolerance toward unity at R ∈ {0.6, 0.8, 1.0},
+      metallic=1, **on both CPU and GPU**, and the two columns agree.
+- [ ] chi² sampler gates (`tests/statistical/test_chi2_bsdf.py`) stay green — no
+      regression from the throughput scaling (validated on the pkg123-corrected lobe).
+- [ ] Live-Cycles A/B on a rough-metal sweep within tolerance.
+- [ ] Research note `.astroray_plan/docs/reflection-multiscatter-turquin-research.md`:
+      Turquin 2019 + `adobe/openpbr-bsdf` (Apache-2.0, pinned commit) + Cycles
+      #107958 (`cycles_precompute.cpp` / `shader.tables`, commit `888bdc1`); the
+      CPU reconciliation decision with furnace evidence; CLAUDE.md §6 citations at
+      every scaling call site.
+
+---
+
+## Non-goals
+
+- **Not transmission multiscatter.** pkg118 fixed rough-dielectric/transmission
+  energy; this package is **reflection** multiscatter only. Do not re-touch the
+  transmission lobe.
+- **Not the sheen/clearcoat lobes.** Their compensation is pkg60 (sheen LTC,
+  clearcoat slice). This package is the GGX metal/dielectric **reflection** lobe.
+- **Not a Heitz-2016 stochastic multiscatter rewrite.** The research (and Cycles
+  #107958) explicitly chose albedo-scaling LUTs over stochastic evaluation
+  (7–15× slower for minimal visual difference); do not port the stochastic path.
+- **Not the Disney spec-lobe pdf fix.** That is pkg123 (this package's dependency);
+  pkg129 does not adjudicate the sample/pdf shape, it consumes the corrected lobe.
+- **Not fuzz / LTC.** The `adobe/openpbr-bsdf` fuzz LTC table is out of scope; port
+  only the metal/dielectric reflection multiscatter LUTs.
+- **No LUT regeneration from scratch.** The tables are pre-baked and license-clean
+  (CLAUDE.md §6: borrow, don't re-derive) — port them, don't run a new ground-truth
+  MC bake.
+
+---
+
+## Provenance
+
+Filed from the **2026-07-18 PBR-advances follow-up pass**
+(`.astroray_plan/docs/2026-07-pbr-advances-research-pass2.md` Axis B — the two
+load-bearing claims verified by direct fetch: Blender commit `888bdc1` /
+PR #107958 replacing stochastic multiscatter with Turquin albedo scaling, and
+`adobe/openpbr-bsdf` Apache-2.0 with 7 CUDA-portable multiscatter LUTs). Grounded
+against the live compensation code: CPU Kulla-Conty in `disney.cpp` (pkg60) and the
+**GPU placeholder returning 0** in `stage_shade_metal.cu` — the concrete reflection
+multiscatter gap this closes, and the GPU follow-up the pkg60 Lessons flagged.
+Reflection counterpart to pkg118's transmission fix. Owner context: rough metals at
+high roughness reading dark is part of the standing Cycles-parity story; matching the
+exact Turquin model Cycles ships is the cleanest way to close it, and the A/B on
+rough metals is a journal-article parity figure.
+
+---
+
+## Progress
+
+- [ ] A — Turquin LUTs ported from `adobe/openpbr-bsdf` (Apache-2.0) + CUDA backend;
+      loaded via `DisneyEnergyCompensationTables`.
+- [ ] B — GPU placeholder/hack replaced by the real LUT lookup.
+- [ ] C — CPU path reconciled onto the same tables (decision recorded).
+- [ ] D — rough-metal furnace toward unity on both backends; chi² green; Cycles A/B.
+- [ ] Research note written.
+
+---
+
+## Lessons
+
+*(Fill in after the package is done.)*


### PR DESCRIPTION
Docs-only. Three open Track-A package specs filed from the 2026-07 PBR-advances research sweep (`.astroray_plan/docs/2026-07-pbr-advances-research.md` + `-pass2.md`). No STATUS/ROADMAP changes.

- **pkg127 — specular-polynomials-sms**: upgrade the SMS caustic seed-finding stage (`include/astroray/manifold/sms_attempt.h` + `newton_iterate.h`, pkg64/pkg106 lineage) from stochastic-seed Newton to deterministic polynomial root-finding (Fan et al., SIGGRAPH 2024, DOI 10.1145/3658132, arXiv:2405.13409). Phase-0 makes mollnn/spoly license verification a blocking task. Single-bounce exact first, two-bounce (hidden-variable resultant) second. Acceptance: prism-bk7/prism-sf11/glass-sphere refbank gates equal-or-better at equal spp; seed-failure rate measured before/after.
- **pkg128 — thin-film-iridescence**: Belcour-Barla 2017 interference layer on the microfacet Fresnel, evaluated **per-wavelength on the spectral core** (no RGB sensitivity fit — the spectral differentiator). Cross-checked against Cycles `bsdf_microfacet.h::FresnelThinFilm` (PR #118477/#141131, Apache-2.0). Closes the six DROPPED-SILENT Thin Film Thickness/IOR addon parity cells (Principled/Glass/Metallic). Showpiece: soap bubbles / oil slicks.
- **pkg129 — turquin-multiscatter-luts**: reflection multiscatter energy compensation via Turquin albedo-scaling LUTs from `adobe/openpbr-bsdf` (Apache-2.0, 7 LUTs + CUDA backend), mirroring modern Cycles (commit 888bdc1 / PR #107958). Replaces the GPU placeholder in `stage_shade_metal.cu` (currently returns 0 + an ad-hoc hack); reconciles with pkg60 CPU Kulla-Conty. Depends on pkg123 (Disney spec-lobe pdf adjudication); composes with pkg60/pkg118. Acceptance: rough-metal furnace → unity on both backends, chi² green, Cycles A/B.

Each spec carries §6 citations + license lines, dependencies, and owner-goal context (spectral showcase + journal article). Repo file/doc anchors verified against the live tree before writing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
