### PR TITLE
docs(pkg142): adjudicate Defect 4 — RGB emission convention (RGBIlluminant → RGBUnbounded, match Cycles)

### DIFF
--- a/.astroray_plan/docs/defect4-rgb-emission-research.md
+++ b/.astroray_plan/docs/defect4-rgb-emission-research.md
@@ -1,0 +1,175 @@
+# Defect 4 — RGB emission-convention adjudication: reference research + citations
+
+**Author:** architect (arch/pkg142-defect4)
+**Date:** 2026-07-21
+**Owner directive (verbatim):** "What ever is best and used by other renderers, your call."
+**Decision:** switch the RGB **emission** lift (`EmissionSpectrum::evalRGB` + the GPU
+mirror) from an **RGBIlluminant** (D65-weighted) lift to an **RGBUnbounded**
+(identity-round-trip, no-illuminant) lift, to reproduce Cycles' RGB-native light
+scaling and close the residual +7–16% equal-wattage brightness offset. Full
+implementation contract in `.astroray_plan/packages/pkg142-rgb-emission-convention.md`.
+
+---
+
+## 1. The question
+
+After pkg122 (PR #500) fixed the per-type radiometry (Defects 1–3: area
+mixed-measure pdf, point `1/π`→`1/(4π)`, blackbody photopic normalization), the
+live headless-Cycles oracle still measures **all four dedicated-light types
+1.07–1.16× brighter than Cycles at equal wattage** on a gray Lambertian floor.
+Decoupled pure-Lambertian analytic checks are 0.99×, so the residual is **not**
+radiometry — it is specifically how an RGB emission color is *lifted to a
+spectrum* in the spectral integrator. Astroray's RGB emission path is:
+
+`EmissionSpectrum::evalRGB` → `RGBIlluminantSpectrum(rgb).sample(wl)`
+(`src/emission_spectrum.cpp:187-191`, `src/spectrum.cpp:475-498`).
+
+`RGBIlluminantSpectrum::sample` computes, per wavelength:
+
+```
+s[i] = scale_ * sigmoid(rsp_, λ_i) * sampleD65(λ_i)      // scale_ = 2·max(rgb)
+```
+
+where `sampleD65(λ) = rawD65(λ) / ∫ rawD65·ȳ dλ` — the D65 SPD **normalized to
+unit photopic luminance** (`src/spectrum.cpp:49-77`). This is a faithful mirror of
+pbrt-v4's `RGBIlluminantSpectrum`.
+
+The **only** structural difference between `RGBIlluminantSpectrum` and
+`RGBUnboundedSpectrum` in Astroray is the `* sampleD65(λ)` factor
+(`src/spectrum.cpp:451-473` vs `475-498`). `RGBUnbounded` is
+`scale_ · sigmoid(rgb/scale_)` — the same Jakob-Hanika reflectance lift the gray
+floor **albedo** already uses (`RGBAlbedoSpectrum`), just with the magnitude
+factored back in. So the fork is precisely: **does emission carry a D65 illuminant
+chromaticity, or is it a plain reflectance-style lift symmetric with the albedo
+path?**
+
+---
+
+## 2. What the reference renderers actually do
+
+### pbrt-v4 (spectral) — RGBIlluminant, D65-weighted. **License: Apache-2.0** (verified `LICENSE.txt`).
+
+- `RGBIlluminantSpectrum::Sample` = `scale * rsp(λ) * illuminant->Sample(λ)`,
+  `illuminant = &cs.illuminant` (= D65 for the sRGB color space).
+  Source: `src/pbrt/util/spectrum.h`.
+- `DiffuseAreaLight::Create` parses emission as
+  `GetOneSpectrum("L", …, SpectrumType::Illuminant, …)` → **`RGBIlluminantSpectrum`**,
+  and additionally does `scale /= SpectrumToPhotometric(L)` (a photometric
+  self-normalization). Source: `src/pbrt/lights.cpp`.
+- `RGBUnboundedSpectrum::Sample` = `scale * rsp(λ)` (**no illuminant**). pbrt uses
+  it for unbounded/HDR *values* where an illuminant assumption is not wanted.
+  Source: `src/pbrt/util/spectrum.h`.
+
+So pbrt's **light emission convention is RGBIlluminant** (D65). Astroray currently
+matches pbrt here. The audit's earlier note that RGBUnbounded is "PBRT-v4
+DiffuseAreaLight" is **incorrect** — pbrt lights use `SpectrumType::Illuminant`.
+
+### Mitsuba 3 (spectral) — D65 illuminant for emitters. **License: BSD-3-Clause** (compatible).
+
+Mitsuba's docs state D65 is "the default emission spectrum used for light sources
+in all spectral rendering modes," and that a flat spectrum value of 1.0 as
+emitter radiance renders purple-ish (because sRGB has a D65 whitepoint), whereas
+the same spectrum as a BSDF reflectance renders white — i.e. Mitsuba's
+`srgb_d65` emitter lift is **D65-weighted**, exactly like pbrt/RGBIlluminant.
+
+### Cycles (RGB-native) — identity linear-RGB scaling, **no** spectral upsampling, **no** D65. **License: Apache-2.0** (verified `LICENSE`).
+
+- `src/kernel/light/area.h::area_light_eval`: `ls->eval_fac = M_1_PI_F * invarea`
+  — a **dimensionless geometric factor**, no color.
+- `src/scene/light.cpp`: `copy_v3_v3(klight->strength, strength);` — the light
+  `strength` (color × power) is stored **directly as a linear-RGB `float3`** and
+  the emitted radiance is `strength × eval_fac`. There is no spectrum, no
+  Jakob-Hanika lift, no D65 anywhere in the light path.
+
+So Cycles' "emission convention" is **the identity**: the RGB you type *is* the
+radiance, in linear Rec.709/sRGB primaries.
+
+---
+
+## 3. Why RGBIlluminant is +7–16% vs Cycles, and why RGBUnbounded fixes it
+
+For a **pure white** light both conventions give unit luminance in isolation
+(`RGBIlluminant` white → `sampleD65` integrates to Y=1 by construction;
+`RGBUnbounded` white → flat sigmoid at ~0.5 × scale 2 ≈ flat 1.0, also Y=1). The
+offset does **not** appear in the emitter alone — it appears in the **reflected
+product** off the gray floor:
+
+- **Cycles (RGB):** `out = albedo_RGB ⊙ light_RGB` — an exact per-channel product
+  (white × 0.5-gray = 0.5).
+- **Astroray spectral:** `out_RGB = M_xyz→rgb · ∫ S_albedo(λ)·S_emit(λ)·CMF(λ) dλ`.
+
+When `S_emit` carries the **D65 tilt** (RGBIlluminant) but `S_albedo` is a plain
+Jakob-Hanika reflectance sigmoid, the two spectra are from **different families**;
+their product integrated against the CMF does **not** round-trip to the RGB
+product — the D65-vs-reflectance spectral mismatch injects a systematic
+metameric offset (measured +7–16%, uniform across all four light types because it
+is a property of the shared `evalRGB`/albedo pipeline, not per-type geometry).
+
+Switching emission to **RGBUnbounded** makes `S_emit = scale · sigmoid(rgb/scale)`
+— the **same reflectance-sigmoid family** as `S_albedo`. Two same-family
+Jakob-Hanika spectra multiplied and integrated round-trip back to the RGB product
+with minimal crosstalk (this is exactly the property Jakob-Hanika 2019 fits for),
+so the spectral render reproduces Cycles' RGB multiply. This is the standard
+technique for making a spectral engine match RGB-native input.
+
+**Vindication of pkg89 phase-b.** The 2026-05-21 cycles-parity review (Defect 2a)
+already recommended `RGBUnboundedSpectrum` for emission. The pkg122 implementer
+over-rode it citing a "~3× too dim" measurement — but that measurement was taken
+with Defects 1–3 (the `1/π` point error, the mixed-measure area pdf) still
+present, which confounded the emission convention with the radiometry. With those
+fixed in PR #500, the clean residual is +7–16% and phase-b's recommendation is the
+correct one.
+
+---
+
+## 4. pbrt vs Cycles genuinely disagree — which to match
+
+They disagree by the **spectral-vs-RGB metamerism gap**. pbrt/Mitsuba deliberately
+imprint a D65 illuminant chromaticity on RGB lights (physically: "this light
+behaves like a real daylight-ish source"). Cycles works in RGB and has no such
+imprint. There is no single "physically correct" answer — it is a **modeling
+convention**, and the two well-known families sit on opposite sides.
+
+**Astroray's entire quality program is Cycles parity**: the reference bank is
+Cycles-calibrated (12/13 passing), every energy gate is keyed on live-Cycles
+numbers, and the pkg122 oracle *is* a headless-Cycles A/B. Given the owner
+directive ("best and used by other renderers, your call") and that the practical
+north star is Cycles, the project should **match Cycles** for the emission lift
+and **document the divergence from pbrt/Mitsuba**. We are not inventing a
+convention — `RGBUnbounded` is a real pbrt-v4 class (`src/pbrt/util/spectrum.h`,
+Apache-2.0) and already exists in Astroray (`RGBUnboundedSpectrum`,
+`src/spectrum.cpp:451-473`); we are re-pointing the emission path at it.
+
+---
+
+## 5. Residual-risk / empirical honesty (CLAUDE.md §1)
+
+The +7–16% → [0.97,1.03] closure is **argued analytically, not yet measured** (the
+architect cannot build the `.pyd`). The metameric offset's *sign* and exact
+magnitude depend on the shipped Jakob-Hanika sRGB LUT and the D65 table, so the
+**gate is the live-Cycles oracle re-run**, not the reasoning. If RGBUnbounded
+**overshoots to < 0.97** (too dim), the documented fallback is to keep
+RGBIlluminant but add pbrt's photometric self-normalization
+(`scale /= SpectrumToPhotometric(emit)`) — a smaller, chromaticity-only
+correction. Primary recommendation remains RGBUnbounded; the fallback is scoped in
+the spec so the implementer can pivot without re-adjudicating.
+
+---
+
+## 6. Sources
+
+- pbrt-v4 `src/pbrt/util/spectrum.h` (RGBAlbedo/Unbounded/Illuminant classes),
+  `src/pbrt/lights.cpp` (DiffuseAreaLight → `SpectrumType::Illuminant`,
+  `scale /= SpectrumToPhotometric`), `LICENSE.txt` — Apache-2.0.
+  https://github.com/mmp/pbrt-v4
+- Cycles `src/kernel/light/area.h` (`eval_fac = M_1_PI_F*invarea`),
+  `src/scene/light.cpp` (`copy_v3_v3(klight->strength, strength)`), `LICENSE` —
+  Apache-2.0. https://github.com/blender/cycles
+- Mitsuba 3 emitter/spectra docs (D65 default emission; reflectance-vs-emission
+  upsampling asymmetry). https://mitsuba.readthedocs.io/en/stable/src/generated/plugins_emitters.html
+  and .../plugins_spectra.html — BSD-3-Clause.
+- Jakob & Hanika 2019, "A Low-Dimensional Function Space for Efficient Spectral
+  Upsampling," Computer Graphics Forum (Eurographics) — the sigmoid RGB→spectrum
+  fit both `RGBAlbedo` and `RGBUnbounded` use.
+- "Spectral rendering, part 3: Spectral vs. RGB," momentsingraphics.de — the
+  E-vs-D65 upsampling-illuminant subtlety.

--- a/.astroray_plan/packages/pkg142-rgb-emission-convention.md
+++ b/.astroray_plan/packages/pkg142-rgb-emission-convention.md
@@ -1,0 +1,208 @@
+# pkg142 — RGB emission convention: RGBIlluminant → RGBUnbounded (Defect 4 adjudication)
+
+**Pillar:** 3 (light transport / emitter energy correctness)
+**Track:** A (single cross-cutting convention change with a live headless-Cycles oracle gate + reference-bank re-bless; needs a build + RTX + Blender-5.1, not a mechanical patch)
+**Codex-paste-ready:** no (one adjudicated convention flip that cross-cuts CPU/GPU/env/materials and moves the Cycles-parity reference bank; empirical sign/magnitude must be confirmed against a live Cycles A/B, and a fallback branch may be taken — judgment at the gate, not a blind edit)
+**Status:** open — dispatchable
+**Estimated effort:** M (the code change is small and localized; the cost is the build + live-Cycles oracle re-run + RTX GPU==CPU parity + evidence-first reference-bank re-bless)
+**Depends on:** pkg122 (PR #500, **merged**) — Defects 1–3 must be in `main` so the residual measured by the oracle is the *clean* emission-lift offset, not confounded by the per-type radiometry bugs. Satisfied.
+
+**Adjudication authority:** owner delegated to the team on 2026-07-21, verbatim:
+*"What ever is best and used by other renderers, your call."* Research + adjudication:
+`.astroray_plan/docs/defect4-rgb-emission-research.md`.
+
+---
+
+## Context — the last standing piece of the "dimmer/brighter than Cycles" program
+
+pkg122 (PR #500) re-derived the four dedicated-light types' wattage→radiance
+against the Cycles kernel and fixed Defects 1–3 (area mixed-measure pdf, point/spot
+`1/π`→`1/(4π)`, blackbody photopic normalization). It **deliberately deferred
+Defect 4** — the RGB emission-lift convention — because arbitrating it needs a
+live-Cycles A/B build (the implementer had no MSVC vcvars) and it moves the
+Cycles-calibrated reference bank (was owner-reserved).
+
+With Defects 1–3 landed, the live headless-Cycles oracle
+(`scripts/verify_pkg122_cycles_oracle.py`) measures **all four dedicated-light
+types 1.07–1.16× brighter than Cycles at equal wattage** on a gray Lambertian
+floor. Decoupled pure-Lambertian analytic checks are **0.99×**, so the residual is
+**not** radiometry — it is the RGB-emission spectral lift, uniform across all light
+types because it lives in the shared `EmissionSpectrum::evalRGB` / albedo pipeline.
+The tight Cycles band **[0.97, 1.03] is unreachable until this is resolved.**
+
+---
+
+## Decision (adjudicated)
+
+**Switch the RGB emission lift from `RGBIlluminantSpectrum` (D65-weighted) to
+`RGBUnboundedSpectrum` (identity round-trip, no illuminant), on both the CPU
+`evalRGB` path and its GPU device mirror.**
+
+### Rationale (full derivation in the research note §2–§4)
+
+- **What the references do.** pbrt-v4 (`SpectrumType::Illuminant` →
+  `RGBIlluminantSpectrum`, `src/pbrt/lights.cpp`) and Mitsuba 3 (`srgb_d65`) both
+  imprint a **D65 illuminant chromaticity** on RGB lights. **Cycles is RGB-native**:
+  `strength` (color × power) is stored as a linear-RGB `float3` and the emitted
+  radiance is `strength × eval_fac` — **no spectral upsampling, no D65**
+  (`src/scene/light.cpp`, `src/kernel/light/area.h`). pbrt/Mitsuba and Cycles
+  **genuinely disagree**, by the spectral-vs-RGB metamerism gap.
+- **Which to match.** Astroray's whole quality program is **Cycles parity** — the
+  reference bank is Cycles-calibrated, every energy gate is keyed on live-Cycles
+  numbers, and the oracle *is* a headless-Cycles A/B. Per the owner directive and
+  the parity program, **match Cycles**. `RGBUnbounded` = `scale·sigmoid(rgb/scale)`
+  is the **same Jakob-Hanika reflectance-sigmoid family** the floor albedo already
+  uses; two same-family spectra multiplied and integrated round-trip to the RGB
+  product with minimal crosstalk, reproducing Cycles' `albedo ⊙ light` multiply.
+  The D65 tilt on `RGBIlluminant` is exactly the source of the +7–16% offset.
+- **Not invented (CLAUDE.md §6).** `RGBUnbounded` is a real pbrt-v4 class
+  (`src/pbrt/util/spectrum.h`, Apache-2.0) and **already exists in Astroray**
+  (`RGBUnboundedSpectrum`, `src/spectrum.cpp:451-473`). This package re-points the
+  emission path at it — no new algorithm.
+- **Vindicates pkg89 phase-b.** The 2026-05-21 parity review (Defect 2a) already
+  recommended `RGBUnbounded` for emitters; it was over-ridden on a measurement
+  confounded by the (now-fixed) Defects 1–3.
+
+### Divergence to document in-code
+
+We deliberately diverge from pbrt-v4/Mitsuba (which keep the D65 illuminant lift
+for emitters). A code comment at `evalRGB` must state: *"RGB emission uses the
+RGBUnbounded (no-D65) lift to match Cycles' RGB-native light scaling — Astroray's
+parity target — rather than the pbrt-v4/Mitsuba RGBIlluminant D65 convention. See
+pkg142 / defect4-rgb-emission-research.md."*
+
+---
+
+## Canonical reference (cite in code)
+
+| Concern | File / function | License |
+|---|---|---|
+| Lift we adopt | pbrt-v4 `RGBUnboundedSpectrum::Sample` (`src/pbrt/util/spectrum.h`) — `scale·rsp(λ)`, no illuminant | Apache-2.0 (verified) |
+| Parity target | Cycles `src/scene/light.cpp` (`copy_v3_v3(klight->strength, strength)`), `src/kernel/light/area.h` (`eval_fac = M_1_PI_F·invarea`) — RGB-native, no upsample | Apache-2.0 (verified) |
+| In-tree class reused | `astroray::RGBUnboundedSpectrum` (`src/spectrum.cpp:451-473`, `include/astroray/spectrum.h:230`) | project |
+
+License compatibility: both references Apache-2.0, both already relied upon
+elsewhere in the tree. No new dependency.
+
+---
+
+## Implementation contract
+
+### CPU
+1. `src/emission_spectrum.cpp` `EmissionSpectrum::evalRGB` (lines 187-191): replace
+   `RGBIlluminantSpectrum rgbSpectrum(...)` with `RGBUnboundedSpectrum rgbSpectrum(...)`.
+   Update the stale block comment (lines 179-186, which argues *for* Illuminant) to
+   the divergence note above.
+2. **Do not** change `RGBAlbedoSpectrum` (surface reflectance) or the blackbody /
+   MeasuredSPD / Composite paths — this is emission-RGB only.
+
+### GPU device mirror (must stay 1:1 with CPU — pkg89 GAP-1 parity is GPU==CPU)
+The device lift is `gpu_rgbSpectrumAt` (`include/astroray/gpu_materials.h:90-109`),
+selected by a `GSpectralMode`. Today it has `GSPEC_RGB_ILLUMINANT` (scale·JH·D65)
+and `GSPEC_RGB_ALBEDO` (JH clamped) but **no UNBOUNDED case**.
+3. Add a `GSPEC_RGB_UNBOUNDED` branch to `gpu_rgbSpectrumAt`:
+   `scale·gpu_jhEvalSpectrum(normalized, λ)` — identical to the ILLUMINANT branch
+   **minus** the `* gpu_sampleD65(λ)` factor. (Add the enum value wherever
+   `GSpectralMode` is defined.)
+4. Re-point the **emission** call sites from `GSPEC_RGB_ILLUMINANT` to
+   `GSPEC_RGB_UNBOUNDED`. Emission sites (grep-confirmed):
+   - `src/gpu/gpu_nee.cuh:352-353` (dedicated-light NEE)
+   - `src/gpu/path_trace_kernel.cu:549` (mesh emitter `Le`)
+   - `src/gpu/multiwavelength_kernel.cu:302` (mesh emitter `Le`)
+   - `src/gpu/wavefront/stage_light_sample.cu:151` (wavefront light sample)
+   **Scope decision — environment/background:** the env/world color also lifts via
+   `GSPEC_RGB_ILLUMINANT` (`gpu_env_spectral.cuh:31,59,80`;
+   `path_trace_kernel.cu:437`; `src/lights/background_light.cpp`; CPU
+   `background_light.cpp`). The world *is* an emitter, so for internal consistency
+   and to keep GPU==CPU, **flip env emission to UNBOUNDED as well** — but this
+   widens the reference-bank blast radius (any HDRI/world-lit parity scene). If the
+   oracle + refbank evidence shows env parity regresses, the fallback is to keep env
+   on ILLUMINANT and flip **only** the dedicated/mesh light paths; record which was
+   chosen. Default: flip env too (consistency), verify, pivot on evidence.
+5. `EmissionSpectrum::deviceReference` / `src/gpu/scene_upload.cu:194`
+   (`g.spectralMode = GSPEC_RGB_ILLUMINANT` for emission): update to the emission
+   mode chosen in (4). Keep `GSPEC_RGB_ALBEDO` untouched for reflectance.
+
+### Build (per CLAUDE.md — no "done" without build evidence)
+6. Rebuild the CUDA module (`configure_and_build.bat`, `--config Release`; the
+   `build_cuda_worktree.bat` Debug footgun is documented in memory). Show `.pyd`
+   mtime vs `git log -1 HEAD` and `astroray.__file__` = `build_cuda/Release/` before
+   any verification.
+
+---
+
+## Gates (evidence-first — the decision is confirmed by the oracle, not by argument)
+
+**Primary gate — live headless-Cycles A/B oracle.** Copy
+`scripts/verify_pkg122_cycles_oracle.py` **into the repo from the `Astroray-pkg122`
+worktree** (it currently lives only there — `git add` it under `scripts/`), then run
+per type on RTX with Blender 5.1:
+```
+blender --background --factory-startup --python scripts/verify_pkg122_cycles_oracle.py -- --light-type POINT --out test_results/pkg142
+```
+for `POINT | AREA | SPOT | SUN`.
+- **PASS:** `ratio_astroray_over_cycles` ∈ **[0.97, 1.03]** per channel, all four types.
+  (Metric: **per-channel mean-ratio**, NOT SSIM — independent RNG streams make
+  windowed SSIM the wrong gate; memory `ssim-wrong-gate-for-independent-rng`.)
+- Record before (expect 1.07–1.16) and after for each type/channel.
+- Honor the two documented oracle caveats already in the script: SUN camera 5° tilt,
+  and the Astroray AREA-light 180°-about-X orientation flip (both are integration
+  artifacts orthogonal to this convention — do **not** "fix" them here).
+
+**Secondary gate — GPU==CPU parity.** Re-run the pkg89/pkg122 GPU==CPU dedicated-light
+parity check on RTX. The device UNBOUNDED branch must reproduce the CPU `evalRGB`
+bit-for-structure (same JH lookup, same scale, D65 dropped on both sides).
+Do not run concurrently with another CUDA-heavy verifier (memory
+`cuda_verifier_concurrency`).
+
+**Tertiary gate — no radiometry regression.** `tests/test_pkg122_light_energy_calibration.py`
+must stay green (this change is chromaticity/level, not per-type geometry).
+
+**Fallback (if the primary gate overshoots to < 0.97, i.e. RGBUnbounded is too dim).**
+Do **not** silently retune. Revert `evalRGB` to `RGBIlluminant` and instead add
+pbrt's photometric self-normalization `scale /= SpectrumToPhotometric(emit)`
+(`src/pbrt/lights.cpp`) — a smaller chromaticity-only correction — and re-run the
+oracle. Report which branch landed. (Rationale in research note §5.)
+
+---
+
+## Reference-bank consequence (scoped INTO this package — evidence-first)
+
+Changing the emission lift moves every RGB-emitter scene, so the Cycles-parity
+reference bank (**12/13 passing**) may need re-blessing. This is **in scope** and
+**capability-available**: Blender 5.1 is installed locally, headless re-bless is
+routine (memory `blender-5-1-installed-locally`).
+
+1. **Measure first.** Re-render the parity-bank scenes (and pkg89 G1/G2/G4/G5, the
+   pkg115 texture grid) on the new build; diff against the current blessed refs.
+   Report per-scene per-channel deltas **before** re-blessing anything.
+2. **Re-bless only scenes that move because of this change** and now match Cycles
+   *better* (the point of the package). Headless Cycles re-render for the new refs;
+   commit refs + a short bless-log noting the measured deltas and that they close
+   the +7–16% offset. Scenes expected to move: any using a dedicated light, a
+   `diffuse_light` mesh emitter, or (if env flipped) an HDRI/world.
+3. If any scene moves the **wrong** way (further from Cycles), stop and report — that
+   is a signal to take the env-scope fallback or the photometric-normalization
+   fallback above, not to re-bless a regression.
+
+---
+
+## Expected numeric effect
+
+- Dedicated lights (POINT/AREA/SPOT/SUN), equal wattage, gray floor:
+  **1.07–1.16× → within [0.97, 1.03]** vs live Cycles (per-channel).
+- Pure-Lambertian analytic decoupled check: stays ~0.99× (unaffected — reflectance
+  path unchanged).
+- Reference bank: 12/13 → re-blessed to reflect the closed offset (target: all
+  RGB-emitter parity scenes within band).
+
+---
+
+## Definition of done
+- [ ] `evalRGB` + GPU emission mirror on `RGBUnbounded`; stale pro-Illuminant comment replaced with the divergence note + pkg142 cite.
+- [ ] `scripts/verify_pkg122_cycles_oracle.py` copied into the repo and committed.
+- [ ] Live-Cycles oracle: all four types per-channel ∈ [0.97, 1.03], before/after recorded.
+- [ ] GPU==CPU dedicated-light parity re-verified on RTX.
+- [ ] `test_pkg122_light_energy_calibration.py` green; build evidence (`.pyd` mtime, `astroray.__file__`) shown.
+- [ ] Reference bank re-blessed evidence-first with a measured-delta bless-log; no scene regressed vs Cycles.
+- [ ] Which branch landed (primary RGBUnbounded / env-scope choice / photometric fallback) recorded in the PR.


### PR DESCRIPTION
## What

Adjudicates **Defect 4** (previously owner-reserved; owner delegated to the team 2026-07-21: *"whatever is best and used by other renderers, your call"*). Doc-only: one research note + one dispatchable package spec.

**Decision:** switch the RGB **emission** lift (`EmissionSpectrum::evalRGB` + GPU mirror) from **RGBIlluminant** (D65-weighted) to **RGBUnbounded** (identity round-trip, no illuminant), to close the residual **+7–16%** equal-wattage brightness offset vs Cycles measured by the live oracle after pkg122 (PR #500) fixed Defects 1–3.

## Why RGBUnbounded

- **pbrt-v4** (`SpectrumType::Illuminant` → `RGBIlluminantSpectrum`) and **Mitsuba 3** (`srgb_d65`) imprint a **D65 chromaticity** on RGB emitters.
- **Cycles is RGB-native**: `strength` stored as linear-RGB `float3`, radiance = `strength × eval_fac`, **no** spectral upsample, **no** D65.
- pbrt/Mitsuba and Cycles genuinely **disagree**; Astroray's whole program is **Cycles parity** (reference bank, all energy gates, the oracle itself). So match Cycles.
- `RGBUnbounded` = `scale·sigmoid(rgb/scale)` — the **same Jakob-Hanika reflectance family** the albedo path uses; same-family emission×albedo round-trips to Cycles' `albedo ⊙ light` multiply. The D65 tilt on `RGBIlluminant` is the source of the offset.
- Not invented: `RGBUnboundedSpectrum` is a real pbrt-v4 class (Apache-2.0) and already exists in Astroray — this re-points the emission path at it. Vindicates the 2026-05-21 phase-b recommendation (was over-ridden on a pre-pkg122, confounded measurement).

## Licenses (verified against the repos)
pbrt-v4 Apache-2.0, Cycles Apache-2.0, Mitsuba 3 BSD-3-Clause — all compatible.

## Gates in the spec
- Live headless-Cycles A/B oracle (`scripts/verify_pkg122_cycles_oracle.py`, to be copied into the repo): all four light types **per-channel mean-ratio ∈ [0.97, 1.03]** (NOT SSIM).
- GPU==CPU dedicated-light parity on RTX (new `GSPEC_RGB_UNBOUNDED` device branch).
- Evidence-first reference-bank re-bless (12/13 → measure deltas before re-blessing; Blender 5.1 headless).
- Documented **fallback** if RGBUnbounded overshoots to <0.97: keep RGBIlluminant + pbrt's `scale /= SpectrumToPhotometric` photometric self-normalization.

## Files
- `.astroray_plan/docs/defect4-rgb-emission-research.md`
- `.astroray_plan/packages/pkg142-rgb-emission-convention.md` (Status: open — dispatchable)

Note: the +7–16% → [0.97,1.03] closure is argued analytically; the **oracle is the gate**, not the argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)