### PR TITLE
docs(pkg142): FINAL adjudication — keep RGBIlluminant (D65); revert #511; open pkg146

### DIFF
--- a/.astroray_plan/docs/defect4-rgb-emission-research.md
+++ b/.astroray_plan/docs/defect4-rgb-emission-research.md
@@ -3,12 +3,52 @@
 **Author:** architect (arch/pkg142-defect4)
 **Date:** 2026-07-21
 **Owner directive (verbatim):** "What ever is best and used by other renderers, your call."
-**Decision:** switch the RGB **emission** lift (`EmissionSpectrum::evalRGB` + the GPU
-mirror) from an **RGBIlluminant** (D65-weighted) lift to an **RGBUnbounded**
-(no-illuminant) lift **+ an explicit `1/CIE_Y_integral` photometric anchor** (see
-Correction), to reproduce Cycles' RGB-native light scaling and close the residual
-+7–16% equal-wattage brightness offset. Full implementation contract in
-`.astroray_plan/packages/pkg142-rgb-emission-convention.md`.
+**FINAL DECISION (2026-07-21, supersedes all below): KEEP `RGBIlluminant` (D65).**
+The D65-weighted illuminant lift is **required and correct** for Astroray's
+D65-referred spectral pipeline; the "switch to RGBUnbounded" premise was a
+misattribution. Revert PR #511; net code change NONE. The residual offset is
+re-attributed to a new investigation (pkg146). Details in the pkg142 spec's
+✅ FINAL ADJUDICATION; the arc is summarized in the Final Adjudication section
+immediately below.
+
+*(Historical decision, now superseded: "switch RGBIlluminant → RGBUnbounded +
+`1/CIE_Y_integral` anchor.")*
+
+---
+
+## Final Adjudication (2026-07-21, post-regate `790eb9e`) — the D65 factor's THREE roles
+
+The regate (RGBUnbounded + explicit anchor) **fixed the units** (suite 68→6) but
+exposed a **new ~30% R-channel excess / pink renders** vs neutral Cycles (R 1.29–1.37,
+G 1.028–1.097, B 0.996–1.071). Root cause: the `· sampleD65(λ)` factor carried **three**
+roles, not two:
+
+1. **Units anchor** `1/CIE_Y_integral` (the ~116×, fixed by the explicit anchor).
+2. **White-point adaptation E→D65** (the ~30% R-excess). The unweighted JH sigmoid for
+   white is near-flat = **illuminant E** (≈(0.333,0.333)); the spectral→RGB path is
+   **D65-referred** (standard sRGB matrix + `data/spectra/rgb_to_spectrum_srgb.coeff`).
+   E-white through a D65 matrix is pink: `XYZ(1,1,1) → sRGB (1.205, 0.948, 0.909)`,
+   **R/G ≈ 1.27** — matching the measurement. The D65 lift makes white emit **D65-white**
+   → neutral, like Cycles.
+3. A small residual tilt, subsumed by (2).
+
+`RGBUnbounded` is a **reflectance/HDR-value** upsampler (dimensionless, E-white). A
+**spectral** renderer's **emission** needs an **illuminant-referred** lift for roles 1+2.
+**pbrt-v4 (`SpectrumType::Illuminant`) and Mitsuba 3 (`srgb_d65`) both do exactly this,
+for white preservation** — it is the standard construction, not a pbrt-vs-Cycles dispute
+(Cycles sidesteps it only by being RGB-native). Option (b) (explicit E→D65 adaptation on
+a flat sigmoid) = multiply by `D65/E ≈ D65` = `RGBIlluminant` again. So **keep
+`RGBIlluminant`**.
+
+The original "+7–16% offset" premise was a misattribution: `RGBIlluminant` renders
+neutral + anchored, and the **pkg139 oracle rows are 0.96–1.01 without pkg142** → the
+offset is scene/type-dependent, not the lift. Re-attributed to **pkg146** (lead: the
+pkg139-vs-pkg122 oracle discrepancy).
+
+**Postmortem:** one symbol did three jobs; each fix peeled one layer and exposed the next
+(units → white point). Lesson: emission needs an illuminant-referred lift; a reflectance
+upsampler is the wrong category for a light; and validate a convention change against a
+**neutral-white render**, not a scalar brightness ratio.
 
 ---
 

--- a/.astroray_plan/docs/defect4-rgb-emission-research.md
+++ b/.astroray_plan/docs/defect4-rgb-emission-research.md
@@ -5,9 +5,50 @@
 **Owner directive (verbatim):** "What ever is best and used by other renderers, your call."
 **Decision:** switch the RGB **emission** lift (`EmissionSpectrum::evalRGB` + the GPU
 mirror) from an **RGBIlluminant** (D65-weighted) lift to an **RGBUnbounded**
-(identity-round-trip, no-illuminant) lift, to reproduce Cycles' RGB-native light
-scaling and close the residual +7–16% equal-wattage brightness offset. Full
-implementation contract in `.astroray_plan/packages/pkg142-rgb-emission-convention.md`.
+(no-illuminant) lift **+ an explicit `1/CIE_Y_integral` photometric anchor** (see
+Correction), to reproduce Cycles' RGB-native light scaling and close the residual
++7–16% equal-wattage brightness offset. Full implementation contract in
+`.astroray_plan/packages/pkg142-rgb-emission-convention.md`.
+
+---
+
+## Correction (2026-07-21, post-hardware-failure) — units vs shape
+
+The first version of this note (and pkg142) said "switch to `RGBUnbounded`" full
+stop. That carried a **category error**: it treated the `· sampleD65(λ)` factor as
+**only** a chromaticity tilt, when it was doing **two** jobs.
+
+**Two-role decomposition of `· sampleD65(λ)` in `RGBIlluminantSpectrum::sample`:**
+
+1. **Shape (chromaticity):** the D65 spectral *tilt* — the ~10% daylight-white
+   imprint that diverges from Cycles' RGB-native scaling. **Removing this is
+   correct** (the Cycles-parity argument in §3–§4 stands).
+2. **Magnitude (units):** a scalar **photometric anchor ≈ `1/CIE_Y_integral =
+   1/116.66`** (1964 10° observer). Astroray's `sampleD65` is normalized so
+   `∫ sampleD65·ȳ dλ = 1` (`src/spectrum.cpp:49-77`), so the multiply also *scales*
+   the emission onto the toXYZ/luminance units. `RGBUnbounded` is pbrt's
+   **reflectance** upsampler — **dimensionless, no photometric anchor** — so
+   swapping the class dropped **both** roles.
+
+**Consequence (measured):** PR #511 HW-verified at **~116× uniform brightness**
+(not the ~10% tilt predicted). `116 ≈ CIE_Y_integral` — the missing anchor is the
+smoking gun. A flat unit reflectance integrates in luminance to `∫ȳ dλ ≈ 116.66`
+instead of `1`.
+
+**Corrected fix:** `RGBUnbounded` **chromaticity + `× 1/cieYIntegral()`** on CPU and
+GPU — exactly pbrt-v4's `SpectrumToPhotometric` reduced to a constant for a white
+emission. Direction (drop the tilt) unchanged; class choice corrected (add the
+anchor). Revised expected effect: **tilt-only**; the live-Cycles oracle
+`[0.97,1.03]` is still the gate.
+
+**Lesson:** when a change removes/replaces a spectral factor, decompose it into
+**shape × magnitude** and account for both — a units constant can hide inside a
+factor named for its shape (`Illuminant`/`Unbounded`/`Albedo`). A uniform,
+large, integer-ish blow-up is a units/normalization bug (here literally
+`CIE_Y_integral`), never a chromaticity tilt. And a fallback clause must model the
+*mechanism* and *magnitude* it guards against: this note's §5 fallback named the
+right remedy (`SpectrumToPhotometric`) but anticipated a −3% undershoot when the
+real trigger was +11,600%.
 
 ---
 
@@ -41,7 +82,9 @@ The **only** structural difference between `RGBIlluminantSpectrum` and
 floor **albedo** already uses (`RGBAlbedoSpectrum`), just with the magnitude
 factored back in. So the fork is precisely: **does emission carry a D65 illuminant
 chromaticity, or is it a plain reflectance-style lift symmetric with the albedo
-path?**
+path?** *(Correction: the `sampleD65` factor is not **only** chromaticity — it also
+carries the `1/CIE_Y_integral` photometric anchor; the fork below decides the
+chromaticity, and the anchor must be re-added explicitly. See Correction above.)*
 
 ---
 
@@ -147,12 +190,17 @@ Apache-2.0) and already exists in Astroray (`RGBUnboundedSpectrum`,
 The +7–16% → [0.97,1.03] closure is **argued analytically, not yet measured** (the
 architect cannot build the `.pyd`). The metameric offset's *sign* and exact
 magnitude depend on the shipped Jakob-Hanika sRGB LUT and the D65 table, so the
-**gate is the live-Cycles oracle re-run**, not the reasoning. If RGBUnbounded
-**overshoots to < 0.97** (too dim), the documented fallback is to keep
-RGBIlluminant but add pbrt's photometric self-normalization
-(`scale /= SpectrumToPhotometric(emit)`) — a smaller, chromaticity-only
-correction. Primary recommendation remains RGBUnbounded; the fallback is scoped in
-the spec so the implementer can pivot without re-adjudicating.
+**gate is the live-Cycles oracle re-run**, not the reasoning.
+
+**[CORRECTED]** This section under-scoped the risk: it named the right remedy
+(pbrt's `SpectrumToPhotometric`) but as a *fallback* for a hypothetical **−3%
+undershoot**. The actual PR #511 trigger was a **+11,600% units blow-up** because
+`RGBUnbounded` (a dimensionless reflectance upsampler) dropped the
+`1/CIE_Y_integral` photometric anchor the D65 factor carried — see Correction.
+So `SpectrumToPhotometric` (as the constant `1/cieYIntegral()`) is **mandatory and
+primary**, not a fallback. With it in place, the *residual* risk this section
+describes (a small chromaticity/crosstalk offset resolved by the live oracle)
+applies as written.
 
 ---
 

--- a/.astroray_plan/packages/pkg142-rgb-emission-convention.md
+++ b/.astroray_plan/packages/pkg142-rgb-emission-convention.md
@@ -1,4 +1,4 @@
-# pkg142 — RGB emission convention: RGBIlluminant → RGBUnbounded (Defect 4 adjudication)
+# pkg142 — RGB emission convention: RGBIlluminant → RGBUnbounded **+ photometric anchor** (Defect 4 adjudication)
 
 **Pillar:** 3 (light transport / emitter energy correctness)
 **Track:** A (single cross-cutting convention change with a live headless-Cycles oracle gate + reference-bank re-bless; needs a build + RTX + Blender-5.1, not a mechanical patch)
@@ -10,6 +10,60 @@
 **Adjudication authority:** owner delegated to the team on 2026-07-21, verbatim:
 *"What ever is best and used by other renderers, your call."* Research + adjudication:
 `.astroray_plan/docs/defect4-rgb-emission-research.md`.
+
+---
+
+## ⚠ CORRECTION (2026-07-21, post-hardware-failure) — a category error in the original adjudication
+
+**Trigger.** The implementation (PR #511) HW-verified with a **~116× uniform
+brightness blow-up** (not the ~10% tilt this spec predicted). The Opus
+gate-failure review confirmed a **category error** in the original adjudication
+below (and in the dispatch): it modeled a **units** factor as a **chromaticity
+tilt**.
+
+**Two-role decomposition of the `· sampleD65(λ)` factor** (the whole crux). In
+`RGBIlluminantSpectrum::sample` the D65 multiply carried **two separable roles**:
+
+1. **Chromaticity / shape** — the D65 spectral *tilt* (its relative distribution),
+   the ~10% daylight-chromaticity imprint. **Removing this is still correct** per
+   the Cycles-parity argument below (Cycles is RGB-native, no tilt).
+2. **Photometric / units** — a scalar **units anchor ≈ `1/CIE_Y_integral`
+   (`1/116.66` on the 1964 10° table)**. Astroray's `sampleD65` is pre-normalized
+   so `∫ sampleD65·ȳ dλ = 1` (`src/spectrum.cpp:49-77`, `d65NormFactor =
+   1/∫D65·ȳ`), i.e. it *carries* that `~1/116.66` magnitude scale. It converts the
+   dimensionless RGB into radiance on the toXYZ/luminance scale.
+
+`RGBUnboundedSpectrum` is pbrt's **reflectance** unbounded upsampler —
+**dimensionless, with no photometric anchor**. Swapping `RGBIlluminant →
+RGBUnbounded` dropped **both** roles. A flat unit "reflectance" then integrates in
+luminance to `∫ȳ dλ = CIE_Y_integral ≈ 116.66` instead of `1` → the **~116×**
+blow-up. That factor *is* the smoking gun: `116 ≈ CIE_Y_integral`.
+
+**Corrected decision.** Keep the intended change (drop the D65 **tilt**, use the
+`RGBUnbounded` **chromaticity**) **and add back the photometric anchor
+explicitly**: multiply the emission lift by **`1/cieYIntegral()`** on **both CPU
+and GPU** (a constant ≈ `1/116.66`). This is exactly pbrt-v4's
+`SpectrumToPhotometric` normalization reduced to a constant for the white-emission
+case — i.e. the remedy this spec's own *Fallback* clause named, but the fallback
+mis-anticipated the **trigger** (it expected a ~−3% tilt undershoot; the real
+trigger was a **+11,600% units** blow-up).
+
+**Revised expected effect.** With the anchor in place, only the **chromaticity
+tilt** changes (RGBUnbounded flat vs RGBIlluminant D65-tilted) → the intended
+**tilt-only** effect. The `+7–16% → [0.97,1.03]` closure argument **stands** (it
+was always a chromaticity/crosstalk effect, never a units effect). The live-Cycles
+oracle `[0.97,1.03]` per-channel is **still the gate**.
+
+**Lesson (postmortem pattern).** The adjudication reasoned about the factor's
+**shape** (chromaticity) while **ignoring its units** — a normalization constant
+(`1/CIE_Y_integral`) was hiding inside a factor labeled "chromaticity/illuminant."
+When a proposed change *removes or replaces a spectral factor*, decompose it into
+**shape × magnitude** and account for **both**; a class named for its *shape*
+(`Illuminant`/`Unbounded`/`Albedo`) may also encode a *units* convention. See the
+research note's Lessons section.
+
+Everything below is preserved for the journal trail; the sections marked
+**[CORRECTED — see above]** are superseded on the specific point noted.
 
 ---
 
@@ -34,6 +88,12 @@ The tight Cycles band **[0.97, 1.03] is unreachable until this is resolved.**
 
 ## Decision (adjudicated)
 
+> **[CORRECTED — see ⚠ CORRECTION above]** The correct decision is `RGBUnbounded`
+> **chromaticity + an explicit `1/cieYIntegral()` photometric anchor** on CPU+GPU.
+> `RGBUnbounded` alone (below) is dimensionless and drops the units anchor → ~116×
+> blow-up. Read the decision below as "drop the D65 **tilt**," with the anchor
+> re-added per the correction.
+
 **Switch the RGB emission lift from `RGBIlluminantSpectrum` (D65-weighted) to
 `RGBUnboundedSpectrum` (identity round-trip, no illuminant), on both the CPU
 `evalRGB` path and its GPU device mirror.**
@@ -54,7 +114,12 @@ The tight Cycles band **[0.97, 1.03] is unreachable until this is resolved.**
   is the **same Jakob-Hanika reflectance-sigmoid family** the floor albedo already
   uses; two same-family spectra multiplied and integrated round-trip to the RGB
   product with minimal crosstalk, reproducing Cycles' `albedo ⊙ light` multiply.
-  The D65 tilt on `RGBIlluminant` is exactly the source of the +7–16% offset.
+  The D65 **tilt** on `RGBIlluminant` is exactly the source of the +7–16% offset.
+  **[CORRECTED]** This round-trip argument is about *chromaticity* only; the same
+  reflectance family is also **dimensionless**, so it drops the `1/CIE_Y_integral`
+  photometric anchor the D65 factor silently carried — which must be re-added
+  explicitly (see ⚠ CORRECTION). The offset closed here is the tilt; the units are
+  restored by the anchor, not by the class.
 - **Not invented (CLAUDE.md §6).** `RGBUnbounded` is a real pbrt-v4 class
   (`src/pbrt/util/spectrum.h`, Apache-2.0) and **already exists in Astroray**
   (`RGBUnboundedSpectrum`, `src/spectrum.cpp:451-473`). This package re-points the
@@ -77,9 +142,10 @@ pkg142 / defect4-rgb-emission-research.md."*
 
 | Concern | File / function | License |
 |---|---|---|
-| Lift we adopt | pbrt-v4 `RGBUnboundedSpectrum::Sample` (`src/pbrt/util/spectrum.h`) — `scale·rsp(λ)`, no illuminant | Apache-2.0 (verified) |
+| Chromaticity lift | pbrt-v4 `RGBUnboundedSpectrum::Sample` (`src/pbrt/util/spectrum.h`) — `scale·rsp(λ)`, no illuminant. **Note: this is a *reflectance* (dimensionless) upsampler — no photometric anchor.** | Apache-2.0 (verified) |
+| Photometric anchor | pbrt-v4 `SpectrumToPhotometric` (`src/pbrt/lights.cpp`) — for a white emission this reduces to the constant `1/CIE_Y_integral`; apply as `× 1/cieYIntegral()` (≈`1/116.66`, 1964 10°). | Apache-2.0 (verified) |
 | Parity target | Cycles `src/scene/light.cpp` (`copy_v3_v3(klight->strength, strength)`), `src/kernel/light/area.h` (`eval_fac = M_1_PI_F·invarea`) — RGB-native, no upsample | Apache-2.0 (verified) |
-| In-tree class reused | `astroray::RGBUnboundedSpectrum` (`src/spectrum.cpp:451-473`, `include/astroray/spectrum.h:230`) | project |
+| In-tree class reused | `astroray::RGBUnboundedSpectrum` (`src/spectrum.cpp:451-473`, `include/astroray/spectrum.h:230`); D65 normalization / `∫D65·ȳ` in `src/spectrum.cpp:49-77` shows the `1/116.66` anchor the tilt carried | project |
 
 License compatibility: both references Apache-2.0, both already relied upon
 elsewhere in the tree. No new dependency.
@@ -90,9 +156,13 @@ elsewhere in the tree. No new dependency.
 
 ### CPU
 1. `src/emission_spectrum.cpp` `EmissionSpectrum::evalRGB` (lines 187-191): replace
-   `RGBIlluminantSpectrum rgbSpectrum(...)` with `RGBUnboundedSpectrum rgbSpectrum(...)`.
-   Update the stale block comment (lines 179-186, which argues *for* Illuminant) to
-   the divergence note above.
+   `RGBIlluminantSpectrum rgbSpectrum(...)` with `RGBUnboundedSpectrum rgbSpectrum(...)`
+   **and multiply the sampled result by the photometric anchor `1/cieYIntegral()`**
+   (a constant ≈ `1/116.66`; add a `cieYIntegral()` helper = `∫ȳ dλ` over the 1964
+   10° table if one does not exist, alongside `computeD65Normalization` in
+   `src/spectrum.cpp`). **Without the anchor the emission is ~116× too bright**
+   (⚠ CORRECTION). Update the stale block comment (lines 179-186, which argues *for*
+   Illuminant) to the divergence note + the two-role decomposition.
 2. **Do not** change `RGBAlbedoSpectrum` (surface reflectance) or the blackbody /
    MeasuredSPD / Composite paths — this is emission-RGB only.
 
@@ -101,9 +171,13 @@ The device lift is `gpu_rgbSpectrumAt` (`include/astroray/gpu_materials.h:90-109
 selected by a `GSpectralMode`. Today it has `GSPEC_RGB_ILLUMINANT` (scale·JH·D65)
 and `GSPEC_RGB_ALBEDO` (JH clamped) but **no UNBOUNDED case**.
 3. Add a `GSPEC_RGB_UNBOUNDED` branch to `gpu_rgbSpectrumAt`:
-   `scale·gpu_jhEvalSpectrum(normalized, λ)` — identical to the ILLUMINANT branch
-   **minus** the `* gpu_sampleD65(λ)` factor. (Add the enum value wherever
-   `GSpectralMode` is defined.)
+   `scale·gpu_jhEvalSpectrum(normalized, λ) · (1/CIE_Y_integral)` — identical to the
+   ILLUMINANT branch **minus** the `* gpu_sampleD65(λ)` tilt **but keeping the
+   `1/116.66` photometric anchor** (a device constant mirroring the CPU
+   `1/cieYIntegral()`; `gpu_sampleD65` folded that anchor in, so dropping it
+   entirely is the ~116× device blow-up). (Add the enum value wherever
+   `GSpectralMode` is defined.) The CPU and GPU anchor constant **must be bit-equal**
+   for GPU==CPU parity.
 4. Re-point the **emission** call sites from `GSPEC_RGB_ILLUMINANT` to
    `GSPEC_RGB_UNBOUNDED`. Emission sites (grep-confirmed):
    - `src/gpu/gpu_nee.cuh:352-353` (dedicated-light NEE)
@@ -158,11 +232,15 @@ Do not run concurrently with another CUDA-heavy verifier (memory
 **Tertiary gate — no radiometry regression.** `tests/test_pkg122_light_energy_calibration.py`
 must stay green (this change is chromaticity/level, not per-type geometry).
 
-**Fallback (if the primary gate overshoots to < 0.97, i.e. RGBUnbounded is too dim).**
-Do **not** silently retune. Revert `evalRGB` to `RGBIlluminant` and instead add
-pbrt's photometric self-normalization `scale /= SpectrumToPhotometric(emit)`
-(`src/pbrt/lights.cpp`) — a smaller chromaticity-only correction — and re-run the
-oracle. Report which branch landed. (Rationale in research note §5.)
+**[CORRECTED] Photometric anchor is now the PRIMARY remedy, not a fallback.** The
+original fallback below named the right repair (pbrt's `SpectrumToPhotometric`) but
+tied it to the wrong trigger (a small tilt undershoot). In fact the anchor is
+**mandatory** — `RGBUnbounded` without it is ~116× too bright. Ship `RGBUnbounded`
+chromaticity **+ `1/cieYIntegral()`** together (contract steps 1/3). *Residual*
+fallback: if, **with the anchor in place**, the oracle still lands outside
+`[0.97,1.03]`, that residual is a genuine chromaticity/crosstalk effect — do not
+silently retune; report the per-channel numbers and re-evaluate the tilt argument
+against the live oracle. (Rationale in research note §5 + Lessons.)
 
 ---
 
@@ -189,17 +267,44 @@ routine (memory `blender-5-1-installed-locally`).
 
 ## Expected numeric effect
 
+**[CORRECTED — tilt-only.]** With the `1/cieYIntegral()` anchor in place the change
+is **chromaticity-only**; there is **no** units change (the ~116× seen on PR #511
+was the missing anchor, now restored — it is *not* an expected effect).
+
 - Dedicated lights (POINT/AREA/SPOT/SUN), equal wattage, gray floor:
-  **1.07–1.16× → within [0.97, 1.03]** vs live Cycles (per-channel).
+  **1.07–1.16× → within [0.97, 1.03]** vs live Cycles (per-channel), from the
+  removed D65 **tilt** alone.
 - Pure-Lambertian analytic decoupled check: stays ~0.99× (unaffected — reflectance
   path unchanged).
 - Reference bank: 12/13 → re-blessed to reflect the closed offset (target: all
   RGB-emitter parity scenes within band).
+- **Sanity check before the oracle:** a white (1,1,1) emission must still integrate
+  to luminance ≈ 1 (same as `RGBIlluminant` white today). If it reads ~116, the
+  anchor is missing.
+
+---
+
+## Lessons
+
+- **Decompose a spectral factor into shape × magnitude before removing it.** The
+  `· sampleD65(λ)` factor was one symbol doing two jobs — a chromaticity **tilt**
+  and a `1/CIE_Y_integral` **units anchor**. The adjudication reasoned about the
+  shape and silently discarded the units. Class names describe *shape*
+  (`Albedo`/`Unbounded`/`Illuminant`); they can also encode a *units* convention
+  (reflectance = dimensionless; illuminant = photometrically anchored).
+- **A uniform, large, integer-ish blow-up (~116×) is a units/normalization bug, not
+  a tilt or RNG effect** — and `116.66 = CIE_Y_integral` (1964 10°) named it exactly.
+  Cross-reference `mc-noise-vs-deterministic` (stable ratios ⇒ units/matrix bug).
+- **A fallback clause is only as good as its trigger model.** This spec's fallback
+  named the correct remedy (photometric self-normalization) but anticipated a −3%
+  undershoot; the real trigger was +11,600%. When you write a fallback, state the
+  *mechanism* it guards against, and sanity-check the magnitude the mechanism can
+  produce.
 
 ---
 
 ## Definition of done
-- [ ] `evalRGB` + GPU emission mirror on `RGBUnbounded`; stale pro-Illuminant comment replaced with the divergence note + pkg142 cite.
+- [ ] `evalRGB` + GPU emission mirror on `RGBUnbounded` **chromaticity + `1/cieYIntegral()` photometric anchor** (CPU + GPU constant bit-equal); white (1,1,1) emission integrates to luminance ≈ 1, not ~116. Stale pro-Illuminant comment replaced with the divergence note + two-role decomposition + pkg142 cite.
 - [ ] `scripts/verify_pkg122_cycles_oracle.py` copied into the repo and committed.
 - [ ] Live-Cycles oracle: all four types per-channel ∈ [0.97, 1.03], before/after recorded.
 - [ ] GPU==CPU dedicated-light parity re-verified on RTX.

--- a/.astroray_plan/packages/pkg142-rgb-emission-convention.md
+++ b/.astroray_plan/packages/pkg142-rgb-emission-convention.md
@@ -1,15 +1,104 @@
-# pkg142 — RGB emission convention: RGBIlluminant → RGBUnbounded **+ photometric anchor** (Defect 4 adjudication)
+# pkg142 — RGB emission convention (Defect 4 adjudication) — **RESOLVED: keep RGBIlluminant (D65)**
 
 **Pillar:** 3 (light transport / emitter energy correctness)
 **Track:** A (single cross-cutting convention change with a live headless-Cycles oracle gate + reference-bank re-bless; needs a build + RTX + Blender-5.1, not a mechanical patch)
 **Codex-paste-ready:** no (one adjudicated convention flip that cross-cuts CPU/GPU/env/materials and moves the Cycles-parity reference bank; empirical sign/magnitude must be confirmed against a live Cycles A/B, and a fallback branch may be taken — judgment at the gate, not a blind edit)
-**Status:** open — dispatchable
+**Status:** **ADJUDICATED — keep `RGBIlluminant` (D65). Net code change: NONE; revert PR #511.** The residual equal-wattage offset is re-attributed to a new investigation (**pkg146**). See ✅ FINAL ADJUDICATION.
 **Estimated effort:** M (the code change is small and localized; the cost is the build + live-Cycles oracle re-run + RTX GPU==CPU parity + evidence-first reference-bank re-bless)
 **Depends on:** pkg122 (PR #500, **merged**) — Defects 1–3 must be in `main` so the residual measured by the oracle is the *clean* emission-lift offset, not confounded by the per-type radiometry bugs. Satisfied.
 
 **Adjudication authority:** owner delegated to the team on 2026-07-21, verbatim:
 *"What ever is best and used by other renderers, your call."* Research + adjudication:
 `.astroray_plan/docs/defect4-rgb-emission-research.md`.
+
+---
+
+## ✅ FINAL ADJUDICATION (2026-07-21, post-regate at `790eb9e`) — keep RGBIlluminant (D65)
+
+**This supersedes both the original decision and the ⚠ CORRECTION below.** The
+D65-weighted illuminant lift was **right all along**; the whole "switch to
+RGBUnbounded" premise was a misattribution. Verdict: **option (a) — revert PR #511,
+keep `RGBIlluminant` on CPU + `GSPEC_RGB_ILLUMINANT` on GPU, net code change NONE.**
+
+### What the regate showed (evidence)
+
+`790eb9e` (RGBUnbounded + explicit `1/cieYIntegral()` anchor) **fixed the units**
+(suite 68→6 failures, G8 0.19%, calibration gates green, render structure restored)
+— but exposed a **new residual: R-channel 1.29–1.37× excess across all four light
+types, visually pink renders vs neutral Cycles** (G 1.028–1.097, B 0.996–1.071;
+`Astroray-pkg142/test_results/pkg142_oracle_v2/`).
+
+### Root cause — the D65 factor had THREE roles, not two (verified)
+
+The `· sampleD65(λ)` factor in `RGBIlluminantSpectrum` did **three** jobs:
+
+1. **Units anchor** (`1/CIE_Y_integral`) — the ~116× (⚠ CORRECTION).
+2. **White-point adaptation (E→D65)** — the ~30% R-excess **just exposed**. The
+   unweighted JH sigmoid for gray/white is near-flat = **illuminant E** (chromaticity
+   ≈ (0.333, 0.333)). Astroray's spectral→XYZ→RGB uses the **D65-referred** sRGB
+   matrix (verified: `data/spectra/rgb_to_spectrum_srgb.coeff`, standard D65 LUT;
+   matrix in `deviceReference`). An E-white spectrum through that matrix renders
+   **pink**. Quantitatively: `XYZ(1,1,1) → sRGB = (1.205, 0.948, 0.909)`, i.e.
+   **R/G ≈ 1.27, B/G ≈ 0.96** — a near-exact match to the measured R 1.29–1.37,
+   B 0.996–1.071. **The pink is the E→D65 white-point error.** The D65 lift makes a
+   white RGB emit a **D65-white** spectrum → sRGB (1,1,1) **neutral**, matching
+   Cycles' neutral white by construction.
+3. **A small residual tilt** — subsumed by (2); negligible.
+
+`RGBUnbounded` is pbrt's **reflectance / HDR-value** upsampler — dimensionless **and**
+E-white. Using it for **emission** drops roles 1 **and** 2, both of which a
+**D65-referred spectral pipeline requires** to produce anchored, neutral-white light.
+
+### Why (a), and why (b)/(c) collapse to it
+
+- **The references already do (a) for exactly this reason.** pbrt-v4 uses
+  `SpectrumType::Illuminant → RGBIlluminantSpectrum` (D65) for lights; Mitsuba 3 uses
+  `srgb_d65`. Mitsuba's docs state a flat-spectrum emitter renders **purple-ish** and
+  you **must** use D65 — i.e. the D65-weighted lift **is** the standard white-preservation
+  construction for spectral emitters. This was **never** a pbrt-vs-Cycles "disagreement"
+  to resolve in Cycles' favor: Cycles avoids it **only** by being RGB-native (no spectral
+  round-trip). Astroray is spectral, so it **must** use an illuminant-referred lift.
+- **(b) reduces to (a).** An explicit E→D65 chromatic adaptation applied to a flat-E
+  sigmoid is multiplication by `(D65/E) ≈ D65` — i.e. **`RGBIlluminant` again**, just a
+  more complicated spelling. No benefit, more surface area.
+- **(c)** — the references offer no better-known construction; `RGBIlluminant` is the
+  standard. Nothing to adopt.
+
+### The original premise was a misattribution
+
+The delegation was to close a "+7–16% uniform equal-wattage offset." But `RGBIlluminant`
+renders **neutral, anchored** white — it was never the chromaticity culprit. The
+**pkg139 oracle rows land at 0.96–1.01 WITHOUT any pkg142 change**, which means the
+offset is **scene/type-dependent, not a universal emission-lift bug**. The pkg122 oracle
+(1.07–1.16) vs pkg139 (0.96–1.01) discrepancy is the real lead. Re-attributed to
+**pkg146** (`.astroray_plan/packages/pkg146-...`).
+
+### Action
+
+- **Revert PR #511** (both the `RGBUnbounded` swap and the explicit `1/cieYIntegral()`
+  anchor — the anchor exists **only** to compensate for the swap; `RGBIlluminant`
+  carries it inside `sampleD65`. Re-adding it on top of `RGBIlluminant` would
+  **double-anchor** → ~116× too dim). Net emission-lift code returns to `main`'s
+  `RGBIlluminant` / `GSPEC_RGB_ILLUMINANT`.
+- **Keep the pkg142 investigation value**: this package is the adjudication record that
+  the D65 illuminant lift is **required and correct** (with references + quantitative
+  E→D65 confirmation), preventing a future re-litigation. Zero code change.
+- **File pkg146** for the misattributed offset (lead: the pkg139-vs-pkg122 oracle
+  discrepancy; check the oracle harness, per-type/scene dependence, exposure/tonemap).
+
+### Three-role postmortem (the whole arc)
+
+One symbol (`· sampleD65`) did **three** jobs; each "fix" peeled one layer and exposed
+the next: switch-to-Unbounded (dropped units **+** white point) → +116× → add anchor
+(fixed units, **exposed** white point) → +30% R pink → **keep Illuminant** (all three
+handled by construction). The durable lesson: **emission in a spectral renderer needs an
+illuminant-referred lift; a reflectance upsampler (`Albedo`/`Unbounded`) is the wrong
+category for a light.** The class names encode this (reflectance vs illuminant) — respect
+them. And **validate a convention change against a neutral-white render, not just a
+brightness ratio** — a scalar gate can't see a white-point error.
+
+Everything below (original decision + ⚠ CORRECTION) is retained for the journal trail
+and is **superseded** by this section.
 
 ---
 

--- a/.astroray_plan/packages/pkg146-equal-wattage-offset-investigation.md
+++ b/.astroray_plan/packages/pkg146-equal-wattage-offset-investigation.md
@@ -1,0 +1,78 @@
+# pkg146 — Investigate the equal-wattage brightness offset (re-attributed from pkg142/Defect 4)
+
+**Pillar:** 3 (light transport / emitter energy — measurement correctness)
+**Track:** A (an investigation: reconcile two disagreeing oracles before proposing any fix; measure first, adjudicate second)
+**Codex-paste-ready:** no (diagnosis with a live-Cycles oracle + harness archaeology; the deliverable is a root-cause + a scoped fix spec, not a blind patch)
+**Status:** open — dispatchable (investigation)
+**Estimated effort:** M (mostly measurement + reconciliation; fix scope unknown until the two oracles are reconciled)
+**Depends on:** pkg142 adjudication (keep `RGBIlluminant`, PR #511 reverted) — this investigation runs on the **`RGBIlluminant`** baseline, not the reverted RGBUnbounded one.
+
+**Origin:** pkg142 ✅ FINAL ADJUDICATION. Defect 4 established that the RGB emission
+**convention** (`RGBIlluminant` D65) is **correct** and is **not** the source of a
+universal brightness offset. But the offset the owner delegated (all four dedicated-light
+types **1.07–1.16×** brighter than Cycles at equal wattage, pkg122 oracle) is still
+**unexplained** — and now looks **scene/type-dependent**, not a convention bug.
+
+---
+
+## The contradiction to resolve
+
+Two oracle runs disagree on the same nominal quantity (Astroray/Cycles equal-wattage
+brightness ratio) on the **unchanged `RGBIlluminant` baseline**:
+
+| Oracle | Measured ratio | Implication |
+|---|---|---|
+| pkg122 (`verify_pkg122_cycles_oracle.py`) | **1.07–1.16×** (all four types) | motivated the whole Defect-4 "switch the convention" effort |
+| pkg139 rows | **0.96–1.01×** (no pkg142 change) | offset is small/absent → scene- or harness-dependent |
+
+If pkg139 already sits at 0.96–1.01 on the same baseline, the pkg122 1.07–1.16 is **not**
+a universal property of the emission lift. **This discrepancy is the primary lead** — it
+almost certainly points at a harness/scene difference, not a renderer energy bug (cf.
+the pkg123 lesson that a test integrator can itself be the artifact, memory
+`ssim-wrong-gate-for-independent-rng` and the pkg123 `rho()` false-positive/negative
+finding).
+
+---
+
+## Investigation contract (measure-first; do NOT ship a brightness fix before reconciling)
+
+1. **Diff the two oracles.** Line up the pkg122 and pkg139 scenes/harnesses:
+   light type + wattage, floor albedo + material (Disney-diffuse vs pure Lambertian —
+   the pkg122 SUN caveat already documents a Disney baseline-Fresnel leak), camera
+   alignment (the pkg122 SUN 5° tilt + AREA 180° flip caveats), spp, colour management
+   (`view_transform=Standard`, `exposure=0`, `gamma=1`), and the measurement patch.
+   Produce a table of every difference.
+2. **Identify which difference moves the ratio.** Re-run one harness while swapping in
+   the other's choices one at a time (exposure/tonemap, material, patch location,
+   wattage normalization) until the 1.16 vs 0.99 gap is explained. Expected suspects,
+   in order: (a) colour-management/exposure mismatch; (b) Disney-diffuse-vs-Lambertian
+   floor at the sampled angles; (c) the measurement patch catching a specular/Fresnel
+   lobe; (d) a genuine residual per-type radiometry error pkg122 left (small).
+3. **Only if a genuine renderer-side offset survives reconciliation**, scope a fix
+   against the **live-Cycles** numbers (per-channel mean-ratio, NOT SSIM) — and it will
+   be a **radiometry/units** fix (per-type or exposure), **not** an emission-convention
+   change (that is closed: keep `RGBIlluminant`).
+
+## Gates
+
+- A written reconciliation: the pkg122↔pkg139 discrepancy explained, with the single
+  dominant cause identified and demonstrated (before/after numbers).
+- If a real offset remains: a live-Cycles oracle showing all four types within
+  **[0.97, 1.03]** per channel after the scoped fix, on the `RGBIlluminant` baseline,
+  with the reference bank re-blessed evidence-first (Blender 5.1 headless).
+- If NO real offset remains (the likely outcome): the pkg122 oracle is corrected/retired
+  as the artifact, and the "dimmer/brighter than Cycles" complaint is closed as a
+  measurement issue with the evidence recorded.
+
+## Non-goals
+
+- **Do not** revisit the emission convention — `RGBIlluminant` (D65) is adjudicated
+  correct (pkg142). Any pinkness or ~116×/~30% artifact belongs to the reverted #511, not
+  here.
+- **Do not** loosen the [0.97,1.03] band; if the renderer is genuinely off, fix the
+  radiometry.
+
+## Definition of done
+- [ ] pkg122 vs pkg139 oracle discrepancy reconciled to a single dominant cause, demonstrated with numbers.
+- [ ] Either: a scoped radiometry fix lands all four types in [0.97,1.03] vs live Cycles (RGBIlluminant baseline) with an evidence-first re-bless; **or** the offset is shown to be a harness artifact and the pkg122 oracle is corrected/retired with the complaint closed.
+- [ ] Finding written to `.astroray_plan/docs/` with both oracle datasets cited.


### PR DESCRIPTION
## Final verdict on Defect 4 (pkg142): **keep `RGBIlluminant` (D65). Revert #511. Net code change: NONE.**

Doc-only. Records the full three-round arc + the closing adjudication, and files the follow-up investigation (pkg146). Supersedes this PR's earlier "units vs shape" correction.

### The arc (three roles of the `· sampleD65` factor)
1. Original: switch RGBIlluminant → RGBUnbounded. → dropped **units + white point** → **~116× blow-up** (HW #511).
2. Correction 1: RGBUnbounded + `1/cieYIntegral()` anchor (`790eb9e`). → fixed **units** (suite 68→6) but **exposed the white point** → **~30% R-excess, pink renders** vs neutral Cycles.
3. **Final: keep RGBIlluminant.** The D65 lift handles all three roles by construction.

### Verified root cause of the pink (coordinator hypothesis, confirmed)
The unweighted JH sigmoid for white ≈ **illuminant E** (chromaticity ~(0.333,0.333)); Astroray's spectral→RGB is **D65-referred** (standard sRGB matrix + `data/spectra/rgb_to_spectrum_srgb.coeff`). E-white through a D65 matrix is pink: `XYZ(1,1,1) → sRGB (1.205, 0.948, 0.909)`, **R/G ≈ 1.27** — matches the measured R 1.29–1.37, B 0.96–1.07. The D65 lift makes white RGB emit **D65-white** → neutral, like Cycles.

### Why (a), not (b)/(c)
A **spectral** renderer's emission needs an **illuminant-referred** lift for white preservation. **pbrt-v4 (`SpectrumType::Illuminant`) and Mitsuba 3 (`srgb_d65`) both do exactly this** — the standard construction, not a pbrt-vs-Cycles dispute (Cycles sidesteps it only by being RGB-native). Option (b) — explicit E→D65 adaptation on a flat sigmoid — is `× (D65/E) ≈ D65` = `RGBIlluminant` again. `RGBUnbounded` is a **reflectance** upsampler — wrong category for a light.

### The original premise was a misattribution
`RGBIlluminant` renders neutral + anchored; the **pkg139 oracle rows are 0.96–1.01 without pkg142**, so the "+7–16% offset" is **scene/type-dependent**, not the convention. Re-attributed to **pkg146** (lead: the pkg122-vs-pkg139 oracle discrepancy — likely a harness/exposure artifact).

### Files
- `pkg142-rgb-emission-convention.md` — Status: ADJUDICATED (keep RGBIlluminant, revert #511, zero code change) + ✅ FINAL ADJUDICATION + three-role postmortem.
- `defect4-rgb-emission-research.md` — final decision + Final Adjudication section.
- **`pkg146-equal-wattage-offset-investigation.md`** (new) — reconcile pkg122 (1.07–1.16) vs pkg139 (0.96–1.01) before any radiometry fix; convention is closed.

### Action for #511
Revert the emission-lift change (both the RGBUnbounded swap and the explicit anchor — the anchor only exists to compensate the swap; re-adding it on RGBIlluminant would double-anchor → ~116× too dim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)