### PR TITLE
fix(pkg122): re-derive dedicated-light wattage->radiance vs Cycles (AREA/POINT/SPOT/DISTANT/blackbody)

### DIFF
--- a/.astroray_plan/docs/pkg122-light-energy-calibration-research.md
+++ b/.astroray_plan/docs/pkg122-light-energy-calibration-research.md
@@ -1,0 +1,175 @@
+# pkg122 — Dedicated-light energy calibration: Cycles derivations + evidence
+
+**Author:** pkg122 implementer (Claude)
+**Date:** 2026-07-20
+**Reference oracle:** Blender Cycles, `blender/cycles` `main` branch (fetched
+2026-07-20 via raw.githubusercontent.com). Apache-2.0. Files cited below are the
+`src/kernel/light/*.h` and `src/scene/light.cpp` device-update path.
+**Prior evidence:** `.astroray_plan/docs/pkg89-energy-audit-2026-07.md` (the GAP-2
+audit that measured the per-type errors).
+
+This note records the per-type wattage→radiance derivation against the Cycles
+kernel, so the code changes are cite-and-borrow (CLAUDE.md §6), not invented.
+
+---
+
+## How Astroray consumes a light sample (the estimator the fixes must satisfy)
+
+`Renderer::pathTraceSpectral` (`include/raytracer.h:2477-2496`) NEE block:
+
+```cpp
+lights.sample(ls, rec.point, rec.normal, lambdas, gen);   // ls.emission_spec, ls.pdf
+...
+f_spec = rec.material->evalSpectral(rec, wo, wi, lambdas); // = f_r · cosθ_x (BSDF·cosine)
+L_spec = ls.emission_spec;
+bsdfPdf = rec.material->pdf(rec, wo, wi);                  // SOLID-ANGLE measure
+wt = (ls.pdf² ) / (ls.pdf² + bsdfPdf² + 1e-8);             // MIS power heuristic
+color += throughput · f_spec · L_spec · (wt / (ls.pdf + 1e-3));
+```
+
+Two consequences that pin every fix:
+1. The estimator divides `L_spec / ls.pdf`. So `emission_spec` and `ls.pdf` must
+   be in **one consistent measure**.
+2. `wt` combines `ls.pdf` with `bsdfPdf`, and **`bsdfPdf` is solid-angle**. So
+   `ls.pdf` must **also be solid-angle**, or the MIS weight is unit-inconsistent
+   and the error is size-dependent. The Cycles-calibrated geometry-emitter path
+   (`light_sampler.cpp:64-70`) already returns a solid-angle pdf
+   (`pdfValue(point,dir)`) with plain-radiance emission; the dedicated lights
+   must match that convention.
+
+---
+
+## Defect 1 — AreaLight: mixed-measure pdf (0.13× at size 3, 1.40× small-far)
+
+**Root cause.** `AreaLight::sampleLi` folded a solid-angle geometric factor
+`cosθ_light/dist²` into `emission_spec` (`geometricFactor`) but returned an
+**area-measure** pdf `1/area`. The `L_spec/ls.pdf` divide happens to stay
+numerically correct (the `area` cancels), so the *value* was right — but `ls.pdf`
+being area-measure makes the MIS weight `wt` combine an area-measure `a` with a
+solid-angle `b`. `a = (1/area)·selPdf` shrinks as the light grows, so `wt`
+collapses with size and the NEE contribution is under-weighted → dim, and
+size-dependent (matches the audit's 7.68× vs 1.40×). This is a **measure bug in
+the pdf/MIS**, exactly as the audit concluded; not a missing scalar.
+
+**Cycles reference.** `src/kernel/light/area.h::area_light_sample` /
+`area_light_eval`: emission is **plain radiance**
+`ls->eval_fac = M_1_PI_F * invarea` (= (1/π)·(1/area)), and the pdf is converted
+to **solid angle**:
+`ls->pdf *= light_pdf_area_to_solid_angle(Ng, -ls->D, ls->t)`
+(Jacobian `dist²/cosθ_light`). `src/scene/light.cpp` sets area `invarea = 1/area`.
+
+**Fix.** Keep `emission_spec = eval·intensity·(1/area)·(1/π)` = plain radiance
+`L_e = P/(πA)` (drop the `geometricFactor` fold). Return the **solid-angle** pdf
+`pdf_ω = (1/area)·dist²/cosθ_light`. The `L_spec/pdf` divide reproduces the same
+physical value `f_r·cosθ_x·P·cosθ_light/(π·dist²)` as before, but now `ls.pdf` is
+solid-angle so MIS matches `bsdfPdf` and the geometry-emitter path → size-
+independent. Verified algebraically; live-Cycles ratio pending the team-lead build.
+
+## Defect 2 — PointLight: 1/π instead of 1/(4π) (3.59× ≈ 4× too bright)
+
+**Root cause.** Radius-0 point radiance factor was
+`normalizeFactor_(=1)·kM1PiF(=1/π)` = `1/π`. An isotropic point light of power P
+has radiant intensity **I = P/(4π)** (textbook: P watts over 4π sr). The code used
+`I = P/π`, i.e. **4× too large**. `evalSpectral` supplies `f_r·cosθ_x`, so the
+reflected radiance is `f_r·cosθ_x·eval·(P/π)/d²` vs the analytic
+`ρ·P·cosθ_x/(4π²·d²)` (with `f_r = ρ/π`). Ratio = `eval·4`; with the RGB-white
+`eval` luminance ≈ 0.9 this is 3.6× — the audit's measured 3.59×. Confirmed.
+
+**Cycles reference.** `src/scene/light.cpp` point path: `area = 4π·radius²`,
+`invarea = 1/area`, `eval_fac = invarea·M_1_PI_F`. Combined with the disk pdf
+`invarea_disk = 1/(π·r²)` and `light_pdf_area_to_solid_angle`, the sphere-light
+estimator reduces to intensity `P/(4π)` (the `M_PI` in `area` is the 1/4π source).
+`kernel/light/point.h::point_light_sample`.
+
+**Fix.** Radius-0 point: `emission = eval·intensity·(1/(4π))·(1/d²)`, pdf = 1
+(delta). Removes the factor of 4.
+
+## Defect 3 — Blackbody: no photopic normalization (14.4× bright)
+
+**Root cause.** `evalBlackbody` returned raw `planck(λ,T)·1e9` with **no photopic
+normalization** (and a white-tint short-circuit that skipped even the geometric
+normalize). Its integrated luminance `Y_planck(6500K) ≈ 3.6` (audit:
+blackbody/RGB-white = 14.4/3.59 = 4.01, and RGB-white eval ≈ 0.9 → Y_planck ≈ 3.6).
+So a blackbody light was ≈4× brighter than an equal-intensity RGB light, and —
+compounded with Defect 2's 4× — 14.4× the analytic value. It is **not** blue: the
+audit's own RGB `[21.4, 19.6, 19.7]` is near-neutral (8.4% spread, < G2's 12%);
+the dominant defect is brightness.
+
+**pkg89 Q11 / Cycles reference.** `src/scene/light.cpp::light_normalize_factor`
+divides emission by its **integrated luminance** so artist intensity is stable
+across temperature. `kernel/svm/svm_blackbody.h` precomputes the normalized XYZ.
+
+**Fix.** Normalize the Planck SPD to **unit photopic luminance**:
+`bbNorm(T) = 1 / ∫ planck(λ,T)·1e9·ȳ(λ) dλ`, integrated over the CIE-1964 10°
+`ȳ` support (360–830 nm, 1 nm grid, the SAME `cieCmf1964_10deg` used by
+`SampledSpectrum::toXYZ`). This is **self-consistent**: `E[toXYZ(evalBlackbody).Y]
+= bbNorm·Y_planck = 1` for any T, independent of `planck`'s absolute scale and of
+the wavelength-sampling pdf (the MC `toXYZ` estimator is unbiased for `∫Sȳdλ`).
+Applied on BOTH the white-tint and tinted branches (spec §C). Chromaticity is
+preserved (scalar divide), so 6500 K stays near-neutral (G2). Result: a blackbody
+light has ≈ unit luminance, comparable to an RGB-white light — closing the 14×.
+
+## SpotLight (spec requires re-derivation, not assumed)
+
+**Two bugs.** (a) Same `1/π` intensity error as the point light (should be
+`1/(4π)` — a Blender spot is a point light masked by the cone, same `eval_fac`;
+`kernel/light/spot.h` inherits `spot.eval_fac` from the point path). (b) The
+radius-0 spot returned pdf `1/coneSolidAngle` instead of the **delta** pdf 1, so
+the `L/pdf` divide multiplied brightness by the cone solid angle (cone-angle-
+dependent over-bright). `tests/test_pkg89_phase_b_dedicated_lights.py:229` already
+documents the compensating "intensity cranked 100→320" hack.
+**Fix.** Radius-0 spot mirrors the point light: `emission =
+eval·intensity·(1/(4π))·(1/d²)·coneAtten`, pdf = 1 (delta). Radius>0 uses the
+sphere-sampling pdf `1/(4π·r²)` (same as the point sphere light).
+
+## DistantLight (spec requires re-derivation, not assumed)
+
+**Root cause.** `emission = eval·intensity` with pdf `1/Ω` (Ω = cone solid angle).
+The `L/pdf` divide multiplies by Ω, so a sun of angular size Ω≈6.6e-5 rendered at
+≈6.6e-5× its intended irradiance — effectively black. Blender sun "Strength" is
+irradiance S (W/m²) delivered to a normal surface; the reflected radiance is
+`f_r·cosθ·S`, independent of angular size.
+**Cycles reference.** `src/scene/light.cpp` sun path: `sun.eval_fac = 1/area`,
+`area = π·sin²(θ_half)` = the disk solid angle; the sun's radiance is
+`S·eval_fac = S/Ω`, and sampling the disk with pdf `1/Ω` yields `f_r·cosθ·S`.
+**Fix.** Finite angle: `emission = eval·intensity/Ω`, pdf = `1/Ω` → net irradiance
+`intensity` delivered. Zero angle (delta sun): `emission = eval·intensity`, pdf = 1.
+
+---
+
+## Defect 4 — RGBIlluminant vs RGBUnbounded emission convention: DEFERRED
+
+The spec (§D) says adjudicate this **once against a live headless-Cycles A/B
+render**. This implementer **cannot build the `.pyd`** (no MSVC vcvars for
+subagents) and therefore cannot run the live-Cycles oracle, and the decision can
+**move the 12/13-passing Cycles-parity reference bank** (owner-reserved re-bless).
+Per CLAUDE.md §1 (surface forks, don't pick silently) this convention is **left
+unchanged** (`evalRGB` stays `RGBIlluminantSpectrum`). After Defects 1–3, the
+residual RGB-white absolute level is ≈0.9× analytic — a ~10% effect that is
+exactly the Defect-4 magnitude and is left for the owner + a live-Cycles build.
+
+**Consequence for gates.** The pkg122 regression tests gate quantities that are
+**invariant to Defect 4** (area size-independence; point inverse-square; blackbody
+temperature-stability and neutrality; blackbody-vs-RGB relative brightness), plus
+a *loose* absolute band on the point light that catches a 4× error but tolerates
+the ~10% Defect-4 residual. The tight [0.97,1.03] absolute band from the spec is
+left for the team-lead's post-build live-Cycles run.
+
+---
+
+## GPU parity
+
+The GPU device NEE (`src/gpu/gpu_nee.cuh::gpu_dedicated_sample`) is a hand-mirror
+of the CPU `sampleLi` (not shared code), so each CPU fix is mirrored there and in
+`fillDeviceParams::staticScale`. Parity (GPU==CPU) must be **re-verified on RTX by
+the team-lead** — this implementer cannot build CUDA either. Changes kept 1:1 with
+the CPU so parity holds by construction.
+
+## Reference-bank re-bless list (owner-reserved — deltas pending build)
+
+Energy of AREA (brighter), POINT (÷4), SPOT (dimmer), DISTANT (much brighter),
+and BLACKBODY (÷≈3.6) all change. Scenes expected to move: pkg89 G1 (zoo), G2
+(blackbody chroma — brightness only, chroma stable), G4 (spot — absolute), G5
+(point hard shadow — dimmer), the pkg115 texture-grid (toward Cycles, brighter
+where area-lit), and any Cycles-parity-bank scene using a dedicated light.
+Measured before/after deltas require the build; implementer does NOT re-bless.

--- a/.astroray_plan/packages/pkg122-dedicated-light-energy-calibration.md
+++ b/.astroray_plan/packages/pkg122-dedicated-light-energy-calibration.md
@@ -3,7 +3,7 @@
 **Pillar:** 3 (light transport / emitter energy correctness)
 **Track:** A (CPU-first re-derivation with a live headless-Cycles A/B oracle; GPU dedicated-light path verified on RTX once pkg89 GAP-1 lands)
 **Codex-paste-ready:** no (multi-type physical re-derivation against a live external oracle, one cross-cutting convention adjudication, and an owner-reserved reference-bank re-bless list — needs judgment at each step, not a mechanical patch)
-**Status:** open — **UNBLOCKED 2026-07-20: pkg89 GAP-1 landed (PR #489, dedicated lights uploaded to GPU, AREA 0.998 / POINT 0.997 parity)** — dispatchable now
+**Status:** in review — **implementation on branch `pkg122-light-energy-calibration` (PR pending)**. Defects 1–3 (AREA solid-angle-pdf measure, POINT/SPOT `1/(4π)` intensity, BLACKBODY photopic normalization) + DISTANT irradiance fix re-derived against Cycles `kernel/light/{area,point,spot,distant}.h` + `scene/light.cpp` (research note: `.astroray_plan/docs/pkg122-light-energy-calibration-research.md`); GPU `gpu_nee.cuh` mirrored for parity; regression gates in `tests/test_pkg122_light_energy_calibration.py`. **Defect 4 (RGBIlluminant vs RGBUnbounded) deliberately DEFERRED** — needs a live-Cycles A/B build (implementer has no MSVC vcvars) and is owner-reserved (moves the reference bank). Team-lead builds, runs the gates, RTX-verifies GPU==CPU, and produces the re-bless deltas.
 **Estimated effort:** M–L (four coupled energy defects across `AreaLight`/`PointLight`/blackbody + one convention decision that cross-cuts materials/env/reference-bank; each fix is small but each must be re-derived and validated against a live Cycles render, not guessed)
 **Depends on:** **pkg89 GAP-1** — the dedicated-light GPU-upload PR (branch `feat/pkg89-dedicated-light-gpu`). Until dedicated lights are actually resident on the GPU, the wavefront leg has nothing to calibrate; GAP-1 must land so the GPU path evaluates the same `EmissionSpectrum` / `sampleLi` energy that this package fixes on the CPU. Land order: GAP-1 → pkg122.
 
@@ -282,12 +282,23 @@ complaint (pkg115 texture-grid finding, re-confirmed 2026-06-12, root-caused
 
 ## Progress
 
-- [ ] A — AreaLight measure re-derivation (`area.h`); size-independence verified.
-- [ ] B — PointLight re-derivation (`point.h`); SpotLight/DistantLight confirmed.
-- [ ] C — Blackbody photopic normalization (Q11), white-tint path included.
-- [ ] D — Emission-spectrum convention adjudicated once; applied uniformly.
-- [ ] E — Live-Cycles A/B harness + per-type gates; GPU leg RTX-verified post-GAP-1.
-- [ ] Owner re-bless list delivered with measured deltas.
+- [x] A — AreaLight measure re-derivation (`area.h`): plain-radiance emission +
+      solid-angle pdf `dist²/(area·cosθ)` (was area-measure `1/area`, breaking MIS).
+      Size-independence gated in `test_area_light_size_independence`; live-Cycles
+      ratio pending team-lead build.
+- [x] B — PointLight re-derivation (`point.h`): intensity `I = P/(4π)` (was `P/π`,
+      the 4× ≈ audit's 3.59×). SpotLight re-derived (same `1/(4π)`, delta pdf; was
+      `1/π`+`1/coneSA`). DistantLight re-derived (carry radiance `S/Ω`; was `Ω×` too
+      dim ≈ black sun).
+- [x] C — Blackbody photopic normalization (Q11): divide by integrated luminance;
+      applied on the white-tint path too. `test_blackbody_temperature_stability`.
+- [ ] D — Emission-spectrum convention: **DEFERRED** (needs live-Cycles build +
+      owner re-bless). Analysis in the research note; `evalRGB` left as `RGBIlluminant`.
+- [~] E — Per-type CPU gates land (`tests/test_pkg122_light_energy_calibration.py`).
+      GPU `gpu_nee.cuh` mirrored; RTX GPU==CPU verify + live-Cycles A/B are the
+      team-lead's post-build step (implementer cannot build the `.pyd`/CUDA).
+- [ ] Owner re-bless list — enumerated qualitatively in the research note; measured
+      deltas require the build (implementer does NOT re-bless).
 
 ---
 

--- a/benchmarks/reference_bank/scenes/glass-mesh-caustic/scene.py
+++ b/benchmarks/reference_bank/scenes/glass-mesh-caustic/scene.py
@@ -77,8 +77,20 @@ def make_scene(astroray):
     # focused caustic streak landing on the floor to the left of the crystal.
     # Strong so the crystal casts a clear shadow (vs the dimmed ambient) for the
     # caustic to land inside.
-    r.add_sun_light_dedicated(_norm([-0.92, -0.33, 0.04]), 0.02,
-                              {"mode": "rgb", "color": [1.0, 1.0, 1.0]}, 16.0)
+    #
+    # pkg122: the DISTANT light now delivers its "Strength" as IRRADIANCE S
+    # directly (Cycles convention); the old units delivered S*Omega (near-black
+    # for a small sun). This scene's intensity 16.0 was calibrated to the broken
+    # units, whose effective irradiance was 16.0*Omega. Pass that same effective
+    # value so the direct-floor level (and the shadow contrast against the
+    # caustic) is byte-identical to pre-pkg122. See glass-sphere-caustic for the
+    # full rationale. (Local showcase; CI does not render this scene.)
+    _sun_dir = [-0.92, -0.33, 0.04]
+    _sun_ang = 0.02
+    _sun_omega = 2.0 * math.pi * (1.0 - math.cos(_sun_ang * 0.5))  # disk solid angle
+    _sun_irradiance = 16.0 * _sun_omega  # ~5.03e-3; preserves the pre-pkg122 balance
+    r.add_sun_light_dedicated(_norm(_sun_dir), _sun_ang,
+                              {"mode": "rgb", "color": [1.0, 1.0, 1.0]}, _sun_irradiance)
 
     # Mid-grey studio floor catches the caustic and lets it pop.
     floor = r.create_material("lambertian", [0.62, 0.63, 0.66], {})

--- a/benchmarks/reference_bank/scenes/glass-sphere-caustic/scene.py
+++ b/benchmarks/reference_bank/scenes/glass-sphere-caustic/scene.py
@@ -54,8 +54,24 @@ def make_scene(astroray):
 
     # Distant collimated sun, angled down and +x so the focused caustic lands on
     # the floor at ~x=+0.7 (offset from the sphere at the origin).
-    r.add_sun_light_dedicated(_norm([0.45, -1.0, 0.0]), 0.01,
-                              {"mode": "rgb", "color": [1.0, 1.0, 1.0]}, 6.0)
+    #
+    # pkg122: the DISTANT light was re-derived to deliver its "Strength" as
+    # IRRADIANCE S directly (Cycles convention); the old broken units delivered
+    # S*Omega (~6.6e-5x for a small sun — the near-black bug). This scene was
+    # authored against the broken units with intensity 6.0, whose EFFECTIVE
+    # delivered irradiance was 6.0*Omega. With the corrected light,
+    # intensity == delivered irradiance, so pass that same effective value to keep
+    # the intended dim-direct-floor / bright-focused-caustic balance (the caustic
+    # magnitude is set by caustic_boost, decoupled from sun intensity in this
+    # forward photon integrator, so the sun only sets the direct-floor level).
+    # intensity_new = intensity_old * Omega makes the direct NEE byte-identical to
+    # pre-pkg122; a physically-dim collimated beam whose lens caustic dominates.
+    _sun_dir = [0.45, -1.0, 0.0]
+    _sun_ang = 0.01
+    _sun_omega = 2.0 * math.pi * (1.0 - math.cos(_sun_ang * 0.5))  # disk solid angle
+    _sun_irradiance = 6.0 * _sun_omega  # ~4.71e-4; preserves the pre-pkg122 balance
+    r.add_sun_light_dedicated(_norm(_sun_dir), _sun_ang,
+                              {"mode": "rgb", "color": [1.0, 1.0, 1.0]}, _sun_irradiance)
 
     # White diffuse floor at the ball-lens FOCAL plane. A clear ior-1.5 sphere of
     # radius 0.6 has paraxial focal distance f = nR/(2(n-1)) = 0.9 from its centre,

--- a/src/emission_spectrum.cpp
+++ b/src/emission_spectrum.cpp
@@ -1,13 +1,56 @@
 #include "astroray/emission_spectrum.h"
 #include "astroray/spectral.h"  // for planck()
-#include "astroray/spectrum.h"  // for RGBAlbedoSpectrum, RGBIlluminantSpectrum
+#include "astroray/spectrum.h"  // for RGBAlbedoSpectrum, RGBIlluminantSpectrum, cieCmf1964_10deg
 #include "astroray/spectral_profile.h"
 #include "raytracer.h"  // for Vec3
 #include <stdexcept>
 #include <algorithm>
 #include <variant>
+#include <cmath>
+#include <unordered_map>
 
 namespace astroray {
+
+namespace {
+
+// pkg122 (Defect 3) — photopic-luminance normalization for a Planck SPD.
+//
+// The pkg89 Q11 resolution (owner-confirmed) requires a `normalize = true`
+// blackbody to divide by its integrated photopic luminance so the artist's
+// intensity slider is perceptually stable across temperature and comparable to
+// an equal-intensity RGB illuminant. Cycles does the same in
+// scene/light.cpp::light_normalize_factor (divide emission by its luminance)
+// and precomputes the normalized XYZ in kernel/svm/svm_blackbody.h (Apache-2.0).
+//
+// Returned factor = 1 / ∫ planck(λ,T)·1e9·ȳ(λ) dλ, integrated over the CIE-1964
+// 10° ȳ support (360–830 nm, 1 nm) using the SAME cieCmf1964_10deg() that
+// SampledSpectrum::toXYZ() uses. This is self-consistent: the evaluated,
+// normalized SPD has E[toXYZ().Y] = 1 for any T, independent of planck()'s
+// absolute scale and of the render's wavelength-sampling pdf (the Monte-Carlo
+// toXYZ estimator is unbiased for ∫Sȳdλ). Chromaticity is preserved (scalar
+// divide), so 6500 K stays near-neutral.
+//
+// thread_local memo keyed on rounded temperature — a light has one temperature,
+// so this is O(1) after warmup and avoids a mutex on the render hot path.
+float blackbodyLuminanceNorm(double temperature_K) {
+    if (!(temperature_K > 0.0)) return 0.0f;
+    static thread_local std::unordered_map<int, float> cache;
+    int key = static_cast<int>(std::lround(temperature_K));
+    auto it = cache.find(key);
+    if (it != cache.end()) return it->second;
+
+    double lumIntegral = 0.0;  // ∫ planck·1e9·ȳ dλ  (dλ = 1 nm)
+    for (int lambda = 360; lambda <= 830; ++lambda) {
+        double bb = planck(static_cast<double>(lambda), temperature_K) * 1e9;
+        float ybar = cieCmf1964_10deg(static_cast<float>(lambda)).Y;
+        lumIntegral += bb * static_cast<double>(ybar);  // ·1 nm
+    }
+    float norm = (lumIntegral > 0.0) ? static_cast<float>(1.0 / lumIntegral) : 0.0f;
+    cache.emplace(key, norm);
+    return norm;
+}
+
+}  // namespace
 
 // Copy constructor (handles unique_ptr in Composite).
 EmissionSpectrum::EmissionSpectrum(const EmissionSpectrum& other)
@@ -107,15 +150,21 @@ SampledSpectrum EmissionSpectrum::evalBlackbody(const Blackbody& bb,
                         std::abs(bb.tint_rgb.y - 1.0f) < 1e-6f &&
                         std::abs(bb.tint_rgb.z - 1.0f) < 1e-6f);
 
+    // pkg122 (Defect 3): photopic-luminance normalization (pkg89 Q11). Applied
+    // on BOTH the white-tint and tinted branches — the previous white-tint
+    // short-circuit skipped normalization entirely, which is why the bare-Planck
+    // case was ~14× over-bright. Chromaticity is preserved (scalar factor).
+    float bbNorm = blackbodyLuminanceNorm(static_cast<double>(bb.temperature_K));
+
     for (int i = 0; i < kSpectrumSamples; ++i) {
         float lambda = wl.lambda(i);
         // Planck blackbody (W/(m²·sr·nm)) — note: spectral.h planck() returns
         // W/(m²·sr·m), so multiply by 1e9 to get per-nm.
         double bbValue = planck(static_cast<double>(lambda), static_cast<double>(bb.temperature_K));
-        float bbFloat = static_cast<float>(bbValue * 1e9);  // W/(m²·sr·m) → W/(m²·sr·nm)
+        float bbFloat = static_cast<float>(bbValue * 1e9) * bbNorm;  // normalized to unit luminance
 
         if (isWhiteTint) {
-            // No tint: pure blackbody emission.
+            // No tint: pure (normalized) blackbody emission.
             result[i] = bbFloat;
         } else {
             // Apply RGB tint as a multiplicative filter via Jakob-Hanika upsample.

--- a/src/gpu/gpu_nee.cuh
+++ b/src/gpu/gpu_nee.cuh
@@ -102,13 +102,11 @@ __device__ inline GNEESample gpu_dedicated_sample(
                    att = t * t * (3.f - 2.f * t); }  // Cycles cubic Hermite smoothstep
             geo *= att;
         }
-        float pdf;
-        if (d.kind == GDED_SPOT) {
-            float coneSA = 2.f * M_PI_F * (1.f - d.cosOuter);
-            pdf = (d.radius > 0.f) ? (1.f / (coneSA * d.radius * d.radius)) : (1.f / coneSA);
-        } else {
-            pdf = (d.radius > 0.f) ? (1.f / (4.f * M_PI_F * d.radius * d.radius)) : 1.f;
-        }
+        // pkg122: point AND spot use the same measure — radius-0 is a delta
+        // light (pdf = 1; the 1/d² and, for spot, the cone attenuation are baked
+        // into dedGeoScale via staticScale = intensity·1/(4π)); radius>0 uses the
+        // sphere-surface pdf 1/(4π·r²). Mirrors the CPU {point,spot}_light.cpp.
+        float pdf = (d.radius > 0.f) ? (1.f / (4.f * M_PI_F * d.radius * d.radius)) : 1.f;
         s.wi          = (sampledPos - shadingPoint) * (1.f / dist);
         s.maxDist     = dist - 0.001f;
         s.lightPdf    = pdf * selPdf;
@@ -145,8 +143,11 @@ __device__ inline GNEESample gpu_dedicated_sample(
         if (cosTheta <= 0.f || cosTheta < cosf(d.spread)) return s;
         s.wi          = (sampledPos - shadingPoint) * (1.f / dist);
         s.maxDist     = dist - 0.001f;
-        s.lightPdf    = (1.f / area) * selPdf;
-        s.dedGeoScale = d.staticScale * (cosTheta / (dist * dist));
+        // pkg122 (Defect 1): plain-radiance emission (staticScale) + SOLID-ANGLE
+        // pdf (pdf_A·dist²/cosθ) so the integrator's MIS is measure-consistent.
+        // Mirrors the CPU area_light.cpp::sampleLi fix.
+        s.lightPdf    = ((dist * dist) / (area * cosTheta)) * selPdf;
+        s.dedGeoScale = d.staticScale;
         s.valid       = 1;
         return s;
     }
@@ -161,11 +162,19 @@ __device__ inline GNEESample gpu_dedicated_sample(
             GVec3 tu, tv; gpu_buildONB(w, tu, tv);
             dir = (w + tu * (rr * cosf(phi)) + tv * (rr * sinf(phi))).normalized();
         }
+        // pkg122 (Distant): Blender sun strength is IRRADIANCE S; carry radiance
+        // L = S/Ω in dedGeoScale so the L/pdf divide reconstructs S. Delta sun
+        // (Ω→0) delivers S directly with pdf = 1. Mirrors CPU distant_light.cpp.
         float solidAngle = 2.f * M_PI_F * (1.f - d.cosOuter);
         s.wi          = dir;
         s.maxDist     = 1e30f;
-        s.lightPdf    = ((solidAngle > 1e-8f) ? (1.f / solidAngle) : 1e30f) * selPdf;
-        s.dedGeoScale = d.staticScale;
+        if (solidAngle > 1e-8f) {
+            s.lightPdf    = (1.f / solidAngle) * selPdf;
+            s.dedGeoScale = d.staticScale / solidAngle;
+        } else {
+            s.lightPdf    = 1.f * selPdf;
+            s.dedGeoScale = d.staticScale;
+        }
         s.valid       = 1;
         return s;
     }

--- a/src/lights/area_light.cpp
+++ b/src/lights/area_light.cpp
@@ -76,18 +76,23 @@ void AreaLight::sampleLi(LiSample& sample,
         return;
     }
 
-    // Lambertian cosine falloff.
-    float cosFalloff = cosTheta;
-
-    // Geometric term: convert area measure to solid angle.
+    // pkg122 (Defect 1): emission is PLAIN RADIANCE and the pdf is returned in
+    // SOLID-ANGLE measure — matching Cycles area_light_sample and the geometry-
+    // emitter path (light_sampler.cpp:64-70). The previous code folded the
+    // geometric factor cosθ/dist² into the emission while returning an area-
+    // measure pdf 1/area; the L/pdf divide was numerically correct but the pdf
+    // being area-measure made the integrator's MIS weight (which combines
+    // ls.pdf with a SOLID-ANGLE bsdfPdf) size-dependent — the 0.13×/1.40× bias
+    // the pkg89 audit measured. See pkg122 research note.
+    // Reference: Cycles kernel/light/area.h::area_light_sample
+    //   (eval_fac = M_1_PI_F * invarea = plain radiance;
+    //    ls->pdf *= light_pdf_area_to_solid_angle(Ng, -D, t)) (Apache-2.0).
     float distSq = distance * distance;
-    float geometricFactor = cosFalloff / distSq;
 
-    // Evaluate spectral emission.
-    // Reference: Cycles intern/cycles/scene/light.cpp:127-131 (eval_fac = invarea * M_1_PI_F, Apache-2.0).
+    // Evaluate spectral emission — plain Lambertian radiance L_e = P/(π·A).
     constexpr float kM1PiF = 0.31830988618f;  // M_1_PI_F = 1/π
     SampledSpectrum emissionSpec = emission_.eval(lambdas);
-    emissionSpec *= (intensity_ * normalizeFactor_ * kM1PiF * geometricFactor);
+    emissionSpec *= (intensity_ * normalizeFactor_ * kM1PiF);
 
     sample.emission_spec = emissionSpec;
 
@@ -99,8 +104,10 @@ void AreaLight::sampleLi(LiSample& sample,
         0.0556434f * xyz.X - 0.2040259f * xyz.Y + 1.0572252f * xyz.Z
     );
 
-    // PDF: 1 / area (uniform area sampling).
-    sample.pdf = 1.0f / area_;
+    // PDF in SOLID-ANGLE measure: pdf_ω = pdf_A · dist²/cosθ_light,
+    // with pdf_A = 1/area (uniform area sampling). cosTheta > 0 here (rejected
+    // above), so the divide is safe.
+    sample.pdf = distSq / (area_ * cosTheta);
 }
 
 float AreaLight::pdfLi(const Vec3& shadingPoint, const Vec3& direction) const {
@@ -163,8 +170,10 @@ bool AreaLight::fillDeviceParams(DeviceLightParams& out) const {
     out.areaShape = static_cast<int>(shape_);  // Rectangle=0, Disk=1, Ellipse=2
     out.spread    = spread_;
     emission_.deviceReference(out.emissionRGB, out.exactIlluminant);
-    // staticScale = intensity·(1/area)·(1/π); normalizeFactor_ == 1/area.
-    // The device recomputes area from shape+width+height for the 1/area pdf.
+    // staticScale = intensity·(1/area)·(1/π) = plain Lambertian radiance L_e =
+    // P/(π·A); normalizeFactor_ == 1/area. pkg122: the device carries L_e directly
+    // and recomputes area from shape+width+height for the SOLID-ANGLE pdf
+    // (dist²/(area·cosθ)); the old cosθ/dist² fold + area-measure pdf is gone.
     constexpr float kM1PiF = 0.31830988618f;
     out.staticScale = intensity_ * normalizeFactor_ * kM1PiF;
     return true;

--- a/src/lights/distant_light.cpp
+++ b/src/lights/distant_light.cpp
@@ -55,9 +55,27 @@ void DistantLight::sampleLi(LiSample& sample,
     sample.normal = -dir;
     sample.distance = std::numeric_limits<float>::max();
 
-    // Evaluate spectral emission.
+    // pkg122 (Distant): Blender sun "Strength" is IRRADIANCE S (W/m²) delivered
+    // to a normal surface; the reflected radiance is f_r·cosθ·S, independent of
+    // angular size. The prior code returned emission = eval·intensity with a
+    // solid-angle pdf 1/Ω, so the L/pdf divide multiplied by Ω (≈6.6e-5 for the
+    // sun) → effectively black. Carry the sun RADIANCE L = S/Ω in emission so
+    // the L/pdf divide reconstructs the delivered irradiance S.
+    // Reference: Cycles scene/light.cpp sun path (sun.eval_fac = 1/area,
+    //   area = π·sin²(θ_half) = disk solid angle) (Apache-2.0).
+    float halfAngle = angularDiameter_ / 2.0f;
+    float solidAngle = 2.0f * static_cast<float>(M_PI) * (1.0f - std::cos(halfAngle));
+
     SampledSpectrum emissionSpec = emission_.eval(lambdas);
-    emissionSpec *= (intensity_ * normalizeFactor_);
+    if (solidAngle > 0.0f) {
+        emissionSpec *= (intensity_ * normalizeFactor_ / solidAngle);  // radiance = S/Ω
+        sample.pdf = 1.0f / solidAngle;                                 // solid-angle pdf
+    } else {
+        // Delta sun (angular diameter 0): a single direction; deliver irradiance
+        // directly with a delta pdf (pdf = 1), no area sampling.
+        emissionSpec *= (intensity_ * normalizeFactor_);
+        sample.pdf = 1.0f;
+    }
 
     sample.emission_spec = emissionSpec;
 
@@ -68,17 +86,13 @@ void DistantLight::sampleLi(LiSample& sample,
         -0.9692660f * xyz.X + 1.8760108f * xyz.Y + 0.0415560f * xyz.Z,
         0.0556434f * xyz.X - 0.2040259f * xyz.Y + 1.0572252f * xyz.Z
     );
-
-    // PDF: 1 / solid angle of the disk.
-    float halfAngle = angularDiameter_ / 2.0f;
-    float solidAngle = 2.0f * static_cast<float>(M_PI) * (1.0f - std::cos(halfAngle));
-    sample.pdf = 1.0f / solidAngle;
 }
 
 float DistantLight::pdfLi(const Vec3& shadingPoint, const Vec3& direction) const {
     float halfAngle = angularDiameter_ / 2.0f;
     float solidAngle = 2.0f * static_cast<float>(M_PI) * (1.0f - std::cos(halfAngle));
-    return 1.0f / solidAngle;
+    // pkg122: delta sun (Ω=0) → 0 ("not useful for MIS"), matching sampleLi.
+    return (solidAngle > 0.0f) ? (1.0f / solidAngle) : 0.0f;
 }
 
 float DistantLight::power() const {

--- a/src/lights/point_light.cpp
+++ b/src/lights/point_light.cpp
@@ -73,10 +73,16 @@ void PointLight::sampleLi(LiSample& sample,
     }
 
     // Evaluate spectral emission.
-    // Reference: Cycles intern/cycles/scene/light.cpp:127-131 (eval_fac = invarea * M_1_PI_F, Apache-2.0).
-    constexpr float kM1PiF = 0.31830988618f;  // M_1_PI_F = 1/π
+    // pkg122 (Defect 2): an isotropic point light of power P has radiant
+    // intensity I = P/(4π) (P watts over 4π sr), giving irradiance E = I/d².
+    // The prior factor normalizeFactor_(=1)·kM1PiF(=1/π) = 1/π was 4× too large
+    // (the pkg89 audit's 3.59× ≈ 4×). Use I = intensity·(1/(4π)).
+    // Reference: Cycles scene/light.cpp point path (area = 4π·radius²,
+    //   invarea = 1/area, eval_fac = invarea·M_1_PI_F) → intensity P/(4π);
+    //   kernel/light/point.h::point_light_sample (Apache-2.0).
+    constexpr float kInvFourPiF = 0.07957747155f;  // 1/(4π)
     SampledSpectrum emissionSpec = emission_.eval(lambdas);
-    emissionSpec *= (intensity_ * normalizeFactor_ * kM1PiF * falloff * iesModulation);
+    emissionSpec *= (intensity_ * kInvFourPiF * falloff * iesModulation);
 
     sample.emission_spec = emissionSpec;
 
@@ -136,10 +142,10 @@ bool PointLight::fillDeviceParams(DeviceLightParams& out) const {
     out.position = position_;
     out.radius   = radius_;
     emission_.deviceReference(out.emissionRGB, out.exactIlluminant);
-    // staticScale = intensity·invarea·(1/π); invarea == normalizeFactor_ (==1 for point).
-    // Matches sampleLi: emissionSpec *= intensity_ * normalizeFactor_ * kM1PiF * falloff.
-    constexpr float kM1PiF = 0.31830988618f;
-    out.staticScale = intensity_ * normalizeFactor_ * kM1PiF;
+    // pkg122 (Defect 2): staticScale = intensity·(1/(4π)) = radiant intensity
+    // I = P/(4π). Matches sampleLi: emissionSpec *= intensity_ * kInvFourPiF * falloff.
+    constexpr float kInvFourPiF = 0.07957747155f;  // 1/(4π)
+    out.staticScale = intensity_ * kInvFourPiF;
     // NOTE: IES modulation is not mirrored on the GPU in v1; an IES PointLight
     // renders isotropic on the device (documented follow-up). Non-IES parity exact.
     return true;

--- a/src/lights/spot_light.cpp
+++ b/src/lights/spot_light.cpp
@@ -88,10 +88,13 @@ void SpotLight::sampleLi(LiSample& sample,
     }
 
     // Evaluate spectral emission.
-    // Reference: Cycles intern/cycles/scene/light.cpp:127-131 (eval_fac = invarea * M_1_PI_F, Apache-2.0).
-    constexpr float kM1PiF = 0.31830988618f;  // M_1_PI_F = 1/π
+    // pkg122: a Blender spot light is a point light of power P masked by the
+    // cone, so it carries the same radiant intensity I = P/(4π) as the point
+    // light (Cycles kernel/light/spot.h inherits spot.eval_fac from the point
+    // path). The prior 1/π was 4× too large. Apache-2.0.
+    constexpr float kInvFourPiF = 0.07957747155f;  // 1/(4π)
     SampledSpectrum emissionSpec = emission_.eval(lambdas);
-    emissionSpec *= (intensity_ * normalizeFactor_ * kM1PiF * falloff * angleFalloffFactor * iesModulation);
+    emissionSpec *= (intensity_ * kInvFourPiF * falloff * angleFalloffFactor * iesModulation);
 
     sample.emission_spec = emissionSpec;
 
@@ -103,12 +106,16 @@ void SpotLight::sampleLi(LiSample& sample,
         0.0556434f * xyz.X - 0.2040259f * xyz.Y + 1.0572252f * xyz.Z
     );
 
-    // PDF: cone solid angle times surface area (if radius > 0).
-    float coneSolidAngle = 2.0f * static_cast<float>(M_PI) * (1.0f - std::cos(outerAngle_));
+    // pkg122: a radius-0 spot is a DELTA light (single direction to the source),
+    // so pdf = 1 like the point light — the 1/d² falloff and cone attenuation are
+    // already baked into emission. The prior 1/coneSolidAngle made the L/pdf
+    // divide multiply brightness by the cone solid angle (cone-angle-dependent
+    // over-bright). For radius>0 the sphere emitter uses uniform-surface pdf
+    // 1/(4π·r²), matching the point sphere light (Cycles spot inherits point).
     if (radius_ > 0.0f) {
-        sample.pdf = 1.0f / (coneSolidAngle * radius_ * radius_);
+        sample.pdf = 1.0f / (4.0f * static_cast<float>(M_PI) * radius_ * radius_);
     } else {
-        sample.pdf = 1.0f / coneSolidAngle;
+        sample.pdf = 1.0f;
     }
 }
 
@@ -119,11 +126,12 @@ float SpotLight::pdfLi(const Vec3& shadingPoint, const Vec3& direction) const {
         return 0.0f;
     }
 
-    float coneSolidAngle = 2.0f * static_cast<float>(M_PI) * (1.0f - std::cos(outerAngle_));
+    // pkg122: mirror sampleLi's measure — radius-0 is a delta light (return 0,
+    // "not useful for MIS", like PointLight::pdfLi); radius>0 uses 1/(4π·r²).
     if (radius_ > 0.0f) {
-        return 1.0f / (coneSolidAngle * radius_ * radius_);
+        return 1.0f / (4.0f * static_cast<float>(M_PI) * radius_ * radius_);
     } else {
-        return 1.0f / coneSolidAngle;
+        return 0.0f;
     }
 }
 
@@ -175,8 +183,9 @@ bool SpotLight::fillDeviceParams(DeviceLightParams& out) const {
     out.cosInner = std::cos(innerAngle_);
     out.cosOuter = std::cos(outerAngle_);
     emission_.deviceReference(out.emissionRGB, out.exactIlluminant);
-    constexpr float kM1PiF = 0.31830988618f;
-    out.staticScale = intensity_ * normalizeFactor_ * kM1PiF;
+    // pkg122: staticScale = intensity·(1/(4π)) = I = P/(4π), matching sampleLi.
+    constexpr float kInvFourPiF = 0.07957747155f;  // 1/(4π)
+    out.staticScale = intensity_ * kInvFourPiF;
     // NOTE: IES modulation not mirrored on the GPU in v1 (follow-up).
     return true;
 }

--- a/tests/test_pkg122_light_energy_calibration.py
+++ b/tests/test_pkg122_light_energy_calibration.py
@@ -1,0 +1,247 @@
+"""pkg122 — Dedicated-light energy calibration regression gates.
+
+Re-derivation of the pkg89 dedicated-light wattage->radiance against the Cycles
+kernel (see .astroray_plan/docs/pkg122-light-energy-calibration-research.md).
+The pkg89 GAP-2 audit measured, at equal wattage vs the Cycles-calibrated
+reference: AREA 0.13x (size-dependent), POINT 3.59x (== 4x), BLACKBODY 14.4x
+(and blue-ish). These gates lock in the fixes.
+
+DESIGN NOTES
+------------
+* Per-channel MEAN-RATIO gates, NOT SSIM (memory ssim-wrong-gate-for-independent-
+  rng): stable ratios that do not shrink with sqrt(SPP) = a units/normalization
+  bug, which is exactly what these gates assert has been fixed.
+* Seeds are pinned NONZERO (memory seed-zero-is-random-sentinel: render seed 0 ==
+  std::random_device).
+* Linear output (apply_gamma=False) so measured floor values are radiance, not a
+  display transform.
+* The gates are deliberately chosen to be INVARIANT to the unresolved Defect-4
+  emission-spectrum convention (RGBIlluminant vs RGBUnbounded), which this package
+  leaves for owner adjudication + a live-Cycles build: they gate relative /
+  structural quantities (inverse-square, size-independence, temperature-stability)
+  plus loose absolute bands that catch a 4x error but tolerate the ~10% Defect-4
+  residual. The tight [0.97,1.03] absolute band from the spec is left for the
+  team-lead's post-build live-Cycles A/B run.
+
+BUILD NOTE: these were authored without a local build (no MSVC vcvars for the
+implementer). They are the team-lead's acceptance gates; run with:
+    pytest tests/test_pkg122_light_energy_calibration.py -v
+"""
+
+import math
+import numpy as np
+import pytest
+
+# 1/(4*pi) — isotropic power->intensity factor (the pkg122 point/spot fix).
+INV_FOUR_PI = 1.0 / (4.0 * math.pi)
+
+
+def _luminance(rgb):
+    """Rec.709 relative luminance of a linear RGB triple."""
+    return 0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2]
+
+
+def _floor_scene(module, seed):
+    """Renderer with a large gray Lambertian floor at y=0 and a black
+    background, camera high above looking straight down. Dedicated lights do not
+    occlude the camera (no geometry), so the light can sit between camera and
+    floor. Returns (renderer, albedo)."""
+    r = module.Renderer()
+    r.set_background_color([0.0, 0.0, 0.0])
+    r.set_seed(seed)
+    r.setup_camera(
+        look_from=[0.0, 20.0, 0.01], look_at=[0.0, 0.0, 0.0], vup=[0.0, 0.0, -1.0],
+        vfov=20.0, aspect_ratio=1.0, aperture=0.0, focus_dist=20.0,
+        width=48, height=48,
+    )
+    albedo = 0.5
+    mat = r.create_material('lambertian', [albedo, albedo, albedo], {})
+    r.add_triangle([-20, 0, -20], [20, 0, -20], [20, 0, 20], mat)
+    r.add_triangle([-20, 0, -20], [20, 0, 20], [-20, 0, 20], mat)
+    return r, albedo
+
+
+def _center_rgb(pixels):
+    """Mean linear RGB of the central 8x8 patch (floor directly under the light)."""
+    h, w = pixels.shape[0], pixels.shape[1]
+    cy, cx = h // 2, w // 2
+    patch = pixels[cy - 4:cy + 4, cx - 4:cx + 4, :3]
+    return np.mean(patch, axis=(0, 1))
+
+
+# ---------------------------------------------------------------------------
+# POINT light
+# ---------------------------------------------------------------------------
+
+def test_point_inverse_square(astroray_module):
+    """POINT illumination falls as 1/d^2 (relative — no calibration constant).
+
+    A measure bug in the falloff/pdf would break this regardless of the absolute
+    scale. Two heights h and 2h => floor radiance ratio == 4.
+    """
+    def floor_at(h, seed):
+        r, _ = _floor_scene(astroray_module, seed)
+        r.add_point_light(position=[0, h, 0],
+                          emission={'mode': 'rgb', 'color': [1, 1, 1]},
+                          intensity=200.0, radius=0.0)
+        px = r.render(128, 3, None, False)
+        return _luminance(_center_rgb(px))
+
+    near = floor_at(5.0, 101)
+    far = floor_at(10.0, 101)
+    ratio = near / max(far, 1e-9)
+    assert 3.4 < ratio < 4.6, f"point 1/d^2 broken: L(5)/L(10)={ratio:.3f} (expect ~4)"
+
+
+def test_point_absolute_calibration(astroray_module):
+    """POINT matches analytic rho*P/(4*pi^2*d^2) within a Defect-4-tolerant band.
+
+    Before pkg122 the point light used intensity P/pi instead of P/(4*pi) and
+    measured 3.59x (== 4x) the analytic value. The band catches that 4x while
+    tolerating the ~10% RGB-convention (Defect 4) residual and the pre-existing
+    delta-light MIS weight (< 1), both out of scope here.
+    """
+    P, d, albedo = 200.0, 10.0, 0.5
+    r, _ = _floor_scene(astroray_module, 202)
+    r.add_point_light(position=[0, d, 0],
+                      emission={'mode': 'rgb', 'color': [1, 1, 1]},
+                      intensity=P, radius=0.0)
+    px = r.render(256, 3, None, False)
+    measured = _luminance(_center_rgb(px))
+    analytic = albedo * P / (4.0 * math.pi * math.pi * d * d)  # rho*P/(4pi^2 d^2), cos=1
+    ratio = measured / analytic
+    assert 0.65 < ratio < 1.35, \
+        f"point absolute calibration off: measured/analytic={ratio:.3f} " \
+        f"(pre-pkg122 bug measured ~3.59)"
+
+
+# ---------------------------------------------------------------------------
+# AREA light — the headline "dimmer than Cycles" defect (Defect 1)
+# ---------------------------------------------------------------------------
+
+def test_area_light_size_independence(astroray_module):
+    """AREA light energy is size-INDEPENDENT in the far field (Defect 1).
+
+    At equal wattage a Lambertian area light emits L = P/(pi*A); a small and a
+    large light HIGH above the floor (both far-field, A << h^2) deliver the same
+    irradiance directly below. The old code returned an AREA-measure pdf while the
+    integrator's MIS combines it with a SOLID-ANGLE bsdf pdf, so the MIS weight —
+    and thus the brightness — depended on 1/A: the audit's 7.68x (size 3) vs 1.40x
+    (small) spread (~5.5x). The fix returns a solid-angle pdf, restoring size
+    independence.
+    """
+    def floor_for_size(size, seed):
+        r, _ = _floor_scene(astroray_module, seed)
+        # Normal = u x v = (1,0,0) x (0,0,1) = (0,-1,0): faces the floor.
+        r.add_area_light_dedicated(
+            center=[0, 10, 0], axis_u=[1, 0, 0], axis_v=[0, 0, 1],
+            size_x=size, size_y=size, shape='RECTANGLE',
+            emission={'mode': 'rgb', 'color': [1, 1, 1]},
+            intensity=300.0, spread=1.5708,  # pi/2: full hemisphere
+        )
+        px = r.render(256, 3, None, False)
+        return _luminance(_center_rgb(px))
+
+    small = floor_for_size(0.1, 303)   # far-field point-like
+    large = floor_for_size(3.0, 303)   # A=9, h^2=100 -> still far-field
+    ratio = small / max(large, 1e-9)
+    # Physically ~1.0 (both far-field). Pre-fix this was ~8x (MIS-measure bias).
+    assert 0.80 < ratio < 1.25, \
+        f"area light size-dependent: L(0.1)/L(3)={ratio:.3f} (expect ~1.0; " \
+        f"pre-pkg122 the MIS-measure bug made this ~8x)"
+
+
+def test_area_light_nonzero(astroray_module):
+    """AREA light produces meaningful illumination (not the 0.13x near-black)."""
+    r, albedo = _floor_scene(astroray_module, 304)
+    P, d = 300.0, 10.0
+    r.add_area_light_dedicated(
+        center=[0, d, 0], axis_u=[1, 0, 0], axis_v=[0, 0, 1],
+        size_x=0.1, size_y=0.1, shape='RECTANGLE',
+        emission={'mode': 'rgb', 'color': [1, 1, 1]},
+        intensity=P, spread=1.5708,
+    )
+    px = r.render(256, 3, None, False)
+    measured = _luminance(_center_rgb(px))
+    # A small far area light of power P delivers ~ E = P/(pi*d^2) directly below;
+    # reflected L ~ albedo * E / pi. Catches a gross (0.13x) under-scale.
+    approx = albedo * (P / (math.pi * d * d)) / math.pi
+    ratio = measured / approx
+    assert 0.4 < ratio < 2.0, \
+        f"area light energy off: measured/approx={ratio:.3f} (pre-pkg122 ~0.13x)"
+
+
+# ---------------------------------------------------------------------------
+# BLACKBODY (Defect 3) — photopic normalization
+# ---------------------------------------------------------------------------
+
+def _blackbody_point_center(module, temperature, seed):
+    r = module.Renderer()
+    r.set_background_color([0.0, 0.0, 0.0])
+    r.set_seed(seed)
+    r.setup_camera(
+        look_from=[0.0, 20.0, 0.01], look_at=[0.0, 0.0, 0.0], vup=[0.0, 0.0, -1.0],
+        vfov=20.0, aspect_ratio=1.0, aperture=0.0, focus_dist=20.0,
+        width=48, height=48,
+    )
+    mat = r.create_material('lambertian', [1.0, 1.0, 1.0], {})  # white for chroma
+    r.add_triangle([-20, 0, -20], [20, 0, -20], [20, 0, 20], mat)
+    r.add_triangle([-20, 0, -20], [20, 0, 20], [-20, 0, 20], mat)
+    r.add_point_light(position=[0, 10, 0],
+                      emission={'mode': 'blackbody', 'temperature_K': temperature,
+                                'tint_rgb': [1, 1, 1]},
+                      intensity=200.0, radius=0.0)
+    px = r.render(256, 3, None, False)
+    return _center_rgb(px)
+
+
+def test_blackbody_temperature_stability(astroray_module):
+    """Q11: a blackbody's PERCEIVED intensity is stable across temperature.
+
+    With photopic-luminance normalization (divide by integrated luminance, per
+    Cycles light_normalize_factor) a 4000 K and a 6500 K light at equal intensity
+    have ~equal luminance. Without it (pre-pkg122, raw Planck) the luminance
+    scaled with the Planck integral and differed by several-fold. Defect-4-
+    invariant (both are blackbody through the same point machinery).
+    """
+    rgb_4000 = _blackbody_point_center(astroray_module, 4000.0, 405)
+    rgb_6500 = _blackbody_point_center(astroray_module, 6500.0, 405)
+    ratio = _luminance(rgb_4000) / max(_luminance(rgb_6500), 1e-9)
+    assert 0.80 < ratio < 1.25, \
+        f"blackbody NOT photopic-stable across T: Y(4000)/Y(6500)={ratio:.3f} " \
+        f"(expect ~1.0; pre-pkg122 raw Planck was several-fold off)"
+
+
+def test_blackbody_vs_rgb_brightness(astroray_module):
+    """A 6500 K blackbody and an RGB-white light at equal intensity are ~equally
+    bright — closing the ~4x blackbody-over-RGB excess (the other half of the 14x).
+    """
+    rgb_bb = _blackbody_point_center(astroray_module, 6500.0, 406)
+
+    r, _ = _floor_scene(astroray_module, 406)
+    # white floor for a fair chroma-neutral comparison
+    matw = r.create_material('lambertian', [1.0, 1.0, 1.0], {})
+    r.add_triangle([-20, 0.001, -20], [20, 0.001, -20], [20, 0.001, 20], matw)
+    r.add_triangle([-20, 0.001, -20], [20, 0.001, 20], [-20, 0.001, 20], matw)
+    r.add_point_light(position=[0, 10, 0],
+                      emission={'mode': 'rgb', 'color': [1, 1, 1]},
+                      intensity=200.0, radius=0.0)
+    px = r.render(256, 3, None, False)
+    rgb_white = _center_rgb(px)
+
+    ratio = _luminance(rgb_bb) / max(_luminance(rgb_white), 1e-9)
+    assert 0.5 < ratio < 1.7, \
+        f"blackbody/RGB brightness off: {ratio:.3f} (expect ~1; pre-pkg122 ~4x)"
+
+
+def test_blackbody_6500k_neutral(astroray_module):
+    """6500 K blackbody on a white surface is near-neutral (G2-style chroma gate).
+
+    Photopic normalization is a scalar, so chromaticity is unchanged; this guards
+    against a regression that tints the SPD.
+    """
+    rgb = _blackbody_point_center(astroray_module, 6500.0, 407)
+    mx, mn = float(np.max(rgb)), float(np.min(rgb))
+    rel_var = (mx - mn) / mx if mx > 0 else 1.0
+    assert rel_var < 0.12, \
+        f"6500K blackbody not neutral: RGB={rgb}, variation={rel_var * 100:.1f}%"

--- a/tests/test_pkg89_phase_b_dedicated_lights.py
+++ b/tests/test_pkg89_phase_b_dedicated_lights.py
@@ -226,10 +226,15 @@ def test_g4_spot_cone_falloff(astroray_module):
     emission_spot = {'mode': 'rgb', 'color': [1, 1, 1]}
     inner_angle = 0.2  # ~11.5 degrees half-angle
     outer_angle = 0.4  # ~23 degrees half-angle
-    # pkg89 (2026-05-22): intensity scaled by π (100 → 320) to compensate for
-    # the Cycles-parity kM1PiF (1/π) factor added in sampleLi. Original 100.0
-    # was tuned against the buggy pre-fix code that omitted the kM1PiF factor;
-    # restoring physical correctness requires re-tuning the scene constant.
+    # pkg122 (2026-07-20): the spot wattage->radiance was re-derived against
+    # Cycles kernel/light/spot.h — a Blender spot is a point light of power P
+    # masked by the cone, radiant intensity I = P/(4π), delta pdf (was 1/π with a
+    # 1/coneSolidAngle pdf that multiplied brightness by the cone solid angle).
+    # The old scene cranked intensity 100->320 to fight those two compensating
+    # bugs; with the physical fix the ABSOLUTE center level changes, so this gate
+    # now asserts the cone STRUCTURE (center >> corner, corner ~ 0) plus a loose
+    # brightness floor. The exact center magnitude is verified against live Cycles
+    # by the team-lead post-build (this implementer cannot build the .pyd).
     r.add_spot_light_dedicated(
         center=[0, 5, 0],
         direction=[0, -1, 0],
@@ -243,16 +248,14 @@ def test_g4_spot_cone_falloff(astroray_module):
     pixels = r.render(256, 1)
 
     # Check center (should be bright, within inner cone) and corner (dark, outside outer cone).
-    # Absolute photometric threshold relaxed from >1.0 to >0.3: with intensity=320
-    # (= 100·π) the dedicated-light pipeline measures ~0.45 at the center, ~3×
-    # below naïve theory. Same spectrum-pipeline calibration shortfall as G2's
-    # D65 chromaticity (RGB→Jakob-Hanika→SampledSpectrum→XYZ→sRGB chain).
-    # TODO(spectrum): calibrate against Cycles reference once a precomputed-XYZ
-    # blackbody / illuminant fast-path lands (mirrors G2 TODO). Until then the
-    # structural assertion (center ≫ corner, corner ≈ 0) is what gates the cone.
+    # pkg122: absolute center threshold lowered 0.3 -> 0.1 because the spot energy
+    # was re-derived (I = P/(4π), delta pdf) — the absolute level shifted and its
+    # exact value is verified against live Cycles by the team-lead. The gate now
+    # rests on the cone STRUCTURE (center >> corner, corner ~ 0), which is what
+    # G4 is actually testing.
     center_lum = np.mean(pixels[32-2:32+2, 32-2:32+2])
     corner_lum = np.mean(pixels[0:4, 0:4])
-    assert center_lum > 0.3, f"G4 FAIL: center too dark ({center_lum}), inner cone not working"
+    assert center_lum > 0.1, f"G4 FAIL: center too dark ({center_lum}), inner cone not working"
     assert corner_lum < 0.01, f"G4 FAIL: corner too bright ({corner_lum}), outer cone not working"
     assert center_lum > 30 * max(corner_lum, 1e-6), \
         f"G4 FAIL: center/corner ratio too low ({center_lum / max(corner_lum, 1e-6):.1f})"
@@ -294,11 +297,15 @@ def test_g5_point_light_isotropy_hard_shadows(astroray_module):
     r.add_sphere([0, 0.5, 0], 0.5, mat_sphere)
 
     # POINT light with radius=0 (hard shadows)
+    # pkg122: intensity 50 -> 200 to offset the corrected point calibration
+    # (I = P/(4π), 4x dimmer than the old P/π). G5 gates shadow SHARPNESS
+    # (radius=0 hard shadow), not absolute brightness, so restoring the signal
+    # level with the scene knob keeps the gradient assertion's sensitivity intact.
     emission_point = {'mode': 'rgb', 'color': [1, 1, 1]}
     r.add_point_light(
         position=[2, 3, 2],
         emission=emission_point,
-        intensity=50.0,
+        intensity=200.0,
         radius=0.0  # Hard shadows (singularity at center)
     )
 


### PR DESCRIPTION
## Summary

Root-causes the standing **"addon renders dimmer than Cycles"** complaint at its source: the pkg89 dedicated-light energy path was per-type miscalibrated in **opposite directions** (pkg89 GAP-2 audit: AREA 0.13× and size-dependent, POINT 3.59×, BLACKBODY 14.4×), so no global brightness knob could reconcile it. Each type is **re-derived against the Cycles kernel** (Apache-2.0), not tuned. Research + citations: `.astroray_plan/docs/pkg122-light-energy-calibration-research.md`.

## Per-type root causes (with derivations + citations)

**Defect 1 — AREA (`src/lights/area_light.cpp`)**: `sampleLi` returned an **area-measure** pdf `1/area` while the integrator's MIS power heuristic (`raytracer.h:2493`) combines it with a **solid-angle** `bsdfPdf`. The `L/pdf` divide was numerically correct (the `area` cancels), but the measure-mismatched `a = (1/area)·selPdf` shrinks as the light grows → the MIS weight collapses with size → the audit's 7.68×(size 3)/1.40×(small) spread. **Fix**: emission is plain radiance `L_e = P/(πA)` (drop the `cosθ/d²` fold) and the pdf is solid-angle `dist²/(area·cosθ)`, matching Cycles `kernel/light/area.h::area_light_sample` (`eval_fac = M_1_PI_F·invarea`; `ls->pdf *= light_pdf_area_to_solid_angle`) and the Cycles-calibrated geometry-emitter path.

**Defect 2 — POINT (`src/lights/point_light.cpp`)**: used radiant intensity `I = P/π` instead of the physical isotropic `I = P/(4π)` — **4× too bright**. With the RGB-white `eval` luminance ≈0.9, that is the audit's measured **3.59×**. **Fix**: `I = intensity·(1/(4π))`. Cycles `scene/light.cpp` point path: `area = 4π·radius²`, `eval_fac = invarea·M_1_PI_F`.

**Defect 3 — BLACKBODY (`src/emission_spectrum.cpp`)**: raw Planck·1e9 with **no photopic normalization** and a white-tint short-circuit that skipped it — `Y_planck(6500K) ≈ 3.6`, i.e. ~4× over an equal-intensity RGB light; compounded with Defect 2's 4× → **14.4×**. **Fix (pkg89 Q11 / Cycles `light_normalize_factor`)**: divide the Planck SPD by its integrated photopic luminance (`∫planck·1e9·ȳdλ`, self-consistent with `SampledSpectrum::toXYZ`) on **both** tint branches → unit luminance, temperature-stable, chromaticity preserved.

**SPOT (`src/lights/spot_light.cpp`)**: shared the point `1/π` bug **and** returned pdf `1/coneSolidAngle` instead of a delta pdf (cone-angle-dependent over-bright; the old scene cranked intensity 100→320 to fight it). **Fix**: `I = P/(4π)`, delta pdf (radius 0) / sphere pdf `1/(4π·r²)` — a point light masked by the cone (Cycles `kernel/light/spot.h` inherits the point `eval_fac`).

**DISTANT (`src/lights/distant_light.cpp`)**: `emission = eval·intensity` with pdf `1/Ω` made the `L/pdf` divide multiply by `Ω` (≈6.6e-5 for the sun) → **effectively black**. **Fix**: carry sun radiance `L = S/Ω` so the divide reconstructs the delivered irradiance `S`; delta sun (angle 0) delivers `S` with pdf 1. Cycles `scene/light.cpp` sun path (`sun.eval_fac = 1/area`, `area = π·sin²(θ_half)`).

## Defect 4 — DEFERRED (not changed)

The RGBIlluminant-vs-RGBUnbounded emission convention (spec §D) requires **a live headless-Cycles A/B render** to adjudicate and can **move the 12/13-passing reference bank** (owner-reserved). This implementer **cannot build the `.pyd`** (no MSVC vcvars for subagents), so per CLAUDE.md §1 the convention is **left unchanged** (`evalRGB` stays `RGBIlluminantSpectrum`). The residual ~10% absolute level on POINT/AREA is exactly the Defect-4 magnitude and is left for the owner + a live-Cycles build.

## GPU parity

`src/gpu/gpu_nee.cuh::gpu_dedicated_sample` is a hand-mirror of the CPU `sampleLi` (not shared code), so all four fixes + `fillDeviceParams::staticScale` are mirrored 1:1. **GPU==CPU must be RTX-verified by the team-lead** — this implementer cannot build CUDA either.

## Tests

`tests/test_pkg122_light_energy_calibration.py` — per-channel **mean-ratio** gates (NOT SSIM, per memory `ssim-wrong-gate-for-independent-rng`), pinned **nonzero** seeds (memory `seed-zero-is-random-sentinel`), linear output. Gates are chosen **invariant to the deferred Defect 4**: point inverse-square, area far-field **size-independence** (the headline Defect-1 signature), blackbody **temperature-stability** and neutrality, blackbody-vs-RGB brightness, plus loose absolute bands that catch a 4× error but tolerate the ~10% Defect-4 residual. The tight [0.97,1.03] absolute band is left for the team-lead's live-Cycles run.

**Behavioral sweep**: pkg89 **G4** spot gate relaxed to structural (spot energy re-derived; absolute level shifted); **G5** point intensity bumped 50→200 to preserve the shadow-sharpness signal after the 4× calibration.

## Acceptance status
- [x] AREA measure bug fixed (solid-angle pdf); size-independence gated
- [x] POINT `1/(4π)`; SPOT + DISTANT re-derived in the same pass
- [x] Blackbody photopic normalization incl. white-tint path
- [ ] Defect 4 adjudicated — **DEFERRED** (needs live-Cycles build + owner re-bless)
- [~] CPU gates land; GPU RTX GPU==CPU + live-Cycles A/B = team-lead post-build
- [ ] Owner re-bless list — enumerated qualitatively; measured deltas need the build
- [x] Research/citation note in `.astroray_plan/docs/`

## NOT verified locally (no MSVC/CUDA toolchain for this implementer)
- **No build was run**; no `.pyd`/CUDA compile. Changes touch `.cpp`/`.cuh` — the Linux `cuda-syntax-check` CI job will compile `gpu_nee.cuh`'s includers.
- Tests are authored against the real pybind11 API but **not executed**.

### Team-lead commands
```
build_cuda_worktree.bat ../Astroray-pkg122 <head-sha>
pytest tests/test_pkg122_light_energy_calibration.py -v
pytest tests/test_pkg89_phase_b_dedicated_lights.py -v
# then RTX GPU==CPU parity + live-Cycles A/B for the tight band + re-bless deltas
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
