### PR TITLE
fix(pkg125): CPU path_tracer honors set_wavelength_range

### DIFF
--- a/.astroray_plan/packages/pkg125-cpu-path-tracer-band-awareness.md
+++ b/.astroray_plan/packages/pkg125-cpu-path-tracer-band-awareness.md
@@ -3,7 +3,7 @@
 **Pillar:** 3 (spectral correctness / integrator parity)
 **Track:** A (CPU-only reference integrator; runs on CI)
 **Codex-paste-ready:** no (a small chip, but it carries one owner-facing design choice — honor vs. reject — that wants a recommendation, not a silent pick)
-**Status:** open
+**Status:** done (PR TBD, 2026-07-20 — Option A-minimal implemented; CPU-only test evidence pending build+PR merge)
 **Estimated effort:** S (small — the band-sampling change is a few lines mirroring `multiwavelength_path_tracer`; the larger option (full non-visible NEE reference) is scoped as an explicit stretch, not required)
 **Depends on:** none. Independent of the pkg120/122/123/124 chain. Composes with **pkg55 Phase C** (Session C3) — closing this gives the wavefront the band-aware **NEE** CPU reference that C3 recorded as missing.
 
@@ -132,18 +132,30 @@ Add a CPU test asserting band awareness on `path_tracer`:
 
 ## Acceptance criteria
 
-- [ ] `path_tracer` (`SpectralPathTracer`) either **honors** `set_wavelength_range`
+- [x] `path_tracer` (`SpectralPathTracer`) either **honors** `set_wavelength_range`
       (Option A: reads `lambda_min`/`lambda_max`, samples that band — recommended)
       or **rejects it with a loud warning** (Option B), with the choice recorded.
-- [ ] Band-awareness test: NIR request renders near-black (not visible-RGB), or (B)
+      **Option A-minimal implemented.**
+- [x] Band-awareness test: NIR request renders near-black (not visible-RGB), or (B)
       the warning fires and visible-band is rendered. Cross-checked against
-      `multiwavelength_path_tracer`.
-- [ ] Visible-band render byte-unchanged (no regression to the default path).
-- [ ] If Option A: the out-of-band material convention (profile → profile
+      `multiwavelength_path_tracer`. (`tests/test_pkg125_cpu_path_tracer_band_awareness.py`
+      — implemented, not yet run on hardware; no local build available to the
+      implementer.)
+- [x] Visible-band render byte-unchanged (no regression to the default path).
+      Fallback defaults preserved as `astroray::kLambdaMin`/`kLambdaMax` (360/830 nm,
+      the actual pre-fix implicit defaults — the spec prose above says "[380, 780]",
+      which does not match the real constants in `spectrum.h:26-27`; the
+      implementation follows the real constants to guarantee true no-regression).
+- [x] If Option A: the out-of-band material convention (profile → profile
       reflectance; no profile → 0) is confirmed to already hold; no new material
-      code needed.
-- [ ] Signature/call-site sweep: confirm no other caller relied on `path_tracer`
-      ignoring the band.
+      code needed. (Verified: the honest-black outcome for `path_tracer` actually
+      comes from `SampledSpectrum::toXYZ`'s CIE CMF projection — `sampleTable()`
+      in `src/spectrum.cpp` returns exactly 0 outside [360, 830] — not from the
+      `evalSpectralExt`/profile dispatch, which `path_tracer`'s `pathTraceSpectral`
+      does not use. No material-side change was needed either way.)
+- [x] Signature/call-site sweep: confirm no other caller relied on `path_tracer`
+      ignoring the band. (`lambdaMin_`/`lambdaMax_` are private members of a
+      single-TU class; constructor signature unchanged; grep swept clean — see PR.)
 
 ---
 
@@ -180,12 +192,44 @@ the `lambda_min`/`lambda_max` params `set_wavelength_range` writes
 
 ## Progress
 
-- [ ] Decide A vs B (recommend A-minimal); record the choice.
-- [ ] Implement the band plumbing (or the loud warning).
-- [ ] Band-awareness test + visible-band no-regression.
+- [x] Decide A vs B (recommend A-minimal); record the choice. **A-minimal chosen**,
+      per the spec's own recommendation — no unexpected NEE coupling surfaced.
+- [x] Implement the band plumbing (or the loud warning).
+      `plugins/integrators/spectral_path_tracer.cpp`: constructor reads
+      `lambda_min`/`lambda_max` via `ParamDict::getFloat`, threads them into
+      `SampledWavelengths::sampleUniform` at the `sampleFull` call site.
+- [x] Band-awareness test + visible-band no-regression.
+      `tests/test_pkg125_cpu_path_tracer_band_awareness.py` (4 tests: NIR
+      near-black, NIR agreement with `multiwavelength_path_tracer`, default-band
+      bit-identity, default-band still non-black sanity check).
 
 ---
 
 ## Lessons
 
-*(Fill in after the package is done.)*
+- The spec's own citation for the "honest black" out-of-band convention
+  (`raytracer.h:613-636`, the `evalSpectralExt`/profile-dispatch path) is not
+  actually what `path_tracer` uses — `Renderer::pathTraceSpectral` calls the
+  base (non-`Ext`) `evalSpectral`/`sampleSpectral`, which have no band gating
+  at all. The real mechanism that makes an out-of-visible-band `path_tracer`
+  render collapse to near-black is `SampledSpectrum::toXYZ`'s CIE color-matching
+  function projection: `sampleTable()` (`src/spectrum.cpp`) returns exactly 0
+  for any wavelength outside the baked CMF table's [360, 830] nm support. This
+  is arguably more correct for the minimal-form scope (no profile/Ext wiring
+  needed at all), but it means the spec's code citation for *why* the fix works
+  should be corrected for future readers.
+- The spec's default-band prose ("[380, 780]") does not match the actual
+  compile-time constants (`kLambdaMin`/`kLambdaMax` = 360/830,
+  `spectrum.h:26-27`) that `SampledWavelengths::sampleUniform(u)` used
+  implicitly pre-fix. The implementation preserves the REAL constants as the
+  `getFloat` fallback so the "byte-unchanged default path" acceptance
+  criterion holds against the actual pre-fix binary, not the spec's paraphrase.
+- Separately observed (out of scope for this package, noted for a future
+  chip): the GPU dispatch path in `module/blender_module.cpp`
+  (`cuda_wavefront_render` / megakernel routing) resolves its own
+  `lambda_min`/`lambda_max` defaults as 380/780 when unset — a different
+  default than the CPU `path_tracer`'s 360/830. This CPU/GPU default-band
+  mismatch pre-dates pkg125 and is unaffected by this fix (both sides only
+  diverge when the band is left unset, which is not a supported "compare CPU
+  vs GPU" configuration in the existing parity tests — they all call
+  `set_wavelength_range` explicitly).

--- a/.astroray_plan/packages/pkg125-cpu-path-tracer-band-awareness.md
+++ b/.astroray_plan/packages/pkg125-cpu-path-tracer-band-awareness.md
@@ -3,7 +3,7 @@
 **Pillar:** 3 (spectral correctness / integrator parity)
 **Track:** A (CPU-only reference integrator; runs on CI)
 **Codex-paste-ready:** no (a small chip, but it carries one owner-facing design choice — honor vs. reject — that wants a recommendation, not a silent pick)
-**Status:** done (PR TBD, 2026-07-20 — Option A-minimal implemented; CPU-only test evidence pending build+PR merge)
+**Status:** done (PR #499, 2026-07-20 — Option A-minimal implemented; CPU-only test evidence pending build+PR review)
 **Estimated effort:** S (small — the band-sampling change is a few lines mirroring `multiwavelength_path_tracer`; the larger option (full non-visible NEE reference) is scoped as an explicit stretch, not required)
 **Depends on:** none. Independent of the pkg120/122/123/124 chain. Composes with **pkg55 Phase C** (Session C3) — closing this gives the wavefront the band-aware **NEE** CPU reference that C3 recorded as missing.
 

--- a/plugins/integrators/spectral_path_tracer.cpp
+++ b/plugins/integrators/spectral_path_tracer.cpp
@@ -58,6 +58,12 @@ class SpectralPathTracer : public Integrator {
     bool spectralNewton_;     // default ON for the prism use case
     amf::SMSConfig smsCfg_;
     std::string causticMode_; // pkg111: "none", "sms" (default), or "photon_map"
+    // pkg125: band awareness. Mirrors multiwavelength_path_tracer.cpp:22-23,45-46
+    // — read the wavelength range Renderer::setWavelengthRange wrote into
+    // integratorParams_ ("lambda_min"/"lambda_max", raytracer.h:2160-2162) so
+    // set_wavelength_range is honored instead of silently ignored.
+    float lambdaMin_;
+    float lambdaMax_;
 
     Renderer* renderer_ = nullptr;
     Camera* camera_ = nullptr;  // pkg87b: for Cryptomatte buffer access
@@ -84,7 +90,17 @@ public:
           // pkg111: caustic mode. "sms" is the default (existing SMS behavior).
           // "photon_map" builds a forward light-traced photon map + gathers at
           // diffuse hits. "none" disables caustics entirely.
-          causticMode_(p.getString("caustics", "sms")) {
+          causticMode_(p.getString("caustics", "sms")),
+          // pkg125: mirror multiwavelength_path_tracer.cpp:45-46 — read the
+          // band set_wavelength_range() wrote (module/blender_module.cpp:2160-2162).
+          // Defaults are astroray::kLambdaMin/kLambdaMax (360/830 nm,
+          // spectrum.h:26-27) — the SAME defaults sampleUniform(u) applied
+          // implicitly pre-pkg125 (this file previously called
+          // sampleUniform(dist01(gen)) with no band args). Keeping these as the
+          // getFloat() fallback preserves byte-identical output when
+          // set_wavelength_range was never called (acceptance: no regression).
+          lambdaMin_(p.getFloat("lambda_min", astroray::kLambdaMin)),
+          lambdaMax_(p.getFloat("lambda_max", astroray::kLambdaMax)) {
         smsCfg_.seeds         = p.getInt("sms_seeds", 1);
         smsCfg_.maxIterations = p.getInt("sms_max_iterations", 20);
         smsCfg_.tolerance     = p.getFloat("sms_tolerance", 1e-4f);
@@ -162,8 +178,10 @@ public:
             }
         }
         std::uniform_real_distribution<float> dist01(0.0f, 1.0f);
+        // pkg125: honor set_wavelength_range (lambdaMin_/lambdaMax_), mirroring
+        // multiwavelength_path_tracer.cpp:74-75.
         astroray::SampledWavelengths lambdas =
-            astroray::SampledWavelengths::sampleUniform(dist01(gen));
+            astroray::SampledWavelengths::sampleUniform(dist01(gen), lambdaMin_, lambdaMax_);
         int bounces = 0;
         float weight = 0.0f;
 

--- a/tests/test_pkg125_cpu_path_tracer_band_awareness.py
+++ b/tests/test_pkg125_cpu_path_tracer_band_awareness.py
@@ -1,0 +1,173 @@
+"""pkg125: CPU `path_tracer` (SpectralPathTracer) band awareness.
+
+Regression test for the pkg55-C3 side finding: `path_tracer` ignored
+`set_wavelength_range` and always sampled the compile-time default band
+(`astroray.kLambdaMin`/`kLambdaMax` = 360/830 nm, spectrum.h:26-27), so a
+request for an out-of-visible band (e.g. NIR [800, 900]) silently rendered
+as a normal visible-RGB image instead of the physically-correct near-black
+result.
+
+Fix (Option A-minimal, mirroring multiwavelength_path_tracer.cpp:45-46,
+74-75): `SpectralPathTracer` now reads `lambda_min`/`lambda_max` from its
+`ParamDict` and threads them into `SampledWavelengths::sampleUniform`. No
+new gating logic was added — the "honest black" outcome falls out of the
+existing `SampledSpectrum::toXYZ` -> CIE CMF projection: `sampleTable()`
+(src/spectrum.cpp:36-39) returns exactly 0 for any wavelength outside
+[kLambdaMin, kLambdaMax] = [360, 830], so an NIR-band sample set (mostly
+> 830 nm) collapses to near-zero XYZ regardless of the material's own
+spectral response.
+
+These tests are CPU-only. Skipped entirely if the `astroray` extension
+module is not importable (no build available in this environment).
+"""
+
+import numpy as np
+import pytest
+
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+
+try:
+    import astroray
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray module not available")
+
+
+def _build_scene(width=32, height=32, seed=42):
+    """Simple lit Lambertian sphere scene (mirrors test_multiwavelength.py::_render)."""
+    r = astroray.Renderer()
+    r.setup_camera(
+        look_from=[0, 0, 3], look_at=[0, 0, 0], vup=[0, 1, 0],
+        vfov=40, aspect_ratio=1.0, aperture=0.0, focus_dist=3.0,
+        width=width, height=height,
+    )
+    # Seed 0 is the std::random_device sentinel (non-deterministic) in this
+    # engine (raytracer.h:2803) -- always pin a nonzero seed for determinism.
+    r.set_seed(seed)
+    r.set_background_color([0.1, 0.1, 0.1])
+    mat = r.create_material("lambertian", [0.2, 0.6, 0.2], {})
+    r.add_sphere([0, 0, 0], 1.0, mat)
+    light = r.create_material("light", [1.0, 1.0, 1.0], {"intensity": 10.0})
+    r.add_sphere([0, 2.5, 0], 0.5, light)
+    return r
+
+
+# ---------------------------------------------------------------------------
+# 1. NIR band awareness: path_tracer must render near-black, not visible-RGB.
+# ---------------------------------------------------------------------------
+
+def test_nir_band_path_tracer_near_black():
+    """FAILS on pre-pkg125 main: path_tracer ignores set_wavelength_range and
+    renders the NIR request [800, 900] as a normal visible-RGB image (pkg55-C3
+    measured mean ~0.1331). PASSES after the fix: NIR mostly falls outside the
+    CIE CMF table support (> 830 nm), so the XYZ projection is near-zero,
+    matching the GPU path_tracer's measured band-aware NIR result (~1.8e-4)."""
+    r = _build_scene(seed=42)
+    r.set_wavelength_range(800.0, 900.0)
+    r.set_integrator("path_tracer")
+    pixels = np.array(
+        r.render(samples_per_pixel=16, max_depth=4, apply_gamma=False),
+        dtype=np.float32,
+    )
+    assert np.all(np.isfinite(pixels)), "NIR path_tracer render has non-finite pixels"
+    mean = float(pixels.mean())
+    assert mean < 0.01, (
+        f"NIR path_tracer not near-black: mean={mean:.4f} "
+        "(pre-fix bug renders visible-RGB, pkg55-C3 measured ~0.1331)"
+    )
+
+
+def test_nir_band_path_tracer_agrees_with_multiwavelength():
+    """Cross-check (spec verification gate): once band-aware, path_tracer (NEE)
+    and multiwavelength_path_tracer (naive, already band-aware pre-pkg125)
+    must agree that the NIR band is near-black -- they differ only by NEE
+    presence, not by which wavelengths get sampled."""
+    r_pt = _build_scene(seed=42)
+    r_pt.set_wavelength_range(800.0, 900.0)
+    r_pt.set_integrator("path_tracer")
+    pt_pixels = np.array(
+        r_pt.render(samples_per_pixel=16, max_depth=4, apply_gamma=False),
+        dtype=np.float32,
+    )
+
+    r_mw = _build_scene(seed=42)
+    r_mw.set_wavelength_range(800.0, 900.0)
+    r_mw.set_integrator("multiwavelength_path_tracer")
+    mw_pixels = np.array(
+        r_mw.render(samples_per_pixel=16, max_depth=4, apply_gamma=False),
+        dtype=np.float32,
+    )
+
+    assert np.all(np.isfinite(pt_pixels))
+    assert np.all(np.isfinite(mw_pixels))
+    pt_mean = float(pt_pixels.mean())
+    mw_mean = float(mw_pixels.mean())
+    assert pt_mean < 0.01, f"path_tracer NIR mean not near-black: {pt_mean:.4f}"
+    assert mw_mean < 0.01, f"multiwavelength_path_tracer NIR mean not near-black: {mw_mean:.4f}"
+    # Both near-zero by the same CMF-clamp mechanism -- absolute (not ratio)
+    # comparison, per the MC-noise-vs-deterministic memory: a ratio of two
+    # near-zero means is dominated by MC noise, not physics.
+    assert abs(pt_mean - mw_mean) < 0.01, (
+        f"path_tracer vs multiwavelength_path_tracer NIR means diverge: "
+        f"{pt_mean:.4f} vs {mw_mean:.4f}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Visible-band no-regression: the default (band unset) path is unchanged.
+# ---------------------------------------------------------------------------
+
+def test_visible_band_default_path_unchanged():
+    """No-regression gate: SpectralPathTracer's constructor now reads
+    lambda_min/lambda_max via ParamDict::getFloat(key, astroray.kLambdaMin /
+    kLambdaMax) -- the SAME constants sampleUniform(u) used implicitly
+    pre-pkg125 (this integrator previously called
+    sampleUniform(dist01(gen)) with no explicit band, relying on
+    SampledWavelengths::sampleUniform's own default arguments, spectrum.h:101-103).
+
+    Note: the pkg125 spec prose states the default band is "[380, 780]": the
+    actual compile-time constants (spectrum.h:26-27, exposed as
+    astroray.kLambdaMin/kLambdaMax) are 360/830, not 380/780. This test pins
+    to the REAL constants so it verifies true byte-for-byte no-regression
+    against the pre-fix binary rather than the spec's inexact paraphrase.
+
+    Renders with the band never set, and with the band set explicitly to the
+    default constants, must be bit-identical for the same seed -- proving the
+    fallback wired in by this fix reproduces the pre-fix implicit default."""
+    r_default = _build_scene(seed=7)
+    r_default.set_integrator("path_tracer")
+    default_pixels = np.array(
+        r_default.render(samples_per_pixel=8, max_depth=4, apply_gamma=False),
+        dtype=np.float32,
+    )
+
+    r_explicit = _build_scene(seed=7)
+    r_explicit.set_wavelength_range(astroray.kLambdaMin, astroray.kLambdaMax)
+    r_explicit.set_integrator("path_tracer")
+    explicit_pixels = np.array(
+        r_explicit.render(samples_per_pixel=8, max_depth=4, apply_gamma=False),
+        dtype=np.float32,
+    )
+
+    assert np.array_equal(default_pixels, explicit_pixels), (
+        "path_tracer with no wavelength range set must be bit-identical to "
+        "an explicit set_wavelength_range(kLambdaMin, kLambdaMax) call"
+    )
+
+
+def test_visible_band_render_still_non_black():
+    """Sanity: an ordinary visible-band render (band unset) still produces a
+    lit, non-black image -- the fix must not have broken the default path
+    into an all-black render."""
+    r = _build_scene(seed=42)
+    r.set_integrator("path_tracer")
+    pixels = np.array(
+        r.render(samples_per_pixel=16, max_depth=4, apply_gamma=False),
+        dtype=np.float32,
+    )
+    assert np.all(np.isfinite(pixels))
+    assert np.any(pixels > 0.01), "Default visible-band path_tracer render is unexpectedly black"


### PR DESCRIPTION
## Summary

CPU `path_tracer` (`SpectralPathTracer`) silently ignored `set_wavelength_range`
and always sampled the compile-time default wavelength band, regardless of
what a caller requested. This was the pkg55-C3 side finding: a request for an
NIR band ([800, 900] nm) rendered as a normal visible-RGB image (measured mean
~0.1331) instead of the physically-correct near-black result the already
band-aware GPU `path_tracer` produces (~1.8e-4).

**Option A-minimal** implemented, per the pkg125 spec's own recommendation:
mirror `multiwavelength_path_tracer.cpp`'s existing band plumbing (param read
+ `sampleUniform` args) into `SpectralPathTracer`. No new gating logic, no new
abstractions — this is a 2-site, ~15-line diff in one file.

## Scope

- CPU-only. Does **not** touch any GPU/CUDA code, the wavefront pipeline, or
  shared headers used by other integrators (`include/raytracer.h`'s
  `pathTraceSpectral` is unchanged; the new members are private to the
  single-TU `SpectralPathTracer` class).
- `plugins/integrators/spectral_path_tracer.cpp`:
  - Constructor now reads `lambda_min`/`lambda_max` via `ParamDict::getFloat`,
    falling back to `astroray::kLambdaMin`/`kLambdaMax` (360/830 nm) — the SAME
    defaults `SampledWavelengths::sampleUniform(u)` applied implicitly
    pre-fix, so the unset-band render path is byte-unchanged.
  - `sampleFull`'s `sampleUniform(dist01(gen))` call now threads
    `lambdaMin_`/`lambdaMax_` through, exactly mirroring
    `multiwavelength_path_tracer.cpp:74-75`.
- `tests/test_pkg125_cpu_path_tracer_band_awareness.py` (new, 4 tests):
  1. `test_nir_band_path_tracer_near_black` — NIR [800,900] request renders
     mean < 0.01 (regression test: fails on pre-fix main, which renders
     visible-RGB ~0.1331; passes after the fix).
  2. `test_nir_band_path_tracer_agrees_with_multiwavelength` — cross-check:
     `path_tracer` and `multiwavelength_path_tracer` both near-black on the
     same NIR band (spec's explicit verification-gate requirement).
  3. `test_visible_band_default_path_unchanged` — no-call vs explicit
     `set_wavelength_range(kLambdaMin, kLambdaMax)` render is bit-identical
     (`np.array_equal`), proving the new fallback reproduces the old implicit
     default exactly.
  4. `test_visible_band_render_still_non_black` — sanity floor: default path
     still lit, not accidentally broken to all-black.

## Root-cause / mechanism note (differs from the spec's citation)

The spec cites `raytracer.h:613-636` (`evalSpectralExt`, the profile-aware
dispatch used by `multiwavelength_path_tracer`'s `sampleSpectralExt`) as the
reason out-of-band wavelengths resolve to honest-black. That's not actually
what `path_tracer` uses — `Renderer::pathTraceSpectral` calls the base
(non-`Ext`) `evalSpectral`/`sampleSpectral`, which have no band gating at all.
The real mechanism: `SampledSpectrum::toXYZ`'s CIE color-matching-function
projection. `sampleTable()` (`src/spectrum.cpp:36-39`) returns exactly `0` for
any wavelength outside the baked CMF table's `[360, 830]` nm support, so an
NIR sample set (mostly `> 830` nm) collapses to near-zero XYZ regardless of
material response. This makes the minimal-form fix even smaller than the spec
anticipated (no profile/`Ext` wiring needed), and is recorded in the spec's
Lessons section for future readers.

Also noted (spec-vs-code discrepancy, and out-of-scope pre-existing
divergence) in the spec file's Lessons section:
- The spec's default-band prose says "[380, 780]"; the actual compile-time
  constants are `kLambdaMin`/`kLambdaMax` = 360/830 (`spectrum.h:26-27`). This
  PR preserves the REAL constants as the fallback so "byte-unchanged default
  path" holds against the actual pre-fix binary.
- The GPU dispatch path (`module/blender_module.cpp`) resolves its own
  `lambda_min`/`lambda_max` unset-default as 380/780 — different from the CPU
  default. Pre-existing, unaffected by this fix, out of this package's scope.

## What I could NOT verify locally

I do not have access to a working MSVC/vcvars toolchain in this environment
and could not build the `.pyd`. **I have not run the new tests or any existing
test suite against this change.** All claims above about behavior (near-black
NIR output, bit-identical default path) are derived from static code reading
of `src/spectrum.cpp` (`sampleTable` CMF clamp) and `SampledWavelengths::
sampleUniform`, not from an executed render. Please treat this as
implementation + reasoning, not measured evidence, until the team lead builds
and runs:

```
pytest tests/test_pkg125_cpu_path_tracer_band_awareness.py -v
```

and, for regression coverage on adjacent band-related tests:

```
pytest tests/test_multiwavelength.py tests/test_pkg64_gpu_cpu_parity.py -v
```

(the pkg64-gpu parity tests call `set_wavelength_range(380.0, 780.0)`
explicitly before selecting `path_tracer`/`multiwavelength_path_tracer` — with
this fix, CPU `path_tracer` will now actually sample `[380,780]` instead of
silently using `[360,830]`, which should only IMPROVE CPU/GPU band parity
since the GPU side already honors the explicit band; flagging in case the
existing SSIM/threshold margins need re-checking.)

## Acceptance criteria

- [x] `path_tracer` honors `set_wavelength_range` (Option A-minimal)
- [x] Band-awareness test added, cross-checked against `multiwavelength_path_tracer`
- [x] Visible-band default path preserved byte-for-byte (reasoned, not yet measured)
- [x] Out-of-band material convention confirmed to already hold (via CMF projection, not `evalSpectralExt`)
- [x] Signature/call-site sweep: `lambdaMin_`/`lambdaMax_` are private, single-TU members; constructor signature unchanged; grepped `SpectralPathTracer` repo-wide, only the registry registration and the (unrelated) `wavefront_path_tracer.cpp` decorator reference it, both unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>