### PR TITLE
test(pkg164): re-pin MAX_GLOSSY_PARITY_MSE 0.04 → 0.006 (owner-approved)

### DIFF
--- a/tests/test_python_bindings.py
+++ b/tests/test_python_bindings.py
@@ -47,12 +47,24 @@ CENTER_SLICE_RADIUS = 12
 # pkg160 removed that additive boost: MetalPlugin now applies the SAME
 # multiplicative Kulla & Conty compensation, off the SAME shipped ggx_E tables,
 # that disney.cpp uses (astroray::ggxDarkeningChannel). Measured on this scene,
-# center-crop MSE fell 0.02474 -> 0.00353 (7x closer). The 0.04 bound is
-# deliberately NOT re-pinned to the new value: it remains a valid upper bound,
-# the two plugins are still genuinely different BRDFs (Disney's alpha floor,
-# schlickScale 0.8 and layering stack have no metal equivalent), and tightening
-# it is a separate decision from pkg160's fix.
-MAX_GLOSSY_PARITY_MSE = 0.04
+# center-crop MSE fell 0.02474 -> 0.00353 (7x closer). pkg160 deliberately left
+# the 0.04 bound alone, flagging the re-pin as a separate owner decision.
+#
+# pkg164: owner approved, so it is re-pinned to 0.006. Measured over 3
+# consecutive runs on RTX 5070 Ti post-pkg160: 0.003411 / 0.003492 / 0.003415 --
+# a ~2% spread, so run-to-run noise is not the binding constraint. 0.006 leaves
+# 1.72x headroom over the worst observed.
+#
+# Why this matters more than tidiness: at 0.04 this gate was 11.5x above the
+# measured value and could not fail on anything realistic. pkg160's actual
+# defect measured 0.02474 and passed here comfortably for months. At 0.006 that
+# same defect FAILS -- which is the whole point of having the gate.
+#
+# The two plugins remain genuinely different BRDFs (Disney's alpha floor,
+# schlickScale 0.8 and layering stack have no metal equivalent), so this is a
+# same-family regression check, not exact-parity. Do not tighten below ~0.005
+# without re-measuring: that would start tripping on the legitimate residual.
+MAX_GLOSSY_PARITY_MSE = 0.006
 MAX_GLASS_PARITY_MEAN_DIFF = 0.25
 MAX_GLASS_PARITY_P95_DIFF = 0.25
 MIN_SUN_SHADOW_MSE = 5e-4


### PR DESCRIPTION
pkg160 deliberately left this bound alone and flagged the re-pin as a separate owner decision. **Owner approved it.**

## Measurement

Three consecutive runs on RTX 5070 Ti against a post-pkg160 binary:

| run | center-crop MSE |
|---|---|
| 1 | 0.003411 |
| 2 | 0.003492 |
| 3 | 0.003415 |

A ~2% spread, so run-to-run noise is **not** the binding constraint. `0.006` leaves **1.72×** headroom over the worst observed.

## Why this matters more than tidiness

At `0.04` this gate sat **11.5× above the measured value** and could not fail on anything realistic. **pkg160's actual defect — plain `metal` creating energy via an invented additive multiscatter term — measured 0.02474 here and passed comfortably for months.**

At `0.006`, that same defect **fails**. That is the entire point of having the gate.

This is the same class of problem found repeatedly across this round: gates that were green for reasons unrelated to whether the code worked. A one-sided bound 11× above the signal is not a gate.

## Scope

The two plugins remain genuinely different BRDFs — Disney's alpha floor, `schlickScale` 0.8 and layering stack have no `metal` equivalent — so this stays a **same-family regression check**, not exact parity. The comment warns against tightening below ~0.005 without re-measuring, since that would start tripping on the legitimate residual.

## Verification

`tests/test_python_bindings.py` → **73 passed, 14 xfailed, 1 xpassed** against the tightened bound on a post-pkg160 build.

Test-threshold change only; no engine code touched.