### PR TITLE
feat(pkg163): GPU metal spectral response per-wavelength for CPU/GPU colour-space parity

### DIFF
--- a/.astroray_plan/docs/pkg163-metal-spectral-colorspace-research.md
+++ b/.astroray_plan/docs/pkg163-metal-spectral-colorspace-research.md
@@ -1,0 +1,62 @@
+# pkg163 — metal spectral colour-space parity: sourcing & citation trail
+
+## Problem
+CPU `MetalPlugin::evalSpectral` (`plugins/materials/metal.cpp:106-146`) builds
+the conductor BSDF **per wavelength**: F0 = albedo spectrum, per-λ Schlick
+Fresnel, per-λ Kulla & Conty energy compensation. The GPU (`gpu_metal_eval`,
+`include/astroray/gpu_materials.h`) built the whole f in **RGB** and then
+upsampled the sum **once** through the Jakob-Hanika LUT in the spectral wrappers
+(`gpu_material_sample_spectral` / `gpu_material_eval_spectral`). The JH upsample
+is nonlinear and not scalar-homogeneous, so the two constructions agree only for
+a flat albedo. Chromatic albedo diverged, worst at high roughness + grazing
+(measured GPU/CPU B = 1.0722 at r=0.9 — pkg160's documented band exception).
+
+## Direction chosen — A (GPU goes per-wavelength for metal)
+Architect recommendation. Implemented `gpu_metal_eval_spectral` as the device
+mirror of `MetalPlugin::evalSpectral`, routed through the two spectral wrappers
+for `GMAT_METAL` and the closure-graph conductor lobe (plain `metal` uploads as
+a closure graph — its `GGXConductor` lobe validates). Sampling/pdf unchanged;
+only the f-spectral construction moves per-λ. Direction B (drop CPU metal to the
+RGB fallback) was NOT taken — it lowers the oracle's spectral accuracy and needs
+owner approval; only warranted if A's measured register cost is material.
+
+## Algorithm sourcing (CLAUDE.md §6)
+This is a mirror of already-in-repo, already-cited code, not a new derivation.
+The canonical sources (carried in the code comments):
+
+- **Kulla & Conty 2017**, "Revisiting Physically Based Shading at Imageworks"
+  (SIGGRAPH course) — the GGX multiple-scattering energy-compensation lineage,
+  net factor `1 + Fms*(1-E)/E`. Same term already in `MetalPlugin` and
+  `DisneyPlugin::ggxCompensationFactor`.
+- **Cycles** `intern/cycles/kernel/closure/bsdf_microfacet.h`
+  (`microfacet_ggx_preserve_energy`), **BSD-3-Clause** (license confirmed by
+  pkg124/#501). Source of the E / Eavg tables (`g_ggxE` / `g_ggxEavg`, uploaded
+  from `DisneyEnergyCompensationTables`).
+- **Jakob & Hanika 2019**, "A Low-Dimensional Function Space for Efficient
+  Spectral Upsampling" (CGF/EGSR) — the RGB→spectral upsampler whose
+  nonlinearity IS the divergence mechanism. GPU device twin `gpu_jhEvalSpectrum`
+  (pkg54c), CPU `RGBAlbedoSpectrum::sample`.
+- CPU canonical mirror source for the per-λ construction:
+  `plugins/materials/metal.cpp::MetalPlugin::evalSpectral`.
+
+## Seam statement (spec §"The seam" binding consequence 2)
+Post-fix, metal's RGB→spectral upsample sits at the **F0 input** (albedo → JH
+per-λ), and the whole BSDF (Fresnel + compensation) is composed per-λ after it —
+identical seam position to CPU `MetalPlugin::evalSpectral`. This satisfies the
+architect's per-material CPU-canonical seam rule: metal's twins are both per-λ;
+Disney's twins remain both per-RGB (its conductor closure lowers to
+`gpu_disney_eval`, `disneyMetalConductor` flag, out of scope); glass stays
+scalar-neutral. No intra-lobe seam was introduced — Fresnel and compensation
+move together per-λ, never one spectral while the other stays RGB.
+
+## Register cost (spec gate 4) — PENDING team-lead HW gate
+Direction A adds per-λ arithmetic on the 4-λ state the kernel already carries.
+The plausible cost is small but plausibility is not evidence; the shade-stage
+regs/thread (runtime profile, not static `-Xptxas -v` under `-rdc=true`) must be
+measured before/after by the team-lead's HW gate. If material vs pkg155's ≤128
+target, escalate to owner/pkg155 before merge.
+
+## Not verified locally
+No CUDA build/verify on the implementer box (no vcvars in subagent shells).
+Build + RTX hardware sweep (both parity gates + register measurement) are the
+team-lead's HW gate.

--- a/.astroray_plan/packages/pkg163-metal-spectral-compensation-colorspace-parity.md
+++ b/.astroray_plan/packages/pkg163-metal-spectral-compensation-colorspace-parity.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 3 (GPU/CPU spectral parity)
 **Track:** A (RTX-gated)
-**Status:** open — dispatchable (precondition MET 2026-07-25: pkg160 merged to main as PR #527/`2d5bb27`; the fix is relative to pkg160's compensation term, which is now the shipped baseline). Not urgent-tier (worst measured error 7.2% at r=0.9 grazing chromatic), but it OWNS a documented gate exception (below) — schedule before the exception ossifies into permanence.
+**Status:** in review — direction A implemented (PR pending, 2026-08-01). GPU metal now builds its spectral response per-wavelength (`gpu_metal_eval_spectral`, the device mirror of `MetalPlugin::evalSpectral`), routed through `gpu_material_eval_spectral` / `gpu_material_sample_spectral` for `GMAT_METAL` and the closure-graph conductor lobe. pkg160's r=0.9 [0.95,1.10] band exception retired; decisive neutral-vs-chromatic control added as `tests/test_pkg163_metal_spectral_colorspace_parity.py`. Local CUDA build/RTX verify + shade-stage register measurement (gate 4) PENDING team-lead HW gate. Precondition MET 2026-07-25: pkg160 merged to main as PR #527/`2d5bb27`.
 **Estimated effort:** S–M (direction A is a per-λ mirror of an existing 30-line CPU function + a register measurement; direction B is trivial but touches the oracle — see Fix contract)
 **Depends on:** pkg160 merged (owner-approved 2026-07-26 with the documented r=0.9 exception). Related: pkg155 (the shade stage is at 221 regs/thread, 1 block/SM — any per-wavelength state added there has a real occupancy cost; this tension is the core design question). Evidence: `test_results/overnight_report_2026-07-25/pkg160_hw_numbers.json`.
 

--- a/.astroray_plan/packages/pkg163-metal-spectral-compensation-colorspace-parity.md
+++ b/.astroray_plan/packages/pkg163-metal-spectral-compensation-colorspace-parity.md
@@ -231,3 +231,89 @@ architect against `plugins/materials/disney.cpp:86-135,689-695`,
 899-904` before scoping — the initial "any chromatic material with compensation"
 generalization is NOT borne out by the code; the honest scope is the class rule
 in §Scope survey.
+
+## Hardware verification 2026-08-02
+
+**Hardware:** NVIDIA GeForce RTX 5070 Ti. **OS:** Windows 11 Enterprise 10.0.26200.
+**CUDA:** v12.8 (`nvcc.exe`). **OptiX:** 9.1.0. **OIDN:** 2.4.1.
+Worktree: `.claude/worktrees/pkg163` (branch
+`pkg163-spectral-compensation-colorspace-parity`), bound to HEAD
+`5a04c2ab76a2b9284e0f0d347674e7e0c1712c08`. Rebuilt clean via
+`scriptsuilduild_cuda_worktree.bat` (first invocation via bare `cmd /c`
+under the Bash tool produced a false-green banner-only interactive shell, exit
+0 with nothing built; re-invoked with `MSYS_NO_PATHCONV=1` to get a real
+build). No compiled source changed between 883fe06 (the material fix) and
+5a04c2a (this commit, test-file-only); confirmed the loaded `.pyd`
+(`build_cuda/astroray.cp313-win_amd64.pyd`, mtime 2026-08-01 23:45:04) is
+newer than `include/astroray/gpu_materials.h` (mtime 2026-08-01 23:32:25,
+last touched at 883fe06), so it reflects the PR's actual code change.
+`astroray.__file__` confirmed to resolve inside the worktree's own
+`build_cuda/`.
+
+This run is the first full execution of the amended gate statistic
+(2560 spp, 4-seed-averaged chromatic spread, bound unchanged at <=0.01). The
+prior head (883fe06) had failed only this sub-assertion at 0.0133 (single
+seed, 256 spp).
+
+### Pass/fail table
+
+| Test | Result |
+|---|---|
+| `test_pkg160_plain_metal_gpu_cpu_parity.py::test_plain_metal_gpu_cpu_parity[0.05]` | **PASSED** |
+| `test_pkg160_plain_metal_gpu_cpu_parity.py::test_plain_metal_gpu_cpu_parity[0.15]` | **PASSED** |
+| `test_pkg160_plain_metal_gpu_cpu_parity.py::test_plain_metal_gpu_cpu_parity[0.3]` | **PASSED** |
+| `test_pkg160_plain_metal_gpu_cpu_parity.py::test_plain_metal_gpu_cpu_parity[0.6]` | **PASSED** |
+| `test_pkg160_plain_metal_gpu_cpu_parity.py::test_plain_metal_gpu_cpu_parity[0.9]` | **PASSED** |
+| `test_pkg163_metal_spectral_colorspace_parity.py::test_neutral_metal_parity_in_band` | **PASSED** |
+| `test_pkg163_metal_spectral_colorspace_parity.py::test_chromatic_metal_parity_in_band_and_spread_bounded` | **PASSED** |
+
+`pytest tests/test_pkg160_plain_metal_gpu_cpu_parity.py tests/test_pkg163_metal_spectral_colorspace_parity.py -v -s --tb=short`
+-> **7 passed in 5.57s**.
+
+### Measured numbers (verbatim)
+
+pkg160 plain-metal GPU/CPU parity (band `[0.95, 1.05]` at all roughnesses,
+restoring the standard band scoped in this package's Gate 1):
+
+```
+roughness=0.05: R ratio(mean/median)=0.9998/0.9999  G=1.0000/0.9996  B=0.9977/0.9974
+roughness=0.15: R ratio(mean/median)=0.9999/1.0031  G=1.0007/1.0004  B=0.9983/1.0007
+roughness=0.3:  R ratio(mean/median)=0.9989/1.0000  G=1.0028/1.0036  B=0.9948/0.9966
+roughness=0.6:  R ratio(mean/median)=1.0100/1.0060  G=1.0052/1.0071  B=1.0085/1.0059
+roughness=0.9:  R ratio(mean/median)=1.0153/1.0076  G=1.0171/1.0078  B=1.0112/1.0062
+```
+
+pkg163 neutral metal (`[0.35]^3`, r=0.9, grazing framing):
+
+```
+GPU/CPU mean ratios R/G/B = 1.0164/1.0204/1.0159, spread=0.0046
+```
+
+pkg163 chromatic metal (`[0.92, 0.78, 0.35]`, r=0.9, grazing framing,
+2560 spp, 4 seeds):
+
+```
+seed=160160: R/G/B = 1.0182/1.0182/1.0187, spread=0.0006
+seed=163163: R/G/B = 1.0174/1.0200/1.0149, spread=0.0051
+seed=271828: R/G/B = 1.0143/1.0136/1.0148, spread=0.0013
+seed=314159: R/G/B = 1.0170/1.0191/1.0200, spread=0.0030
+seed-averaged spread = 0.0025 over seeds [160160, 163163, 271828, 314159]
+(per-seed [0.0006, 0.0051, 0.0013, 0.0030])
+```
+
+Seed-averaged spread 0.0025 is well under the <=0.01 bound in Gate 2, with
+per-seed values ranging 0.0006-0.0051 (i.e. even the worst single seed would
+have passed the original bound; the 2560 spp + 4-seed averaging resolved
+noise in the statistic, not a marginal pass).
+
+### Visual inspection
+
+Both gate files are numeric-only parity assertions (mean/median channel
+ratios); neither writes PNGs to `test_results/`, `benchmarks/`, or
+`tests/reference/`. No visual inspection artifacts were produced by this run.
+
+### Anomalies
+
+None observed. All roughness bands (0.05 through 0.9) are within
+`[0.95, 1.05]` on both mean and median, retiring pkg160's roughness-0.9-only
+`[0.95, 1.10]` band exception per this package's Gate 1.

--- a/include/astroray/gpu_materials.h
+++ b/include/astroray/gpu_materials.h
@@ -254,6 +254,70 @@ __device__ inline GVec3 gpu_metal_eval(
            gpu_ggxCompensationFactor(mat.baseColor, mat.roughness, NdotV);
 }
 
+// pkg163: native per-wavelength metal BSDF, the device mirror of CPU
+// MetalPlugin::evalSpectral (plugins/materials/metal.cpp:106-146). Its purpose
+// is CPU<->GPU colour-space parity: gpu_metal_eval builds f in RGB and the
+// spectral wrappers upsample the sum ONCE through the Jakob-Hanika LUT (Jakob &
+// Hanika 2019, "A Low-Dimensional Function Space for Efficient Spectral
+// Upsampling"), whereas the CPU is natively per-lambda. The JH upsample is
+// nonlinear and not scalar-homogeneous (JH(a+b) != JH(a)+JH(b),
+// JH(c*a) != c*JH(a)), so the two constructions agree only for a flat albedo;
+// for a chromatic albedo they diverge, worst at high roughness + grazing angle
+// (measured B=1.0722 at r=0.9, the pkg160 gate exception this package retires).
+//
+// Mirrors the WHOLE evalSpectral construction (spec §"The seam" binding
+// consequence 1: no term-level patch): per-lambda F0 from the same albedo
+// upsampler, per-lambda Schlick Fresnel, and the multiplicative Kulla & Conty
+// 2017 (Eq. 6-9) / Cycles microfacet_ggx_preserve_energy (bsdf_microfacet.h,
+// BSD-3-Clause) compensation via gpu_ggxDarkeningChannel, all off the same
+// achromatic scalar E/Eavg tables gpu_metal_eval reads. Sampling/pdf logic is
+// unchanged; only the f-spectral construction moves per-lambda.
+__device__ inline GSampledSpectrum gpu_metal_eval_spectral(
+    const GMaterial& mat, const GHitRecord& rec, const GVec3& wo, const GVec3& wi,
+    const GSampledWavelengths& wl)
+{
+    // Near-delta path mirrors MetalPlugin::evalSpectral lines 109-114:
+    // albedo spectrum * exp(-deviation) narrow lobe.
+    if (mat.roughness <= 0.1f) {
+        GVec3 perfectRefl = rec.normal * (2.f * wo.dot(rec.normal)) - wo;
+        float dev = (wi - perfectRefl).length();
+        float factor = (dev < 0.1f) ? expf(-dev * 100.f) : 0.f;
+        return gpu_rgbToSampledSpectrum(mat.baseColor, wl, mat.spectralMode) * factor;
+    }
+
+    float NdotL = rec.normal.dot(wi);
+    float NdotV = rec.normal.dot(wo);
+    if (NdotL <= 0.f || NdotV <= 0.f) return GSampledSpectrum(0.f);
+
+    GVec3 h    = (wo + wi).normalized();
+    float NdotH = fmaxf(rec.normal.dot(h), 0.001f);
+    float a     = mat.roughness * mat.roughness;
+    float a2    = a * a;
+    float denom = NdotH * NdotH * (a2 - 1.f) + 1.f;
+    float D     = a2 / (M_PI_F * denom * denom + 0.001f);
+    // Per-wavelength F0 = albedo spectrum, upsampled the same way the CPU's
+    // albedo_spec_.sample(lambdas) does (RGBAlbedoSpectrum -> JH), then per-
+    // lambda Schlick Fresnel.
+    GSampledSpectrum F0 = gpu_rgbToSampledSpectrum(mat.baseColor, wl, mat.spectralMode);
+    float fresnelPow5 = powf(1.f - fminf(fmaxf(h.dot(wo), 0.f), 1.f), 5.f);
+    GSampledSpectrum F = F0 + (GSampledSpectrum(1.f) - F0) * fresnelPow5;
+    float k = (mat.roughness + 1.f) * (mat.roughness + 1.f) / 8.f;
+    float G = (NdotL / (NdotL * (1.f - k) + k)) * (NdotV / (NdotV * (1.f - k) + k));
+    GSampledSpectrum singleScatter = F * (D * G / (4.f * NdotV + 0.001f));
+
+    // Multiplicative Kulla & Conty compensation, per wavelength: Fss is the
+    // conductor's reflectance F0 (= albedo spectrum at these lambdas), E/Eavg
+    // are achromatic geometry and stay scalar. Null-table fallback is the 1.0
+    // identity (single-scatter lobe), matching gpu_ggxCompensationFactor.
+    if (!g_ggxE || !g_ggxEavg) return singleScatter;
+    float E = fmaxf(gpu_ggxE(mat.roughness, NdotV), 1e-4f);
+    float Eavg = fminf(fmaxf(gpu_ggxEavg(mat.roughness), 0.f), 0.999f);
+    GSampledSpectrum result = singleScatter;
+    for (int i = 0; i < G_SPECTRUM_SAMPLES; ++i)
+        result[i] *= gpu_ggxDarkeningChannel(F0[i], E, Eavg);
+    return result;
+}
+
 template <typename TRng>
 __device__ inline GBSDFSample gpu_metal_sample(
     const GMaterial& mat, GHitRecord& rec, const GVec3& wo, TRng* rng)
@@ -1268,6 +1332,42 @@ __device__ inline GVec3 gpu_closure_graph_eval(
     return sum;
 }
 
+// pkg163: does this closure graph carry a metal (non-Disney) conductor lobe?
+// Only those lobes lower to gpu_metal_eval and therefore have the CPU-per-lambda
+// vs GPU-RGB colour-space seam. A Disney-originated conductor closure lowers to
+// gpu_disney_eval (per-RGB on both sides, consistent twins) and is out of scope.
+__device__ inline bool gpu_closure_graph_has_metal(const GMaterial& mat) {
+    if (mat.disneyMetalConductor) return false;
+    int count = mat.closureCount < G_MAX_MATERIAL_CLOSURES ? mat.closureCount : G_MAX_MATERIAL_CLOSURES;
+    for (int i = 0; i < count; ++i)
+        if (mat.closures[i].type == GCLOSURE_GGX_CONDUCTOR) return true;
+    return false;
+}
+
+// pkg163: per-wavelength closure-graph eval, used only when the graph carries a
+// metal conductor lobe (gpu_closure_graph_has_metal). The metal lobe is built
+// per-lambda via gpu_metal_eval_spectral (CPU-canonical colour space); any other
+// lobe keeps its existing per-lobe RGB eval then upsample. Non-metal graphs
+// never reach here, so their summed-then-upsampled behaviour is unchanged.
+__device__ inline GSampledSpectrum gpu_closure_graph_eval_spectral(
+    const GMaterial& mat, GHitRecord& rec, const GVec3& wo, const GVec3& wi,
+    const GSampledWavelengths& wl)
+{
+    GSampledSpectrum sum(0.0f);
+    int count = mat.closureCount < G_MAX_MATERIAL_CLOSURES ? mat.closureCount : G_MAX_MATERIAL_CLOSURES;
+    for (int i = 0; i < count; ++i) {
+        const GMaterialClosure& closure = mat.closures[i];
+        if (closure.type == GCLOSURE_EMISSION || closure.weight <= 0.0f) continue;
+        GMaterial tmp = gpu_closure_as_material(mat, closure);
+        if (tmp.type == GMAT_METAL)
+            sum += gpu_metal_eval_spectral(tmp, rec, wo, wi, wl) * closure.weight;
+        else
+            sum += gpu_rgbToSampledSpectrum(
+                gpu_closure_eval(mat, closure, rec, wo, wi), wl, mat.spectralMode);
+    }
+    return sum;
+}
+
 __device__ inline float gpu_closure_graph_pdf(
     const GMaterial& mat, const GHitRecord& rec, const GVec3& wo, const GVec3& wi)
 {
@@ -1375,6 +1475,14 @@ __device__ inline GSampledSpectrum gpu_material_eval_spectral(
     const GMaterial& mat, GHitRecord& rec, const GVec3& wo, const GVec3& wi,
     const GSampledWavelengths& wl)
 {
+    // pkg163: metal is natively per-lambda on the CPU (MetalPlugin::evalSpectral);
+    // build its spectrum per-lambda here too instead of upsampling the RGB eval,
+    // so the CPU/GPU colour spaces match. Plain `metal` uploads as a closure
+    // graph (its GGXConductor lobe validates), so both entry points are covered.
+    if (mat.type == GMAT_METAL)
+        return gpu_metal_eval_spectral(mat, rec, wo, wi, wl);
+    if (mat.type == GMAT_CLOSURE_GRAPH && gpu_closure_graph_has_metal(mat))
+        return gpu_closure_graph_eval_spectral(mat, rec, wo, wi, wl);
     return gpu_rgbToSampledSpectrum(
         gpu_material_eval(mat, rec, wo, wi), wl, mat.spectralMode);
 }
@@ -1438,6 +1546,23 @@ __device__ inline GBSDFSample gpu_material_sample_spectral(
     // the already-computed `s.f` -- numerically equivalent (same underlying
     // eval dispatch for the same (wo,wi)) and avoids a redundant device-side
     // re-eval.
+    // pkg163: metal is natively per-lambda on the CPU. For a non-delta metal
+    // bounce, build fSpectral per-lambda (gpu_metal_eval_spectral) rather than
+    // upsampling the RGB s.f, matching gpu_material_eval_spectral and the CPU
+    // oracle. The near-delta metal branch (s.isDelta, s.f = albedo mirror) keeps
+    // the plain albedo upsample below -- MetalPlugin::sample()'s delta lobe does
+    // not apply the eval factor either. Plain `metal` uploads as a closure graph
+    // (its GGXConductor lobe validates), so both entry points are covered; the
+    // closure-graph sampler has already recomputed s.wi's f for non-delta lobes.
+    bool metalSpectral = (mat.type == GMAT_METAL) ||
+        (mat.type == GMAT_CLOSURE_GRAPH && gpu_closure_graph_has_metal(mat));
+    if (metalSpectral && !s.isDelta && s.pdf > 0.0f && s.f.length2() > 0.0f) {
+        s.fSpectral = (mat.type == GMAT_METAL)
+            ? gpu_metal_eval_spectral(mat, rec, wo, s.wi, wl)
+            : gpu_closure_graph_eval_spectral(mat, rec, wo, s.wi, wl);
+        return s;
+    }
+
     float m = fmaxf(fmaxf(s.f.x, s.f.y), s.f.z);
     if (m > 1.0f) {
         s.fSpectral = gpu_rgbToSampledSpectrum(s.f * (1.0f / m), wl, mat.spectralMode) * m;

--- a/tests/test_pkg160_plain_metal_gpu_cpu_parity.py
+++ b/tests/test_pkg160_plain_metal_gpu_cpu_parity.py
@@ -31,10 +31,13 @@ environment, with nothing else in the scene. Deliberate:
 Gate
 ----
 Per channel, BOTH the mean ratio and the median ratio must land in
-[0.95, 1.05] — except roughness 0.9, whose CEILING is 1.10 under an
-owner-approved documented exception (see the RATIO_HIGH_ROUGHNESS_0_9 block
-below for the measured value, the confirmed cause, the evidence, and why it is
-a widened ceiling rather than an xfail). The floor is 0.95 at every roughness.
+[0.95, 1.05] at EVERY roughness. pkg160 shipped with a documented
+roughness-0.9-only ceiling of 1.10 (measured B=1.0722) because the GPU built
+the metal spectral response in RGB then upsampled once while the CPU was
+natively per-wavelength; pkg163 made the GPU per-wavelength too
+(gpu_metal_eval_spectral, the device mirror of MetalPlugin::evalSpectral), so
+the seam closed and the exception self-retired (PR #<pkg163>). The band is now
+uniform.
 
 The median is not redundant: the original defect measured mean 0.279 but
 median 0.141, i.e. the typical pixel was twice as wrong as the mean said, and a
@@ -98,63 +101,30 @@ RATIO_LOW = 0.95
 RATIO_HIGH = 1.05
 
 # ---------------------------------------------------------------------------
-# DOCUMENTED EXCEPTION at roughness 0.9 (owner-approved, PR #527, 2026-07-26)
+# pkg160's roughness-0.9 ceiling exception (1.10) was RETIRED by pkg163.
 # ---------------------------------------------------------------------------
-# The first RTX 5070 Ti run of this gate measured 31/32 assertions inside
-# [0.95, 1.05]. The one outside was roughness 0.9, channel B: **1.0722**.
-# Full sweep, GPU/CPU mean ratio:
+# pkg160 shipped with a documented r=0.9-only ceiling of 1.10: its first
+# RTX 5070 Ti run measured 31/32 assertions inside [0.95, 1.05], the one
+# outside being r=0.9 channel B at 1.0722. Cause: the CPU
+# (MetalPlugin::evalSpectral) applied the GGX energy compensation PER
+# WAVELENGTH off Fss = albedo_spec_.sample(lambdas), while the GPU
+# (gpu_metal_eval) applied it PER RGB CHANNEL and upsampled the product once
+# through the Jakob-Hanika LUT; the two agree only for a flat spectrum, so a
+# chromatic albedo diverged, worst at high roughness + grazing framing.
 #
-#     roughness      R        G        B
-#     0.05        0.9998   1.0000   0.9977
-#     0.15        1.0174   0.9863   1.0133
-#     0.30        1.0052   0.9980   1.0040
-#     0.60        1.0247   0.9964   1.0288
-#     0.90        1.0393   1.0137   1.0722   <- this row
-#
-# CAUSE — pre-existing architecture that pkg160 EXPOSED, not introduced.
-# CPU MetalPlugin::evalSpectral applies the compensation PER WAVELENGTH, from
-# Fss = albedo_spec_.sample(lambdas) (the Jakob-Hanika upsample of the albedo);
-# GPU gpu_metal_eval applies it PER RGB CHANNEL from mat.baseColor and then
-# upsamples the product. The two agree exactly only for a flat (achromatic)
-# spectrum. This is the same class of CPU-spectral/GPU-RGB difference the
-# Fresnel term in these two functions has always had; pkg160 simply put a
-# second, roughness-amplified factor through the same seam.
-#
-# EVIDENCE it is the upsampler and not a missing/incorrect term (team-lead,
-# three isolations on hardware, PR #527):
-#   1. r=0.05 sits at 0.9977-1.0000 — the near-delta branch where the
-#      compensation is inert. A missing or wrong term would diverge there too.
-#   2. Neutral albedo [0.35,0.35,0.35] collapses the per-channel spread 25x
-#      (0.0589 -> 0.0023).
-#   3. Decisive: neutral [0.35,0.35,0.35] gives B = 1.0074, while chromatic
-#      [0.92,0.78,0.35] — the SAME B value — gives B = 1.0743. Ten times the
-#      divergence with the only variable being whether the OTHER channels
-#      differ. That is a spectral-upsampling signature and nothing else.
-# Camera framing is the amplifier: the same material at a far camera measures
-# R/G/B = 1.0052/1.0025/1.0056. This test's close 60-degree framing is
-# grazing-dominated, which is where the two upsampling orders diverge most.
-# The chromatic background contributes only ~0.3%.
-#
-# WHY A WIDENED CEILING AND NOT AN xfail. An xfail would make ANY future
-# regression at r=0.9 invisible, and the repo already carries non-strict
-# xfails that assert nothing. 1.0722 against a 1.10 ceiling leaves ~3%
-# headroom, so a genuine regression beyond the known divergence STILL FAILS.
-# That is the difference between an exception and a hole. The floor is NOT
-# widened: the divergence is one-directional (GPU brighter), so a GPU-dim
-# regression must still trip at 0.95.
-#
-# FOLLOW-UP: the architect filed a package for the CPU-spectral vs GPU-RGB
-# compensation mismatch off this gate run (see PR #527's HW-gate comment
-# thread for the measurements above). When that lands, delete this exception
-# and put r=0.9 back on RATIO_HIGH.
-RATIO_HIGH_ROUGHNESS_0_9 = 1.10
+# pkg163 closed the seam: the GPU now builds the metal spectral response
+# per-wavelength (gpu_metal_eval_spectral in include/astroray/gpu_materials.h,
+# the device mirror of MetalPlugin::evalSpectral), routed through
+# gpu_material_eval_spectral / gpu_material_sample_spectral for GMAT_METAL and
+# the closure-graph conductor lobe. Both twins are now per-lambda, so r=0.9 is
+# back inside the standard [0.95, 1.05] band and the exception is gone. The
+# decisive neutral-vs-chromatic control is now its own regression test,
+# tests/test_pkg163_metal_spectral_colorspace_parity.py.
 
 
 def _band(roughness: float) -> tuple[float, float]:
-    """Per-roughness acceptance band. See the exception block above: only the
-    r=0.9 CEILING is relaxed, and only to 1.10."""
-    if roughness == 0.9:
-        return RATIO_LOW, RATIO_HIGH_ROUGHNESS_0_9
+    """Per-roughness acceptance band. Uniform [0.95, 1.05] at every roughness
+    since pkg163 retired the r=0.9 ceiling exception."""
     return RATIO_LOW, RATIO_HIGH
 
 

--- a/tests/test_pkg163_metal_spectral_colorspace_parity.py
+++ b/tests/test_pkg163_metal_spectral_colorspace_parity.py
@@ -52,9 +52,23 @@ if AVAILABLE and not astroray.__features__.get("cuda", False):
     )
 
 WIDTH = HEIGHT = 48
-SAMPLES = 256
+# 2560 spp (not 256): the HW gate proved the channel-spread statistic at 256 spp
+# is pure MC noise, not signal. On this same scene the single-seed 256-spp spread
+# ranged 0.0059-0.0133 across seeds (draw-dependent), the worst channel flipped
+# G<->B by seed, and chromatic-minus-neutral even flipped SIGN (seed 314159:
+# chromatic 0.0083 < neutral 0.0100). At 2560 spp it converges (seed 160160:
+# neutral == chromatic == 0.0006), so we measure the seed-AVERAGED spread here.
+SAMPLES = 2560
 MAX_DEPTH = 4
 SEED = 163163
+
+# Four fixed seeds, averaged for the spread statistic. 163163 is included
+# deliberately -- it was the anomalously-noisy 256-spp draw (0.0133); averaging
+# over multiple seeds at 2560 spp keeps it from pinning the gate on noise. Two
+# of these seeds were measured at 2560 spp (160160 -> 0.0006, 163163 -> 0.0051);
+# the 4-seed average is estimated ~0.003 (comfortably under the 0.01 bound). The
+# full 4-seed run executes for the first time at the HW re-gate.
+SEEDS = [160160, 163163, 271828, 314159]
 
 ROUGHNESS = 0.9  # the seam's worst case (compensation-dominated + grazing)
 
@@ -69,6 +83,8 @@ RATIO_HIGH = 1.05
 
 # Post-fix chromatic channel spread bound. Pre-fix the chromatic spread was
 # 0.0589 (25x the neutral 0.0023); the fix must collapse it well under 0.01.
+# The bound sits above the converged floor (~0.0006-0.005 at 2560 spp) and is
+# asserted on the seed-AVERAGED spread, not any single noisy draw.
 MAX_CHROMATIC_SPREAD = 0.01
 
 
@@ -88,18 +104,18 @@ def _make_metal_scene(use_gpu: bool, albedo):
     return r
 
 
-def _render(use_gpu: bool, albedo) -> np.ndarray:
+def _render(use_gpu: bool, albedo, seed: int) -> np.ndarray:
     r = _make_metal_scene(use_gpu=use_gpu, albedo=albedo)
-    r.set_seed(SEED)
+    r.set_seed(seed)
     # 4th positional arg is applyGamma -- False keeps both sides linear
     # (memory gamma-vs-linear-comparison-artifact); a gamma render would clamp
     # to [0,1] and could never detect an energy gain.
     return np.asarray(r.render(SAMPLES, MAX_DEPTH, None, False), dtype=np.float64)
 
 
-def _mean_ratios(albedo) -> list[float]:
-    gpu = _render(use_gpu=True, albedo=albedo)
-    cpu = _render(use_gpu=False, albedo=albedo)
+def _mean_ratios(albedo, seed: int) -> list[float]:
+    gpu = _render(use_gpu=True, albedo=albedo, seed=seed)
+    cpu = _render(use_gpu=False, albedo=albedo, seed=seed)
     assert gpu.shape == (HEIGHT, WIDTH, 3)
     assert cpu.shape == (HEIGHT, WIDTH, 3)
     assert np.all(np.isfinite(gpu)), "GPU render produced NaN/Inf"
@@ -115,7 +131,7 @@ def _mean_ratios(albedo) -> list[float]:
 
 
 def test_neutral_metal_parity_in_band():
-    ratios = _mean_ratios(NEUTRAL)
+    ratios = _mean_ratios(NEUTRAL, SEED)
     print(f"\n[pkg163 neutral metal r={ROUGHNESS}] GPU/CPU mean ratios "
           f"R/G/B = {ratios[0]:.4f}/{ratios[1]:.4f}/{ratios[2]:.4f} "
           f"spread={max(ratios) - min(ratios):.4f}")
@@ -127,22 +143,38 @@ def test_neutral_metal_parity_in_band():
 
 
 def test_chromatic_metal_parity_in_band_and_spread_bounded():
-    ratios = _mean_ratios(CHROMATIC)
-    spread = max(ratios) - min(ratios)
-    print(f"\n[pkg163 chromatic metal r={ROUGHNESS}] GPU/CPU mean ratios "
-          f"R/G/B = {ratios[0]:.4f}/{ratios[1]:.4f}/{ratios[2]:.4f} "
-          f"spread={spread:.4f}")
-    # Both floor AND ceiling: the seam divergence was one-directional (GPU
-    # brighter, B=1.0722 pre-fix), so the 1.05 ceiling is the load-bearing bound.
-    for c, ch in enumerate("RGB"):
-        assert RATIO_LOW <= ratios[c] <= RATIO_HIGH, (
-            f"chromatic metal channel {ch} ratio {ratios[c]:.4f} outside "
-            f"[{RATIO_LOW}, {RATIO_HIGH}] -- the colour-space seam is not closed"
-        )
-    # The decisive control: with the seam closed, the chromatic spread must
-    # collapse toward the neutral case (pre-fix 0.0589 -> assert <= 0.01).
-    assert spread <= MAX_CHROMATIC_SPREAD, (
-        f"chromatic channel spread {spread:.4f} exceeds {MAX_CHROMATIC_SPREAD}; "
-        f"the per-wavelength/per-RGB colour-space divergence has not collapsed "
-        f"(ratios R/G/B = {ratios[0]:.4f}/{ratios[1]:.4f}/{ratios[2]:.4f})"
+    # Per-seed: assert the mean ratios are in-band (the seam-closed check, which
+    # is NOT noise-sensitive). Collect each seed's spread and assert the
+    # SEED-AVERAGED spread against the bound -- a single 256-spp draw's spread is
+    # pure MC noise (HW gate: 0.0059-0.0133 across these four seeds, worst channel
+    # flips G<->B by seed, chromatic-minus-neutral flips sign; at 2560 spp it
+    # converges to ~0.0006-0.005). Averaging over four fixed seeds at 2560 spp
+    # measures the converged floor, not the draw.
+    spreads = []
+    for seed in SEEDS:
+        ratios = _mean_ratios(CHROMATIC, seed)
+        spread = max(ratios) - min(ratios)
+        spreads.append(spread)
+        print(f"\n[pkg163 chromatic metal r={ROUGHNESS} seed={seed}] "
+              f"GPU/CPU mean ratios "
+              f"R/G/B = {ratios[0]:.4f}/{ratios[1]:.4f}/{ratios[2]:.4f} "
+              f"spread={spread:.4f}")
+        # Both floor AND ceiling: the seam divergence was one-directional (GPU
+        # brighter, B=1.0722 pre-fix), so 1.05 is the load-bearing bound.
+        for c, ch in enumerate("RGB"):
+            assert RATIO_LOW <= ratios[c] <= RATIO_HIGH, (
+                f"chromatic metal channel {ch} ratio {ratios[c]:.4f} outside "
+                f"[{RATIO_LOW}, {RATIO_HIGH}] at seed={seed} -- the colour-space "
+                f"seam is not closed"
+            )
+
+    avg_spread = sum(spreads) / len(spreads)
+    print(f"\n[pkg163 chromatic metal r={ROUGHNESS}] seed-averaged spread="
+          f"{avg_spread:.4f} over seeds {SEEDS} (per-seed {[f'{s:.4f}' for s in spreads]})")
+    # The decisive control: with the seam closed, the seed-averaged chromatic
+    # spread must collapse toward the neutral case (pre-fix 0.0589 -> assert <= 0.01).
+    assert avg_spread <= MAX_CHROMATIC_SPREAD, (
+        f"seed-averaged chromatic channel spread {avg_spread:.4f} exceeds "
+        f"{MAX_CHROMATIC_SPREAD}; the per-wavelength/per-RGB colour-space "
+        f"divergence has not collapsed (per-seed spreads {[f'{s:.4f}' for s in spreads]})"
     )

--- a/tests/test_pkg163_metal_spectral_colorspace_parity.py
+++ b/tests/test_pkg163_metal_spectral_colorspace_parity.py
@@ -1,0 +1,148 @@
+"""pkg163 — GPU/CPU metal colour-space parity: the neutral-vs-chromatic control.
+
+Why this file exists
+--------------------
+pkg160 gave plain `metal` its energy-compensation term but left a CPU/GPU
+colour-space seam: the CPU (MetalPlugin::evalSpectral) built the metal spectral
+response PER WAVELENGTH, while the GPU (gpu_metal_eval) built it PER RGB CHANNEL
+and upsampled the sum ONCE through the nonlinear Jakob-Hanika LUT. The two agree
+only for a flat (achromatic) albedo; a chromatic albedo diverged, worst at high
+roughness + grazing framing (r=0.9, channel B measured GPU/CPU = 1.0722).
+
+pkg163 made the GPU per-wavelength too (gpu_metal_eval_spectral, the device
+mirror of MetalPlugin::evalSpectral, routed through gpu_material_eval_spectral /
+gpu_material_sample_spectral). This test locks in the DECISIVE isolation that
+pins the mechanism as spectral-upsampling and nothing else (pkg160 HW gate,
+isolations 2 & 3):
+
+  * NEUTRAL albedo [0.35, 0.35, 0.35] barely diverges (channel spread of the
+    GPU/CPU mean ratios measured 0.0023 on the pkg160 HW run) because a flat
+    spectrum is the one case where RGB-then-upsample equals per-wavelength.
+  * CHROMATIC albedo [0.92, 0.78, 0.35] diverged 25x more pre-fix (spread
+    0.0589). Post-fix it must collapse back toward the neutral case.
+
+The scene, framing, sampling, and linear (apply_gamma=False) rendering mirror
+tests/test_pkg160_plain_metal_gpu_cpu_parity.py so the two gates measure the
+same quantity; this one fixes roughness at 0.9 (the seam's worst case) and adds
+the channel-spread bound the per-roughness band gate cannot express.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+
+try:
+    import astroray  # noqa: E402
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray not built")
+
+if AVAILABLE and not astroray.__features__.get("cuda", False):
+    pytest.skip(
+        "CUDA feature not in this build -- pkg163 metal colour-space parity "
+        "needs the RTX box.",
+        allow_module_level=True,
+    )
+
+WIDTH = HEIGHT = 48
+SAMPLES = 256
+MAX_DEPTH = 4
+SEED = 163163
+
+ROUGHNESS = 0.9  # the seam's worst case (compensation-dominated + grazing)
+
+CHROMATIC = [0.92, 0.78, 0.35]
+NEUTRAL = [0.35, 0.35, 0.35]
+BACKGROUND = [0.35, 0.45, 0.60]
+
+# Standard parity band, uniform across channels (matches the pkg160 gate that
+# pkg163 un-widened). Ratios are GPU/CPU linear per-channel means.
+RATIO_LOW = 0.95
+RATIO_HIGH = 1.05
+
+# Post-fix chromatic channel spread bound. Pre-fix the chromatic spread was
+# 0.0589 (25x the neutral 0.0023); the fix must collapse it well under 0.01.
+MAX_CHROMATIC_SPREAD = 0.01
+
+
+def _make_metal_scene(use_gpu: bool, albedo):
+    r = astroray.Renderer()
+    r.set_background_color(BACKGROUND)
+    metal = r.create_material("metal", albedo, {"roughness": ROUGHNESS})
+    r.add_sphere([0.0, 0.0, 0.0], 0.9, metal)
+    # Close 60-degree framing: the sphere fills every pixel (grazing-dominated,
+    # where the two upsampling orders diverge most). Identical to the pkg160 gate.
+    r.setup_camera([0.0, 0.0, 1.35], [0.0, 0.0, 0.0], [0.0, 1.0, 0.0],
+                   60.0, WIDTH / HEIGHT, 0.0, 1.35, WIDTH, HEIGHT)
+    r.set_integrator("path_tracer")
+    r.set_integrator_param("max_depth", MAX_DEPTH)
+    if use_gpu:
+        r.set_use_gpu(True)
+    return r
+
+
+def _render(use_gpu: bool, albedo) -> np.ndarray:
+    r = _make_metal_scene(use_gpu=use_gpu, albedo=albedo)
+    r.set_seed(SEED)
+    # 4th positional arg is applyGamma -- False keeps both sides linear
+    # (memory gamma-vs-linear-comparison-artifact); a gamma render would clamp
+    # to [0,1] and could never detect an energy gain.
+    return np.asarray(r.render(SAMPLES, MAX_DEPTH, None, False), dtype=np.float64)
+
+
+def _mean_ratios(albedo) -> list[float]:
+    gpu = _render(use_gpu=True, albedo=albedo)
+    cpu = _render(use_gpu=False, albedo=albedo)
+    assert gpu.shape == (HEIGHT, WIDTH, 3)
+    assert cpu.shape == (HEIGHT, WIDTH, 3)
+    assert np.all(np.isfinite(gpu)), "GPU render produced NaN/Inf"
+    assert np.all(np.isfinite(cpu)), "CPU render produced NaN/Inf"
+    # Full-coverage guard (see pkg160 gate): background pixels would drag every
+    # ratio toward 1.0 and silently weaken the gate.
+    missed = int(np.sum(np.all(np.isclose(cpu, np.array(BACKGROUND), atol=1e-6),
+                               axis=-1)))
+    assert missed == 0, (
+        f"{missed} pixels missed the metal sphere; re-check the camera framing"
+    )
+    return [float(gpu[..., c].mean()) / float(cpu[..., c].mean()) for c in range(3)]
+
+
+def test_neutral_metal_parity_in_band():
+    ratios = _mean_ratios(NEUTRAL)
+    print(f"\n[pkg163 neutral metal r={ROUGHNESS}] GPU/CPU mean ratios "
+          f"R/G/B = {ratios[0]:.4f}/{ratios[1]:.4f}/{ratios[2]:.4f} "
+          f"spread={max(ratios) - min(ratios):.4f}")
+    for c, ch in enumerate("RGB"):
+        assert RATIO_LOW <= ratios[c] <= RATIO_HIGH, (
+            f"neutral metal channel {ch} ratio {ratios[c]:.4f} outside "
+            f"[{RATIO_LOW}, {RATIO_HIGH}]"
+        )
+
+
+def test_chromatic_metal_parity_in_band_and_spread_bounded():
+    ratios = _mean_ratios(CHROMATIC)
+    spread = max(ratios) - min(ratios)
+    print(f"\n[pkg163 chromatic metal r={ROUGHNESS}] GPU/CPU mean ratios "
+          f"R/G/B = {ratios[0]:.4f}/{ratios[1]:.4f}/{ratios[2]:.4f} "
+          f"spread={spread:.4f}")
+    # Both floor AND ceiling: the seam divergence was one-directional (GPU
+    # brighter, B=1.0722 pre-fix), so the 1.05 ceiling is the load-bearing bound.
+    for c, ch in enumerate("RGB"):
+        assert RATIO_LOW <= ratios[c] <= RATIO_HIGH, (
+            f"chromatic metal channel {ch} ratio {ratios[c]:.4f} outside "
+            f"[{RATIO_LOW}, {RATIO_HIGH}] -- the colour-space seam is not closed"
+        )
+    # The decisive control: with the seam closed, the chromatic spread must
+    # collapse toward the neutral case (pre-fix 0.0589 -> assert <= 0.01).
+    assert spread <= MAX_CHROMATIC_SPREAD, (
+        f"chromatic channel spread {spread:.4f} exceeds {MAX_CHROMATIC_SPREAD}; "
+        f"the per-wavelength/per-RGB colour-space divergence has not collapsed "
+        f"(ratios R/G/B = {ratios[0]:.4f}/{ratios[1]:.4f}/{ratios[2]:.4f})"
+    )


### PR DESCRIPTION
## Summary
Closes the CPU↔GPU colour-space seam for plain `metal`. The CPU
(`MetalPlugin::evalSpectral`) builds the conductor BSDF **per wavelength**; the
GPU (`gpu_metal_eval`) built it in **RGB** and upsampled the sum **once**
through the nonlinear Jakob-Hanika LUT. The two agree only for a flat albedo, so
a chromatic albedo diverged — worst at high roughness + grazing (GPU/CPU
B = **1.0722** at r=0.9, the pkg160 documented band exception).

**Direction A** (architect recommendation): the GPU now builds the metal
spectral response per-wavelength too.

## What changed
- New device fn `gpu_metal_eval_spectral` (`include/astroray/gpu_materials.h`) —
  the term-for-term device mirror of `MetalPlugin::evalSpectral`: per-λ F0 from
  the same albedo upsampler, per-λ Schlick Fresnel, multiplicative Kulla & Conty
  compensation via `gpu_ggxDarkeningChannel` off the same scalar `E`/`Eavg`
  tables `gpu_metal_eval` reads.
- Routed through `gpu_material_eval_spectral` (NEE) and
  `gpu_material_sample_spectral` (BSDF sampling) for `GMAT_METAL` **and** the
  closure-graph conductor lobe (plain `metal` uploads as a closure graph — its
  `GGXConductor` lobe validates). Sampling/pdf logic unchanged; only the
  f-spectral construction moves per-λ.
- `gpu_closure_graph_has_metal` gate keeps every non-metal closure graph on its
  exact existing summed-then-upsampled behaviour (Disney conductor lobe →
  `gpu_disney_eval`, `disneyMetalConductor`, out of scope; glass scalar-neutral).
- Near-delta metal (roughness ≤ 0.1, `s.isDelta`) keeps the plain albedo
  upsample — `MetalPlugin::sample()`'s delta lobe applies no eval factor either.

## Seam statement (spec §"The seam")
Post-fix, metal's RGB→spectral upsample sits at the **F0 input** and the whole
BSDF (Fresnel + compensation) composes per-λ after it — identical seam position
to the CPU. Per-material CPU-canonical seam rule satisfied: metal twins both
per-λ; Disney twins both per-RGB; glass scalar. No intra-lobe seam introduced
(Fresnel + compensation move together per-λ, never one spectral / one RGB).

## Gates
- [x] **Gate 1 — un-widen pkg160's band exception.**
  `test_pkg160_plain_metal_gpu_cpu_parity.py` band is now uniform `[0.95, 1.05]`
  at every roughness (the r=0.9 → 1.10 ceiling and its constant/`_band` special
  case removed).
- [x] **Gate 2 — decisive control as a regression test.**
  `test_pkg163_metal_spectral_colorspace_parity.py`: neutral `[0.35]³` and
  chromatic `[0.92,0.78,0.35]` at r=0.9 grazing, both channels asserted in-band
  (floor + ceiling), chromatic channel spread bounded `≤ 0.01` (pre-fix 0.0589).
  Rendered linear (`apply_gamma=False`); `[0.95,1.05]` supplies the upper bound.
- [ ] **Gate 3 — no regression at r ≤ 0.3.** Covered by the existing pkg160
  sweep rows (0.05/0.15/0.3); confirmed by HW gate.
- [ ] **Gate 4 — shade-stage regs/thread (runtime profile) before/after.**
  PENDING team-lead HW gate (see below).
- [ ] **Gate 5 — furnace/energy suites green, RTX-verified.** PENDING HW gate.

## Algorithm sourcing (CLAUDE.md §6)
Mirror of already-in-repo, already-cited code. Citations carried in the code and
in `.astroray_plan/docs/pkg163-metal-spectral-colorspace-research.md`:
Kulla & Conty 2017; Cycles `bsdf_microfacet.h` (`microfacet_ggx_preserve_energy`,
BSD-3-Clause); Jakob & Hanika 2019 (the upsampler whose nonlinearity is the
mechanism); CPU canonical `plugins/materials/metal.cpp::MetalPlugin::evalSpectral`.

## Not verified locally — team-lead HW gate required
No CUDA `.pyd` build on the implementer box (no vcvars in subagent shells), so
**no build log and no RTX numbers are attached**. The team-lead's HW gate must:
1. build (`build_cuda_worktree.bat`),
2. run both parity gates on the RTX 5070 Ti (linear), confirming r=0.9 lands in
   `[0.95,1.05]` and the chromatic spread collapses ≤ 0.01,
3. measure shade-stage regs/thread (runtime profile, **not** static `-Xptxas -v`
   under `-rdc=true`) before/after for gate 4 — escalate to owner/pkg155 if the
   growth is material vs the ≤128 target.

Direction B (drop CPU metal to the RGB fallback) was **not** taken — it lowers
the oracle and needs owner approval; only warranted if A's register cost is material.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
