### PR TITLE
docs(pkg130-137): eight platform-technique specs from the 2026-07 engine sweeps

### DIFF
--- a/.astroray_plan/packages/pkg130-light-groups-emission-decomposition.md
+++ b/.astroray_plan/packages/pkg130-light-groups-emission-decomposition.md
@@ -1,0 +1,136 @@
+# pkg130 — Light groups + emission-mechanism decomposition (LuxCore radiance-group model)
+
+**Pillar:** 5 (production polish / AOV output — journal-figure production)
+**Track:** A (per-group framebuffers + post-render rebalancing gate runs CPU-side; wavefront write-out verified on RTX)
+**Codex-paste-ready:** no (new per-group framebuffer plumbing across CPU + wavefront + EXR write + addon UI; emitter-group tagging is a scene-convention decision)
+**Status:** open
+**Estimated effort:** M (~1 session per the research doc — emitter id plumbing + per-group buffers + EXR layers + addon UI)
+**Depends on:** none hard. Composes cleanly after pkg55 Phase C (single spectral pipeline → per-group buffers land in one CPU + one GPU path, not four). The **emission-mechanism** alphabet defined here is the label source pkg134 (LPE) extends — file/land pkg130 first so pkg134 has the group ids to consume.
+
+---
+
+## Goal
+
+**Before:** Astroray renders one combined radiance buffer. There is no way to
+separate a frame's contributions by which emitter produced them, so publication
+figures that need "disk thermal vs. jet synchrotron vs. lensed starfield vs.
+envmap" as independent, re-balanceable layers cannot be produced without
+re-rendering the scene once per emitter set.
+
+**After:** Port LuxCoreRender's **radiance-group** model (Apache-2.0): every
+emitter / emissive material carries a small group id; the integrator writes each
+path's contribution into the framebuffer for its originating group; the film keeps
+one radiance buffer per group (8 groups, matching LuxCore's GPU cap) and exports
+them as separate EXR layers. Groups can be re-scaled / re-tinted **in post without
+re-rendering**. The Astroray-unique deliverable is that the group axis is
+**physical emission mechanism** — `disk_thermal`, `jet_synchrotron`, `starfield`,
+`envmap` — which no other open engine labels; that is the journal-figure win.
+
+---
+
+## Design sketch (cite the research doc; don't duplicate it)
+
+Full source record: `.astroray_plan/docs/2026-07-other-engines-research.md` §2
+(LuxCore radiance groups, "tier 1"). Two-part change:
+
+1. **Emitter group id.** Add a per-emitter / per-emissive-material `group_id`
+   (uint8, 0–7). Mirror LuxCore's `.id` (materials `.emission.id`) semantics: the
+   id selects which radiance buffer receives that emitter's contribution. Default
+   all emitters to group 0 (a scene with no group tags renders bit-identically to
+   today, into a single layer).
+2. **Per-group framebuffers.** The film holds `N_groups` radiance accumulators of
+   length `numPixels`. At the point where a path's emission is accumulated, index
+   by the originating emitter's `group_id`. On the wavefront this is one extra SoA
+   index at accumulation — the path already carries its light selection, so the
+   group id rides alongside it into `stageAccumulateXYZKernel`
+   (`src/gpu/wavefront/stage_advance.cu` accumulation). CPU mirrors in
+   `pathTraceSpectral`. EXR write (`src/io/exr_writer.{h,cpp}`) gains one named
+   layer per non-empty group.
+
+**Emission-mechanism mapping (the Astroray-unique part).** Provide a scene-side
+convention that tags the four canonical mechanisms to fixed group ids so figures
+are reproducible across scenes: `disk_thermal`, `jet_synchrotron`, `starfield`,
+`envmap`. This is a labeling convention over the generic group id, not new
+machinery.
+
+---
+
+## Implementation plan
+
+- **A. Emitter group id + scene plumbing.** Add `group_id` to the emitter /
+  emissive-material representation and the exporter; addon UI exposes it (8-way
+  enum with the four named mechanisms + generic groups). Default 0.
+- **B. Per-group framebuffers (CPU + wavefront).** Allocate `N_groups` accumulators;
+  route emission accumulation by `group_id`; sum-of-groups must equal the single
+  combined buffer bit-for-bit when every emitter is in one group.
+- **C. Multi-layer EXR export + post rebalancing.** Write one EXR layer per
+  non-empty group; add a post-render per-group scale/tint pass. Gate: re-scaling a
+  group in post equals re-rendering with that emitter scaled (within tolerance).
+
+---
+
+## Acceptance criteria
+
+- [ ] Emitter/emissive-material `group_id` (0–7) plumbed CPU → exporter → wavefront
+      → EXR; default-0 render is identical to today's single-buffer output.
+- [ ] Per-group framebuffers on CPU and wavefront; **Σ groups == combined buffer**
+      bit-identically for the single-group case, within noise for multi-group.
+- [ ] Multi-layer EXR export (one named layer per active group).
+- [ ] Post-render per-group rescale matches a re-render with the emitter scaled
+      (tolerance gate).
+- [ ] Emission-mechanism convention (`disk_thermal` / `jet_synchrotron` /
+      `starfield` / `envmap`) documented and produces the 4-layer decomposition on
+      a black-hole + envmap reference scene.
+- [ ] CPU↔GPU wavefront-diff parity holds per group.
+
+---
+
+## Non-goals
+
+- **Not full LPE.** Path-grammar routing (Heckbert `L(S|D)*E`) is pkg134; pkg130 is
+  membership-based group ids only (LuxCore "tier 1"). pkg134 extends this group
+  alphabet.
+- **Not >8 groups.** 8 matches LuxCore's GPU cap and the four mechanisms + spares;
+  no dynamic group count.
+- **Not a denoiser/AOV rework.** Existing Cryptomatte (Pillar 5) and other AOVs are
+  untouched.
+
+---
+
+## Algorithm sourcing (CLAUDE.md §6)
+
+- **LuxCoreRender** `github.com/LuxCoreRender/LuxCore` — **Apache-2.0 (verified —
+  `COPYING.txt`)**. Radiance groups: per-light `.id` / `.emission.id`, one film
+  radiance buffer per group, 8 groups on GPU engines, per-group post rescale/tint
+  and per-group pass export. Wiki: "LuxCoreRender Light Groups".
+- **Cycles** `github.com/blender/cycles` — Apache-2.0 (verified). Limited
+  membership-based `lightgroup` passes (no path grammar) — secondary reference.
+- **Research doc:** `.astroray_plan/docs/2026-07-other-engines-research.md` §2
+  (tier 1) + adoption table rank 2.
+- **Emission-mechanism decomposition** is Astroray-original (no external source);
+  it is a labeling convention over the ported group-id machinery, not a new algorithm.
+
+---
+
+## Provenance
+
+Filed from the **other-engines technique sweep (2026-07-19)**
+(`.astroray_plan/docs/2026-07-other-engines-research.md` §2, adoption rank 2:
+"Light groups by emission mechanism … before journal-figure production"). Owner
+goal: publication-quality figures that separate the black-hole emission mechanisms
+into independently re-balanceable layers — a decomposition no other open renderer
+offers.
+
+---
+
+## Progress
+
+- [ ] A — emitter `group_id` + scene/exporter/addon plumbing.
+- [ ] B — per-group framebuffers (CPU + wavefront); Σ-groups identity verified.
+- [ ] C — multi-layer EXR + post rescale gate; 4-mechanism decomposition on a BH scene.
+
+---
+
+## Lessons
+
+*(Fill in after the package is done.)*

--- a/.astroray_plan/packages/pkg131-zero-knob-adaptive-sampling.md
+++ b/.astroray_plan/packages/pkg131-zero-knob-adaptive-sampling.md
@@ -1,0 +1,136 @@
+# pkg131 — Zero-knob adaptive sampling (Cycles `adaptive_sampling.h` model, wavefront-integrated)
+
+**Pillar:** 3 (light transport / render efficiency)
+**Track:** A (CPU-first convergence-check + scheduler on CI; wavefront active-pixel compaction leg verified on RTX)
+**Codex-paste-ready:** no (one film convergence kernel + scheduler change + wavefront compaction integration + addon UI *removal* — architectural, needs the wavefront's compaction owner in the loop)
+**Status:** open
+**Estimated effort:** M (2–3 sessions per the research doc — one film kernel, scheduler change, addon UI removal rather than addition)
+**Depends on:** progressive-in-samples RNG (pkg92's sequence must have the PMJ/Sobol prefix property — a hard prerequisite; verify before implementing). Composes with pkg55 Phase C (the wavefront already owns active-pixel compaction — the convergence check feeds it). OIDN pairing is fine (Cycles ships the same combination).
+
+---
+
+## Goal
+
+**Before:** Astroray renders a fixed `samples = N` per pixel. Converged regions
+keep drawing samples they don't need while noisy regions stay noisy at the same
+budget — the classic uniform-sampling waste, worst on the 8 GB travel laptop where
+every wasted sample costs wall-clock the hardware can't spare.
+
+**After:** Port Cycles' **zero-knob** adaptive sampler
+(`kernel/film/adaptive_sampling.h`, Apache-2.0): per-pixel noise is estimated from
+a half-sample auxiliary buffer against the Dammertz 2010 brightness-relative error
+metric; pixels below an **auto-derived** threshold stop; the unconverged mask is
+dilated so neighborhoods sample together; a minimum-sample floor and a `max_samples`
+safety cap replace the `samples = N` knob. Integrated into the wavefront: render in
+waves → convergence-check kernel → compact the active-pixel list (the wavefront
+already owns compaction) → stop when all pixels converge or the cap hits.
+
+---
+
+## Design sketch (cite the research doc; don't duplicate it)
+
+Full source record: `.astroray_plan/docs/2026-07-other-engines-research.md` §5.
+
+- **Error metric (Dammertz §2.1, as Cycles implements it):**
+  `error = (|I−A|₁) · (exposure/samples) / (0.0001 + error_normalize)` with
+  `error_normalize = sqrt(intensity)` below 1.0 else `intensity` (brightness-relative
+  noise); converged when `error < threshold`.
+- **Auto threshold (the zero-knob mechanism):** Cycles' `threshold = 0` derives the
+  noise threshold from the sample budget in `integrator/render_scheduler.cpp`. Port
+  that derivation — that is what "no sampling knobs" means.
+- **Dilated mask:** `film_adaptive_sampling_filter_x/_y()` two-pass box filter over
+  the unconverged mask so neighborhoods keep sampling together (avoids splotchy
+  early-out boundaries).
+- **Wavefront integration:** the convergence check writes the active-pixel mask; the
+  wavefront's existing compaction (`stageRegenKernel` / alive-queue compaction,
+  `src/gpu/wavefront/stage_advance.cu`) consumes it to retire converged pixels.
+
+**8 GB / architecture constraints (from the research doc):** (a) RNG must be
+progressive-in-samples (pkg92 prefix property); (b) the half-buffer must be **scalar
+luminance**, not full spectral, to avoid doubling framebuffer memory on 8 GB;
+(c) OIDN interacts fine; (d) the telescope noise pass (pkg51) applies after and is
+unaffected.
+
+---
+
+## Implementation plan
+
+- **A. Convergence-check film kernel (CPU-first).** Scalar-luminance half-buffer +
+  Dammertz error metric + per-pixel converged flag. Mirror
+  `film_adaptive_sampling_convergence_check()`.
+- **B. Auto-threshold scheduler.** Port the `threshold = 0` sample-budget derivation
+  + minimum-sample floor + `max_samples` cap; check every N samples.
+- **C. Wavefront integration + UI removal.** Wire the mask into active-pixel
+  compaction; remove the `samples = N` addon knob, expose `max_samples` + (optional)
+  a noise-threshold override defaulted to auto.
+
+---
+
+## Acceptance criteria
+
+- [ ] Convergence-check kernel (scalar-luminance half-buffer, Dammertz metric) on
+      CPU and wavefront; converged mask dilated (filter_x/_y).
+- [ ] Auto threshold derived from the sample budget (`threshold = 0` semantics) +
+      minimum-sample floor + `max_samples` cap; no per-pixel sample knob remains.
+- [ ] Wavefront retires converged pixels via existing compaction; equal-quality
+      image reached in fewer total samples than fixed-N on a noisy reference scene
+      (measured speedup reported).
+- [ ] Half-buffer is scalar luminance (framebuffer memory not doubled) — verified on
+      the 8 GB config.
+- [ ] No-regression: OIDN and the pkg51 telescope pass still work; CPU↔GPU
+      wavefront-diff parity holds.
+
+---
+
+## Non-goals
+
+- **Not a new sampler.** Uses the existing (pkg92) sequence; only requires its
+  prefix property. If pkg92's sequence lacks it, that is a blocking prerequisite,
+  not in-scope work here.
+- **Not variance-estimator infrastructure.** pbrt-v4's `VarianceEstimator` (Welford)
+  is the alternative if half-buffers prove insufficient — note it, don't build both.
+- **Not the denoiser.** OIDN is orthogonal; this only ensures they compose.
+
+---
+
+## Algorithm sourcing (CLAUDE.md §6)
+
+- **Cycles** `github.com/blender/cycles` — **Apache-2.0 (verified)**.
+  `src/kernel/film/adaptive_sampling.h` (`film_adaptive_sampling_convergence_check`,
+  `_filter_x/_y` dilation); `src/integrator/render_scheduler.cpp` (check cadence,
+  min-sample floor, `threshold = 0` auto-derivation).
+- **Dammertz, Hanika, Keller, Lensch**, "A Hierarchical Automatic Stopping Condition
+  for Monte Carlo Global Illumination", WSCG 2010 — the per-pixel error metric.
+- **Christensen et al.**, "RenderMan: An Advanced Path-Tracing Architecture", ACM
+  TOG 37(3), 2018, DOI 10.1145/3182162 — odd/even half-buffer variance (Cycles'
+  stated inspiration).
+- **Christensen, Kensler, Kilpatrick**, "Progressive Multi-Jittered Sample
+  Sequences", CGF 37(4)/EGSR 2018 — the prefix property the RNG must satisfy.
+- **pbrt-v4** `github.com/mmp/pbrt-v4` — Apache-2.0 (verified). `VarianceEstimator`
+  (`src/pbrt/util/math.h`) — Welford online variance, the fallback infra only.
+- **Research doc:** `.astroray_plan/docs/2026-07-other-engines-research.md` §5 +
+  adoption rank 3.
+
+---
+
+## Provenance
+
+Filed from the **other-engines technique sweep (2026-07-19)**
+(`.astroray_plan/docs/2026-07-other-engines-research.md` §5, adoption rank 3: "big
+render-time win on 8 GB hardware"). Owner goal: kill wasted samples on the
+memory-constrained travel laptop and remove a user-facing sampling knob rather than
+add one.
+
+---
+
+## Progress
+
+- [ ] A — convergence-check film kernel (scalar-luminance half-buffer, Dammertz).
+- [ ] B — auto-threshold scheduler + min floor + max cap.
+- [ ] C — wavefront compaction integration + addon UI removal; speedup measured.
+
+---
+
+## Lessons
+
+*(Fill in after the package is done.)*

--- a/.astroray_plan/packages/pkg132-host-mapped-memory-fallback.md
+++ b/.astroray_plan/packages/pkg132-host-mapped-memory-fallback.md
@@ -1,0 +1,131 @@
+# pkg132 — Host-mapped memory fallback (Cycles `device_impl.cpp` DEVICEMAP spill)
+
+**Pillar:** 1 (CUDA device infrastructure / robustness)
+**Track:** A (allocation-fallback logic is CPU/host-side; the degraded-but-correct render is verified on RTX under induced VRAM pressure)
+**Codex-paste-ready:** no (device-allocation policy touching every large buffer's alloc path + a coldest-buffer selection heuristic — needs judgment about what to spill)
+**Status:** open
+**Estimated effort:** M (1–2 sessions per the research doc — pure CUDA, no architecture change)
+**Depends on:** none. Independent of pkg55 Phase C. Complements pkg135 (demand-loaded sparse textures) — this is the low-cost first line of defense; pkg135 is the heavier second tier that only activates on observed texture overflow.
+
+---
+
+## Goal
+
+**Before:** When a large buffer won't fit in VRAM, the allocation fails and the
+render dies (OOM). On the 8 GB travel laptop this makes FITS-volume, photon-heavy,
+or high-res-envmap scenes simply un-renderable rather than slow.
+
+**After:** Port Cycles' device-mapped **pinned-host fallback**
+(`device/cuda/device_impl.cpp`, Apache-2.0): on allocation failure, place the
+**coldest** large buffers in device-mapped host memory via
+`cuMemHostAlloc(CU_MEMHOSTALLOC_DEVICEMAP | CU_MEMHOSTALLOC_WRITECOMBINED)` (gated
+on the `can_map_host` capability). The render **slows down instead of dying** — the
+correct behavior for the memory-constrained hardware. Renders that OOM today
+complete (slowly) after this lands.
+
+---
+
+## Design sketch (cite the research doc; don't duplicate it)
+
+Full source record: `.astroray_plan/docs/2026-07-other-engines-research.md` §4
+(priority 1). Mechanism:
+
+- **Capability probe:** query `can_map_host`; the fallback is only available when the
+  device supports mapped pinned memory (all target GPUs do).
+- **Mapped allocation:** `shared_alloc()` uses
+  `cuMemHostAlloc(... DEVICEMAP | WRITECOMBINED)` and maps the host pointer into the
+  device address space. Kernels read it over PCIe — slow, but correct.
+- **Headroom prediction:** Cycles uses `CU_CTX_LMEM_RESIZE_TO_MAX` +
+  `reserve_local_memory()` to predict headroom *before* deciding what to spill (so it
+  doesn't spill something it didn't need to). Port the prediction, not just the
+  reactive catch.
+- **Coldest-first selection:** spill the least-frequently-touched large buffers
+  first. In Astroray those are, roughly coldest→hottest: FITS volume grids
+  (`src/io/fits_io.cpp`), photon maps (`src/gpu/photon_store.cu`,
+  `photon_emission.cu`), high-res env maps (`src/lights/background_light.cpp`),
+  texture-atlas overflow (`src/gpu/scene_upload.cu`). Do **not** spill hot
+  per-bounce SoA / BVH.
+
+**Port note (from the research doc's verify-list):** the exact Cycles file owning
+`move_textures_to_host` (GPU-device base class) must be pinned when implementing;
+`shared_alloc` in `device_impl.cpp` is the verified anchor.
+
+---
+
+## Implementation plan
+
+- **A. Capability + mapped-alloc primitive.** Add a `can_map_host`-gated
+  `shared_alloc()` wrapper producing a device-mapped pointer; a compile/run flag to
+  force-enable for testing under induced pressure.
+- **B. Headroom prediction + coldest-first policy.** Predict VRAM headroom before
+  large uploads; when a buffer won't fit, spill the coldest eligible buffer to mapped
+  host memory instead of failing. Order the eligible list coldest→hottest as above.
+- **C. Degraded-render gate.** A scene sized to exceed a synthetic VRAM cap must
+  render correctly (image matches the in-VRAM reference within noise) via the
+  fallback, and must **not** spill hot buffers.
+
+---
+
+## Acceptance criteria
+
+- [ ] `can_map_host`-gated device-mapped allocation
+      (`cuMemHostAlloc DEVICEMAP|WRITECOMBINED`) wrapper exists and maps into the
+      device address space.
+- [ ] Headroom predicted before large uploads (Cycles `reserve_local_memory` model);
+      spill decision is coldest-first over the enumerated eligible buffers.
+- [ ] A scene that OOMs today renders correctly via fallback (image == in-VRAM
+      reference within noise) under an induced VRAM cap.
+- [ ] Hot per-bounce SoA / BVH are never spilled; the fallback engages only on
+      genuine allocation pressure (no perf regression when VRAM is sufficient).
+- [ ] Capability-absent path degrades gracefully (clear error, no silent corruption).
+
+---
+
+## Non-goals
+
+- **Not demand-paged sparse textures.** Page-granularity texture streaming is pkg135
+  (OTK model); pkg132 is whole-buffer mapped fallback only.
+- **Not BLAS/geometry streaming.** Out-of-core triangle streaming is deferred
+  indefinitely per the research doc (astro scenes are volume/texture-heavy, not
+  triangle-heavy).
+- **Not a memory-budget UI.** The fallback is automatic; no new user knob.
+
+---
+
+## Algorithm sourcing (CLAUDE.md §6)
+
+- **Cycles** `github.com/blender/cycles` — **Apache-2.0 (verified)**.
+  `src/device/cuda/device_impl.cpp`: `shared_alloc()` with
+  `cuMemHostAlloc(CU_MEMHOSTALLOC_DEVICEMAP | CU_MEMHOSTALLOC_WRITECOMBINED)`,
+  `can_map_host` flag, `CU_CTX_LMEM_RESIZE_TO_MAX` + `reserve_local_memory()` headroom
+  prediction; `move_textures_to_host` in the GPU-device base class (**pin the exact
+  file at port** — research-doc verify item).
+- **Jaroš et al.**, "GPU Accelerated Path Tracing of Massive Scenes", ACM TOG 40(2),
+  2021, DOI 10.1145/3447807 — wavefront batching hides host-memory latency (our
+  architecture); fetch the author preprint if the design leans on it (ACM page 403'd
+  per the research doc).
+- **Research doc:** `.astroray_plan/docs/2026-07-other-engines-research.md` §4
+  priority 1 + adoption rank 4.
+
+---
+
+## Provenance
+
+Filed from the **other-engines technique sweep (2026-07-19)**
+(`.astroray_plan/docs/2026-07-other-engines-research.md` §4, adoption rank 4:
+"robustness for FITS/photon-heavy scenes"). Owner goal: on the 8 GB travel laptop,
+large astrophysical scenes should render slowly rather than fail outright.
+
+---
+
+## Progress
+
+- [ ] A — `can_map_host`-gated mapped-alloc primitive.
+- [ ] B — headroom prediction + coldest-first spill policy.
+- [ ] C — degraded-render gate under induced VRAM cap; hot buffers never spilled.
+
+---
+
+## Lessons
+
+*(Fill in after the package is done.)*

--- a/.astroray_plan/packages/pkg133-srf-spectral-sensors.md
+++ b/.astroray_plan/packages/pkg133-srf-spectral-sensors.md
@@ -1,0 +1,131 @@
+# pkg133 — SRF spectral sensors (Mitsuba `specfilm` — detector QE × filter curves)
+
+**Pillar:** 2 (spectral core) — **Pillar-4-adjacent** (activates the astronomical-detector story)
+**Track:** A (SRF distribution build + wavelength-importance-sampling change is CPU-gated; wavefront spectral leg verified on RTX)
+**Codex-paste-ready:** no (touches the hero-wavelength-aware spectral sampling pdf + film accumulation — spectral-core surgery, needs care)
+**Status:** open
+**Estimated effort:** M (2–3 sessions per the research doc — the SRF distribution build is simple CDF inversion; the sampling-pdf + film changes are the delicate part)
+**Depends on:** the spectral wavelength sampler (Pillar-2 core, already present — hero-wavelength per Wilkie 2014). **Pillar-4-adjacent dependency note:** this is the *render-time* half of the paused **pkg51** telescope post-process — it activates when the owner lifts the Pillar-4 pause **or** ships standalone as a spectral-camera feature. Sequence after pkg51 resumes, or fold in as **pkg51-B**.
+
+---
+
+## Goal
+
+**Before:** Astroray samples path wavelengths uniformly across the band and weights
+at the end. A JWST/NIRCam-style channel (filter transmission × detector QE) is
+narrow, so uniform sampling wastes most samples outside the channel's sensitivity
+and leaves narrow-band output noisy. There is no per-instrument-channel output.
+
+**After:** Port Mitsuba 3's **`specfilm`** (BSD-3, verified): the film takes N named
+**Sensor Response Functions** (one per output channel — e.g. filter transmission ×
+detector QE), builds a combined continuous distribution over all SRFs, and
+**importance-samples path wavelengths where the instruments are actually sensitive**
+instead of uniformly. Output is a multichannel EXR (one channel per SRF). Correct
+per-channel photon statistics and far lower spectral noise in narrow bands.
+
+---
+
+## Design sketch (cite the research doc; don't duplicate it)
+
+Full source record: `.astroray_plan/docs/2026-07-other-engines-research.md` §3.
+
+- **SRF channels:** each output channel is a spectral response curve (filter × QE),
+  supplied as a tabulated `spectrum` per channel (Mitsuba's nested-`spectrum`
+  model). N channels → N EXR layers (alphabetical, per `specfilm`).
+- **Combined importance distribution:** build one continuous distribution over the
+  union of all SRFs via inverse-transform sampling (simple CDF inversion), and draw
+  path wavelengths from it. This is the render-time correctness win — it must be
+  **hero-wavelength-aware** (Astroray's basis is hero-wavelength, Wilkie 2014), so
+  the pdf feeds the existing hero machinery rather than replacing it.
+- **Film accumulation:** each sampled wavelength deposits into the channels whose SRF
+  is non-zero there, weighted by SRF value / sampling pdf.
+
+**Boundary with pkg51 (from the research doc):** `specfilm` is the render-time half —
+SRF-importance-sampled per-channel radiance. pkg51's PSF convolution + Poisson/read
+noise stay **image-space** (pkg51 design decision 1). This package does not touch
+those; it feeds them cleaner per-channel input.
+
+---
+
+## Implementation plan
+
+- **A. SRF channel representation + combined distribution.** Per-channel tabulated
+  SRF; build the combined CDF; expose channel definitions through the scene/exporter.
+- **B. Hero-aware wavelength importance sampling.** Replace uniform band sampling with
+  draws from the combined SRF distribution, wired through the existing hero-wavelength
+  pdf so weights stay unbiased. CPU-first, then wavefront spectral mirror.
+- **C. Multichannel EXR output + gate.** Write one EXR layer per SRF; gate that a
+  narrow-band channel reaches target noise in far fewer samples than uniform
+  sampling, and that a flat/full-band SRF reproduces today's output.
+
+---
+
+## Acceptance criteria
+
+- [ ] N named SRF channels (tabulated filter × QE) definable per scene; combined
+      importance distribution built by CDF inversion.
+- [ ] Path-wavelength sampling draws from the combined SRF distribution, hero-aware,
+      and remains **unbiased** (a flat full-band SRF reproduces the current uniform
+      result within noise).
+- [ ] Narrow-band channel reaches a target noise level in materially fewer samples
+      than uniform sampling (measured variance-reduction reported).
+- [ ] Multichannel EXR output (one layer per SRF, alphabetical per `specfilm`).
+- [ ] CPU↔GPU wavefront-diff parity for the spectral sampling change.
+- [ ] Dependency note honored: does not touch pkg51's image-space PSF/noise passes.
+
+---
+
+## Non-goals
+
+- **Not the telescope PSF / noise pipeline.** PSF convolution + Poisson/read noise are
+  pkg51 (image-space); this is the render-time SRF half only.
+- **Not polarization / fluorescence.** ART-style bi-spectral features are
+  literature-only (GPL) and out of scope.
+- **Not a lens/aperture camera model.** Mitsuba `thinlens`/aperture is a separate
+  low-cost add — file a follow-up if wanted; not bundled here.
+
+---
+
+## Algorithm sourcing (CLAUDE.md §6)
+
+- **Mitsuba 3 `specfilm`** `github.com/mitsuba-renderer/mitsuba3` — **BSD-3-Clause
+  (verified)**. Film plugin: N SRF `spectrum` channels → combined continuous
+  distribution via inverse-transform sampling → wavelength importance sampling →
+  multichannel EXR. Docs: mitsuba.readthedocs.io → Plugins → Films.
+- **Wilkie, Nawaz, Droske, Weidlich, Hanika**, "Hero Wavelength Spectral Sampling",
+  EGSR 2014, CGF 33(4), DOI 10.1111/cgf.12419 — Astroray's existing hero basis the
+  SRF pdf must compose with.
+- **Fascione et al.**, "Manuka: A Batch-Shading Architecture for Spectral Path
+  Tracing", ACM TOG 37(3):32, 2018, DOI 10.1145/3182161 (preprint
+  jo.dreggn.org/home/2018_manuka.pdf) — camera-space measured spectral-response
+  sensor model (**literature only**; skim §sensor before citing in the article, per
+  the research doc's coverage-gap note).
+- **"Spectral imaging in production"**, SIGGRAPH 2021 Courses,
+  DOI 10.1145/3450508.3464582 — production sensor-response handling (literature).
+- **ART** (cgg.mff.cuni.cz/ART) — GPL → **literature/concept only**, do not port.
+- **Research doc:** `.astroray_plan/docs/2026-07-other-engines-research.md` §3 +
+  adoption rank 5 ("pair with pkg51 resume — pkg51-B").
+
+---
+
+## Provenance
+
+Filed from the **other-engines technique sweep (2026-07-19)**
+(`.astroray_plan/docs/2026-07-other-engines-research.md` §3, adoption rank 5). Owner
+goal: render what the **instrument** actually sees — filter × detector-QE channels
+with correct per-channel photon statistics — the render-time complement to the paused
+pkg51 telescope pipeline.
+
+---
+
+## Progress
+
+- [ ] A — SRF channel representation + combined-distribution build.
+- [ ] B — hero-aware wavelength importance sampling (CPU + wavefront).
+- [ ] C — multichannel EXR + narrow-band variance-reduction gate.
+
+---
+
+## Lessons
+
+*(Fill in after the package is done.)*

--- a/.astroray_plan/packages/pkg134-light-path-expressions.md
+++ b/.astroray_plan/packages/pkg134-light-path-expressions.md
@@ -1,0 +1,138 @@
+# pkg134 — Light Path Expressions (OSL `liboslexec` LPE automata port)
+
+**Pillar:** 5 (production polish / AOV routing)
+**Track:** A (host-side DFA compile + AOV routing is CPU-gated; wavefront path-state transitions verified on RTX)
+**Codex-paste-ready:** no (OSL automata port + a new uint16 path-state SoA field carried through every wavefront stage + per-event transition logic — cross-cutting)
+**Status:** open
+**Estimated effort:** M–L (2–4 sessions per the research doc — OSL automata port, DFA upload, path-state field, AOV routing)
+**Depends on:** **pkg130** (light groups) — pkg130's emission-mechanism group ids are the alphabet-extension labels this package's LPE grammar matches on. Composes after pkg55 Phase C (path-state field added once, to the single surviving wavefront SoA). Land order: pkg130 → pkg134.
+
+---
+
+## Goal
+
+**Before:** Astroray can (after pkg130) separate contributions by emitter **group**,
+but cannot select paths by their **interaction history** — "caustics only"
+(`C<.D><.S>+L`), "diffuse-then-glossy", "direct vs. indirect", or black-hole
+photon-ring subimages. There is no path-grammar AOV mechanism.
+
+**After:** Port OSL's renderer-agnostic **Light Path Expression** subsystem (BSD-3,
+verified): user LPEs (Heckbert `L(S|D)*E` grammar) compile **host-side** to a DFA;
+each wavefront path carries one `uint16` DFA state in the SoA; every scatter /
+emission event advances `state = dfa[state][event]` (one table lookup per bounce —
+divergence-free); contributions at accepting states route to the mapped AOV. Two
+Astroray-unique alphabet extensions: **emission-mechanism** event labels (from
+pkg130's group ids) and a **photon-ring winding-number counter** (n=0/1/2 black-hole
+subimages) as an extra path-state integer.
+
+---
+
+## Design sketch (cite the research doc; don't duplicate it)
+
+Full source record: `.astroray_plan/docs/2026-07-other-engines-research.md` §2
+(tier 2). Grammar: events `C/L/O/B`, interactions `R/T/V`, scattering modes
+`D/G/S/s`, event tokens `<TypeMode'label'>`, regex operators `. [] [^] * + ? {n,m}`.
+
+- **Host DFA compile:** port OSL `lpeparse` (parser) + `lpexp` (AST) + `automata`
+  (NFA build → subset-construction to DFA) + `accum` (DFA-state-driven AOV
+  accumulator). This subsystem is deliberately renderer-agnostic (no OSL shading
+  dependency), so it ports as self-contained C++. Upload the DFA table to constant
+  memory.
+- **Path-state field:** add a `uint16` DFA state to the wavefront path-state SoA
+  (`src/gpu/wavefront/wavefront_state.cu`), initialized at camera and advanced at
+  each scatter/emission event in `stage_advance.cu`. Cost is one `dfa[state][event]`
+  lookup per bounce.
+- **AOV routing:** at accepting states, route the path contribution to the LPE's
+  mapped output layer (reuse pkg130's per-layer framebuffer/EXR machinery).
+
+**Astroray-unique alphabet (the journal angle):** (1) emission-mechanism labels —
+attach pkg130's `disk_thermal` / `jet_synchrotron` / `starfield` / `envmap` ids as
+LPE label tokens, so an LPE can select "lensed starlight that scattered off the
+disk". (2) **Photon-ring winding number** — a trivial extra path-state integer
+counting equatorial-plane crossings, giving the n=0/1/2 black-hole subimages as
+separable layers. This is a path-state counter, **not** an LPE grammar feature.
+
+---
+
+## Implementation plan
+
+- **A. Host LPE compiler.** Port OSL `lpeparse`/`lpexp`/`automata`/`accum` as
+  self-contained C++; unit-test against OSL's `accum_test.cpp` cases; compile user
+  LPE strings → DFA table.
+- **B. Wavefront path-state transitions.** Add the `uint16` DFA-state SoA field;
+  advance per event in the wavefront (and CPU mirror); route accepting-state
+  contributions to LPE-mapped layers.
+- **C. Astroray alphabet extensions.** Wire pkg130 emission-mechanism labels into the
+  event alphabet; add the photon-ring winding-number counter + a canned
+  "photon-ring n=0/1/2" LPE preset. Gate on a caustic LPE (`C<.D><.S>+L`) and the
+  photon-ring decomposition on a black-hole scene.
+
+---
+
+## Acceptance criteria
+
+- [ ] Host-side LPE parser + NFA→DFA compile ported from OSL; passes the OSL
+      `accum_test` grammar cases.
+- [ ] `uint16` DFA-state SoA field advanced per event on the wavefront (one lookup
+      per bounce) and mirrored on CPU; CPU↔GPU wavefront-diff parity holds.
+- [ ] A caustics LPE (`C<.D><.S>+L`) produces a caustics-only AOV that matches the
+      photon-caustic pass qualitatively.
+- [ ] Emission-mechanism labels (from pkg130) usable as LPE label tokens.
+- [ ] Photon-ring winding-number counter yields separable n=0/1/2 subimage layers on
+      a black-hole reference scene.
+- [ ] Default render (no LPEs defined) is unchanged and pays no measurable per-bounce
+      cost beyond the single state lookup.
+
+---
+
+## Non-goals
+
+- **Not the membership light-group tier.** That is pkg130 (its prerequisite); pkg134
+  is the path-grammar tier that consumes pkg130's ids.
+- **Not OSL shading.** Only the LPE subsystem (parse/automata/accum) is ported — no
+  OSL shader execution.
+- **Not appleseed-style full path recording.** Per-pixel light-path inspection
+  (appleseed `lightpathstream`) is a separate debugging feature — reference only.
+
+---
+
+## Algorithm sourcing (CLAUDE.md §6)
+
+- **OpenShadingLanguage**
+  `github.com/AcademySoftwareFoundation/OpenShadingLanguage` — **BSD-3-Clause
+  (verified — `LICENSE.md`)**. `src/liboslexec/lpeparse.{cpp,h}` (~464 lines),
+  `lpexp.{cpp,h}` (~220), `automata.{cpp,h}` (NFA→DFA subset construction, ~661),
+  `accum.{cpp,h}` (~244), test `accum_test.cpp`. Renderer-agnostic by design.
+- **Heckbert**, "Adaptive Radiosity Textures for Bidirectional Ray Tracing",
+  SIGGRAPH 1990, DOI 10.1145/97879.97895 — the `L(S|D)*E` path-regex notation.
+- **OSL Light Path Expressions** wiki (AcademySoftwareFoundation/OpenShadingLanguage)
+  — the grammar spec. Arnold / RenderMan document the same grammar (proprietary —
+  **semantics reference only**).
+- **appleseed** `github.com/appleseedhq/appleseed` — MIT (*verify-at-port*).
+  `lightpathstream.{cpp,h}` — complementary path recording, **reference only**.
+- **Research doc:** `.astroray_plan/docs/2026-07-other-engines-research.md` §2
+  (tier 2) + adoption rank 6.
+
+---
+
+## Provenance
+
+Filed from the **other-engines technique sweep (2026-07-19)**
+(`.astroray_plan/docs/2026-07-other-engines-research.md` §2, adoption rank 6: "after
+light groups, before article figures"). Owner goal: path-grammar AOV separation
+(caustics-only, direct/indirect) plus the Astroray-unique photon-ring subimage
+decomposition for the journal.
+
+---
+
+## Progress
+
+- [ ] A — host LPE compiler ported (parse/automata/accum); OSL test cases pass.
+- [ ] B — wavefront `uint16` DFA-state field + per-event transitions + AOV routing.
+- [ ] C — emission-mechanism labels + photon-ring winding-number counter + presets.
+
+---
+
+## Lessons
+
+*(Fill in after the package is done.)*

--- a/.astroray_plan/packages/pkg135-demand-loaded-sparse-textures.md
+++ b/.astroray_plan/packages/pkg135-demand-loaded-sparse-textures.md
@@ -1,0 +1,124 @@
+# pkg135 — Demand-loaded sparse textures (NVIDIA OptiX Toolkit DemandLoading model)
+
+**Pillar:** 1 (CUDA device infrastructure)
+**Track:** A (host-side page-request servicing is CPU-gated; the sparse-texture device path is verified on RTX)
+**Codex-paste-ready:** no (CUDA virtual-memory / sparse-texture APIs + a device request list + inter-launch host servicing — research-grade device work)
+**Status:** open — **CONDITIONAL**: this package activates **only when texture overflow is actually observed** on real astrophysical scenes (large FITS cubes). Until then it stays filed-but-dormant. Do not implement pre-emptively.
+**Estimated effort:** M–L (2–4 sessions per the research doc — CUDA virtual-memory APIs)
+**Depends on:** none hard. Second tier above **pkg132** (host-mapped fallback): pkg132 is the cheap whole-buffer spill that should ship first; pkg135 is page-granularity texture streaming that only earns its cost once whole-buffer spill is insufficient. **Phase-0 task:** verify the OTK `LICENSE.txt` is BSD-3 against the actual repo before any code is mirrored (research-doc flags it as README-asserted, not fetched).
+
+---
+
+## Goal
+
+**Before:** Textures (including large FITS-derived cubes and high-res env maps) must
+fit in VRAM in full. A scene whose texture working set exceeds VRAM cannot render,
+even if any single frame only touches a fraction of the texels.
+
+**After:** Port NVIDIA OptiX Toolkit's **DemandLoading** model (BSD-3 per README —
+verify at phase 0): CUDA **sparse textures** launch with unresolved pages; kernels
+record page requests in a device-side request list; the host services requests
+between launches and re-launches. Only the texels a frame actually samples are
+resident — the texture working set decouples from total texture size. The
+sparse-texture + request-list machinery is CUDA-level and works **without OptiX**
+(the demand-loaded *geometry* half is OptiX-tied and explicitly **not** ported).
+
+---
+
+## Design sketch (cite the research doc; don't duplicate it)
+
+Full source record: `.astroray_plan/docs/2026-07-other-engines-research.md` §4
+(priority 2). Mechanism:
+
+- **Sparse (tiled) textures:** back each demand-loaded texture with CUDA sparse
+  texture memory so pages can be mapped/unmapped independently.
+- **Device request list:** on a sample of an unresolved page, the kernel appends the
+  page id to a device-side request buffer (atomic append) instead of stalling.
+- **Inter-launch servicing:** after a launch, the host reads the request list, loads
+  the requested pages (from the FITS cube / texture source) into sparse-texture
+  backing, and re-launches; the previously-requested samples now resolve.
+- **Portability:** all of the above is CUDA virtual-memory / sparse-texture API — no
+  OptiX dependency. Demand-loaded geometry (OTK's other half) is OptiX-tied and out
+  of scope.
+
+Astroray integration point: the texture atlas / sampling path in
+`src/gpu/scene_upload.cu` and the FITS source in `src/io/fits_io.cpp`.
+
+---
+
+## Implementation plan (only when the conditional trigger fires)
+
+- **Phase 0 — license + trigger.** Fetch OTK `LICENSE.txt`, confirm BSD-3. Confirm a
+  real scene overflows VRAM textures under pkg132's whole-buffer fallback (i.e.
+  whole-texture spill is too slow / too large). Only then proceed.
+- **A. Sparse-texture backing + request list.** Wrap demand-loaded textures in CUDA
+  sparse memory; add the device request buffer + atomic-append on unresolved sample.
+- **B. Host page servicer + re-launch loop.** Read the request list between launches,
+  page in from the texture/FITS source, re-launch until resolved.
+- **C. Overflow gate.** A scene whose texture working set exceeds a synthetic VRAM
+  cap renders correctly (matches the fully-resident reference within noise) with a
+  bounded resident page budget.
+
+---
+
+## Acceptance criteria
+
+- [ ] Phase-0 license verification recorded (OTK `LICENSE.txt` == BSD-3) **and** an
+      observed-overflow trigger documented before any implementation.
+- [ ] Sparse-texture backing + device request list (atomic append on unresolved page).
+- [ ] Host services requests between launches; re-launch loop converges (all sampled
+      pages resolve).
+- [ ] Overflow scene renders correctly within a bounded resident page budget (image
+      == fully-resident reference within noise).
+- [ ] No OptiX dependency introduced; pure-CUDA sparse-texture path only.
+- [ ] No regression when textures fit (demand path is a no-op / off).
+
+---
+
+## Non-goals
+
+- **Not demand-loaded geometry.** OTK's geometry demand loading is OptiX-tied —
+  explicitly excluded.
+- **Not whole-buffer host mapping.** That is pkg132 (the prerequisite cheaper tier);
+  pkg135 is page-granularity texture streaming.
+- **Not a pre-emptive build.** Conditional package — no implementation until overflow
+  is observed in practice.
+
+---
+
+## Algorithm sourcing (CLAUDE.md §6)
+
+- **NVIDIA OptiX Toolkit — DemandLoading** `github.com/NVIDIA/optix-toolkit` —
+  **BSD-3-Clause (per README; `LICENSE.txt` VERIFY at phase 0)**. CUDA sparse
+  textures + device request list + inter-launch host servicing; the sparse-texture /
+  request-list machinery is CUDA-level (no OptiX). Demand-loaded geometry is OptiX-
+  tied and out of scope.
+- **Garanzha et al.**, "Out-of-core GPU ray tracing of complex scenes" (2011) —
+  foundational out-of-core reference.
+- **Research doc:** `.astroray_plan/docs/2026-07-other-engines-research.md` §4
+  priority 2 + adoption rank 7 ("only when texture overflow is observed").
+
+---
+
+## Provenance
+
+Filed from the **other-engines technique sweep (2026-07-19)**
+(`.astroray_plan/docs/2026-07-other-engines-research.md` §4, adoption rank 7). Owner
+goal: render texture-heavy astrophysical scenes (large FITS cubes) that exceed VRAM.
+**Conditional** — dormant until overflow is observed; pkg132 is the first line of
+defense.
+
+---
+
+## Progress
+
+- [ ] Phase 0 — OTK license verification + observed-overflow trigger.
+- [ ] A — sparse-texture backing + device request list.
+- [ ] B — host page servicer + re-launch loop.
+- [ ] C — overflow gate within a bounded resident page budget.
+
+---
+
+## Lessons
+
+*(Fill in after the package is done.)*

--- a/.astroray_plan/packages/pkg136-svo-wavefront-path-guiding.md
+++ b/.astroray_plan/packages/pkg136-svo-wavefront-path-guiding.md
@@ -1,0 +1,128 @@
+# pkg136 — SVO-based wavefront path guiding (Yalçıner & Akyüz 2024)
+
+**Pillar:** 3 (light transport / path guiding)
+**Track:** A (SVO build + cone-trace PDF query is CPU-verifiable; the wavefront guiding leg is verified on RTX)
+**Codex-paste-ready:** no (a global sparse-voxel-octree of radiant exitance + on-the-fly PDF/CDF via cone tracing, wired into wavefront sampling — a guiding subsystem, research-grade)
+**Status:** open
+**Estimated effort:** M (moderate per the research doc — one global SVO, cone-trace query, no persistent per-region PDF storage)
+**Depends on:** **pkg55 Phase C completion** — guiding wires into the wavefront sampling stage, and Phase C stabilizes the wavefront as the *only* pipeline (a moving target otherwise). **Phase-0 task:** locate and license-verify a public reference implementation; if none exists, plan a **paper-only port** (the research doc flags "no confirmed public repo — VERIFY availability"). Land after Phase C.
+
+---
+
+## Goal
+
+**Before:** Astroray samples continuation directions from the BSDF (and NEE for
+direct light). In scenes where indirect radiance is concentrated (accretion-disk
+glow, bright envmap regions seen through complex transport), unguided sampling wastes
+paths on low-contribution directions — high variance that adaptive sampling (pkg131)
+can only partly absorb.
+
+**After:** Port the **SVO-based wavefront path-guiding** method (Yalçıner & Akyüz,
+Computers & Graphics 2024): a single global **sparse voxel octree** stores
+directionless **radiant exitance**; guiding PDFs/CDFs are generated **on-the-fly** via
+cone-trace queries in shared memory — no persistent per-region PDF storage. Fixed
+~3.96 MiB SVO (vs a PPG SD-tree at 19→37 MiB) makes it the **wavefront-native,
+VRAM-frugal** guiding option — the uniquely-fitted match for our CUDA wavefront +
+8–16 GB budgets. Guided sampling reduces variance on indirect-heavy scenes.
+
+---
+
+## Design sketch (cite the research doc; don't duplicate it)
+
+Full source record: `.astroray_plan/docs/2026-07-pbr-advances-research.md` finding 7.
+
+- **Global SVO of radiant exitance:** one sparse voxel octree over the scene stores a
+  directionless radiant-exitance value per occupied voxel (built/updated from path
+  contributions — cheap, no directional histograms per region).
+- **On-the-fly PDF/CDF via cone tracing:** at a shading point, cone-trace the SVO in
+  shared memory to synthesize a directional guiding PDF/CDF on demand, then sample it
+  (optionally MIS-combined with the BSDF pdf). No persistent per-region PDF store —
+  this is what keeps VRAM flat (~3.96 MiB).
+- **Wavefront fit:** the query is a bounded cone-trace per guided sample, done inside
+  the wavefront shade stage (`src/gpu/wavefront/stage_advance.cu`) — no per-region
+  learned structure to store or synchronize across the SoA.
+
+**Why this one and not OpenPGL:** OpenPGL is CPU-oriented (Cycles' guiding is
+CPU-only) — a design reference, not a GPU drop-in. The SVO method is the wavefront-
+native choice (research-doc finding 9 vs 7). Compose guiding with the BSDF via MIS.
+
+---
+
+## Implementation plan (after Phase C)
+
+- **Phase 0 — reference + license.** Locate a public implementation; verify its
+  license (Apache/BSD/MIT/MPL per CLAUDE.md §6). If none, plan a paper-only port and
+  record that decision.
+- **A. Global SVO build/update.** Sparse voxel octree of radiant exitance, updated
+  from path contributions across waves.
+- **B. Cone-trace PDF query + guided sampling.** Shared-memory cone-trace → on-the-fly
+  directional PDF/CDF → sample; MIS-combine with the BSDF pdf in the wavefront shade
+  stage.
+- **C. Variance gate.** On an indirect-heavy reference scene, guided sampling reaches
+  a target noise level in fewer samples than unguided (measured variance reduction);
+  SVO VRAM stays within the paper's ~few-MiB envelope; guiding is unbiased (matches
+  the unguided converged image within noise).
+
+---
+
+## Acceptance criteria
+
+- [ ] Phase-0 reference-availability + license verification recorded (public impl or
+      documented paper-only port).
+- [ ] Global SVO of radiant exitance built/updated on the wavefront within a bounded
+      (few-MiB) VRAM budget.
+- [ ] On-the-fly cone-trace PDF/CDF query + guided sampling, MIS-combined with the
+      BSDF; **unbiased** (converges to the unguided image within noise).
+- [ ] Measured variance reduction vs unguided on an indirect-heavy scene.
+- [ ] CPU↔GPU wavefront-diff parity for the guided-sampling path; no regression when
+      guiding is off.
+
+---
+
+## Non-goals
+
+- **Not OpenPGL / SD-tree guiding.** CPU-oriented; reference only. This package is the
+  SVO wavefront-native method exclusively.
+- **Not ReSTIR-PG.** Guiding × resampling fusion (research finding 10) is a horizon
+  item requiring both a guiding and a ReSTIR-PT subsystem — out of scope.
+- **Not photon-guiding.** 3D-Gaussian / photon-emission guiding (findings 4) augments
+  the photon stage, a separate concern.
+
+---
+
+## Algorithm sourcing (CLAUDE.md §6)
+
+- **Yalçıner & Akyüz**, "SVO-based wavefront path guiding", Computers & Graphics 121
+  (2024) 103945, arXiv:2405.06997 — first guiding method designed for a wavefront GPU
+  path tracer; global SVO of radiant exitance, on-the-fly PDF/CDF via cone tracing,
+  ~3.96 MiB SVO. **No confirmed public repo — phase-0 VERIFY availability.**
+- **OpenPGL** `github.com/OpenPathGuidingLibrary/openpgl` — Apache-2.0 — CPU-oriented
+  guiding, **algorithm/design reference only** (not a GPU drop-in).
+- **Research doc:** `.astroray_plan/docs/2026-07-pbr-advances-research.md` finding 7
+  (3-0 core / 2-1 priority) + finding 9 (why not OpenPGL); NEXT_STAGE_REPORT horizon
+  list ("the architectural match to our wavefront kernel — VERIFY repo availability").
+
+---
+
+## Provenance
+
+Filed from the **PBR advances 2023–2026 research sweep (2026-07-17)**
+(`.astroray_plan/docs/2026-07-pbr-advances-research.md` finding 7). Owner goal: the
+wavefront-native, VRAM-frugal path-guiding option — variance reduction on
+indirect-heavy scenes without the SD-tree memory cost. Sequenced after Phase C
+stabilizes the wavefront as the only pipeline.
+
+---
+
+## Progress
+
+- [ ] Phase 0 — reference-availability + license verification.
+- [ ] A — global SVO of radiant exitance (build/update on wavefront).
+- [ ] B — cone-trace PDF query + MIS-combined guided sampling.
+- [ ] C — variance gate + VRAM-budget check; unbiasedness verified.
+
+---
+
+## Lessons
+
+*(Fill in after the package is done.)*

--- a/.astroray_plan/packages/pkg137-partitioned-sms-restir-caustics.md
+++ b/.astroray_plan/packages/pkg137-partitioned-sms-restir-caustics.md
@@ -1,0 +1,140 @@
+# pkg137 — Partitioned SMS + ReSTIR caustics (Hong et al. SIGGRAPH Asia 2025)
+
+**Pillar:** 3 (light transport / interactive caustics)
+**Track:** A (tile-partitioned SMS + reservoir reuse is CPU-verifiable; the wavefront caustics leg is verified on RTX)
+**Codex-paste-ready:** no (tile-partitioned specular-manifold sampling fused with ReSTIR spatiotemporal reuse — depends on reservoir SoA infrastructure and SMS internals)
+**Status:** open
+**Estimated effort:** L (high but staged per the research doc — partitioning-alone is a cheaper standalone first increment; the full method presupposes ReSTIR reservoirs)
+**Depends on:** **pkg55 Phase C Session C6** (ReSTIR reservoir SoA + wavefront reuse stages — see `.astroray_plan/docs/pkg55-phase-c-plan-2026-07.md` §5) **and pkg127** (Specular Polynomials for SMS seed finding — the deterministic Newton-free seed solver this partitions the manifold walk around). Land after both. The **partitioning-alone** increment (below) can precede C6 as a standalone SMS robustness win.
+
+---
+
+## Goal
+
+**Before:** Astroray's specular-manifold-sampling caustics (pkg64/pkg106 lineage) do
+an unbounded Newton manifold walk per seed, with the classic SMS failure modes:
+divergence from a bad seed and one-solution-per-seed. Caustics are offline-only and
+noisy per frame.
+
+**After:** Port Hong et al.'s **Partitioned SMS + ReSTIR** (SIGGRAPH Asia 2025;
+Zeltner — the SMS originator — is a co-author): tile-based **sample-space
+partitioning** bounds the Newton manifold walk to a local vicinity plus a per-frame
+prior (killing the divergence/one-solution failures), and **ReSTIR spatiotemporal
+reuse** amortizes sample generation across pixels and frames. Interactive-quality
+caustics; the partitioning half alone is already a robustness win for our existing
+SMS.
+
+---
+
+## Design sketch (cite the research doc; don't duplicate it)
+
+Full source record: `.astroray_plan/docs/2026-07-pbr-advances-research.md` finding 2.
+
+- **Sample-space partitioning (the standalone-able half):** partition the sample
+  space into tiles; each tile bounds the manifold walk to a local vicinity + a
+  per-frame prior, so the Newton solve starts near a solution and stays there. This
+  directly attacks our SMS's bad-seed divergence and one-solution-per-seed limits —
+  and it does **not** require ReSTIR, so it can ship first as a standalone SMS
+  robustness increment.
+- **ReSTIR spatiotemporal reuse (the amortization half):** reuse specular-sample
+  reservoirs across neighbors and frames, built on the Phase-C C6 reservoir SoA. The
+  reservoir `update`/`merge`/`finalizeWeight` core is the shared `__host__ __device__`
+  template C6 establishes (`.astroray_plan/docs/pkg55-phase-c-plan-2026-07.md` §5,
+  one-generator rule) — reuse it, do not transcribe.
+- **Wavefront fit:** SMS seeds + reservoir reuse run as wavefront stages between shade
+  and the next intersect, mirroring C6's reuse-stage placement.
+
+**Staging (from the research doc):** partitioning-alone first (cheaper, no reservoir
+dependency), then fold in ReSTIR reuse once C6's reservoirs exist.
+
+---
+
+## Implementation plan
+
+- **Phase 0 — license.** Verify the Falcor module `PSMS-ReSTIR` license against the
+  actual repo (Falcor base is BSD-3; the module license is the phase-0 check per
+  CLAUDE.md §6). Falcor/RTXDI-proprietary reservoir code must not be mirrored — reuse
+  our C6 reservoir core.
+- **A. Sample-space partitioning (standalone).** Tile the SMS sample space; bound the
+  Newton walk to a tile + per-frame prior. Gate: fewer diverged/failed seeds and
+  lower caustic variance than current SMS at equal cost. **Can land before C6.**
+- **B. ReSTIR reuse over specular reservoirs.** Build on C6's reservoir SoA + shared
+  template; add spatiotemporal reuse of specular samples. Gate: temporal variance
+  reduction on a caustics scene (analogous to the C6 temporal-variance gate).
+- **C. Wavefront integration + caustics gate.** Wire as wavefront stages; verify
+  interactive-quality caustics vs the offline SMS reference (SSIM/energy-parity gate
+  in the pkg64 style).
+
+---
+
+## Acceptance criteria
+
+- [ ] Phase-0 Falcor `PSMS-ReSTIR` module license verified; no RTXDI/proprietary
+      reservoir code mirrored (C6 reservoir core reused).
+- [ ] Sample-space partitioning bounds the Newton walk; measurably fewer
+      diverged/failed seeds + lower caustic variance than current SMS (standalone,
+      before C6).
+- [ ] ReSTIR spatiotemporal reuse over specular reservoirs built on the C6 SoA +
+      shared reservoir template (one-generator rule honored — no transcription).
+- [ ] Interactive-quality caustics gate vs the offline SMS reference (SSIM +
+      energy-parity, pkg64 style); temporal-variance reduction demonstrated.
+- [ ] CPU↔GPU wavefront-diff parity for the new stages; no regression to offline SMS.
+
+---
+
+## Non-goals
+
+- **Not a new reservoir subsystem.** Reuses pkg55 Phase C C6's reservoir SoA + shared
+  template; does not build parallel ReSTIR infrastructure.
+- **Not Specular Polynomials seed-finding.** Newton-free polynomial seed finding
+  (research finding 1) is **pkg127** (a dependency, not re-implemented here) — this
+  package bounds the manifold walk via partitioning around pkg127's seeds; it does
+  not replace the solver.
+- **Not general ReSTIR-PT / GRIS.** Path-space resampling generalization is the C6 /
+  GRIS roadmap; pkg137 is caustics-specific reuse.
+
+---
+
+## Algorithm sourcing (CLAUDE.md §6)
+
+- **Hong, Duan, Wang, Yuksel, Zeltner, Lin**, "Partitioned SMS + ReSTIR" (interactive
+  caustics), SIGGRAPH Asia 2025, DOI 10.1145/3757377.3763927 (co-author = SMS
+  originator Zeltner). Ref impl: Falcor 8.0 module
+  `github.com/Utah-Graphics-Lab/PSMS-ReSTIR` (**Falcor base BSD-3; module license =
+  phase-0 VERIFY**).
+- **Zeltner et al.** — Specular Manifold Sampling (the SMS foundation Astroray already
+  ports, pkg64/pkg106) — the method this bounds.
+- **GRIS — Lin, Kettunen, Bitterli, Pantaleoni, Yuksel, Wyman**, "Generalized
+  Resampled Importance Sampling", ACM TOG 41(4), SIGGRAPH 2022,
+  DOI 10.1145/3528223.3530158 — the reservoir-reuse foundation (cited by C6). **NVIDIA
+  RTXDI is proprietary — DISQUALIFIED; do not read or mirror it.**
+- **Research doc:** `.astroray_plan/docs/2026-07-pbr-advances-research.md` finding 2
+  (3-0, high) + adoption note ("after Phase C's reservoirs exist"; "partitioning alone
+  is a cheaper standalone win").
+- **C6 design:** `.astroray_plan/docs/pkg55-phase-c-plan-2026-07.md` §5 (reservoir SoA,
+  one-generator rule).
+
+---
+
+## Provenance
+
+Filed from the **PBR advances 2023–2026 research sweep (2026-07-17)**
+(`.astroray_plan/docs/2026-07-pbr-advances-research.md` finding 2). Owner goal:
+interactive-quality caustics for the black-hole / disk showcase. Depends on pkg55
+Phase C C6 (ReSTIR reservoirs) + pkg127; the partitioning half is a standalone SMS
+robustness win that can land earlier.
+
+---
+
+## Progress
+
+- [ ] Phase 0 — Falcor module license verification.
+- [ ] A — sample-space partitioning (standalone SMS robustness; can precede C6).
+- [ ] B — ReSTIR reuse over specular reservoirs (on the C6 SoA + shared template).
+- [ ] C — wavefront integration + interactive-caustics gate.
+
+---
+
+## Lessons
+
+*(Fill in after the package is done.)*


### PR DESCRIPTION
Goal-capture spec-writing pass (dialogue skipped per owner directive). Files eight package specs drawn from the two research records already in the tree — each spec references its research doc for depth and carries its own §6 citations/licenses, dependency lines, and owner-goal context. **Docs-only; no STATUS/ROADMAP changes.**

Numbers 130-137 were reserved by the team lead; templates were pkg120/pkg122.

Source records:
- `.astroray_plan/docs/2026-07-other-engines-research.md` (families 2-5 + adoption table) -> pkg130-135
- `.astroray_plan/docs/2026-07-pbr-advances-research.md` (findings 2, 7) -> pkg136-137

| pkg | Technique | Source (license) | Status / dep note |
|---|---|---|---|
| 130 | Light groups + emission-mechanism decomposition | LuxCore radiance groups (Apache-2.0, verified) | open; label source for pkg134 |
| 131 | Zero-knob adaptive sampling | Cycles `adaptive_sampling.h` (Apache-2.0, verified) | open; needs progressive-prefix RNG (pkg92) |
| 132 | Host-mapped memory fallback | Cycles `device_impl.cpp` DEVICEMAP (Apache-2.0, verified) | open; cheap tier below pkg135 |
| 133 | SRF spectral sensors (detector QE) | Mitsuba `specfilm` (BSD-3, verified) | open; **Pillar-4-adjacent**, pairs with paused pkg51 |
| 134 | Light Path Expressions | OSL `liboslexec` LPE (BSD-3, verified) | open; **depends pkg130** |
| 135 | Demand-loaded sparse textures | NVIDIA OptiX Toolkit DemandLoading (BSD-3, phase-0 verify) | open — **CONDITIONAL** (activates on observed texture overflow) |
| 136 | SVO wavefront path guiding | Yalciner & Akyuz 2024 (arXiv:2405.06997) | open; **after Phase C**; phase-0 repo/license verify |
| 137 | Partitioned SMS + ReSTIR caustics | Hong et al. SIGGRAPH Asia 2025 (DOI 10.1145/3757377.3763927) | open; **depends pkg55-C6 + pkg127**; partitioning-alone standalone increment |

All eight: Status open (pkg135 conditional), Track A, §6 sourcing with licenses re-verify-flagged where the research docs flagged them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)