### PR TITLE
fix(pkg148): default-integrator empty-string fix

### DIFF
--- a/.astroray_plan/packages/pkg148-default-integrator-empty-string.md
+++ b/.astroray_plan/packages/pkg148-default-integrator-empty-string.md
@@ -3,7 +3,13 @@
 **Pillar:** 3 (light transport plumbing / API footgun)
 **Track:** A
 **Codex-paste-ready:** no (small, but the fix choice is a convention decision + needs an RTX-verified render gate)
-**Status:** open — dispatchable (small; may run in the 2026-07-23 overnight if a slot frees — serialize the RTX leg behind the GPU lock)
+**Status:** done (PR #516, 2026-07-24 — Option A: `integratorName_` defaults to
+`"path_tracer"` at construction and at both reset sites (`clear()`,
+`set_integrator("auto"|"default"|"")`); binding-level `get_integrator()`
+added; GPU dedicated-light non-black gate measured locally on RTX 5070 Ti
+(gpu_mean > 0.05, CPU/GPU ratio in [0.9, 1.1]) — official `/verify` RTX sweep
+still pending per protocol, this was opportunistic since the dev box has a
+CUDA build)
 **Estimated effort:** S
 **Depends on:** none
 

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -358,7 +358,15 @@ class PyRenderer {
     std::shared_ptr<EnvironmentMap> envMap;
     bool useGPU = false;
     astroray::ParamDict integratorParams_;
-    std::string integratorName_;
+    // pkg148: default-construct to "path_tracer" instead of empty. This mirrors
+    // Renderer::ensureDefaultIntegrator()'s lazy CPU default (src/default_integrator.cpp),
+    // which silently patches a null CPU integrator_ to "path_tracer" inside
+    // Renderer::render() — a fallback the GPU dispatch below has no equivalent
+    // of. The GPU branch keys directly off integratorName_ (":1745-1766"), so an
+    // empty name fell through to the legacy no-NEE megakernel and rendered
+    // dedicated-light scenes solid black on a fresh Renderer. See
+    // .astroray_plan/packages/pkg148-default-integrator-empty-string.md.
+    std::string integratorName_ = "path_tracer";
     // pkg55-C6b: globally-unique id assigned at each set_integrator call. The
     // GPU ReSTIR driver keys its persistent (double-buffered) reservoir history
     // on this id and RESETS the temporal history when it changes — so a fresh
@@ -2229,8 +2237,16 @@ public:
 
     void setIntegrator(const std::string& name) {
         if (name == "auto" || name == "default" || name.empty()) {
-            renderer.setIntegrator(nullptr);
-            integratorName_.clear();
+            // pkg148: reset to the "path_tracer" default rather than empty —
+            // an empty integratorName_ only fell back correctly on CPU (via
+            // Renderer::ensureDefaultIntegrator()'s lazy default); the GPU
+            // dispatch has no such fallback and silently dropped dedicated-light
+            // NEE. This is itself one of the reset sites the footgun could
+            // reappear through, so it gets the same default as construction.
+            auto integrator = astroray::IntegratorRegistry::instance().create(
+                "path_tracer", integratorParams_);
+            renderer.setIntegrator(integrator);
+            integratorName_ = "path_tracer";
             return;
         }
         auto integrator = astroray::IntegratorRegistry::instance().create(name, integratorParams_);
@@ -2241,6 +2257,13 @@ public:
         // a freed-then-realloc'd renderer address.
         static uint64_t g_restirSessionCounter = 0;
         restirSessionId_ = ++g_restirSessionCounter;
+    }
+
+    // pkg148: expose the currently-selected integrator name so the default
+    // (now "path_tracer" rather than empty) can be pinned by a binding-level
+    // test — see test_pkg148_default_integrator.py.
+    std::string getIntegrator() const {
+        return integratorName_;
     }
 
     py::dict getIntegratorStats() const {
@@ -2496,7 +2519,9 @@ public:
         textureManager = TextureManager();
         envMap.reset();
         useGPU = false;
-        integratorName_.clear();
+        // pkg148: reset to the "path_tracer" default, not empty — see the
+        // construction-site comment above integratorName_'s declaration.
+        integratorName_ = "path_tracer";
         integratorParams_ = astroray::ParamDict();
 #ifdef ASTRORAY_CUDA_ENABLED
         cudaRenderer.reset();
@@ -2856,6 +2881,11 @@ PYBIND11_MODULE(astroray, m) {
              "type"_a, "params"_a, "x"_a, "y"_a, "z"_a,
              "pkg115 debug helper: evaluate texture at explicit (x,y,z) point")
         .def("set_integrator", &PyRenderer::setIntegrator, "name"_a)
+        .def("get_integrator", &PyRenderer::getIntegrator,
+             "pkg148: return the currently-selected integrator name. Defaults "
+             "to 'path_tracer' on a fresh Renderer (and after clear() / "
+             "set_integrator('auto'|'default'|'')) rather than an empty "
+             "string, so the GPU dedicated-light NEE branch is always engaged.")
         .def("get_integrator_stats", &PyRenderer::getIntegratorStats,
              "Return optional diagnostic counters from the active integrator.")
         .def("set_integrator_param", &PyRenderer::setIntegratorParam,

--- a/tests/test_pkg148_default_integrator.py
+++ b/tests/test_pkg148_default_integrator.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python
+"""pkg148 — `integratorName_` no longer default-constructs empty.
+
+Spec: .astroray_plan/packages/pkg148-default-integrator-empty-string.md
+
+Option A (chosen — see PR body for the call-site sweep): default
+`integratorName_` to `"path_tracer"` at construction, mirroring
+`Renderer::ensureDefaultIntegrator()`'s existing lazy CPU default
+(src/default_integrator.cpp), and reset to that same default (not empty)
+at the `clear()` and `set_integrator("auto"|"default"|"")` reset sites
+(module/blender_module.cpp:2233 pre-fix line numbers, :2499).
+
+Before this fix: a fresh `Renderer` + GPU device + a dedicated light,
+rendered without an explicit `set_integrator()` call, was solid black —
+the GPU dispatch keys directly off `integratorName_` and has no
+equivalent of the CPU's lazy `ensureDefaultIntegrator()` fallback. The
+non-black GPU acceptance gate is HW-verifier territory (see the
+HW-pending test at the bottom of this file); the tests here pin the
+plumbing (binding-level default + CPU behavioral parity) that the GPU
+fix depends on.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+
+try:
+    import astroray
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray not built")
+
+WIDTH = HEIGHT = 48
+SPP = 8
+MAX_DEPTH = 4
+SEED = 11
+
+
+def _lit_sphere_scene(r):
+    m = r.create_material("lambertian", [0.6, 0.6, 0.6], {})
+    r.add_sphere([0, 0, 0], 1.0, m)
+    m_light = r.create_material("emissive", [4.0, 4.0, 4.0], {})
+    r.add_sphere([0, 2.2, 0], 0.4, m_light)
+    r.setup_camera(look_from=[0, 0.5, 4.0], look_at=[0, 0, 0], vup=[0, 1, 0],
+                   vfov=40.0, aspect_ratio=1.0, aperture=0.0, focus_dist=4.0,
+                   width=WIDTH, height=HEIGHT)
+    r.set_background_color([0.0, 0.0, 0.0])
+
+
+# ---------------------------------------------------------------------------
+# Binding-level default pin (acceptance criterion 2).
+# ---------------------------------------------------------------------------
+
+def test_fresh_renderer_default_integrator_is_path_tracer():
+    """A brand-new Renderer must report 'path_tracer' as its integrator name,
+    not empty — the C++-level default this whole package is about."""
+    r = astroray.Renderer()
+    assert r.get_integrator() == "path_tracer"
+
+
+def test_clear_resets_integrator_to_path_tracer_not_empty():
+    """clear() must reset to the same default as construction (spec's
+    :2499 reset site) — otherwise the footgun returns after a scene reset."""
+    r = astroray.Renderer()
+    r.set_integrator("ambient_occlusion")
+    assert r.get_integrator() == "ambient_occlusion"
+    r.clear()
+    assert r.get_integrator() == "path_tracer"
+
+
+@pytest.mark.parametrize("alias", ["auto", "default", ""])
+def test_auto_default_empty_aliases_reset_to_path_tracer_not_empty(alias):
+    """set_integrator('auto'|'default'|'') must reset to 'path_tracer', not
+    empty (spec's :2233 reset site) — this sentinel is itself a way the
+    empty-name footgun could reappear post-reset."""
+    r = astroray.Renderer()
+    r.set_integrator("ambient_occlusion")
+    r.set_integrator(alias)
+    assert r.get_integrator() == "path_tracer"
+
+
+# ---------------------------------------------------------------------------
+# CPU behavioral parity (acceptance criterion 1's CPU half).
+# ---------------------------------------------------------------------------
+
+def test_cpu_default_construction_matches_explicit_path_tracer():
+    """A default-constructed Renderer (no set_integrator call) must render
+    identically to one with set_integrator('path_tracer') explicitly set,
+    at a fixed seed. This is the CPU-side half of the CPU==GPU parity
+    acceptance gate; the GPU half is HW-verifier territory (see below)."""
+    r_default = astroray.Renderer()
+    _lit_sphere_scene(r_default)
+    r_default.set_seed(SEED)
+    pixels_default = np.asarray(
+        r_default.render(SPP, MAX_DEPTH, None, False), dtype=np.float32)
+
+    r_explicit = astroray.Renderer()
+    _lit_sphere_scene(r_explicit)
+    r_explicit.set_integrator("path_tracer")
+    r_explicit.set_seed(SEED)
+    pixels_explicit = np.asarray(
+        r_explicit.render(SPP, MAX_DEPTH, None, False), dtype=np.float32)
+
+    assert not np.any(np.isnan(pixels_default))
+    assert float(pixels_default.mean()) > 0.001, \
+        "default-constructed CPU render is unexpectedly dark/black"
+    np.testing.assert_allclose(
+        pixels_default, pixels_explicit, rtol=0.0, atol=1e-6,
+        err_msg="default-constructed Renderer must match explicit "
+                "set_integrator('path_tracer') bit-for-bit at a fixed seed")
+
+
+# ---------------------------------------------------------------------------
+# GPU acceptance gate — HW-PENDING. CI has no NVIDIA GPU (memory
+# ci_has_no_gpu_runtime_blindspot); this module-level-skips on CUDA-less
+# builds and the implementer does not run it. /verify runs it on the RTX box.
+# ---------------------------------------------------------------------------
+
+if AVAILABLE and not astroray.__features__.get("cuda", False):
+    pytest.skip("CUDA feature not in this build — pkg148 GPU gate needs "
+                "CUDA; /verify runs this on the RTX box.",
+                allow_module_level=True)
+
+
+def _gpu_available() -> bool:
+    return astroray.Renderer().gpu_available
+
+
+def test_gpu_dedicated_light_nonblack_at_default_construction():
+    """HW-PENDING (RTX-verified, not run here): a fresh Renderer + GPU +
+    a dedicated AREA light, rendered WITHOUT an explicit set_integrator()
+    call, must be non-black and match the CPU render of the same
+    default-constructed scene (mean-ratio parity) — mirrors
+    tests/test_pkg89_gpu_dedicated_lights.py, but omits the explicit
+    set_integrator('path_tracer') call that test relies on, since that is
+    exactly the footgun this package closes."""
+    if not _gpu_available():
+        pytest.skip("no GPU on this machine")
+
+    def _build():
+        r = astroray.Renderer()
+        m = r.create_material('lambertian', [0.5, 0.5, 0.5], {})
+        r.add_triangle([-50, 0, -50], [50, 0, -50], [50, 0, 50], m)
+        r.add_triangle([-50, 0, -50], [50, 0, 50], [-50, 0, 50], m)
+        r.setup_camera(look_from=[0, 3.0, 0.0001], look_at=[0, 0, 0],
+                       vup=[0, 0, -1], vfov=30.0, aspect_ratio=1.0,
+                       aperture=0.0, focus_dist=3.0, width=64, height=64)
+        r.set_background_color([0.0, 0.0, 0.0])
+        r.add_area_light_dedicated([0, 3, 0], [1, 0, 0], [0, 0, 1], 3.0, 3.0,
+                                   'RECTANGLE', {'mode': 'rgb', 'color': [1, 1, 1]},
+                                   300.0, 1.57)
+        return r
+
+    r_gpu = _build()
+    r_gpu.set_use_gpu(True)
+    r_gpu.set_seed(7)
+    gpu_pixels = np.asarray(r_gpu.render(128, 3, None, False))
+
+    r_cpu = _build()
+    r_cpu.set_use_gpu(False)
+    r_cpu.set_seed(7)
+    cpu_pixels = np.asarray(r_cpu.render(128, 3, None, False))
+
+    assert np.all(np.isfinite(gpu_pixels))
+    gpu_mean = float(gpu_pixels.mean())
+    cpu_mean = float(cpu_pixels.mean())
+    assert gpu_mean > 0.05, \
+        f"GPU still dark at default construction (mean={gpu_mean:.5f})"
+    ratio = gpu_mean / max(cpu_mean, 1e-9)
+    assert 0.9 <= ratio <= 1.1, \
+        f"GPU/CPU mean-ratio {ratio:.3f} outside [0.9,1.1] " \
+        f"(gpu={gpu_mean:.4f} cpu={cpu_mean:.4f})"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_pkg89_gpu_dedicated_lights.py
+++ b/tests/test_pkg89_gpu_dedicated_lights.py
@@ -65,8 +65,10 @@ def _render(r, use_gpu):
     # path_tracer is the production route the Blender addon uses by default
     # (_effective_integrator_name -> "path_tracer"); on GPU it dispatches to the
     # spectral multiwavelength megakernel — the kernel wired for dedicated lights.
-    # An unset integrator falls through to the legacy RGB megakernel, which does
-    # NOT sample dedicated lights and is not the addon's production route.
+    # Set explicitly here for clarity; pkg148 made an unset integrator default
+    # to "path_tracer" too (previously it fell through to the legacy no-NEE
+    # megakernel and rendered dedicated-light scenes black — see
+    # test_pkg148_default_integrator.py).
     r.set_integrator("path_tracer")
     r.set_use_gpu(use_gpu)
     r.set_seed(SEED)

--- a/tests/test_spectral_path_tracer.py
+++ b/tests/test_spectral_path_tracer.py
@@ -107,8 +107,10 @@ def test_explicit_path_tracer_renders_cornell():
     """set_integrator('path_tracer') must produce a valid non-black Cornell render.
 
     Since pkg14, 'path_tracer' is the canonical (and only) full-spectrum
-    integrator.  A Renderer with no set_integrator() produces all-black output;
-    callers must set it explicitly (or use base_helpers.create_renderer()).
+    integrator. This test still sets it explicitly for clarity, but a
+    Renderer with no set_integrator() call also defaults to 'path_tracer'
+    (see tests/test_pkg148_default_integrator.py) — pkg148 fixed the prior
+    empty-name default that silently broke GPU dedicated-light NEE.
     """
     r = astroray.Renderer()
     create_cornell_box(r)


### PR DESCRIPTION
## Spec

`.astroray_plan/packages/pkg148-default-integrator-empty-string.md`

## Bug

`PyRenderer::integratorName_` (module/blender_module.cpp) default-constructed
empty. The GPU render dispatch keys directly off `integratorName_` to decide
whether to route through the spectral megakernel with dedicated-light NEE
(`enableNEE = (integratorName_ == "path_tracer")`, `:1745-1766` pre-fix line
numbers). An empty name fell through to the legacy no-NEE megakernel, so a
fresh `Renderer` + GPU device + a dedicated light (e.g. AREA lamp), rendered
without an explicit `set_integrator()` call, was solid black.

The CPU path never hit this because `Renderer::render()` calls
`Renderer::ensureDefaultIntegrator()` (`src/default_integrator.cpp`), which
lazily patches a null CPU `integrator_` to `"path_tracer"` -- a fallback the
GPU dispatch has no equivalent of. So CPU and GPU disagreed on a
default-constructed renderer (the parity trap the spec calls out).

## Option chosen: A -- default to "path_tracer"

Call-site sweep before choosing (spec asks for this explicitly):

- `blender_addon/__init__.py` / `exporter.py`: always resolves a concrete
  integrator name via `_effective_integrator_name(settings)` before calling
  `renderer.set_integrator(...)` (pkg80 non-goal: "There is no 'auto'
  plugin and there shouldn't be one -- the addon owns this UX choice"). The
  addon never depends on the empty-name legacy branch.
- `apps/main.cpp` (CLI) uses `Renderer` directly, not `PyRenderer` -- untouched
  by this fix.
- Only one test (`tests/test_integrator_plugin.py::test_auto_integrator_alias_resets_to_default_policy`)
  exercises the raw C++-level `set_integrator("auto")` sentinel, and it
  already asserts a non-black render -- i.e. it already expected the
  "auto" reset to behave like a real default, not a black-render fallback.

No caller anywhere relies on the empty-name legacy megakernel branch being
reachable from a default-constructed or reset `PyRenderer`. Option B (fail
loudly) would have broken the addon's implicit reliance on "some sensible
default renders" at first camera setup and added a footgun surface with no
offsetting benefit, since nothing needs the empty sentinel. Went with A.

### Changes (module/blender_module.cpp)

1. `std::string integratorName_;` -> `std::string integratorName_ = "path_tracer";`
   (mirrors the CPU's existing lazy default).
2. `setIntegrator("auto"|"default"|"")` now eagerly constructs `"path_tracer"`
   (via `integratorParams_`) and sets `integratorName_ = "path_tracer"`,
   instead of `renderer.setIntegrator(nullptr); integratorName_.clear();`.
   This sentinel is itself a reset site the spec calls out -- it must not
   reintroduce the empty name.
3. `clear()`: `integratorName_.clear()` -> `integratorName_ = "path_tracer"`.
4. Added `get_integrator()` / `.def("get_integrator", ...)` binding so the
   default can be pinned at the binding level (didn't exist before).

`"path_tracer"` is registered unconditionally
(`ASTRORAY_REGISTER_INTEGRATOR("path_tracer", SpectralPathTracer)`,
`plugins/integrators/spectral_path_tracer.cpp:630`, no `#ifdef` guard), so
this default is safe in every build configuration.

## Tests

New: `tests/test_pkg148_default_integrator.py`
- `test_fresh_renderer_default_integrator_is_path_tracer` -- binding-level pin.
- `test_clear_resets_integrator_to_path_tracer_not_empty` -- `:2499` reset site.
- `test_auto_default_empty_aliases_reset_to_path_tracer_not_empty[auto|default|""]` -- `:2233` reset site.
- `test_cpu_default_construction_matches_explicit_path_tracer` -- CPU parity:
  default-constructed render is bit-identical (rtol=0, atol=1e-6) to explicit
  `set_integrator("path_tracer")` at a fixed seed, and not black (mean > 0.001).
- `test_gpu_dedicated_light_nonblack_at_default_construction` -- HW-PENDING by
  protocol (module-skips when `astroray.__features__["cuda"]` is false; on a
  CUDA build it also skips if no GPU present). However this dev box has a
  CUDA build + RTX 5070 Ti, so it executed opportunistically as a side effect
  of running the new test file -- it is NOT a substitute for the official
  `/verify` RTX gate, flagging per protocol anyway. Measured locally:
  gpu_mean > 0.05 (non-black; pre-fix would have been ~0), GPU/CPU
  mean-ratio in [0.9, 1.1] -- see "Measured numbers" below.

Updated stale comments (no behavior asserted, just descriptive text that was
now factually wrong) in `tests/test_spectral_path_tracer.py` and
`tests/test_pkg89_gpu_dedicated_lights.py` -- both previously said "an unset
integrator renders black / falls to the legacy megakernel," which pkg148
fixes. Neither test's assertions changed; both already passed before and
after (they set `path_tracer` explicitly).

## Measured numbers

Local build machine (RTX 5070 Ti, CUDA build) -- ran opportunistically, not as
the official gate:

- `test_gpu_dedicated_light_nonblack_at_default_construction`: PASSED.
  gpu_mean > 0.05 (non-black; pre-fix this scene rendered exactly 0 via the
  legacy megakernel's `numLights==0` dedicated-light gap), GPU/CPU mean-ratio
  in [0.9, 1.1].
- Full new test file: 7 passed in 21.80s.
- Targeted integrator suite (`test_pkg148_default_integrator.py`,
  `test_integrator_plugin.py`, `test_integrator_capabilities.py`,
  `test_pkg89_gpu_dedicated_lights.py`, `test_spectral_path_tracer.py`,
  `test_pkg91_integrator_param_lifecycle.py`,
  `test_pkg64_phase3_default_integrator.py`,
  `test_pkg64_gpu_phase3_default_integrator.py`,
  `test_integrator_float_param.py`): 32 passed, 1 skipped, 1 xfailed
  (the xfail is pre-existing, unrelated to this change --
  `test_pkg64_gpu_phase3_prism_psnr_floor`).
- Full suite (`pytest tests/ --ignore=wavefront_diff`, excluded per protocol):
  8 failed, 1452 passed, 68 skipped, 25 xfailed, 5 xpassed in 316.98s.
  All 8 failures are pre-existing and unrelated to this diff:
  - 5x `ModuleNotFoundError: No module named 'astroray_test_helpers'`
    (`test_pkg92_wavefront_rng.py`, `test_pkg92_practrand_gate.py`) -- a
    separate CMake target (`astroray_test_helpers`) this build didn't
    compile (only `--target astroray` was built per the build wrapper).
  - 1x `FileNotFoundError` in `test_kerr_validation.py` for a missing
    `scripts/generate_gyoto_references.py` -- unrelated repo/script gap.
  - 1x `test_wavefront_photon_caustic_parity` SSIM gate -- both legs
    explicitly `set_integrator("wavefront_path_tracer")`; unrelated to
    default-integrator naming.
  Confirmed none of the 8 touch integrator naming/defaulting.

## Build log (last lines)

```
     Creating library C:/Users/hgcom/OneDrive/Astroray/Astroray_repo/Astroray-pkg148/build_cuda/Release/astroray.lib and object ...astroray.exp
  Generating code
  Finished generating code
  astroray.vcxproj -> C:\Users\hgcom\OneDrive\Astroray\Astroray_repo\Astroray-pkg148\build_cuda\Release\astroray.cp313-win_amd64.pyd
Build succeeded
```

## Acceptance criteria (spec)

- [x] GPU dedicated-light scene renders non-black at default construction,
      per-channel mean well above black floor -- RTX-verified opportunistically
      on this box (see above); official `/verify` RTX sweep still pending per
      protocol (implementer must not self-certify the HW gate).
- [x] CPU==GPU parity on the same default-constructed scene within the usual
      band (ratio 0.9-1.1, matches the existing `test_pkg89_gpu_dedicated_lights.py` gate).
- [x] Binding-level test pinning the default (`get_integrator()` == `"path_tracer"`).
- [x] Existing integrator-selection tests (`test_integrator_capabilities.py`,
      `test_integrator_plugin.py`) unchanged and green.

## Non-goals (respected)

No integrator behavior changes beyond the default/failure-mode plumbing -- no
change to any integrator's sampling, GPU kernel dispatch logic, or MIS/NEE
math.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
