### PR TITLE
docs(pkg123-126): correctness/sampling specs — Disney chi² adjudication, VNDF, CPU band-awareness, mesh-emitter unification

### DIFF
--- a/.astroray_plan/packages/pkg123-disney-spec-lobe-chi2-adjudication.md
+++ b/.astroray_plan/packages/pkg123-disney-spec-lobe-chi2-adjudication.md
@@ -1,0 +1,260 @@
+# pkg123 — Disney specular-lobe sample()/pdf() chi² adjudication (un-xfail the merged gates)
+
+**Pillar:** 3 (correctness / statistical BSDF validation)
+**Track:** A (CPU-only chi² harness + CPU BSDF path; runs on CI, no GPU)
+**Codex-paste-ready:** no (an open statistical adjudication — the residual root cause is *not yet known*; needs per-cell evidence and an engine-vs-harness judgement call, not a mechanical patch)
+**Status:** open — **highest priority**; the xfail gates that reference this package are already merged (pkg121 PR #485)
+**Estimated effort:** M (1–2 sessions — residual localization via per-cell chi² maps, one engine-or-harness fix with evidence, harness full-sphere extension, un-xfail + full-grid re-run)
+**Depends on:** **pkg121 (landed, PR #485, merged 75ba67a)** — the chi² harness, the `debug_bsdf_sample_batch`/`debug_bsdf_pdf_batch` bindings, and the xfail(strict=False) Disney gates all exist and point here. No other package blocks this. **Related (not blocking):** **pkg120** — the one-sided spectral integrator is *why* a wrong `Material::pdf` has production impact (see Context); **pkg124** builds on this package's adjudication (its VNDF change must not reopen the mismatch).
+
+---
+
+## Context — why a chi²-only defect still matters for the journal
+
+`tests/statistical/test_chi2_bsdf.py` currently ships three Disney gates as
+`xfail(strict=False)` (metallic, oblique-diffuse, glass) plus the slow full grid.
+They are **not** cosmetic: the pkg121 investigation proved the harness is correct
+(Lambertian anchor passes χ²=818.06, d.o.f.=789, p=0.2298) and that the residual
+Disney failures localize to a **specular-lobe sample()/pdf() shape mismatch** —
+`Material::pdf` reports a density that disagrees with what `Material::sample`
+actually draws. This is invisible to every other gate we have:
+
+- **Furnace / white-furnace gates** stay green because unbiased Monte Carlo
+  absorbs a wrong pdf as *variance*, not *bias* (dead samples contribute zero).
+- **CPU↔GPU parity gates** stay green because CPU and GPU share the same pdf, so a
+  common error cancels in the difference.
+- Only a **goodness-of-fit test** (chi²) can see it, which is exactly why pkg121
+  built the harness.
+
+Production impact (this is the journal-relevant part): `Material::pdf` feeds the
+NEE-side power-heuristic weight `wt = lightPdf²/(lightPdf²+bsdfPdf²)`. With the
+**one-sided** spectral integrator (pkg120: the diffuse BSDF-ray-hits-emitter term
+is dropped, so there is no compensating BSDF-side leg), a wrong `bsdfPdf`
+**mis-weights NEE with nothing to cancel it** — a real, uncorrected error in
+direct lighting, not just extra noise. Closing pkg123 makes the Disney BSDF a
+statistically-validated closure the journal-article correctness section can cite,
+and hardens the pdf that pkg120's MIS math depends on.
+
+---
+
+## Goal
+
+**Before:** The Disney specular reflection lobe samples the **standard GGX NDF**
+(`disney.cpp:496-513`: half-vector `h` from `cosθ = √((1−r₂)/(1+(a²−1)r₂))`, then
+`wi = 2(wo·h)h − wo`) and reports density `D·NdotH/(4·HdotV)`
+(`disney.cpp:529-536`). The `sample()` and `pdf()` were **already reconciled once**
+during pkg121 — the code comment at `disney.cpp:496-500` records that a prior
+VNDF-sample-against-NDF-pdf mismatch was reverted because it "darkened disney
+metal/specular reflection." Despite that reconciliation, chi² still fails:
+
+- **Diffuse-only Disney** (`specular=0`, roughness 1) **passes at normal incidence**
+  but **fails at θ=45°** (`test_chi2_disney_diffuse`, xfail).
+- **Every metallic config fails p≈0 at every roughness**, including 0.4/0.8 where
+  the 80×160 grid fully resolves the lobe (so it is *not* a grid-resolution
+  artifact), with a clear **angle dependence** (`test_chi2_disney_metallic`, xfail).
+- **Glass/transmission** cannot even be tested correctly today — the gate uses a
+  `HemisphericalDomain` for a lobe that emits into the lower hemisphere
+  (`test_chi2_disney_glass:261-263`, xfail).
+
+**After:** The residual specular-lobe shape mismatch is **adjudicated with per-cell
+chi² residual evidence**, the responsible side (engine `sample()`/`pdf()` **or**
+harness) is fixed with a documented reason, the chi² harness gains a **full-sphere
+domain** so transmission lobes are testable, the **near-delta roughness floor** is
+documented so grid-unresolvable configs are excused explicitly rather than
+silently, and the merged Disney gates are **un-xfailed** and pass across the full
+grid (or any genuine engine↔reference divergence is owner-adjudicated and recorded,
+not suppressed).
+
+---
+
+## Root cause posture (what is known vs. what pkg123 must establish)
+
+**Known (pkg121, all verified — see `.astroray_plan/docs/pkg121-disney-pdf-finding.md`):**
+
+1. The harness is proven correct against the analytic Lambertian case.
+2. The failed-sample convention is understood and is *not* a bug: NDF-sampled
+   reflections below the horizon return pdf=0 dead samples, so `∫pdf` over the
+   hemisphere equals the **live fraction**, not 1.0; the harness now counts dead
+   samples in the denominator but not the bins (validity weights).
+3. The obvious `sample`/`pdf` mismatch (VNDF-sample vs NDF-pdf) was already found
+   and reverted; the current reflection lobe is a matched NDF-sample + NDF-pdf pair.
+
+**Unknown (pkg123 must establish with evidence):** *why a matched NDF-sample /
+NDF-pdf pair still fails chi² for metals at all roughness with angle dependence,
+and for diffuse only at oblique incidence.* Candidate suspects to test with the
+per-cell residual maps — **name them, do not assume one**:
+
+- The **denominator epsilon asymmetry**: `pdf()` divides by `4·HdotV + 0.001f`
+  (`disney.cpp:535`) while `sample()` reflects with no matching epsilon — a small
+  but angle-dependent density bias that grows as `HdotV → 0` (grazing), consistent
+  with the observed θ-dependence.
+- **Half-vector density vs reflected-direction density**: confirm the
+  `D·NdotH/(4·HdotV)` Jacobian is applied against the same `H`, `a`, and
+  frame the sampler uses (Walter 2007 §5.3 half-vector→direction Jacobian
+  `1/(4·|H·wo|)`); check the `NdotH>0 && HdotV>0` guard (`disney.cpp:533`) against
+  the sampler's below-horizon rejection (`disney.cpp:509`) — a density that is
+  nonzero on directions the sampler can never produce (or vice-versa) is a pure
+  shape mismatch.
+- **Lobe-mixture weight leakage**: the diffuse gate sets `specular=0` yet still
+  fails at θ=45° — check whether the specular lobe retains nonzero mixture weight
+  (`specWeight=1, total=diffWeight+specWeight`, `disney.cpp:524-526`) even when the
+  specular *contribution* is meant to be suppressed, and whether `pdf()` and
+  `sample()` compute that mixture weight identically.
+- The **roughness→α mapping** (`a = max(roughness², 0.0064f)`, applied at both
+  `disney.cpp:501` and `:530`) — verify it is byte-identical on both sides (it
+  appears to be; confirm, don't assume).
+
+pkg123's deliverable is the *answer*, backed by residual maps — not a guess.
+
+---
+
+## Fix plan (cite — no inventions, CLAUDE.md §6)
+
+### A. Localize with per-cell chi² residual maps
+
+Extend the harness (or add a debug path) to dump the per-cell
+`(observed − expected)/√expected` residual grid for a failing config, not just the
+pooled scalar χ²/p-value. This shows **where** on the (θ,φ) hemisphere the sampled
+histogram and the integrated pdf disagree — a ring at the specular peak vs. a
+systematic tilt vs. a horizon artifact each implicate a different suspect above.
+Mitsuba's `chi2.py` already retains the failure-dump mechanism (pkg121 §Phase B
+note: "keep Mitsuba's `chi2_data.py` failure-dump"); reuse it, add the residual
+heatmap. Start with **metallic roughness 0.4, θ=45°** (fully grid-resolved, clearly
+failing) as the diagnostic anchor.
+
+**Cite:** Mitsuba 3 `src/python/python/chi2.py` `ChiSquareTest` + `chi2_data.py`
+(BSD-3-Clause, already ported in pkg121); pbrt-v4 `src/pbrt/bsdfs_test.cpp`
+(Apache-2.0) for the residual-inspection convention.
+
+### B. Compare `disney.cpp` GGX sample vs pdf against the canonical construction
+
+Put the engine's three pieces side by side against the reference math:
+
+- **Sampler** (`disney.cpp:496-513`) — standard GGX NDF half-vector sample.
+- **Density** (`disney.cpp:529-536`) — `D_GTR2(NdotH,a)·NdotH/(4·HdotV)`.
+- **Reference** — pbrt-v4 `src/pbrt/bxdfs.h`/`microfacet.h`
+  `TrowbridgeReitzDistribution::Sample_wm` + `PDF`, and Walter 2007 "Microfacet
+  Models for Refraction through Rough Surfaces" (EGSR 2007) §5.3 — the half-vector
+  sampling and its `p(ωo) = p(ωm)/(4·(ωo·ωm))` Jacobian. The in-tree
+  `smithG1_GGX` already cites Walter 2007 Eq. 34 (`disney.cpp:26-32`); reuse that
+  citation anchor.
+
+Determine whether the reported density is the correct pushforward of the sampling
+procedure. Fix the side that is wrong **with the residual map as evidence**:
+
+- If the **engine** density is wrong (e.g. the epsilon, a missing/extra Jacobian
+  factor, or a guard mismatch), fix `disney.cpp` and cite the reference line.
+- If the **harness** is wrong (e.g. the hemisphere integration doesn't account for
+  the failed-sample live-fraction normalization the way the sampler does), fix the
+  harness and record why the pkg121 Lambertian anchor didn't catch it.
+
+Do **not** lower a tolerance or widen a bin to make the gate pass — pkg121 §Scope
+and the merged xfail reasons both forbid it.
+
+### C. Harness full-sphere domain (make transmission testable)
+
+The glass gate uses `HemisphericalDomain` with a stale "reflection-only" comment
+(`test_chi2_disney_glass:261-263`) even though transmission emits into the lower
+hemisphere; its xfail reason already says it "needs full-sphere domain." The ported
+harness **already imports `SphericalDomain`** (`test_chi2_bsdf.py:21`, from
+`chi2.py`). Switch the glass/transmission gates to `SphericalDomain`, verify the
+`debug_bsdf_sample_batch` adapter round-trips lower-hemisphere `wi` correctly
+(the adapter transposes (N,3)↔(3,N) — confirm sign handling), and confirm the
+sampler emits the full BTDF domain. Cite Mitsuba `SphericalDomain` (already ported).
+
+### D. Document the near-delta roughness floor
+
+pkg121 established that **near-delta configs** (metallic roughness 0.1, smooth
+glass roughness 0.0) are excused from chi² **only** for grid-resolution reasons —
+an 80×160 grid cannot resolve a near-mirror lobe — **not** because the engine is
+wrong there. Document this explicitly: record the α-floor
+(`a = max(roughness², 0.0064f)`, `disney.cpp:501,530`), state which configs the
+80×160 grid cannot resolve, and mark them as grid-limited (skip/expected) rather
+than leaving a bare xfail that reads as "engine defect." This keeps the un-xfailed
+grid honest about *what is validated* vs *what is grid-unresolvable*.
+
+### E. Un-xfail and re-run the full grid
+
+Once the residual is fixed with evidence: remove the `xfail(strict=False)` markers
+from the configs that now pass (`test_chi2_disney_metallic`,
+`test_chi2_disney_diffuse`, `test_chi2_disney_glass`, and the slow
+`test_chi2_disney_full_grid`), keeping only genuinely grid-limited near-delta
+configs marked (per D). Run the full slow grid (`pytest -v -m slow`) and record the
+pass/fail map. If any config exhibits a **genuine engine↔reference divergence**
+that is physically correct but statistically flagged, surface it for **owner
+adjudication** (do not silently suppress) — matching the pkg120 "or divergences
+owner-adjudicated" acceptance pattern.
+
+---
+
+## Acceptance criteria
+
+- [ ] Per-cell chi² residual maps produced for the diagnostic anchor(s) and
+      archived (metallic 0.4/θ=45° at minimum); the residual localizes the mismatch.
+- [ ] The responsible side (engine `disney.cpp` `sample()`/`pdf()` **or** the
+      harness) is fixed **with the residual map as the cited evidence**; the fix
+      cites pbrt-v4 `microfacet.h` / Walter 2007 §5.3 (engine) or the ported
+      Mitsuba `chi2.py` invariant (harness). No tolerance/bin fudging.
+- [ ] Harness gains a **full-sphere domain** path; glass/transmission gates use
+      `SphericalDomain` and the adapter round-trips lower-hemisphere `wi`.
+- [ ] Near-delta roughness floor documented; grid-unresolvable configs marked as
+      grid-limited (not bare "engine defect" xfails).
+- [ ] Merged Disney gates **un-xfailed** and passing:
+      `test_chi2_disney_metallic`, `test_chi2_disney_diffuse`,
+      `test_chi2_disney_glass`, and `test_chi2_disney_full_grid` (slow) — or any
+      residual divergence explicitly owner-adjudicated and recorded.
+- [ ] Lambertian anchor still passes (harness not regressed by the changes).
+- [ ] No production regression: furnace/white-furnace and CPU↔GPU parity gates stay
+      green (the fix, if in the engine pdf, must not perturb the unbiased estimator).
+- [ ] Research/citation note in `.astroray_plan/docs/` recording the adjudication
+      (which side was wrong, the residual-map evidence, the cited reference lines);
+      extend `pkg121-disney-pdf-finding.md` rather than starting a new doc.
+
+---
+
+## Non-goals
+
+- **Not VNDF sampling.** Replacing the reflection lobe's NDF-sample-then-reflect
+  with visible-NDF sampling is **pkg124**. pkg123 adjudicates the *current* lobe's
+  sample/pdf consistency; pkg124 changes the sampler afterward (and must re-pass
+  these gates). If B concludes the cleanest fix *is* to move to VNDF, stop and hand
+  to pkg124 rather than doing it here — keep pkg123 to the shape-consistency
+  adjudication so the two packages stay separable.
+- **Not the one-sided→two-sided MIS change.** That is **pkg120**; pkg123 only
+  hardens the `bsdfPdf` that pkg120's weight consumes.
+- **Not new BSDF lobes.** Sheen, clearcoat, subsurface chi² validation is the
+  pkg121 Phase B campaign, not this package.
+- **Not GPU.** CPU BSDF path only, matching pkg121's CPU-only scope. Any GPU chi²
+  extension is a future package.
+- **Not re-blessing reference images.** No image references move here (chi² is a
+  sampler test, not a render gate).
+
+---
+
+## Provenance
+
+Filed from the **pkg121 Disney BSDF chi² investigation FINAL STATE (2026-07-20)**
+(`.astroray_plan/docs/pkg121-disney-pdf-finding.md`, "The residual finding for
+pkg123"). pkg121 (PR #485, merged 75ba67a) proved the harness correct against
+Lambertian, resolved two harness bugs and the failed-sample convention, and
+isolated a **real, unexplained specular-lobe sample()/pdf() shape mismatch** that
+its xfail(strict=False) gates document and defer here. The gate reasons in
+`tests/statistical/test_chi2_bsdf.py:111-120, 175-180, 233` name pkg123 explicitly.
+The production stake is the pkg120 one-sided integrator's dependence on a correct
+`Material::pdf` for its NEE MIS weight.
+
+---
+
+## Progress
+
+- [ ] A — per-cell residual maps; diagnostic anchor localized.
+- [ ] B — engine sample/pdf vs pbrt-v4/Walter 2007 comparison; responsible side fixed with evidence.
+- [ ] C — full-sphere domain; glass/transmission gates testable.
+- [ ] D — near-delta roughness floor documented; grid-limited configs marked.
+- [ ] E — Disney gates un-xfailed; full slow grid re-run and recorded.
+
+---
+
+## Lessons
+
+*(Fill in after the package is done.)*

--- a/.astroray_plan/packages/pkg124-vndf-sampling.md
+++ b/.astroray_plan/packages/pkg124-vndf-sampling.md
@@ -1,0 +1,198 @@
+# pkg124 — Visible-NDF (VNDF) sampling for the Disney specular reflection lobe
+
+**Pillar:** 3 (sampling efficiency / BSDF correctness)
+**Track:** A (CPU BSDF path first, chi²-gated on CI; the change is shared math so the GPU spec lobe mirrors it — RTX-verify the GPU leg)
+**Codex-paste-ready:** no (a sampler replacement whose sample() and pdf() must change **together** to stay chi²-consistent; needs the pkg123 adjudication as its correctness baseline and an equal-time noise measurement to justify)
+**Status:** open — **blocked on pkg123** (the specular-lobe sample/pdf shape must be adjudicated and the gates un-xfailed *before* the sampler is swapped, so the swap is measured against a green baseline)
+**Estimated effort:** M (swap the reflection lobe to VNDF sample + matching VNDF pdf — most machinery already exists in-tree; re-pass chi², measure dead-sample rate before/after, equal-time noise A/B)
+**Depends on:** **pkg123** — the Disney spec-lobe chi² gates must be **passing (un-xfailed)** first. pkg124 changes the sampler and *must not reopen* the mismatch; that is only checkable against a green chi² grid. Land order: pkg123 → pkg124.
+
+---
+
+## Context — measured waste, not a theoretical improvement
+
+pkg121 measured the Disney sampler's **live fraction** directly: at roughness 1 the
+diffuse-Disney config has live fraction **0.7514** — i.e. the specular half of the
+mixture throws away **≈25% of its draws** as below-horizon dead samples
+(`.astroray_plan/docs/pkg121-disney-pdf-finding.md` §3: "~25% dead samples at high
+roughness is real waste — VNDF sampling (Heitz 2018, JCGT) eliminates most of it").
+The current reflection lobe samples the **full GGX NDF** and then reflects, so any
+half-vector that produces a `wi` below the horizon is rejected (`disney.cpp:509`
+`if (rec.normal.dot(s.wi) > 0)`). Visible-NDF sampling draws only from the
+distribution of normals **visible from the outgoing direction**, which by
+construction almost never yields a below-horizon reflection — turning most of those
+wasted draws into useful samples and lowering variance at equal sample count.
+
+This is not speculative: the same VNDF machinery is **already in the tree** and
+already used on the Disney **transmission/glass** path (see Root cause). pkg124
+extends it to the reflection lobe, which pkg121 flagged and which the current code
+comment (`disney.cpp:496-500`) explicitly left as NDF sampling only because the
+earlier attempt mis-paired VNDF-sample with the NDF pdf.
+
+---
+
+## Goal
+
+**Before:** The Disney specular **reflection** lobe samples the standard GGX NDF and
+reflects (`disney.cpp:496-513`), paired with the NDF reflection pdf
+`D·NdotH/(4·HdotV)` (`disney.cpp:529-536`). At roughness 1 this discards ~25% of
+specular draws below the horizon (pkg121). The comment at `disney.cpp:496-500`
+records that VNDF sampling was tried here and reverted — **because it was left
+paired against the NDF pdf**, a sample/pdf mismatch that darkened metal. So the tree
+today has VNDF sampling available but deliberately unused on the reflection lobe.
+
+**After:** The reflection lobe samples the **visible** GGX NDF (Heitz 2018) paired
+with its **matching VNDF pdf**, both changed together so the estimator stays
+chi²-consistent. Below-horizon dead samples on the reflection lobe drop from ~25%
+(roughness 1) toward the VNDF near-zero floor, direct-specular variance falls at
+equal sample count, and the Disney chi² gates (un-xfailed by pkg123) **still pass**.
+The CPU and GPU specular lobes stay in lockstep (shared VNDF sample + pdf), so no
+CPU↔GPU parity regression.
+
+---
+
+## Root cause — the machinery already exists; only the reflection lobe opts out
+
+The in-tree VNDF pieces, all present and cited:
+
+- **`sampleGgxVNDF(rec, wo, gen)`** — `disney.cpp:95-97`, cites *Heitz 2018,
+  "Sampling the GGX Distribution of Visible Normals," JCGT 7(4)*. Already used on
+  the transmission path (`disney.cpp:425-426`).
+- **`vndfPdf(rec.normal, wo, wm)`** — `disney.cpp:200-211`, the VNDF density
+  `D(wm)·G1(wo)·|wo·wm|/|wo·n|`, cites *PBRT-v4 `DielectricBxDF::PDF`*.
+- **`smithG1_GGX`** — `disney.cpp:32`, the Smith Λ masking term, cites *Walter 2007
+  Eq. 34*, used by both `vndfPdf` and the reflection-reflection Jacobian.
+
+The transmission branch already composes them correctly: sample `wm` via VNDF,
+reflect, and set `pdf = vndfPdf(...) / (4·|HdotO|) · R/(R+T)` (`disney.cpp:441-442`).
+The **opaque** specular reflection lobe (metallic/dielectric, non-transmission) is
+the only path still on NDF-sample-then-reflect. pkg124's core change is therefore
+small and local: replace the `disney.cpp:496-513` NDF sampler with a VNDF sampler
+whose reflected-direction pdf is `vndfPdf(n, wo, wm) / (4·|wo·wm|)`, and update
+`pdf()` (`disney.cpp:529-536`) for the reflection lobe to report that **same** VNDF
+density — the two must move as one edit.
+
+---
+
+## Fix plan (cite — no inventions, CLAUDE.md §6)
+
+### A. Replace the reflection-lobe sampler with VNDF
+
+In `sample()`'s opaque-specular branch (`disney.cpp:496-513`): draw
+`wm = sampleGgxVNDF(rec, wo, gen)`, reflect `wi = 2(wo·wm)wm − wo`, and set the pdf
+to the VNDF reflected-direction density `vndfPdf(rec.normal, wo, wm) / (4·|wo·wm|)`
+(mirroring exactly what the transmission-reflection sub-branch already does at
+`disney.cpp:436-442`, minus the `R/(R+T)` Fresnel-split factor that is
+transmission-specific). Reuse the existing `sampleGgxVNDF` / `vndfPdf` — **do not
+add a second VNDF implementation**. Remove the now-obsolete `disney.cpp:496-500`
+comment (its warning was about the *mismatch*, which this package resolves by
+changing both sides).
+
+**Cite:**
+- *Heitz 2018, "Sampling the GGX Distribution of Visible Normals," JCGT 7(4)* —
+  already cited at `disney.cpp:95`; the canonical VNDF sampling routine.
+- **Cycles reference implementation:**
+  `intern/cycles/kernel/closure/bsdf_microfacet.h` (Apache-2.0) —
+  `bsdf_microfacet_ggx_sample` and its VNDF half-vector helper
+  (`microfacet_ggx_sample_vndf` / `microfacet_sample_stretched`); this is the
+  production mirror the task requires. Pin the commit SHA in the research note.
+- *PBRT-v4 `src/pbrt/bxdfs.h` `ConductorBxDF`/`DielectricBxDF::Sample_f` +
+  `TrowbridgeReitzDistribution::Sample_wm`* (Apache-2.0) — the reflected-direction
+  Jacobian `1/(4·|wo·wm|)`; already the source for the in-tree `vndfPdf`.
+
+### B. Update the reflection-lobe pdf to the matching VNDF density
+
+In `pdf()` (`disney.cpp:529-536`): replace the NDF reflection term
+`D·NdotH/(4·HdotV)` with `vndfPdf(rec.normal, wo, wm)/(4·|wo·wm|)` for the specular
+reflection component, keeping the diffuse and (already-VNDF) transmission terms and
+the mixture weighting `specWeight/total` unchanged. **A and B are one atomic change**
+— sample and pdf must agree, which is precisely the invariant pkg123 adjudicates and
+pkg124 must preserve.
+
+### C. Keep CPU and GPU in lockstep
+
+The GPU specular lobe is described as an NDF-spec lobe matching the CPU
+(`disney.cpp:496-497` comment: "matches ... the GPU non-transmission spec lobe").
+Mirror the VNDF sample + pdf into the GPU material sampler so CPU and GPU stay
+term-for-term identical, and verify with the existing CPU↔GPU wavefront-diff parity
+gate. If the GPU port is non-trivial, it may split into a follow-up **only if** the
+CPU↔GPU parity gate is kept green in the interim (i.e. do not land a CPU-only VNDF
+that desyncs the two); prefer landing both together.
+
+### D. Verify: chi², dead-sample rate, equal-time noise
+
+1. **chi² still passes.** Re-run the Disney gates pkg123 un-xfailed
+   (`test_chi2_disney_metallic`, `_diffuse`, `_glass`, and the slow full grid). VNDF
+   sample + VNDF pdf must be chi²-consistent; a failure here means A/B desynced.
+2. **Dead-sample rate before/after.** Instrument the specular lobe's live fraction
+   (the pkg121 metric) at roughness ∈ {0.4, 0.8, 1.0}; report the drop (target: the
+   ~25%-waste roughness-1 case falls toward the VNDF near-zero floor).
+3. **Equal-time noise A/B.** Render a specular-dominant scene (e.g. the metal test
+   material) at **equal wall-clock time** NDF-sampling vs VNDF-sampling and report
+   the variance/noise reduction (MSE vs a high-spp reference, or per-pixel
+   variance). This is the justification the package exists for; record the number.
+
+---
+
+## Acceptance criteria
+
+- [ ] Reflection lobe samples VNDF (`sampleGgxVNDF`) with matching VNDF pdf
+      (`vndfPdf(...)/(4·|wo·wm|)`); sample and pdf changed as one atomic edit; the
+      obsolete `disney.cpp:496-500` NDF-only comment removed. No second VNDF
+      implementation added (reuse the existing helpers).
+- [ ] Disney chi² gates (un-xfailed by pkg123) **still pass** — the swap does not
+      reopen the sample/pdf mismatch.
+- [ ] Dead-sample (live-fraction) rate measured before/after at roughness
+      {0.4, 0.8, 1.0}; the ~25% roughness-1 waste demonstrably drops.
+- [ ] Equal-time noise A/B (NDF vs VNDF) measured on a specular-dominant scene;
+      variance reduction reported.
+- [ ] CPU↔GPU parity: GPU spec lobe mirrors the VNDF sample+pdf; wavefront-diff
+      parity gate stays green (CPU and GPU term-for-term identical).
+- [ ] No energy/furnace regression: white-furnace + specular energy-conservation
+      gates stay green (VNDF is a variance change, not an energy change).
+- [ ] Research/citation note in `.astroray_plan/docs/`: Heitz 2018 + Cycles
+      `bsdf_microfacet.h` (pinned SHA) + PBRT-v4 Jacobian, with the before/after
+      dead-sample and equal-time-noise numbers.
+
+---
+
+## Non-goals
+
+- **Not the sample/pdf shape adjudication.** That is **pkg123**, which must land
+  first; pkg124 assumes a green chi² baseline and preserves it.
+- **Not the transmission/glass lobe.** It already uses VNDF (`disney.cpp:425-448`);
+  leave it unchanged except where pkg123's full-sphere domain work touches its gate.
+- **Not multiple-scattering GGX.** Energy compensation for rough-conductor
+  multiscatter (the `1 + Fms·((1−E)/E)` factor, `disney.cpp:384`) is a separate
+  concern; VNDF is single-scatter importance sampling only.
+- **Not a new microfacet distribution.** Same GGX/Trowbridge-Reitz `D_GTR2`; only
+  the *sampling strategy* for that distribution changes.
+- **Not diffuse/sheen/clearcoat samplers.** Only the specular reflection lobe.
+
+---
+
+## Provenance
+
+Filed from the **pkg121 Disney BSDF chi² investigation FINAL STATE (2026-07-20)**
+(`.astroray_plan/docs/pkg121-disney-pdf-finding.md` §3: the ~25%-dead-sample
+measurement at roughness 1 and the explicit "VNDF sampling (Heitz 2018, JCGT)
+eliminates most of it ... recorded as a follow-up candidate" note). The in-tree VNDF
+helpers (`sampleGgxVNDF` `disney.cpp:97`, `vndfPdf` `disney.cpp:200`) already exist
+and are used on the transmission path; the reflection lobe was deliberately left on
+NDF sampling (`disney.cpp:496-500`) pending the sample/pdf adjudication now scoped as
+pkg123. Depends on pkg123 landing first.
+
+---
+
+## Progress
+
+- [ ] A — reflection-lobe VNDF sampler (reuse `sampleGgxVNDF`); obsolete comment removed.
+- [ ] B — matching VNDF reflection pdf; A+B atomic.
+- [ ] C — GPU spec lobe mirror; CPU↔GPU parity green.
+- [ ] D — chi² re-pass + dead-sample before/after + equal-time noise A/B.
+
+---
+
+## Lessons
+
+*(Fill in after the package is done.)*

--- a/.astroray_plan/packages/pkg125-cpu-path-tracer-band-awareness.md
+++ b/.astroray_plan/packages/pkg125-cpu-path-tracer-band-awareness.md
@@ -1,0 +1,191 @@
+# pkg125 — CPU `path_tracer` band awareness (honor `set_wavelength_range`, or reject it loudly)
+
+**Pillar:** 3 (spectral correctness / integrator parity)
+**Track:** A (CPU-only reference integrator; runs on CI)
+**Codex-paste-ready:** no (a small chip, but it carries one owner-facing design choice — honor vs. reject — that wants a recommendation, not a silent pick)
+**Status:** open
+**Estimated effort:** S (small — the band-sampling change is a few lines mirroring `multiwavelength_path_tracer`; the larger option (full non-visible NEE reference) is scoped as an explicit stretch, not required)
+**Depends on:** none. Independent of the pkg120/122/123/124 chain. Composes with **pkg55 Phase C** (Session C3) — closing this gives the wavefront the band-aware **NEE** CPU reference that C3 recorded as missing.
+
+---
+
+## Context — discovered during pkg55-C3, out of that package's scope
+
+While closing pkg55 Phase C Session C3 (PR #486), the agent re-measured the
+multiwavelength paths on a fresh build and corrected a shadow-`.pyd`-contaminated
+dossier. The corrected finding
+(`.astroray_plan/docs/pkg55-phase-c-plan-2026-07.md` §3, Session C3 status —
+"Side finding" and "Coverage gap"):
+
+- The GPU megakernel and the GPU `path_tracer` are **band-aware** (NIR darkens to
+  ~1.8e-4, correctly out-of-band-black under D65 gating).
+- **The CPU `path_tracer` is NOT band-aware:** it "ignores `wavelength_range`
+  (renders NIR as visible RGB, 0.1331)."
+- Consequence flagged as a follow-up chip: "**no band-aware NEE CPU reference
+  exists** for the wavefront's NEE+luminance+profile-override path — `path_tracer`
+  ignores the band, `multiwavelength_path_tracer` is naive [no NEE], and the CPU
+  wavefront twin is the RGB Lambertian-Cornell skeleton." C3 explicitly scoped this
+  out: "pre-existing CPU-side path_tracer band-unawareness, out of C3 scope."
+
+This package is that follow-up chip.
+
+---
+
+## Root cause (verified in code)
+
+`set_wavelength_range(lambda_min, lambda_max)` stores the band into the integrator
+params: `Renderer::setWavelengthRange` sets `integratorParams_["lambda_min"]` /
+`["lambda_max"]` (`include/raytracer.h:2160-2162`, bound at
+`module/blender_module.cpp:2819`). Only an integrator that **reads those params**
+honors the band.
+
+- **`multiwavelength_path_tracer`** reads them —
+  `lambdaMin_(p.getFloat("lambda_min", kVisMin))`,
+  `lambdaMax_(p.getFloat("lambda_max", kVisMax))`
+  (`plugins/integrators/multiwavelength_path_tracer.cpp:44-46`) — and samples
+  `SampledWavelengths::sampleUniform(u, lambdaMin_, lambdaMax_)` (`:74-75`), plus
+  sets `useLuminanceOutput_` when outside the visible band (`:49`).
+- **The CPU `path_tracer`** is `SpectralPathTracer`
+  (`plugins/integrators/spectral_path_tracer.cpp`, registered
+  `ASTRORAY_REGISTER_INTEGRATOR("path_tracer", SpectralPathTracer)` at `:612`). Its
+  render loop samples `SampledWavelengths::sampleUniform(dist01(gen))`
+  (`:165-166`) — **no `lambda_min`/`lambda_max` argument**, so it always uses the
+  default visible band [`kLambdaMin`, `kLambdaMax`] = [380, 780]
+  (`module/blender_module.cpp:3576` confirms the default). It never reads the params
+  `set_wavelength_range` wrote. So a user who calls `set_wavelength_range(800, 900)`
+  and renders with the default `path_tracer` silently gets a **visible-band render
+  mislabeled as NIR** (the measured 0.1331 vs. the correct ~1.8e-4).
+
+The default `SampledWavelengths::sampleUniform(u)` overload defaulting to the
+visible band is correct for a visible render; the defect is purely that
+`path_tracer` never plumbs the requested band into that call.
+
+---
+
+## Options (present both; recommend one)
+
+**Option A — honor the band (recommended).** Make `SpectralPathTracer` read
+`lambda_min`/`lambda_max` from its `ParamDict` (exactly as
+`multiwavelength_path_tracer` does) and pass them to `sampleUniform`. This makes the
+**NEE + MIS reference integrator** band-aware, which is the piece pkg55-C3 said is
+missing: it becomes the band-aware CPU oracle the wavefront's
+NEE+luminance+profile-override path can be validated against.
+
+- *Minimal form:* read the two params, thread them into
+  `SampledWavelengths::sampleUniform(u, lambdaMin_, lambdaMax_)` at
+  `spectral_path_tracer.cpp:165-166`. Out-of-visible wavelengths already resolve
+  correctly downstream — materials with a spectral **profile** use it, materials
+  without one return 0 outside [380,780] (the honest-black convention already
+  implemented in the base material `evalSpectral`, `include/raytracer.h:613-636`),
+  and emission/env are D65-gated to zero past 780 nm. So the minimal change is
+  genuinely small.
+- *Stretch (optional, not required to close the package):* also mirror
+  `useLuminanceOutput` (`multiwavelength_path_tracer.cpp:49`) and the Rayleigh-sky
+  miss fallback so NIR/UV renders are photometrically presented the same way the
+  naive integrator and the wavefront present them. This is the difference between "a
+  band-aware NEE reference for parity numbers" (minimal) and "a
+  production-quality NIR/UV NEE integrator" (stretch). Recommend shipping minimal
+  first; file the stretch as a follow-up if a live NIR-emissive NEE scene is wanted.
+
+**Option B — reject the band loudly.** Keep `path_tracer` visible-only, but when
+`lambda_min`/`lambda_max` deviate from the visible band, emit a **loud one-time
+warning** ("path_tracer is visible-band only; use multiwavelength_path_tracer for
+NIR/UV — the requested [800,900] nm range is ignored, rendering [380,780]").
+Cheaper, and honest, but leaves the NEE-band-reference gap open — the wavefront
+still has no band-aware NEE CPU oracle.
+
+**Recommendation: Option A (minimal form).** It is barely larger than the warning,
+it removes a silent-wrong-output footgun, and it closes the concrete pkg55-C3 gap
+(band-aware NEE reference) instead of merely documenting it. Option B is the
+fallback only if honoring the band surfaces an unexpected coupling in the NEE path
+during implementation; if so, ship B and file A as the follow-up.
+
+---
+
+## Fix plan (cite — no inventions, CLAUDE.md §6)
+
+The reference is **in-tree, same repo**: `multiwavelength_path_tracer.cpp` already
+does exactly the band plumbing this package needs. Mirror its param read
+(`:44-46`), its `sampleUniform(u, lambdaMin_, lambdaMax_)` call (`:74-75`), and (for
+the stretch) its `useLuminanceOutput_` gate (`:49`) into `SpectralPathTracer`
+(`spectral_path_tracer.cpp:44-46` constructor region and `:165-166` sampling site).
+No external algorithm is involved — this is a plumbing/consistency fix between two
+in-repo integrators, so §6 is satisfied by citing the existing
+`multiwavelength_path_tracer` as the mirror and the honest-black out-of-band
+convention already documented at `include/raytracer.h:613-615`.
+
+### Verification gate
+
+Add a CPU test asserting band awareness on `path_tracer`:
+
+- Render a scene with `set_wavelength_range` set to an NIR band (e.g. [800, 900])
+  and assert the out-of-band output is **near-black** (matching the GPU
+  `path_tracer`'s measured ~1.8e-4), **not** the visible-RGB 0.1331 it produces
+  today. Cross-check against `multiwavelength_path_tracer` on the same scene
+  (they should now agree on the band, differing only by NEE presence).
+- Visible-band no-regression: a plain visible render is byte-unchanged (the default
+  path still samples [380,780]).
+- If Option B is chosen instead: assert the warning fires and the render stays
+  visible-band.
+
+---
+
+## Acceptance criteria
+
+- [ ] `path_tracer` (`SpectralPathTracer`) either **honors** `set_wavelength_range`
+      (Option A: reads `lambda_min`/`lambda_max`, samples that band — recommended)
+      or **rejects it with a loud warning** (Option B), with the choice recorded.
+- [ ] Band-awareness test: NIR request renders near-black (not visible-RGB), or (B)
+      the warning fires and visible-band is rendered. Cross-checked against
+      `multiwavelength_path_tracer`.
+- [ ] Visible-band render byte-unchanged (no regression to the default path).
+- [ ] If Option A: the out-of-band material convention (profile → profile
+      reflectance; no profile → 0) is confirmed to already hold; no new material
+      code needed.
+- [ ] Signature/call-site sweep: confirm no other caller relied on `path_tracer`
+      ignoring the band.
+
+---
+
+## Non-goals
+
+- **Not the GPU path.** The GPU `path_tracer` is already band-aware (pkg55-C3
+  re-measurement); this is CPU-only.
+- **Not the wavefront.** Threading the band through the CPU/GPU wavefront twins is
+  pkg55 Phase C territory; pkg125 only fixes the megakernel-era CPU reference
+  integrator.
+- **Not a new spectral pipeline.** Uses the existing `SampledWavelengths`,
+  profile-reflectance, and D65-gated emission machinery unchanged.
+- **Not the naive `multiwavelength_path_tracer`.** It already honors the band; this
+  package brings the **NEE** reference (`path_tracer`) to parity with it, not the
+  other way around.
+- **Not luminance-output / Rayleigh-sky presentation** in the minimal form — that
+  is the explicitly-optional stretch, filed as a follow-up if not shipped here.
+
+---
+
+## Provenance
+
+Filed from the **pkg55 Phase C Session C3 closeout (PR #486, 2026-07-19)**
+(`.astroray_plan/docs/pkg55-phase-c-plan-2026-07.md` §3, Session C3 status — the
+"Side finding" that re-measured CPU `path_tracer` at NIR = 0.1331 vs the band-aware
+GPU ~1.8e-4, and the "Coverage gap (follow-up chip)" noting no band-aware NEE CPU
+reference exists). C3 explicitly scoped this out as "pre-existing CPU-side
+path_tracer band-unawareness, out of C3 scope." Verified in code:
+`spectral_path_tracer.cpp:165-166` samples the default visible band and never reads
+the `lambda_min`/`lambda_max` params `set_wavelength_range` writes
+(`raytracer.h:2160-2162`), unlike `multiwavelength_path_tracer.cpp:44-46, 74-75`.
+
+---
+
+## Progress
+
+- [ ] Decide A vs B (recommend A-minimal); record the choice.
+- [ ] Implement the band plumbing (or the loud warning).
+- [ ] Band-awareness test + visible-band no-regression.
+
+---
+
+## Lessons
+
+*(Fill in after the package is done.)*

--- a/.astroray_plan/packages/pkg126-mesh-emitter-unification.md
+++ b/.astroray_plan/packages/pkg126-mesh-emitter-unification.md
@@ -1,0 +1,220 @@
+# pkg126 — Mesh-emitter unification (pkg89 Phase C: one sampling interface for dedicated + emissive-geometry lights)
+
+**Pillar:** 3 (light transport / emitter architecture)
+**Track:** A (CPU-first interface unification, gated on no-regression against the existing emissive-mesh + dedicated-light suites; GPU mirror follows the established CPU-virtual → GPU-tagged-union pattern)
+**Codex-paste-ready:** no (a cross-cutting interface unification touching every integrator's NEE call site and the `Hittable` light-virtual surface — a re-architecture requiring judgement and staged verification, not a mechanical patch)
+**Status:** open — **blocked on pkg122** (dedicated-light energy calibration must land first, see Depends on)
+**Estimated effort:** L (unify two light-sampling paths under one interface across five integrators + the light-tree + the GPU mirror, while keeping every existing emissive-mesh and dedicated-light gate green — a large, staged change)
+**Depends on:** **pkg122 (dedicated-light energy calibration)**. Both the dedicated lights and the emissive-geometry `diffuse_light` material currently emit through the **same disputed `RGBIlluminantSpectrum` convention** (energy audit: "Both the dedicated lights and the geometry `diffuse_light` material emit through `RGBIlluminantSpectrum`"). pkg122 re-derives each dedicated type's wattage→radiance **and adjudicates that emission-spectrum convention once** (pkg122 Defect 4). Unifying the two sampling paths **before** that convention is settled would bake an un-calibrated, possibly-wrong energy contract into the unified interface. Land order: pkg122 → pkg126. **Composes with pkg86** (Light Tree) — the unified interface must keep feeding `Light::power()`/`orientationCone()`/`bounds()` to the Conty 2018 metric.
+
+---
+
+## Context — the long-deferred pkg89 Phase C
+
+pkg89 shipped a first-class `astroray::Light` interface (Phase A, PR #294) and the
+Blender addon migration (Phase B, PR #317), and uploaded dedicated lights to the GPU
+(GAP 1, PR #489). Its **Phase C was explicitly carved out as a separate future
+package** from the start:
+
+- pkg89 spec Phase list, row C: *"Wrap emissive triangles into `TriangleAreaLight`
+  under the hood; `DiffuseLight` / `Emissive` materials become thin shims"* —
+  marked **"(out of scope) … separate package"** (`pkg89-dedicated-lights.md:76`).
+- pkg89 Non-goals: *"Removing the emissive-`Material` codepath. `DiffuseLightPlugin`
+  and `EmissivePlugin` materials continue to work … Unification is Phase C"*
+  (`pkg89-dedicated-lights.md:92-95`).
+- pkg89 Non-goals: *"Touching `Hittable`'s seven light-related virtuals. They stay
+  in v1; removing them is Phase C surface area"* (`pkg89-dedicated-lights.md:105-106`).
+
+This package is that Phase C.
+
+---
+
+## Goal
+
+**Before:** Astroray samples lights through **two parallel paths** that NEE code
+must handle separately. `LightList` carries both an emissive-**geometry** list —
+`std::vector<...> lights` of `Hittable`s with an emissive `Material`
+(`include/raytracer.h:1241` region) — and a dedicated-**Light** list —
+`std::vector<std::unique_ptr<astroray::Light>> dedicatedLights`
+(`include/raytracer.h:1243`), added via `addLight` (`:1276`), exposed via
+`getDedicatedLights` (`:1313`). Emissive geometry is sampled through seven
+light-related virtuals bolted onto **every** `Hittable`, emissive or not —
+`pdfValue`, `isLight`, `emittedRadiance()`, `directionFalloff`, and the
+`emittedRadiance(lightNormal, toPointDir)` overload
+(`include/raytracer.h:762-768`) — carried as no-op overrides by every non-emissive
+primitive. Dedicated lights are sampled through `Light::sampleLi`. NEE, MIS,
+light-tree traversal, and the GPU mirror all straddle both representations.
+
+**After:** Emissive geometry is wrapped, under the hood, as first-class `Light`
+objects (a `TriangleAreaLight` / mesh-emitter `Light` around emissive triangles),
+so **all** NEE sampling goes through the single `Light` interface. `DiffuseLight`
+and `Emissive` materials become **thin shims** that register a wrapping `Light` at
+scene-build time instead of driving a separate `Hittable`-virtual sampling path. The
+seven `Hittable` light virtuals are retired (or reduced to the minimum the BVH-hit
+emission-lookup genuinely needs). `LightList::sample`, the light tree, the five
+integrators, and the GPU tagged-union all see **one** light kind. No visible change
+to any render: every existing emissive-mesh and dedicated-light gate stays green,
+now served through the unified path.
+
+---
+
+## Root cause — why two paths is a standing liability
+
+The dual representation is the reason several recent packages had to do their work
+*twice* or reason about *both* sides:
+
+- The pkg89 GAP-2 energy audit had to compare dedicated AREA vs the **geometry**
+  `AreaLightShape` emitter as separate calibration targets, and found they disagree
+  (dedicated 0.13× the geometry path) partly *because* they are different code
+  (`pkg89-energy-audit-2026-07.md`, Measurement 1).
+- pkg120's two-sided MIS must reconstruct `lightPdf_hit` for a BSDF-ray that hits an
+  emitter — and that emitter can be either kind, so the pdf reconstruction has to
+  match **both** the `Hittable::pdfValue` path and the `Light` selection pdf.
+- The light tree (pkg86) already had to wrap emissive `Hittable`s in a shim that
+  synthesizes `power()`/`orientationCone()`/`bounds()` from geometry
+  (pkg89 spec "Cross-package notes"). Unification makes that shim the *only* path.
+
+Unifying collapses these into one sampling contract, one pdf, one energy
+calibration surface, and one GPU mirror — which is exactly why it must wait for
+pkg122 to fix and freeze the energy/convention contract first.
+
+---
+
+## Fix plan (cite — no inventions, CLAUDE.md §6)
+
+### A. A mesh-emitter `Light` wrapping emissive triangles
+
+Introduce a `TriangleAreaLight` (or mesh-emitter) `Light` type that samples an
+emissive triangle by area and returns a `LightSample` in the same measure and with
+the same `emission_spec` contract as the pkg89 dedicated `AreaLight`. Cache
+per-triangle area at construction (pkg89 Q2 resolution:
+`pkg89-dedicated-lights.md:127-140`, "cached at construction … we mirror the CDF
+caching"). Emission comes from the triangle's emissive `Material`, evaluated through
+the **pkg122-adjudicated** emission-spectrum convention (not re-litigated here).
+
+**Cite:** Cycles `intern/cycles/kernel/light/triangle.h` `triangle_light_sample`
+(Apache-2.0) — the canonical emissive-triangle area sample and its area→solid-angle
+pdf; the pkg89 spec already names this as the Q2 reference
+(`pkg89-dedicated-lights.md:137-140`). PBRT-v4 `src/pbrt/lights.h`
+`DiffuseAreaLight` (Apache-2.0) as the interface second opinion. Reuse the pkg122
+`AreaLight` measure derivation so the mesh emitter and the dedicated area light use
+**one** area→solid-angle pdf (the whole point of unification).
+
+### B. `DiffuseLight` / `Emissive` materials become thin shims
+
+At scene build, an emissive `Material` (`plugins/materials/diffuse_light.cpp`,
+`plugins/materials/emissive.cpp`) registers a wrapping mesh-emitter `Light` for its
+faces via `LightList::addLight` (`include/raytracer.h:1276`) instead of relying on
+the `Hittable` light-virtual path. The material still evaluates emission when a BSDF
+ray *hits* the surface directly (camera/specular emission lookup), but **NEE
+sampling** of that emitter goes through the `Light`. Keep the materials working —
+pkg89 Non-goals kept them functional; Phase C makes them shims, not deletions of the
+emission-on-hit behavior.
+
+### C. Retire the seven `Hittable` light virtuals
+
+Once all NEE sampling is via `Light`, remove (or reduce to the minimum the
+BVH-hit-emission path needs) the light virtuals at `include/raytracer.h:762-768`
+(`pdfValue`, `isLight`, `emittedRadiance()`, `directionFalloff`,
+`emittedRadiance(lightNormal, toPointDir)`). This is the "Phase C surface area" pkg89
+deferred (`pkg89-dedicated-lights.md:105-106`). Do a repo-wide sweep for each
+retired virtual before removing it (CLAUDE.md build/verification rule) — these are
+overridden as no-ops across many primitives, so the sweep confirms no caller depends
+on the emissive branch outside the emitter path.
+
+### D. Unify `LightList::sample`, the light tree, and the five integrators
+
+`LightList::sample` and the power CDF already span both kinds
+(`include/raytracer.h:1309` `empty()` checks both lists); collapse the sampling body
+so it iterates one unified light collection. The light tree keeps reading
+`Light::power()`/`orientationCone()`/`bounds()` (pkg86 composability — now the
+mesh emitters expose these natively instead of via a synthesized shim). Update the
+five integrator NEE call sites pkg89 Phase A already touched
+(`multiwavelength_path_tracer`, `spectral_path_tracer`, `restir_di`, `neural_cache`,
+`caustic`/`sms_caustic` — pkg89 spec Q7, `pkg89-dedicated-lights.md:190-204`) so they
+consume the unified `LightSample`. Preserve the ReSTIR RGB `emission` field contract
+(pkg89 Q6).
+
+### E. GPU mirror
+
+Mirror the mesh-emitter into the GPU dedicated-light tagged union established by
+pkg89 GAP-1 (`GDedicatedLight` POD + device `sampleLi`, PR #489). The unified CPU
+`sampleLi` is the oracle; assert GPU==CPU parity on a mixed dedicated + emissive-mesh
+scene (the pkg89 GAP-1 parity harness already measures AREA/POINT ratios — extend it
+with a mesh emitter). Follow the pkg64 → pkg64-gpu CPU-virtual → GPU-tagged-union
+pattern pkg89 cites (`pkg89-dedicated-lights.md:85-87`).
+
+---
+
+## Acceptance criteria
+
+- [ ] Mesh-emitter `Light` (emissive-triangle wrapper) exists, samples by area with
+      a cached per-triangle area, and returns a `LightSample` in the **same measure
+      and emission-convention as the pkg122-calibrated `AreaLight`** (one pdf, one
+      energy contract).
+- [ ] `DiffuseLight` / `Emissive` materials are thin shims: NEE samples the wrapping
+      `Light`; direct BSDF-hit emission still evaluates through the material.
+- [ ] The seven `Hittable` light virtuals (`raytracer.h:762-768`) are retired or
+      minimized, with a repo-wide call-site sweep proving no orphaned caller.
+- [ ] `LightList::sample`, the light tree, and all five integrator NEE sites consume
+      one unified light collection; ReSTIR RGB `emission` contract preserved.
+- [ ] GPU mesh-emitter mirrors the CPU `sampleLi`; GPU==CPU parity on a mixed
+      dedicated + emissive-mesh scene.
+- [ ] **No render regression:** the existing emissive-mesh suite (pkg89 G6,
+      `test_emissive_spectral_emits`) and the dedicated-light suite (G1–G5) stay
+      green through the unified path; the light-tree variance-reduction gate (pkg86
+      G7) holds on a mixed scene.
+- [ ] Research/citation note in `.astroray_plan/docs/` recording the Cycles
+      `triangle.h` / PBRT-v4 `DiffuseAreaLight` derivations (pinned SHA) and the
+      unified-interface design.
+
+---
+
+## Non-goals
+
+- **Not emitter energy calibration.** That is **pkg122**, which must land first;
+  pkg126 consumes pkg122's calibrated measure + emission convention and must not
+  re-tune energy. If a unified-path energy discrepancy appears, it is a pkg122
+  calibration bug to hand back, not a pkg126 re-tune.
+- **Not the two-sided MIS change.** pkg120 adds the BSDF-side leg; pkg126 must keep
+  the unified `lightPdf` reconstruction consistent with whatever pkg120 landed, but
+  does not itself change MIS weighting.
+- **Not new light types or new sampling strategies.** Only unifies the existing
+  emissive-geometry and dedicated-`Light` paths under one interface.
+- **Not removing the emission-on-hit material behavior.** A BSDF ray that hits an
+  emissive face still gets its `Le` from the material; only the **NEE sampling** of
+  that emitter moves to the `Light` interface.
+- **Not GoniometricLight / ProjectionLight / portal lights.** Those remain pkg89
+  follow-ups (`pkg89-dedicated-lights.md` Non-goals) independent of unification.
+- **Not re-blessing reference images.** If the unified path shifts any reference
+  beyond noise, produce an owner-visible list (as pkg122 does); do not re-bless.
+
+---
+
+## Provenance
+
+Filed as **pkg89 Phase C**, deferred from the start of pkg89 as a "separate future
+package, unfiled" (`pkg89-dedicated-lights.md:76, 92-95, 105-106`). The unification
+target — wrap emissive triangles as `Light`, make `DiffuseLight`/`Emissive`
+materials shims, retire the `Hittable` light virtuals — is specified there. The
+dependency on pkg122 is grounded in the pkg89 GAP-2 energy audit
+(`.astroray_plan/docs/pkg89-energy-audit-2026-07.md`), which found the dedicated and
+geometry `diffuse_light` emitters share the disputed `RGBIlluminantSpectrum`
+convention that pkg122 adjudicates: the energy/convention contract must be frozen
+before the two sampling paths are merged into one.
+
+---
+
+## Progress
+
+- [ ] A — mesh-emitter `Light` (emissive-triangle wrapper), cached area, pkg122 measure.
+- [ ] B — `DiffuseLight` / `Emissive` materials as thin shims registering the wrapper.
+- [ ] C — retire/minimize the seven `Hittable` light virtuals; call-site sweep.
+- [ ] D — unify `LightList::sample` + light tree + five integrator NEE sites.
+- [ ] E — GPU mesh-emitter mirror; GPU==CPU parity on a mixed scene.
+
+---
+
+## Lessons
+
+*(Fill in after the package is done.)*


### PR DESCRIPTION
Four open Track-A package specs from the 2026-07 statistical-correctness pass. Docs-only; no STATUS/ROADMAP changes.

| Pkg | Scope | Effort | Depends on |
|---|---|---|---|
| **pkg123** (highest priority) | Adjudicate the Disney specular-lobe `sample()`/`pdf()` shape mismatch that pkg121's **merged** xfail chi² gates (`tests/statistical/test_chi2_bsdf.py`) document; per-cell residual maps localize it; fix engine or harness with evidence; extend the harness to a full-sphere domain so glass/transmission is testable; document the near-delta roughness floor; un-xfail the gates. | M | pkg121 (landed, #485) |
| **pkg124** | Replace the Disney reflection lobe's NDF-sample-then-reflect with visible-NDF sampling (Heitz 2018; Cycles `bsdf_microfacet.h`). Motivated by pkg121's measured ~25% dead samples at roughness 1. Reuses in-tree VNDF machinery already on the transmission path. | M | pkg123 |
| **pkg125** (small chip) | CPU `path_tracer` ignores `set_wavelength_range` (renders NIR/UV as visible RGB) — found during pkg55-C3. Honor the band like `multiwavelength_path_tracer`, or reject it loudly. Both options presented; A recommended. | S | none |
| **pkg126** | pkg89 Phase C: unify dedicated + emissive-geometry lights under one `Light` sampling interface; retire the seven `Hittable` light virtuals. | L | pkg122 |

Every code/doc anchor cited was read and verified against the tree (Disney `sample`/`pdf` at `disney.cpp:496-546`, `spectral_path_tracer.cpp:165-166`+`:612`, `LightList`/`dedicatedLights` at `raytracer.h:1241-1313`, Hittable light virtuals at `raytracer.h:762-768`). §6 citations name the reference files/licenses in each spec.

Note for reviewers: a concurrent shared-worktree commit briefly bundled these four with pkg127–137; this branch is reset to contain **exactly** the four pkg123–126 files. The bundle is preserved under tag `rescue/pkg123-137-tangle` for the other doc-PR agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)