### PR TITLE
fix(pkg147): OpenMP-enabled .pyd deadlocks Blender CPU addon renders

### DIFF
--- a/.astroray_plan/packages/pkg147-addon-cpu-render-hang.md
+++ b/.astroray_plan/packages/pkg147-addon-cpu-render-hang.md
@@ -3,7 +3,13 @@
 **Pillar:** 5 (Blender addon reliability)
 **Track:** A
 **Codex-paste-ready:** no (Blender-in-the-loop debugging; needs headless Blender 5.1 + build access)
-**Status:** open — dispatchable. **2026-07-24 re-assessment (architect): overnight-SAFE with guardrails — scheduled as Lane C of the 2026-07-24 overnight run.** The 2026-07-23 "not overnight" call assumed interactive debugging; in practice headless Blender 5.1 is local (memory `blender-5-1-installed-locally`) and the hang IS the observable — every diagnostic is a scriptable pass/timeout. **Mandatory guardrails:** (1) every Blender invocation runs as a subprocess with a hard external timeout (≤120 s per render attempt) and is killed on expiry — never render in the agent's own process, never wait on a hung Blender; (2) first diagnostic is the cheap one: which `.pyd` did the failing repro load (`astroray.__file__`) and was it OpenMP-enabled (the `mingw_openmp_blender_deadlock` / pkg115-generalized MSVC-vcomp precedent — **any addon-use build needs `-DASTRORAY_DISABLE_OPENMP=ON`**); (3) if the OpenMP-free addon build still hangs, bisect the glue per the Suspected-layer list, each probe timeout-bounded; (4) time-box the package to ~3 h — if no root cause by then, write up the bisection state and stop. Files are fully disjoint from Lanes A/B (`blender_addon/`, build scripts/flags).
+**Status:** done (PR #TBD, 2026-07-25 — root cause confirmed as the suspected OpenMP/GIL precedent; structural guard added; 32px and 256px CPU addon renders both 0.01-0.05s on the currently-deployed build, which was already unaffected). See "Findings (2026-07-25)" below.
+
+<details><summary>Original 2026-07-24 dispatch note</summary>
+
+open — dispatchable. **2026-07-24 re-assessment (architect): overnight-SAFE with guardrails — scheduled as Lane C of the 2026-07-24 overnight run.** The 2026-07-23 "not overnight" call assumed interactive debugging; in practice headless Blender 5.1 is local (memory `blender-5-1-installed-locally`) and the hang IS the observable — every diagnostic is a scriptable pass/timeout. **Mandatory guardrails:** (1) every Blender invocation runs as a subprocess with a hard external timeout (≤120 s per render attempt) and is killed on expiry — never render in the agent's own process, never wait on a hung Blender; (2) first diagnostic is the cheap one: which `.pyd` did the failing repro load (`astroray.__file__`) and was it OpenMP-enabled (the `mingw_openmp_blender_deadlock` / pkg115-generalized MSVC-vcomp precedent — **any addon-use build needs `-DASTRORAY_DISABLE_OPENMP=ON`**); (3) if the OpenMP-free addon build still hangs, bisect the glue per the Suspected-layer list, each probe timeout-bounded; (4) time-box the package to ~3 h — if no root cause by then, write up the bisection state and stop. Files are fully disjoint from Lanes A/B (`blender_addon/`, build scripts/flags).
+
+</details>
 **Estimated effort:** S–M (diagnosis-first; the fix is likely a build/threading flag or a glue-loop bug, not new features)
 **Depends on:** none
 
@@ -53,3 +59,75 @@ thread-count or tiling boundary (e.g. work splitting kicks in above one tile).
 
 - No CPU-path performance work beyond un-hanging it.
 - Does not block pkg146 — its oracle runs GPU.
+
+## Findings (2026-07-25)
+
+**Root cause confirmed: hypothesis (a), the OpenMP/GIL precedent, generalized
+to BOTH MinGW (libgomp) and MSVC (vcomp).**
+
+1. **The currently-deployed addon `.pyd`** (`.../extensions/user_default/astroray`,
+   build-ID `5503ee2+20260612T143020Z`, tcnn/CUDA backend) is **already
+   OpenMP-disabled** (`build_report.json` cmake_flags includes
+   `-DASTRORAY_DISABLE_OPENMP=ON` — `build_blender_addon.py`'s `common_opts`
+   applies this flag unconditionally for every backend). Measured directly in
+   headless Blender 5.1, `device_mode='cpu'`: 16×16 = 0.042s, 32×32 = 0.010s,
+   256×256 = 0.053s. **No hang on the deployed build, at any size tested.**
+2. **Mechanism, isolated Blender-independently**: `PyRenderer::render()`
+   (`module/blender_module.cpp:1655`) does not release the GIL for the
+   duration of the call. Its progress-callback lambda does
+   `py::gil_scoped_acquire acquire; progressCallback(progress);`
+   (`blender_module.cpp:1796-1800`), and `Renderer::render()`
+   (`include/raytracer.h:2975` `#pragma omp parallel for schedule(dynamic)
+   collapse(2)`, tileSize=16) calls `progress(...)` at
+   `raytracer.h:3167` from **whichever OpenMP worker thread finishes a tile**
+   — not necessarily the thread that called `render()` and holds the GIL.
+   When OpenMP is compiled in, a worker thread's `gil_scoped_acquire`
+   deadlocks against the calling thread, which is blocked in the implicit
+   end-of-parallel-region barrier while still holding the GIL. Reproduced in
+   plain Python (no Blender at all) against a from-scratch OpenMP-enabled
+   CPU-only build: hangs with a progress callback (even at 16×16 — the
+   16px-safe boundary from the original repro is a race, not a guarantee:
+   whichever thread the OpenMP runtime schedules the lone tile onto), renders
+   instantly (0.13s @ 32×32) with `progress_callback=None` (matches "direct
+   Python bindings ... complete instantly" in the pkg146 repro, since those
+   never pass a callback).
+3. **The routine dev/CUDA build path (`configure_and_build.bat`,
+   `build_cuda_worktree.bat`) also compiles with OpenMP enabled by default**
+   (`ASTRORAY_DISABLE_OPENMP` defaults `OFF`) — confirmed by objdump: the
+   `astroray.cp313-win_amd64.pyd` built via this repo's own
+   `build_cuda_worktree.bat` links `VCOMP140.DLL`. If that `.pyd` is ever
+   dropped into the Blender addon directory (a very plausible mistake — this
+   is almost certainly what the pkg146 repro's `.pyd` was), it reproduces the
+   hang exactly. This is the most likely explanation for how pkg146 hit it in
+   the first place.
+4. **A latent gap discovered and fixed while building the guard:**
+   `OpenMP_CXX_FOUND` (CMakeLists.txt) is only ever set via
+   `find_package(OpenMP)` in the GNU/Clang branch; the MSVC branch adds
+   `/openmp` directly without touching that variable. A first draft of the
+   feature-detection compile-definition, gated on `OpenMP_CXX_FOUND`, silently
+   misreported `openmp: False` for the MSVC/CUDA build that actually links
+   `VCOMP140.DLL`. Fixed by gating on `ASTRORAY_DISABLE_OPENMP` directly (the
+   one option both compiler branches gate their real `/openmp`/`-fopenmp` on).
+
+**Fix shipped:**
+- `CMakeLists.txt`: the `astroray` pybind target now gets
+  `-DASTRORAY_OPENMP_ENABLED` compiled in whenever `ASTRORAY_DISABLE_OPENMP`
+  is not set.
+- `module/blender_module.cpp`: `__features__["openmp"]` surfaces that flag to
+  Python.
+- `blender_addon/__init__.py`: `_check_openmp_disabled()`, called from
+  `configure_backend()` at every point CPU mode is actually selected
+  (explicit `device_mode='cpu'`, or an auto/gpu→cpu fallback) — **not** from
+  `register()`, which would also block legitimate GPU-only use of the same
+  ad-hoc build (this over-broad version regressed
+  `test_blender_parity_matrix_generation`, a pre-existing GPU-mode test, and
+  was corrected before merge). Raises a loud `RuntimeError` naming the fix
+  (`build_blender_addon.py`) before any render is attempted, making the guard
+  structural rather than tribal knowledge, per the acceptance gate.
+
+**Acceptance gate: met.** 32×32 and 256×256 CPU addon renders complete in
+under a second on the deployed build; GPU addon path and direct-bindings CPU
+path unchanged (full regression suite green apart from 7 pre-existing,
+unrelated failures — see PR for detail); the OpenMP guard is now structural
+(compile-time flag → runtime feature dict → addon refusal) and covers both
+MinGW and MSVC.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -631,6 +631,27 @@ if(BUILD_PYTHON_MODULE)
         target_link_libraries(astroray PRIVATE OpenMP::OpenMP_CXX)
     endif()
 
+    # pkg147: surface OpenMP-enabled status to Python via __features__ so
+    # blender_addon's _check_build_integrity() can refuse to register an
+    # OpenMP-enabled .pyd — Renderer::render()'s progress callback (called
+    # from whichever OpenMP worker thread finishes a tile, raytracer.h's
+    # `#pragma omp parallel for` render loop) deadlocks against the GIL held
+    # by the calling thread for the whole render() call (no
+    # gil_scoped_release on PyRenderer::render in module/blender_module.cpp).
+    # Gated on ASTRORAY_DISABLE_OPENMP directly (not OpenMP_CXX_FOUND): that
+    # variable is only ever set via find_package(OpenMP) in the GNU/Clang
+    # branch above — the MSVC branch adds /openmp without touching it, so
+    # OpenMP_CXX_FOUND is always false for MSVC even when /openmp (and
+    # VCOMP140.DLL) are actually linked in. ASTRORAY_DISABLE_OPENMP is the
+    # single option both compiler branches gate their real /openmp / -fopenmp
+    # application on, so it's the correct compiler-agnostic predicate here.
+    # build_blender_addon.py always passes -DASTRORAY_DISABLE_OPENMP=ON so the
+    # shipped addon never hits this; this guards ad-hoc/dev builds (e.g. a raw
+    # cmake configure or configure_and_build.bat run) that bypass that script.
+    if(NOT ASTRORAY_DISABLE_OPENMP)
+        target_compile_definitions(astroray PRIVATE ASTRORAY_OPENMP_ENABLED)
+    endif()
+
     if(ASTRORAY_OIDN_FOUND)
         target_link_libraries(astroray PRIVATE ${ASTRORAY_OIDN_TARGET})
         target_compile_definitions(astroray PRIVATE ASTRORAY_OIDN_ENABLED)

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -1049,7 +1049,8 @@ class CustomRaytracerRenderEngine(RenderEngine):
             integrator_name = _effective_integrator_name(settings)
             try:
                 active_device = _configure_backend_for_context(renderer, settings, self.report, integrator_name)
-            except RuntimeError:
+            except RuntimeError as exc:
+                self.report({'ERROR'}, str(exc))
                 return
             if active_device == "gpu":
                 try:

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -504,6 +504,11 @@ def configure_backend(renderer, settings, reporter=None, integrator_name=None) -
     """
     mode = getattr(settings, "device_mode", "auto")
     if mode == "cpu":
+        # pkg147: an OpenMP-enabled .pyd deadlocks CPU renders >16px; refuse
+        # right at the point CPU mode is actually selected (not at register()
+        # time, which would also block legitimate GPU-only use of the same
+        # ad-hoc build).
+        _check_openmp_disabled()
         return "cpu"
 
     selected_integrator = integrator_name or _effective_integrator_name(settings)
@@ -518,6 +523,7 @@ def configure_backend(renderer, settings, reporter=None, integrator_name=None) -
             _report_backend(reporter, 'ERROR', message)
             raise RuntimeError(message)
         _report_backend(reporter, 'INFO', message + "; using CPU")
+        _check_openmp_disabled()  # pkg147
         return "cpu"
 
     try:
@@ -540,6 +546,7 @@ def configure_backend(renderer, settings, reporter=None, integrator_name=None) -
                 _report_backend(reporter, 'ERROR', message)
                 raise RuntimeError(message) from exc
             _report_backend(reporter, 'INFO', f"Astroray: GPU initialization failed ({exc}); using CPU")
+    _check_openmp_disabled()  # pkg147
     return "cpu"
 
 
@@ -5097,6 +5104,49 @@ def _check_build_integrity():
             f"  Loaded module build-ID:    {loaded_build_id}\n"
             f"  Installed manifest build-ID: {manifest_build_id}\n\n"
             f"Quit Blender completely, then restart it to pick up the new module.\n"
+            f"{'='*70}\n"
+        )
+
+
+def _check_openmp_disabled():
+    """pkg147: refuse to render CPU with an OpenMP-enabled .pyd.
+
+    render()'s progress callback is invoked from whichever OpenMP worker
+    thread finishes a tile (raytracer.h's `#pragma omp parallel for` render
+    loop), and PyRenderer::render() (module/blender_module.cpp) holds the GIL
+    for the whole call. A worker thread's gil_scoped_acquire deadlocks
+    against the calling thread, which is blocked in the implicit end-of-
+    parallel-region barrier while still holding the GIL — this hangs any CPU
+    addon render with 2+ tiles (device_mode='cpu' at >16px, tileSize=16).
+
+    Called from configure_backend() at every point CPU mode is actually
+    selected (explicit device_mode='cpu', or an auto/gpu fallback to CPU) —
+    NOT from register(), so an OpenMP-enabled dev build can still register
+    and render on GPU without being blocked; only the CPU path it would
+    actually deadlock is refused.
+
+    build_blender_addon.py always passes -DASTRORAY_DISABLE_OPENMP=ON, so a
+    properly-packaged addon build never hits this. This guard catches ad-hoc
+    dev builds (e.g. a raw `cmake --build` or configure_and_build.bat run)
+    that get dropped into the addon directory without going through the
+    packaging script.
+    """
+    if not RAYTRACER_AVAILABLE:
+        return
+    if bool(astroray.__features__.get("openmp", False)):
+        raise RuntimeError(
+            f"\n{'='*70}\n"
+            f"ASTRORAY REFUSING CPU RENDER — OpenMP-enabled build\n"
+            f"{'='*70}\n"
+            f"This astroray.pyd was compiled WITH OpenMP linked in. Rendering\n"
+            f"with device_mode='cpu' at more than one tile (>16px) will hang\n"
+            f"indefinitely: the render() progress callback is invoked from an\n"
+            f"OpenMP worker thread and deadlocks against the GIL held by the\n"
+            f"calling thread for the duration of the call.\n\n"
+            f"Rebuild via scripts/build/build_blender_addon.py, which always\n"
+            f"passes -DASTRORAY_DISABLE_OPENMP=ON for addon builds. Do not\n"
+            f"install a .pyd built via a raw cmake/configure_and_build.bat\n"
+            f"invocation into the Blender addon directory.\n"
             f"{'='*70}\n"
         )
 

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -4419,9 +4419,18 @@ PYBIND11_MODULE(astroray, m) {
         "cuda"_a=false,
 #endif
 #ifdef ASTRORAY_WAVEFRONT_CUDA_N3
-        "wavefront_cuda"_a=true
+        "wavefront_cuda"_a=true,
 #else
-        "wavefront_cuda"_a=false
+        "wavefront_cuda"_a=false,
+#endif
+        // pkg147: whether this .pyd was compiled with OpenMP linked in.
+        // blender_addon's _check_build_integrity() refuses to register when
+        // true — see CMakeLists.txt's ASTRORAY_OPENMP_ENABLED comment for the
+        // GIL-deadlock mechanism this guards against.
+#ifdef ASTRORAY_OPENMP_ENABLED
+        "openmp"_a=true
+#else
+        "openmp"_a=false
 #endif
     );
 

--- a/tests/test_pkg147_openmp_guard.py
+++ b/tests/test_pkg147_openmp_guard.py
@@ -1,0 +1,177 @@
+"""pkg147: OpenMP-enabled-build guard tests.
+
+Verifies blender_addon._check_openmp_disabled() — the structural guard added
+to fix the addon CPU-render hang (device_mode='cpu', >16px): an OpenMP-
+enabled .pyd's render() progress callback is invoked from whichever OpenMP
+worker thread finishes a tile (raytracer.h's `#pragma omp parallel for`
+render loop) and deadlocks against the GIL held by the calling thread for
+the whole render() call. build_blender_addon.py always passes
+-DASTRORAY_DISABLE_OPENMP=ON, so this only guards ad-hoc/dev builds
+(e.g. a raw cmake or configure_and_build.bat run) that get dropped into the
+addon directory without going through the packaging script.
+"""
+
+import sys
+import types
+from unittest.mock import patch
+
+import pytest
+
+
+def _make_stub_bpy():
+    """Build minimal stub bpy module for testing blender_addon without real Blender."""
+    bpy_module = types.ModuleType("bpy")
+    bpy_types_module = types.ModuleType("bpy.types")
+    bpy_props_module = types.ModuleType("bpy.props")
+    bpy_utils_module = types.ModuleType("bpy.utils")
+
+    class _Base:
+        pass
+
+    bpy_types_module.Panel = _Base
+    bpy_types_module.Operator = _Base
+    bpy_types_module.AddonPreferences = _Base
+    bpy_types_module.PropertyGroup = _Base
+    bpy_types_module.RenderEngine = _Base
+    bpy_types_module.Material = _Base
+    bpy_types_module.Scene = _Base
+    bpy_types_module.Object = _Base
+    bpy_module.types = bpy_types_module
+
+    for name in ("BoolProperty", "IntProperty", "FloatProperty", "StringProperty",
+                 "PointerProperty", "FloatVectorProperty", "EnumProperty"):
+        setattr(bpy_props_module, name, lambda **_kwargs: None)
+    bpy_module.props = bpy_props_module
+
+    registered = []
+    bpy_utils_module.register_class = lambda cls: registered.append(cls)
+    bpy_utils_module.unregister_class = lambda cls: registered.remove(cls) if cls in registered else None
+    bpy_module.utils = bpy_utils_module
+    bpy_module.path = types.SimpleNamespace(abspath=lambda p: p)
+
+    mathutils_module = types.ModuleType("mathutils")
+    mathutils_module.Vector = lambda values: values
+
+    sys.modules["bpy"] = bpy_module
+    sys.modules["bpy.types"] = bpy_types_module
+    sys.modules["bpy.props"] = bpy_props_module
+    sys.modules["bpy.utils"] = bpy_utils_module
+    sys.modules["mathutils"] = mathutils_module
+
+    return bpy_module
+
+
+def _cleanup_bpy_mock():
+    for key in list(sys.modules.keys()):
+        if key.startswith("bpy") or key == "blender_addon" or key == "shader_blending":
+            del sys.modules[key]
+
+
+def test_features_dict_has_openmp_key(astroray_module):
+    """astroray.__features__ must expose an 'openmp' key (added pkg147) so the
+    addon guard has something to check."""
+    assert "openmp" in astroray_module.__features__
+    assert isinstance(astroray_module.__features__["openmp"], bool)
+
+
+def test_openmp_enabled_register_raises(astroray_module):
+    """When __features__['openmp'] is True, _check_openmp_disabled() raises a
+    loud RuntimeError instead of letting register() proceed into the hang."""
+    _make_stub_bpy()
+    try:
+        import blender_addon
+        with patch.object(astroray_module, "__features__", {"openmp": True}):
+            with patch.object(blender_addon, "RAYTRACER_AVAILABLE", True):
+                with pytest.raises(RuntimeError) as exc_info:
+                    blender_addon._check_openmp_disabled()
+                msg = str(exc_info.value)
+                assert "OPENMP" in msg.upper()
+                assert "build_blender_addon.py" in msg
+    finally:
+        _cleanup_bpy_mock()
+
+
+def test_openmp_disabled_register_succeeds(astroray_module):
+    """When __features__['openmp'] is False (the shipped-addon case —
+    build_blender_addon.py always passes -DASTRORAY_DISABLE_OPENMP=ON),
+    _check_openmp_disabled() is a silent no-op."""
+    _make_stub_bpy()
+    try:
+        import blender_addon
+        with patch.object(astroray_module, "__features__", {"openmp": False}):
+            with patch.object(blender_addon, "RAYTRACER_AVAILABLE", True):
+                blender_addon._check_openmp_disabled()  # should not raise
+    finally:
+        _cleanup_bpy_mock()
+
+
+def test_openmp_key_missing_defaults_safe(astroray_module):
+    """Older .pyd builds (pre-pkg147) won't have the 'openmp' key at all —
+    the guard must default to False (permissive) rather than crash or
+    false-positive refuse to load."""
+    _make_stub_bpy()
+    try:
+        import blender_addon
+        with patch.object(astroray_module, "__features__", {}):
+            with patch.object(blender_addon, "RAYTRACER_AVAILABLE", True):
+                blender_addon._check_openmp_disabled()  # should not raise
+    finally:
+        _cleanup_bpy_mock()
+
+
+def test_raytracer_unavailable_skips_openmp_guard():
+    """If the raytracer module didn't load, the guard silently skips (mirrors
+    _check_build_integrity's same-named precedent)."""
+    _make_stub_bpy()
+    try:
+        import blender_addon
+        with patch.object(blender_addon, "RAYTRACER_AVAILABLE", False):
+            blender_addon._check_openmp_disabled()  # should not raise
+    finally:
+        _cleanup_bpy_mock()
+
+
+class _StubSettings:
+    device_mode = "gpu"
+    wavelength_preset = "visible"
+    integrator_type = "path_tracer"
+
+
+class _StubRenderer:
+    gpu_available = True
+
+    def set_use_gpu(self, flag):
+        pass
+
+
+def test_configure_backend_gpu_mode_ignores_openmp(astroray_module):
+    """An OpenMP-enabled build must NOT be blocked from registering/rendering
+    on GPU — only the CPU path it would actually deadlock is refused (the
+    design fork resolved after test_blender_parity_matrix_generation, which
+    renders via device_mode='auto'+GPU, regressed under a register()-time
+    block)."""
+    _make_stub_bpy()
+    try:
+        import blender_addon
+        with patch.object(astroray_module, "__features__", {"openmp": True}):
+            settings = _StubSettings()
+            settings.device_mode = "gpu"
+            result = blender_addon.configure_backend(_StubRenderer(), settings)
+            assert result == "gpu"
+    finally:
+        _cleanup_bpy_mock()
+
+
+def test_configure_backend_cpu_mode_raises_with_openmp(astroray_module):
+    """device_mode='cpu' with an OpenMP-enabled build must raise before any
+    render is attempted — this is the actual pkg147 hang trigger."""
+    _make_stub_bpy()
+    try:
+        import blender_addon
+        with patch.object(astroray_module, "__features__", {"openmp": True}):
+            settings = _StubSettings()
+            settings.device_mode = "cpu"
+            with pytest.raises(RuntimeError, match="OPENMP"):
+                blender_addon.configure_backend(_StubRenderer(), settings)
+    finally:
+        _cleanup_bpy_mock()


### PR DESCRIPTION
## Summary

- **Root cause confirmed:** `PyRenderer::render()` (`module/blender_module.cpp`) holds the GIL for the whole call. Its progress-callback lambda does `py::gil_scoped_acquire acquire; progressCallback(progress);`, and `Renderer::render()`'s `#pragma omp parallel for` render loop (`include/raytracer.h:2975`, tileSize=16) calls that callback from whichever OpenMP worker thread finishes a tile — not necessarily the thread holding the GIL. When OpenMP is compiled in, a worker thread's `gil_scoped_acquire` deadlocks against the calling thread, which is blocked in the implicit end-of-parallel-region barrier while still holding the GIL.
- **The currently-deployed addon `.pyd` is already unaffected** (`build_blender_addon.py` applies `-DASTRORAY_DISABLE_OPENMP=ON` unconditionally for every backend) — measured 16×16/32×32/256×256 all complete in well under a second.
- **The routine CUDA dev-build path is NOT unaffected**: `configure_and_build.bat` / `build_cuda_worktree.bat` compile with OpenMP enabled by default (`ASTRORAY_DISABLE_OPENMP` defaults `OFF`) — confirmed the built `.pyd` links `VCOMP140.DLL`. Dropping that build into the addon directory reproduces the hang exactly and is almost certainly how pkg146 hit it.
- Adds a **structural guard** (per the spec's acceptance gate) so this can never silently reoccur: a compile-time feature flag surfaced through `__features__["openmp"]`, checked by the addon at the point CPU mode is actually selected.

## Root cause detail

Reproduced **Blender-independently** against a from-scratch OpenMP-enabled CPU-only build (plain Python, no `bpy` at all):
- With a non-null `progress_callback`: hangs (even at 16×16 in some runs — the "16px is safe" boundary from the original repro is a scheduling race, not a guarantee, since with only 1 tile whichever OpenMP-team thread grabs it may or may not be the GIL-holding thread).
- With `progress_callback=None`: renders instantly (0.13s @ 32×32) — matches "direct Python bindings … complete instantly" from the original pkg146 repro, since those never pass a callback.

A **latent MSVC-detection gap** was found and fixed while building the guard: `OpenMP_CXX_FOUND` (CMakeLists.txt) is only ever set via `find_package(OpenMP)` in the GNU/Clang branch — the MSVC branch adds `/openmp` directly without touching that variable. A first draft of the feature flag, gated on `OpenMP_CXX_FOUND`, silently misreported `openmp: False` for an MSVC/CUDA build that actually links `VCOMP140.DLL`. Fixed by gating on `ASTRORAY_DISABLE_OPENMP` directly (the option both compiler branches gate their real `/openmp`/`-fopenmp` on).

## Design fork resolved (see spec + commit for detail)

Should the guard fire at `register()` time (matches the pre-existing `_check_build_integrity` precedent, simplest) or only when CPU mode is actually selected? Register()-time blocking is empirically too broad: it broke the pre-existing GPU-mode test `test_blender_parity_matrix_generation` (which registers and renders via `device_mode='auto'`+GPU using the same OpenMP-enabled dev build). Moved the check into `configure_backend()`, firing at every point CPU mode is actually chosen (explicit `device_mode='cpu'`, or an auto/gpu→cpu fallback) — this satisfies the acceptance gate without blocking legitimate GPU-only use of an ad-hoc dev build.

## Measured numbers

| Resolution | Deployed (OpenMP-disabled) addon build, `device_mode='cpu'` |
|---|---|
| 16×16  | 0.042s |
| 32×32  | 0.010s |
| 256×256 | 0.053s |

| Build | `progress_callback` | Result (plain Python, no Blender) |
|---|---|---|
| OpenMP-enabled (scratch build) | present | hangs (60s timeout, killed) |
| OpenMP-enabled (scratch build) | `None` | 0.128s @ 32×32 |
| OpenMP-disabled (scratch build) | present | 0.128s @ 32×32 |

Guard verified directly in headless Blender 5.1: registering+rendering with the deployed (OpenMP-disabled) `.pyd` at 32×32 succeeds unchanged; registering `blender_addon` against an OpenMP-enabled `.pyd` and calling `configure_backend()` with `device_mode='cpu'` raises the new `RuntimeError` before any render is attempted; the same build with `device_mode='gpu'` still returns `'gpu'` without raising.

## Method

- Diagnostic ladder per spec: (a) checked deployed `.pyd`'s OpenMP status first (`build_report.json` cmake_flags) — already disabled, ruling out the deployed build as the culprit; (b) built a from-scratch OpenMP-enabled CPU-only module and reproduced the hang mechanism directly in plain Python (no Blender), then confirmed it in headless Blender via a throwaway addon-source copy (never touched the real installed extension binary).
- Every Blender/render invocation run in the foreground via `subprocess`/Bash-tool with a hard external timeout (≤60-100s), never backgrounded.
- CPU-only throughout — no GPU renders were used for the diagnostic or fix; the full CUDA build (`build_cuda_worktree.bat`-equivalent, `--config Release`) was run only to compile, not to render, and confirmed the whole repo builds cleanly with these changes on this machine's toolchain (MSVC 19.44 + nvcc 12.8).
- 7 pre-existing test failures observed in the full suite (`astroray_test_helpers` module not built by the `--target astroray`-only convention; pkg55 wavefront photon-caustic SSIM) are unrelated to the changed files (CMakeLists.txt's OpenMP block, blender_module.cpp's `__features__` dict, blender_addon/__init__.py's `configure_backend`) and were not touched by this diff.

## Acceptance criteria (spec)

- [x] 32×32 **and** 256×256 CPU addon renders complete in seconds, not minutes (0.01s / 0.05s measured).
- [x] GPU addon path and direct-bindings CPU path unchanged (regression suite green apart from the 7 unrelated pre-existing failures noted above).
- [x] Root cause is the OpenMP build flag — guard is now structural (compile-time flag → `__features__` → addon refusal), covering both MinGW and MSVC.

## Build log (last 5 lines, `--config Release --target astroray`)

```
     Creating library C:/Users/hgcom/OneDrive/Astroray/Astroray_repo/Astroray-pkg147/build_cuda/Release/astroray.lib and object C:/Users/hgcom/OneDrive/Astroray/Astroray_repo/Astroray-pkg147/build_cuda/Release/astroray.exp
  Generating code
  Finished generating code
  astroray.vcxproj -> C:\Users\hgcom\OneDrive\Astroray\Astroray_repo\Astroray-pkg147\build_cuda\Release\astroray.cp313-win_amd64.pyd
```
Exit code: 0

## HW/GPU status

CPU-only package. GPU addon path was not exercised tonight (no GPU renders were run, per the dispatch's CRITICAL RULE and the concurrent GPU-lock held by another verifier lane) beyond confirming `configure_backend()` still returns `'gpu'` without raising for an OpenMP-enabled build in `device_mode='gpu'`/`'auto'`+GPU-available.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>