### PR TITLE
fix(pkg139): addon AREA-light orientation (-Z convention) + world strength-0 black background

### DIFF
--- a/.astroray_plan/packages/pkg139-addon-area-light-orientation.md
+++ b/.astroray_plan/packages/pkg139-addon-area-light-orientation.md
@@ -106,11 +106,64 @@ checkout: `blender_addon/__init__.py:3947-3968` (AREA basis), `:3941`/`:3971`
 
 - [x] AREA basis flip (normal → local −Z) + non-square axis check (PR #505).
 - [x] Strength-0 world background fix (PR #505).
-- [ ] Cycles A/B parity gates (identity + rotated + non-square) — convention
-      verified mathematically via unit tests in PR #505 (no `.pyd` access for
-      the implementer); live headless-Blender-vs-Cycles pixel measurement
-      still owned by the hardware-verifier.
+- [x] Cycles A/B parity gates (identity + rotated + non-square) — convention
+      verified live against headless Cycles on RTX 5070 Ti hardware
+      (2026-07-21, PR #505). See Hardware verification section below.
 
 ## Lessons
 
-*(Fill in after the package is done — pending hardware-verifier close-out.)*
+### Hardware verification 2026-07-21
+
+**Hardware:** NVIDIA GeForce RTX 5070 Ti, driver 610.47, CUDA 12.8 (nvcc,
+build_cuda/CMakeCache.txt), Windows 11 Enterprise 10.0.26200. Blender 5.1.0
+(hash adfe2921d5f3, built 2026-03-17). PR #505 head
+8f74fc067488af655b892e7e024dc4dedfa9c951, PYTHON-ONLY branch (blender_addon +
+tests) off origin/main; verified against main's fresh build_cuda/Release
+astroray.pyd (engine code identical between branch and main, per dispatch
+instructions) via ASTRORAY_BUILD_DIR. Confirmed both module provenances at
+render time: `astroray.__file__` resolved to
+`Astroray/build_cuda/Release/astroray.cp313-win_amd64.pyd` (main, fresh --
+built after main HEAD 2b18a1d 17:38:11, .pyd mtime 17:41:54/56) and
+`blender_addon.__file__` resolved to
+`Astroray-pkg139/blender_addon/__init__.py` (the PR's fixed addon, not
+main's).
+
+Live headless-Blender-vs-Cycles oracle
+(`scripts/verify_pkg139_area_orientation_oracle.py`, adapted from
+`Astroray-pkg122/scripts/verify_pkg122_cycles_oracle.py`), 128x128, 512 spp,
+seed 7, `--background --factory-startup`:
+
+| Scenario | Cycles mean RGB | Astroray mean RGB | Astroray/Cycles ratio | NaN px | Verdict |
+|---|---|---|---|---|---|
+| AREA identity rotation (3x3 rect, energy 300W, height 3m) | [1.2621999871730805, 1.2621999871730805, 1.2621999871730805] | [1.2447374701499938, 1.2453984093666077, 1.218624472618103] | [0.9861650156864626, 0.9866886563324225, 0.9654765370006282] | 0/0 | PASS -- within normal band, not the pre-fix 0.089-0.116x regime |
+| AREA rotated 45 deg about local X | [1.111258443593979, 1.111258443593979, 1.111258443593979] | [1.0886146026849746, 1.0902422112226486, 1.0686646163463593] | [0.9796232451239959, 0.9810878985959732, 0.961670637921216] | 0/0 | PASS -- convention holds under non-identity rotation, not a compensating identity-only hack |
+| AREA non-square rectangle (size_x=2.4, size_y=0.4), center patch | [1.5125463318824768 x3] | [1.5297622787952423, 1.5305179703235625, 1.4970408940315247] | [1.0113820955760997, 1.0118817110340803, 0.9897487848642267] | 0/0 | PASS |
+| non-square, probe +X (u / size_x, long axis) | [0.8557976856827736 x3] | [0.8368318201974034, 0.8357639908790588, 0.8177063912153244] | [0.9778383772208512, 0.9765906181579219, 0.9554903044204202] | 0/0 | PASS -- brighter than +Y probe in both engines (long axis correctly along u) |
+| non-square, probe +Y (v / size_y, short axis) | [0.7634025095030665 x3] | [0.7410957077518106, 0.7434861361980438, 0.7317604580894113] | [0.9707797636586544, 0.9739110455400688, 0.9585512871391364] | 0/0 | PASS -- no axis swap/mirror: X > Y ordering matches Cycles in both engines |
+| World strength=0.0, SPOT-cone scene, corner patch outside cone | [0.0, 0.0, 0.0] | [0.0, 0.0, 0.0] | n/a (both exactly black) | 0/0 | PASS -- `Set background color: [0.0, 0.0, 0.0]` logged by the addon (guard removed, call now fires at strength 0); pre-fix this log line would not have printed at all and the engine default background would have leaked into the corner |
+
+**Visual inspection:** read every PNG in
+`Astroray-pkg139/test_results/pkg139_oracle/*_view.png`. Identity and
+rotated45: Astroray and Cycles both show a bright, correctly-oriented lit
+disc on the floor in matching positions -- no evidence of the light facing
+away from the scene. Non-square: both engines show a saturated central
+highlight (aspect-ratio elongation is clipped by overexposure at this
+tonemap, not usable for the mirror check by eye -- relied on the quantitative
++X/+Y probes above instead, which agree on ordering). World-strength-zero:
+both PNGs show a solid black frame with a small white spot-cone circle in
+matching position/size -- no leaked background in either engine. No
+fireflies, no banding, no magenta/black NaN pixels, no mode regressions
+observed in any of the 8 renders (4 scenarios x 2 engines).
+
+**Anomalies worth watching:** none blocking. `[CUDA] Scene uploaded: ...,
+0 lights, ...` printed in every Astroray run despite the dedicated area/spot
+light clearly contributing (ratios ~0.96-1.01x); this is a stats-line label
+question (dedicated lights apparently not counted in that particular log
+field), not a functional issue -- radiance output matches Cycles. Did not
+rerun the full pytest suite or pkg89 parity gates in this session (per
+dispatch scope: those were already verified green by the
+team-lead/implementer -- 6 new convention unit tests + 71 addon-adjacent
+tests, CI pending on the py-only branch); this session's gate was
+specifically the live Cycles A/B pixel oracle the spec called out as still
+open.
+

--- a/.astroray_plan/packages/pkg139-addon-area-light-orientation.md
+++ b/.astroray_plan/packages/pkg139-addon-area-light-orientation.md
@@ -3,7 +3,7 @@
 **Pillar:** 2 (Blender integration correctness)
 **Track:** A (addon/CPU lane; parity-tested against headless Cycles — Blender 5.1 installed locally)
 **Codex-paste-ready:** no (a sign/convention fix, but it must be validated against a live Cycles A/B render, not unit-tested in isolation)
-**Status:** open — dispatchable now (independent of the pkg122 energy calibration in flight; do NOT conflate — see Non-goals)
+**Status:** in review (PR #505, 2026-07-21 — AREA basis flip verified convention-correct at identity+rotated+non-square via mocked-bpy/real-vector-math unit tests; strength-0 background fix verified; live headless-Blender-vs-Cycles pixel A/B still pending hardware-verifier, no `.pyd` build access for this implementer). Independent of the pkg122 energy calibration in flight; do NOT conflate — see Non-goals.
 **Estimated effort:** S (one-line basis flip + a small world-background guard fix + a parity test)
 **Depends on:** none. Composes with pkg122 (energy) and pkg119-B (parity harness) but blocks on neither.
 
@@ -104,10 +104,13 @@ checkout: `blender_addon/__init__.py:3947-3968` (AREA basis), `:3941`/`:3971`
 
 ## Progress
 
-- [ ] AREA basis flip (normal → local −Z) + non-square axis check.
-- [ ] Strength-0 world background fix.
-- [ ] Cycles A/B parity gates (identity + rotated + non-square).
+- [x] AREA basis flip (normal → local −Z) + non-square axis check (PR #505).
+- [x] Strength-0 world background fix (PR #505).
+- [ ] Cycles A/B parity gates (identity + rotated + non-square) — convention
+      verified mathematically via unit tests in PR #505 (no `.pyd` access for
+      the implementer); live headless-Blender-vs-Cycles pixel measurement
+      still owned by the hardware-verifier.
 
 ## Lessons
 
-*(Fill in after the package is done.)*
+*(Fill in after the package is done — pending hardware-verifier close-out.)*

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -3946,9 +3946,20 @@ class CustomRaytracerRenderEngine(RenderEngine):
                 )
             elif light.type == 'AREA':
                 # pkg89 Phase B: use dedicated AreaLight with EmissionSpectrum.
+                # pkg139: AreaLight emits along u x v (area_light.h:59). Cycles area
+                # lights emit along local -Z (intern/cycles/blender/light.cpp
+                # BlenderSync::sync_light: axisu=local X, axisv=local Y, direction=-Z
+                # of the light transform) -- the same convention already used here
+                # for SUN (:3941) and SPOT (:3971 below). Using +Y for axis_v made
+                # u x v = +Z, pointing the light away from the scene at identity
+                # rotation (measured 0.089-0.116x vs Cycles). Flipping axis_v to -Y
+                # gives u x v = X x (-Y) = -Z, matching Cycles (measured 1.07-1.09x
+                # at the same rotation). size_x/size_y still map to u/v respectively;
+                # this flip only mirrors v about u, which is a no-op for the centered
+                # RECTANGLE/ELLIPSE/DISK shapes we support (symmetric about center).
                 basis = matrix.to_3x3()
                 axis_u = list((basis @ mathutils.Vector((1, 0, 0))).normalized())
-                axis_v = list((basis @ mathutils.Vector((0, 1, 0))).normalized())
+                axis_v = list((basis @ mathutils.Vector((0, -1, 0))).normalized())
                 shape = getattr(light, 'shape', 'SQUARE')
                 spread = float(getattr(light, 'spread', 1.0))
                 size_x = float(light.size)
@@ -4079,8 +4090,14 @@ class CustomRaytracerRenderEngine(RenderEngine):
             else:
                 print(f"Failed to load HDRI: {hdri_path}")
 
-        # Fallback: solid background color
-        if bg_color and strength > 0.01:
+        # Fallback: solid background color.
+        # pkg139: strength == 0.0 is artist intent for a black background, not
+        # "no background set" -- previously the `strength > 0.01` guard skipped
+        # set_background_color entirely at strength 0, leaving the engine's
+        # built-in default background visible instead of black. Always call
+        # set_background_color when bg_color is present; strength 0 scales it
+        # to explicit black.
+        if bg_color is not None:
             scaled_color = [c * strength for c in bg_color]
             renderer.set_background_color(scaled_color)
             print(f"Set background color: {scaled_color}")

--- a/scripts/verify_pkg139_area_orientation_oracle.py
+++ b/scripts/verify_pkg139_area_orientation_oracle.py
@@ -1,0 +1,260 @@
+# -*- coding: utf-8 -*-
+"""pkg139 hardware verification -- live headless-Cycles A/B oracle for the
+AREA-light orientation fix + world strength-0 background fix.
+
+Adapted from Astroray-pkg122/scripts/verify_pkg122_cycles_oracle.py (same
+methodology: same bpy light object driven through CYCLES then through the
+Astroray CUSTOM_RAYTRACER addon engine). CRITICAL: this script lives in the
+pkg139 WORKTREE scripts/ dir; ROOT resolves to the pkg139 worktree so
+"import blender_addon" picks up the worktree fixed __init__.py, not
+main. astroray (.pyd) is instead loaded via ASTRORAY_BUILD_DIR pointed at
+main fresh build_cuda/Release (engine code identical between branch/main).
+
+Run headless, once per --scenario:
+    blender --background --factory-startup --python scripts/verify_pkg139_area_orientation_oracle.py -- --scenario identity --out test_results/pkg139_oracle
+"""
+import argparse
+import glob
+import math
+import os
+import sys
+from pathlib import Path
+
+import bpy
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "tests"))
+import runtime_setup  # noqa: E402
+runtime_setup.configure_test_imports()
+sys.path.insert(0, ROOT)
+
+
+def _bootstrap_astroray_addon():
+    import astroray  # noqa: F401
+    print(f"[pkg139-oracle] astroray module: {astroray.__file__}")
+    import blender_addon
+    print(f"[pkg139-oracle] blender_addon module: {blender_addon.__file__}")
+    try:
+        blender_addon.register()
+    except Exception as exc:
+        if "already registered" not in str(exc):
+            raise
+
+
+def build_scene(scenario, engine=None):
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+    scene = bpy.context.scene
+
+    world = bpy.data.worlds.new("W")
+    scene.world = world
+    world.use_nodes = True
+    bg = world.node_tree.nodes.get("Background")
+
+    world_strength_zero = scenario == "world_strength_zero"
+    bg.inputs[0].default_value = (0.6, 0.3, 0.1, 1.0)
+    bg.inputs[1].default_value = 0.0 if world_strength_zero else 0.0
+
+    bpy.ops.mesh.primitive_plane_add(size=40.0, location=(0.0, 0.0, 0.0))
+    floor = bpy.context.active_object
+    mat = bpy.data.materials.new("Floor")
+    mat.use_nodes = True
+    nt = mat.node_tree
+    for n in list(nt.nodes):
+        nt.nodes.remove(n)
+    diff = nt.nodes.new("ShaderNodeBsdfDiffuse")
+    diff.inputs["Color"].default_value = (0.5, 0.5, 0.5, 1.0)
+    diff.inputs["Roughness"].default_value = 0.0
+    out = nt.nodes.new("ShaderNodeOutputMaterial")
+    nt.links.new(diff.outputs["BSDF"], out.inputs["Surface"])
+    floor.data.materials.append(mat)
+
+    cam_data = bpy.data.cameras.new("Cam")
+    cam_data.type = "PERSP"
+    cam_data.lens_unit = "FOV"
+    cam_data.angle = math.radians(20.0)
+    cam = bpy.data.objects.new("Cam", cam_data)
+    scene.collection.objects.link(cam)
+    cam.location = (0.0, 0.0, 20.0)
+    cam.rotation_euler = (0.0, 0.0, 0.0)
+    scene.camera = cam
+
+    if scenario == "world_strength_zero":
+        light_data = bpy.data.lights.new("L", type="SPOT")
+        light_obj = bpy.data.objects.new("L", light_data)
+        scene.collection.objects.link(light_obj)
+        light_obj.rotation_euler = (0.0, 0.0, 0.0)
+        light_data.energy = 800.0
+        light_obj.location = (0.0, 0.0, 3.0)
+        light_data.shadow_soft_size = 0.0
+        light_data.spot_size = math.radians(20.0)
+        light_data.spot_blend = 0.2
+        return scene
+
+    light_data = bpy.data.lights.new("L", type="AREA")
+    light_obj = bpy.data.objects.new("L", light_data)
+    scene.collection.objects.link(light_obj)
+    light_data.energy = 300.0
+    light_obj.location = (0.0, 0.0, 3.0)
+    light_data.shape = "RECTANGLE"
+
+    if scenario == "identity":
+        light_data.size = 3.0
+        light_data.size_y = 3.0
+        light_obj.rotation_euler = (0.0, 0.0, 0.0)
+    elif scenario == "rotated45":
+        light_data.size = 3.0
+        light_data.size_y = 3.0
+        light_obj.rotation_euler = (math.radians(45.0), 0.0, 0.0)
+    elif scenario == "nonsquare":
+        light_data.size = 2.4
+        light_data.size_y = 0.4
+        light_obj.rotation_euler = (0.0, 0.0, 0.0)
+    else:
+        raise ValueError(f"unknown scenario {scenario}")
+
+    return scene
+
+
+def render_engine(scene, engine, spp, out_stem):
+    scene.render.engine = engine
+    scene.render.resolution_x = 128
+    scene.render.resolution_y = 128
+    scene.render.resolution_percentage = 100
+    scene.view_settings.view_transform = "Standard"
+    scene.view_settings.exposure = 0.0
+    scene.view_settings.gamma = 1.0
+    scene.render.image_settings.file_format = "OPEN_EXR"
+    scene.render.image_settings.color_depth = "32"
+    scene.render.image_settings.exr_codec = "NONE"
+    scene.cycles.seed = 7
+    if engine == "CYCLES":
+        scene.cycles.samples = spp
+        scene.cycles.use_denoising = False
+        scene.cycles.use_adaptive_sampling = False
+    elif hasattr(scene, "custom_raytracer"):
+        scene.custom_raytracer.samples = spp
+        scene.custom_raytracer.preview_samples = spp
+        if hasattr(scene.custom_raytracer, "device_mode"):
+            scene.custom_raytracer.device_mode = "gpu"
+
+    for f in glob.glob(str(out_stem) + "*"):
+        os.remove(f)
+    scene.render.filepath = str(out_stem)
+    bpy.ops.render.render(write_still=True)
+
+    matches = sorted(glob.glob(str(out_stem) + "*"))
+    if not matches:
+        raise RuntimeError(f"no render output found for stem {out_stem}")
+    out_path = matches[0]
+
+    img = bpy.data.images.load(out_path)
+    w, h = img.size
+    px = list(img.pixels[:])
+    import array
+    arr = array.array("f", px)
+    bpy.data.images.remove(img)
+
+    png_stem = str(out_stem) + "_view"
+    scene.render.image_settings.file_format = "PNG"
+    scene.render.image_settings.color_depth = "8"
+    for f in glob.glob(png_stem + "*"):
+        os.remove(f)
+    scene.render.filepath = png_stem
+    bpy.ops.render.render(write_still=True)
+
+    return arr, w, h, out_path
+
+
+def patch_mean(arr, w, h, cx, cy, patch=8):
+    x0, x1 = max(0, cx - patch // 2), min(w, cx + patch // 2)
+    y0, y1 = max(0, cy - patch // 2), min(h, cy + patch // 2)
+    sums = [0.0, 0.0, 0.0]
+    n = 0
+    for y in range(y0, y1):
+        for x in range(x0, x1):
+            idx = (y * w + x) * 4
+            sums[0] += arr[idx]
+            sums[1] += arr[idx + 1]
+            sums[2] += arr[idx + 2]
+            n += 1
+    return [s / n for s in sums] if n else [float("nan")] * 3
+
+
+def world_to_pixel(wx, wy, w, h, cam_height=20.0, fov_deg=20.0):
+    half_width = cam_height * math.tan(math.radians(fov_deg) / 2.0)
+    fx = wx / half_width
+    fy = wy / half_width
+    px = int(round(w / 2 + fx * (w / 2)))
+    py = int(round(h / 2 - fy * (h / 2)))
+    return px, py
+
+
+def count_nan(arr):
+    n = 0
+    for v in arr:
+        if v != v:
+            n += 1
+    return n
+
+
+def main():
+    argv = sys.argv[sys.argv.index("--") + 1:] if "--" in sys.argv else []
+    p = argparse.ArgumentParser()
+    p.add_argument("--scenario", required=True,
+                    choices=["identity", "rotated45", "nonsquare", "world_strength_zero"])
+    p.add_argument("--out", type=Path, default=Path("test_results/pkg139_oracle"))
+    p.add_argument("--spp", type=int, default=512)
+    args = p.parse_args(argv)
+
+    args.out = args.out.resolve()
+    args.out.mkdir(parents=True, exist_ok=True)
+
+    results = {}
+    nan_counts = {}
+    paths = {}
+    for engine in ("CYCLES", "CUSTOM_RAYTRACER"):
+        scene = build_scene(args.scenario, engine=engine)
+        if engine == "CUSTOM_RAYTRACER":
+            _bootstrap_astroray_addon()
+        stem = args.out / f"{args.scenario}_{engine.lower()}"
+        arr, w, h, out_path = render_engine(scene, engine, args.spp, stem)
+        nan_counts[engine] = count_nan(arr)
+        paths[engine] = out_path
+
+        if args.scenario == "world_strength_zero":
+            rgb = patch_mean(arr, w, h, w - 10, 10, patch=8)
+        elif args.scenario == "nonsquare":
+            cx, cy = w // 2, h // 2
+            px_x, py_x = world_to_pixel(2.0, 0.0, w, h)
+            px_y, py_y = world_to_pixel(0.0, 2.0, w, h)
+            rgb = {
+                "center": patch_mean(arr, w, h, cx, cy, patch=10),
+                "probe_pX_u_sizex": patch_mean(arr, w, h, px_x, py_x, patch=8),
+                "probe_pY_v_sizey": patch_mean(arr, w, h, px_y, py_y, patch=8),
+            }
+        else:
+            cx, cy = w // 2, h // 2
+            rgb = patch_mean(arr, w, h, cx, cy, patch=10)
+
+        results[engine] = rgb
+        print(f"[pkg139-oracle] {args.scenario} {engine}: rgb={rgb} nan={nan_counts[engine]} file={out_path}")
+
+    cyc = results["CYCLES"]
+    ast = results["CUSTOM_RAYTRACER"]
+
+    if args.scenario == "nonsquare":
+        for key in ("center", "probe_pX_u_sizex", "probe_pY_v_sizey"):
+            c = cyc[key]
+            a = ast[key]
+            ratios = [x / y if y > 1e-9 else float("nan") for x, y in zip(a, c)]
+            print(f"[pkg139-oracle] {args.scenario} {key} RESULT cycles_rgb={c} astroray_rgb={a} ratio={ratios}")
+    elif args.scenario == "world_strength_zero":
+        print(f"[pkg139-oracle] {args.scenario} RESULT cycles_corner_rgb={cyc} astroray_corner_rgb={ast}")
+    else:
+        ratios = [a / c if c > 1e-9 else float("nan") for a, c in zip(ast, cyc)]
+        print(f"[pkg139-oracle] {args.scenario} RESULT cycles_rgb={cyc} astroray_rgb={ast} ratio_astroray_over_cycles={ratios}")
+
+    print(f"[pkg139-oracle] {args.scenario} NAN_COUNTS cycles={nan_counts['CYCLES']} astroray={nan_counts['CUSTOM_RAYTRACER']}")
+
+
+main()

--- a/tests/test_pkg139_area_light_orientation.py
+++ b/tests/test_pkg139_area_light_orientation.py
@@ -1,0 +1,353 @@
+"""pkg139: AREA-light orientation convention + world strength-0 background fix.
+
+Root cause (verified in code, `blender_addon/__init__.py` `convert_lights`
+AREA branch): the engine's `AreaLight` emits along its normal `u x v`
+(`include/astroray/lights/area_light.h:59`), but Blender/Cycles area lights
+emit along the light's local -Z axis (Cycles `BlenderSync::sync_light`,
+`intern/cycles/blender/light.cpp`: `axisu` = local X, `axisv` = local Y,
+emission direction = -Z of the light transform) -- the same convention the
+addon itself already uses for SUN (`__init__.py:3941`) and SPOT
+(`__init__.py:3971`). Before the fix, `axis_u = local +X`, `axis_v = local
++Y` gave `u x v = +Z`, pointing every default-orientation area light AWAY
+from the scene (measured 0.089-0.116x vs Cycles by the pkg122 hardware
+verifier; 180 deg local-X flip measured 1.07-1.09x).
+
+These tests exercise the real `convert_lights`/`setup_world` code paths
+(loaded from `blender_addon/__init__.py` via `importlib`, matching the
+pattern in `test_addon_instanced_lights.py`) with a minimal but REAL 3-D
+vector/matrix implementation standing in for `mathutils` -- rotation
+matrices and cross products are undergraduate-textbook math (CLAUDE.md
+Sec 6 "trivial"), not the thing under test. What IS under test is the
+addon's convention: for an arbitrary light-to-world basis, is the emitted
+normal (`axis_u x axis_v`) equal to `basis @ (0, 0, -1)`, matching Cycles?
+
+This validates the fix's math/convention. It does NOT replace a live
+headless-Blender-vs-Cycles pixel A/B (this implementer cannot build the
+`.pyd`; the hardware-verifier owns that gate per the spec's verification
+checklist).
+"""
+
+import importlib.util
+import math
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Minimal real 3-D vector/matrix stand-ins for mathutils (undergrad math).
+# ---------------------------------------------------------------------------
+
+class _FakeVector:
+    def __init__(self, xyz):
+        self._v = tuple(float(c) for c in xyz)
+
+    def normalized(self):
+        x, y, z = self._v
+        n = math.sqrt(x * x + y * y + z * z)
+        if n == 0.0:
+            return _FakeVector((0.0, 0.0, 0.0))
+        return _FakeVector((x / n, y / n, z / n))
+
+    def __iter__(self):
+        return iter(self._v)
+
+    def __len__(self):
+        return 3
+
+    def __getitem__(self, i):
+        return self._v[i]
+
+    @property
+    def x(self):
+        return self._v[0]
+
+    @property
+    def y(self):
+        return self._v[1]
+
+    @property
+    def z(self):
+        return self._v[2]
+
+
+class _FakeMatrix3:
+    """3x3 matrix given as 3 row tuples; supports `matrix @ vector`."""
+
+    def __init__(self, rows):
+        self.rows = rows
+
+    def __matmul__(self, vec):
+        x, y, z = tuple(vec)
+        return _FakeVector((
+            self.rows[0][0] * x + self.rows[0][1] * y + self.rows[0][2] * z,
+            self.rows[1][0] * x + self.rows[1][1] * y + self.rows[1][2] * z,
+            self.rows[2][0] * x + self.rows[2][1] * y + self.rows[2][2] * z,
+        ))
+
+
+def _rot_x(theta):
+    c, s = math.cos(theta), math.sin(theta)
+    return ((1, 0, 0), (0, c, -s), (0, s, c))
+
+
+def _rot_y(theta):
+    c, s = math.cos(theta), math.sin(theta)
+    return ((c, 0, s), (0, 1, 0), (-s, 0, c))
+
+
+def _rot_z(theta):
+    c, s = math.cos(theta), math.sin(theta)
+    return ((c, -s, 0), (s, c, 0), (0, 0, 1))
+
+
+def _matmul3(a, b):
+    return tuple(
+        tuple(sum(a[i][k] * b[k][j] for k in range(3)) for j in range(3))
+        for i in range(3)
+    )
+
+
+def _cross(u, v):
+    ux, uy, uz = u
+    vx, vy, vz = v
+    return (uy * vz - uz * vy, uz * vx - ux * vz, ux * vy - uy * vx)
+
+
+def _dot(u, v):
+    return sum(a * b for a, b in zip(u, v))
+
+
+IDENTITY = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+# Composed, non-axis-aligned rotation (three Euler-like rotations chained) --
+# an arbitrary basis, not tied to any single axis, to catch a fix that only
+# happens to work at identity or about one axis.
+ROTATED = _matmul3(_matmul3(_rot_z(math.radians(37.0)), _rot_y(math.radians(52.0))),
+                    _rot_x(math.radians(19.0)))
+
+
+# ---------------------------------------------------------------------------
+# Addon loader (mirrors tests/test_addon_instanced_lights.py).
+# ---------------------------------------------------------------------------
+
+def _load_blender_addon(monkeypatch):
+    bpy_module = types.ModuleType("bpy")
+    bpy_types_module = types.ModuleType("bpy.types")
+    bpy_props_module = types.ModuleType("bpy.props")
+
+    class _Base:
+        pass
+
+    class _RenderEngineBase:
+        def report(self, *_a, **_k): return None
+        def update_progress(self, *_a, **_k): return None
+        def update_stats(self, *_a, **_k): return None
+        def test_break(self): return False
+
+    bpy_types_module.Panel = _Base
+    bpy_types_module.Operator = _Base
+    bpy_types_module.AddonPreferences = _Base
+    bpy_types_module.PropertyGroup = _Base
+    bpy_types_module.RenderEngine = _RenderEngineBase
+    bpy_module.types = bpy_types_module
+
+    for name in ("BoolProperty", "IntProperty", "FloatProperty", "StringProperty",
+                 "PointerProperty", "FloatVectorProperty", "EnumProperty"):
+        setattr(bpy_props_module, name, lambda **_kwargs: None)
+    bpy_module.props = bpy_props_module
+    bpy_module.path = types.SimpleNamespace(abspath=lambda p: p)
+
+    shader_blending_module = types.ModuleType("shader_blending")
+    shader_blending_module.blend_shader_specs = {}
+    shader_blending_module.add_shader_specs = {}
+
+    mathutils_module = types.ModuleType("mathutils")
+    mathutils_module.Vector = _FakeVector
+
+    astroray_module = types.ModuleType("astroray")
+    astroray_module.__version__ = "test"
+    astroray_module.__features__ = {"cuda": False, "spectral": True}
+    astroray_module.__file__ = "/fake/astroray.pyd"
+    astroray_module.integrator_registry_names = lambda: ["path_tracer"]
+    astroray_module.material_registry_names = lambda: ["lambertian"]
+    astroray_module.pass_registry_names = lambda: []
+
+    monkeypatch.setitem(sys.modules, "bpy", bpy_module)
+    monkeypatch.setitem(sys.modules, "bpy.types", bpy_types_module)
+    monkeypatch.setitem(sys.modules, "bpy.props", bpy_props_module)
+    monkeypatch.setitem(sys.modules, "shader_blending", shader_blending_module)
+    monkeypatch.setitem(sys.modules, "mathutils", mathutils_module)
+    monkeypatch.setitem(sys.modules, "astroray", astroray_module)
+
+    module_path = Path(__file__).parent.parent / "blender_addon" / "__init__.py"
+    spec = importlib.util.spec_from_file_location("astroray_blender_addon_pkg139_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class _RecordingRenderer:
+    def __init__(self):
+        self.area_light_calls = []
+        self.background_calls = []
+
+    def add_area_light_dedicated(self, *args, **_kw):
+        self.area_light_calls.append(args)
+
+    def add_point_light(self, *a, **k): pass
+    def add_sun_light_dedicated(self, *a, **k): pass
+    def add_spot_light_dedicated(self, *a, **k): pass
+
+    def set_background_color(self, color):
+        self.background_calls.append(list(color))
+
+    def set_world_volume(self, *a, **k): pass
+    def set_world_max_bounces(self, *a, **k): pass
+
+
+def _make_area_light_instance(basis_rows, size_x=1.0, size_y=1.0, shape='SQUARE'):
+    light = types.SimpleNamespace(
+        type='AREA',
+        color=(1.0, 1.0, 1.0),
+        energy=100.0,
+        shape=shape,
+        spread=1.0,
+        size=size_x,
+        size_y=size_y,
+    )
+    obj = types.SimpleNamespace(type='LIGHT', data=light, pass_index=0)
+    matrix = types.SimpleNamespace(
+        translation=[0.0, 0.0, 0.0],
+        to_3x3=lambda: _FakeMatrix3(basis_rows),
+    )
+    return types.SimpleNamespace(object=obj, matrix_world=matrix, is_instance=False)
+
+
+def _convert_one_area_light(monkeypatch, basis_rows, size_x=1.0, size_y=1.0, shape='SQUARE'):
+    addon = _load_blender_addon(monkeypatch)
+    engine = addon.CustomRaytracerRenderEngine()
+    renderer = _RecordingRenderer()
+    instance = _make_area_light_instance(basis_rows, size_x=size_x, size_y=size_y, shape=shape)
+    depsgraph = types.SimpleNamespace(object_instances=[instance], objects=[])
+    engine.convert_lights(depsgraph, renderer)
+    assert len(renderer.area_light_calls) == 1
+    return renderer.area_light_calls[0]
+
+
+@pytest.mark.parametrize("basis_rows,label", [(IDENTITY, "identity"), (ROTATED, "rotated")])
+def test_area_light_normal_matches_cycles_minus_z(monkeypatch, basis_rows, label):
+    """u x v must equal basis @ (0, 0, -1) -- the Cycles emission convention
+    (BlenderSync::sync_light: axisu=local X, axisv=local Y, direction=-Z of
+    the light transform), for both identity and an arbitrary rotated basis.
+    Pre-fix this failed at identity (u x v = +Z, measured 0.089-0.116x vs
+    Cycles); a fix that only special-cased identity would still fail here.
+    """
+    call = _convert_one_area_light(monkeypatch, basis_rows)
+    _position, axis_u, axis_v, size_x, size_y, shape, _emission, _intensity, _spread = call[:9]
+
+    normal = _cross(tuple(axis_u), tuple(axis_v))
+    n = math.sqrt(sum(c * c for c in normal))
+    normal = tuple(c / n for c in normal)
+
+    expected = tuple(_FakeMatrix3(basis_rows) @ _FakeVector((0.0, 0.0, -1.0)))
+
+    cos_angle = _dot(normal, expected)
+    assert cos_angle > 0.999, (
+        f"[{label}] AREA light normal (u x v = {normal}) does not match the "
+        f"Cycles -Z emission convention (expected {expected}), cos={cos_angle:.6f}"
+    )
+
+
+def test_area_light_axis_u_still_maps_size_x(monkeypatch):
+    """Non-square RECTANGLE: axis_u must remain local +X (unchanged by the
+    -Z fix) so size_x still maps to u -- only axis_v flips sign, which is a
+    no-op for the centered RECTANGLE/ELLIPSE/DISK shapes (symmetric about
+    the light's origin), so the long axis is not mirrored or swapped.
+    """
+    call = _convert_one_area_light(
+        monkeypatch, IDENTITY, size_x=3.0, size_y=1.0, shape='RECTANGLE')
+    _position, axis_u, axis_v, size_x, size_y, shape, _emission, _intensity, _spread = call[:9]
+
+    assert tuple(round(c, 6) for c in axis_u) == (1.0, 0.0, 0.0), (
+        f"axis_u changed by the orientation fix: {axis_u} (expected local +X, unchanged)"
+    )
+    assert tuple(round(c, 6) for c in axis_v) == (0.0, -1.0, 0.0), (
+        f"axis_v not flipped to local -Y: {axis_v}"
+    )
+    assert size_x == 3.0 and size_y == 1.0, (
+        f"size_x/size_y mapping changed by the orientation fix: ({size_x}, {size_y})"
+    )
+    assert shape == 'RECTANGLE'
+
+
+def test_area_light_ellipse_normal_matches_cycles(monkeypatch):
+    """Same -Z check for ELLIPSE (non-square, rotated) -- the shape/basis
+    fix must be convention-correct across shapes, not just RECTANGLE.
+    """
+    call = _convert_one_area_light(
+        monkeypatch, ROTATED, size_x=2.0, size_y=0.6, shape='ELLIPSE')
+    _position, axis_u, axis_v, size_x, size_y, shape, _emission, _intensity, _spread = call[:9]
+
+    normal = _cross(tuple(axis_u), tuple(axis_v))
+    n = math.sqrt(sum(c * c for c in normal))
+    normal = tuple(c / n for c in normal)
+    expected = tuple(_FakeMatrix3(ROTATED) @ _FakeVector((0.0, 0.0, -1.0)))
+    assert _dot(normal, expected) > 0.999
+    assert shape == 'ELLIPSE'
+    assert size_x == 2.0 and size_y == 0.6
+
+
+# ---------------------------------------------------------------------------
+# setup_world: strength-0 background must render black, not the engine
+# default (previously skipped by the `strength > 0.01` guard).
+# ---------------------------------------------------------------------------
+
+def _make_world(strength, color=(0.3, 0.4, 0.5)):
+    bg_node = types.SimpleNamespace(
+        type='BACKGROUND',
+        inputs={
+            'Strength': types.SimpleNamespace(default_value=strength),
+            'Color': types.SimpleNamespace(is_linked=False, default_value=(*color, 1.0)),
+        },
+    )
+    node_tree = types.SimpleNamespace(nodes=[bg_node])
+    return types.SimpleNamespace(
+        node_tree=node_tree,
+        light_settings=types.SimpleNamespace(max_bounces=1024),
+    )
+
+
+def test_world_strength_zero_sets_explicit_black_background(monkeypatch):
+    addon = _load_blender_addon(monkeypatch)
+    engine = addon.CustomRaytracerRenderEngine()
+    renderer = _RecordingRenderer()
+    scene = types.SimpleNamespace(world=_make_world(strength=0.0))
+
+    engine.setup_world(scene, renderer)
+
+    assert renderer.background_calls == [[0.0, 0.0, 0.0]], (
+        f"strength=0.0 world must set an explicit black background, "
+        f"got {renderer.background_calls} (engine default would otherwise show through)"
+    )
+
+
+def test_world_nonzero_strength_still_scales_background(monkeypatch):
+    """Regression: the strength>0 path (pre-existing behavior) must be
+    unchanged by dropping the `> 0.01` guard.
+    """
+    addon = _load_blender_addon(monkeypatch)
+    engine = addon.CustomRaytracerRenderEngine()
+    renderer = _RecordingRenderer()
+    scene = types.SimpleNamespace(world=_make_world(strength=2.0, color=(0.1, 0.2, 0.3)))
+
+    engine.setup_world(scene, renderer)
+
+    assert len(renderer.background_calls) == 1
+    got = renderer.background_calls[0]
+    expected = [0.2, 0.4, 0.6]
+    assert all(abs(a - b) < 1e-6 for a, b in zip(got, expected)), (
+        f"expected {expected}, got {got}"
+    )


### PR DESCRIPTION
## Summary

- `blender_addon/__init__.py` `convert_lights()` AREA branch built `axis_u=+X`, `axis_v=+Y`, giving the engine `AreaLight` normal `u x v = +Z`. Cycles area lights emit along local **-Z** (`intern/cycles/blender/light.cpp` `BlenderSync::sync_light`: `axisu`=local X, `axisv`=local Y, emission direction=-Z of the light transform) — the same convention the addon already uses for SUN (`:3941`) and SPOT (`:3971`). Every default-orientation area light pointed away from the scene.
- Fix: `axis_v = basis @ Vector((0, -1, 0))` so `u x v = X x (-Y) = -Z`. `axis_u` stays `+X` (unaffected, `size_x` mapping unchanged). The sign flip only mirrors `v` about `u`, which is a no-op for the centered RECTANGLE/ELLIPSE/DISK shapes we support — no mirroring/axis-swap for non-square shapes.
- `setup_world()`'s solid-background fallback previously used `if bg_color and strength > 0.01`, silently skipping `set_background_color` at `strength == 0.0` (artist intent: black background) and leaving the engine's built-in default background visible instead. Dropped the `> 0.01` floor: `bg_color is not None` now always sets an explicit (possibly black) background.

## Evidence (pkg122 hardware verifier, cited in the spec)

- Identity-rotation area light: Astroray/Cycles mean ratio **0.089-0.116x** pre-fix (scene lit only by leakage/bounce).
- Same scene, light flipped 180 deg about local X (equivalent to the fix): ratio **1.07-1.09x**, in the normal parity band.
- Evidence recorded in `Astroray-pkg122/test_results/` + `scripts/verify_pkg122_cycles_oracle.py` (2026-07-20 overnight run, see spec Provenance section).

## What is verified here vs. unverified

**Verified by this PR** (`tests/test_pkg139_area_light_orientation.py`, all passing, no `.pyd` needed):
- `convert_lights` (loaded via `importlib` against the real `blender_addon/__init__.py`, mocked `bpy`/`mathutils` per the `test_addon_instanced_lights.py` pattern, but with a REAL minimal 3x3-matrix/cross-product implementation — undergrad math, not the thing under test) produces `axis_u x axis_v == basis @ (0, 0, -1)` for both an **identity** basis and an **arbitrary rotated** basis (three composed rotations, not axis-aligned) — the fix is convention-correct, not an identity-only compensating hack.
- Same -Z check holds for a rotated, non-square **ELLIPSE**; `axis_u` is unchanged (`size_x` still maps to `u`) and `size_x`/`size_y` pass through unmirrored/unswapped for a non-square **RECTANGLE**.
- `setup_world`: `strength=0.0` now calls `set_background_color([0, 0, 0])` (previously no call at all); `strength=2.0` regression case still scales the background color correctly (unchanged pre-existing behavior).
- Broader addon-touching suite green (no regressions): `test_addon_instanced_lights.py`, `test_pkg96_reconcile_then_upload.py`, `test_blender_viewport_passes.py`, `test_blender_viewport_session.py`, `test_blender_view_layers.py`, `test_blender_light_sampler_wiring.py`, `test_blender_camera_motion_blur_wiring.py`, `test_blender_backend_policy.py`, `test_pkg116_exporter_caches.py`.

**NOT verified by this implementer** (no `.pyd` build access in this environment, per the standard implementer constraint):
- A live headless-Blender-vs-Cycles pixel A/B render (the spec's actual acceptance gate: "Astroray/Cycles mean ratio moves from ~0.09-0.12x to the normal band ~0.9-1.1x"). The team-lead / hardware-verifier needs to build the `.pyd` and re-run something in the shape of `verify_pkg122_cycles_oracle.py` / `verify_pkg115_textures_blender.py` against an area-light scene (identity rotation, a rotated case, and a non-square RECTANGLE/ELLIPSE case) to close that gate.
- `pkg89` GPU parity gates that depend on a build.

## Test commands

```
python -m pytest tests/test_pkg139_area_light_orientation.py -v
python -m pytest tests/test_addon_instanced_lights.py tests/test_pkg96_reconcile_then_upload.py tests/test_blender_viewport_passes.py tests/test_blender_viewport_session.py tests/test_blender_view_layers.py tests/test_blender_light_sampler_wiring.py tests/test_blender_camera_motion_blur_wiring.py tests/test_blender_backend_policy.py tests/test_pkg116_exporter_caches.py -q
```

## Acceptance criteria (spec `.astroray_plan/packages/pkg139-addon-area-light-orientation.md`)

- [x] AREA basis flip (normal -> local -Z), convention-correct for identity AND rotated bases (not a compensating identity-only hack).
- [x] Non-square RECTANGLE/ELLIPSE: long axis not mirrored/swapped (axis_u/size_x mapping unchanged, verified by test).
- [x] Strength-0 world renders black background (not the engine default).
- [x] Existing addon light tests + pkg89 parity gates stay green (addon-level; pkg89 GPU gates need a build, not run by this implementer).
- [ ] Live headless-Blender-vs-Cycles pixel A/B (identity + rotated + non-square) -- **pending hardware-verifier**, no `.pyd` in this environment.

## Non-goals (per spec)

- Not energy calibration (pkg122, in flight) — no wattage->radiance factors touched.
- Not Defect 4 (RGBIlluminant-vs-RGBUnbounded) — owner-reserved.
- Not spread/shape sampling — only the basis orientation + the world guard.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>