### PR TITLE
feat(pkg55-C6a): ReSTIR reservoir SoA infrastructure

### DIFF
--- a/include/astroray/gpu_wavefront_state.h
+++ b/include/astroray/gpu_wavefront_state.h
@@ -130,6 +130,35 @@ struct GPUWavefrontState {
     float*    photon_xyz_y    = nullptr;
     float*    photon_xyz_z    = nullptr;
 
+    // pkg55-C6 / pkg24: ReSTIR reservoir SoA (double-buffered via persistent
+    // WfContext, swapped per frame). Layout mirrors Reservoir<ReSTIRCandidate>
+    // + PixelHistory per plan §5. Each array has length `numPixels` (NOT
+    // capacity — these are per-pixel, not per-path-slot). The driver allocates
+    // two copies (current + previous) and swaps device pointers per frame.
+    //
+    // Selected candidate y (ReSTIRCandidate, from light_sample.h):
+    float*    res_y_pos_x       = nullptr;  // candidate.position
+    float*    res_y_pos_y       = nullptr;
+    float*    res_y_pos_z       = nullptr;
+    float*    res_y_normal_x    = nullptr;  // candidate.normal
+    float*    res_y_normal_y    = nullptr;
+    float*    res_y_normal_z    = nullptr;
+    float*    res_y_emission_x  = nullptr;  // candidate.emission (RGB)
+    float*    res_y_emission_y  = nullptr;
+    float*    res_y_emission_z  = nullptr;
+    float*    res_y_pdf         = nullptr;  // candidate.pdf
+    float*    res_y_distance    = nullptr;  // candidate.distance
+    // Reservoir bookkeeping (Bitterli 2020):
+    float*    res_w_sum         = nullptr;  // Reservoir.w_sum
+    int*      res_M             = nullptr;  // Reservoir.M
+    float*    res_W             = nullptr;  // Reservoir.W (final RIS weight)
+    // PixelHistory (temporal-validity gate, frame_state.h):
+    float*    meta_normal_x     = nullptr;  // PixelHistory.normal
+    float*    meta_normal_y     = nullptr;
+    float*    meta_normal_z     = nullptr;
+    float*    meta_depth        = nullptr;  // PixelHistory.depth
+    int*      meta_valid        = nullptr;  // PixelHistory.valid (0/1)
+
     // Path-continuation flags.
     int*      was_specular  = nullptr;  // 0/1
     int*      path_alive    = nullptr;  // 0 = terminated, 1 = active

--- a/include/astroray/restir/frame_state.h
+++ b/include/astroray/restir/frame_state.h
@@ -40,8 +40,11 @@ struct PixelHistory {
 
 // Flat, pixel-indexed buffer of reservoirs plus per-pixel history metadata.
 // Indexing: pixel (x, y) maps to index y * width + x.
+//
+// pkg55-C6: Use the explicit std::mt19937-specialized reservoir type (the
+// type alias is backward compat so this struct doesn't need to change).
 struct ReservoirBuffer {
-    std::vector<Reservoir<ReSTIRCandidate>> reservoirs;
+    std::vector<Reservoir<ReSTIRCandidate, std::mt19937>> reservoirs;
     std::vector<PixelHistory>               history;
     int width  = 0;
     int height = 0;
@@ -49,12 +52,12 @@ struct ReservoirBuffer {
     void resize(int w, int h) {
         width  = w;
         height = h;
-        reservoirs.assign(static_cast<size_t>(w * h), Reservoir<ReSTIRCandidate>{});
+        reservoirs.assign(static_cast<size_t>(w * h), Reservoir<ReSTIRCandidate, std::mt19937>{});
         history.assign(static_cast<size_t>(w * h), PixelHistory{});
     }
 
-    Reservoir<ReSTIRCandidate>&       at(int x, int y)       { return reservoirs[y * width + x]; }
-    const Reservoir<ReSTIRCandidate>& at(int x, int y) const { return reservoirs[y * width + x]; }
+    Reservoir<ReSTIRCandidate, std::mt19937>&       at(int x, int y)       { return reservoirs[y * width + x]; }
+    const Reservoir<ReSTIRCandidate, std::mt19937>& at(int x, int y) const { return reservoirs[y * width + x]; }
 
     PixelHistory&       meta(int x, int y)       { return history[y * width + x]; }
     const PixelHistory& meta(int x, int y) const { return history[y * width + x]; }
@@ -64,7 +67,7 @@ struct ReservoirBuffer {
     }
 
     void clear() {
-        std::fill(reservoirs.begin(), reservoirs.end(), Reservoir<ReSTIRCandidate>{});
+        std::fill(reservoirs.begin(), reservoirs.end(), Reservoir<ReSTIRCandidate, std::mt19937>{});
         std::fill(history.begin(),    history.end(),    PixelHistory{});
     }
 };

--- a/include/astroray/restir/reservoir.h
+++ b/include/astroray/restir/reservoir.h
@@ -1,9 +1,9 @@
 #pragma once
 
-// ReSTIR reservoir core (pkg20).
+// ReSTIR reservoir core (pkg20, refactored pkg55-C6).
 //
-// Header-only Reservoir<T> implementing the weighted reservoir sampling update
-// and merge rules from Bitterli et al. 2020, "Spatiotemporal reservoir
+// Header-only Reservoir<T,TRng> implementing the weighted reservoir sampling
+// update and merge rules from Bitterli et al. 2020, "Spatiotemporal reservoir
 // resampling for real-time ray tracing with dynamic direct lighting."
 //
 // Terminology matches the paper:
@@ -12,7 +12,18 @@
 //   W      — final RIS weight (set by finalizeWeight)
 //   y      — currently selected candidate
 //
-// The caller injects randomness via std::mt19937&; the reservoir owns no RNG.
+// pkg55-C6: Template over RNG type (TRng) per spec decision #9 (one-generator
+// rule). The CPU `restir_di` uses `std::mt19937`; the GPU wavefront uses
+// `WavefrontRNG`. Templated functions are __host__ __device__, callable from
+// both CPU and CUDA kernels. CPU callers still pass `std::mt19937&` via the
+// explicit `Reservoir<T,std::mt19937>` instantiation; GPU callers instantiate
+// `Reservoir<T,WavefrontRNG>` and draw via the ADL-dispatched `rng_uniform`.
+//
+// References:
+//   - Bitterli et al. 2020 (DOI 10.1145/3386569.3392481), Algorithm 1–2
+//   - DQLin/ReSTIR_PT (BSD-3-Clause, NVIDIA), reservoir structure
+//   - pkg55 Phase C plan §5 (one-generator rule)
+//
 // Weights that are NaN, infinite, or negative are treated as zero: M is still
 // incremented (the candidate was seen) but cannot displace the selected sample.
 
@@ -20,15 +31,25 @@
 #include <limits>
 #include <random>
 
+// Host-side ADL dispatch for std::mt19937 (inlined in the header so CPU TUs
+// don't need to see device code).
+inline float rng_uniform(std::mt19937& gen) {
+    std::uniform_real_distribution<float> u01(0.0f, 1.0f);
+    return u01(gen);
+}
+
 namespace astroray::restir {
 
-template <typename T>
+template <typename T, typename TRng>
 struct Reservoir {
     T     y{};      // selected candidate
     float w_sum{};  // sum of candidate weights
     int   M{};      // candidates seen
     float W{};      // final RIS weight
 
+#ifdef __CUDACC__
+    __host__ __device__
+#endif
     void reset() {
         y     = T{};
         w_sum = 0.0f;
@@ -38,13 +59,26 @@ struct Reservoir {
 
     // Weighted reservoir update (Algorithm 1, Bitterli 2020).
     // w < 0, NaN, or Inf is clamped to 0: M still increments.
-    void update(const T& x, float w, std::mt19937& gen) {
+    //
+    // pkg55-C6: Template-RNG arc — TRng can be std::mt19937 (CPU) or
+    // WavefrontRNG (GPU). The uniform draw is dispatched via ADL-based
+    // `rng_uniform(gen)`, where:
+    //   - CPU: rng_uniform(std::mt19937&) is defined above (inline header func)
+    //   - GPU: rng_uniform(WavefrontRNG&) is defined in the wavefront headers
+    //          (device-only, so not visible here — ADL picks it up in caller TU)
+#ifdef __CUDACC__
+    __host__ __device__
+#endif
+    void update(const T& x, float w, TRng& gen) {
+#ifdef __CUDA_ARCH__
+        if (!isfinite(w) || w < 0.0f) w = 0.0f;
+#else
         if (!std::isfinite(w) || w < 0.0f) w = 0.0f;
+#endif
         w_sum += w;
         M     += 1;
         if (w_sum > 0.0f) {
-            std::uniform_real_distribution<float> u01(0.0f, 1.0f);
-            if (u01(gen) < w / w_sum)
+            if (rng_uniform(gen) < w / w_sum)
                 y = x;
         }
     }
@@ -52,7 +86,10 @@ struct Reservoir {
     // Combine another reservoir into this one (Algorithm 2, Bitterli 2020).
     // target_pdf_other_y is p_hat evaluated at other.y in the current domain.
     // Caller must call finalizeWeight after all merges are done.
-    void merge(const Reservoir<T>& other, float target_pdf_other_y, std::mt19937& gen) {
+#ifdef __CUDACC__
+    __host__ __device__
+#endif
+    void merge(const Reservoir<T,TRng>& other, float target_pdf_other_y, TRng& gen) {
         int combined_M = M + other.M;
         update(other.y, other.W * target_pdf_other_y * static_cast<float>(other.M), gen);
         M = combined_M;  // override: paper sets M = sum(M_i), not M + 1
@@ -61,6 +98,9 @@ struct Reservoir {
     // Compute the final RIS weight W = w_sum / (p_hat(y) * M).
     // Call once after all updates/merges are complete.
     // Returns 0 if M == 0 or target_pdf_y <= 0 (avoids division by zero).
+#ifdef __CUDACC__
+    __host__ __device__
+#endif
     void finalizeWeight(float target_pdf_y) {
         if (M == 0 || !(target_pdf_y > 0.0f))
             W = 0.0f;
@@ -68,5 +108,10 @@ struct Reservoir {
             W = w_sum / (target_pdf_y * static_cast<float>(M));
     }
 };
+
+// Type alias for CPU uses (backward compat — existing code references
+// `Reservoir<ReSTIRCandidate>` without the RNG template parameter).
+template <typename T>
+using ReservoirMT19937 = Reservoir<T, std::mt19937>;
 
 } // namespace astroray::restir

--- a/include/astroray/sampling/wavefront_rng_device.h
+++ b/include/astroray/sampling/wavefront_rng_device.h
@@ -144,6 +144,23 @@ private:
     }
 };
 
+// pkg55-C6: ADL-visible uniform-draw overload for astroray::restir::Reservoir
+// <T, TRng> (restir/reservoir.h). Reservoir::update()/merge() call the
+// dependent, unqualified name `rng_uniform(gen)`; under strict two-phase
+// lookup (GCC/nvcc, enforced by CI's cuda-syntax-check) a dependent call in a
+// template is resolved at instantiation ONLY via ADL on the argument's
+// associated namespaces — for `WavefrontRNG` that is exactly this namespace,
+// `astroray`, and nothing else (NOT the global namespace, regardless of
+// where a same-signature overload happens to be declared there). This
+// overload must therefore live here, next to the type, not in a consuming
+// .cu file. (MSVC's non-conformant, lenient template lookup re-resolves
+// unqualified names at instantiation almost as if ADL searched everywhere,
+// which is why a global-namespace overload in a .cu file compiled locally
+// but failed nvcc/GCC's CI syntax check — see PR #497.)
+WF_RNG_HD inline float rng_uniform(WavefrontRNG& rng) {
+    return rng.Uniform();
+}
+
 }  // namespace astroray
 
 #endif  // ASTRORAY_SAMPLING_WAVEFRONT_RNG_DEVICE_H

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -3686,7 +3686,7 @@ PYBIND11_MODULE(astroray, m) {
     // Exposed only for unit testing; not part of the production API.
     // -----------------------------------------------------------------------
     struct FloatReservoir {
-        astroray::restir::Reservoir<float> res;
+        astroray::restir::Reservoir<float, std::mt19937> res;
         std::mt19937 rng;
         explicit FloatReservoir(uint32_t seed = 42) : rng(seed) {}
         void   update(float x, float w)                           { res.update(x, w, rng); }

--- a/plugins/integrators/restir_di.cpp
+++ b/plugins/integrators/restir_di.cpp
@@ -191,7 +191,7 @@ public:
 
             // Direct lighting: RIS initial sampling + optional temporal/spatial reuse.
             if (!rec.isDelta && !lights.empty()) {
-                Reservoir<ReSTIRCandidate> res;
+                Reservoir<ReSTIRCandidate, std::mt19937> res;
 
                 // --- Initial sampling (Algorithm 1) ---
                 // Use RGB luminance (wavelength-independent) so W values are
@@ -223,7 +223,7 @@ public:
                     if (useTemporal_) {
                         if (isTemporallyValid(frameState_.previous, px, py,
                                               rec.normal, rec.t)) {
-                            const Reservoir<ReSTIRCandidate>& prev =
+                            const Reservoir<ReSTIRCandidate, std::mt19937>& prev =
                                 frameState_.previous.at(px, py);
                             float pHatPrev = prev.y.targetLuminanceRGB();
                             res.merge(prev, pHatPrev, gen);
@@ -243,7 +243,7 @@ public:
                             if (!isTemporallyValid(frameState_.previous, nx, ny,
                                                    rec.normal, rec.t))
                                 continue;
-                            const Reservoir<ReSTIRCandidate>& nbr =
+                            const Reservoir<ReSTIRCandidate, std::mt19937>& nbr =
                                 frameState_.previous.at(nx, ny);
                             float pHatNbr = nbr.y.targetLuminanceRGB();
                             res.merge(nbr, pHatNbr, gen);

--- a/src/gpu/wavefront/stage_restir.cu
+++ b/src/gpu/wavefront/stage_restir.cu
@@ -19,20 +19,20 @@
 #include "astroray/restir/reservoir.h"
 #include "astroray/restir/light_sample.h"
 #include "astroray/sampling/wavefront_rng_device.h"  // astroray::WavefrontRNG
+                                                       // + ADL rng_uniform() overload
 #include <cuda_runtime.h>
 #include <curand_kernel.h>
 
-// Device-side WavefrontRNG uniform draw (ADL dispatch for the templated
-// Reservoir). The CPU side has rng_uniform(std::mt19937&) in reservoir.h;
-// this is the GPU twin. WavefrontRNG lives in the ::astroray namespace (NOT
-// astroray::wavefront — see wavefront_rng_device.h), so this overload must
-// also be found via ADL from that namespace. Mirrors stage_advance.cu:64
-// (gpu_rng_uniform(WavefrontRNG*) — this is the by-reference twin for the
-// Reservoir template, a distinct name so it does not collide with the
-// existing gpu_rng_uniform overload set used by the material samplers).
-__device__ inline float rng_uniform(astroray::WavefrontRNG& rng) {
-    return rng.Uniform();
-}
+// NOTE: the WavefrontRNG uniform-draw overload consumed by
+// astroray::restir::Reservoir<T, WavefrontRNG>::update()/merge() (the
+// dependent, ADL-only name `rng_uniform(gen)` in reservoir.h) is declared in
+// `astroray/sampling/wavefront_rng_device.h`, inside `namespace astroray` —
+// NOT here. Strict two-phase lookup (GCC/nvcc, enforced by CI's
+// cuda-syntax-check) resolves that dependent call via ADL on the argument's
+// associated namespaces only, which for `astroray::WavefrontRNG` is exactly
+// `astroray`. A global-namespace overload declared in THIS .cu file compiled
+// under MSVC's lenient template lookup but is invisible to ADL under GCC —
+// see PR #497 for the failure + fix.
 
 namespace astroray::wavefront {
 

--- a/src/gpu/wavefront/stage_restir.cu
+++ b/src/gpu/wavefront/stage_restir.cu
@@ -18,21 +18,29 @@
 #include "astroray/gpu_types.h"
 #include "astroray/restir/reservoir.h"
 #include "astroray/restir/light_sample.h"
+#include "astroray/sampling/wavefront_rng_device.h"  // astroray::WavefrontRNG
 #include <cuda_runtime.h>
 #include <curand_kernel.h>
 
 // Device-side WavefrontRNG uniform draw (ADL dispatch for the templated
-// Reservoir). The CPU side has rng_uniform(std::mt19937&) in the header;
-// this is the GPU twin. Mirrors stage_advance.cu:60-62 (PCG32 draw).
-__device__ inline float rng_uniform(astroray::wavefront::WavefrontRNG& rng) {
-    return rng.uniformFloat();  // WavefrontRNG::uniformFloat defined elsewhere
+// Reservoir). The CPU side has rng_uniform(std::mt19937&) in reservoir.h;
+// this is the GPU twin. WavefrontRNG lives in the ::astroray namespace (NOT
+// astroray::wavefront — see wavefront_rng_device.h), so this overload must
+// also be found via ADL from that namespace. Mirrors stage_advance.cu:64
+// (gpu_rng_uniform(WavefrontRNG*) — this is the by-reference twin for the
+// Reservoir template, a distinct name so it does not collide with the
+// existing gpu_rng_uniform overload set used by the material samplers).
+__device__ inline float rng_uniform(astroray::WavefrontRNG& rng) {
+    return rng.Uniform();
 }
 
 namespace astroray::wavefront {
 
-// Forward decl of WavefrontRNG (defined in the GPU wavefront headers, not
-// duplicated here to avoid include-order issues).
-struct WavefrontRNG;
+// WavefrontRNG is astroray::WavefrontRNG (sampling/wavefront_rng_device.h),
+// not a member of this namespace. Pull it in via a using-declaration instead
+// of a (wrong) forward decl, so unqualified `WavefrontRNG` below resolves to
+// the real type instead of shadowing it with an incomplete stub.
+using ::astroray::WavefrontRNG;
 
 // Device-side ReSTIRCandidate helper (mirrors light_sample.h but device-callable).
 // The CPU side uses Vec3 (not device-callable); this uses GVec3.
@@ -96,11 +104,14 @@ __global__ void stageRestirInitialRISKernel(
     // Reconstruct per-pixel RNG from the path slot (assuming slot = pixelIdx at
     // bounce 0; this is a simplification — the driver passes the mapping).
     // TODO C6b: thread the correct pixel→slot mapping from the driver.
-    WavefrontRNG rng;
-    rng.pixel     = state.rng_pixel[pixelIdx];
-    rng.sample    = state.rng_sample[pixelIdx];
-    rng.dimension = state.rng_dimension[pixelIdx];
-    rng.seed      = state.rng_seed[pixelIdx];
+    // WavefrontRNG has no default constructor (wavefront_rng_device.h:72) and
+    // pixel_/sample_/seed_ are private with no setters — resume via the
+    // (pixel, sample, seed) constructor + setDimension() (the one mutable
+    // field), mirroring the carried-live-RNG convention used elsewhere in the
+    // wavefront (e.g. stage_advance.cu).
+    WavefrontRNG rng(state.rng_pixel[pixelIdx], state.rng_sample[pixelIdx],
+                      state.rng_seed[pixelIdx]);
+    rng.setDimension(state.rng_dimension[pixelIdx]);
 
     // --- Initial sampling (Algorithm 1) ---
     // For C6a: stub loop (no lights sampled). C6b wires light_tree or light list.
@@ -134,7 +145,7 @@ __global__ void stageRestirInitialRISKernel(
     state.res_W[pixelIdx]            = res.W;
 
     // Write back RNG state (dimension counter advanced by uniform draws).
-    state.rng_dimension[pixelIdx] = rng.dimension;
+    state.rng_dimension[pixelIdx] = rng.dimension();
 }
 
 void launchStageRestirInitialRIS(

--- a/src/gpu/wavefront/stage_restir.cu
+++ b/src/gpu/wavefront/stage_restir.cu
@@ -1,0 +1,253 @@
+// stage_restir.cu — pkg55-C6: ReSTIR reservoir SoA + reuse stages on GPU wavefront
+//
+// Implements ReSTIR-DI on the GPU wavefront following the plan §5:
+//   1. Initial RIS stage — draw numCandidates light samples, reservoir update
+//   2. Temporal reuse stage — merge previous frame's reservoir (validity-gated)
+//   3. Spatial reuse stage — merge spatial neighbours from previous frame
+//   4. Resolve stage — finalize weight, shadow ray, accumulate contribution
+//
+// References:
+//   - Bitterli et al. 2020 (ReSTIR DI), DOI 10.1145/3386569.3392481
+//   - DQLin/ReSTIR_PT (BSD-3-Clause, NVIDIA), reservoir/reuse structure
+//   - pkg55 Phase C plan §5 (one-generator rule, double-buffered SoA layout)
+//   - CPU reference: plugins/integrators/restir_di.cpp (mirrored)
+//
+// pkg55-C6a scope (this session): Initial RIS + resolve (temporal/spatial in C6b).
+
+#include "astroray/gpu_wavefront_state.h"
+#include "astroray/gpu_types.h"
+#include "astroray/restir/reservoir.h"
+#include "astroray/restir/light_sample.h"
+#include <cuda_runtime.h>
+#include <curand_kernel.h>
+
+// Device-side WavefrontRNG uniform draw (ADL dispatch for the templated
+// Reservoir). The CPU side has rng_uniform(std::mt19937&) in the header;
+// this is the GPU twin. Mirrors stage_advance.cu:60-62 (PCG32 draw).
+__device__ inline float rng_uniform(astroray::wavefront::WavefrontRNG& rng) {
+    return rng.uniformFloat();  // WavefrontRNG::uniformFloat defined elsewhere
+}
+
+namespace astroray::wavefront {
+
+// Forward decl of WavefrontRNG (defined in the GPU wavefront headers, not
+// duplicated here to avoid include-order issues).
+struct WavefrontRNG;
+
+// Device-side ReSTIRCandidate helper (mirrors light_sample.h but device-callable).
+// The CPU side uses Vec3 (not device-callable); this uses GVec3.
+struct GReSTIRCandidate {
+    GVec3  position;
+    GVec3  normal;
+    GVec3  emission;  // RGB
+    float  pdf;
+    float  distance;
+
+    __device__ GReSTIRCandidate()
+        : position{0,0,0}, normal{0,0,1}, emission{0,0,0}, pdf(0), distance(0) {}
+
+    __device__ bool isValid() const {
+        return pdf > 0.0f && isfinite(pdf);
+    }
+
+    // Target function: RGB luminance (wavelength-independent, matches CPU).
+    __device__ float targetLuminanceRGB() const {
+        return 0.2126f * emission.x + 0.7152f * emission.y + 0.0722f * emission.z;
+    }
+
+    // Construct from a light sample (mirrors ReSTIRCandidate::fromLightSample).
+    // This is a placeholder — the real implementation samples lights via
+    // gpu_nee_sample or the existing light sampler. For C6a, we'll start with
+    // a simple stub that returns a zero candidate (no lights sampled yet).
+    __device__ static GReSTIRCandidate fromLightSample(/* TODO: light sample args */) {
+        GReSTIRCandidate c;
+        // Stub for C6a: no light sampling wired yet. C6b will fill this.
+        return c;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Initial RIS stage (Algorithm 1, Bitterli 2020)
+// ---------------------------------------------------------------------------
+//
+// For each pixel, draw numCandidates light samples and feed into a reservoir.
+// Writes the finalized reservoir to current_res_* SoA.
+//
+// NOTE (C6a scope): This is a skeleton. The full implementation needs:
+//   - Light sampling via gpu_nee_sample or light tree pick
+//   - Proper GReSTIRCandidate construction from light samples
+//   - Integration with the wavefront driver (called after primary hit)
+//
+// C6a delivers the SoA layout + kernel structure; light sampling is the next step.
+
+__global__ void stageRestirInitialRISKernel(
+    GPUWavefrontState state,
+    int numCandidates,
+    int numPixels)
+{
+    int pixelIdx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (pixelIdx >= numPixels) return;
+
+    // Local reservoir (GPU instantiation of Reservoir<GReSTIRCandidate, WavefrontRNG>).
+    using ResType = ::astroray::restir::Reservoir<GReSTIRCandidate, WavefrontRNG>;
+    ResType res;
+    res.reset();
+
+    // Reconstruct per-pixel RNG from the path slot (assuming slot = pixelIdx at
+    // bounce 0; this is a simplification — the driver passes the mapping).
+    // TODO C6b: thread the correct pixel→slot mapping from the driver.
+    WavefrontRNG rng;
+    rng.pixel     = state.rng_pixel[pixelIdx];
+    rng.sample    = state.rng_sample[pixelIdx];
+    rng.dimension = state.rng_dimension[pixelIdx];
+    rng.seed      = state.rng_seed[pixelIdx];
+
+    // --- Initial sampling (Algorithm 1) ---
+    // For C6a: stub loop (no lights sampled). C6b wires light_tree or light list.
+    for (int i = 0; i < numCandidates; ++i) {
+        GReSTIRCandidate cand = GReSTIRCandidate::fromLightSample(/* TODO */);
+        if (cand.pdf <= 0.0f || !isfinite(cand.pdf)) continue;
+        float pHat = cand.targetLuminanceRGB();
+        res.update(cand, pHat / cand.pdf, rng);
+    }
+
+    // M-cap (Bitterli §5.2): cap at 20×M to prevent history build-up.
+    // TODO C6b: make mCap configurable via driver param.
+    int effectiveMCap = 20 * numCandidates;
+    res.M = min(res.M, effectiveMCap);
+
+    // Write reservoir SoA (current frame).
+    // NOTE: GReSTIRCandidate.position/normal/emission are GVec3 (3 floats).
+    state.res_y_pos_x[pixelIdx]      = res.y.position.x;
+    state.res_y_pos_y[pixelIdx]      = res.y.position.y;
+    state.res_y_pos_z[pixelIdx]      = res.y.position.z;
+    state.res_y_normal_x[pixelIdx]   = res.y.normal.x;
+    state.res_y_normal_y[pixelIdx]   = res.y.normal.y;
+    state.res_y_normal_z[pixelIdx]   = res.y.normal.z;
+    state.res_y_emission_x[pixelIdx] = res.y.emission.x;
+    state.res_y_emission_y[pixelIdx] = res.y.emission.y;
+    state.res_y_emission_z[pixelIdx] = res.y.emission.z;
+    state.res_y_pdf[pixelIdx]        = res.y.pdf;
+    state.res_y_distance[pixelIdx]   = res.y.distance;
+    state.res_w_sum[pixelIdx]        = res.w_sum;
+    state.res_M[pixelIdx]            = res.M;
+    state.res_W[pixelIdx]            = res.W;
+
+    // Write back RNG state (dimension counter advanced by uniform draws).
+    state.rng_dimension[pixelIdx] = rng.dimension;
+}
+
+void launchStageRestirInitialRIS(
+    GPUWavefrontState& state,
+    int numCandidates,
+    int numPixels)
+{
+    int threadsPerBlock = 256;
+    int numBlocks = (numPixels + threadsPerBlock - 1) / threadsPerBlock;
+    stageRestirInitialRISKernel<<<numBlocks, threadsPerBlock>>>(
+        state, numCandidates, numPixels);
+    cudaDeviceSynchronize();  // TODO: async in production
+}
+
+// ---------------------------------------------------------------------------
+// Resolve stage — finalize weight, shadow ray, accumulate
+// ---------------------------------------------------------------------------
+//
+// For each pixel with a valid reservoir (W > 0, y.isValid()), cast a shadow
+// ray to the selected light sample. If unoccluded, evaluate BSDF and accumulate
+// the weighted contribution to state.color.
+//
+// C6a scope: skeleton only (no BVH occlusion test or BSDF eval wired yet).
+
+__global__ void stageRestirResolveKernel(
+    GPUWavefrontState state,
+    int numPixels,
+    const GBVHNode*   d_bvhNodes,
+    const GPrimitive* d_prims,
+    const GTriangle*  d_tris,
+    const GSphere*    d_spheres,
+    const GMaterial*  d_materials)
+{
+    int pixelIdx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (pixelIdx >= numPixels) return;
+
+    // Read reservoir from SoA.
+    GReSTIRCandidate y;
+    y.position.x = state.res_y_pos_x[pixelIdx];
+    y.position.y = state.res_y_pos_y[pixelIdx];
+    y.position.z = state.res_y_pos_z[pixelIdx];
+    y.normal.x   = state.res_y_normal_x[pixelIdx];
+    y.normal.y   = state.res_y_normal_y[pixelIdx];
+    y.normal.z   = state.res_y_normal_z[pixelIdx];
+    y.emission.x = state.res_y_emission_x[pixelIdx];
+    y.emission.y = state.res_y_emission_y[pixelIdx];
+    y.emission.z = state.res_y_emission_z[pixelIdx];
+    y.pdf        = state.res_y_pdf[pixelIdx];
+    y.distance   = state.res_y_distance[pixelIdx];
+
+    float W = state.res_W[pixelIdx];
+
+    // Guard: skip if reservoir is empty or invalid.
+    if (W <= 0.0f || !y.isValid()) return;
+
+    // Finalize weight: W = w_sum / (pHat(y) * M).
+    // NOTE: The CPU integrator calls finalizeWeight AFTER reuse. For C6a (no
+    // reuse yet), we finalize here. C6b will move finalization after reuse.
+    float pHatY = y.targetLuminanceRGB();
+    int M = state.res_M[pixelIdx];
+    float w_sum = state.res_w_sum[pixelIdx];
+    if (M > 0 && pHatY > 0.0f) {
+        W = w_sum / (pHatY * static_cast<float>(M));
+    } else {
+        W = 0.0f;
+    }
+    state.res_W[pixelIdx] = W;
+
+    if (W <= 0.0f) return;
+
+    // TODO C6b: Recompute direction from shading point (read from hitBufs),
+    // cast shadow ray via gpu_bvh_occluded, eval BSDF, accumulate to color.
+    // For C6a: stub (no accumulation).
+}
+
+void launchStageRestirResolve(
+    GPUWavefrontState& state,
+    GPUWavefrontHitBuffers& hitBufs,
+    int numPixels,
+    const GBVHNode*   d_bvhNodes,
+    const GPrimitive* d_prims,
+    const GTriangle*  d_tris,
+    const GSphere*    d_spheres,
+    const GMaterial*  d_materials)
+{
+    int threadsPerBlock = 256;
+    int numBlocks = (numPixels + threadsPerBlock - 1) / threadsPerBlock;
+    stageRestirResolveKernel<<<numBlocks, threadsPerBlock>>>(
+        state, numPixels, d_bvhNodes, d_prims, d_tris, d_spheres, d_materials);
+    cudaDeviceSynchronize();  // TODO: async in production
+}
+
+// ---------------------------------------------------------------------------
+// Temporal reuse stage (Algorithm 2, Bitterli 2020) — DEFERRED to C6b
+// ---------------------------------------------------------------------------
+//
+// For each pixel, read previous frame's reservoir (validity-gated) and merge
+// into current. Reads from state_prev (separate device pointer set), writes
+// to state_current.
+//
+// C6b will implement this; C6a ships the SoA layout + RIS + resolve structure.
+
+// void launchStageRestirTemporalReuse(...) { /* C6b */ }
+
+// ---------------------------------------------------------------------------
+// Spatial reuse stage (Algorithm 3, Bitterli 2020) — DEFERRED to C6b
+// ---------------------------------------------------------------------------
+//
+// For each pixel, sample N random neighbours from previous frame's buffer,
+// merge valid neighbours into current reservoir.
+//
+// C6b will implement this.
+
+// void launchStageRestirSpatialReuse(...) { /* C6b */ }
+
+} // namespace astroray::wavefront


### PR DESCRIPTION
## Scope: pkg55 Phase C Session C6a (infrastructure only)

This PR implements the **one-generator reservoir refactor + SoA layout** per `.astroray_plan/docs/pkg55-phase-c-plan-2026-07.md` §5. **Sessions C6b (temporal/spatial reuse stages) and full driver integration are deferred** — this establishes the infrastructure the team lead will complete/verify.

## What's in this PR

1. **Reservoir template refactor (one-generator rule):**
   - `Reservoir<T>` → `Reservoir<T, TRng>` (template over RNG type)
   - Functions are `__host__ __device__`, callable from CPU (`std::mt19937`) and GPU (`WavefrontRNG`)
   - ADL-dispatched `rng_uniform(TRng&)` for CPU (std::uniform_real_distribution) and GPU (WavefrontRNG::Uniform)
   - CPU `restir_di.cpp` updated to explicit `Reservoir<ReSTIRCandidate, std::mt19937>` instantiation
   - Backward-compat type alias: `ReservoirMT19937<T>` for CPU code

2. **GPU reservoir SoA layout (GPUWavefrontState):**
   - 20 new SoA fields (res_y_pos_*, res_y_normal_*, res_y_emission_*, res_w_sum, res_M, res_W, meta_*)
   - Layout mirrors `Reservoir<ReSTIRCandidate>` + `PixelHistory` per plan §5
   - Double-buffered (current + previous) via persistent WfContext (to be wired in C6b)
   - Per-pixel arrays (NOT per-path-slot — numPixels length)

3. **Skeleton stage_restir.cu:**
   - `GReSTIRCandidate` device struct (mirrors CPU `ReSTIRCandidate` with GVec3)
   - Initial RIS kernel structure (`stageRestirInitialRISKernel` — INCOMPLETE, light sampling not wired)
   - Resolve kernel structure (`stageRestirResolveKernel` — INCOMPLETE, no shadow ray or BSDF eval yet)
   - Clear TODOs for C6b: temporal reuse, spatial reuse, light sampling, BVH occlusion

## References (CLAUDE.md §6)

- **Bitterli et al. 2020** (ReSTIR DI), DOI 10.1145/3386569.3392481 — Algorithm 1 (RIS update), Algorithm 2 (merge)
- **DQLin/ReSTIR_PT** (BSD-3-Clause, NVIDIA) — reservoir/reuse structure reference (license verified in `.astroray_plan/docs/restir-pt-license-verification.md`)
- **CPU reference:** `plugins/integrators/restir_di.cpp` (mirrored by shared-kernel construction)
- **pkg55 Phase C plan** §5 (one-generator rule + double-buffered SoA layout)

## What I could NOT verify (no CUDA build on this machine)

- **CUDA compilation:** `nvcc` accepts the `__host__ __device__` reservoir template
- **CPU test regression:** existing `test_restir_*.py` still pass with the template refactor
- **Linking:** `stage_restir.cu` symbols resolve, no multiply-defined errors
- **GPU test:** `test_restir_validation.py::TestTemporalVariance::test_temporal_reduces_variance` passes on GPU wavefront (gate for C6 closeout)

## Required next steps (C6b or team lead)

1. **Build verification:**
   ```
   C:\path\to\main\build_cuda_worktree.bat C:/Users/hgcom/OneDrive/Astroray/Astroray_repo/Astroray-pkg55-c6 147cb57
   ```
   Gate: clean CUDA build, no new warnings on `stage_restir.cu`.

2. **CPU regression:**
   ```
   pytest tests/test_restir_*.py -v
   ```
   Gate: all existing CPU ReSTIR tests pass (the template refactor should be transparent).

3. **Complete C6b scope (or separate PR):**
   - Wire `GReSTIRCandidate::fromLightSample` (use `gpu_nee_sample` or light tree pick, mirroring CPU `lights.sample`)
   - Implement `launchStageRestirTemporalReuse` (merge previous reservoir, validity-gated per `isTemporallyValid`)
   - Implement `launchStageRestirSpatialReuse` (sample + merge neighbours via `selectSpatialNeighbors` device twin)
   - Complete `stageRestirResolveKernel` (recompute direction from shading point, `gpu_bvh_occluded`, BSDF eval, accumulate to `state.color`)
   - Allocation helpers: `allocateGPUReservoirSoA(numPixels)` / `freeGPUReservoirSoA()` in `wavefront_state.cu`
   - Driver integration: `cuda_wavefront_render` ReSTIR dispatch path (call RIS → temporal → spatial → resolve at bounce 0)
   - Python bindings: `restir_di.cpp::capabilities()` → `gpuSupported = True` when CUDA + wavefront enabled
   - GPU test gate: `pytest tests/test_restir_validation.py::TestTemporalVariance::test_temporal_reduces_variance -v` with GPU wavefront

4. **Final C6 gate (spec Phase C criterion):**
   ```
   stddev_temporal_gpu < stddev_no_reuse_gpu
   ```
   measured on the GPU wavefront (30 frames, 1 spp/frame, 24×24 cornell box).

## Files touched

- `include/astroray/restir/reservoir.h` — template refactor + `__host__ __device__`
- `include/astroray/restir/frame_state.h` — explicit `Reservoir<T, std::mt19937>` in `ReservoirBuffer`
- `include/astroray/gpu_wavefront_state.h` — 20 new SoA fields (res_*, meta_*)
- `plugins/integrators/restir_di.cpp` — explicit `std::mt19937` template arg
- `src/gpu/wavefront/stage_restir.cu` — NEW, skeleton RIS + resolve kernels

## Strategy note

The spec (`.astroray_plan/docs/pkg55-phase-c-plan-2026-07.md` §3) allows splitting C6 into C6a (SoA + initial RIS) and C6b (temporal + spatial reuse). This PR is **C6a only** — it establishes the one-generator rule and the SoA layout. The team lead will complete C6b stages or delegate to a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)