### PR TITLE
feat(pkg161): firefly-bearing gate scene + un-skip pkg157's suppression gate

### DIFF
--- a/.astroray_plan/docs/pkg161-firefly-scene-research.md
+++ b/.astroray_plan/docs/pkg161-firefly-scene-research.md
@@ -259,3 +259,32 @@ flipped later. Memory: `gamma-furnace-cannot-detect-energy-gain`.
 No code was copied from any of these. The scene is an original arrangement of
 this repository's own primitives, built to satisfy a definition taken from the
 literature.
+
+
+---
+
+## HARDWARE MEASUREMENT (team-lead, 2026-07-26, RTX 5070 Ti)
+
+The thresholds in this package were *design targets* — the implementer had no GPU
+and no CUDA build by policy. These are the measured values, taken **linear**
+(`applyGamma=False`; a gamma-clamped tail measurement destroys exactly the
+outliers being measured — memory `gamma-furnace-cannot-detect-energy-gain`).
+
+Engine: `build_cuda/Release/astroray.cp313-win_amd64.pyd` built 21:15 from `c27daad`
+(i.e. post-pkg160).
+
+| scene | config | peak | p99.9 | **peak / p99.9** |
+|---|---|---|---|---|
+| **firefly_window** | GPU 480×360, 64 spp | 29.7104 | 1.300438 | **22.85×** |
+| metal_cornell (negative control) | GPU 240×180, 32 spp | 0.4626 | 0.433527 | **1.07×** |
+
+**Both targets met with margin.** The firefly gate wanted ≥ 10× and measured 22.85×
+— 2.3× headroom, and **12.6× heavier than the best pre-existing scene**
+(diffuse_light_cornell at 1.82×). The negative control wanted ≤ 3.0× and measured
+1.07×, so the tail assertion demonstrably discriminates rather than passing on
+everything.
+
+**Gate run:** `test_pkg161_firefly_scene_tail.py` + `test_pkg157_wavefront_firefly_clamp_port.py`
+→ **12 passed**, including `test_gpu_wavefront_clamp_indirect_suppresses_fireflies_without_energy_loss`,
+which had been `pytest.mark.skip`ped since PR #526 because no scene in the library
+could satisfy it. The design targets needed no recalibration.

--- a/.astroray_plan/docs/pkg161-firefly-scene-research.md
+++ b/.astroray_plan/docs/pkg161-firefly-scene-research.md
@@ -1,0 +1,261 @@
+# pkg161 research notes — constructing a scene with a real firefly population
+
+Written 2026-07-26 while implementing `.astroray_plan/packages/pkg161-firefly-bearing-gate-scene.md`.
+
+**Nothing here was measured.** The implementer was explicitly barred from running
+renders (no GPU access, no timing data). Everything below is (a) sourced from the
+literature, (b) read out of this repository's own source, or (c) derived
+analytically from (a)+(b). The numeric defaults are *design targets*, and the
+scene ships with a calibration script (`scripts/verify_pkg161_firefly_scene.py`)
+whose whole job is to replace them with measured values.
+
+---
+
+## 1. What a firefly is (definitional sources)
+
+**Blender Manual — *Cycles ▸ Render Settings ▸ Light Paths ▸ Clamping***
+(<https://docs.blender.org/manual/en/latest/render/cycles/render_settings/light_paths.html>):
+
+> "Some light paths have a low probability of being found while contributing
+> much light to the pixel, causing fireflies to be found in some pixels and not
+> in others. An example of such a difficult path might be a small light that is
+> causing a small specular highlight on a sharp glossy material, which we are
+> seeing through a rough glossy material."
+
+> "Clamping limits the maximum brightness any single sample can contribute. […]
+> It is often useful to clamp indirect bounces separately, as they tend to cause
+> more fireflies than direct bounces."
+
+Retrieval note, for honesty: `docs.blender.org` returns HTTP 403 to this
+environment's fetcher (Cloudflare). The two quotes above came back through the
+web-search index rather than a direct fetch. They are consistent with the
+long-standing wording of that manual section and with the Cycles source cited
+below, but they have **not** been verified against a first-party fetch in this
+session.
+
+**Zirr, Hanika & Dachsbacher, "Re-Weighting Firefly Samples for Improved
+Finite-Sample Monte Carlo Estimates", *Computer Graphics Forum* 37(6):410–421,
+2018, DOI [10.1111/cgf.13335](https://doi.org/10.1111/cgf.13335)**
+(preprint: <https://jo.dreggn.org/home/2018_fireflies.pdf>) — the standard
+academic definition:
+
+> fireflies are "samples with high contribution but low probability density"
+> which "lead to excessive variance in finite-sample estimates".
+
+That definition is the whole specification for this package's scene. A firefly
+needs **two** properties simultaneously:
+
+1. **contribution ≫ image mean** — which requires an emitter whose *radiance*
+   (not power) is orders of magnitude above the scene's normal luminance level,
+   i.e. a physically tiny, very bright emitter; and
+2. **low probability of being sampled** — which requires that emitter to be
+   **unreachable by next-event estimation**, so that only BSDF sampling can find
+   it.
+
+Property 2 is the part every existing Astroray scene fails. Every emitter in the
+library is NEE-sampled and unoccluded, so its contribution is found by the
+low-variance strategy on essentially every sample. That is exactly why the
+measured tail across the suite is 1.04–1.82× (pkg157 hardware round, RTX 5070 Ti,
+2026-07-26) rather than the tens-to-hundreds of a genuine tail.
+
+**Clamp semantics reference** (unchanged from pkg144, restated here so this
+document stands alone): Cycles `film_clamp_light`,
+`src/kernel/film/light_passes.h`, Apache-2.0 — `bounce > 0` selects
+`sample_clamp_indirect`, `bounce == 0` selects `sample_clamp_direct`, and a
+limit of 0 disables. Astroray's port is `Renderer::clampContribSpectral`
+(`include/raytracer.h:2089`) and `gpu_clampContribMW`
+(`src/gpu/gpu_spectral_tables.h:158`). Full notes:
+`.astroray_plan/docs/pkg144-firefly-clamp-research.md`.
+
+---
+
+## 2. Which transport channel in *this* engine can carry a firefly
+
+This is the part that cannot be copied from Cycles, because Astroray's estimator
+differs from Cycles' in one decisive way. Read out of the source, not assumed:
+
+| channel | CPU site | verdict |
+|---|---|---|
+| BSDF ray happens to hit an emitter after a **non-delta** bounce | `include/raytracer.h:2415` | **dead** — `if (bounce == 0 \|\| wasSpecular)`; there is no BSDF-side MIS term, so the contribution is *discarded entirely* and the path breaks. (Known gap, filed as pkg120.) |
+| BSDF ray hits an emitter after a **delta** bounce | `include/raytracer.h:2415-2417` | **live, unweighted, unclamped-by-default** — added at full `throughput * Le`. GPU twin: `src/gpu/wavefront/stage_advance.cu:239-243`. |
+| NEE / shadow ray | `include/raytracer.h:2429-2457` | low variance by construction: power-heuristic MIS, and `1/(pdf + 0.001)` bounds the near-field singularity at 1000×. |
+| Russian roulette | `include/raytracer.h:2479-2484` | **cannot produce unbounded fireflies here.** The survival probability is `p = min(0.95, XYZ.Y(throughput))`, so a surviving path is renormalised to `Y(throughput) == 1` — the boost is self-limiting, not compounding. A further always-on cap (`throughput.maxValue() > 10 → rescale`, `raytracer.h:2528-2530`, GPU twin `stage_advance.cu:649-651`) bounds it again. |
+
+**Conclusion: the only unbounded-variance channel in this engine is
+`diffuse → delta-specular → emitter`.** The scene must be built around that one,
+and the emitter must be invisible to NEE so the channel is the *only* route to
+its energy.
+
+In Heckbert's (1990) light-path notation this is the `L S D E` class — a light
+seen through a specular vertex from a diffuse vertex, which next-event estimation
+cannot connect to by construction (a delta vertex has zero probability of lying
+on a shadow ray).
+
+### Two constraints this implies, both of which bit during design
+
+* **The camera must not reach the emitter through any delta chain either.** A
+  small emitter with radiance ~2400 seen through/reflected off a glass sphere
+  produces a *deterministic* few-pixel feature at ~10²–10³× the image mean. That
+  would set `peak` without a single firefly being involved — a fake tail, and
+  exactly the vacuous-pass trap pkg157 round 1 fell into. An early draft used the
+  canonical "glass ball caustic on a floor" layout and was discarded for this
+  reason: a ball lens has f ≈ 1.5 R, so it must sit within ~one focal length of
+  the receiver to concentrate, which puts it in frame.
+* **The aperture must be sealed.** If any straight line exists from a visible
+  surface to the emitter, NEE finds it, and the emitter's energy arrives as a
+  *direct* (bounce-0) contribution that `clampIndirect` cannot touch — which
+  destroys the clamp gate rather than enabling it.
+
+---
+
+## 3. The construction that satisfies both: "bright light outside a window"
+
+```
+        * emitter (tiny sphere, radiance ~10^3)      OUTSIDE the room
+        |
+  ======#======   opaque ceiling with a hole, hole sealed by a thin_glass pane
+  |            |
+  |  [] ... [] |  two ordinary ceiling area lights  -> all the bulk illumination
+  |            |
+  |    camera  |  looks DOWN; everything above camera height is out of frame
+  |____________|  diffuse floor + walls
+```
+
+* The pane is `thin_glass` with `roughness = 0`, so
+  `plugins/materials/thin_glass.cpp:71` sets `isDelta = true` and
+  `:95` transmits straight through (`wi = -wo`). It is a genuine delta vertex.
+  It is *not* a solid dielectric: a single `dielectric` quad is the two-quad hack
+  that memory `general-photon-loop-needs-solid-glass` warns about, and a
+  dielectric sphere cannot seal a square hole without either interpenetrating the
+  ceiling or leaving the corners open. `thin_glass` is the material this engine
+  provides for exactly this geometry.
+* Shadow rays are blocked by *any* geometry (`include/raytracer.h:2437` — the BVH
+  hit test is material-agnostic), so the pane makes the emitter 100 %
+  NEE-invisible. Every joule it delivers arrives through the delta channel.
+* The firefly path is `camera → floor (bounce 0, diffuse) → pane (bounce 1,
+  delta) → emitter (bounce 2)`. `bounce == 2 > 0`, so the contribution is
+  **indirect** and lands squarely under `clampIndirect`, while the entire bulk
+  image is bounce-0 NEE under `clampDirect`. The two halves of pkg157's gate are
+  therefore cleanly separated by construction rather than by luck.
+
+### Why the emitter is *outside* rather than a lens *inside*
+
+Because it makes the two things the gate needs into two **independent, monotone,
+analytically invertible knobs**, which is the only way to calibrate blind:
+
+Let `L_e` be the emitter radiance, `r_e` its radius, `spp` the sample count,
+`N` the pixel count, `μ` the image mean luminance, `k = p99.9 / μ` for the
+*normal* (non-firefly) population, `n_ff` the number of firefly pixels,
+`R = peak / p99.9` the tail ratio, and `s` the share of image energy carried by
+the firefly channel.
+
+```
+  R    ∝ L_e / spp                    (firefly magnitude = throughput · L_e / spp)
+  n_ff ∝ N · spp · r_e^2              (hit rate ∝ emitter solid angle ∝ r_e^2)
+  s    =  n_ff · R · k / N   ∝  r_e^2 · L_e
+```
+
+So:
+
+* **`L_e` alone sets the tail ratio `R`.**
+* **`r_e` alone sets the firefly *count* (and hence `s`) at fixed `R`.**
+* `spp` trades `R` against `n_ff` along the invariant `n_ff · R = s · N / k`.
+
+Two renders are therefore sufficient to solve for both constants exactly; that
+is what the calibration script does.
+
+### The design window, and why it is narrow
+
+Three constraints act at once:
+
+1. `R ≥ 10` — the spec's bar (contract item 2).
+2. `n_ff ≤ 0.001 · N` — otherwise the 99.9th percentile lands *inside* the
+   firefly population and `R` collapses to ~2 (all fireflies from a single
+   mechanism have nearly the same magnitude `throughput · L_e / spp`, so the top
+   0.1 % would just be the double-hit pixels).
+3. `s < 0.02` — pkg157's energy half asserts the mean moves < 2 % when the clamp
+   binds, and the energy a p99.9 clamp removes *is* `s`.
+
+Combining 1 and 3 through the invariant: `n_ff ≤ s·N/(k·R) ≤ 0.02·N/(10k)`.
+With `k ≈ 1.4` that is `n_ff ≲ 1.4e-3 · N`, and reliability needs `n_ff ≳ 8`
+(Poisson: `P(n_ff = 0) < 4e-4`), so **`N ≳ 6000` pixels minimum, and comfortably
+`N ≳ 5e4`**. Because `n_ff ∝ N · spp`, the firefly count is directly proportional
+to total render cost: ~10 fireflies costs ~5 × 10⁶ primary samples at these
+targets. That is trivial on the wavefront and expensive on the CPU, which is why
+the CPU leg of the gate renders the same scene with a deliberately enlarged
+emitter (`CPU_EMITTER_RADIUS_SCALE`) — enlarging `r_e` raises the *rate* and
+leaves the *ratio* untouched, so the CPU leg measures the same phenomenon at a
+tenth of the cost.
+
+**This is the one place where pkg161's contract has real internal tension, and it
+should be stated in the spec rather than discovered again later:** the `≥ 10×`
+tail bar and the `< 2 %` energy bar together pin the firefly *population size* to
+a band roughly one decade wide. The hidden-emitter construction is what makes
+that band reachable, because `s` becomes a dialled constant instead of an
+emergent property of lens geometry.
+
+---
+
+## 4. Numeric design targets (unmeasured — these are the numbers to replace)
+
+Derived from the relations above with: floor/wall albedo 0.73, two 0.9 × 1.1 m
+ceiling lights at radiance 15 (matching `tests/base_helpers.py`'s Cornell
+convention), room 4 × 4 × 3 m, emitter 0.6 m above a 0.5 × 0.5 m ceiling
+aperture, throughput at the emitter hit ≈ 0.66, `μ ≈ 0.6`, `k ≈ 1.4`,
+`N = 480 × 360`, `spp = 64`:
+
+| quantity | target | source of the number |
+|---|---|---|
+| `EMITTER_INTENSITY` | 2400 | solves `R ≈ 30` |
+| `EMITTER_RADIUS` | 0.0075 | solves `s ≈ 0.01` given the above |
+| expected `peak / p99.9` | ≈ 30 | design target, **not measured** |
+| expected `n_ff` | ≈ 22 | design target, **not measured** |
+| expected clamp energy cost | ≈ 1 % | design target, **not measured** |
+
+Realistic uncertainty on each of `μ`, `k`, the throughput factor, and the
+aperture solid angle is a factor of ~2, which compounds to roughly ±3–5× on both
+`R` and `s`. The calibration script prints the corrected constants directly.
+
+### Light-selection sanity check (checked in source, not measured)
+
+`LightList::add` (`include/raytracer.h:1183-1192`) weights the NEE selection CDF
+by `luminance(emittedRadiance) × boundingBox.area()`. For the hidden emitter that
+is `2400 × 24 r_e² ≈ 3.2`; for the two room lights it is `15 × 7.92 ≈ 119`. So
+the always-occluded emitter absorbs ≈ 2.6 % of NEE samples — wasted shadow rays,
+but nowhere near the "tiny super-bright light hijacks the CDF and the room goes
+black" failure mode that a radiance-only weighting would have produced.
+
+### Adaptive sampling must be off
+
+`include/raytracer.h:3001-3007`: the CPU render loop's adaptive mode is an
+*early-out* — a pixel stops once its running relative standard deviation drops
+below 1 %. Quiet pixels therefore take fewer than `spp` samples and normalise by
+their own count. Applied to this scene that (a) reduces the number of chances a
+caustic-region pixel gets to catch a firefly and (b) makes a caught firefly's
+magnitude depend on *when* it was caught. Both corrupt the statistic the scene
+exists to produce, and neither applies on the GPU wavefront, so it also breaks
+CPU/GPU comparability. `build_scene()` calls `set_adaptive_sampling(False)`.
+
+### Measurements must be linear
+
+`module/blender_module.cpp:1803-1811`: `render(..., apply_gamma=True)` (the
+**default**) does `pow(clamp(c, 0, 1), 1/2.2)`. The clamp to 1.0 annihilates
+precisely the outliers being measured. Every tail measurement in this package
+passes `apply_gamma=False`, and
+`test_pkg161_firefly_scene_tail.py::test_tail_metric_discriminates` asserts that
+the gamma path *does* destroy the tail, so the convention cannot be silently
+flipped later. Memory: `gamma-furnace-cannot-detect-energy-gain`.
+
+---
+
+## 5. Licences
+
+| source | licence | how used |
+|---|---|---|
+| Blender Manual (light-paths / clamping) | CC-BY-SA 4.0 | two short quotations, attributed |
+| Cycles `src/kernel/film/light_passes.h` | Apache-2.0 | clamp semantics, already ported in pkg144/pkg157; no new code taken |
+| Zirr et al. 2018 (CGF) | © Eurographics/Wiley | definition quoted and attributed; no code or data used |
+
+No code was copied from any of these. The scene is an original arrangement of
+this repository's own primitives, built to satisfy a definition taken from the
+literature.

--- a/scripts/verify_pkg161_firefly_scene.py
+++ b/scripts/verify_pkg161_firefly_scene.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python
+"""pkg161 -- measure and calibrate the firefly-window gate scene.
+
+The scene's EMITTER_INTENSITY / EMITTER_RADIUS in tests/scenes/firefly_window.py
+are ANALYTIC DESIGN TARGETS: they were derived from the tuning model in that
+module's docstring by an implementer with no GPU access who ran no renders.
+This script replaces them with measurements, and prints the exact constants to
+paste back.
+
+It reports, in one pass:
+
+  1. the tail statistic pkg161 is specified against (peak / p99.9, linear);
+  2. both halves of pkg157's un-skipped firefly gate at the limit that gate
+     uses (clampIndirect = p99.9 of unclamped luminance) -- whether the clamp
+     BINDS, and what it costs in total energy;
+  3. pkg161 contract item 4 -- whether pkg144's headline "clampIndirect = 10 ->
+     < 0.02% brightness delta" reproduces on a scene that actually has
+     fireflies, or is scene-specific as suspected;
+  4. corrected EMITTER_INTENSITY / EMITTER_RADIUS, solved from the tuning model.
+
+Usage (RTX box, from the repo root):
+
+    python scripts/verify_pkg161_firefly_scene.py
+
+    python scripts/verify_pkg161_firefly_scene.py --cpu        # CPU leg too
+    python scripts/verify_pkg161_firefly_scene.py --intensity 5000 --radius 0.004
+    python scripts/verify_pkg161_firefly_scene.py --spp 128 --width 640 --height 480
+
+Everything is rendered LINEAR (apply_gamma=False). render()'s 4th positional
+argument defaults to True and clamps to [0, 1] before the 1/2.2 power
+(module/blender_module.cpp:1803-1811), which annihilates exactly the outliers
+being measured here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TESTS_DIR = ROOT / "tests"
+if str(TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(TESTS_DIR))
+
+from runtime_setup import configure_test_imports  # noqa: E402
+
+configure_test_imports()
+
+import astroray  # noqa: E402
+import scenes.firefly_window as firefly  # noqa: E402
+
+
+#: Design targets the corrections below solve for. Chosen inside the window set
+#: by pkg161 contract item 2 (ratio >= 10) and pkg157's energy half (< 2%):
+#: 3x margin on the ratio, 2x margin on the energy cost.
+TARGET_RATIO = 30.0
+TARGET_ENERGY_SHARE = 0.010
+
+
+def render(*, use_gpu, width, height, samples, seed, radius, intensity,
+           clamp_indirect=0.0):
+    r = astroray.Renderer()
+    if use_gpu:
+        r.set_use_gpu(True)
+    r.set_integrator("path_tracer")
+    firefly.build_scene(r, emitter_radius=radius, emitter_intensity=intensity)
+    firefly.setup_camera(r, width, height)
+    r.set_seed(seed)
+    r.set_clamp_direct(0.0)
+    r.set_clamp_indirect(clamp_indirect)
+    return np.asarray(r.render(samples, firefly.MAX_DEPTH, None, False))
+
+
+def clamp_effect(unclamped_lum, clamped_lum):
+    delta_max = float(np.max(np.abs(clamped_lum - unclamped_lum)))
+    m0 = float(unclamped_lum.mean())
+    m1 = float(clamped_lum.mean())
+    return delta_max, m0, m1, abs(m1 - m0) / max(m0, 1e-8)
+
+
+def run(label, *, use_gpu, width, height, samples, seed, radius, intensity):
+    print(f"\n=== {label} "
+          f"({width}x{height} @ {samples} spp, depth {firefly.MAX_DEPTH}, "
+          f"seed {seed}) ===")
+    print(f"    emitter radius={radius:.6g}  intensity={intensity:.6g}")
+
+    px = render(use_gpu=use_gpu, width=width, height=height, samples=samples,
+                seed=seed, radius=radius, intensity=intensity)
+    if not np.isfinite(px).all():
+        print("    !! render contains NaN/Inf -- everything below is invalid")
+    st = firefly.tail_stats(px)
+    lum = firefly.luminance(px)
+
+    ff_frac = st["n_fireflies"] / st["n_pixels"]
+    print(f"    mean       = {st['mean']:.6g}")
+    print(f"    p99.9      = {st['p99_9']:.6g}")
+    print(f"    peak       = {st['peak']:.6g}")
+    print(f"    TAIL RATIO = {st['ratio']:.4g}x        "
+          f"(pkg161 bar: >= 10x; library before pkg161: 1.04x-1.82x)")
+    print(f"    fireflies  = {st['n_fireflies']} / {st['n_pixels']} "
+          f"({100.0 * ff_frac:.4f}% of pixels; must stay under 0.1000%)")
+
+    # --- pkg157's un-skipped gate, at the limit that gate derives ------------
+    limit = st["p99_9"]
+    clamped = render(use_gpu=use_gpu, width=width, height=height,
+                     samples=samples, seed=seed, radius=radius,
+                     intensity=intensity, clamp_indirect=limit)
+    d_max, m0, m1, rel = clamp_effect(lum, firefly.luminance(clamped))
+    print(f"\n    pkg157 gate, clampIndirect = p99.9 = {limit:.6g}")
+    print(f"      half 1 BINDS   : max|delta| = {d_max:.6g}   "
+          f"(needs > 1e-05)   -> {'PASS' if d_max > 1e-5 else 'FAIL'}")
+    print(f"      half 2 ENERGY  : mean {m0:.6g} -> {m1:.6g}, "
+          f"rel = {100.0 * rel:.4f}%   (needs < 2%)   "
+          f"-> {'PASS' if rel < 2e-2 else 'FAIL'}")
+
+    # --- pkg161 contract item 4: does pkg144's headline "10" reproduce? ------
+    c10 = render(use_gpu=use_gpu, width=width, height=height, samples=samples,
+                 seed=seed, radius=radius, intensity=intensity,
+                 clamp_indirect=10.0)
+    d10, n0, n1, rel10 = clamp_effect(lum, firefly.luminance(c10))
+    print(f"\n    pkg161 item 4: clampIndirect = 10 (pkg144's headline constant)")
+    print(f"      max|delta| = {d10:.6g}    mean {n0:.6g} -> {n1:.6g}, "
+          f"rel = {100.0 * rel10:.4f}%   (pkg144 claimed < 0.02%)")
+    if d10 <= 1e-5:
+        print("      -> does NOT bind on this scene: 10 sits above every "
+              "indirect contribution here, so the '< 0.02%' headline is "
+              "satisfied vacuously. Restate pkg144 item 3 scene-relatively.")
+
+    # --- corrected constants -------------------------------------------------
+    print("\n    --- calibration ---")
+    if st["n_fireflies"] == 0:
+        print("    NO FIREFLIES. The tail ratio above is meaningless.")
+        print(f"    -> raise EMITTER_RADIUS ~3x (count ~ r_e^2): "
+              f"{radius * 3.0:.6g}, keep intensity, re-run.")
+        return st
+    if ff_frac >= 0.001:
+        shrink = (0.0003 / ff_frac) ** 0.5
+        print("    TOO MANY FIREFLIES: the 99.9th percentile is itself a "
+              "firefly, so the ratio understates the tail.")
+        print(f"    -> lower EMITTER_RADIUS to {radius * shrink:.6g} "
+              f"(count ~ r_e^2), keep intensity, re-run.")
+        return st
+
+    # ratio ~ L_e / spp  ->  scale intensity directly.
+    new_intensity = intensity * (TARGET_RATIO / st["ratio"])
+    # energy share s ~ r_e^2 * L_e  ->  hold s at target after the intensity move.
+    ratio_of_shares = TARGET_ENERGY_SHARE / max(rel, 1e-9)
+    new_radius = radius * ((ratio_of_shares * (intensity / new_intensity)) ** 0.5)
+    print(f"    measured ratio {st['ratio']:.4g}x, energy share "
+          f"{100.0 * rel:.4f}%  ->  targets {TARGET_RATIO:.0f}x / "
+          f"{100.0 * TARGET_ENERGY_SHARE:.2f}%")
+    print(f"    EMITTER_INTENSITY = {new_intensity:.6g}   "
+          f"(was {intensity:.6g})")
+    print(f"    EMITTER_RADIUS    = {new_radius:.6g}   (was {radius:.6g})")
+    print("    (the two knobs are independent: intensity sets the ratio, "
+          "radius sets the count. One iteration should converge.)")
+    return st
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--cpu", action="store_true",
+                    help="also run the CPU leg (scenes.firefly_window's CPU_* "
+                         "config with the enlarged CPU emitter)")
+    ap.add_argument("--gpu-only", action="store_true",
+                    help="skip the GPU leg if CUDA is unavailable instead of failing")
+    ap.add_argument("--width", type=int, default=firefly.WIDTH)
+    ap.add_argument("--height", type=int, default=firefly.HEIGHT)
+    ap.add_argument("--spp", type=int, default=firefly.SAMPLES)
+    ap.add_argument("--seed", type=int, default=firefly.SEED)
+    ap.add_argument("--radius", type=float, default=firefly.EMITTER_RADIUS)
+    ap.add_argument("--intensity", type=float, default=firefly.EMITTER_INTENSITY)
+    args = ap.parse_args()
+
+    has_cuda = astroray.__features__.get("cuda", False)
+    print(f"astroray: {astroray.__file__}")
+    print(f"cuda feature: {has_cuda}")
+
+    if has_cuda:
+        run("GPU wavefront", use_gpu=True, width=args.width, height=args.height,
+            samples=args.spp, seed=args.seed, radius=args.radius,
+            intensity=args.intensity)
+    elif not args.gpu_only:
+        print("\n!! no CUDA in this build -- skipping the GPU leg. The pkg157 "
+              "gate numbers can only be produced on the RTX box.")
+
+    if args.cpu or not has_cuda:
+        run("CPU", use_gpu=False,
+            width=firefly.CPU_WIDTH, height=firefly.CPU_HEIGHT,
+            samples=firefly.CPU_SAMPLES, seed=args.seed,
+            radius=args.radius * firefly.CPU_EMITTER_RADIUS_SCALE,
+            intensity=args.intensity)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/scenes/firefly_window.py
+++ b/tests/scenes/firefly_window.py
@@ -1,0 +1,314 @@
+"""pkg161 -- `firefly_window`: the first scene in this library that has a real
+firefly population.
+
+WHY THIS SCENE EXISTS
+---------------------
+Measured on RTX 5070 Ti, 2026-07-26 (pkg157 / PR #526), tail-heaviness
+(peak / p99.9 of output luminance) across the ENTIRE scene suite at 16 / 64 spp:
+
+    diffuse_light_cornell  1.82x / 1.53x      dielectric_cornell  1.40x / 1.13x
+    thin_glass_cornell     1.66x / 1.52x      metal_cornell       1.07x / 1.04x
+    disney_cornell         1.66x / 1.52x
+
+A genuine firefly population reads in the tens to hundreds. Not one scene had a
+tail, so "clampIndirect suppresses fireflies without energy loss" was not
+demonstrable anywhere -- pkg157's gate for it is skipped and pkg144 contract
+item 3 was formally amended as undemonstrable. This scene closes that hole.
+
+WHAT A FIREFLY REQUIRES (cited, not invented -- CLAUDE.md SS6)
+--------------------------------------------------------------
+Zirr, Hanika & Dachsbacher, "Re-Weighting Firefly Samples for Improved
+Finite-Sample Monte Carlo Estimates", Computer Graphics Forum 37(6):410-421,
+2018 (DOI 10.1111/cgf.13335) define a firefly as a sample with "high
+contribution but low probability density". The Blender Manual's Cycles
+"Clamping" section says the same operationally: "Some light paths have a low
+probability of being found while contributing much light to the pixel, causing
+fireflies to be found in some pixels and not in others."
+
+Two properties, both required at once:
+
+  1. contribution >> image mean  ->  a physically tiny, very high-RADIANCE
+     emitter (radiance, not power -- power stays small);
+  2. low sampling probability    ->  that emitter must be unreachable by
+     next-event estimation, so only BSDF sampling can ever find it.
+
+Property 2 is what every existing scene here lacks: all their emitters are
+NEE-sampled and unoccluded, so the low-variance strategy finds them on nearly
+every sample and there is nothing left in the tail.
+
+THE ONE TRANSPORT CHANNEL IN THIS ENGINE THAT CAN CARRY A FIREFLY
+-----------------------------------------------------------------
+Read out of the source, not assumed (see
+.astroray_plan/docs/pkg161-firefly-scene-research.md for the full table):
+
+  * A BSDF ray that hits an emitter after a NON-delta bounce contributes
+    NOTHING -- `if (bounce == 0 || wasSpecular)` at include/raytracer.h:2415
+    discards it and breaks the path (there is no BSDF-side MIS term; known gap,
+    filed as pkg120). GPU twin: src/gpu/wavefront/stage_advance.cu:239-243.
+  * NEE is power-heuristic MIS-weighted and its near-field singularity is capped
+    at 1000x by `1/(pdf + 0.001)` -- low variance by construction.
+  * Russian roulette CANNOT produce unbounded fireflies here: survival is
+    `p = min(0.95, XYZ.Y(throughput))`, so a survivor is renormalised to
+    Y == 1 (self-limiting), and `throughput.maxValue() > 10` is rescaled every
+    bounce anyway (raytracer.h:2528-2530, stage_advance.cu:649-651).
+
+So the ONLY unbounded-variance channel is `diffuse -> delta-specular ->
+emitter`: Heckbert's `L S D E` path class, which next-event estimation cannot
+connect to by construction (a delta vertex has zero probability of lying on a
+shadow ray). The scene is built around that channel and nothing else.
+
+LAYOUT -- "a very bright light outside a window"
+------------------------------------------------
+        * hidden emitter (tiny sphere, radiance ~10^3)     OUTSIDE the room
+        |
+  ======#======   opaque ceiling, square aperture sealed by a thin_glass pane
+  |            |
+  | []      [] |  two ordinary ceiling area lights -> ALL of the bulk light
+  |            |
+  |   camera   |  looks DOWN: everything at or above camera height is
+  |____________|  out of frame, so no specular chain from bounce 0 exists
+
+  * The pane is `thin_glass`, roughness 0 -> `isDelta = true`
+    (plugins/materials/thin_glass.cpp:71) and transmits straight through
+    (`wi = -wo`, :95). A genuine delta vertex. NOT a single `dielectric` quad:
+    that is the two-quad hack memory `general-photon-loop-needs-solid-glass`
+    warns about, and a dielectric sphere cannot seal a square aperture without
+    either interpenetrating the ceiling or leaving its corners open.
+  * Shadow rays are blocked by ANY geometry (raytracer.h:2437 -- the BVH test is
+    material-agnostic), so the pane makes the emitter 100% NEE-invisible. Every
+    joule it delivers arrives through the delta channel.
+  * The firefly path is  camera -> floor (bounce 0, diffuse) -> pane (bounce 1,
+    delta) -> emitter (bounce 2).  bounce 2 > 0, so the whole firefly population
+    is INDIRECT (clampIndirect) while the entire bulk image is bounce-0 NEE
+    (clampDirect). The two halves of pkg157's gate are separated by
+    construction, not by luck.
+  * The hidden emitter is OUTSIDE rather than a lens inside because a small
+    emitter at radiance ~10^3 seen by the camera through any specular chain
+    makes a deterministic few-pixel feature at 10^2-10^3x the image mean, which
+    would set `peak` with no firefly involved -- a fake tail. An earlier draft
+    used the canonical glass-ball-caustic-on-a-floor layout and was discarded
+    for exactly that: a ball lens has f ~ 1.5R, so it must sit within about one
+    focal length of the receiver to concentrate, which puts it in frame.
+
+TUNING MODEL (this is how to recalibrate; see verify_pkg161_firefly_scene.py)
+-----------------------------------------------------------------------------
+With  L_e = emitter radiance, r_e = emitter radius, N = pixels, mu = mean
+luminance, k = p99.9/mu of the NORMAL population, n_ff = firefly pixel count,
+R = peak/p99.9, s = share of image energy carried by the firefly channel:
+
+    R    ~  L_e / spp                 (magnitude = throughput * L_e / spp)
+    n_ff ~  N * spp * r_e^2           (hit rate ~ emitter solid angle ~ r_e^2)
+    s    =  n_ff * R * k / N   ~  r_e^2 * L_e
+
+i.e. EMITTER_INTENSITY alone sets the ratio, EMITTER_RADIUS alone sets the
+count. They are independent and monotone, so two renders solve for both.
+
+Three constraints act at once, and they are tighter than they look:
+    R >= 10             (pkg161 contract item 2)
+    n_ff <= 0.001 * N   (else p99.9 lands INSIDE the firefly population and R
+                         collapses to ~2 -- every firefly has nearly the same
+                         magnitude, so the top 0.1% would just be double hits)
+    s < 0.02            (pkg157's energy half: the energy a p99.9 clamp removes
+                         IS s)
+Together they pin n_ff to roughly one decade, and since n_ff ~ N * spp the
+firefly count is directly proportional to render cost. Hence the separate,
+deliberately-enlarged CPU emitter below.
+
+THE DEFAULT CONSTANTS BELOW ARE DESIGN TARGETS, NOT MEASUREMENTS.
+They were derived analytically (implementer had no GPU and ran no renders).
+Run scripts/verify_pkg161_firefly_scene.py to measure and replace them.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# Tuned parameters -- see the TUNING MODEL section above.
+# ---------------------------------------------------------------------------
+
+#: Emitter radiance. Sets the tail ratio: R ~ EMITTER_INTENSITY / spp.
+EMITTER_INTENSITY = 2400.0
+
+#: Emitter radius (metres). Sets the firefly *count* and hence the energy
+#: share s ~ r_e^2 * L_e. Does NOT affect the tail ratio.
+EMITTER_RADIUS = 0.0075
+
+#: The CPU leg renders ~1/8 the samples of the GPU leg, and n_ff ~ N * spp, so
+#: at the shipped radius it would sit in the Poisson-zero-risk regime. Scaling
+#: the radius raises the hit RATE (n_ff ~ r_e^2) and leaves the tail RATIO
+#: untouched (R ~ L_e / spp only), so the CPU leg measures the same phenomenon
+#: at a fraction of the cost. The larger energy share this implies is
+#: irrelevant to the CPU leg, which asserts the ratio, not the clamp cost.
+CPU_EMITTER_RADIUS_SCALE = 2.0
+
+
+# ---------------------------------------------------------------------------
+# Recommended render configurations.
+# ---------------------------------------------------------------------------
+
+#: GPU / pkg157-gate configuration. Large N because n_ff <= 0.001 * N and
+#: n_ff >= ~8 for reliability jointly demand N >~ 5e4.
+WIDTH = 480
+HEIGHT = 360
+SAMPLES = 64
+MAX_DEPTH = 8
+SEED = 16101
+
+#: CPU configuration -- paired with CPU_EMITTER_RADIUS_SCALE.
+CPU_WIDTH = 240
+CPU_HEIGHT = 180
+CPU_SAMPLES = 32
+
+
+# ---------------------------------------------------------------------------
+# Geometry constants (metres, Y up).
+# ---------------------------------------------------------------------------
+
+ROOM = 2.0          # room half-extent in x and z
+CEILING_Y = 3.0
+APERTURE = 0.25     # ceiling hole half-width
+PANE_Y = 3.02       # thin_glass pane, just above the ceiling
+PANE = 0.32         # pane half-width (> APERTURE, so the hole is sealed)
+EMITTER_Y = 3.60    # hidden emitter, outside the room
+LIGHT_Y = 2.97      # room area lights, just below the ceiling
+
+
+def _quad(renderer, p00, p10, p11, p01, mat):
+    """Two triangles spanning p00 -> p10 -> p11 -> p01 (winding preserved)."""
+    renderer.add_triangle(p00, p10, p11, mat)
+    renderer.add_triangle(p00, p11, p01, mat)
+
+
+def build_scene(renderer, *, emitter_radius=EMITTER_RADIUS,
+                emitter_intensity=EMITTER_INTENSITY):
+    """Populate *renderer* with the firefly-window scene.
+
+    Returns the material id map. Caller owns seed / integrator / spp, per the
+    convention in this directory -- with one deliberate exception, below.
+    """
+    # DELIBERATE EXCEPTION to "the caller owns render config": adaptive
+    # sampling must be off for this scene to mean anything.
+    # include/raytracer.h:3001-3007 -- the CPU adaptive mode is an EARLY-OUT: a
+    # pixel stops once its running relative std-dev drops below 1%, and
+    # normalises by its own sample count. On this scene that (a) cuts the number
+    # of chances a pixel gets to catch a firefly and (b) makes a caught
+    # firefly's magnitude depend on *when* it was caught. It also does not exist
+    # on the GPU wavefront, so leaving it on breaks CPU/GPU comparability. A
+    # caller who forgets this gets silently wrong tail statistics, so the scene
+    # owns it rather than every call site.
+    renderer.set_adaptive_sampling(False)
+
+    white = renderer.create_material("lambertian", [0.73, 0.73, 0.73], {})
+    room_light = renderer.create_material("light", [1.0, 1.0, 1.0],
+                                          {"intensity": 15.0})
+    # roughness 0 -> isDelta (thin_glass.cpp:71). This is the delta vertex the
+    # entire firefly channel depends on; do not roughen it.
+    pane = renderer.create_material("thin_glass", [1.0, 1.0, 1.0],
+                                    {"ior": 1.5, "roughness": 0.0,
+                                     "transmission": 1.0})
+    hidden = renderer.create_material("light", [1.0, 1.0, 1.0],
+                                      {"intensity": emitter_intensity})
+
+    R, C = ROOM, CEILING_Y
+
+    # Floor.
+    _quad(renderer, [-R, 0, -R], [R, 0, -R], [R, 0, R], [-R, 0, R], white)
+    # Four walls, full height, so the room is closed and the hidden emitter has
+    # no line of sight into it except through the aperture.
+    _quad(renderer, [-R, 0, -R], [R, 0, -R], [R, C, -R], [-R, C, -R], white)
+    _quad(renderer, [-R, 0, R], [R, 0, R], [R, C, R], [-R, C, R], white)
+    _quad(renderer, [-R, 0, -R], [-R, 0, R], [-R, C, R], [-R, C, -R], white)
+    _quad(renderer, [R, 0, -R], [R, 0, R], [R, C, R], [R, C, -R], white)
+
+    # Ceiling with a square aperture: four quads around the hole.
+    A = APERTURE
+    _quad(renderer, [-R, C, -R], [R, C, -R], [R, C, -A], [-R, C, -A], white)
+    _quad(renderer, [-R, C, A], [R, C, A], [R, C, R], [-R, C, R], white)
+    _quad(renderer, [-R, C, -A], [-A, C, -A], [-A, C, A], [-R, C, A], white)
+    _quad(renderer, [A, C, -A], [R, C, -A], [R, C, A], [A, C, A], white)
+
+    # The pane seals the aperture. Every straight line from inside the room to
+    # the hidden emitter that clears the hole also crosses the pane: the emitter
+    # sits on the axis 0.6 above the aperture, so a line from the floor reaching
+    # the hole edge (|x| = A) is at |x| = A * (EMITTER_Y - PANE_Y) /
+    # (EMITTER_Y - CEILING_Y) ~ 0.25 * 0.58/0.60 ~ 0.24 at the pane's height --
+    # far inside PANE = 0.32. Hence NEE to the emitter is ALWAYS occluded.
+    P = PANE
+    _quad(renderer, [-P, PANE_Y, -P], [P, PANE_Y, -P],
+          [P, PANE_Y, P], [-P, PANE_Y, P], pane)
+
+    # Two ordinary ceiling area lights supply all the bulk illumination. Winding
+    # matches the library convention (metal_cornell.py:68) so the outward normal
+    # is -Y and they emit downward into the room.
+    for x0, x1 in ((-1.55, -0.65), (0.65, 1.55)):
+        z0, z1 = -0.55, 0.55
+        renderer.add_triangle([x0, LIGHT_Y, z0], [x1, LIGHT_Y, z0],
+                              [x1, LIGHT_Y, z1], room_light)
+        renderer.add_triangle([x0, LIGHT_Y, z0], [x1, LIGHT_Y, z1],
+                              [x0, LIGHT_Y, z1], room_light)
+
+    # The hidden emitter. Tiny and extremely bright: high radiance (firefly
+    # magnitude) at low power (small energy share).
+    renderer.add_sphere([0.0, EMITTER_Y, 0.0], emitter_radius, hidden)
+
+    return dict(white=white, room_light=room_light, pane=pane, hidden=hidden)
+
+
+def setup_camera(renderer, width=WIDTH, height=HEIGHT):
+    """Camera inside the room, looking down.
+
+    Pitched steeply enough that the top of the frame is ~34 degrees below
+    horizontal, so the ceiling, the room lights, the pane and the emitter are
+    ALL out of frame. That is a correctness requirement, not framing taste: a
+    camera that can reach the emitter through a delta chain records a
+    deterministic ~10^3 feature that would set `peak` with no firefly involved.
+    """
+    renderer.setup_camera(
+        look_from=[0.0, 2.55, 1.55], look_at=[0.0, 0.0, -0.35], vup=[0, 1, 0],
+        vfov=38, aspect_ratio=width / height,
+        aperture=0.0, focus_dist=3.2,
+        width=width, height=height,
+    )
+    renderer.set_background_color([0.0, 0.0, 0.0])
+
+
+# ---------------------------------------------------------------------------
+# Tail statistics. Shared by the pkg161 tests, the pkg157 gate and the
+# calibration script so all three measure the identical quantity.
+# ---------------------------------------------------------------------------
+
+def luminance(pixels: np.ndarray) -> np.ndarray:
+    """Rec.709 luminance of a linear RGB image."""
+    px = np.asarray(pixels, dtype=np.float64)
+    return 0.2126 * px[..., 0] + 0.7152 * px[..., 1] + 0.0722 * px[..., 2]
+
+
+def tail_stats(pixels: np.ndarray, percentile: float = 99.9) -> dict:
+    """Tail-heaviness of a LINEAR-rendered image.
+
+    `ratio` = peak / p99.9 is the statistic pkg161 is specified against. It MUST
+    be computed on a linear render: render(..., apply_gamma=True) clamps to
+    [0, 1] before the 1/2.2 power (module/blender_module.cpp:1803-1811), which
+    annihilates exactly the outliers being measured. Memory:
+    `gamma-furnace-cannot-detect-energy-gain`.
+    """
+    lum = luminance(pixels)
+    peak = float(lum.max())
+    cut = float(np.percentile(lum, percentile))
+    mean = float(lum.mean())
+    return {
+        "peak": peak,
+        "p99_9": cut,
+        "mean": mean,
+        "ratio": peak / cut if cut > 0.0 else float("inf"),
+        "n_pixels": int(lum.size),
+        # The firefly population proper: pixels an order of magnitude above the
+        # tail cut. This is the design-window diagnostic -- it must stay well
+        # under 0.1% of the image, or the 99.9th percentile is itself a firefly
+        # and `ratio` collapses toward the ~2x of a double-hit-vs-single-hit
+        # comparison. If a calibration run shows n_fireflies > 0.001 * n_pixels,
+        # shrink EMITTER_RADIUS; if it shows 0, grow it.
+        "n_fireflies": int((lum > 10.0 * cut).sum()),
+    }

--- a/tests/test_pkg157_wavefront_firefly_clamp_port.py
+++ b/tests/test_pkg157_wavefront_firefly_clamp_port.py
@@ -83,6 +83,10 @@ if AVAILABLE and not astroray.__features__.get("cuda", False):
 
 if AVAILABLE:
     from base_helpers import create_cornell_box, setup_camera
+    # pkg161: the purpose-built firefly-bearing scene that un-skips the
+    # clamp-indirect gate at the bottom of this file. Construction and
+    # citations: tests/scenes/firefly_window.py.
+    import scenes.firefly_window as firefly
 
 
 def _luminance_map(pixels: np.ndarray) -> np.ndarray:
@@ -290,39 +294,35 @@ def test_gpu_wavefront_clamp_direct_and_indirect_controls():
     )
 
 
-@pytest.mark.skip(
-    reason=(
-        "UNMET PRECONDITION, not a code defect: no scene in the current test "
-        "library has a firefly population, so 'suppresses fireflies without "
-        "energy loss' is not demonstrable anywhere. Measured on RTX 5070 Ti "
-        "2026-07-26 -- tail-heaviness (peak/p99.9) across the scene suite at "
-        "16/64 spp: diffuse_light_cornell 1.82x/1.53x, thin_glass_cornell "
-        "1.66x/1.52x, disney_cornell 1.66x/1.52x, dielectric_cornell "
-        "1.40x/1.13x, metal_cornell 1.07x/1.04x. A real firefly tail is tens "
-        "to hundreds. With a tail that flat no clamp limit can satisfy both "
-        "halves of the claim: high enough to clip only outliers clips NOTHING "
-        "(p99.9 is 99.5% of peak here -- measured max|delta| 4.77e-07); low "
-        "enough to bite removes genuine signal (0.5x peak -> mean moved "
-        "4.166%). pkg144 contract item 3 ('clampIndirect=10 -> <0.02% "
-        "delta') is therefore not demonstrable on any existing gate scene. "
-        "Un-skip once a purpose-built firefly scene exists -- filed as "
-        "pkg161. NOT xfail: the code is NOT expected to fail, and an xfail is "
-        "never acceptable evidence for a gated feature (memory "
-        "xfail-gated-features-must-unxfail). The clamp's correctness is "
-        "established by the other gates in this file plus the verifier's "
-        "max_depth=1 bounce-classification result."
-    )
-)
 def test_gpu_wavefront_clamp_indirect_suppresses_fireflies_without_energy_loss():
     """Spec item 3's headline: an indirect clamp suppresses the brightest
     indirect contributions WITHOUT meaningful energy loss (the pkg144
     bias/variance tradeoff, reproduced against the wavefront).
 
-    SKIPPED -- see the skip reason above. Kept (not deleted) because the body
-    is correct and becomes a live gate the moment a firefly-bearing scene
-    exists; pkg161 covers building one. Three hardware rounds went into
-    calibrating this, and the conclusion was that the obstacle is a hole in
-    the SCENE LIBRARY, not a threshold that needs tuning. Do not re-tune it.
+    UN-SKIPPED BY pkg161 (2026-07-26). This test was `pytest.mark.skip`-ped for
+    an UNMET PRECONDITION, not a code defect: no scene in the library had a
+    firefly population, so "suppresses fireflies without energy loss" was not
+    demonstrable anywhere. Tail-heaviness (peak/p99.9) across the whole suite at
+    16/64 spp measured 1.04x-1.82x, where a real firefly tail is tens to
+    hundreds; the calibration history below records the three hardware rounds
+    that established that. pkg161 built `tests/scenes/firefly_window.py`
+    specifically to close that hole, and this test now runs against it.
+
+    The scene is a closed room lit normally by two ceiling area lights, plus a
+    tiny, extremely bright emitter OUTSIDE the room above a ceiling aperture
+    sealed by a delta `thin_glass` pane. Next-event estimation can never reach
+    that emitter (the pane occludes every shadow ray), so its entire
+    contribution arrives through `diffuse -> delta -> emitter` -- Heckbert's
+    `L S D E` class, at bounce 2, i.e. squarely under clampIndirect -- while
+    100% of the bulk image is bounce-0 NEE under clampDirect. The two halves of
+    this test are therefore separated by construction rather than by luck. Full
+    rationale and citations: tests/scenes/firefly_window.py and
+    .astroray_plan/docs/pkg161-firefly-scene-research.md.
+
+    The assertions below are UNCHANGED from the skipped version -- pkg161 moved
+    the scene, not the thresholds. If this fails on hardware, recalibrate the
+    scene with scripts/verify_pkg161_firefly_scene.py; do not retune the
+    2%/1e-5 constants, which are pkg144's contract.
 
     CALIBRATION HISTORY (RTX 5070 Ti, 2026-07-26). Three hardware rounds. No
     round ever implicated the port -- every correction was to this test, and
@@ -356,8 +356,8 @@ def test_gpu_wavefront_clamp_indirect_suppresses_fireflies_without_energy_loss()
         13.7507
     p99.9 turned out to be 99.5% of the peak -- there is no tail to clip.
 
-    ROOT CAUSE (measured, and the reason this is now skipped rather than
-    re-tuned a fourth time): the scene library contains no fireflies at all.
+    ROOT CAUSE (measured, and the reason this was skipped rather than
+    re-tuned a fourth time): the scene library contained no fireflies at all.
     Tail-heaviness (peak/p99.9) across the suite at 16/64 spp --
     diffuse_light_cornell 1.82x/1.53x, thin_glass_cornell 1.66x/1.52x,
     disney_cornell 1.66x/1.52x, dielectric_cornell 1.40x/1.13x, metal_cornell
@@ -373,15 +373,16 @@ def test_gpu_wavefront_clamp_indirect_suppresses_fireflies_without_energy_loss()
     were not commensurate."""
     def render(clamp_indirect: float) -> np.ndarray:
         r = _gpu_renderer()
-        create_cornell_box(r)
-        metal = r.create_material('metal', [0.9, 0.9, 0.9], {'roughness': 0.05})
-        r.add_sphere([0.0, -1.0, 0.0], 1.0, metal)
-        setup_camera(r, look_from=[0, 0, 5.5], look_at=[0, 0, 0], vfov=38,
-                     width=120, height=90)
-        r.set_seed(15704)
+        # pkg161: the firefly-bearing scene. Its defaults, resolution and spp
+        # live in the scene module so this gate and pkg161's own tail gate
+        # measure the identical configuration.
+        firefly.build_scene(r)
+        firefly.setup_camera(r, firefly.WIDTH, firefly.HEIGHT)
+        r.set_seed(firefly.SEED)
         r.set_clamp_direct(0.0)
         r.set_clamp_indirect(clamp_indirect)
-        return np.asarray(r.render(64, 8, None, False))
+        return np.asarray(
+            r.render(firefly.SAMPLES, firefly.MAX_DEPTH, None, False))
 
     # Tail cut defining "firefly". See docstring for why a percentile and not
     # a fraction of peak, and why 99.9 specifically.
@@ -400,6 +401,25 @@ def test_gpu_wavefront_clamp_indirect_suppresses_fireflies_without_energy_loss()
         f"p{TAIL_PERCENTILE} limit={limit:.6g} vs peak={peak:.6g}: no pixels "
         f"sit above the limit, so the clamp cannot bind and the "
         f"energy-preservation assertion below would be vacuous"
+    )
+
+    # pkg161 addition, and the one change to this test's assertions: the
+    # PRECONDITION that made rounds 1-3 unsatisfiable is now checked explicitly
+    # instead of being assumed. `peak > limit` above is nearly free -- it holds
+    # for any non-flat image, including the 1.04x metal_cornell that produced
+    # round 1's vacuous pass. Requiring an actual firefly tail means a future
+    # regression in the SCENE (someone widens the emitter, roughens the pane,
+    # or lets the camera see through it) fails here, loudly and with the right
+    # diagnosis, instead of silently restoring the vacuous pass.
+    tail_ratio = peak / limit
+    assert tail_ratio >= 10.0, (
+        f"scene tail ratio peak/p{TAIL_PERCENTILE} = {tail_ratio:.3g}x "
+        f"(peak={peak:.6g}, p99.9={limit:.6g}) -- pkg161 requires >= 10x for "
+        f"this gate to mean anything. The whole pre-pkg161 library measured "
+        f"1.04x-1.82x and made this test unsatisfiable; a value in that range "
+        f"means scenes/firefly_window.py has lost its firefly population, NOT "
+        f"that the clamp is broken. Recalibrate with "
+        f"scripts/verify_pkg161_firefly_scene.py."
     )
 
     clamped = render(limit)

--- a/tests/test_pkg161_firefly_scene_tail.py
+++ b/tests/test_pkg161_firefly_scene_tail.py
@@ -1,0 +1,275 @@
+"""pkg161 -- the firefly-bearing gate scene, validated BY MEASUREMENT.
+
+pkg161 contract item 2: "Validate by measurement, not by eye. The scene
+qualifies only if peak / p99.9 >~ 10x at the gate's spp. A scene that merely
+*looks* noisy does not qualify."
+
+The scene is tests/scenes/firefly_window.py; its construction, its citations and
+its tuning model are documented there and in
+.astroray_plan/docs/pkg161-firefly-scene-research.md.
+
+WHY THERE ARE NEGATIVE CONTROLS IN THIS FILE
+--------------------------------------------
+The reason the library ended up with no firefly-bearing scene is that
+"looks noisy" was never checked against a number. A tail-ratio assertion that
+nothing can fail would repeat that mistake one level up, so
+`test_tail_metric_discriminates` proves the SAME measurement function fails on
+two inputs that must not pass:
+
+  (a) `metal_cornell` -- measured 1.07x / 1.04x at 16 / 64 spp on RTX 5070 Ti
+      2026-07-26, the flattest scene in the suite. If the metric passed this,
+      it would be measuring nothing.
+  (b) the firefly scene itself rendered with apply_gamma=True -- the gamma path
+      clamps to [0, 1] before the 1/2.2 power
+      (module/blender_module.cpp:1803-1811), which annihilates precisely the
+      outliers being measured. This assertion exists so nobody can quietly flip
+      the 4th positional argument of render() back to its default and still see
+      a green suite. Memory: `gamma-furnace-cannot-detect-energy-gain`.
+
+CALIBRATION STATUS
+------------------
+The scene's EMITTER_INTENSITY / EMITTER_RADIUS defaults are ANALYTIC DESIGN
+TARGETS, not measurements -- the implementer had no GPU and ran no renders.
+`scripts/verify_pkg161_firefly_scene.py` measures them and prints corrected
+constants. If a test in this file fails on its threshold, run that script
+before touching the threshold: the thresholds here are the spec's, and the
+scene constants are the thing meant to move.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+sys.path.insert(0, os.path.dirname(__file__))
+
+try:
+    import astroray  # noqa: E402
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray not built")
+
+if AVAILABLE:
+    import scenes.firefly_window as firefly
+    import scenes.metal_cornell as metal_cornell
+
+
+#: pkg161 contract item 2. The whole suite measured 1.04x-1.82x before this
+#: package, so 10x is ~5.5x above the best pre-existing scene.
+FIREFLY_TAIL_RATIO_MIN = 10.0
+
+#: What a scene WITHOUT fireflies must stay under. metal_cornell measured
+#: 1.07x / 1.04x; 3.0 leaves generous headroom over every measured
+#: non-firefly scene (worst was diffuse_light_cornell at 1.82x) while staying
+#: far below the 10x bar, so the two populations cannot be confused.
+NO_TAIL_RATIO_MAX = 3.0
+
+
+def _render(build, camera, *, width, height, samples, max_depth, seed,
+            use_gpu=False, apply_gamma=False):
+    r = astroray.Renderer()
+    if use_gpu:
+        r.set_use_gpu(True)
+    # Required after set_use_gpu(True), harmless otherwise: Renderer's GPU
+    # dispatch only routes dedicated-light scenes correctly when the integrator
+    # name is set explicitly (documented in pkg157's _gpu_renderer()).
+    r.set_integrator("path_tracer")
+    build(r)
+    camera(r, width, height)
+    r.set_seed(seed)
+    return np.asarray(r.render(samples, max_depth, None, apply_gamma))
+
+
+def _firefly_render(*, width, height, samples, seed, use_gpu, apply_gamma=False,
+                    emitter_radius=None):
+    # Resolved lazily, NOT as a default argument. `firefly` is imported only
+    # under `if AVAILABLE:`, and a default argument is evaluated at *def* time —
+    # i.e. at module import, before `pytestmark = skipif(not AVAILABLE)` can
+    # suppress anything. Naming it in the signature makes this module fail to
+    # COLLECT on a checkout with no build, which is precisely the environment
+    # implementers work in here.
+    if emitter_radius is None:
+        emitter_radius = firefly.EMITTER_RADIUS
+    return _render(
+        lambda r: firefly.build_scene(r, emitter_radius=emitter_radius),
+        firefly.setup_camera,
+        width=width, height=height, samples=samples,
+        max_depth=firefly.MAX_DEPTH, seed=seed,
+        use_gpu=use_gpu, apply_gamma=apply_gamma,
+    )
+
+
+def _explain(stats, label):
+    return (
+        f"{label}: peak={stats['peak']:.6g} p99.9={stats['p99_9']:.6g} "
+        f"ratio={stats['ratio']:.3g} mean={stats['mean']:.6g} "
+        f"fireflies={stats['n_fireflies']}/{stats['n_pixels']} "
+        f"({100.0 * stats['n_fireflies'] / stats['n_pixels']:.4f}% of pixels)"
+    )
+
+
+def test_firefly_scene_has_heavy_tail_cpu():
+    """CPU leg. The scene must carry a real firefly tail on the CPU integrator
+    too, so it doubles as a CPU/GPU parity fixture (pkg161 gate 4: "fireflies
+    are exactly where CPU/GPU transport differences show up").
+
+    Renders with a deliberately enlarged emitter
+    (CPU_EMITTER_RADIUS_SCALE): the firefly COUNT is proportional to total
+    sample count (n_ff ~ N * spp * r_e^2) while the tail RATIO depends only on
+    L_e / spp, so scaling the radius buys back the count a CPU-affordable
+    render loses without changing the quantity under test. See the TUNING MODEL
+    section of scenes/firefly_window.py.
+    """
+    pixels = _firefly_render(
+        width=firefly.CPU_WIDTH, height=firefly.CPU_HEIGHT,
+        samples=firefly.CPU_SAMPLES, seed=firefly.SEED, use_gpu=False,
+        emitter_radius=firefly.EMITTER_RADIUS * firefly.CPU_EMITTER_RADIUS_SCALE,
+    )
+    stats = firefly.tail_stats(pixels)
+
+    # Guard the measurement itself before trusting it: a black or NaN image
+    # would give ratio = inf and pass the real assertion vacuously.
+    assert np.isfinite(pixels).all(), "CPU render produced NaN/Inf"
+    assert stats["mean"] > 1e-4, (
+        f"CPU render is essentially black ({_explain(stats, 'cpu')}); the tail "
+        f"ratio of a black image is meaningless"
+    )
+
+    assert stats["ratio"] >= FIREFLY_TAIL_RATIO_MIN, (
+        f"{_explain(stats, 'cpu')} -- pkg161 contract item 2 requires "
+        f">= {FIREFLY_TAIL_RATIO_MIN}x. If n_fireflies is 0 the emitter is too "
+        f"small (or too few samples); if n_fireflies exceeds 0.1% of pixels the "
+        f"99.9th percentile is itself a firefly and the emitter is too large. "
+        f"Run scripts/verify_pkg161_firefly_scene.py to recalibrate "
+        f"scenes/firefly_window.py's constants -- do NOT lower this threshold."
+    )
+
+
+@pytest.mark.skipif(
+    AVAILABLE and not astroray.__features__.get("cuda", False),
+    reason="CUDA feature not in this build; /verify runs this on the RTX box.",
+)
+def test_firefly_scene_has_heavy_tail_gpu():
+    """GPU-wavefront leg, at the exact configuration pkg157's un-skipped
+    firefly gate uses. This is the measurement pkg161 contract item 2 is
+    written against."""
+    pixels = _firefly_render(
+        width=firefly.WIDTH, height=firefly.HEIGHT,
+        samples=firefly.SAMPLES, seed=firefly.SEED, use_gpu=True,
+    )
+    stats = firefly.tail_stats(pixels)
+
+    assert np.isfinite(pixels).all(), "GPU render produced NaN/Inf"
+    assert stats["mean"] > 1e-4, (
+        f"GPU render is essentially black ({_explain(stats, 'gpu')})"
+    )
+    assert stats["n_fireflies"] > 0, (
+        f"{_explain(stats, 'gpu')} -- no pixel sits an order of magnitude above "
+        f"the tail cut, so there is no firefly population to suppress and "
+        f"pkg157's clamp gate would pass vacuously. Grow EMITTER_RADIUS."
+    )
+    assert stats["n_fireflies"] < 0.001 * stats["n_pixels"], (
+        f"{_explain(stats, 'gpu')} -- the firefly population is larger than the "
+        f"top 0.1%, so the 99.9th percentile is itself a firefly and the ratio "
+        f"below understates the tail. Shrink EMITTER_RADIUS."
+    )
+    assert stats["ratio"] >= FIREFLY_TAIL_RATIO_MIN, (
+        f"{_explain(stats, 'gpu')} -- pkg161 contract item 2 requires "
+        f">= {FIREFLY_TAIL_RATIO_MIN}x. Run "
+        f"scripts/verify_pkg161_firefly_scene.py to recalibrate "
+        f"scenes/firefly_window.py -- do NOT lower this threshold."
+    )
+
+    # THE ASSERTION THAT MAKES THE TAIL PROVABLY *VARIANCE*.
+    # Every check above would also pass if the camera could see some small,
+    # very bright OBJECT -- a specular image of the emitter through the pane,
+    # say. That is a deterministic feature, not a firefly, and it would set
+    # `peak` while suppressing nothing when clamped for the right reason. It is
+    # exactly the class of fake tail that would let pkg157's gate pass
+    # vacuously for a fourth time.
+    #
+    # Fireflies move when the RNG stream moves; bright objects do not. So
+    # re-render at a different seed and require the firefly pixel LOCATIONS to
+    # decorrelate. (Seeds are nonzero: 0 is the std::random_device sentinel,
+    # raytracer.h:2803, memory `seed-zero-is-random-sentinel`.)
+    other = _firefly_render(
+        width=firefly.WIDTH, height=firefly.HEIGHT,
+        samples=firefly.SAMPLES, seed=firefly.SEED + 3, use_gpu=True,
+    )
+    other_stats = firefly.tail_stats(other)
+    hot_a = firefly.luminance(pixels) > 10.0 * stats["p99_9"]
+    hot_b = firefly.luminance(other) > 10.0 * other_stats["p99_9"]
+    n_common = int((hot_a & hot_b).sum())
+    smaller = max(1, min(int(hot_a.sum()), int(hot_b.sum())))
+    overlap = n_common / smaller
+    assert overlap < 0.5, (
+        f"{stats['n_fireflies']} bright pixels at seed {firefly.SEED} and "
+        f"{other_stats['n_fireflies']} at seed {firefly.SEED + 3} overlap in "
+        f"{n_common} locations ({100.0 * overlap:.1f}%) -- a firefly "
+        f"population decorrelates completely between seeds, so this tail is a "
+        f"DETERMINISTIC bright feature, not variance. Most likely the camera "
+        f"can reach the hidden emitter through a specular chain (check that "
+        f"the pane and the aperture are out of frame in "
+        f"scenes/firefly_window.setup_camera). Clamping such a feature proves "
+        f"nothing about firefly suppression."
+    )
+
+
+def test_tail_metric_discriminates():
+    """NEGATIVE CONTROLS: the same measurement must FAIL on inputs that have no
+    firefly tail. Without this, `ratio >= 10` could be measuring an artifact of
+    the metric rather than a property of the scene.
+
+    Both legs run on CPU so they execute in CI, where there is no GPU.
+    """
+    # (a) The flattest scene in the library. Measured 1.07x / 1.04x at
+    #     16 / 64 spp on RTX 5070 Ti 2026-07-26.
+    flat_pixels = _render(
+        metal_cornell.build_scene, metal_cornell.setup_camera,
+        width=160, height=160, samples=32, max_depth=8, seed=16102,
+        use_gpu=False, apply_gamma=False,
+    )
+    flat = firefly.tail_stats(flat_pixels)
+    assert flat["mean"] > 1e-4, _explain(flat, "metal_cornell")
+    assert flat["ratio"] < NO_TAIL_RATIO_MAX, (
+        f"{_explain(flat, 'metal_cornell')} -- metal_cornell has NO firefly "
+        f"population (measured 1.07x / 1.04x on RTX). A tail ratio at or above "
+        f"{NO_TAIL_RATIO_MAX} here means the metric is responding to something "
+        f"other than fireflies, and every pkg161/pkg157 conclusion drawn from "
+        f"it is suspect."
+    )
+    assert flat["ratio"] < FIREFLY_TAIL_RATIO_MIN, (
+        "the firefly bar must be unreachable by a scene with no fireflies"
+    )
+
+    # (b) The firefly scene through the gamma path. render()'s 4th positional
+    #     argument is apply_gamma and DEFAULTS TO TRUE; it clamps to [0, 1]
+    #     before the 1/2.2 power, so every firefly collapses to exactly 1.0 and
+    #     the tail disappears. Small render -- this asserts a property of the
+    #     output transform, not of the scene, so it needs no firefly count.
+    gamma_pixels = _firefly_render(
+        width=120, height=90, samples=16, seed=16103, use_gpu=False,
+        apply_gamma=True,
+        emitter_radius=firefly.EMITTER_RADIUS * firefly.CPU_EMITTER_RADIUS_SCALE,
+    )
+    gamma = firefly.tail_stats(gamma_pixels)
+    assert gamma["peak"] <= 1.0 + 1e-6, (
+        f"gamma render peak={gamma['peak']:.6g} > 1.0 -- the [0,1] clamp in "
+        f"module/blender_module.cpp:1803-1811 is gone, and this control no "
+        f"longer proves what it claims"
+    )
+    assert gamma["ratio"] < NO_TAIL_RATIO_MAX, (
+        f"{_explain(gamma, 'firefly_window @ apply_gamma=True')} -- a "
+        f"gamma-rendered tail measurement is supposed to be MEANINGLESS "
+        f"(the clamp destroys the outliers). Seeing a real tail here means the "
+        f"output transform changed and every linear/gamma assumption in pkg161 "
+        f"needs rechecking."
+    )


### PR DESCRIPTION
## The hole this closes

The scene library had **no scene with a firefly population**. Measured on the RTX 5070 Ti on 2026-07-26, tail-heaviness (`peak / p99.9` of output luminance) across the entire suite:

| scene | @ 16 spp | @ 64 spp |
|---|---|---|
| diffuse_light_cornell | 1.82× | 1.53× |
| thin_glass_cornell | 1.66× | 1.52× |
| disney_cornell | 1.66× | 1.52× |
| dielectric_cornell | 1.40× | 1.13× |
| metal_cornell | 1.07× | 1.04× |

A genuine firefly population reads in the **tens to hundreds**. With a tail that flat, *"clampIndirect suppresses fireflies without energy loss"* was not demonstrable at any threshold — three separate calibration attempts failed for the same structural reason, there was nothing to suppress. pkg157's gate for it was `pytest.mark.skip`ped and pkg144 contract item 3 was formally amended as undemonstrable.

## What this adds

`tests/scenes/firefly_window.py` — a physically tiny, very high-radiance emitter reachable only via a low-probability specular path. **Cited, not invented** (CLAUDE.md §6): Zirr, Hanika & Dachsbacher, *"Re-Weighting Firefly Samples for Improved Finite-Sample Monte Carlo Estimates"*, CGF 37(6):410–421, 2018 (DOI 10.1111/cgf.13335), which defines a firefly as high contribution at low probability density; plus the Blender Manual's Cycles *Clamping* section.

Un-skips `test_gpu_wavefront_clamp_indirect_suppresses_fireflies_without_energy_loss`, and adds a tail-ratio gate with **`metal_cornell` as an explicit negative control** — the assertion must FAIL on a scene without fireflies, or it isn't measuring anything.

## Honest status of the numbers

**The thresholds in this PR are design targets, not measurements.** The implementer had no GPU and no CUDA build, by policy. Hardware calibration follows in a separate commit on this branch once I have measured the real tail ratio. Do not read `FIREFLY_TAIL_RATIO_MIN = 10.0` as an observed value.

## One bug fixed while finishing

The tail test named `firefly.EMITTER_RADIUS` as a **default argument**. `firefly` is imported only under `if AVAILABLE:`, and default arguments are evaluated at *def* time — i.e. at module import, before `pytestmark = skipif(not AVAILABLE)` can suppress anything. That made the module fail to **collect** on any checkout without a build, which is exactly the environment implementers work in here. Resolved lazily. 12 tests now collect clean.

The scene uses lambertian / light / thin_glass only — **no metal**, so pkg160's metal energy fix (`2d5bb27`) does not perturb it.