### PR TITLE
feat(pkg144): Cycles-style direct/indirect firefly clamp split

### DIFF
--- a/.astroray_plan/docs/pkg144-firefly-clamp-research.md
+++ b/.astroray_plan/docs/pkg144-firefly-clamp-research.md
@@ -1,0 +1,118 @@
+# pkg144 research notes — Cycles `film_clamp_light` (direct/indirect firefly clamp split)
+
+## Source
+
+- **Repo:** `blender/cycles` (upstream, mirrored into `blender/blender` as a submodule/subtree).
+  Fetched via `https://raw.githubusercontent.com/blender/cycles/main/src/kernel/film/light_passes.h`
+  and `https://raw.githubusercontent.com/blender/cycles/main/src/scene/integrator.cpp`
+  (2026-07-23).
+- **License:** Apache-2.0 (Blender/Cycles kernel sources). Already an established
+  reference in this codebase (cited throughout `raytracer.h`, `path_trace_kernel.cu`,
+  etc. for other Cycles-derived algorithms).
+
+## The function (device-side clamp selection)
+
+`src/kernel/film/light_passes.h`:
+
+```c
+ccl_device_forceinline void film_clamp_light(KernelGlobals kg,
+                                             ccl_private Spectrum *L,
+                                             const int bounce)
+{
+  *L = ensure_finite(*L);
+#ifdef __CLAMP_SAMPLE__
+  const float limit = (bounce > 0) ? kernel_data.integrator.sample_clamp_indirect :
+                                     kernel_data.integrator.sample_clamp_direct;
+  const float sum = reduce_add(fabs(*L));
+  if (sum > limit) {
+    *L *= limit / sum;
+  }
+#endif
+}
+```
+
+Call sites (per-contribution, each passing the CURRENT path's bounce count):
+`film_write_direct_light` (NEE/shadow-ray contribution), `film_write_background`
+(environment miss), `film_write_volume_emission`, `film_write_surface_emission`.
+
+## Host-side default handling (`src/scene/integrator.cpp`, `device_update`)
+
+```c++
+kintegrator->sample_clamp_direct = (sample_clamp_direct == 0.0f) ? FLT_MAX :
+                                                                   sample_clamp_direct * 3.0f;
+kintegrator->sample_clamp_indirect = (sample_clamp_indirect == 0.0f) ?
+                                         FLT_MAX :
+                                         sample_clamp_indirect * 3.0f;
+```
+
+`0` (the user-facing default for both) maps to `FLT_MAX`, i.e. **no clamp** —
+Cycles ships firefly control fully opt-in, split direct/indirect, with direct
+unclamped by default (documented UI guidance: "clamping direct light paths can
+have a too extreme effect").
+
+## What we ported vs. what we deliberately did NOT port
+
+- **Ported:** the bounce-indexed limit SELECTION (`bounce > 0 ? indirect : direct`),
+  applied per-contribution (at each site a value is added to the path's running
+  radiance), and the `0 == disabled` semantics.
+- **NOT ported literally:** Cycles' clamp METRIC is `sum(|R|+|G|+|B|)` (an RGB
+  magnitude proxy) and the host-side `* 3.0f` scale-up that goes with it. Astroray's
+  existing brightness metric (already established by the pre-pkg144
+  `if (sLum > 20.0f)` cap this package removes, and by `clampLuminance()` elsewhere
+  in `raytracer.h`) is **CIE XYZ photometric luminance (Y)** via
+  `SampledSpectrum::toXYZ(lambdas).Y`. We kept that metric rather than switching to
+  Cycles' RGB-sum convention, since (a) it's the metric already in use throughout
+  this codebase, (b) switching metrics would require re-deriving the `*3.0f`
+  calibration factor (which exists specifically to make an RGB-sum threshold behave
+  like a luminance threshold for roughly-grey light), and (c) the bounce-indexed
+  SELECTION logic (the actual "invented algorithm" concern under CLAUDE.md §6) is
+  what we're porting, not the choice of scalar reduction. This is a metric
+  substitution, not a re-derivation of Cycles' clamp-selection algorithm.
+
+## Astroray's existing (dead) plumbing
+
+`include/raytracer.h` already declared `clampDirect`/`clampIndirect` fields
+(default 0), setters (`setClampDirect`/`setClampIndirect`), a `clear()` reset, and
+Python bindings (`module/blender_module.cpp`: `set_clamp_direct`/`set_clamp_indirect`)
+— all pre-pkg144, never read anywhere. pkg144 adds `getClampDirect()`/
+`getClampIndirect()` and wires the fields into:
+
+- `Renderer::pathTraceSpectral` / `Renderer::pathTraceSpectralCaustic` (CPU,
+  `include/raytracer.h`) via a new private helper `clampContribSpectral()`.
+- `tracePathGPU` (`src/gpu/path_trace_kernel.cu`, the production GPU megakernel
+  for non-`path_tracer`/non-MW integrator names) via `gpu_clampContrib()`.
+- `tracePathMW` (`src/gpu/multiwavelength_kernel.cu`, the production GPU megakernel
+  actually dispatched for the DEFAULT `path_tracer` integrator name when
+  `set_use_gpu(True)` — see `module/blender_module.cpp`'s
+  `integratorName_ == "path_tracer" || ... ` branch, which routes to
+  `renderMultiwavelength`) via `gpu_clampContribMW()`.
+
+## Defaults (evidence-first, per spec)
+
+- `clampDirect = 0.0f` (off) — non-negotiable, unchanged from the existing
+  (dead) default.
+- `clampIndirect = 0.0f` (off) — **measured**: the full firefly/caustic/furnace
+  test suite (`test_disney_energy_conservation.py`, `test_dielectric_glass_furnace.py`,
+  `test_disney_rough_glass_furnace.py`, `test_disney_reflection_not_black.py`,
+  `test_caustic_validation.py`, `test_pkg140_distant_light_zero_angle.py`) passes
+  in full with `clampIndirect = 0`. Per the spec's own instruction ("If the tests
+  pass with clampIndirect = 0 too, prefer full Cycles parity"), we ship both
+  clamps off — exact Cycles-default parity, no legacy "20" reintroduced.
+
+## Deliberately out of scope (noted, not silently dropped)
+
+- `src/gpu/wavefront/stage_advance.cu` (`stageRegenKernel`,
+  `stageAccumulateXYZKernel`) and `src/gpu/wavefront/stage_restir.cu` carry their
+  own copies of the old whole-path `lum > 20` clamp (applied at path-death /
+  accumulate time, same pre-pkg144 bug shape). These are the pkg55 SoA wavefront
+  **development/parity harness** (gated behind `ASTRORAY_WAVEFRONT_INTERSECT` /
+  invoked only from the `tests/wavefront_diff` bit-identity suite), **not** the
+  production GPU dispatch path (confirmed: `cuda_renderer.cu`'s `render()` /
+  `renderMultiwavelength()` call `launchPathTraceKernel` / `launchMultiwavelengthKernel`
+  directly, never the wavefront stage launchers). Restructuring them to a
+  per-contribution split would require re-deriving where each contribution
+  (NEE/emission/background) is added across several separate kernel-launch stages,
+  and would touch the strict bit-identity gates in `tests/wavefront_diff`. Left
+  as a follow-up (flagged in the PR body), consistent with "GPU parity if
+  applicable... else note N/A" — the actual production twins (megakernels) are
+  fixed; the dev-harness twins are not.

--- a/.astroray_plan/packages/pkg144-firefly-clamp-direct-indirect-split.md
+++ b/.astroray_plan/packages/pkg144-firefly-clamp-direct-indirect-split.md
@@ -3,7 +3,7 @@
 **Pillar:** 3 (light transport / integrator correctness)
 **Track:** A (integrator clamp restructuring against the Cycles reference + an energy-linearity gate; needs a build + evidence-first default tuning)
 **Codex-paste-ready:** no (an adjudicated integrator change that moves firefly control from an always-on top-level cap to a per-contribution bounce-split, with a default that must be tuned against the existing firefly/caustic tests — judgment at the gate)
-**Status:** open — dispatchable
+**Status:** done (PR #TBD, 2026-07-23 — clamp split wired CPU+GPU megakernels, both defaults 0/off per measured evidence, bright-sun linearity ratio ~0.9995 across 3 decades; secondary light-selection-importance deferred; 2 of 3 pkg144-adjacent xfails resolved, 2 Disney-highlight tests reassigned to pkg145's remit with measured evidence — see PR body)
 **Estimated effort:** M (primary clamp-split); secondary light-selection section is a separable S–M follow-up
 **Depends on:** none (pkg140 landed the delta-sun MIS/`power()` fixes in `060cfd0`; this is the pre-existing clamp that masks them)
 
@@ -165,9 +165,10 @@ area light of similar illuminance — the `× solidAngle` factor **understates**
 ---
 
 ## Definition of done
-- [ ] Hardcoded `sLum > 20` cap removed; `clampDirect`/`clampIndirect` wired per-bounce (bounce==0→direct, bounce>0→indirect), 0=disabled, mirroring `film_clamp_light`.
-- [ ] `clampDirect` default 0 (off); `clampIndirect` default chosen evidence-first to keep firefly/caustic tests green, and documented.
-- [ ] NEW bright-sun energy-linearity gate added and green (with_sun ∝ S across ≥3 decades, ratio-to-analytic ~1).
-- [ ] Existing firefly/caustic + furnace + render suites unchanged; build evidence shown.
-- [ ] GPU firefly-cap parity handled or noted N/A.
-- [ ] Secondary: distant-vs-area selection-importance either fixed (with a cited Cycles/Estevez-Kulla importance metric + a mixed-scene gate) or explicitly deferred to a follow-up package, decision recorded in the PR.
+- [x] Hardcoded `sLum > 20` cap removed; `clampDirect`/`clampIndirect` wired per-bounce (bounce==0→direct, bounce>0→indirect), 0=disabled, mirroring `film_clamp_light`.
+- [x] `clampDirect` default 0 (off); `clampIndirect` default chosen evidence-first (measured 0 keeps the full firefly/caustic/furnace suite green — full Cycles parity, both off), documented in `.astroray_plan/docs/pkg144-firefly-clamp-research.md`.
+- [x] NEW bright-sun energy-linearity gate added and green (with_sun ∝ S across 3 decades — 1e6/1e7/1e8 — ratio-to-analytic ~0.9995).
+- [x] Existing firefly/caustic + furnace + render suites unchanged; build evidence shown (see PR).
+- [x] GPU firefly-cap parity handled: the two PRODUCTION GPU megakernels (`path_trace_kernel.cu` tracePathGPU, `multiwavelength_kernel.cu` tracePathMW — the latter is what the default `path_tracer` integrator actually dispatches to on GPU) got the same bounce-indexed split. The pkg55 wavefront SoA dev-harness kernels (`stage_advance.cu`/`stage_restir.cu`, not in the production dispatch path) still carry the old whole-path clamp — explicitly deferred, see research doc.
+- [ ] Secondary: distant-vs-area selection-importance — DEFERRED, not attempted this round (time-boxed to the primary clamp-split fix). Still open.
+- **Un-xfail note:** `test_direct_and_indirect_clamp_controls` (test_python_bindings.py) un-xfailed — genuinely fixed by this package. The two Disney-highlight tests named in the dispatch (`test_disney_metallic_tints_specular_highlight`, `test_disney_roughness_changes_glossiness`) were investigated in depth and found NOT to be caused by the firefly clamp (converged, stable R/B and mean gaps of ~0.03-0.06 and ~0.0087 respectively, well under their 0.10/0.015 gates, unchanged across clamp settings 0/20/1e6 and across 64-2048 spp) — root cause is a Pillar-2 Disney specular-magnitude question adjacent to pkg145 (Disney specular energy compensation refit), not pkg144's integrator clamp. Their xfail reasons were updated with the measured evidence and left in place; see PR body.

--- a/.astroray_plan/packages/pkg144-firefly-clamp-direct-indirect-split.md
+++ b/.astroray_plan/packages/pkg144-firefly-clamp-direct-indirect-split.md
@@ -3,7 +3,7 @@
 **Pillar:** 3 (light transport / integrator correctness)
 **Track:** A (integrator clamp restructuring against the Cycles reference + an energy-linearity gate; needs a build + evidence-first default tuning)
 **Codex-paste-ready:** no (an adjudicated integrator change that moves firefly control from an always-on top-level cap to a per-contribution bounce-split, with a default that must be tuned against the existing firefly/caustic tests — judgment at the gate)
-**Status:** done (PR #TBD, 2026-07-23 — clamp split wired CPU+GPU megakernels, both defaults 0/off per measured evidence, bright-sun linearity ratio ~0.9995 across 3 decades; secondary light-selection-importance deferred; 2 of 3 pkg144-adjacent xfails resolved, 2 Disney-highlight tests reassigned to pkg145's remit with measured evidence — see PR body)
+**Status:** done (PR #515, 2026-07-23 — clamp split wired CPU+GPU megakernels, both defaults 0/off per measured evidence, bright-sun linearity ratio ~0.9995 across 3 decades; secondary light-selection-importance deferred; 2 of 3 pkg144-adjacent xfails resolved, 2 Disney-highlight tests reassigned to pkg145's remit with measured evidence — see PR body)
 **Estimated effort:** M (primary clamp-split); secondary light-selection section is a separable S–M follow-up
 **Depends on:** none (pkg140 landed the delta-sun MIS/`power()` fixes in `060cfd0`; this is the pre-existing clamp that masks them)
 

--- a/include/raytracer.h
+++ b/include/raytracer.h
@@ -2157,6 +2157,32 @@ class Renderer {
         return c;
     }
 
+    // pkg144 — Cycles-style per-contribution firefly clamp, selected by bounce
+    // depth. Ports `film_clamp_light` (src/kernel/film/light_passes.h, Cycles,
+    // Apache-2.0):
+    //   const float limit = (bounce > 0) ? sample_clamp_indirect : sample_clamp_direct;
+    //   const float sum = reduce_add(fabs(*L));
+    //   if (sum > limit) *L *= limit / sum;
+    // Cycles compares against sum(|RGB|); Astroray's existing brightness metric
+    // (the pre-pkg144 always-on `sLum > 20` cap this replaces) is XYZ photometric
+    // luminance (Y), so this clamps on toXYZ(lambdas).Y instead — same bounce-
+    // indexed limit selection and 0-disables semantics, different (but
+    // already-established in this codebase) brightness metric. Applied to each
+    // contribution BEFORE it is summed into the path color, so direct (bounce==0,
+    // including delta-light NEE) and indirect (bounce>0) contributions are
+    // clamped independently rather than the old top-level clamp on the whole
+    // summed path.
+    astroray::SampledSpectrum clampContribSpectral(const astroray::SampledSpectrum& contrib,
+                                                    const astroray::SampledWavelengths& lambdas,
+                                                    int bounce) const {
+        float limit = (bounce > 0) ? clampIndirect : clampDirect;
+        if (limit <= 0.0f) return contrib;
+        astroray::XYZ xyz = contrib.toXYZ(lambdas);
+        float lum = xyz.Y;
+        if (lum > limit && lum > 0.0f) return contrib * (limit / lum);
+        return contrib;
+    }
+
     Vec3 worldTransmittance(float distance) const {
         if (!hasWorldVolume || worldVolumeDensity <= 0.0f || distance <= 0.0f) return Vec3(1.0f);
         float d = std::max(0.0f, distance);
@@ -2183,6 +2209,8 @@ public:
     void setTransparentGlass(bool use) { transparentGlass = use; }
     void setClampDirect(float value) { clampDirect = std::max(0.0f, value); }
     void setClampIndirect(float value) { clampIndirect = std::max(0.0f, value); }
+    float getClampDirect() const { return clampDirect; }
+    float getClampIndirect() const { return clampIndirect; }
     void setFilterGlossy(float value) { filterGlossy = std::max(0.0f, value); }
     void setUseReflectiveCaustics(bool use) { useReflectiveCaustics = use; }
     void setUseRefractiveCaustics(bool use) { useRefractiveCaustics = use; }
@@ -2427,7 +2455,7 @@ public:
                         Vec3 bg = (Vec3(1) * (1 - t) + Vec3(0.5f, 0.7f, 1.0f) * t) * 0.2f;
                         envSpec = astroray::RGBIlluminantSpectrum({bg.x, bg.y, bg.z}).sample(lambdas);
                     }
-                    color += throughput * envSpec;
+                    color += clampContribSpectral(throughput * envSpec, lambdas, bounce);
                 }
                 break;
             }
@@ -2440,7 +2468,7 @@ public:
                         grEmission[i] = finiteClamped(grResult.emission[i], 0.0f, 20.0f);
                     }
                     if (!grEmission.isZero()) {
-                        color += throughput * grEmission;
+                        color += clampContribSpectral(throughput * grEmission, lambdas, bounce);
                     }
                 }
                 if (grResult.captured) {
@@ -2471,7 +2499,7 @@ public:
                 rec.material->emittedSpectral(rec, lambdas);
             if (!Le_spec.isZero()) {
                 if (bounce == 0 || wasSpecular) {
-                    color += throughput * Le_spec;
+                    color += clampContribSpectral(throughput * Le_spec, lambdas, bounce);
                 }
                 break;
             }
@@ -2479,6 +2507,11 @@ public:
             Vec3 wo = -ray.direction.normalized();
 
             // Area-light NEE (MIS via power heuristic). Skipped on delta lobes.
+            // pkg144: NEE fires at the CURRENT vertex's bounce depth, so a
+            // bounce==0 NEE sample (first-hit direct lighting, including
+            // delta-light NEE) is clamped by clampDirect (default 0/off) — this
+            // is the fix for the delta-sun energy-linearity bug this package
+            // exists to close (never silently cap deterministic delta-light NEE).
             if (!rec.isDelta && !lights.empty()) {
                 LightSample ls;
                 lights.sample(ls, rec.point, rec.normal, lambdas, gen);
@@ -2505,7 +2538,9 @@ public:
                         // the finite-angle limit) to selPdf (O(1)) right at
                         // angle == 0, undercounting the delta sun's energy.
                         float wt = ls.isDelta ? 1.0f : (a * a) / (a * a + b * b + 1e-8f);
-                        color += throughput * f_spec * L_spec * (wt / (ls.pdf + 0.001f));
+                        astroray::SampledSpectrum neeContrib =
+                            throughput * f_spec * L_spec * (wt / (ls.pdf + 0.001f));
+                        color += clampContribSpectral(neeContrib, lambdas, bounce);
                     }
                 }
             }
@@ -2522,7 +2557,7 @@ public:
                 astroray::SampledSpectrum smsContribution =
                     smsHook(rec, wo, throughput, lambdas, gen);
                 if (!smsContribution.isZero()) {
-                    color += throughput * smsContribution;
+                    color += clampContribSpectral(throughput * smsContribution, lambdas, bounce);
                 }
             }
 
@@ -2632,7 +2667,7 @@ public:
                         Vec3 bg = (Vec3(1) * (1 - t) + Vec3(0.5f, 0.7f, 1.0f) * t) * 0.2f;
                         envSpec = astroray::RGBIlluminantSpectrum({bg.x, bg.y, bg.z}).sample(lambdas);
                     }
-                    color += throughput * envSpec;
+                    color += clampContribSpectral(throughput * envSpec, lambdas, bounce);
                 }
                 break;
             }
@@ -2643,7 +2678,7 @@ public:
                     for (int i = 0; i < astroray::kSpectrumSamples; ++i) {
                         grEmission[i] = finiteClamped(grResult.emission[i], 0.0f, 20.0f);
                     }
-                    color += throughput * grEmission;
+                    color += clampContribSpectral(throughput * grEmission, lambdas, bounce);
                 }
                 if (grResult.captured) break;
                 Vec3 exitDir = grResult.exitDirection;
@@ -2666,7 +2701,8 @@ public:
 
             astroray::SampledSpectrum Le_spec = rec.material->emittedSpectral(rec, lambdas);
             if (!Le_spec.isZero()) {
-                if (bounce == 0 || wasSpecular) color += throughput * Le_spec;
+                if (bounce == 0 || wasSpecular)
+                    color += clampContribSpectral(throughput * Le_spec, lambdas, bounce);
                 break;
             }
 
@@ -2692,7 +2728,9 @@ public:
                         // pkg140: see pathTraceSpectral's identical comment --
                         // delta-light NEE samples always get full MIS weight.
                         float wt = ls.isDelta ? 1.0f : (a * a) / (a * a + b * b + 1e-8f);
-                        color += throughput * f_spec * L_spec * (wt / (ls.pdf + 0.001f));
+                        astroray::SampledSpectrum neeContrib =
+                            throughput * f_spec * L_spec * (wt / (ls.pdf + 0.001f));
+                        color += clampContribSpectral(neeContrib, lambdas, bounce);
                     }
                 }
             }
@@ -2753,9 +2791,13 @@ public:
                         astroray::SampledSpectrum Le = wrec.material->emittedSpectral(wrec, walkLambdas);
                         if (!Le.isZero()) {
                             astroray::SampledSpectrum contribution = walkThroughput * Le;
-                            color += contribution;
                             causticConnections += 1;
                             causticEnergy += contribution.maxValue();
+                            // pkg144: this specular-chain vertex is always at least
+                            // one bounce past the primary hit (only entered after a
+                            // delta BSDF sample), so it is always "indirect" for the
+                            // clamp split regardless of the outer `bounce` value.
+                            color += clampContribSpectral(contribution, walkLambdas, bounce + 1);
                             break;
                         }
 
@@ -2777,9 +2819,11 @@ public:
                                              std::max(dist2, 1e-4f);
                                 astroray::SampledSpectrum contribution =
                                     walkThroughput * f_spec * Li * (geom / (ls.pdf + 0.001f));
-                                color += contribution;
                                 causticConnections += 1;
                                 causticEnergy += contribution.maxValue();
+                                // pkg144: same indirect classification as the emissive
+                                // walk-vertex case above.
+                                color += clampContribSpectral(contribution, walkLambdas, bounce + 1);
                                 break;
                             }
                         }
@@ -3015,9 +3059,14 @@ inline void Renderer::render(Camera& cam, int maxSamples, int maxDepth,
                                 sPass = ir.passes;
                             }
                             sCol = finiteVecOrZero(sCol);
-                            // Per-sample firefly suppression: sCol is XYZ, Y is photometric luminance.
-                            float sLum = sCol.y;
-                            if (sLum > 20.0f) sCol = sCol * (20.0f / sLum);
+                            // pkg144: the always-on, direct+indirect-combined `sLum > 20`
+                            // top-level clamp that used to live here has been REMOVED. It
+                            // biased delta-light NEE (deterministic, zero-variance contributions
+                            // have no fireflies to suppress) and could not distinguish direct
+                            // from indirect contributions. Firefly control is now applied
+                            // per-contribution, by bounce depth, inside the integrator itself
+                            // (Renderer::clampContribSpectral, wired into pathTraceSpectral /
+                            // pathTraceSpectralCaustic) — see clampDirect/clampIndirect.
                             color += sCol;
                             for (int passIndex = 0; passIndex < PASS_COUNT; ++passIndex) {
                                 passColor[passIndex] += sPass[passIndex];

--- a/src/gpu/cuda_renderer.cu
+++ b/src/gpu/cuda_renderer.cu
@@ -40,6 +40,7 @@ void launchPathTraceKernel(
     float* d_framebuffer, int width, int height,
     int samplesPerPixel, int maxDepth,
     bool useCaustics,  // pkg64-gpu Phase 2
+    float clampDirect, float clampIndirect,  // pkg144
     const GTLASNode*  d_tlas, const GInstance* d_instances, const GBLAS* d_blas,  // pkg114
     const GBVHNode*  d_bvhNodes,
     const GPrimitive* d_prims,
@@ -91,6 +92,7 @@ void launchMultiwavelengthKernel(
     float* d_framebuffer, int width, int height,
     int samplesPerPixel, int maxDepth,
     int worldMaxBounces,  // pkg55-B' N+6 follow-up: env gate, raytracer.h:2412
+    float clampDirect, float clampIndirect,  // pkg144
     float lambdaMin, float lambdaMax, bool useLuminanceOutput,
     bool enableNEE,
     bool useCaustics,  // pkg64-gpu Phase 2
@@ -865,9 +867,16 @@ void CUDARenderer::render(
     // disable the legacy SMS attempt so the caustic is not double-counted.
     if (caustic.ready) useCaustics = false;
 
+    // pkg144: clampDirect/clampIndirect wired from the host Renderer (mirrors
+    // the getWorldMaxBounces() pattern below). Defaults 0/off unless the host
+    // set them via set_clamp_direct/set_clamp_indirect.
+    float clampDirect = impl->hostRenderer ? impl->hostRenderer->getClampDirect() : 0.0f;
+    float clampIndirect = impl->hostRenderer ? impl->hostRenderer->getClampIndirect() : 0.0f;
+
     // Launch megakernel
     launchPathTraceKernel(
         impl->d_framebuffer, width, height, samplesPerPixel, maxDepth, useCaustics,
+        clampDirect, clampIndirect,  // pkg144
         impl->d_tlas, impl->d_instances, impl->d_blas,  // pkg114
         impl->d_bvhNodes, impl->d_prims, impl->d_triangles, impl->d_spheres,
         impl->d_materials,
@@ -964,10 +973,14 @@ void CUDARenderer::renderMultiwavelength(
     // from the CPU whenever a scene sets world max bounces < max_depth.
     int worldMaxBounces = impl->hostRenderer
         ? impl->hostRenderer->getWorldMaxBounces() : 1024;
+    // pkg144: clampDirect/clampIndirect wired from the host Renderer.
+    float clampDirect = impl->hostRenderer ? impl->hostRenderer->getClampDirect() : 0.0f;
+    float clampIndirect = impl->hostRenderer ? impl->hostRenderer->getClampIndirect() : 0.0f;
 
     launchMultiwavelengthKernel(
         impl->d_framebuffer, width, height, samplesPerPixel, maxDepth,
         worldMaxBounces,
+        clampDirect, clampIndirect,  // pkg144
         lambdaMin, lambdaMax, useLuminanceOutput, enableNEE, useCaustics,
         impl->d_tlas, impl->d_instances, impl->d_blas,  // pkg114
         impl->d_bvhNodes, impl->d_prims, impl->d_triangles, impl->d_spheres,

--- a/src/gpu/multiwavelength_kernel.cu
+++ b/src/gpu/multiwavelength_kernel.cu
@@ -116,6 +116,34 @@ __device__ GSampledSpectrum sampleDirectSpectralMW(
 }
 
 // ---------------------------------------------------------------------------
+// pkg144 — GPU twin (multiwavelength) of Renderer::clampContribSpectral.
+// Ports Cycles `film_clamp_light`'s bounce-indexed clamp selection
+// (src/kernel/film/light_passes.h, Apache-2.0; see path_trace_kernel.cu's
+// gpu_clampContrib for the full citation/rationale). The MW kernel's
+// brightness metric mirrors its own final per-sample conversion
+// (multiwavelengthKernel below, and the CPU MW integrator it mirrors): mean of
+// the spectral samples when useLuminanceOutput (non-visible bands carry no
+// CIE CMF signal, so XYZ.Y would be ~0 and never clamp), else XYZ.Y via
+// spectrumToXYZ.
+// ---------------------------------------------------------------------------
+__device__ inline GSampledSpectrum gpu_clampContribMW(
+        const GSampledSpectrum& contrib, const GSampledWavelengths& lambdas,
+        int bounce, float clampDirect, float clampIndirect, bool useLuminanceOutput) {
+    float limit = (bounce > 0) ? clampIndirect : clampDirect;
+    if (limit <= 0.f) return contrib;
+    float lum;
+    if (useLuminanceOutput) {
+        float avg = 0.f;
+        for (int i = 0; i < G_SPECTRUM_SAMPLES; ++i) avg += contrib.v[i];
+        lum = avg / float(G_SPECTRUM_SAMPLES);
+    } else {
+        lum = spectrumToXYZ(contrib, lambdas).y;
+    }
+    if (lum > limit && lum > 0.f) return contrib * (limit / lum);
+    return contrib;
+}
+
+// ---------------------------------------------------------------------------
 // Spectral path trace — area-light NEE + MIS, mirroring the CPU
 // Renderer::pathTraceSpectral integrator (the CPU `path_tracer` selects this;
 // see plugins/integrators/spectral_path_tracer.cpp). The emissive-on-hit term
@@ -126,6 +154,7 @@ __device__ GSampledSpectrum sampleDirectSpectralMW(
 __device__ GSampledSpectrum tracePathMW(
     GRay ray, int maxDepth,
     int worldMaxBounces,  // pkg55-B' N+6 follow-up: env gate, raytracer.h:2412
+    float clampDirect, float clampIndirect,  // pkg144
     GSampledWavelengths& lambdas,
     bool useLuminanceOutput,
     bool enableNEE,
@@ -182,7 +211,8 @@ __device__ GSampledSpectrum tracePathMW(
                 envSpec = gpu_env_miss_spectral(
                     envMap, backgroundColor, hasBackgroundColor, dir, lambdas);
             }
-            color += throughput * envSpec;
+            color += gpu_clampContribMW(throughput * envSpec, lambdas, bounce,
+                                        clampDirect, clampIndirect, useLuminanceOutput);
             break;
         }
 
@@ -192,7 +222,8 @@ __device__ GSampledSpectrum tracePathMW(
         GSampledSpectrum Le = gpu_material_emitted_spectral(mat, rec.frontFace, lambdas);
         if (Le.maxValue() > 0.f) {
             if (bounce == 0 || wasSpecular)
-                color += throughput * Le;
+                color += gpu_clampContribMW(throughput * Le, lambdas, bounce,
+                                            clampDirect, clampIndirect, useLuminanceOutput);
             break;
         }
 
@@ -204,13 +235,15 @@ __device__ GSampledSpectrum tracePathMW(
         // MultiwavelengthPathTracer (gated by integrator name in
         // module/blender_module.cpp).
         if (enableNEE && !rec.isDelta && (numLights + numDed) > 0) {
-            color += throughput * sampleDirectSpectralMW(
+            GSampledSpectrum neeContrib = throughput * sampleDirectSpectralMW(
                 rec, wo, lambdas, tlas, instances, blas, bvhNodes, prims, tris, spheres, materials,
                 lights, numLights, totalLightPower,
                 dedLights, numDed,   // pkg89-GPU / GAP 1
                 lightTree,
                 ray.time, motionVerts,  // pkg88-C.0
                 rng);
+            color += gpu_clampContribMW(neeContrib, lambdas, bounce,
+                                        clampDirect, clampIndirect, useLuminanceOutput);
         }
 
         // pkg64-gpu Phase 2: SMS caustic attempt at non-delta vertices.
@@ -308,7 +341,8 @@ __device__ GSampledSpectrum tracePathMW(
                         // Additive MIS: write contribution to hero channel only (matches CPU hook).
                         GSampledSpectrum smsContrib(0.0f);
                         smsContrib.v[0] = sampleHero;
-                        color += throughput * smsContrib;
+                        color += gpu_clampContribMW(throughput * smsContrib, lambdas, bounce,
+                                                    clampDirect, clampIndirect, useLuminanceOutput);
                     }
                 }
             }
@@ -392,6 +426,7 @@ __global__ void multiwavelengthKernel(
     float* framebuffer, int width, int height,
     int samplesPerPixel, int maxDepth,
     int worldMaxBounces,  // pkg55-B' N+6 follow-up: env gate, raytracer.h:2412
+    float clampDirect, float clampIndirect,  // pkg144
     float lambdaMin, float lambdaMax,
     bool  useLuminanceOutput,
     bool  enableNEE,
@@ -458,6 +493,7 @@ __global__ void multiwavelengthKernel(
 
         GSampledSpectrum rad = tracePathMW(
             ray, maxDepth, worldMaxBounces,
+            clampDirect, clampIndirect,  // pkg144
             lambdas, useLuminanceOutput, enableNEE, useCaustics,
             tlas, instances, blas,  // pkg114
             bvhNodes, prims, tris, spheres, materials,
@@ -511,12 +547,10 @@ __global__ void multiwavelengthKernel(
         sample.y = isfinite(sample.y) ? sample.y : 0.f;
         sample.z = isfinite(sample.z) ? sample.z : 0.f;
 
-        // Per-sample firefly clamp on XYZ.Y (photometric luminance, matches CPU
-        // raytracer.h:2550). For useLuminanceOutput the triplet is (L,L,L) so
-        // .y == L; same clamp applies.
-        float sLum = sample.y;
-        if (sLum > 20.f) sample *= (20.f / sLum);
-
+        // pkg144: the always-on, whole-path `sLum > 20` clamp that used to live
+        // here has been REMOVED — see gpu_clampContribMW / tracePathMW, which
+        // now clamps direct vs indirect contributions independently, per
+        // bounce, mirroring the CPU fix (include/raytracer.h clampContribSpectral).
         colorAccum += sample;
     }
 
@@ -544,6 +578,7 @@ void launchMultiwavelengthKernel(
     float* d_framebuffer, int width, int height,
     int samplesPerPixel, int maxDepth,
     int worldMaxBounces,  // pkg55-B' N+6 follow-up: env gate, raytracer.h:2412
+    float clampDirect, float clampIndirect,  // pkg144
     float lambdaMin, float lambdaMax, bool useLuminanceOutput,
     bool enableNEE,
     bool useCaustics,  // pkg64-gpu Phase 2
@@ -576,6 +611,7 @@ void launchMultiwavelengthKernel(
         multiwavelengthKernel<<<blocks, threadsPerBlock>>>(
             d_framebuffer, width, height, samplesPerPixel, maxDepth,
             worldMaxBounces,
+            clampDirect, clampIndirect,  // pkg144
             lambdaMin, lambdaMax, useLuminanceOutput, enableNEE, useCaustics,
             d_tlas, d_instances, d_blas,  // pkg114
             d_bvhNodes, d_prims, d_tris, d_spheres, d_materials,

--- a/src/gpu/path_trace_kernel.cu
+++ b/src/gpu/path_trace_kernel.cu
@@ -378,11 +378,31 @@ bsdf_mis:
 }
 
 // ---------------------------------------------------------------------------
+// pkg144 — GPU twin of Renderer::clampContribSpectral (include/raytracer.h).
+// Ports Cycles `film_clamp_light` (src/kernel/film/light_passes.h, Apache-2.0):
+// per-contribution clamp selected by bounce depth (bounce==0 -> clampDirect,
+// bounce>0 -> clampIndirect; limit<=0 disables, Cycles semantics). Compares
+// against the RGB luminance() already defined in gpu_types.h (Rec.709),
+// matching this megakernel's RGB-space `color` accumulator — the GPU-side
+// counterpart of the CPU's XYZ.Y metric substitution (see the CPU helper's
+// comment for why the metric differs from Cycles' sum(|RGB|)).
+// ---------------------------------------------------------------------------
+__device__ inline GVec3 gpu_clampContrib(const GVec3& contrib, int bounce,
+                                          float clampDirect, float clampIndirect) {
+    float limit = (bounce > 0) ? clampIndirect : clampDirect;
+    if (limit <= 0.f) return contrib;
+    float lum = luminance(contrib);
+    if (lum > limit && lum > 0.f) return contrib * (limit / lum);
+    return contrib;
+}
+
+// ---------------------------------------------------------------------------
 // tracePathGPU — port of Renderer::pathTrace()
 // ---------------------------------------------------------------------------
 __device__ GVec3 tracePathGPU(
     GRay ray, int maxDepth,
     bool useCaustics,  // pkg64-gpu Phase 2
+    float clampDirect, float clampIndirect,  // pkg144
     const GTLASNode*  tlas,        // pkg114
     const GInstance*  instances,   // pkg114
     const GBLAS*      blas,        // pkg114
@@ -431,7 +451,7 @@ __device__ GVec3 tracePathGPU(
                 envColor *= 0.2f;
             }
             if (bounce == 0 || wasSpecular)
-                color += throughput * envColor;
+                color += gpu_clampContrib(throughput * envColor, bounce, clampDirect, clampIndirect);
             if (bounce == 0 || wasSpecular)
                 colorSpectral += throughputSpectral *
                     gpu_rgbToSampledSpectrum(envColor, lambdas, GSPEC_RGB_ILLUMINANT);
@@ -444,7 +464,7 @@ __device__ GVec3 tracePathGPU(
         GSampledSpectrum emittedSpectral = gpu_material_emitted_spectral(mat, rec.frontFace, lambdas);
         if (emitted != GVec3(0.f)) {
             if (bounce == 0 || wasSpecular) {
-                color += throughput * emitted;
+                color += gpu_clampContrib(throughput * emitted, bounce, clampDirect, clampIndirect);
                 colorSpectral += throughputSpectral * emittedSpectral;
             }
             break;
@@ -453,10 +473,11 @@ __device__ GVec3 tracePathGPU(
         // NEE direct lighting
         if (!rec.isDelta) {
             GVec3 wo = -ray.direction.normalized();
-            color += throughput * sampleDirectGPU(
+            GVec3 neeContrib = throughput * sampleDirectGPU(
                 rec, wo, tlas, instances, blas, bvhNodes, prims, tris, spheres,
                 materials, lights, numLights, totalLightPower,
                 lightTree, envMap, ray.time, motionVerts, rng);
+            color += gpu_clampContrib(neeContrib, bounce, clampDirect, clampIndirect);
         }
 
         // pkg113 Phase 3: photon-map caustic gather at the FIRST non-emissive hit
@@ -560,7 +581,7 @@ __device__ GVec3 tracePathGPU(
                         float g_ = -0.9689f * xyz.x + 1.8758f * xyz.y + 0.0415f * xyz.z;
                         float b_ =  0.0557f * xyz.x - 0.2040f * xyz.y + 1.0570f * xyz.z;
                         GVec3 smsRGB(r_, g_, b_);
-                        color += throughput * smsRGB;
+                        color += gpu_clampContrib(throughput * smsRGB, bounce, clampDirect, clampIndirect);
                     }
                 }
             }
@@ -640,6 +661,7 @@ __global__ void pathTraceKernel(
     float* framebuffer, int width, int height,
     int samplesPerPixel, int maxDepth,
     bool useCaustics,  // pkg64-gpu Phase 2
+    float clampDirect, float clampIndirect,  // pkg144
     const GTLASNode*  tlas,        // pkg114
     const GInstance*  instances,   // pkg114
     const GBLAS*      blas,        // pkg114
@@ -738,6 +760,7 @@ __global__ void pathTraceKernel(
 
         GVec3 sample = tracePathGPU(
             ray, maxDepth, useCaustics,
+            clampDirect, clampIndirect,  // pkg144
             tlas, instances, blas,  // pkg114
             bvhNodes, prims, tris, spheres,
             materials, lights, numLights, totalLightPower,
@@ -750,10 +773,10 @@ __global__ void pathTraceKernel(
             &localRng,
             pixelCryptoObj, pixelCryptoMat, cryptoDepth, cryptomatteEnabled);
 
-        // Per-sample firefly clamp (matches CPU: lum > 20 → scale down)
-        float lum = luminance(sample);
-        if (lum > 20.f) sample *= (20.f / lum);
-
+        // pkg144: the always-on, whole-path `lum > 20` clamp that used to live
+        // here has been REMOVED — see gpu_clampContrib / tracePathGPU, which
+        // now clamps direct vs indirect contributions independently, per
+        // bounce, mirroring the CPU fix (include/raytracer.h clampContribSpectral).
         color += sample;
     }
 
@@ -778,6 +801,7 @@ void launchPathTraceKernel(
     float* d_framebuffer, int width, int height,
     int samplesPerPixel, int maxDepth,
     bool useCaustics,  // pkg64-gpu Phase 2
+    float clampDirect, float clampIndirect,  // pkg144
     const GTLASNode*  d_tlas, const GInstance* d_instances, const GBLAS* d_blas,  // pkg114
     const GBVHNode*  d_bvhNodes,
     const GPrimitive* d_prims,
@@ -810,6 +834,7 @@ void launchPathTraceKernel(
             (const void*)pathTraceKernel, blocks, threadsPerBlock);
         pathTraceKernel<<<blocks, threadsPerBlock>>>(
             d_framebuffer, width, height, samplesPerPixel, maxDepth, useCaustics,
+            clampDirect, clampIndirect,  // pkg144
             d_tlas, d_instances, d_blas,  // pkg114
             d_bvhNodes, d_prims, d_tris, d_spheres, d_materials,
             d_lights, numLights, totalLightPower,

--- a/tests/test_material_properties.py
+++ b/tests/test_material_properties.py
@@ -363,15 +363,25 @@ def test_glass_less_opaque_than_black():
 # ===========================================================================
 
 @pytest.mark.xfail(
-    reason="pkg144: the always-on sLum>20 direct-light firefly clamp "
-    "(raytracer.h:3005) masks the metallic gold-highlight tint at the test's "
-    "light intensity (25). Runtime intensity-proxy (engage/disengage the clamp "
-    "by scaling the light): rb_metal-rb_diel = 0.211 at intensity 8 (clamp "
-    "inactive -> PASSES) collapses to 0.048 at intensity 25 (clamp active -> "
-    "FAILS). The material tint is correct; pkg123's chi2-correct (dimmer) pdf no "
-    "longer over-brightens the highlight enough to overcome the clamp the way "
-    "main's pdf-inflated highlight did. Fix: pkg144 (Cycles direct/indirect clamp "
-    "split, both default off). Literal patch-rebuild A/B deferred to pkg144.",
+    reason="pkg144 UPDATE (2026-07-23, measured against the built clamp-split "
+    "fix): the always-on sLum>20 clamp this package removed was NOT the actual "
+    "gate here. Empirically (raytracer.h clampContribSpectral wired, "
+    "clampDirect=clampIndirect=0/fully off by default -- the fix this test's "
+    "old xfail reason asked for): rb_metal-rb_diel converges to ~0.03-0.05 "
+    "(seed-stable across 4 reruns and across clamp settings 0/20/1e6 alike, "
+    "and stable from 96 to 2048 spp -- i.e. NOT clamp-driven and NOT MC noise), "
+    "still well under the 0.10 gate. The pkg144 clamp-split fix is real and "
+    "verified working (aggressive clampDirect values visibly dim the render; "
+    "see test_pkg144_firefly_clamp_direct_indirect_split.py), but it is not "
+    "sufficient by itself: pkg123's chi2-correct (dimmer, true-D) Disney "
+    "specular pdf/eval genuinely produces a smaller metallic-vs-dielectric R/B "
+    "gap than this test's threshold assumes -- the same class of post-pkg123 "
+    "Disney specular-magnitude recalibration pkg145 (Disney specular energy "
+    "compensation refit) already exists to address. Un-xfailing this test is "
+    "therefore a Pillar-2 Disney-specular-calibration decision (recalibrate "
+    "the 0.10 threshold with measured evidence, or find/fix a genuine "
+    "metallic-tint-magnitude bug), not a pkg144 (Pillar-3 integrator clamp) "
+    "one -- see pkg144 PR body for the full measurement.",
     strict=False,
 )
 def test_disney_metallic_tints_specular_highlight():
@@ -424,17 +434,22 @@ def test_disney_metallic_tints_specular_highlight():
 
 
 @pytest.mark.xfail(
-    reason="pkg144: the always-on sLum>20 direct-light firefly clamp "
-    "(raytracer.h:3005) masks the roughness gloss response at the test's light "
-    "intensity (15). Runtime intensity-proxy: smooth(r=0.05)/rough(r=0.7) center "
-    "mean ratio = 1.169 at intensity 1 (clamp inactive -> smooth correctly "
-    "glossier/brighter) collapses to 1.068 at intensity 15 (test) and inverts to "
-    "0.990 at 30 (clamp active). The concentrated smooth highlight is exactly what "
-    "the sLum cap suppresses. The material's roughness response is correct; "
-    "pkg123's chi2-correct (dimmer) pdf no longer over-brightens the smooth "
-    "highlight enough to clear the 0.015 mean-gap under the clamp the way main's "
-    "pdf-inflated highlight did. Fix: pkg144 (Cycles direct/indirect clamp split, "
-    "both default off). Literal patch-rebuild A/B deferred to pkg144.",
+    reason="pkg144 UPDATE (2026-07-23, measured against the built clamp-split "
+    "fix): the always-on sLum>20 clamp this package removed was NOT the actual "
+    "gate here. Empirically (clampDirect=clampIndirect=0/fully off by default), "
+    "smooth(r=0.05)/rough(r=0.7) center-mean gap converges to ~0.0087 (stable "
+    "from 64 to 2048 spp -- i.e. a real, converged physical result, not MC "
+    "noise the clamp was suppressing), still under the 0.015 gate. The pkg144 "
+    "clamp-split fix is real and verified working (see "
+    "test_pkg144_firefly_clamp_direct_indirect_split.py), but it is not "
+    "sufficient here: pkg123's chi2-correct (dimmer, true-D) Disney specular "
+    "pdf/eval genuinely produces a smaller smooth-vs-rough gloss gap than this "
+    "test's threshold assumes -- the same class of post-pkg123 Disney "
+    "specular-magnitude recalibration pkg145 (Disney specular energy "
+    "compensation refit) already exists to address. Un-xfailing this test is "
+    "therefore a Pillar-2 Disney-specular-calibration decision, not a pkg144 "
+    "(Pillar-3 integrator clamp) one -- see pkg144 PR body for the full "
+    "measurement.",
     strict=False,
 )
 def test_disney_roughness_changes_glossiness():

--- a/tests/test_pkg144_firefly_clamp_direct_indirect_split.py
+++ b/tests/test_pkg144_firefly_clamp_direct_indirect_split.py
@@ -1,0 +1,193 @@
+"""pkg144 -- firefly clamp direct/indirect split.
+
+The package's reason to exist: the pre-pkg144 code had an always-on,
+unconditional `sLum > 20.0f` cap applied to the WHOLE per-sample path color
+(include/raytracer.h, per-pixel accumulation loop). This capped delta-light
+NEE, which is deterministic (a delta light's `sampleLi` returns emission
+with pdf==1/delta selection, so there is zero variance to suppress --
+clamping it is pure downward bias, not noise control). For a bright delta
+sun this made the measured floor brightness asymptote at ~14-20 across
+S = 1e6...1e9 instead of growing linearly with S (measured, PR #507,
+pkg140 gate-5 investigation).
+
+Fix (this package): remove the hardcoded top-level cap; wire the
+already-stubbed `clampDirect`/`clampIndirect` fields into the integrator,
+applied per-CONTRIBUTION by bounce depth -- mirrors Cycles
+`film_clamp_light` (src/kernel/film/light_passes.h, Apache-2.0):
+    const float limit = (bounce > 0) ? sample_clamp_indirect : sample_clamp_direct;
+`bounce == 0` (camera-visible emission + first-hit direct NEE, INCLUDING
+delta-light NEE) uses clampDirect; `bounce > 0` (indirect) uses
+clampIndirect. limit <= 0 disables (Cycles semantics: user 0 -> no clamp).
+
+Defaults (evidence-first, per spec):
+  - clampDirect  = 0 (off), non-negotiable -- direct/delta NEE must never be
+    silently biased. This is the whole point of the package.
+  - clampIndirect = 0 (off) -- the existing firefly/caustic/furnace test
+    suite (test_disney_energy_conservation.py, test_dielectric_glass_furnace.py,
+    test_disney_rough_glass_furnace.py, test_caustic_validation.py, etc.)
+    was measured to pass with clampIndirect fully disabled, so this package
+    ships full Cycles parity (both clamps off) rather than reintroducing a
+    nonzero indirect cap "just in case".
+
+DESIGN NOTES
+------------
+* Real bindings only (astroray_module fixture / astroray.Renderer()).
+* Seeds pinned nonzero (memory seed-zero-is-random-sentinel).
+* Linear output (apply_gamma=False) so measured values are radiance
+  (memory gamma-vs-linear-comparison-artifact).
+* Metric is per-channel mean-ratio to the analytic Lambertian value, NOT
+  SSIM (memory ssim-wrong-gate-for-independent-rng: independent MC streams
+  at different S values have no reason to correlate pixel-for-pixel; SSIM
+  would be meaningless here. A stable per-channel ratio across three
+  decades of S is exactly the signature of correct linear energy scaling).
+* CPU-only (renderer.render(...) without set_use_gpu(True)); this test does
+  not touch the GPU megakernels (see PR body for the HW-verification gate
+  that mirrors this on GPU).
+"""
+
+import math
+import numpy as np
+import pytest
+
+
+def _luminance(rgb):
+    return 0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2]
+
+
+def _floor_scene(module, seed, half_extent=20.0, width=48, height=48, albedo=0.5):
+    """Large gray Lambertian floor at y=0, camera high above looking straight
+    down, black background. Mirrors test_pkg140_distant_light_zero_angle.py's
+    _floor_scene (same winding / camera convention, already validated)."""
+    r = module.Renderer()
+    r.set_background_color([0.0, 0.0, 0.0])
+    r.set_seed(seed)
+    r.setup_camera(
+        look_from=[0.0, 20.0, 0.01], look_at=[0.0, 0.0, 0.0], vup=[0.0, 0.0, -1.0],
+        vfov=20.0, aspect_ratio=1.0, aperture=0.0, focus_dist=20.0,
+        width=width, height=height,
+    )
+    mat = r.create_material('lambertian', [albedo, albedo, albedo], {})
+    e = half_extent
+    r.add_triangle([-e, 0, -e], [e, 0, -e], [e, 0, e], mat)
+    r.add_triangle([-e, 0, -e], [e, 0, e], [-e, 0, e], mat)
+    return r
+
+
+def _center_rgb(pixels):
+    """Mean linear RGB of the central 8x8 patch."""
+    h, w = pixels.shape[0], pixels.shape[1]
+    cy, cx = h // 2, w // 2
+    patch = pixels[cy - 4:cy + 4, cx - 4:cx + 4, :3]
+    return np.mean(patch, axis=(0, 1))
+
+
+ALBEDO = 0.5
+SUN_S_DECADES = [1.0e6, 1.0e7, 1.0e8]  # >= 3 decades, per spec gate
+
+
+def _sun_floor_rgb(module, S, angular_diameter, seed, samples=128):
+    r = _floor_scene(module, seed, albedo=ALBEDO)
+    r.add_sun_light_dedicated(
+        direction=[0.0, -1.0, 0.0],  # straight down -> cos(theta) = 1 on the floor
+        angular_diameter=angular_diameter,
+        emission={'mode': 'rgb', 'color': [1.0, 1.0, 1.0]},
+        intensity=S,
+    )
+    px = r.render(samples, 3, None, False)
+    return _center_rgb(px)
+
+
+@pytest.mark.parametrize("angular_diameter", [0.0, 0.00918])
+@pytest.mark.parametrize("S", SUN_S_DECADES)
+def test_bright_sun_energy_linearity(astroray_module, S, angular_diameter):
+    """THE gate this package exists for: a delta (or near-delta) sun's
+    reflected radiance off a Lambertian floor must grow linearly with S
+    across >= 3 decades (S = 1e6, 1e7, 1e8), matching the analytic
+    albedo*S/pi per-channel within noise. Pre-pkg144, the always-on
+    sLum>20 cap made this asymptote at ~14-20 regardless of S -- the ratio
+    would collapse toward 0 as S grows. Post-fix the ratio stays ~1 at
+    every S (measured 0.9995 empirically at this scene/sample setup).
+    """
+    rgb = _sun_floor_rgb(astroray_module, S, angular_diameter, seed=14401)
+    analytic = ALBEDO * S / math.pi
+    for ch, name in enumerate('RGB'):
+        ratio = rgb[ch] / analytic
+        assert 0.85 < ratio < 1.15, (
+            f"S={S:.0e} angular_diameter={angular_diameter}: channel {name} "
+            f"measured={rgb[ch]:.6g} analytic={analytic:.6g} ratio={ratio:.4f} "
+            f"-- expected ~1.0 (linear growth with S); a collapse toward 0 "
+            f"here is the pre-pkg144 firefly-clamp bias reappearing"
+        )
+
+
+def test_bright_sun_ratio_stable_across_decades(astroray_module):
+    """Stronger form of the linearity gate: compare the ratio-to-analytic at
+    the smallest and largest swept S directly. Pre-pkg144, S/selPdf converges
+    to a clamp-bounded constant (~14-20) independent of S once the sun is
+    bright enough to trip the cap, so ratio(S=1e8)/ratio(S=1e6) would collapse
+    toward (20/analytic(1e8)) / (20/analytic(1e6)) = analytic(1e6)/analytic(1e8)
+    = 1e-2 -- i.e. a 100x drop. Post-fix this ratio-of-ratios stays ~1.
+    """
+    lo = _luminance(_sun_floor_rgb(astroray_module, 1.0e6, 0.00918, seed=14402))
+    hi = _luminance(_sun_floor_rgb(astroray_module, 1.0e8, 0.00918, seed=14402))
+    analytic_lo = ALBEDO * 1.0e6 / math.pi
+    analytic_hi = ALBEDO * 1.0e8 / math.pi
+    ratio_lo = lo / analytic_lo
+    ratio_hi = hi / analytic_hi
+    rr = ratio_hi / ratio_lo
+    assert 0.7 < rr < 1.43, (
+        f"ratio(S=1e8)/ratio(S=1e6) = {rr:.4f} (expect ~1.0); a collapse "
+        f"here means the direct-light clamp is still active and biasing "
+        f"bright delta-light NEE"
+    )
+
+
+def test_clamp_direct_default_is_off():
+    """clampDirect must default to 0 (disabled) -- non-negotiable per spec:
+    direct/delta NEE must never be silently biased by a default-on clamp."""
+    import astroray
+    r = astroray.Renderer()
+    # No Python getter is exposed for clampDirect/clampIndirect (setters
+    # only, module/blender_module.cpp set_clamp_direct/set_clamp_indirect);
+    # verify behaviourally instead: setting an aggressive clampDirect must
+    # visibly dim a direct-lit render relative to the (default, off) baseline,
+    # proving 0 truly means "no clamp" and the field is wired.
+    r.set_background_color([0.0, 0.0, 0.0])
+    r.set_seed(14403)
+    r.setup_camera(
+        look_from=[0.0, 20.0, 0.01], look_at=[0.0, 0.0, 0.0], vup=[0.0, 0.0, -1.0],
+        vfov=20.0, aspect_ratio=1.0, aperture=0.0, focus_dist=20.0,
+        width=32, height=32,
+    )
+    mat = r.create_material('lambertian', [0.5, 0.5, 0.5], {})
+    r.add_triangle([-20, 0, -20], [20, 0, -20], [20, 0, 20], mat)
+    r.add_triangle([-20, 0, -20], [20, 0, 20], [-20, 0, 20], mat)
+    r.add_sun_light_dedicated(
+        direction=[0.0, -1.0, 0.0], angular_diameter=0.00918,
+        emission={'mode': 'rgb', 'color': [1.0, 1.0, 1.0]}, intensity=1.0e6,
+    )
+    baseline = _luminance(_center_rgb(r.render(64, 3, None, False)))
+
+    r2 = astroray.Renderer()
+    r2.set_clamp_direct(0.01)  # aggressively small -- must dim the render
+    r2.set_background_color([0.0, 0.0, 0.0])
+    r2.set_seed(14403)
+    r2.setup_camera(
+        look_from=[0.0, 20.0, 0.01], look_at=[0.0, 0.0, 0.0], vup=[0.0, 0.0, -1.0],
+        vfov=20.0, aspect_ratio=1.0, aperture=0.0, focus_dist=20.0,
+        width=32, height=32,
+    )
+    mat2 = r2.create_material('lambertian', [0.5, 0.5, 0.5], {})
+    r2.add_triangle([-20, 0, -20], [20, 0, -20], [20, 0, 20], mat2)
+    r2.add_triangle([-20, 0, -20], [20, 0, 20], [-20, 0, 20], mat2)
+    r2.add_sun_light_dedicated(
+        direction=[0.0, -1.0, 0.0], angular_diameter=0.00918,
+        emission={'mode': 'rgb', 'color': [1.0, 1.0, 1.0]}, intensity=1.0e6,
+    )
+    clamped = _luminance(_center_rgb(r2.render(64, 3, None, False)))
+
+    assert clamped < baseline * 0.1, (
+        f"set_clamp_direct(0.01) did not visibly dim the render "
+        f"(clamped={clamped:.4g} vs baseline(off)={baseline:.4g}) -- "
+        f"clampDirect does not appear to be wired into the integrator"
+    )

--- a/tests/test_python_bindings.py
+++ b/tests/test_python_bindings.py
@@ -933,7 +933,6 @@ def test_adaptive_sampling_flag():
     assert_valid_image(px_fixed, H, W, min_mean=0.02, label='fixed')
 
 
-@pytest.mark.xfail(reason="direct/indirect clamp not ported to the spectral path_tracer — deferred", strict=False)
 def test_direct_and_indirect_clamp_controls():
     """Direct/indirect clamp settings should reduce bright outliers when enabled."""
     def luminance_map(pixels: np.ndarray) -> np.ndarray:


### PR DESCRIPTION
## Summary

Spec: `.astroray_plan/packages/pkg144-firefly-clamp-direct-indirect-split.md`

Removes the always-on, unconditional `sLum > 20.0f` cap applied to the
whole per-sample path color (`include/raytracer.h`, per-pixel accumulation
loop). This cap silently biased **delta-light NEE**: a delta light's `sampleLi`
is deterministic (pdf=1/delta selection, zero variance), so clamping it is
pure downward bias, not noise control. For a bright delta sun the measured
brightness asymptoted at ~14-20 across S = 1e6...1e9 instead of growing
linearly (PR #507 finding, pkg140 gate-5 investigation).

Wires the already-stubbed (declared, setter-only, never-read) `clampDirect`/
`clampIndirect` fields into the integrator, applied **per-contribution by
bounce depth**, mirroring Cycles `film_clamp_light`
(`src/kernel/film/light_passes.h`, Apache-2.0):

```
const float limit = (bounce > 0) ? sample_clamp_indirect : sample_clamp_direct;
```

`bounce == 0` (camera-visible emission + first-hit direct NEE, **including
delta-light NEE**) uses `clampDirect`. `bounce > 0` (indirect) uses
`clampIndirect`. `limit <= 0` disables (Cycles semantics: user `0` maps to no clamp).

Research notes + full citation: `.astroray_plan/docs/pkg144-firefly-clamp-research.md`.

### Where it's wired

- **CPU** (default `path_tracer` integrator): `Renderer::pathTraceSpectral`
  and `Renderer::pathTraceSpectralCaustic` (`include/raytracer.h`), via a new
  private helper `clampContribSpectral()` applied at every contribution site
  (env miss, GR emission, material emission, NEE, SMS hook, specular-chain
  caustic connections).
- **GPU** (both PRODUCTION megakernels, confirmed via `cuda_renderer.cu`'s
  actual dispatch -- `launchPathTraceKernel`/`launchMultiwavelengthKernel`,
  never the wavefront stage launchers):
  - `src/gpu/path_trace_kernel.cu` `tracePathGPU` (used for non-`path_tracer`
    integrator names) via new `gpu_clampContrib()`.
  - `src/gpu/multiwavelength_kernel.cu` `tracePathMW` -- **this is what the
    default `path_tracer` integrator actually dispatches to on GPU**
    (`module/blender_module.cpp`'s `integratorName_ == "path_tracer" -> renderMultiwavelength`)
    -- via new `gpu_clampContribMW()`.
  - `clampDirect`/`clampIndirect` threaded host to device exactly like the
    existing `worldMaxBounces` pattern (new `Renderer::getClampDirect()`/
    `getClampIndirect()` getters).

### Deliberately deferred (noted, not silently dropped)

- **pkg55 wavefront SoA dev-harness kernels** (`src/gpu/wavefront/stage_advance.cu`
  `stageRegenKernel`/`stageAccumulateXYZKernel`, `stage_restir.cu`) still carry
  the old whole-path `lum > 20` clamp. These are the parity/dev harness for the
  in-progress wavefront refactor (gated behind `ASTRORAY_WAVEFRONT_INTERSECT`,
  exercised only by `tests/wavefront_diff`'s strict bit-identity gates), **not**
  the production GPU dispatch path -- confirmed empirically (`cuda_renderer.cu`
  never calls the wavefront launchers for normal renders). Restructuring
  them would need to find each contribution-add site across several
  kernel-launch stages and risks the bit-identity gates; left as a follow-up.
- **Secondary finding** (DistantLight vs AreaLight `power()` unit-scale
  mismatch for light selection importance) -- not attempted this round,
  time-boxed to the primary clamp-split fix. Still open per the spec.

## Measured numbers

**The gate this package exists for** -- bright delta sun over a Lambertian
floor, `S = 1e6, 1e7, 1e8` (3 decades), analytic = `albedo * S / pi`:

```
S=1e+06 measured=159073      analytic=159155      ratio=0.9995
S=1e+07 measured=1.59073e+06 analytic=1.59155e+06 ratio=0.9995
S=1e+08 measured=1.59073e+07 analytic=1.59155e+07 ratio=0.9995
```

Pre-fix this asymptoted at ~14-20 regardless of S (per PR #507's finding);
post-fix the ratio is stable to within 0.05% across 3 decades.

**Evidence-first `clampIndirect` default**: ran the full firefly/caustic/
furnace suite (`test_disney_energy_conservation.py`,
`test_dielectric_glass_furnace.py`, `test_disney_rough_glass_furnace.py`,
`test_disney_reflection_not_black.py`, `test_caustic_validation.py`,
`test_pkg140_distant_light_zero_angle.py` -- 290 tests) with
`clampIndirect = 0` (full Cycles parity): **all 290 passed**. Per the spec's
own instruction ("if the tests pass with clampIndirect=0 too, prefer full
Cycles parity"), shipped both clamps off -- no legacy "20" reintroduced.

**Full local suite** (`pytest tests/ --ignore=tests/wavefront_diff`):
`1451 passed, 68 skipped, 25 xfailed, 6 xpassed, 1 failed`. The 1 failure
(`test_pkg55_c5_photon_wavefront.py::test_wavefront_photon_caustic_parity`,
SSIM=-0.0000) is confirmed **pre-existing on unmodified main** (identical
SSIM/peak values measured against `main`'s already-built `.pyd`, unrelated
to this change -- pkg55 wavefront/MW photon-caustic parity gap). The xpasses
are pre-existing/unrelated except one genuinely fixed by this PR (below).

## Un-xfailed tests

- **`test_direct_and_indirect_clamp_controls`** (`tests/test_python_bindings.py`)
  -- marker **removed**. This is literally the pkg144 feature
  ("direct/indirect clamp not ported to the spectral path_tracer"). Verified
  5x reruns, all PASSED (was a flaky XPASS on unmodified main -- the clamp
  fields were dead code there, so the old pass was RNG luck, not real
  behavior; now it's a genuine, wired, reproducible pass).
- New file `tests/test_pkg144_firefly_clamp_direct_indirect_split.py` (8
  tests): the bright-sun energy-linearity gate (parametrized over 3 decades
  x 2 angular diameters), a ratio-of-ratios stability check, and a
  behavioral sanity check that `clampDirect` is actually wired
  (`set_clamp_direct(0.01)` visibly dims a render vs the off default).

### The 2 dispatch-named xfails -- investigated, NOT fixed by this package (flagging clearly, not silently)

`test_disney_metallic_tints_specular_highlight` and
`test_disney_roughness_changes_glossiness` (`tests/test_material_properties.py`)
were quarantined behind xfail in #498 pointing at pkg144. I investigated in
depth (see updated xfail reasons in the diff) and found the firefly clamp is
**empirically not the cause**:

- Metallic-highlight R/B gap: converged **~0.03-0.05** (stable across seeds,
  across clamp settings 0 / 20 / 1e6, and from 96 to 2048 spp) -- well under
  the test's 0.10 gate, and unaffected by the clamp fix (this PR's default
  is already clampDirect=clampIndirect=0, i.e. the "clamp inactive" case the
  xfail's proxy measurement predicted would pass -- it doesn't).
- Roughness/glossiness mean gap: converged **~0.0087** (stable 64 to 2048 spp)
  vs the required 0.015.

Both are real, converged (not noise-driven) results, smaller than the old
xfail reasoning assumed. Root cause is that pkg123's chi2-correct (dimmer,
true-D) Disney specular pdf/eval genuinely produces a smaller
metallic/roughness signal than these thresholds were calibrated against --
the same class of post-pkg123 Disney specular-magnitude recalibration that
**pkg145** (Disney specular energy compensation refit, already open) exists
to address. This is a Pillar-2 materials-calibration decision, not a
Pillar-3 integrator-clamp one, so I did not unilaterally rewrite the
thresholds or touch Disney material code as part of this PR -- I updated
both xfail reasons with the full measured evidence and left the markers in
place, pointing at pkg145's remit. **Flagging this explicitly as the one
dispatch item not resolved**, with the reasoning and numbers for review.

## Acceptance criteria (spec Definition of Done)

- [x] Hardcoded `sLum > 20` cap removed; clampDirect/clampIndirect wired per-bounce
- [x] clampDirect default 0 (off); clampIndirect default 0, evidence-first
- [x] NEW bright-sun energy-linearity gate added and green
- [x] Existing firefly/caustic + furnace + render suites unchanged (build evidence below)
- [x] GPU firefly-cap parity handled for both production megakernels; wavefront dev-harness noted deferred
- [ ] Secondary (distant-vs-area selection importance): deferred, not attempted this round

## Build evidence

`.pyd` mtime (2026-07-23 22:37) newer than all changed C++ sources (22:24-22:30);
`astroray.__file__` resolves to `build_cuda/Release/astroray.cp313-win_amd64.pyd`
in the worktree (verified before every gate run).

Last lines of `cmake --build build_cuda --config Release --target astroray`:

```
  astroray_cuda.vcxproj -> ...\build_cuda\Release\astroray_cuda.lib
  stb_image_write_lib.vcxproj -> ...\build_cuda\Release\stb_image_write_lib.lib
  stb_impl.vcxproj -> ...\build_cuda\Release\stb_impl.lib
  astroray.vcxproj -> ...\build_cuda\Release\astroray.cp313-win_amd64.pyd
```
Exit code 0. All 3 changed `.cu` files (`cuda_renderer.cu`, `path_trace_kernel.cu`,
`multiwavelength_kernel.cu`) compiled clean via nvcc (verified individually in
the build log, no errors/warnings attributable to this change).

## Test plan

- [x] `pytest tests/test_pkg144_firefly_clamp_direct_indirect_split.py -v` -- 8/8 passed
- [x] `pytest tests/test_material_properties.py tests/test_python_bindings.py tests/test_disney_energy_conservation.py tests/test_dielectric_glass_furnace.py tests/test_disney_reflection_not_black.py tests/test_disney_rough_glass_furnace.py tests/test_pkg140_distant_light_zero_angle.py tests/test_caustic_validation.py` -- 390 passed, 16 xfailed, 1 xpassed (pre-existing/unrelated)
- [x] `pytest tests/ --ignore=tests/wavefront_diff` -- 1451 passed, 1 failed (pre-existing on main, confirmed), 68 skipped, 25 xfailed, 6 xpassed
- [x] CPU-only throughout (no `set_use_gpu(True)` calls in the new/modified tests); no GPU renders executed by me during implementation beyond what pytest's default (CPU-only unless `set_use_gpu`) already runs

## HW gate pending (owner / orchestrator to run)

The GPU megakernel changes (`path_trace_kernel.cu`, `multiwavelength_kernel.cu`,
`cuda_renderer.cu`) compile clean but were **not exercised at runtime** by me
(GPU reserved for the orchestrator's serialized verifier; memory
`cuda_verifier_concurrency`). Needs an RTX hardware pass covering:
- Bright-sun scene (this PR's linearity gate) rendered with `set_use_gpu(True)`
  -- should no longer asymptote at ~14-20; should track the CPU ratio (~1.0).
- Firefly reduction on the contact-sheet metal sphere / showcase renders --
  visual check that removing the always-on clamp didn't reintroduce visible
  indirect fireflies (clampIndirect=0 means indirect is now genuinely
  unclamped on GPU too, matching CPU).
- `test_gpu_caustic_parity.py` / GPU caustic validation suite (skipped by me,
  GPU-gated).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
