### PR TITLE
fix(pkg162): correct the last phantom launchStageInit overload; drop its shadow

### DIFF
--- a/include/astroray/gpu_wavefront_state.h
+++ b/include/astroray/gpu_wavefront_state.h
@@ -207,12 +207,25 @@ struct GPUWavefrontHitBuffers;  // forward decl; full definition below
 
 // stage_init: writes ray_origin/ray_direction/lambdas/throughput/rng_*/etc.
 // for slot i. Uses WavefrontRNG (PCG32) to match CPU baseline.
+// pkg162: this declaration MUST stay in sync with the definition in
+// stage_init.cu. It previously declared only 6 parameters (`..., uint64_t seed,
+// int sample_index = 0`) while the definition takes 8, making it a PHANTOM
+// overload that no definition matched. It compiled only because
+// gpu_wavefront_snapshot.cu carried a private re-declaration that shadowed it
+// for that translation unit; that duplicate is now deleted and this is the
+// single source of truth.
+//
+// The `= 0` default on sample_index was REMOVED rather than relocated: a
+// defaulted parameter cannot precede non-defaulted ones, and all 6 call sites
+// pass sample_index explicitly, so the default was never actually used.
 void launchStageInit(
     GPUWavefrontState& state,
     const GCameraParams& cam,
     int width, int height,
     uint64_t seed,
-    int sample_index = 0);  // Session N+6: per-sample RNG keying
+    int sample_index,        // Session N+6: per-sample RNG keying
+    float lambdaMin,
+    float lambdaMax);
 
 // Session N+3 part 2: intersect stage.
 void launchStageIntersect_SessionN3(

--- a/src/gpu/wavefront/gpu_wavefront_snapshot.cu
+++ b/src/gpu/wavefront/gpu_wavefront_snapshot.cu
@@ -46,27 +46,12 @@ namespace astroray::wavefront {
 // Forward declarations for stage launch functions from stage_advance.cu + stage_init.cu
 // (pkg55-C3: added useLuminanceOutput, enableNEE, lambdaMin/Max params)
 
-// From stage_init.cu
-// pkg157 NOTE — DO NOT DELETE this one (unlike the three removed below).
-// It is LOAD-BEARING: `gpu_wavefront_state.h` declares launchStageInit with
-// only 6 params (`..., uint64_t seed, int sample_index = 0`), but the
-// DEFINITION in stage_init.cu takes 8 (`..., int sample_index, float
-// lambdaMin, float lambdaMax`). The header's version is therefore a phantom
-// overload no definition matches — the same pre-existing defect pkg157 found
-// and fixed for launchStageShadeBucketed. All 6 call sites in this file pass
-// 8 arguments and resolve against THIS declaration; deleting it breaks the
-// build. Left in place deliberately: correcting the header decl means
-// removing/relocating its `= 0` default (a default arg cannot precede
-// non-defaulted params), which is a behaviour-affecting change outside
-// pkg157's scope and unverifiable without a build. Filed for follow-up.
-void launchStageInit(
-    GPUWavefrontState& state,
-    const GCameraParams& cam,
-    int width, int height,
-    uint64_t seed,
-    int sample_index,
-    float lambdaMin,
-    float lambdaMax);
+// pkg162: the private re-declaration of launchStageInit that used to sit here
+// is GONE. It existed only to shadow a phantom 6-parameter declaration in
+// gpu_wavefront_state.h that no definition matched. That header declaration is
+// now correct (8 params, matching stage_init.cu), so this file's `#include` of
+// it suffices — as it always should have. pkg157 removed three duplicates of
+// this same pattern; this was the fourth and last.
 
 void launchStageRegen(
     GPUWavefrontState& state,


### PR DESCRIPTION
Closes the follow-up pkg157 filed but deliberately did not take.

## The defect

`gpu_wavefront_state.h` declared `launchStageInit` with **6** parameters (`..., uint64_t seed, int sample_index = 0`) while the definition in `stage_init.cu` takes **8** (`..., int sample_index, float lambdaMin, float lambdaMax`). That declaration was a **phantom overload no definition matched**. It compiled only because `gpu_wavefront_snapshot.cu` carried a private re-declaration that shadowed it for that translation unit.

This is the **fourth and last** instance of the pattern. pkg157 removed three of them and correctly left this one, because fixing it requires removing or relocating the `= 0` default (a defaulted parameter cannot precede non-defaulted ones) — behaviour-affecting, and unverifiable without a build the implementer could not run.

## Resolution

The default is simply **removed**. All 6 call sites pass `sample_index` explicitly, so it was never used. The header now matches the definition parameter-for-parameter and is the single source of truth; the private re-declaration is deleted.

## Verified, not assumed

- **Build:** full Release+CUDA succeeds (MSVC + nvcc 12.8), fresh `.pyd`.
- **Behaviourally inert:** same scene/seed/settings against the pre-change binary gives **identical image sums** (22315.917969 both), max difference 4.77e-07 = **2.48e-07 relative to peak** — the wavefront's own atomic-ordering noise floor, ~40× inside the 1e-5 MC convention. A declarations-only change should be inert, and it measurably is.

## Sweep

Swept every `void launchStage*` declaration against its definition across `include/astroray/` and `src/gpu/wavefront/`. **Strip comments first** — commas inside parameter comments produce false positives; my first pass wrongly flagged pkg157's merged `launchStageShadeBucketed` for exactly that reason.

After this fix, **one** mismatch remains and is deliberately untouched: `launchStageInit(IntegratorStateSoA&, const GCameraParams&, int, int)` at `integrator_state_soa.h:124` — a 4-param Phase-A.1 overload with **no definition and no caller**. Dead scaffolding; reported rather than deleted per CLAUDE.md §3.

HW verification beyond the no-op comparison above is not applicable — this changes no executable code.