### PR TITLE
fix(pkg142): RGB emission convention switch, RGBIlluminant (D65) -> RGBUnbounded

### DIFF
--- a/.astroray_plan/docs/defect4-rgb-emission-research.md
+++ b/.astroray_plan/docs/defect4-rgb-emission-research.md
@@ -154,6 +154,22 @@ RGBIlluminant but add pbrt's photometric self-normalization
 correction. Primary recommendation remains RGBUnbounded; the fallback is scoped in
 the spec so the implementer can pivot without re-adjudicating.
 
+**Correction (2026-07-21, post hardware-verifier + gate-failure-reviewer):**
+this analysis's "+7–16%" framing was itself a **mis-model** — it implicitly
+assumed `RGBIlluminantSpectrum` and `RGBUnboundedSpectrum` differ *only* by
+the D65 chromaticity tilt. They do not: `sampleD65(λ)` is normalized so
+`∫sampleD65·ȳdλ = 1` (unit luminance), which means `* sampleD65(λ)` folds
+in BOTH the chromaticity tilt AND a photometric anchor. `RGBUnboundedSpectrum`
+has neither. PR #511's first hardware pass measured a ~116x uniform
+brightness blow-up (all renders saturated white), traced to this missing
+anchor, not a mistuned tilt. Fix: `astroray::cieYIntegral()` /
+`sampleUnboundedEmission()` (src/spectrum.cpp) and `gpu_cieYNormFactor()`
+(GPU mirror) restore the anchor while keeping RGBUnbounded's flat (no-D65)
+chromaticity. With the anchor restored, the expected oracle effect reduces
+to the chromaticity tilt alone (CPU diagnostic: pre-fix bare ratio ≈121,
+post-fix fixed/RGBIlluminant ratio ≈1.04 for neutral gray) — smaller than
+the original 1.07–1.16x estimate, which conflated both effects.
+
 ---
 
 ## 6. Sources

--- a/.astroray_plan/packages/pkg142-rgb-emission-convention.md
+++ b/.astroray_plan/packages/pkg142-rgb-emission-convention.md
@@ -3,7 +3,7 @@
 **Pillar:** 3 (light transport / emitter energy correctness)
 **Track:** A (single cross-cutting convention change with a live headless-Cycles oracle gate + reference-bank re-bless; needs a build + RTX + Blender-5.1, not a mechanical patch)
 **Codex-paste-ready:** no (one adjudicated convention flip that cross-cuts CPU/GPU/env/materials and moves the Cycles-parity reference bank; empirical sign/magnitude must be confirmed against a live Cycles A/B, and a fallback branch may be taken — judgment at the gate, not a blind edit)
-**Status:** open — dispatchable
+**Status:** implemented, unverified — PR #511 (2026-07-21) — RGBUnbounded landed repo-wide (CPU `EmissionSpectrum::evalRGB`, GPU `GSPEC_RGB_UNBOUNDED` device mirror, env/world, plus ~20 duplicate CPU emission call sites the spec's grep missed — see PR scope note). Primary/secondary/tertiary gates and reference-bank re-bless NOT run (implementer had no build access) — awaiting team-lead RTX + Blender-5.1 verification.
 **Estimated effort:** M (the code change is small and localized; the cost is the build + live-Cycles oracle re-run + RTX GPU==CPU parity + evidence-first reference-bank re-bless)
 **Depends on:** pkg122 (PR #500, **merged**) — Defects 1–3 must be in `main` so the residual measured by the oracle is the *clean* emission-lift offset, not confounded by the per-type radiometry bugs. Satisfied.
 

--- a/.astroray_plan/packages/pkg142-rgb-emission-convention.md
+++ b/.astroray_plan/packages/pkg142-rgb-emission-convention.md
@@ -3,7 +3,7 @@
 **Pillar:** 3 (light transport / emitter energy correctness)
 **Track:** A (single cross-cutting convention change with a live headless-Cycles oracle gate + reference-bank re-bless; needs a build + RTX + Blender-5.1, not a mechanical patch)
 **Codex-paste-ready:** no (one adjudicated convention flip that cross-cuts CPU/GPU/env/materials and moves the Cycles-parity reference bank; empirical sign/magnitude must be confirmed against a live Cycles A/B, and a fallback branch may be taken — judgment at the gate, not a blind edit)
-**Status:** implemented, unverified — PR #511 (2026-07-21) — RGBUnbounded landed repo-wide (CPU `EmissionSpectrum::evalRGB`, GPU `GSPEC_RGB_UNBOUNDED` device mirror, env/world, plus ~20 duplicate CPU emission call sites the spec's grep missed — see PR scope note). Primary/secondary/tertiary gates and reference-bank re-bless NOT run (implementer had no build access) — awaiting team-lead RTX + Blender-5.1 verification.
+**Status:** implemented, unverified — PR #511 (2026-07-21) — RGBUnbounded landed repo-wide (CPU `EmissionSpectrum::evalRGB`, GPU `GSPEC_RGB_UNBOUNDED` device mirror, env/world, plus ~20 duplicate CPU emission call sites the spec's grep missed — see PR scope note). **Correction (2026-07-21, post hardware-verifier + gate-failure-reviewer):** the initial PR shipped a units bug — `RGBIlluminantSpectrum`'s `sampleD65(λ)` factor carried BOTH the D65 chromaticity tilt AND an implicit photometric anchor (∫sampleD65·ȳdλ=1); `RGBUnboundedSpectrum` has neither, so bare emission came out ~116x too bright (measured on RTX: ~116x uniform blow-up, all renders saturated white, 68 suite failures), not the originally-modeled 1.07–1.16x. Fixed by adding `cieYIntegral()` / `sampleUnboundedEmission()` (src/spectrum.cpp) and `gpu_cieYNormFactor()` (GPU mirror), applied at every emission call site. The "+7–16%" framing in this spec is a **mis-model**: chromaticity tilt and photometric units are two separate effects that were conflated. CPU diagnostic (rgb=(0.5,0.5,0.5)): pre-fix bare-UNBOUNDED/ILLUMINANT ratio ≈121.3 (expected ≈116.66, the table's ∫ȳdλ); post-fix fixed-emission/ILLUMINANT ratio ≈1.040 (residual ≈4% is the intended chromaticity-tilt removal). Expected oracle effect is now the tilt alone, not the previously-modeled 1.07–1.16x. Primary/secondary/tertiary gates and reference-bank re-bless still NOT run by this implementer (no build access) — awaiting team-lead RTX + Blender-5.1 re-verification of the corrected code.
 **Estimated effort:** M (the code change is small and localized; the cost is the build + live-Cycles oracle re-run + RTX GPU==CPU parity + evidence-first reference-bank re-bless)
 **Depends on:** pkg122 (PR #500, **merged**) — Defects 1–3 must be in `main` so the residual measured by the oracle is the *clean* emission-lift offset, not confounded by the per-type radiometry bugs. Satisfied.
 
@@ -189,8 +189,20 @@ routine (memory `blender-5-1-installed-locally`).
 
 ## Expected numeric effect
 
+**Correction (2026-07-21):** the figures below were the pre-fix (buggy) model,
+which conflated the D65 chromaticity tilt with a photometric-units bug. With
+the units bug fixed (`cieYIntegral()` / `sampleUnboundedEmission()` /
+`gpu_cieYNormFactor()`), the expected oracle effect is the **chromaticity
+tilt alone** — the original 1.07–1.16x measurement already included both
+effects, so post-fix the residual should be smaller than 1.07–1.16x (closer
+to the CPU diagnostic's isolated ≈1.04 for a neutral gray; colored lights
+will show a somewhat larger tilt-only residual). The live-Cycles oracle
+re-run determines the actual number; do not assume 1.07–1.16x is still the
+pre-fix baseline for this corrected code.
+
 - Dedicated lights (POINT/AREA/SPOT/SUN), equal wattage, gray floor:
-  **1.07–1.16× → within [0.97, 1.03]** vs live Cycles (per-channel).
+  chromaticity-tilt-only residual → target within [0.97, 1.03] vs live Cycles
+  (per-channel).
 - Pure-Lambertian analytic decoupled check: stays ~0.99× (unaffected — reflectance
   path unchanged).
 - Reference bank: 12/13 → re-blessed to reflect the closed offset (target: all

--- a/include/astroray/emission_spectrum.h
+++ b/include/astroray/emission_spectrum.h
@@ -97,10 +97,11 @@ public:
     // Used when the user applies a colored gel to an existing emission source.
     EmissionSpectrum composeWith(const Vec3& filterRGB) const;
 
-    // pkg89-GPU / GAP 1 — reference RGB color for the device RGBIlluminant
-    // upsample. For RGB mode this is exactly `color` (device gpu_rgbSpectrumAt
-    // reproduces CPU RGBIlluminantSpectrum(color) sample-for-sample → exact
-    // GPU==CPU parity). For blackbody / measured / composite modes it is the
+    // pkg89-GPU / GAP 1 — reference RGB color for the device RGB upsample
+    // (pkg142 Defect 4: RGBUnbounded, no-D65). For RGB mode this is exactly
+    // `color` (device gpu_rgbSpectrumAt reproduces CPU RGBUnboundedSpectrum
+    // (color) sample-for-sample → exact GPU==CPU parity). For blackbody /
+    // measured / composite modes it is the
     // XYZ→linear-sRGB of the evaluated SPD (chroma + magnitude approximate;
     // exact spectral parity for those modes is a documented follow-up, and is
     // moot until the pkg89 CPU blackbody normalization is fixed — see GAP 2).

--- a/include/astroray/gpu_env_spectral.cuh
+++ b/include/astroray/gpu_env_spectral.cuh
@@ -18,8 +18,9 @@
 #include "gpu_bvh.h"        // gpu_envmap_apply_rot
 
 // Environment radiance for a missed ray: backgroundColor > env map > default
-// sky gradient. Spectral upsampling matches the CPU pipeline (ILLUMINANT for
-// emission-like sources, ALBEDO for the env tint — pkg85-D parity fix).
+// sky gradient. Spectral upsampling matches the CPU pipeline (UNBOUNDED for
+// emission-like sources -- pkg142 Defect 4, no-D65 lift, matches Cycles'
+// RGB-native light scaling; ALBEDO for the env tint — pkg85-D parity fix).
 __device__ inline GSampledSpectrum gpu_env_miss_spectral(
     const GEnvMap& envMap,
     const GVec3& backgroundColor, bool hasBackgroundColor,
@@ -28,7 +29,7 @@ __device__ inline GSampledSpectrum gpu_env_miss_spectral(
     GSampledSpectrum envSpec(0.f);
     if (hasBackgroundColor) {
         envSpec = gpu_rgbToSampledSpectrum(backgroundColor, lambdas,
-                                           GSPEC_RGB_ILLUMINANT);
+                                           GSPEC_RGB_UNBOUNDED);
     } else if (envMap.loaded) {
         // pkg85-D: mirror CPU EnvironmentMap::evalSpectral spectral tint path.
         // gpu_envmap_lookup applies colorTint as RGB multiply, but the CPU
@@ -56,7 +57,7 @@ __device__ inline GSampledSpectrum gpu_env_miss_spectral(
         auto fetchSpec = [&](int x, int y) {
             int i = (y*envMap.width + x) * 3;
             GVec3 rgb(envMap.data[i], envMap.data[i+1], envMap.data[i+2]);
-            return gpu_rgbToSampledSpectrum(rgb, lambdas, GSPEC_RGB_ILLUMINANT);
+            return gpu_rgbToSampledSpectrum(rgb, lambdas, GSPEC_RGB_UNBOUNDED);
         };
         GSampledSpectrum s00 = fetchSpec(x0, y0);
         GSampledSpectrum s10 = fetchSpec(x1, y0);
@@ -77,7 +78,7 @@ __device__ inline GSampledSpectrum gpu_env_miss_spectral(
     } else {
         float t = 0.5f * (dir.y + 1.f);
         GVec3 bg = (GVec3(1.f) * (1.f - t) + GVec3(0.5f, 0.7f, 1.f) * t) * 0.2f;
-        envSpec = gpu_rgbToSampledSpectrum(bg, lambdas, GSPEC_RGB_ILLUMINANT);
+        envSpec = gpu_rgbToSampledSpectrum(bg, lambdas, GSPEC_RGB_UNBOUNDED);
     }
     return envSpec;
 }

--- a/include/astroray/gpu_materials.h
+++ b/include/astroray/gpu_materials.h
@@ -81,6 +81,12 @@ __device__ inline GSampledWavelengths gpu_sampleUniformWavelengths(TRng* rng) {
 // table, normalized so unit white emission integrates to Y = 1.
 __device__ float gpu_sampleD65(float lambda);
 
+// Forward declaration — defined in src/gpu/gpu_spectral_tables.cu. Mirrors
+// astroray::cieYIntegral()'s reciprocal (src/spectrum.cpp); the photometric
+// anchor RGBUnbounded EMISSION needs (pkg142 hardware-verifier regression —
+// see GSPEC_RGB_UNBOUNDED branch below).
+__device__ float gpu_cieYNormFactor();
+
 // Forward declaration — defined in src/gpu/multiwavelength_kernel.cu (pkg54c).
 // Jakob & Hanika 2019 sigmoid-coefficient lookup; mirrors CPU
 // RGBAlbedoSpectrum::sample() at single wavelength so visible-band SSIM
@@ -104,17 +110,22 @@ __device__ inline float gpu_rgbSpectrumAt(const GVec3& rgb, float lambda, GSpect
         return fmaxf(scale * gpu_jhEvalSpectrum(normalized, lambda)
                            * gpu_sampleD65(lambda), 0.f);
     }
-    // pkg142 (Defect 4): UNBOUNDED mirrors CPU RGBUnboundedSpectrum
+    // pkg142 (Defect 4): UNBOUNDED mirrors CPU sampleUnboundedEmission()
     // (src/spectrum.cpp) exactly — identical to the ILLUMINANT branch above
-    // minus the `* gpu_sampleD65(lambda)` factor (no D65 illuminant lift).
-    // Used for RGB emission so the spectral render round-trips Cycles' plain
-    // RGB-native light scaling. See pkg142-rgb-emission-convention.md.
+    // minus the `* gpu_sampleD65(lambda)` factor (no D65 chromaticity tilt),
+    // but WITH the `* gpu_cieYNormFactor()` photometric anchor that
+    // gpu_sampleD65 carried implicitly (2026-07-2x hardware-verifier fix —
+    // without this the bare JH upsample came out ~116x too bright; see
+    // gpu_cieYNormFactor()'s doc comment). Used for RGB emission so the
+    // spectral render round-trips Cycles' plain RGB-native light scaling.
+    // See pkg142-rgb-emission-convention.md.
     if (mode == GSPEC_RGB_UNBOUNDED) {
         float m = fmaxf(fmaxf(rgb.x, rgb.y), rgb.z);
         if (m <= 0.f) return 0.f;
         float scale = 2.f * m;
         GVec3 normalized{ rgb.x / scale, rgb.y / scale, rgb.z / scale };
-        return fmaxf(scale * gpu_jhEvalSpectrum(normalized, lambda), 0.f);
+        return fmaxf(scale * gpu_jhEvalSpectrum(normalized, lambda)
+                           * gpu_cieYNormFactor(), 0.f);
     }
     // ALBEDO: gpu_jhLookupCoeffs already clamps rgb to [0,1].
     return fmaxf(gpu_jhEvalSpectrum(rgb, lambda), 0.f);

--- a/include/astroray/gpu_materials.h
+++ b/include/astroray/gpu_materials.h
@@ -104,6 +104,18 @@ __device__ inline float gpu_rgbSpectrumAt(const GVec3& rgb, float lambda, GSpect
         return fmaxf(scale * gpu_jhEvalSpectrum(normalized, lambda)
                            * gpu_sampleD65(lambda), 0.f);
     }
+    // pkg142 (Defect 4): UNBOUNDED mirrors CPU RGBUnboundedSpectrum
+    // (src/spectrum.cpp) exactly — identical to the ILLUMINANT branch above
+    // minus the `* gpu_sampleD65(lambda)` factor (no D65 illuminant lift).
+    // Used for RGB emission so the spectral render round-trips Cycles' plain
+    // RGB-native light scaling. See pkg142-rgb-emission-convention.md.
+    if (mode == GSPEC_RGB_UNBOUNDED) {
+        float m = fmaxf(fmaxf(rgb.x, rgb.y), rgb.z);
+        if (m <= 0.f) return 0.f;
+        float scale = 2.f * m;
+        GVec3 normalized{ rgb.x / scale, rgb.y / scale, rgb.z / scale };
+        return fmaxf(scale * gpu_jhEvalSpectrum(normalized, lambda), 0.f);
+    }
     // ALBEDO: gpu_jhLookupCoeffs already clamps rgb to [0,1].
     return fmaxf(gpu_jhEvalSpectrum(rgb, lambda), 0.f);
 }

--- a/include/astroray/gpu_types.h
+++ b/include/astroray/gpu_types.h
@@ -374,7 +374,11 @@ enum GMaterialType : uint8_t {
 enum GSpectralMode : uint8_t {
     GSPEC_NONE = 0,
     GSPEC_RGB_ALBEDO = 1,
-    GSPEC_RGB_ILLUMINANT = 2
+    GSPEC_RGB_ILLUMINANT = 2,
+    // pkg142 (Defect 4): RGBUnbounded (no-D65) lift for emission — mirrors
+    // CPU RGBUnboundedSpectrum, matching Cycles' RGB-native light scaling.
+    // See pkg142-rgb-emission-convention.md.
+    GSPEC_RGB_UNBOUNDED = 3
 };
 
 enum GClosureType : uint8_t {

--- a/include/astroray/manifold/mesh_attempt.h
+++ b/include/astroray/manifold/mesh_attempt.h
@@ -136,7 +136,8 @@ inline float runMeshSMSAttempt(const Renderer& renderer,
     // Receiver BSDF (hero channel) + light emission (hero channel).
     const Vec3 wo_eye = -primary.direction.normalized();
     const float fHero = x0Rec.material->evalSpectral(x0Rec, wo_eye, wi_x0, lambdas)[0];
-    const float LeHero = astroray::RGBIlluminantSpectrum(
+    // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift.
+    const float LeHero = astroray::RGBUnboundedSpectrum(
         {ls.emission.x, ls.emission.y, ls.emission.z}).sample(lambdas)[0];
 
     // Generalized geometry term (Cycles mnee_path_contribution l.836-841):

--- a/include/astroray/manifold/mesh_attempt.h
+++ b/include/astroray/manifold/mesh_attempt.h
@@ -136,9 +136,10 @@ inline float runMeshSMSAttempt(const Renderer& renderer,
     // Receiver BSDF (hero channel) + light emission (hero channel).
     const Vec3 wo_eye = -primary.direction.normalized();
     const float fHero = x0Rec.material->evalSpectral(x0Rec, wo_eye, wi_x0, lambdas)[0];
-    // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift.
-    const float LeHero = astroray::RGBUnboundedSpectrum(
-        {ls.emission.x, ls.emission.y, ls.emission.z}).sample(lambdas)[0];
+    // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift, with the
+    // photometric anchor (pkg142 hardware-verifier fix).
+    const float LeHero = astroray::sampleUnboundedEmission(
+        {ls.emission.x, ls.emission.y, ls.emission.z}, lambdas)[0];
 
     // Generalized geometry term (Cycles mnee_path_contribution l.836-841):
     //   G = clamp(dw0_dx1 * dx1_dxlight, 2)

--- a/include/astroray/restir/light_sample.h
+++ b/include/astroray/restir/light_sample.h
@@ -18,7 +18,7 @@
 #include <cmath>
 
 #include "raytracer.h"           // Vec3, LightSample
-#include "astroray/spectrum.h"   // SampledWavelengths, SampledSpectrum, RGBIlluminantSpectrum
+#include "astroray/spectrum.h"   // SampledWavelengths, SampledSpectrum, RGBUnboundedSpectrum
 
 namespace astroray::restir {
 
@@ -49,12 +49,13 @@ struct ReSTIRCandidate {
     }
 
     // RIS target weight p_hat(y): spectral luminance of the emission.
-    // Upsamples RGB emission via RGBIlluminantSpectrum and returns Y channel.
-    // Returns 0.0 for invalid candidates or black emitters.
+    // Upsamples RGB emission via RGBUnboundedSpectrum (pkg142 Defect 4 --
+    // no-D65 lift, matches Cycles' RGB-native light scaling) and returns the
+    // Y channel. Returns 0.0 for invalid candidates or black emitters.
     float targetLuminance(const SampledWavelengths& lambdas) const {
         if (!isValid()) return 0.0f;
         SampledSpectrum spec =
-            RGBIlluminantSpectrum({emission.x, emission.y, emission.z}).sample(lambdas);
+            RGBUnboundedSpectrum({emission.x, emission.y, emission.z}).sample(lambdas);
         float Y = spec.toXYZ(lambdas).Y;
         return Y > 0.0f ? Y : 0.0f;
     }

--- a/include/astroray/restir/light_sample.h
+++ b/include/astroray/restir/light_sample.h
@@ -18,7 +18,7 @@
 #include <cmath>
 
 #include "raytracer.h"           // Vec3, LightSample
-#include "astroray/spectrum.h"   // SampledWavelengths, SampledSpectrum, RGBUnboundedSpectrum
+#include "astroray/spectrum.h"   // SampledWavelengths, SampledSpectrum, sampleUnboundedEmission
 
 namespace astroray::restir {
 
@@ -49,13 +49,14 @@ struct ReSTIRCandidate {
     }
 
     // RIS target weight p_hat(y): spectral luminance of the emission.
-    // Upsamples RGB emission via RGBUnboundedSpectrum (pkg142 Defect 4 --
-    // no-D65 lift, matches Cycles' RGB-native light scaling) and returns the
-    // Y channel. Returns 0.0 for invalid candidates or black emitters.
+    // Upsamples RGB emission via sampleUnboundedEmission() (pkg142 Defect 4 --
+    // no-D65 lift + photometric anchor, matches Cycles' RGB-native light
+    // scaling) and returns the Y channel. Returns 0.0 for invalid candidates
+    // or black emitters.
     float targetLuminance(const SampledWavelengths& lambdas) const {
         if (!isValid()) return 0.0f;
         SampledSpectrum spec =
-            RGBUnboundedSpectrum({emission.x, emission.y, emission.z}).sample(lambdas);
+            sampleUnboundedEmission({emission.x, emission.y, emission.z}, lambdas);
         float Y = spec.toXYZ(lambdas).Y;
         return Y > 0.0f ? Y : 0.0f;
     }

--- a/include/astroray/spectrum.h
+++ b/include/astroray/spectrum.h
@@ -37,6 +37,12 @@ XYZ cieCmf1964_10deg(float lambda);
 // gives Y = 1.0 (relative colorimetry for a perfect reflector).
 float sampleD65(float lambda);
 
+// ∫ (bare 1964 10° CMF Y-bar) dλ over the table grid (360-830 nm), no
+// illuminant weighting. This is the photometric anchor RGBUnboundedSpectrum
+// needs when used for EMISSION -- see sampleUnboundedEmission() below and
+// the pkg142 hardware-verifier regression note in src/spectrum.cpp.
+float cieYIntegral();
+
 // Filesystem path of the shipped Jakob-Hanika sRGB LUT. Resolved lazily on
 // first call; see src/spectrum.cpp for the search order.
 std::string spectrumLutPath();
@@ -244,6 +250,18 @@ private:
     float scale_ = 0.0f;
     RGBAlbedoSpectrum rsp_{};
 };
+
+// RGBUnbounded emission upsample WITH the photometric anchor applied
+// (RGBUnboundedSpectrum(rgb).sample(wl) * (1/cieYIntegral())). Use this at
+// every production EMISSION call site (light Le, mesh emitter, env
+// background/HDRI); do NOT call RGBUnboundedSpectrum(...).sample(...)
+// directly for emission -- see cieYIntegral() above and the pkg142
+// hardware-verifier regression note in src/spectrum.cpp. Non-emission
+// RGBUnbounded uses (env color-tint spectral multiply in raytracer.h,
+// Phong specular_spec_ in plugins/materials/phong.cpp) stay on the bare
+// class and must NOT go through this helper.
+SampledSpectrum sampleUnboundedEmission(const std::array<float, 3>& rgb,
+                                         const SampledWavelengths& wl);
 
 class RGBIlluminantSpectrum {
 public:

--- a/include/raytracer.h
+++ b/include/raytracer.h
@@ -783,6 +783,12 @@ public:
         GRResult rgb = traceGR(r, gen);
         astroray::SampledSpectrum emission(0.0f);
         if (rgb.hasEmission) {
+            // NOTE (pkg142 Defect 4 scope): GR/accretion-disk emission is left on
+            // RGBIlluminantSpectrum (D65) deliberately -- it is a distinct pillar
+            // (GR/black-hole rendering, own calibration) with no live-Cycles
+            // oracle coverage, and pkg142's contract does not name it. Standard
+            // light/mesh/env emission moved to RGBUnboundedSpectrum; see
+            // pkg142-rgb-emission-convention.md.
             emission = astroray::RGBIlluminantSpectrum(
                 {rgb.color.x, rgb.color.y, rgb.color.z}).sample(lambdas);
         }
@@ -1341,7 +1347,10 @@ class EnvironmentMap {
     std::vector<float> marginalCdf;     // size: height
     std::vector<float> marginalFunc;    // size: height (row totals)
     float totalPower = 0.0f;
-    std::vector<astroray::RGBIlluminantSpectrum> spectralAtlas_; // width*height, pre-strength
+    // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift for the env/HDRI
+    // texel atlas, matching Cycles' RGB-native light scaling. See
+    // .astroray_plan/packages/pkg142-rgb-emission-convention.md.
+    std::vector<astroray::RGBUnboundedSpectrum> spectralAtlas_; // width*height, pre-strength
 
     // Compute and store the baked rotation matrix.
     // Cycles cycles/blender/shader.cpp: XYZ extrinsic Euler order (Apache-2.0).
@@ -2420,12 +2429,13 @@ public:
                     if (envMap && envMap->loaded()) {
                         envSpec = envMap->evalSpectral(ray.direction.normalized(), lambdas);
                     } else if (backgroundColor.x >= 0) {
-                        envSpec = astroray::RGBIlluminantSpectrum(
+                        // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift.
+                        envSpec = astroray::RGBUnboundedSpectrum(
                             {backgroundColor.x, backgroundColor.y, backgroundColor.z}).sample(lambdas);
                     } else {
                         float t = 0.5f * (ray.direction.normalized().y + 1.0f);
                         Vec3 bg = (Vec3(1) * (1 - t) + Vec3(0.5f, 0.7f, 1.0f) * t) * 0.2f;
-                        envSpec = astroray::RGBIlluminantSpectrum({bg.x, bg.y, bg.z}).sample(lambdas);
+                        envSpec = astroray::RGBUnboundedSpectrum({bg.x, bg.y, bg.z}).sample(lambdas);
                     }
                     color += throughput * envSpec;
                 }
@@ -2625,12 +2635,13 @@ public:
                     if (envMap && envMap->loaded()) {
                         envSpec = envMap->evalSpectral(ray.direction.normalized(), lambdas);
                     } else if (backgroundColor.x >= 0) {
-                        envSpec = astroray::RGBIlluminantSpectrum(
+                        // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift.
+                        envSpec = astroray::RGBUnboundedSpectrum(
                             {backgroundColor.x, backgroundColor.y, backgroundColor.z}).sample(lambdas);
                     } else {
                         float t = 0.5f * (ray.direction.normalized().y + 1.0f);
                         Vec3 bg = (Vec3(1) * (1 - t) + Vec3(0.5f, 0.7f, 1.0f) * t) * 0.2f;
-                        envSpec = astroray::RGBIlluminantSpectrum({bg.x, bg.y, bg.z}).sample(lambdas);
+                        envSpec = astroray::RGBUnboundedSpectrum({bg.x, bg.y, bg.z}).sample(lambdas);
                     }
                     color += throughput * envSpec;
                 }
@@ -2771,8 +2782,9 @@ public:
                             astroray::SampledSpectrum f_spec =
                                 wrec.material->evalSpectral(wrec, wwo, wiToLight, walkLambdas);
                             if (!f_spec.isZero()) {
+                                // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift.
                                 astroray::SampledSpectrum Li =
-                                    astroray::RGBIlluminantSpectrum({ls.emission.x, ls.emission.y, ls.emission.z}).sample(walkLambdas);
+                                    astroray::RGBUnboundedSpectrum({ls.emission.x, ls.emission.y, ls.emission.z}).sample(walkLambdas);
                                 float geom = std::max(0.0f, std::abs(ls.normal.dot(-wiToLight))) /
                                              std::max(dist2, 1e-4f);
                                 astroray::SampledSpectrum contribution =

--- a/include/raytracer.h
+++ b/include/raytracer.h
@@ -1518,7 +1518,13 @@ public:
 
         astroray::SampledSpectrum s0 = s00 * (1.0f - uFract) + s10 * uFract;
         astroray::SampledSpectrum s1 = s01 * (1.0f - uFract) + s11 * uFract;
-        astroray::SampledSpectrum out = (s0 * (1.0f - vFract) + s1 * vFract) * strength;
+        // pkg142 hardware-verifier fix: spectralAtlas_ elements are bare
+        // RGBUnboundedSpectrum (no photometric anchor) -- apply
+        // astroray::cieYIntegral()'s reciprocal here (mirrors
+        // sampleUnboundedEmission(); can't use that helper directly since the
+        // atlas stores pre-constructed objects, not raw RGB).
+        astroray::SampledSpectrum out = (s0 * (1.0f - vFract) + s1 * vFract)
+            * strength * (1.0f / astroray::cieYIntegral());
         // pkg63: apply RGB color tint as a reflectance-style (no D65 weighting)
         // multiplicative filter on the env-map spectrum. RGBUnboundedSpectrum
         // collapses to a flat scalar for grayscale tints (e.g. (0.5,0.5,0.5)
@@ -2429,13 +2435,14 @@ public:
                     if (envMap && envMap->loaded()) {
                         envSpec = envMap->evalSpectral(ray.direction.normalized(), lambdas);
                     } else if (backgroundColor.x >= 0) {
-                        // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift.
-                        envSpec = astroray::RGBUnboundedSpectrum(
-                            {backgroundColor.x, backgroundColor.y, backgroundColor.z}).sample(lambdas);
+                        // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift,
+                        // with the photometric anchor (pkg142 hw-verifier fix).
+                        envSpec = astroray::sampleUnboundedEmission(
+                            {backgroundColor.x, backgroundColor.y, backgroundColor.z}, lambdas);
                     } else {
                         float t = 0.5f * (ray.direction.normalized().y + 1.0f);
                         Vec3 bg = (Vec3(1) * (1 - t) + Vec3(0.5f, 0.7f, 1.0f) * t) * 0.2f;
-                        envSpec = astroray::RGBUnboundedSpectrum({bg.x, bg.y, bg.z}).sample(lambdas);
+                        envSpec = astroray::sampleUnboundedEmission({bg.x, bg.y, bg.z}, lambdas);
                     }
                     color += throughput * envSpec;
                 }
@@ -2635,13 +2642,14 @@ public:
                     if (envMap && envMap->loaded()) {
                         envSpec = envMap->evalSpectral(ray.direction.normalized(), lambdas);
                     } else if (backgroundColor.x >= 0) {
-                        // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift.
-                        envSpec = astroray::RGBUnboundedSpectrum(
-                            {backgroundColor.x, backgroundColor.y, backgroundColor.z}).sample(lambdas);
+                        // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift,
+                        // with the photometric anchor (pkg142 hw-verifier fix).
+                        envSpec = astroray::sampleUnboundedEmission(
+                            {backgroundColor.x, backgroundColor.y, backgroundColor.z}, lambdas);
                     } else {
                         float t = 0.5f * (ray.direction.normalized().y + 1.0f);
                         Vec3 bg = (Vec3(1) * (1 - t) + Vec3(0.5f, 0.7f, 1.0f) * t) * 0.2f;
-                        envSpec = astroray::RGBUnboundedSpectrum({bg.x, bg.y, bg.z}).sample(lambdas);
+                        envSpec = astroray::sampleUnboundedEmission({bg.x, bg.y, bg.z}, lambdas);
                     }
                     color += throughput * envSpec;
                 }
@@ -2782,9 +2790,12 @@ public:
                             astroray::SampledSpectrum f_spec =
                                 wrec.material->evalSpectral(wrec, wwo, wiToLight, walkLambdas);
                             if (!f_spec.isZero()) {
-                                // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift.
+                                // pkg142 (Defect 4): UNBOUNDED (no-D65) emission
+                                // lift, with the photometric anchor (pkg142
+                                // hardware-verifier fix).
                                 astroray::SampledSpectrum Li =
-                                    astroray::RGBUnboundedSpectrum({ls.emission.x, ls.emission.y, ls.emission.z}).sample(walkLambdas);
+                                    astroray::sampleUnboundedEmission(
+                                        {ls.emission.x, ls.emission.y, ls.emission.z}, walkLambdas);
                                 float geom = std::max(0.0f, std::abs(ls.normal.dot(-wiToLight))) /
                                              std::max(dist2, 1e-4f);
                                 astroray::SampledSpectrum contribution =

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -1421,10 +1421,11 @@ public:
         return {s[0], s[1], s[2], s[3]};
     }
 
-    // Reference fallback: RGB lookup then RGBUnboundedSpectrum upsample
-    // (pkg142 Defect 4 — must track whatever convention the atlas/evalSpectral
-    // path uses; test_eval_spectral_atlas_matches_upsample_fallback asserts
-    // these two paths agree). Mirrors the pkg11-style path that evalSpectral
+    // Reference fallback: RGB lookup then sampleUnboundedEmission() upsample
+    // (pkg142 Defect 4 -- must track whatever convention the atlas/evalSpectral
+    // path uses, including the photometric anchor (pkg142 hardware-verifier
+    // fix); test_eval_spectral_atlas_matches_upsample_fallback asserts these
+    // two paths agree). Mirrors the pkg11-style path that evalSpectral
     // replaces.
     std::vector<float> evalEnvRGBUpsample(const std::vector<float>& dir, float u) const {
         if (!envMap || !envMap->loaded()) return {0,0,0,0};
@@ -1432,7 +1433,7 @@ public:
         Vec3 c = envMap->lookup(d);
         astroray::SampledWavelengths wls = astroray::SampledWavelengths::sampleUniform(u);
         astroray::SampledSpectrum s =
-            astroray::RGBUnboundedSpectrum({c.x, c.y, c.z}).sample(wls);
+            astroray::sampleUnboundedEmission({c.x, c.y, c.z}, wls);
         return {s[0], s[1], s[2], s[3]};
     }
 

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -1421,15 +1421,18 @@ public:
         return {s[0], s[1], s[2], s[3]};
     }
 
-    // Reference fallback: RGB lookup then RGBIlluminantSpectrum upsample.
-    // Mirrors the pkg11-style path that evalSpectral replaces.
+    // Reference fallback: RGB lookup then RGBUnboundedSpectrum upsample
+    // (pkg142 Defect 4 — must track whatever convention the atlas/evalSpectral
+    // path uses; test_eval_spectral_atlas_matches_upsample_fallback asserts
+    // these two paths agree). Mirrors the pkg11-style path that evalSpectral
+    // replaces.
     std::vector<float> evalEnvRGBUpsample(const std::vector<float>& dir, float u) const {
         if (!envMap || !envMap->loaded()) return {0,0,0,0};
         Vec3 d(dir[0], dir[1], dir[2]);
         Vec3 c = envMap->lookup(d);
         astroray::SampledWavelengths wls = astroray::SampledWavelengths::sampleUniform(u);
         astroray::SampledSpectrum s =
-            astroray::RGBIlluminantSpectrum({c.x, c.y, c.z}).sample(wls);
+            astroray::RGBUnboundedSpectrum({c.x, c.y, c.z}).sample(wls);
         return {s[0], s[1], s[2], s[3]};
     }
 
@@ -1660,8 +1663,8 @@ public:
             // so GPU must do the same via multiwavelength_kernel.cu. The legacy RGB
             // path_trace_kernel.cu (used pre-pkg14) is no longer accurate for HDRI
             // env-map rendering because it converts env RGB → spectral → RGB via
-            // RGBIlluminantSpectrum, which is lossy compared to the CPU's direct
-            // RGBIlluminantSpectrum spectral atlas sampling.
+            // RGBUnboundedSpectrum (pkg142 Defect 4), which is lossy compared to the
+            // CPU's direct RGBUnboundedSpectrum spectral atlas sampling.
 #ifdef ASTRORAY_WAVEFRONT_CUDA_N3
             if (integratorName_ == "wavefront_path_tracer") {
                 // pkg55-C3: resolve spectral params (visible-band spectral is the

--- a/plugins/integrators/multiwavelength_path_tracer.cpp
+++ b/plugins/integrators/multiwavelength_path_tracer.cpp
@@ -164,9 +164,10 @@ private:
                 Vec3 dir = ray.direction.normalized();
                 if (bgColor.x >= 0) {
                     // Explicit background color always takes precedence (including black).
-                    // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift.
-                    envSpec = astroray::RGBUnboundedSpectrum(
-                        {bgColor.x, bgColor.y, bgColor.z}).sample(lambdas);
+                    // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift, with
+                    // the photometric anchor (pkg142 hardware-verifier fix).
+                    envSpec = astroray::sampleUnboundedEmission(
+                        {bgColor.x, bgColor.y, bgColor.z}, lambdas);
                 } else if (envMap && envMap->loaded()) {
                     envSpec = envMap->evalSpectral(dir, lambdas);
                 } else if (useLuminanceOutput_) {
@@ -179,7 +180,7 @@ private:
                 } else {
                     float t = 0.5f * (dir.y + 1.0f);
                     Vec3 bg = (Vec3(1) * (1 - t) + Vec3(0.5f, 0.7f, 1.0f) * t) * 0.2f;
-                    envSpec = astroray::RGBUnboundedSpectrum({bg.x, bg.y, bg.z}).sample(lambdas);
+                    envSpec = astroray::sampleUnboundedEmission({bg.x, bg.y, bg.z}, lambdas);
                 }
                 color += throughput * envSpec;
                 break;

--- a/plugins/integrators/multiwavelength_path_tracer.cpp
+++ b/plugins/integrators/multiwavelength_path_tracer.cpp
@@ -164,7 +164,8 @@ private:
                 Vec3 dir = ray.direction.normalized();
                 if (bgColor.x >= 0) {
                     // Explicit background color always takes precedence (including black).
-                    envSpec = astroray::RGBIlluminantSpectrum(
+                    // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift.
+                    envSpec = astroray::RGBUnboundedSpectrum(
                         {bgColor.x, bgColor.y, bgColor.z}).sample(lambdas);
                 } else if (envMap && envMap->loaded()) {
                     envSpec = envMap->evalSpectral(dir, lambdas);
@@ -178,7 +179,7 @@ private:
                 } else {
                     float t = 0.5f * (dir.y + 1.0f);
                     Vec3 bg = (Vec3(1) * (1 - t) + Vec3(0.5f, 0.7f, 1.0f) * t) * 0.2f;
-                    envSpec = astroray::RGBIlluminantSpectrum({bg.x, bg.y, bg.z}).sample(lambdas);
+                    envSpec = astroray::RGBUnboundedSpectrum({bg.x, bg.y, bg.z}).sample(lambdas);
                 }
                 color += throughput * envSpec;
                 break;

--- a/plugins/integrators/neural_cache.cpp
+++ b/plugins/integrators/neural_cache.cpp
@@ -110,12 +110,13 @@ class NeuralCacheIntegrator : public Integrator {
             return envMap->evalSpectral(ray.direction.normalized(), lambdas);
         }
         if (bgColor.x >= 0.0f) {
-            return astroray::RGBIlluminantSpectrum(
+            // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift.
+            return astroray::RGBUnboundedSpectrum(
                 {bgColor.x, bgColor.y, bgColor.z}).sample(lambdas);
         }
         float t = 0.5f * (ray.direction.normalized().y + 1.0f);
         Vec3 bg = (Vec3(1.0f) * (1.0f - t) + Vec3(0.5f, 0.7f, 1.0f) * t) * 0.2f;
-        return astroray::RGBIlluminantSpectrum({bg.x, bg.y, bg.z}).sample(lambdas);
+        return astroray::RGBUnboundedSpectrum({bg.x, bg.y, bg.z}).sample(lambdas);
     }
 
     astroray::SampledSpectrum directLighting(
@@ -146,8 +147,9 @@ class NeuralCacheIntegrator : public Integrator {
 
         astroray::SampledSpectrum f =
             rec.material->evalSpectral(rec, wo, wi, lambdas);
+        // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift.
         astroray::SampledSpectrum L =
-            astroray::RGBIlluminantSpectrum(
+            astroray::RGBUnboundedSpectrum(
                 {ls.emission.x, ls.emission.y, ls.emission.z}).sample(lambdas);
         float bsdfPdf = rec.material->pdf(rec, wo, wi);
         float a = ls.pdf;
@@ -443,7 +445,9 @@ public:
             color += indirect;
         } else {
             Vec3 rgb = queryCacheRGB(feat);
-            color += astroray::RGBIlluminantSpectrum({rgb.x, rgb.y, rgb.z}).sample(lambdas);
+            // pkg142 (Defect 4): UNBOUNDED (no-D65) lift, consistent with the
+            // rest of the radiance pipeline this cached RGB estimate feeds into.
+            color += astroray::RGBUnboundedSpectrum({rgb.x, rgb.y, rgb.z}).sample(lambdas);
         }
 
         astroray::XYZ xyz = color.toXYZ(lambdas);

--- a/plugins/integrators/neural_cache.cpp
+++ b/plugins/integrators/neural_cache.cpp
@@ -110,13 +110,14 @@ class NeuralCacheIntegrator : public Integrator {
             return envMap->evalSpectral(ray.direction.normalized(), lambdas);
         }
         if (bgColor.x >= 0.0f) {
-            // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift.
-            return astroray::RGBUnboundedSpectrum(
-                {bgColor.x, bgColor.y, bgColor.z}).sample(lambdas);
+            // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift, with the
+            // photometric anchor (pkg142 hardware-verifier fix).
+            return astroray::sampleUnboundedEmission(
+                {bgColor.x, bgColor.y, bgColor.z}, lambdas);
         }
         float t = 0.5f * (ray.direction.normalized().y + 1.0f);
         Vec3 bg = (Vec3(1.0f) * (1.0f - t) + Vec3(0.5f, 0.7f, 1.0f) * t) * 0.2f;
-        return astroray::RGBUnboundedSpectrum({bg.x, bg.y, bg.z}).sample(lambdas);
+        return astroray::sampleUnboundedEmission({bg.x, bg.y, bg.z}, lambdas);
     }
 
     astroray::SampledSpectrum directLighting(
@@ -147,10 +148,11 @@ class NeuralCacheIntegrator : public Integrator {
 
         astroray::SampledSpectrum f =
             rec.material->evalSpectral(rec, wo, wi, lambdas);
-        // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift.
+        // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift, with the
+        // photometric anchor (pkg142 hardware-verifier fix).
         astroray::SampledSpectrum L =
-            astroray::RGBUnboundedSpectrum(
-                {ls.emission.x, ls.emission.y, ls.emission.z}).sample(lambdas);
+            astroray::sampleUnboundedEmission(
+                {ls.emission.x, ls.emission.y, ls.emission.z}, lambdas);
         float bsdfPdf = rec.material->pdf(rec, wo, wi);
         float a = ls.pdf;
         float b = bsdfPdf;
@@ -447,7 +449,10 @@ public:
             Vec3 rgb = queryCacheRGB(feat);
             // pkg142 (Defect 4): UNBOUNDED (no-D65) lift, consistent with the
             // rest of the radiance pipeline this cached RGB estimate feeds into.
-            color += astroray::RGBUnboundedSpectrum({rgb.x, rgb.y, rgb.z}).sample(lambdas);
+            // Photometric anchor applied (pkg142 hardware-verifier fix) -- the
+            // cached value is trained from real spectral radiance (see
+            // enqueueTrainingSample above), so it carries physical units too.
+            color += astroray::sampleUnboundedEmission({rgb.x, rgb.y, rgb.z}, lambdas);
         }
 
         astroray::XYZ xyz = color.toXYZ(lambdas);

--- a/plugins/integrators/restir_di.cpp
+++ b/plugins/integrators/restir_di.cpp
@@ -135,14 +135,15 @@ public:
                     if (envMap && envMap->loaded()) {
                         envSpec = envMap->evalSpectral(pathRay.direction.normalized(), lambdas);
                     } else if (bgColor.x >= 0) {
-                        // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift.
-                        envSpec = astroray::RGBUnboundedSpectrum(
-                            {bgColor.x, bgColor.y, bgColor.z}).sample(lambdas);
+                        // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift,
+                        // with the photometric anchor (pkg142 hw-verifier fix).
+                        envSpec = astroray::sampleUnboundedEmission(
+                            {bgColor.x, bgColor.y, bgColor.z}, lambdas);
                     } else {
                         float t = 0.5f * (pathRay.direction.normalized().y + 1.0f);
                         Vec3 bg = (Vec3(1) * (1 - t) + Vec3(0.5f, 0.7f, 1.0f) * t) * 0.2f;
-                        envSpec = astroray::RGBUnboundedSpectrum(
-                            {bg.x, bg.y, bg.z}).sample(lambdas);
+                        envSpec = astroray::sampleUnboundedEmission(
+                            {bg.x, bg.y, bg.z}, lambdas);
                     }
                     color += throughput * envSpec;
                 }
@@ -284,11 +285,12 @@ public:
                     if (!occluded) {
                         astroray::SampledSpectrum f_spec =
                             rec.material->evalSpectral(rec, wo, wi, lambdas);
-                        // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift.
+                        // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift,
+                        // with the photometric anchor (pkg142 hw-verifier fix).
                         astroray::SampledSpectrum L_spec =
-                            astroray::RGBUnboundedSpectrum(
-                                {res.y.emission.x, res.y.emission.y, res.y.emission.z}
-                            ).sample(lambdas);
+                            astroray::sampleUnboundedEmission(
+                                {res.y.emission.x, res.y.emission.y, res.y.emission.z},
+                                lambdas);
 
                         // pkg87b: Cryptomatte accumulation at ReSTIR resolved shade point.
                         // Weight = average(throughput · f_spec · L_spec · res.W), per Cycles.

--- a/plugins/integrators/restir_di.cpp
+++ b/plugins/integrators/restir_di.cpp
@@ -135,12 +135,13 @@ public:
                     if (envMap && envMap->loaded()) {
                         envSpec = envMap->evalSpectral(pathRay.direction.normalized(), lambdas);
                     } else if (bgColor.x >= 0) {
-                        envSpec = astroray::RGBIlluminantSpectrum(
+                        // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift.
+                        envSpec = astroray::RGBUnboundedSpectrum(
                             {bgColor.x, bgColor.y, bgColor.z}).sample(lambdas);
                     } else {
                         float t = 0.5f * (pathRay.direction.normalized().y + 1.0f);
                         Vec3 bg = (Vec3(1) * (1 - t) + Vec3(0.5f, 0.7f, 1.0f) * t) * 0.2f;
-                        envSpec = astroray::RGBIlluminantSpectrum(
+                        envSpec = astroray::RGBUnboundedSpectrum(
                             {bg.x, bg.y, bg.z}).sample(lambdas);
                     }
                     color += throughput * envSpec;
@@ -283,8 +284,9 @@ public:
                     if (!occluded) {
                         astroray::SampledSpectrum f_spec =
                             rec.material->evalSpectral(rec, wo, wi, lambdas);
+                        // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift.
                         astroray::SampledSpectrum L_spec =
-                            astroray::RGBIlluminantSpectrum(
+                            astroray::RGBUnboundedSpectrum(
                                 {res.y.emission.x, res.y.emission.y, res.y.emission.z}
                             ).sample(lambdas);
 

--- a/plugins/integrators/sms_caustic_path_tracer.cpp
+++ b/plugins/integrators/sms_caustic_path_tracer.cpp
@@ -179,9 +179,10 @@ public:
                     rad = rad + sms;
                 } else if (!casters_.empty()) {
                     Vec3 sms = sampleSMSRGB(rec, ray, lambdas, gen);
-                    // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift.
-                    rad = rad + astroray::RGBUnboundedSpectrum(
-                        {sms.x, sms.y, sms.z}).sample(lambdas);
+                    // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift, with
+                    // the photometric anchor (pkg142 hardware-verifier fix).
+                    rad = rad + astroray::sampleUnboundedEmission(
+                        {sms.x, sms.y, sms.z}, lambdas);
                 }
             }
         }
@@ -281,9 +282,10 @@ private:
 
             // Project RGB emission to the hero wavelength via Jakob-Hanika
             // upsampling — the per-λ Le evaluation needed for the prism
-            // rainbow. pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift.
-            float LeHero = astroray::RGBUnboundedSpectrum(
-                {Le.x, Le.y, Le.z}).sample(lambdas)[0];
+            // rainbow. pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift,
+            // with the photometric anchor (pkg142 hardware-verifier fix).
+            float LeHero = astroray::sampleUnboundedEmission(
+                {Le.x, Le.y, Le.z}, lambdas)[0];
 
             float fHero  = fSpec[0];
             float sampleHero = fHero * LeHero * Tr * w;

--- a/plugins/integrators/sms_caustic_path_tracer.cpp
+++ b/plugins/integrators/sms_caustic_path_tracer.cpp
@@ -24,7 +24,7 @@
 //
 // Phase 1 scope (default, `spectral_newton=false`): RGB only, scalar IOR.
 //   Spherical refractive casters; one Newton solve per ray, one specular
-//   vertex; contribution upsampled via RGBIlluminantSpectrum.
+//   vertex; contribution upsampled via RGBUnboundedSpectrum (pkg142 Defect 4).
 //
 // Phase 2 scope (`spectral_newton=true`): the Newton residual, refraction
 //   direction, and Schlick Fresnel are evaluated at the hero wavelength
@@ -179,7 +179,8 @@ public:
                     rad = rad + sms;
                 } else if (!casters_.empty()) {
                     Vec3 sms = sampleSMSRGB(rec, ray, lambdas, gen);
-                    rad = rad + astroray::RGBIlluminantSpectrum(
+                    // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift.
+                    rad = rad + astroray::RGBUnboundedSpectrum(
                         {sms.x, sms.y, sms.z}).sample(lambdas);
                 }
             }
@@ -280,8 +281,8 @@ private:
 
             // Project RGB emission to the hero wavelength via Jakob-Hanika
             // upsampling — the per-λ Le evaluation needed for the prism
-            // rainbow.
-            float LeHero = astroray::RGBIlluminantSpectrum(
+            // rainbow. pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift.
+            float LeHero = astroray::RGBUnboundedSpectrum(
                 {Le.x, Le.y, Le.z}).sample(lambdas)[0];
 
             float fHero  = fSpec[0];

--- a/plugins/integrators/spectral_path_tracer.cpp
+++ b/plugins/integrators/spectral_path_tracer.cpp
@@ -293,9 +293,10 @@ private:
                                     C, eta, casterPickPdf, ls, smsCfg_,
                                     fSpec, w, Le, Tr, wi))
                 continue;
-            // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift.
-            float LeHero = astroray::RGBUnboundedSpectrum(
-                {Le.x, Le.y, Le.z}).sample(lambdas)[0];
+            // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift, with the
+            // photometric anchor (pkg142 hardware-verifier fix).
+            float LeHero = astroray::sampleUnboundedEmission(
+                {Le.x, Le.y, Le.z}, lambdas)[0];
             float fHero  = fSpec[0];
             float sampleHero = fHero * LeHero * Tr * w;
             if (sampleHero > smsCfg_.contribClamp) sampleHero = smsCfg_.contribClamp;
@@ -349,9 +350,10 @@ private:
             smsConverged_ += 1.0f;
             smsEnergy_ += maxC;
         }
-        // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift.
-        return astroray::RGBUnboundedSpectrum(
-            {contribRGB.x, contribRGB.y, contribRGB.z}).sample(lambdas);
+        // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift, with the
+        // photometric anchor (pkg142 hardware-verifier fix).
+        return astroray::sampleUnboundedEmission(
+            {contribRGB.x, contribRGB.y, contribRGB.z}, lambdas);
     }
 
     // pkg111: Build the photon map (forward light-tracing from caustic casters).

--- a/plugins/integrators/spectral_path_tracer.cpp
+++ b/plugins/integrators/spectral_path_tracer.cpp
@@ -293,7 +293,8 @@ private:
                                     C, eta, casterPickPdf, ls, smsCfg_,
                                     fSpec, w, Le, Tr, wi))
                 continue;
-            float LeHero = astroray::RGBIlluminantSpectrum(
+            // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift.
+            float LeHero = astroray::RGBUnboundedSpectrum(
                 {Le.x, Le.y, Le.z}).sample(lambdas)[0];
             float fHero  = fSpec[0];
             float sampleHero = fHero * LeHero * Tr * w;
@@ -348,7 +349,8 @@ private:
             smsConverged_ += 1.0f;
             smsEnergy_ += maxC;
         }
-        return astroray::RGBIlluminantSpectrum(
+        // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift.
+        return astroray::RGBUnboundedSpectrum(
             {contribRGB.x, contribRGB.y, contribRGB.z}).sample(lambdas);
     }
 

--- a/plugins/materials/diffuse_light.cpp
+++ b/plugins/materials/diffuse_light.cpp
@@ -4,7 +4,10 @@
 class DiffuseLightPlugin : public Material {
     Vec3 color_;
     float intensity_;
-    astroray::RGBIlluminantSpectrum emission_spec_;
+    // pkg142 (Defect 4): RGBUnbounded (no-D65) lift, matching Cycles' RGB-native
+    // light scaling and astroray::EmissionSpectrum::evalRGB. See
+    // .astroray_plan/packages/pkg142-rgb-emission-convention.md.
+    astroray::RGBUnboundedSpectrum emission_spec_;
 
 public:
     explicit DiffuseLightPlugin(const astroray::ParamDict& p)

--- a/plugins/materials/diffuse_light.cpp
+++ b/plugins/materials/diffuse_light.cpp
@@ -23,7 +23,11 @@ public:
             const HitRecord& rec,
             const astroray::SampledWavelengths& lambdas) const override {
         if (!rec.frontFace) return astroray::SampledSpectrum(0.0f);
-        return emission_spec_.sample(lambdas);
+        // pkg142 hardware-verifier fix: RGBUnboundedSpectrum::sample() has no
+        // photometric anchor -- apply astroray::cieYIntegral()'s reciprocal
+        // here (mirrors sampleUnboundedEmission(); can't use that helper
+        // directly since emission_spec_ is a stored, pre-constructed object).
+        return emission_spec_.sample(lambdas) * (1.0f / astroray::cieYIntegral());
     }
 
     astroray::SampledSpectrum evalSpectral(

--- a/plugins/materials/emissive.cpp
+++ b/plugins/materials/emissive.cpp
@@ -8,7 +8,10 @@
 class EmissivePlugin : public Material {
     Vec3 color_;
     float intensity_;
-    astroray::RGBIlluminantSpectrum emission_spec_;
+    // pkg142 (Defect 4): RGBUnbounded (no-D65) lift, matching Cycles' RGB-native
+    // light scaling and astroray::EmissionSpectrum::evalRGB. See
+    // .astroray_plan/packages/pkg142-rgb-emission-convention.md.
+    astroray::RGBUnboundedSpectrum emission_spec_;
 
 public:
     explicit EmissivePlugin(const astroray::ParamDict& p)

--- a/plugins/materials/emissive.cpp
+++ b/plugins/materials/emissive.cpp
@@ -26,7 +26,11 @@ public:
     astroray::SampledSpectrum emittedSpectral(
             const HitRecord& rec,
             const astroray::SampledWavelengths& lambdas) const override {
-        return emission_spec_.sample(lambdas);  // no front-face gate
+        // pkg142 hardware-verifier fix: RGBUnboundedSpectrum::sample() has no
+        // photometric anchor -- apply astroray::cieYIntegral()'s reciprocal
+        // here (mirrors sampleUnboundedEmission(); can't use that helper
+        // directly since emission_spec_ is a stored, pre-constructed object).
+        return emission_spec_.sample(lambdas) * (1.0f / astroray::cieYIntegral());  // no front-face gate
     }
 
     astroray::SampledSpectrum evalSpectral(

--- a/scripts/verify_pkg122_cycles_oracle.py
+++ b/scripts/verify_pkg122_cycles_oracle.py
@@ -1,0 +1,230 @@
+# -*- coding: utf-8 -*-
+"""pkg122 hardware verification -- live headless-Cycles A/B oracle.
+
+Builds ONE native-Blender-light scene per dedicated-light type (POINT, AREA,
+SPOT, SUN) and renders it twice -- once with CYCLES, once with the Astroray
+CUSTOM_RAYTRACER addon engine -- using literally the same bpy light object
+(light.energy in Watts / W/m^2 for SUN), so the addons own light-conversion
+path (blender_addon/__init__.py convert_lights: intensity = light.energy) is
+exercised exactly as an artist would see it. This is the live-Cycles A/B the
+pkg122 spec calls for (docs/pkg122-light-energy-calibration-research.md,
+left for the team-leads post-build live-Cycles run).
+
+Floor: 40x40 gray Diffuse BSDF (roughness=0 -> exact Lambertian in Cycles;
+near-identical to Astrorays Disney-diffuse-at-roughness-0 at the near-normal
+incidence angles sampled here). Camera straight down, matching a top-down
+radiometric probe.
+
+Run headless, once per --light-type:
+    blender --background --factory-startup --python scripts/verify_pkg122_cycles_oracle.py -- --light-type POINT --out test_results/pkg122_cycles_oracle
+"""
+import argparse
+import glob
+import math
+import os
+import sys
+from pathlib import Path
+
+import bpy
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "tests"))
+import runtime_setup  # noqa: E402
+runtime_setup.configure_test_imports()
+sys.path.insert(0, ROOT)
+
+
+def _bootstrap_astroray_addon():
+    import astroray  # noqa: F401
+    print(f"[pkg122-oracle] astroray module: {astroray.__file__}")
+    import blender_addon
+    try:
+        blender_addon.register()
+    except Exception as exc:
+        if "already registered" not in str(exc):
+            raise
+
+
+def build_scene(light_type, energy, height, extra, engine=None):
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+    scene = bpy.context.scene
+
+    world = bpy.data.worlds.new("W")
+    scene.world = world
+    world.use_nodes = True
+    bg = world.node_tree.nodes.get("Background")
+    bg.inputs[0].default_value = (0.0, 0.0, 0.0, 1.0)
+    bg.inputs[1].default_value = 0.0
+
+    bpy.ops.mesh.primitive_plane_add(size=40.0, location=(0.0, 0.0, 0.0))
+    floor = bpy.context.active_object
+    mat = bpy.data.materials.new("Floor")
+    mat.use_nodes = True
+    nt = mat.node_tree
+    for n in list(nt.nodes):
+        nt.nodes.remove(n)
+    diff = nt.nodes.new("ShaderNodeBsdfDiffuse")
+    diff.inputs["Color"].default_value = (0.5, 0.5, 0.5, 1.0)
+    diff.inputs["Roughness"].default_value = 0.0
+    out = nt.nodes.new("ShaderNodeOutputMaterial")
+    nt.links.new(diff.outputs["BSDF"], out.inputs["Surface"])
+    floor.data.materials.append(mat)
+
+    cam_data = bpy.data.cameras.new("Cam")
+    cam_data.type = "PERSP"
+    cam_data.lens_unit = "FOV"
+    cam_data.angle = math.radians(20.0)
+    cam = bpy.data.objects.new("Cam", cam_data)
+    scene.collection.objects.link(cam)
+    cam.location = (0.0, 0.0, 20.0)
+    # SUN only: tilt 5 deg off the exact vertical camera/light alignment.
+    # KNOWN FINDING (pkg122 verifier, 2026-07-20): at exact vertical
+    # alignment, Astroray Disney-material floors carry a baseline
+    # Fresnel-specular lobe (present regardless of roughness/specular
+    # create_material params) that NEE-evaluates to a true delta for
+    # delta lights (POINT/SPOT/AREA -- zero contribution, no artifact)
+    # but leaks extra energy against SUN's finite-angle cone sampling
+    # (measured 1.67x-1.85x excess; vanishes with pure 'lambertian').
+    # Tilting breaks the exact alignment; <1% cos-falloff effect.
+    if light_type == "SUN":
+        cam.rotation_euler = (math.radians(5.0), 0.0, 0.0)
+    else:
+        cam.rotation_euler = (0.0, 0.0, 0.0)
+    scene.camera = cam
+
+    light_data = bpy.data.lights.new("L", type=light_type)
+    light_obj = bpy.data.objects.new("L", light_data)
+    scene.collection.objects.link(light_obj)
+    light_obj.rotation_euler = (0.0, 0.0, 0.0)
+
+    if light_type == "SUN":
+        light_data.energy = energy
+        light_data.angle = extra.get("angle", math.radians(0.526))
+        light_obj.location = (0.0, 0.0, 10.0)
+    else:
+        light_data.energy = energy
+        light_obj.location = (0.0, 0.0, height)
+        if light_type == "POINT":
+            light_data.shadow_soft_size = 0.0
+        elif light_type == "AREA":
+            light_data.shape = "RECTANGLE"
+            light_data.size = extra["size_x"]
+            light_data.size_y = extra["size_y"]
+            if engine == "CUSTOM_RAYTRACER":
+                # KNOWN FINDING (pkg122 verifier, 2026-07-20): the Astroray
+                # AreaLight normal = axis_u x axis_v = local +X x local +Y =
+                # local +Z. Cycles area lights (like spot/sun/camera) use
+                # local -Z as forward. With identity rotation the Astroray
+                # dedicated area light therefore points AWAY from a floor
+                # below (measured ratio ~0.09-0.12x, i.e. the OLD pre-pkg122
+                # 0.13x symptom, reproduced by orientation not intensity).
+                # This is an addon integration bug orthogonal to pkg122's
+                # wattage fix. Flip 180 deg about X ONLY for the Astroray
+                # render so this oracle isolates the INTENSITY ratio; do
+                # NOT read this as "AREA still broken" -- see verifier
+                # report for the orientation-bug writeup.
+                light_obj.rotation_euler = (math.pi, 0.0, 0.0)
+        elif light_type == "SPOT":
+            light_data.shadow_soft_size = 0.0
+            light_data.spot_size = extra["spot_size"]
+            light_data.spot_blend = extra["spot_blend"]
+
+    return scene
+
+
+def render_engine(scene, engine, spp, out_stem):
+    scene.render.engine = engine
+    scene.render.resolution_x = 64
+    scene.render.resolution_y = 64
+    scene.render.resolution_percentage = 100
+    scene.view_settings.view_transform = "Standard"
+    scene.view_settings.exposure = 0.0
+    scene.view_settings.gamma = 1.0
+    scene.render.image_settings.file_format = "OPEN_EXR"
+    scene.render.image_settings.color_depth = "32"
+    scene.render.image_settings.exr_codec = "NONE"
+    scene.cycles.seed = 7
+    if engine == "CYCLES":
+        scene.cycles.samples = spp
+        scene.cycles.use_denoising = False
+        scene.cycles.use_adaptive_sampling = False
+    elif hasattr(scene, "custom_raytracer"):
+        scene.custom_raytracer.samples = spp
+        scene.custom_raytracer.preview_samples = spp
+        if hasattr(scene.custom_raytracer, "device_mode"):
+            scene.custom_raytracer.device_mode = "gpu"
+
+    for f in glob.glob(str(out_stem) + "*"):
+        os.remove(f)
+    scene.render.filepath = str(out_stem)
+    bpy.ops.render.render(write_still=True)
+
+    matches = sorted(glob.glob(str(out_stem) + "*"))
+    if not matches:
+        raise RuntimeError(f"no render output found for stem {out_stem}")
+    out_path = matches[0]
+
+    img = bpy.data.images.load(out_path)
+    w, h = img.size
+    px = list(img.pixels[:])
+    import array
+    arr = array.array("f", px)
+    bpy.data.images.remove(img)
+    return arr, w, h, out_path
+
+
+def center_patch_mean(arr, w, h, patch=8):
+    cx, cy = w // 2, h // 2
+    x0, x1 = cx - patch // 2, cx + patch // 2
+    y0, y1 = cy - patch // 2, cy + patch // 2
+    sums = [0.0, 0.0, 0.0]
+    n = 0
+    for y in range(y0, y1):
+        for x in range(x0, x1):
+            idx = (y * w + x) * 4
+            sums[0] += arr[idx]
+            sums[1] += arr[idx + 1]
+            sums[2] += arr[idx + 2]
+            n += 1
+    return [s / n for s in sums]
+
+
+SCENES = {
+    "POINT": dict(energy=800.0, height=3.0, extra={}),
+    "AREA": dict(energy=300.0, height=3.0, extra={"size_x": 3.0, "size_y": 3.0}),
+    "SPOT": dict(energy=800.0, height=3.0,
+                 extra={"spot_size": math.radians(46.0), "spot_blend": 0.5}),
+    "SUN": dict(energy=5.0, height=10.0, extra={"angle": math.radians(0.526)}),
+}
+
+
+def main():
+    argv = sys.argv[sys.argv.index("--") + 1:] if "--" in sys.argv else []
+    p = argparse.ArgumentParser()
+    p.add_argument("--light-type", required=True, choices=list(SCENES.keys()))
+    p.add_argument("--out", type=Path, default=Path("test_results/pkg122_cycles_oracle"))
+    p.add_argument("--spp", type=int, default=512)
+    args = p.parse_args(argv)
+
+    cfg = SCENES[args.light_type]
+    args.out = args.out.resolve()
+    args.out.mkdir(parents=True, exist_ok=True)
+
+    results = {}
+    for engine in ("CYCLES", "CUSTOM_RAYTRACER"):
+        scene = build_scene(args.light_type, cfg["energy"], cfg["height"], cfg["extra"], engine=engine)
+        if engine == "CUSTOM_RAYTRACER":
+            _bootstrap_astroray_addon()
+        stem = args.out / f"{args.light_type.lower()}_{engine.lower()}"
+        arr, w, h, out_path = render_engine(scene, engine, args.spp, stem)
+        rgb = center_patch_mean(arr, w, h)
+        results[engine] = rgb
+        print(f"[pkg122-oracle] {args.light_type} {engine}: center_rgb={rgb} file={out_path}")
+
+    cyc = results["CYCLES"]
+    ast = results["CUSTOM_RAYTRACER"]
+    ratios = [a / c if c > 1e-9 else float("nan") for a, c in zip(ast, cyc)]
+    print(f"[pkg122-oracle] {args.light_type} RESULT cycles_rgb={cyc} astroray_rgb={ast} ratio_astroray_over_cycles={ratios}")
+
+
+main()

--- a/src/cpu/wavefront/path_kernel.cpp
+++ b/src/cpu/wavefront/path_kernel.cpp
@@ -196,14 +196,15 @@ bool advance_one_bounce(PathState& ps, HitRecord& rec,
             if (envMap && envMap->loaded()) {
                 envSpec = envMap->evalSpectral(ps.ray_direction, ps.lambdas);
             } else if (backgroundColor.x >= 0) {
-                // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift.
-                envSpec = RGBUnboundedSpectrum(
-                    {backgroundColor.x, backgroundColor.y, backgroundColor.z}).sample(ps.lambdas);
+                // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift, with the
+                // photometric anchor (pkg142 hardware-verifier fix).
+                envSpec = sampleUnboundedEmission(
+                    {backgroundColor.x, backgroundColor.y, backgroundColor.z}, ps.lambdas);
             } else {
                 // Default sky gradient (matches production line 2350-2352).
                 float t = 0.5f * (ps.ray_direction.y + 1.0f);
                 Vec3 bg = (Vec3(1) * (1 - t) + Vec3(0.5f, 0.7f, 1.0f) * t) * 0.2f;
-                envSpec = RGBUnboundedSpectrum({bg.x, bg.y, bg.z}).sample(ps.lambdas);
+                envSpec = sampleUnboundedEmission({bg.x, bg.y, bg.z}, ps.lambdas);
             }
             ps.color += ps.throughput * envSpec;
         }

--- a/src/cpu/wavefront/path_kernel.cpp
+++ b/src/cpu/wavefront/path_kernel.cpp
@@ -196,13 +196,14 @@ bool advance_one_bounce(PathState& ps, HitRecord& rec,
             if (envMap && envMap->loaded()) {
                 envSpec = envMap->evalSpectral(ps.ray_direction, ps.lambdas);
             } else if (backgroundColor.x >= 0) {
-                envSpec = RGBIlluminantSpectrum(
+                // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift.
+                envSpec = RGBUnboundedSpectrum(
                     {backgroundColor.x, backgroundColor.y, backgroundColor.z}).sample(ps.lambdas);
             } else {
                 // Default sky gradient (matches production line 2350-2352).
                 float t = 0.5f * (ps.ray_direction.y + 1.0f);
                 Vec3 bg = (Vec3(1) * (1 - t) + Vec3(0.5f, 0.7f, 1.0f) * t) * 0.2f;
-                envSpec = RGBIlluminantSpectrum({bg.x, bg.y, bg.z}).sample(ps.lambdas);
+                envSpec = RGBUnboundedSpectrum({bg.x, bg.y, bg.z}).sample(ps.lambdas);
             }
             ps.color += ps.throughput * envSpec;
         }

--- a/src/emission_spectrum.cpp
+++ b/src/emission_spectrum.cpp
@@ -118,8 +118,10 @@ EmissionSpectrum EmissionSpectrum::composeWith(const Vec3& filterRGB) const {
 // pkg89-GPU / GAP 1 — reference RGB for the device RGB upsample.
 // pkg142: the caller (scene_upload.cu) selects the device spectral mode for
 // this RGB; as of pkg142 that is GSPEC_RGB_UNBOUNDED for emission, so device
-// gpu_rgbSpectrumAt(color, λ, UNBOUNDED) reproduces CPU
-// RGBUnboundedSpectrum(color).sample() exactly (same pkg54c mirror pattern).
+// gpu_rgbSpectrumAt(color, λ, UNBOUNDED) (scale*JH*gpu_cieYNormFactor())
+// reproduces CPU sampleUnboundedEmission(color, ...) exactly (same pkg54c
+// mirror pattern; both apply the pkg142 hardware-verifier photometric
+// anchor).
 void EmissionSpectrum::deviceReference(Vec3& outRGB, bool& exactRGB) const {
     if (const RGB* rgb = std::get_if<RGB>(&data_)) {
         outRGB   = rgb->color;
@@ -189,22 +191,29 @@ SampledSpectrum EmissionSpectrum::evalBlackbody(const Blackbody& bb,
 // src/pbrt/lights.cpp) and Mitsuba 3 (srgb_d65) both imprint a D65 illuminant
 // chromaticity on RGB lights. Cycles is RGB-native: light `strength` is stored
 // as a linear-RGB float3 and radiance = strength * eval_fac, with no spectral
-// upsampling and no D65 (src/scene/light.cpp, src/kernel/light/area.h). With
-// the pkg122 (PR #500) per-type radiometry fixed, the live headless-Cycles
-// oracle measured all four dedicated-light types 1.07-1.16x brighter than
-// Cycles -- a residual traced to the D65 tilt on RGBIlluminant clashing with
-// the plain Jakob-Hanika RGBAlbedoSpectrum family used for surface albedo:
-// two same-family JH spectra multiply/integrate back to the RGB product with
-// minimal crosstalk (Cycles' albedo (dot) light multiply); a D65-tilted
-// emission spectrum does not. RGBUnboundedSpectrum = scale*sigmoid(rgb/scale)
-// is that same reflectance-sigmoid family with no illuminant, closing the gap.
+// upsampling and no D65 (src/scene/light.cpp, src/kernel/light/area.h).
+//
+// The chromaticity tilt vs. photometric units are TWO SEPARATE things, not
+// one (2026-07-2x hardware-verifier correction to the framing below):
+// RGBIlluminantSpectrum's `* sampleD65(lambda)` factor carried BOTH the D65
+// chromaticity tilt AND an implicit photometric anchor (sampleD65 is
+// normalized so unit-white integrates to Y=1). Dropping the whole factor to
+// switch to RGBUnboundedSpectrum removed BOTH -- RGBUnboundedSpectrum::sample()
+// has no illuminant and no luminance normalization at all, so bare emission
+// came out ~116x too bright (this build's 1964 10° CMF-Y table integral),
+// not merely mis-tilted. sampleUnboundedEmission() (src/spectrum.cpp)
+// restores just the photometric anchor (1/cieYIntegral()) while keeping
+// RGBUnbounded's flat (no-D65) chromaticity -- see cieYIntegral()'s doc
+// comment there. With the anchor restored, the expected oracle effect is the
+// chromaticity tilt alone (previously modeled as 1.07-1.16x; the "+7-16%"
+// framing conflated the tilt with the units bug -- see PR history).
+//
 // RGBUnboundedSpectrum is pbrt-v4's class (src/pbrt/util/spectrum.h,
-// Apache-2.0), already in-tree (src/spectrum.cpp) -- this only re-points the
-// emission call site, no new algorithm (CLAUDE.md SS6).
+// Apache-2.0), already in-tree (src/spectrum.cpp) -- this re-points the
+// emission call site at it (plus the anchor), no new algorithm (CLAUDE.md SS6).
 SampledSpectrum EmissionSpectrum::evalRGB(const RGB& rgb,
                                            const SampledWavelengths& wl) const {
-    RGBUnboundedSpectrum rgbSpectrum({rgb.color.x, rgb.color.y, rgb.color.z});
-    return rgbSpectrum.sample(wl);
+    return sampleUnboundedEmission({rgb.color.x, rgb.color.y, rgb.color.z}, wl);
 }
 
 // Internal: evaluate MeasuredSPD mode.

--- a/src/emission_spectrum.cpp
+++ b/src/emission_spectrum.cpp
@@ -1,6 +1,6 @@
 #include "astroray/emission_spectrum.h"
 #include "astroray/spectral.h"  // for planck()
-#include "astroray/spectrum.h"  // for RGBAlbedoSpectrum, RGBIlluminantSpectrum, cieCmf1964_10deg
+#include "astroray/spectrum.h"  // for RGBAlbedoSpectrum, RGBUnboundedSpectrum, cieCmf1964_10deg
 #include "astroray/spectral_profile.h"
 #include "raytracer.h"  // for Vec3
 #include <stdexcept>
@@ -115,11 +115,13 @@ EmissionSpectrum EmissionSpectrum::composeWith(const Vec3& filterRGB) const {
     return EmissionSpectrum(std::move(comp));
 }
 
-// pkg89-GPU / GAP 1 — reference RGB for the device RGBIlluminant upsample.
+// pkg89-GPU / GAP 1 — reference RGB for the device RGB upsample.
+// pkg142: the caller (scene_upload.cu) selects the device spectral mode for
+// this RGB; as of pkg142 that is GSPEC_RGB_UNBOUNDED for emission, so device
+// gpu_rgbSpectrumAt(color, λ, UNBOUNDED) reproduces CPU
+// RGBUnboundedSpectrum(color).sample() exactly (same pkg54c mirror pattern).
 void EmissionSpectrum::deviceReference(Vec3& outRGB, bool& exactRGB) const {
     if (const RGB* rgb = std::get_if<RGB>(&data_)) {
-        // RGB mode: device gpu_rgbSpectrumAt(color, λ, ILLUMINANT) reproduces
-        // CPU RGBIlluminantSpectrum(color).sample() exactly (same pkg54c path).
         outRGB   = rgb->color;
         exactRGB = true;
         return;
@@ -177,16 +179,31 @@ SampledSpectrum EmissionSpectrum::evalBlackbody(const Blackbody& bb,
 }
 
 // Internal: evaluate RGB mode.
-// Uses RGBIlluminantSpectrum (D65-weighted) to match the existing engine
-// convention for rgb-mode emission intensities. The parity-report change to
-// RGBUnboundedSpectrum was over-broad: it would drop point/background/spot-rgb
-// illuminance ~3×, breaking G5 (point hard shadow) and G4 (spot RGB center).
-// G2's AreaLight D65 chromaticity is addressed by the geometric normalize +
-// white-tint short-circuit in evalBlackbody; this evalRGB path stays Illuminant
-// so existing scene intensities continue to work.
+// pkg142 (Defect 4): RGB emission uses the RGBUnbounded (no-D65) lift to match
+// Cycles' RGB-native light scaling -- Astroray's parity target -- rather than
+// the pbrt-v4/Mitsuba RGBIlluminant D65 convention. See
+// .astroray_plan/packages/pkg142-rgb-emission-convention.md and
+// .astroray_plan/docs/defect4-rgb-emission-research.md.
+//
+// pbrt-v4 (`SpectrumType::Illuminant` -> RGBIlluminantSpectrum,
+// src/pbrt/lights.cpp) and Mitsuba 3 (srgb_d65) both imprint a D65 illuminant
+// chromaticity on RGB lights. Cycles is RGB-native: light `strength` is stored
+// as a linear-RGB float3 and radiance = strength * eval_fac, with no spectral
+// upsampling and no D65 (src/scene/light.cpp, src/kernel/light/area.h). With
+// the pkg122 (PR #500) per-type radiometry fixed, the live headless-Cycles
+// oracle measured all four dedicated-light types 1.07-1.16x brighter than
+// Cycles -- a residual traced to the D65 tilt on RGBIlluminant clashing with
+// the plain Jakob-Hanika RGBAlbedoSpectrum family used for surface albedo:
+// two same-family JH spectra multiply/integrate back to the RGB product with
+// minimal crosstalk (Cycles' albedo (dot) light multiply); a D65-tilted
+// emission spectrum does not. RGBUnboundedSpectrum = scale*sigmoid(rgb/scale)
+// is that same reflectance-sigmoid family with no illuminant, closing the gap.
+// RGBUnboundedSpectrum is pbrt-v4's class (src/pbrt/util/spectrum.h,
+// Apache-2.0), already in-tree (src/spectrum.cpp) -- this only re-points the
+// emission call site, no new algorithm (CLAUDE.md SS6).
 SampledSpectrum EmissionSpectrum::evalRGB(const RGB& rgb,
                                            const SampledWavelengths& wl) const {
-    RGBIlluminantSpectrum rgbSpectrum({rgb.color.x, rgb.color.y, rgb.color.z});
+    RGBUnboundedSpectrum rgbSpectrum({rgb.color.x, rgb.color.y, rgb.color.z});
     return rgbSpectrum.sample(wl);
 }
 

--- a/src/gpu/cuda_renderer.cu
+++ b/src/gpu/cuda_renderer.cu
@@ -723,11 +723,12 @@ void CUDARenderer::render(
     int totalPixels = width * height;
 
     // path_trace_kernel.cu uses gpu_rgbToSampledSpectrum(...) with
-    // GSPEC_RGB_ILLUMINANT for environment colour, which now reads the
-    // D65 SPD baked into MW kernel constant memory — make sure it's
-    // uploaded before the kernel runs. pkg54c additionally requires the
-    // Jakob-Hanika sigmoid LUT in device global memory because
-    // gpu_rgbSpectrumAt now upsamples via gpu_jhEvalSpectrum.
+    // GSPEC_RGB_UNBOUNDED for environment colour (pkg142 Defect 4 — no-D65
+    // lift), which upsamples via the Jakob-Hanika sigmoid LUT baked into MW
+    // kernel constant/global memory — make sure it's uploaded before the
+    // kernel runs. pkg54c additionally requires the Jakob-Hanika sigmoid LUT
+    // in device global memory because gpu_rgbSpectrumAt now upsamples via
+    // gpu_jhEvalSpectrum.
     uploadCmfTables();
     uploadJakobHanikaLut();
 

--- a/src/gpu/gpu_nee.cuh
+++ b/src/gpu/gpu_nee.cuh
@@ -352,14 +352,15 @@ __device__ inline GSampledSpectrum gpu_nee_resolve(
         gpu_material_eval_spectral(mat, const_cast<GHitRecord&>(rec), wo, s.wi, lambdas);
     // pkg89-GPU / GAP 1 — dedicated lights carry their emission intrinsically
     // (no light material). The reference RGB is upsampled through the SAME
-    // RGBIlluminant path the CPU uses (gpu_rgbSpectrumAt == CPU
-    // RGBIlluminantSpectrum::sample), scaled by the wavelength-independent
-    // dedGeoScale (staticScale · per-sample geometric factor).
+    // path the CPU uses (gpu_rgbSpectrumAt == CPU RGBUnboundedSpectrum::sample,
+    // pkg142 Defect 4 — no-D65 lift, matches Cycles' RGB-native light
+    // scaling), scaled by the wavelength-independent dedGeoScale (staticScale
+    // · per-sample geometric factor).
     GSampledSpectrum L_spec;
     if (s.isDedicated) {
         for (int i = 0; i < G_SPECTRUM_SAMPLES; ++i)
             L_spec[i] = gpu_rgbSpectrumAt(s.dedEmissionRGB, lambdas.lambda[i],
-                                          GSPEC_RGB_ILLUMINANT) * s.dedGeoScale;
+                                          GSPEC_RGB_UNBOUNDED) * s.dedGeoScale;
     } else {
         L_spec = gpu_material_emitted_spectral(materials[s.lightMatId], lightFront, lambdas);
     }

--- a/src/gpu/gpu_spectral_tables.cu
+++ b/src/gpu/gpu_spectral_tables.cu
@@ -112,6 +112,14 @@ namespace d65_baked {
 __constant__ float g_d65SPD[G_CMF_COUNT];
 __constant__ float g_d65NormFactor;
 
+// pkg142 hardware-verifier regression (2026-07-2x): photometric anchor for
+// RGBUnbounded EMISSION use only. k = 1 / ∫cmfY dλ over [360,830] (bare,
+// no D65 weighting) -- mirrors src/spectrum.cpp::cieYIntegral()/
+// sampleUnboundedEmission(). Without this, GSPEC_RGB_UNBOUNDED emission came
+// out ~116x too bright (unlike GSPEC_RGB_ILLUMINANT, whose gpu_sampleD65
+// factor folds this same anchor in together with the D65 chromaticity tilt).
+__constant__ float g_cieYNormFactor;
+
 void uploadCmfTables() {
     static bool uploaded = false;
     if (uploaded) return;
@@ -148,6 +156,23 @@ void uploadCmfTables() {
     if (eN != cudaSuccess) {
         fprintf(stderr, "D65 norm upload failed: %s\n", cudaGetErrorString(eN));
         throw std::runtime_error("D65 norm upload failed");
+    }
+
+    // pkg142 hardware-verifier regression: compute + upload the bare CIE-Y
+    // photometric anchor (mirrors src/spectrum.cpp::computeCieYIntegral(),
+    // same trapezoid integration, no D65 weighting).
+    double cieYInt = 0.0;
+    for (int i = 0; i + 1 < cmf_baked::kCieCmfCount; ++i) {
+        double dLam = static_cast<double>(cmf_baked::kCieCmfLambdaStep);
+        double a = cmf_baked::kCieCmfY[i];
+        double b = cmf_baked::kCieCmfY[i + 1];
+        cieYInt += 0.5 * dLam * (a + b);
+    }
+    float cieYNormF = 1.0f / static_cast<float>(cieYInt);
+    cudaError_t eY = cudaMemcpyToSymbol(g_cieYNormFactor, &cieYNormF, sizeof(float));
+    if (eY != cudaSuccess) {
+        fprintf(stderr, "CIE-Y norm upload failed: %s\n", cudaGetErrorString(eY));
+        throw std::runtime_error("CIE-Y norm upload failed");
     }
     uploaded = true;
 }
@@ -312,6 +337,13 @@ __device__ float gpu_sampleD65(float lambda) {
     float t = idx - (float)i;
     float v = g_d65SPD[i] * (1.f - t) + g_d65SPD[i + 1] * t;
     return v * g_d65NormFactor;
+}
+
+// pkg142 hardware-verifier regression: photometric anchor for RGBUnbounded
+// EMISSION use (GSPEC_RGB_UNBOUNDED branch in gpu_materials.h), mirroring
+// CPU astroray::cieYIntegral(). See g_cieYNormFactor's doc comment above.
+__device__ float gpu_cieYNormFactor() {
+    return g_cieYNormFactor;
 }
 
 // pkg55-B' Session N+6: non-inline export of spectrumToXYZ for the wavefront

--- a/src/gpu/multiwavelength_kernel.cu
+++ b/src/gpu/multiwavelength_kernel.cu
@@ -298,8 +298,9 @@ __device__ GSampledSpectrum tracePathMW(
                             ls, cfg, fSpec, w, Le, Tr, wi)) {
                         // Clamp and accumulate hero-channel contribution
                         float fHero = fSpec.v[0];
-                        // Convert Le (linear sRGB) to spectral
-                        GSampledSpectrum LeSpec = gpu_rgbToSampledSpectrum(Le, lambdas, GSPEC_RGB_ILLUMINANT);
+                        // Convert Le (linear sRGB) to spectral.
+                        // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift.
+                        GSampledSpectrum LeSpec = gpu_rgbToSampledSpectrum(Le, lambdas, GSPEC_RGB_UNBOUNDED);
                         float LeHero = LeSpec.v[0];
                         float sampleHero = fHero * LeHero * Tr * w;
                         if (sampleHero > cfg.contribClamp) sampleHero = cfg.contribClamp;

--- a/src/gpu/path_trace_kernel.cu
+++ b/src/gpu/path_trace_kernel.cu
@@ -433,8 +433,9 @@ __device__ GVec3 tracePathGPU(
             if (bounce == 0 || wasSpecular)
                 color += throughput * envColor;
             if (bounce == 0 || wasSpecular)
+                // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift.
                 colorSpectral += throughputSpectral *
-                    gpu_rgbToSampledSpectrum(envColor, lambdas, GSPEC_RGB_ILLUMINANT);
+                    gpu_rgbToSampledSpectrum(envColor, lambdas, GSPEC_RGB_UNBOUNDED);
             break;
         }
 
@@ -479,7 +480,8 @@ __device__ GVec3 tracePathGPU(
 
         // pkg64-gpu Phase 2: SMS caustic attempt (RGB path mirrors spectral MW path).
         // The SMS attempt writes hero-channel contribution; the CPU hook converts to RGB via XYZ.
-        // Here, we mirror that: get SMS hero contrib, convert via RGBIlluminantSpectrum→XYZ→sRGB.
+        // Here, we mirror that: get SMS hero contrib, convert via RGBUnboundedSpectrum
+        // (pkg142 Defect 4)→XYZ→sRGB.
         if (useCaustics && !rec.isDelta && numSMSCasters > 0 && numLights > 0) {
             int cIdx = (int)(curand_uniform(rng) * numSMSCasters);
             if (cIdx >= numSMSCasters) cIdx = numSMSCasters - 1;
@@ -545,8 +547,9 @@ __device__ GVec3 tracePathGPU(
                             rec, primaryRay, lambdas, r1, r2, C, eta, casterPickPdf,
                             ls, cfg, fSpec, w, Le, Tr, wi)) {
                         // Convert hero contribution to RGB via XYZ (mirrors CPU hook).
+                        // pkg142 (Defect 4): UNBOUNDED (no-D65) emission lift.
                         float fHero = fSpec.v[0];
-                        GSampledSpectrum LeSpec = gpu_rgbToSampledSpectrum(Le, lambdas, GSPEC_RGB_ILLUMINANT);
+                        GSampledSpectrum LeSpec = gpu_rgbToSampledSpectrum(Le, lambdas, GSPEC_RGB_UNBOUNDED);
                         float LeHero = LeSpec.v[0];
                         float sampleHero = fHero * LeHero * Tr * w;
                         if (sampleHero > cfg.contribClamp) sampleHero = cfg.contribClamp;

--- a/src/gpu/scene_upload.cu
+++ b/src/gpu/scene_upload.cu
@@ -191,7 +191,10 @@ static GMaterial convertMaterial(const std::shared_ptr<Material>& mat) {
         g.baseColor = GVec3(a.x, a.y, a.z);
     } else if (gpuType == "diffuse_light") {
         g.type = GMAT_DIFFUSE_LIGHT;
-        g.spectralMode = GSPEC_RGB_ILLUMINANT;
+        // pkg142 (Defect 4): emission uses the no-D65 RGBUnbounded lift, to
+        // match Cycles' RGB-native light scaling. See
+        // pkg142-rgb-emission-convention.md.
+        g.spectralMode = GSPEC_RGB_UNBOUNDED;
         Vec3 em = mat->getEmission();
         // Store color and intensity separately: emissionIntensity=1, baseColor=full emission
         g.baseColor = GVec3(em.x, em.y, em.z);

--- a/src/gpu/wavefront/stage_light_sample.cu
+++ b/src/gpu/wavefront/stage_light_sample.cu
@@ -146,9 +146,9 @@ __device__ GLightSample sampleAreaLight(
     result.pdf = (area > 0.0f) ? (1.0f / (area * num_lights)) : 0.0f;
 
     // Emitted radiance: convert light RGB emission to spectral.
-    // Mirrors CPU LightSample::emission_spec = RGBIlluminantSpectrum(emission).sample(lambdas).
-    // Session N+4: default illuminant spectral mode for area lights (no per-light spectralMode yet).
-    result.emission = gpu_rgbToSampledSpectrum(light.emission, lambdas, GSPEC_RGB_ILLUMINANT);
+    // Mirrors CPU LightSample::emission_spec = RGBUnboundedSpectrum(emission).sample(lambdas)
+    // (pkg142 Defect 4: no-D65 lift, matches Cycles' RGB-native light scaling).
+    result.emission = gpu_rgbToSampledSpectrum(light.emission, lambdas, GSPEC_RGB_UNBOUNDED);
 
     return result;
 }

--- a/src/gpu/wavefront/stage_light_sample.cu
+++ b/src/gpu/wavefront/stage_light_sample.cu
@@ -146,8 +146,9 @@ __device__ GLightSample sampleAreaLight(
     result.pdf = (area > 0.0f) ? (1.0f / (area * num_lights)) : 0.0f;
 
     // Emitted radiance: convert light RGB emission to spectral.
-    // Mirrors CPU LightSample::emission_spec = RGBUnboundedSpectrum(emission).sample(lambdas)
-    // (pkg142 Defect 4: no-D65 lift, matches Cycles' RGB-native light scaling).
+    // Mirrors CPU LightSample::emission_spec = sampleUnboundedEmission(emission,
+    // lambdas) (pkg142 Defect 4: no-D65 lift, matches Cycles' RGB-native light
+    // scaling; includes the pkg142 hardware-verifier photometric anchor).
     result.emission = gpu_rgbToSampledSpectrum(light.emission, lambdas, GSPEC_RGB_UNBOUNDED);
 
     return result;

--- a/src/light_sampler.cpp
+++ b/src/light_sampler.cpp
@@ -67,10 +67,12 @@ void PowerLightSampler::sample(LightSample& out, const Vec3& point, const Vec3& 
             out.distance = rec.t;
             out.pdf = lights[idx]->pdfValue(point, dir) * selPdf;
 
-            // Spectral emission: upsample RGB via RGBUnboundedSpectrum (pkg142
-            // Defect 4 -- no-D65 lift, matches Material::emittedSpectral() /
-            // EmissionSpectrum::evalRGB for the same light).
-            out.emission_spec = RGBUnboundedSpectrum({out.emission.x, out.emission.y, out.emission.z}).sample(lambdas);
+            // Spectral emission: upsample RGB via sampleUnboundedEmission()
+            // (pkg142 Defect 4 -- no-D65 lift + photometric anchor, matches
+            // Material::emittedSpectral() / EmissionSpectrum::evalRGB for the
+            // same light).
+            out.emission_spec = sampleUnboundedEmission(
+                {out.emission.x, out.emission.y, out.emission.z}, lambdas);
         }
     } else {
         // Dedicated Light path (pkg89 Phase A).
@@ -174,10 +176,12 @@ void TreeLightSampler::sample(LightSample& out, const Vec3& point, const Vec3& n
             out.distance = rec.t;
             out.pdf = lights[pick.lightIndex]->pdfValue(point, dir) * treePdf;
 
-            // Spectral emission: upsample RGB via RGBUnboundedSpectrum (pkg142
-            // Defect 4 -- no-D65 lift, matches Material::emittedSpectral() /
-            // EmissionSpectrum::evalRGB for the same light).
-            out.emission_spec = RGBUnboundedSpectrum({out.emission.x, out.emission.y, out.emission.z}).sample(lambdas);
+            // Spectral emission: upsample RGB via sampleUnboundedEmission()
+            // (pkg142 Defect 4 -- no-D65 lift + photometric anchor, matches
+            // Material::emittedSpectral() / EmissionSpectrum::evalRGB for the
+            // same light).
+            out.emission_spec = sampleUnboundedEmission(
+                {out.emission.x, out.emission.y, out.emission.z}, lambdas);
         }
     } else {
         // Dedicated Light path.

--- a/src/light_sampler.cpp
+++ b/src/light_sampler.cpp
@@ -67,8 +67,10 @@ void PowerLightSampler::sample(LightSample& out, const Vec3& point, const Vec3& 
             out.distance = rec.t;
             out.pdf = lights[idx]->pdfValue(point, dir) * selPdf;
 
-            // Spectral emission: upsample RGB via RGBIlluminantSpectrum (temporary).
-            out.emission_spec = RGBIlluminantSpectrum({out.emission.x, out.emission.y, out.emission.z}).sample(lambdas);
+            // Spectral emission: upsample RGB via RGBUnboundedSpectrum (pkg142
+            // Defect 4 -- no-D65 lift, matches Material::emittedSpectral() /
+            // EmissionSpectrum::evalRGB for the same light).
+            out.emission_spec = RGBUnboundedSpectrum({out.emission.x, out.emission.y, out.emission.z}).sample(lambdas);
         }
     } else {
         // Dedicated Light path (pkg89 Phase A).
@@ -172,8 +174,10 @@ void TreeLightSampler::sample(LightSample& out, const Vec3& point, const Vec3& n
             out.distance = rec.t;
             out.pdf = lights[pick.lightIndex]->pdfValue(point, dir) * treePdf;
 
-            // Spectral emission: upsample RGB via RGBIlluminantSpectrum.
-            out.emission_spec = RGBIlluminantSpectrum({out.emission.x, out.emission.y, out.emission.z}).sample(lambdas);
+            // Spectral emission: upsample RGB via RGBUnboundedSpectrum (pkg142
+            // Defect 4 -- no-D65 lift, matches Material::emittedSpectral() /
+            // EmissionSpectrum::evalRGB for the same light).
+            out.emission_spec = RGBUnboundedSpectrum({out.emission.x, out.emission.y, out.emission.z}).sample(lambdas);
         }
     } else {
         // Dedicated Light path.

--- a/src/lights/background_light.cpp
+++ b/src/lights/background_light.cpp
@@ -44,9 +44,12 @@ void BackgroundLight::sampleLi(LiSample& sample,
     // upsampling is a temporary workaround until EnvironmentMap is extended.
     Vec3 emissionRGB = envMap_->lookup(dir);
 
-    // Upsample RGB to spectral via RGBIlluminantSpectrum (D65-weighted),
-    // matching the existing engine convention for env-map rgb emission.
-    RGBIlluminantSpectrum rgbSpectrum({emissionRGB.x, emissionRGB.y, emissionRGB.z});
+    // pkg142 (Defect 4): the world/background is itself an emitter, so for
+    // internal consistency with EmissionSpectrum::evalRGB and to keep
+    // GPU==CPU, env emission uses the same no-D65 RGBUnbounded lift (matches
+    // Cycles' RGB-native light scaling). See
+    // pkg142-rgb-emission-convention.md §"Scope decision — environment".
+    RGBUnboundedSpectrum rgbSpectrum({emissionRGB.x, emissionRGB.y, emissionRGB.z});
     sample.emission_spec = rgbSpectrum.sample(lambdas);
     sample.emission_rgb = emissionRGB;
 

--- a/src/lights/background_light.cpp
+++ b/src/lights/background_light.cpp
@@ -49,8 +49,8 @@ void BackgroundLight::sampleLi(LiSample& sample,
     // GPU==CPU, env emission uses the same no-D65 RGBUnbounded lift (matches
     // Cycles' RGB-native light scaling). See
     // pkg142-rgb-emission-convention.md §"Scope decision — environment".
-    RGBUnboundedSpectrum rgbSpectrum({emissionRGB.x, emissionRGB.y, emissionRGB.z});
-    sample.emission_spec = rgbSpectrum.sample(lambdas);
+    sample.emission_spec = sampleUnboundedEmission(
+        {emissionRGB.x, emissionRGB.y, emissionRGB.z}, lambdas);
     sample.emission_rgb = emissionRGB;
 
     // PDF: 1 / (4π) for uniform sphere sampling.

--- a/src/spectrum.cpp
+++ b/src/spectrum.cpp
@@ -64,6 +64,32 @@ float d65NormFactor() {
     return k;
 }
 
+// pkg142 hardware-verifier regression (2026-07-2x): ∫ bare kCieCmfY dλ over
+// the table grid, i.e. computeD65Normalization() WITHOUT the D65 weighting.
+// RGBIlluminantSpectrum's `* sampleD65(lambda)` factor folded TWO things into
+// one multiply -- the D65 chromaticity tilt (the ~7-16% pkg142 set out to
+// remove) AND a photometric anchor (sampleD65 is normalized so
+// ∫sampleD65·ȳdλ = 1, i.e. unit luminance for unit-white input). Switching
+// emission to RGBUnboundedSpectrum removed BOTH, not just the tilt: bare
+// RGBUnboundedSpectrum::sample() has no illuminant and no luminance
+// normalization at all, so its integrated Y came out ~116x too bright (this
+// build's 1964 10° CMF-Y table integral -- NOT the 2° observer's ~106.857;
+// always derive from the table, never hardcode). cieYIntegral() restores
+// just the anchor while keeping RGBUnbounded's flat (no-D65) chromaticity.
+// See cieYIntegral()'s callers: emission_spectrum.cpp::evalRGB and
+// gpu_materials.h's GSPEC_RGB_UNBOUNDED branch must both apply this factor,
+// byte-equivalent.
+float computeCieYIntegral() {
+    double yInt = 0.0;
+    for (int i = 0; i + 1 < baked::kCieCmfCount; ++i) {
+        double dLam = static_cast<double>(baked::kCieCmfLambdaStep);
+        double a = baked::kCieCmfY[i];
+        double b = baked::kCieCmfY[i + 1];
+        yInt += 0.5 * dLam * (a + b);
+    }
+    return static_cast<float>(yInt);
+}
+
 }  // namespace
 
 XYZ cieCmf1964_10deg(float lambda) {
@@ -74,6 +100,23 @@ XYZ cieCmf1964_10deg(float lambda) {
 
 float sampleD65(float lambda) {
     return sampleTable(baked::kD65Spd, lambda) * d65NormFactor();
+}
+
+float cieYIntegral() {
+    static const float k = computeCieYIntegral();
+    return k;
+}
+
+// Every production EMISSION call site (light Le, mesh emitter, env
+// background/HDRI) must upsample RGB emission through this helper, not
+// RGBUnboundedSpectrum(rgb).sample(wl) directly -- see cieYIntegral() above
+// for why the anchor is required. Non-emission RGBUnbounded uses (env
+// color-tint spectral multiply in raytracer.h, Phong specular_spec_ in
+// plugins/materials/phong.cpp) are dimensionless reflectance-style lifts and
+// must NOT receive this anchor; they are unchanged by this function.
+SampledSpectrum sampleUnboundedEmission(const std::array<float, 3>& rgb,
+                                         const SampledWavelengths& wl) {
+    return RGBUnboundedSpectrum(rgb).sample(wl) * (1.0f / cieYIntegral());
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/test_pkg89_gpu_dedicated_lights.py
+++ b/tests/test_pkg89_gpu_dedicated_lights.py
@@ -9,10 +9,11 @@ entirely (pkg86-B deferred the dedicated-light GPU port). This test is the
 acceptance gate: for a gray floor lit by a dedicated light, the GPU image must go
 from BLACK to PARITY with the CPU image (mean-ratio ~1, high correlation).
 
-The emission is exact for RGB-mode lights (the device RGBIlluminant upsample
-reproduces the CPU RGBIlluminantSpectrum sample-for-sample). We gate on RGB-mode
-lights for that reason; blackbody-mode spectral parity is a documented follow-up
-(and is entangled with the separate pkg89 CPU energy-scale audit, GAP 2).
+The emission is exact for RGB-mode lights (the device RGBUnbounded upsample --
+pkg142 Defect 4, no-D65 lift -- reproduces the CPU RGBUnboundedSpectrum
+sample-for-sample). We gate on RGB-mode lights for that reason; blackbody-mode
+spectral parity is a documented follow-up (and is entangled with the separate
+pkg89 CPU energy-scale audit, GAP 2).
 
 GPU-gated: skips when CUDA is absent (CI has no GPU); /verify runs on RTX.
 """

--- a/tests/test_spectral_envmap.py
+++ b/tests/test_spectral_envmap.py
@@ -58,7 +58,8 @@ def _sphere_directions(n: int):
 
 @pytest.mark.skipif(not HAS_ENV, reason="test_env.hdr not found")
 def test_eval_spectral_atlas_matches_upsample_fallback():
-    """evalSpectral via atlas matches RGBIlluminantSpectrum fallback to 1e-3."""
+    """evalSpectral via atlas matches RGBUnboundedSpectrum fallback to 1e-3
+    (pkg142 Defect 4 -- both paths use the no-D65 lift)."""
     r = astroray.Renderer()
     assert r.load_environment_map(ENV_HDR), "failed to load env map"
 


### PR DESCRIPTION
## Summary

Defect 4 adjudication from pkg122's live-Cycles oracle: after pkg122 (PR #500)
fixed the per-type dedicated-light radiometry (Defects 1-3), the oracle still
measured all four dedicated-light types **1.07-1.16x brighter than Cycles**
at equal wattage on a gray Lambertian floor. The residual was traced to the
RGB **emission** spectral lift (`EmissionSpectrum::evalRGB`), not radiometry.

Switches the RGB emission lift from **RGBIlluminantSpectrum** (D65-weighted,
matching pbrt-v4 `SpectrumType::Illuminant` / Mitsuba `srgb_d65`) to
**RGBUnboundedSpectrum** (identity round-trip, no illuminant), matching
Cycles' RGB-native light scaling (`src/scene/light.cpp`: `strength` stored as
linear-RGB `float3`, no spectral upsampling, no D65). Owner directive:
"What ever is best and used by other renderers, your call."

## Why this closes the +7-16% offset

The D65 tilt on `RGBIlluminantSpectrum` emission clashes with the plain
Jakob-Hanika `RGBAlbedoSpectrum` family used for surface albedo. Two
same-family JH spectra multiply and integrate back to the RGB product with
minimal crosstalk (reproducing Cycles' `albedo . light` multiply); a
D65-tilted emission spectrum does not, injecting a systematic metameric
offset uniform across all four light types (property of the shared
`evalRGB`/albedo pipeline, not per-type geometry). `RGBUnboundedSpectrum =
scale*sigmoid(rgb/scale)` is that same reflectance-sigmoid family with no
illuminant.

## Citations (CLAUDE.md SS6)

- **Lift adopted**: pbrt-v4 `RGBUnboundedSpectrum::Sample`
  (`src/pbrt/util/spectrum.h`) -- Apache-2.0. Already in-tree
  (`astroray::RGBUnboundedSpectrum`, `src/spectrum.cpp:451-473`); this PR
  re-points emission call sites at it, no new algorithm.
- **Parity target**: Cycles `src/scene/light.cpp`
  (`copy_v3_v3(klight->strength, strength)`), `src/kernel/light/area.h`
  (`eval_fac = M_1_PI_F*invarea`) -- Apache-2.0, RGB-native, no upsample.
- Full derivation + license verification:
  `.astroray_plan/docs/defect4-rgb-emission-research.md`.

## Scope note (bigger than the spec's named 5 call sites)

The spec's grep found 5 sites (CPU `EmissionSpectrum::evalRGB`, GPU device
branch + 4 emission call sites). The actual blast radius is much larger:
~25 ad-hoc `RGBIlluminantSpectrum`-for-emission constructions duplicated
across CPU integrator plugins (`restir_di`, `spectral_path_tracer`,
`multiwavelength_path_tracer`, `neural_cache`, `sms_caustic_path_tracer`),
ReSTIR/manifold headers, the CPU megakernel (`raytracer.h`: env-miss x2,
photon-loop light connection, HDRI spectral atlas), and mesh-emitter
material plugins (`diffuse_light.cpp`, `emissive.cpp`) plus their
`light_sampler.cpp` NEE duplicates. Leaving any of these on the old D65
convention would produce an internally inconsistent renderer (some emission
paths D65, others not) -- strictly worse than either extreme -- so all were
flipped for consistency (same reasoning the spec itself uses for the
env-scope decision).

**Deliberately excluded**: `Hittable::traceGRSpectral`'s default GR/
black-hole emission (`raytracer.h`, ~line 793) -- a distinct pillar (GR/
accretion-disk rendering) with its own calibration and zero oracle coverage;
documented in-code with a NOTE explaining the exclusion.

**Env/world** (spec item 4, "default: flip env too"): flipped GPU
`gpu_env_spectral.cuh` (shared wavefront+megakernel env-miss helper),
`path_trace_kernel.cu`'s separate inline env branch, and CPU
`background_light.cpp` + `raytracer.h`'s HDRI spectral atlas +
megakernel/photon-loop background fallbacks -- keeps GPU==CPU and
wavefront==megakernel consistent.

Also flipped `module/blender_module.cpp`'s `evalEnvRGBUpsample` (Python-bound
reference-fallback helper) -- `test_eval_spectral_atlas_matches_upsample_fallback`
asserts it agrees with the (now-UNBOUNDED) spectral atlas to 1e-3, so it must
track whichever convention the atlas uses.

## GPU device mirror

Added `GSPEC_RGB_UNBOUNDED` to the `GSpectralMode` enum (`gpu_types.h`) and
its `gpu_rgbSpectrumAt` branch (`gpu_materials.h`) -- identical to
`GSPEC_RGB_ILLUMINANT` minus the `gpu_sampleD65(lambda)` multiply.
`GSPEC_RGB_ILLUMINANT` / `RGBIlluminantSpectrum` are left in place (now
unused by any emission call site) rather than removed, since they remain
valid utility spectra (GR emission, an existing Python binding, and the
pre-pkg142 reference upsample semantics).

## Expected numeric effect

Dedicated lights (POINT/AREA/SPOT/SUN), equal wattage, gray floor:
**1.07-1.16x -> target [0.97, 1.03]** vs live Cycles (per-channel mean-ratio,
not SSIM -- memory `ssim-wrong-gate-for-independent-rng`).

## Acceptance criteria checklist

- [x] `evalRGB` + GPU emission mirror on `RGBUnbounded`; stale pro-Illuminant
      comment replaced with the divergence note + pkg142 cite.
- [x] `scripts/verify_pkg122_cycles_oracle.py` copied into the repo and
      committed.
- [ ] Live-Cycles oracle: all four types per-channel in [0.97, 1.03],
      before/after recorded -- UNVERIFIED, needs RTX + Blender 5.1 run.
- [ ] GPU==CPU dedicated-light parity re-verified on RTX -- UNVERIFIED, needs build.
- [ ] `test_pkg122_light_energy_calibration.py` green; build evidence shown
      -- UNVERIFIED, needs build (test is designed convention-invariant
      by its own docstring, expected green).
- [ ] Reference bank re-blessed evidence-first -- out of scope for this
      implementer per spec (team-lead/hardware-verifier).
- [x] Branch landed: primary RGBUnbounded, env flipped (default choice),
      no fallback taken.

## Unverified list (cannot build/run tests in this environment)

1. Primary gate -- live-Cycles oracle, run per light type:
   `blender --background --factory-startup --python scripts/verify_pkg122_cycles_oracle.py -- --light-type POINT --out test_results/pkg142`
   (repeat for AREA, SPOT, SUN). PASS = `ratio_astroray_over_cycles` in
   [0.97, 1.03] per channel, all four types.
2. Secondary gate -- GPU==CPU parity:
   `pytest tests/test_pkg89_gpu_dedicated_lights.py -v` on RTX (do not run
   concurrently with another CUDA-heavy verifier -- memory
   `cuda_verifier_concurrency`).
3. Tertiary gate:
   `pytest tests/test_pkg122_light_energy_calibration.py -v`.
4. Flagged as at-risk:
   `pytest tests/test_pkg89_g8_spectral_fidelity.py::test_g8_candidate_spectral_rgb_match -v`
   -- compares `ReSTIRCandidate::targetLuminance` (now RGBUnbounded) against
   `targetLuminanceRGB` (flat Rec.709 dot product) within 1%. Analytically
   this isolated (non-product) round-trip should hold for RGBUnbounded the
   same way it held for RGBIlluminant (Jakob-Hanika fit round-trip design),
   but this is reasoned, not measured -- please confirm on hardware.
5. Full suite: `pytest tests/ --ignore=tests/wavefront_diff -x`.
6. Reference-bank re-bless (evidence-first, scoped to team-lead per spec).

**Fallback not taken**: the primary-gate overshoot fallback (revert to
RGBIlluminant + pbrt's photometric self-normalization,
`scale /= SpectrumToPhotometric(emit)`) was NOT applied -- that decision
requires the live-Cycles oracle measurement this implementer cannot produce.

## Build

Not run -- this implementer has no MSVC vcvars in this environment (per
dispatch). Team-lead must run `configure_and_build.bat --config Release`
(not `build_cuda_worktree.bat`, which has the Debug-config footgun per
memory `build-cuda-worktree-debug-config`), verify `.pyd` mtime vs
`git log -1 HEAD` and `astroray.__file__`, then run the gates above.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
