### PR TITLE
docs(pkg139-141): three specs from overnight verifier findings — AREA orientation, delta-sun black, GPU near-delta metal

### DIFF
--- a/.astroray_plan/packages/pkg139-addon-area-light-orientation.md
+++ b/.astroray_plan/packages/pkg139-addon-area-light-orientation.md
@@ -1,0 +1,113 @@
+# pkg139 — Addon AREA-light orientation convention (emits +Z, Cycles emits −Z) + world strength-0 background skip
+
+**Pillar:** 2 (Blender integration correctness)
+**Track:** A (addon/CPU lane; parity-tested against headless Cycles — Blender 5.1 installed locally)
+**Codex-paste-ready:** no (a sign/convention fix, but it must be validated against a live Cycles A/B render, not unit-tested in isolation)
+**Status:** open — dispatchable now (independent of the pkg122 energy calibration in flight; do NOT conflate — see Non-goals)
+**Estimated effort:** S (one-line basis flip + a small world-background guard fix + a parity test)
+**Depends on:** none. Composes with pkg122 (energy) and pkg119-B (parity harness) but blocks on neither.
+
+---
+
+## Context — found by the pkg122 hardware verifier (2026-07-20 overnight)
+
+While validating the pkg122 per-type energy derivations against a live Cycles
+oracle, the verifier isolated an **orientation** bug that is independent of the
+energy scaling: an artist-placed **default-rotation Blender area light points
+AWAY from the scene in Astroray**. Evidence in the pkg122 worktree
+(`Astroray-pkg122/test_results/`, script
+`scripts/verify_pkg122_cycles_oracle.py`):
+
+- Identity-rotation area light: Astroray/Cycles mean ratio **0.089–0.116×**
+  (scene lit only by leakage/bounce — the exact pre-pkg122 "dim area light"
+  symptom, reproduced through a **second, independent mechanism**).
+- Same scene with the light flipped 180° about local X: ratio **1.07–1.09×**
+  (normal, consistent with the post-#489 parity band).
+
+This is likely a large chunk of the remaining owner-visible dimness in real
+`.blend` scenes: every default-orientation area lamp faces backwards.
+
+## Root cause (verified in code)
+
+`blender_addon/__init__.py` `convert_lights()` AREA branch
+(`__init__.py:3947-3968`):
+
+```python
+basis = matrix.to_3x3()
+axis_u = list((basis @ mathutils.Vector((1, 0, 0))).normalized())   # local +X
+axis_v = list((basis @ mathutils.Vector((0, 1, 0))).normalized())   # local +Y
+```
+
+The engine `AreaLight` emits along its normal `u × v` = local **+Z**. But
+Blender/Cycles lights emit along local **−Z** — the same convention the addon
+itself already uses for SUN (`__init__.py:3941`,
+`matrix.to_3x3() @ Vector((0, 0, -1))`) and SPOT (`__init__.py:3971`). Only the
+AREA branch got the sign wrong, so the emitting face points opposite to what
+the artist sees in Blender.
+
+## Fix plan (cite — no inventions, CLAUDE.md §6)
+
+**Flip the basis so the implied normal is local −Z**, e.g.
+`axis_v = basis @ Vector((0, -1, 0))` (u = +X, v = −Y ⇒ u×v = −Z), which is the
+same 180°-about-local-X flip the verifier measured at 1.07–1.09×. Keep the
+`size_x`/`size_y` mapping consistent with the chosen flip (u stays +X so
+`size_x` still maps to u; verify the ELLIPSE/RECTANGLE non-square case renders
+with the correct long axis, not mirrored).
+
+**Cite:** Cycles Blender sync,
+`intern/cycles/blender/light.cpp` (`BlenderSync::sync_light`, Apache-2.0 /
+Blender GPL-compatible source tree — cite the convention, port no code):
+`axisu` = transform X axis, `axisv` = transform Y axis, emission direction =
+**−Z** of the light transform — the same convention as spot/sun/camera. In-repo
+precedent: the addon's own SUN/SPOT branches (`__init__.py:3941, 3971`).
+
+### Secondary (bounded, same file, verifier-evidenced): world strength-0 background skip
+
+`setup_world()` (`__init__.py:4082-4086`) only calls
+`renderer.set_background_color(...)` when `bg_color and strength > 0.01`. A
+Blender world with **strength = 0.0** (artist intent: black background) is
+silently skipped, leaving the **engine's built-in default background** visible
+— the verifier saw it outside spot cones. Fix: when `bg_color` exists, always
+call `set_background_color([c * strength for c in bg_color])` (strength 0 ⇒
+explicit black), dropping the `strength > 0.01` guard. One line; test with a
+strength-0 world (background must render black, not the engine default).
+
+## Verification gates
+
+- [ ] Headless-Blender parity A/B (reuse `verify_pkg122_cycles_oracle.py`
+      methodology or `scripts/verify_pkg115_textures_blender.py` harness):
+      default-rotation area light scene — Astroray/Cycles mean ratio moves from
+      ~0.09–0.12× to the normal band (~0.9–1.1×; exact bound calibrated to the
+      post-#489/pkg122 parity numbers at test time).
+- [ ] Rotated (non-identity) area light agrees with Cycles — the flip must be
+      convention-correct, not a compensating hack that only fixes identity.
+- [ ] Non-square RECTANGLE/ELLIPSE case: long axis matches Cycles (no mirror /
+      axis swap).
+- [ ] Strength-0 world renders a black background (not the engine default).
+- [ ] Existing addon light tests + pkg89 parity gates stay green.
+
+## Non-goals
+
+- **Not energy calibration** — that is pkg122 (in flight). This package fixes
+  *direction*; magnitudes are pkg122's. Do not touch wattage→radiance factors.
+- **Not Defect 4** (RGBIlluminant-vs-RGBUnbounded convention) — owner-reserved.
+- **Not spread/shape sampling** — only the basis orientation + the world guard.
+
+## Provenance
+
+Filed from the **pkg122 hardware-verifier findings (2026-07-20 overnight)**:
+measured identity-rotation ratio 0.089–0.116× vs Cycles, 180°-local-X flip →
+1.07–1.09×; evidence in `Astroray-pkg122/test_results/` +
+`scripts/verify_pkg122_cycles_oracle.py`. Code anchors verified in main
+checkout: `blender_addon/__init__.py:3947-3968` (AREA basis), `:3941`/`:3971`
+(SUN/SPOT already −Z), `:4082-4086` (strength guard).
+
+## Progress
+
+- [ ] AREA basis flip (normal → local −Z) + non-square axis check.
+- [ ] Strength-0 world background fix.
+- [ ] Cycles A/B parity gates (identity + rotated + non-square).
+
+## Lessons
+
+*(Fill in after the package is done.)*

--- a/.astroray_plan/packages/pkg140-distant-light-zero-angle-delta.md
+++ b/.astroray_plan/packages/pkg140-distant-light-zero-angle-delta.md
@@ -1,0 +1,133 @@
+# pkg140 — DistantLight angular_diameter≈0 renders pure black (delta-sun semantics + small-angle cancellation)
+
+**Pillar:** 3 (light transport correctness)
+**Track:** A (CPU light code + GPU mirror; CPU-gated tests on CI, GPU leg RTX-verified)
+**Codex-paste-ready:** no (delta-light semantics touch sampling, pdf, power-CDF selection, and the light-tree orientation cone together — the pieces must stay consistent)
+**Status:** open — dispatchable now (small, engine lane, independent of everything in flight)
+**Estimated effort:** S–M (a delta branch mirroring pbrt-v4 + a two-character numerical identity in four sites + the GPU mirror; the care is in keeping sampleLi/pdfLi/power/cone consistent)
+**Depends on:** none. Do NOT conflate with pkg122 (energy calibration, in flight) — this is a zero-measure/degenerate-geometry bug, not a scaling bug.
+
+---
+
+## Context — found by the pkg122 hardware verifier (2026-07-20 overnight)
+
+Sweep on both CPU and GPU (identical behavior, evidence in
+`Astroray-pkg122/test_results/`):
+
+- `angular_diameter = 0.0` rad → **pure black**
+- `angular_diameter = 0.00017` rad → **pure black**
+- `angular_diameter = 0.00175` rad and above → correct (~0.99× analytic)
+
+Blender's default sun angle is 0.526°, so realistic scenes never hit this, but
+it is a correctness hole for the true-delta sun case (and any tiny-angle sun an
+astro scene might legitimately want — e.g. a star at astronomical distance).
+
+## Root cause (verified in code — `src/lights/distant_light.cpp`)
+
+All four sites compute `solidAngle = 2π(1 − cos(halfAngle))` and degenerate
+together as `halfAngle → 0`:
+
+1. **`sampleLi` (`:73-75`):** `sample.pdf = 1/solidAngle` → **+inf** at 0 ⇒
+   contribution `emission/pdf` = 0. (Note: the direction itself is fine — the
+   `angularDiameter_ > 0` guard at `:36` correctly falls back to the exact
+   `-axis_` direction; only the pdf is wrong.)
+2. **`pdfLi` (`:78-82`):** same `1/solidAngle` → inf.
+3. **`power` (`:84-93`):** returns `luminance · intensity · normalizeFactor ·
+   solidAngle` → **0** ⇒ the power-CDF light selection gives the light zero
+   probability — it is never sampled at all (sufficient for black on its own).
+4. **`orientationCone` (`:101-104`):** `fromAxisAngle(-axis_, 0)` — a
+   zero-extent cone for the light tree.
+
+**Why 0.00017 rad is ALSO black (float cancellation):** `1.0f − cosf(h)`
+suffers catastrophic cancellation: `cos(h) ≈ 1 − h²/2`, and for
+`h²/2 < ~6e-8` (i.e. `h ≲ 3.4e-4` rad) `cosf(h)` rounds to exactly `1.0f`, so
+`solidAngle == 0.0f` even for a nonzero angle. The sweep matches: diameter
+0.00017 (half-angle 8.5e-5) is inside the cancellation zone; 0.00175
+(half-angle 8.75e-4, `1−cos ≈ 3.8e-7`) is just outside and renders correctly.
+
+The GPU mirrors the same radiometry (`:106-112`,
+`out.cosOuter = cos(angularDiameter_ · 0.5)`) — the device disk pdf has the
+same `1 − cosOuter` cancellation, consistent with the verifier's
+CPU-and-GPU-identically-black observation.
+
+## Fix plan (cite — no inventions, CLAUDE.md §6)
+
+**A. Small-angle numerical stability (all sites, CPU + GPU).** Replace
+`1 − cos(h)` with the identity `2·sin²(h/2)` (exact, and `sinf` has no
+cancellation at small arguments). Textbook identity (trivial per CLAUDE.md §6);
+this alone fixes the 0 < angle ≲ 7e-4 rad zone in `sampleLi`, `pdfLi`,
+`power`, and the GPU `cosOuter`-derived pdf (mirror with
+`sinf(h*0.5f)`-based solid angle or equivalent).
+
+**B. True-delta branch for `angular_diameter == 0` — mirror pbrt-v4
+`DistantLight`** (`pbrt-v4 src/pbrt/lights.h/.cpp`, Apache-2.0):
+
+- `SampleLi`: fixed direction `-axis_`, **pdf = 1** (delta convention — the
+  1-sample estimator divides by 1, contribution is the full radiance; pbrt-v4
+  `DistantLight::SampleLi` returns `wi` with `pdf = 1`).
+- `PDF_Li`: **return 0** (a delta direction can never be hit by BSDF/solid-angle
+  sampling; pbrt-v4 `DistantLight::PDF_Li` returns 0). This also makes the MIS
+  weight for the NEE sample come out 1, which is correct for a delta light.
+- `power`: must be **nonzero** or the power-CDF starves the light (site 3
+  above). pbrt-v4 uses `Phi = π · sceneRadius² · L`; adapt to our selection-CDF
+  convention (`luminance · intensity · normalizeFactor · <delta-power
+  convention>`) — the absolute scale only matters relative to other lights in
+  the CDF, but document the chosen convention and keep it consistent with the
+  finite-angle limit (no discontinuity as angle → 0⁺ after fix A: consider
+  `max(solidAngle, delta_floor)` vs the pbrt scene-radius form and record the
+  choice with the citation).
+- `orientationCone`: a zero-`halfAngle` cone about `-axis_` is legitimate for
+  the light tree (a delta emitter emits in exactly one direction); verify the
+  light-tree importance math does not divide by the cone extent — if it does,
+  clamp per the existing light-tree conventions (`pkg86` code) and record it.
+- Check `isDelta`/delta-flag plumbing: if `LiSample`/NEE has a delta-light flag
+  (as the BSDF side does), set it so MIS treats the sample as delta; if it does
+  not exist, the pdf=1/PDF_Li=0 pair achieves the same estimator — do not
+  invent new plumbing unless a gate fails without it.
+
+## Verification gates
+
+- [ ] Sweep test (CPU): `angular_diameter ∈ {0.0, 1.7e-4, 1.75e-3, 0.00918
+      (Blender default)}` — all render within ~1–2% of the analytic
+      direct-lighting value (the 0.99× band the verifier measured for the
+      working case); 0.0 and 1.7e-4 are the regression rows (both black today).
+- [ ] GPU leg matches CPU at the 1e-5 Monte-Carlo convention on the same sweep
+      (RTX-verified — CI is GPU-blind).
+- [ ] Continuity: no brightness jump between the delta branch (0.0) and the
+      smallest finite angle (1.7e-4) beyond MC noise.
+- [ ] Existing sun/distant-light tests + pkg89 parity gates stay green
+      (Blender-default 0.526° behavior byte-unchanged is the no-regression
+      anchor).
+- [ ] Light-selection check: a scene with a delta sun + one area light — both
+      contribute (the power-CDF starvation row).
+
+## Non-goals
+
+- **Not energy calibration** (pkg122, in flight — including its blackbody/sun
+  magnitudes; this package must not touch `normalizeFactor_` conventions
+  beyond the delta-power choice, and must rebase cleanly on pkg122's changes).
+- **Not the light tree generally** — only the degenerate-cone interaction if a
+  gate exposes it.
+- **Not Blender addon changes** — the addon already passes the angle through
+  (`__init__.py:3941-3946`).
+
+## Provenance
+
+Filed from the **pkg122 hardware-verifier findings (2026-07-20 overnight)**:
+angle sweep 0.0/0.00017 → black, 0.00175+ → ~0.99× analytic, CPU and GPU
+identical; evidence in `Astroray-pkg122/test_results/`. Mechanism verified in
+code by the architect: `src/lights/distant_light.cpp:73-75, 78-82, 84-93,
+101-104` all share the `2π(1−cos(halfAngle))` form (pdf→inf, power→0), and the
+float cancellation zone `h ≲ 3.4e-4` rad explains the nonzero-but-black row.
+GPU mirror at `:106-112` (`cosOuter`).
+
+## Progress
+
+- [ ] A — `2sin²(h/2)` identity in all CPU sites + GPU mirror.
+- [ ] B — delta branch (sampleLi pdf=1, pdfLi=0, nonzero delta power,
+      cone/flag audit) with pbrt-v4 citations.
+- [ ] Sweep + continuity + selection gates (CPU CI + RTX GPU leg).
+
+## Lessons
+
+*(Fill in after the package is done.)*

--- a/.astroray_plan/packages/pkg141-gpu-near-delta-disney-metal-brightness.md
+++ b/.astroray_plan/packages/pkg141-gpu-near-delta-disney-metal-brightness.md
@@ -1,0 +1,124 @@
+# pkg141 — GPU near-delta Disney-metal over-brightness (GPU/CPU 2.7–4.0× at roughness→0; adjudicate pdf-convention asymmetry vs closure-graph twin)
+
+**Pillar:** 3 (GPU/CPU parity / MIS-pdf consistency)
+**Track:** A (GPU lane; RTX-gated — CI is blind to it)
+**Codex-paste-ready:** no (diagnostic-first: two candidate mechanisms must be distinguished by instrumentation before the fix is chosen; the fix then needs parity + wavefront-diff re-validation)
+**Status:** open — **blocked on pkg123 (PR #498) merging first** (the CPU is the canonical baseline only post-#498; the evidence xfail rows live on that branch)
+**Estimated effort:** M (instrumentation + one localized fix + un-xfail; the risk is the fix touching the shared GPU sampling path used by both megakernel and wavefront)
+**Depends on:** **pkg123 (PR #498)**. Related but distinct from **pkg124** (CPU VNDF swap for the opaque lobe — do not entangle; land order between pkg141 and pkg124 is free, but each must leave the other's gates green) and **pkg138** (dielectric eval — different lobe). This package OWNS the CPU/GPU mixture-pdf asymmetry that pkg138's Notes flagged as out-of-scope.
+
+---
+
+## Context — measured tonight (2026-07-20 overnight), pre-existing on main
+
+GPU renders Disney **metal at roughness = 0.0** substantially brighter than the
+CPU reference:
+
+- **GPU/CPU mean ratio 2.70×** on PRE-#498 main (GPU 0.02387 vs CPU 0.00884).
+- The GPU image is **byte-identical pre/post #498** (the #498 fixes are
+  CPU-side) — so this is NOT a #498 regression; it is a pre-existing GPU
+  defect exposed by tightening the CPU.
+- Post-#498 the CPU is canonical (chi²-adjudicated), and the measured gap
+  becomes **4.0×**.
+- Evidence is **xfail'd** in
+  `tests/test_pkg123_disney_metal_gpu_cpu_parity.py` (near-delta rows) on the
+  #498 branch — this package un-xfails them.
+
+## Candidate mechanisms (adjudicate FIRST — do not fix blind)
+
+Instrument before fixing; the two suspects live in different code and imply
+different fixes:
+
+**S1 — sample-pdf convention asymmetry (flagged by the #498 Opus review,
+recorded in pkg138 Notes).** The CPU opaque-specular `sample()` returns the
+**full-mixture** density: `s.f = eval(...)`, `s.pdf = pdf(...)`
+(`plugins/materials/disney.cpp:512-514`, post-#498 anchors). The GPU inline
+sampler pairs the **full-mixture f** with a **selected-lobe-only pdf**:
+`s.f = gpu_disney_eval(...)` (full mixture) but
+`s.pdf = D·NdotH/(4·HdotV) · (specW/total)` — the specular-lobe density only
+(`include/astroray/gpu_materials.h:849-857`). A full-mixture `f` over a
+partial-mixture `pdf` is an inconsistent one-sample estimator (Veach 1997
+§9.2 one-sample model: with lobe-selection probability folded in, either pair
+full-f with full-mixture pdf, or lobe-f with lobe-pdf — never mixed). Whether
+this quantitatively yields 2.7–4.0× at near-delta must be shown by the
+instrumentation, not assumed: dump `(f, pdf, f/pdf)` per event CPU-vs-GPU for
+identical `(wo, wi)` at roughness 0 and compare.
+
+**S2 — the GPU closure-graph Disney twin.** Plain dielectric/Disney-glass
+shades via `GMAT_CLOSURE_GRAPH` on the GPU, not the inline path (memory:
+`gpu-dielectric-lowers-to-closure-graph`, PR #404 fixed an eta²-clamp there).
+**Check whether Disney METAL also lowers to the closure graph** in the scene
+used by the parity test — if it does, the defect may live in the closure-graph
+metal lobe (its own F/D/G or pdf), and `gpu_materials.h:849-857` is not even
+the executing code. Instrument: log which GPU material path
+(`GMAT_*`/closure-graph node) actually shades the test sphere.
+
+**Ruled out by architect pre-check:** the near-delta roughness clamp is
+IDENTICAL on both sides — `max(roughness², 0.0064)` at
+`disney.cpp:{99,178,208,346,501,530}` and `gpu_materials.h:{519,606,638,714,833}`
+(verified 2026-07-20) — so an alpha-floor mismatch is not the mechanism.
+
+## Fix plan (cite — no inventions, CLAUDE.md §6)
+
+After adjudication, fix the guilty site so **CPU and GPU compute the same
+estimator term-for-term**:
+
+- If **S1**: make the GPU sampler's `(f, pdf)` pair consistent — either mirror
+  the CPU's full-mixture convention (pdf of the whole mixture at the sampled
+  direction, matching `disney.cpp:514`) or the selected-lobe convention on BOTH
+  f and pdf. **Prefer mirroring the CPU** (it is the chi²-validated canonical
+  side post-#498). Cite Veach 1997 §9.2 (one-sample mixture estimator) and the
+  CPU implementation as the in-repo generator; Cycles
+  `intern/cycles/kernel/closure/bsdf.h` (`bsdf_sample`/`bsdf_pdf` mixture
+  handling) as the production cross-reference.
+- If **S2**: fix the closure-graph metal lobe against the same references (and
+  the #404 precedent for how closure-graph energy bugs get fixed + gated).
+- Either way: the megakernel and wavefront share this code — run BOTH legs.
+
+## Verification gates
+
+- [ ] Instrumentation note recorded in the PR: which mechanism (S1/S2/other),
+      with the per-event `(f, pdf)` dump or path-taken log as evidence.
+- [ ] **Un-xfail the near-delta rows of
+      `tests/test_pkg123_disney_metal_gpu_cpu_parity.py`** — GPU/CPU mean ratio
+      within the test's parity band at roughness 0.0 (and the near-delta grid
+      the test covers), on RTX.
+- [ ] Rough-metal no-regression: mid/high-roughness metal parity rows stay
+      green (the fix must not shift the already-agreeing regime).
+- [ ] Wavefront-diff gate suite stays green (megakernel + wavefront legs both
+      re-run — shared sampling code).
+- [ ] White-furnace / energy gates on metal stay green.
+- [ ] If S1: the CPU/GPU "mixture-pdf asymmetry" flag in pkg138's Notes is
+      resolved by this package — update that spec's note to point here.
+
+## Non-goals
+
+- **Not the CPU sampler** — post-#498 CPU is canonical; this package changes
+  the GPU side (or the closure graph) to match it.
+- **Not pkg124's VNDF swap** — if pkg124 lands first, re-anchor and keep its
+  gates green; do not fold the VNDF change in here.
+- **Not the dielectric lobe** (pkg138).
+- **Not a general GPU MIS audit** — only the metal near-delta defect and
+  whichever single mechanism the instrumentation convicts.
+
+## Provenance
+
+Filed from the **2026-07-20 overnight hardware-verifier measurement**: GPU/CPU
+2.70× at roughness 0.0 on pre-#498 main (GPU 0.02387 / CPU 0.00884), GPU
+byte-identical pre/post #498, 4.0× vs the post-#498 canonical CPU; xfail
+evidence in `tests/test_pkg123_disney_metal_gpu_cpu_parity.py` on
+`origin/pkg123-disney-chi2`. S1 was first flagged by the #498 Opus review
+(recorded in pkg138 Notes, now owned here). Clamp-parity pre-check
+(`0.0064` floor identical both sides) done by the architect 2026-07-20.
+
+## Progress
+
+- [ ] Instrument: which GPU path shades the test scene (S2 check) + per-event
+      `(f, pdf)` CPU-vs-GPU dump (S1 check).
+- [ ] Fix the convicted mechanism with citations.
+- [ ] Un-xfail near-delta parity rows; both-legs + furnace + wavefront-diff
+      green on RTX.
+
+## Lessons
+
+*(Fill in after the package is done.)*


### PR DESCRIPTION
Doc-only: files three package specs from the pkg122 hardware-verifier + #498-review findings (architect agent). Touches only `.astroray_plan/packages/`.

**pkg139 — addon AREA-light orientation convention (HIGH-VALUE, addon lane, S).** `convert_lights()` AREA branch (`blender_addon/__init__.py:3947-3968`) builds `axis_u`=+X, `axis_v`=+Y so the AreaLight normal u×v = local **+Z**, but Cycles lights emit along local **-Z** (the addon SUN/SPOT branches already use -Z at `:3941`/`:3971`). Default-rotation area lights point AWAY from the scene: measured 0.089-0.116x vs Cycles, 1.07-1.09x after a 180° local-X flip — a second, independent mechanism behind the owner-visible dimness. Folds the bounded `setup_world()` strength==0 background-skip fix (`:4082-4086`). Status: open, dispatchable now.

**pkg140 — DistantLight angular_diameter≈0 pure black (engine lane, S-M).** Verified mechanism is sharper than the initial suspicion: `sampleLi` pdf = 1/solidAngle → **inf** at 0 (`distant_light.cpp:73-75`), `power()` ∝ solidAngle → **0** = power-CDF starvation (`:84-93`), and **float cancellation** in `1-cos(halfAngle)` zeroes solidAngle for half-angles ≲3.4e-4 rad — exactly why the 0.00017-rad sweep row is also black while 0.00175 works. Fix: `2sin²(h/2)` identity in all four CPU sites + the GPU `cosOuter` mirror, plus a true-delta branch citing pbrt-v4 `DistantLight` (SampleLi pdf=1, PDF_Li=0, nonzero delta power). Status: open, dispatchable now.

**pkg141 — GPU near-delta Disney-metal over-brightness (GPU lane, M).** GPU/CPU 2.70x at roughness 0.0 on pre-#498 main (GPU byte-identical pre/post #498; 4.0x vs the post-#498 canonical CPU). Diagnostic-first: adjudicate S1 = full-mixture `f` paired with selected-lobe-only `pdf` on GPU (`gpu_materials.h:849-857` vs CPU full-mixture at `disney.cpp:514`; the asymmetry the #498 Opus review flagged — this pkg now OWNS the pkg138 Notes item) vs S2 = the closure-graph Disney twin (check whether metal lowers there; #404 precedent). Alpha-floor mismatch RULED OUT by pre-check (0.0064 clamp identical both sides, all sites listed). Gates: un-xfail the near-delta rows of `tests/test_pkg123_disney_metal_gpu_cpu_parity.py`, both kernel legs + furnace + wavefront-diff green on RTX. Status: blocked on #498 merging.

Not spec'd (flag only, per coordinator latitude): the Disney floor baseline Fresnel-specular energy-leak observation — needs a minimal repro and overlaps pkg138's Cspec0 territory; recommend re-measuring after pkg138 lands.

No conflation with pkg122 (in flight; both new light specs carry explicit do-not-touch-energy non-goals) and no Defect-4 preemption (owner-reserved).

Doc-only closeout rule applies: auto-merge eligible on green CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)