### PR TITLE
test(pkg166): convert furnace/energy suites to linear + naming guard

### DIFF
--- a/.astroray_plan/packages/pkg166-furnace-suites-linear-rendering.md
+++ b/.astroray_plan/packages/pkg166-furnace-suites-linear-rendering.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 3 (test hygiene / energy conservation gating)
 **Track:** A (CPU-gated on CI; any GPU-leg re-pins RTX-verified at closeout)
-**Status:** open — dispatchable (not urgent-tier — nothing is red today — but every future energy-ADDING change is under-gated until this lands; schedule ahead of the next transport/BSDF energy package)
+**Status:** done (PR #538, 2026-08-02) — all *furnace*/*energy* in-process render tests converted to linear with floor+ceiling pairs; autouse naming guard + negative self-test landed; 315 passed / 5 xfailed on the converted suites; 1.5x BSDF mutation caught by the white-metal furnace case (1.156 > 1.02). REAL FINDING surfaced: Disney glass transmission furnace creates energy (CPU 1.10–1.78, GPU rough up to 2.30, gamma hid it) — those 3 cases xfail'd against the conserving band, NOT pinned in; needs an architect-filed follow-up (Disney glass transmission energy gain, CPU+GPU).
 **Estimated effort:** S–M (the conversion is mechanical; the work is re-pinning 278 param-case expected values on linear output and justifying each shift)
 **Depends on:** nothing open. Motivated by PR #534's full HW sweep (2026-08-02) and memory `gamma-furnace-cannot-detect-energy-gain` (pkg160, 2026-07-26).
 

--- a/.astroray_plan/packages/pkg166-furnace-suites-linear-rendering.md
+++ b/.astroray_plan/packages/pkg166-furnace-suites-linear-rendering.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 3 (test hygiene / energy conservation gating)
 **Track:** A (CPU-gated on CI; any GPU-leg re-pins RTX-verified at closeout)
-**Status:** done (PR #538, 2026-08-02) — all *furnace*/*energy* in-process render tests converted to linear with floor+ceiling pairs; autouse naming guard + negative self-test landed; 315 passed / 5 xfailed on the converted suites; 1.5x BSDF mutation caught by the white-metal furnace case (1.156 > 1.02). REAL FINDING surfaced: Disney glass transmission furnace creates energy (CPU 1.10–1.78, GPU rough up to 2.30, gamma hid it) — those 3 cases xfail'd against the conserving band, NOT pinned in; needs an architect-filed follow-up (Disney glass transmission energy gain, CPU+GPU).
+**Status:** done (PR #538, 2026-08-02) — all *furnace*/*energy* in-process render tests converted to linear with floor+ceiling pairs; autouse naming guard + negative self-test landed; 315 passed / 5 xfailed on the converted suites; 1.5x BSDF mutation caught by the white-metal furnace case (1.156 > 1.02). REAL FINDING surfaced: Disney glass transmission furnace creates energy (CPU 1.10–1.78, GPU rough up to 2.30, gamma hid it) — those 3 cases xfail'd against the conserving band, NOT pinned in; owned by pkg169 (Disney glass transmission energy gain, CPU+GPU, HIGH) whose fix PR must remove the xfail markers.
 **Estimated effort:** S–M (the conversion is mechanical; the work is re-pinning 278 param-case expected values on linear output and justifying each shift)
 **Depends on:** nothing open. Motivated by PR #534's full HW sweep (2026-08-02) and memory `gamma-furnace-cannot-detect-energy-gain` (pkg160, 2026-07-26).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,20 @@ with Pillar 4 astrophysics and Pillar 5 production polish queued/ongoing.
 
 All tests write images/charts to `test_results/` (gitignored).
 
+## Furnace/energy tests
+
+Any test whose name matches `*furnace*` or `*energy*` MUST render linear —
+`renderer.render(..., apply_gamma=False)` (or `render_image(..., apply_gamma=False)`)
+— and assert BOTH a floor and a ceiling. `apply_gamma` defaults to `True`, which
+clamps output to `[0, 1]`, so a gamma-rendered furnace can only ever detect energy
+LOSS, never GAIN: pkg160's white-metal conductor created energy up to **4.139** in
+linear (18,338 of 27,648 pixels above 1.0) yet every gamma furnace suite read a max
+of exactly **1.000000** and stayed green (PR #527, 2026-07-26). A floor-only assert
+is still half-blind even in linear — the ceiling is the half that catches a gain.
+This is enforced at test time by an autouse fixture (`tests/conftest.py` +
+`tests/_linear_render_guard.py`, pkg166): a furnace/energy test that renders gamma
+fails at the render call, not merely by convention.
+
 ## Rendering Notes
 
 - `Material::eval(rec, wo, wi)` returns **brdf × NdotL** (cosine INCLUDED). Do NOT multiply by NdotL again.

--- a/tests/_linear_render_guard.py
+++ b/tests/_linear_render_guard.py
@@ -1,0 +1,74 @@
+"""pkg166 — furnace/energy tests must render LINEAR, enforced at test time.
+
+`Renderer.render(...)`'s `apply_gamma` argument defaults to True, which clamps
+output to [0, 1]. A furnace/energy test rendered through gamma can therefore
+only ever detect energy LOSS, never GAIN — structurally, not statistically:
+pkg160's white-metal conductor created energy up to 4.139 in linear (18,338 of
+27,648 pixels above 1.0), yet every gamma-rendered furnace suite read a max of
+exactly 1.000000 and stayed green (memory `gamma-furnace-cannot-detect-energy-gain`,
+PR #527, 2026-07-26). pkg120 later ADDED energy the same way and sailed through
+every shipped furnace suite; only its own purpose-built linear gate caught it
+(PR #534 sweep, 2026-08-02).
+
+This module supplies the guard the conftest autouse fixture installs for any
+test whose name matches `*furnace*` or `*energy*`: it wraps `Renderer.render`
+and FAILS at call time if that render requests gamma. It is not a convention
+note — it fires.
+"""
+from __future__ import annotations
+
+import contextlib
+
+# A test whose name contains any of these renders radiometric quantities where
+# the gamma clamp would hide energy gain. Matched as a substring of the pytest
+# node name (so parametrized ids like `...[1.5]` still match).
+NAME_TAGS = ("furnace", "energy")
+
+
+def name_matches(node_name: str) -> bool:
+    return any(tag in node_name for tag in NAME_TAGS)
+
+
+def renders_gamma(args: tuple, kwargs: dict) -> bool:
+    """True if this Renderer.render(...) call would apply gamma.
+
+    Signature (pybind): render(samples_per_pixel, max_depth,
+    progress_callback=None, apply_gamma=True, ...). `args` excludes `self`.
+    """
+    if "apply_gamma" in kwargs:
+        return bool(kwargs["apply_gamma"])
+    if len(args) >= 4:  # samples, max_depth, progress_callback, apply_gamma
+        return bool(args[3])
+    return True  # apply_gamma defaults to True
+
+
+@contextlib.contextmanager
+def linear_render_guard(node_name: str):
+    """Wrap `astroray.Renderer.render` so a furnace/energy test that renders
+    gamma raises AssertionError at the render call. No-op if astroray is not
+    importable (the whole suite is skipped in that case)."""
+    try:
+        import astroray
+    except ImportError:
+        yield
+        return
+
+    renderer_cls = astroray.Renderer
+    original_render = renderer_cls.render
+
+    def guarded_render(self, *args, **kwargs):
+        assert not renders_gamma(args, kwargs), (
+            f"furnace/energy test '{node_name}' called render(...) with "
+            "apply_gamma=True. Furnace/energy tests MUST render linear "
+            "(apply_gamma=False): gamma clamps to [0, 1], so a gamma furnace "
+            "detects energy LOSS but never GAIN. pkg160's conductor read 4.139 "
+            "in linear yet 1.000000 through gamma (pkg166; memory "
+            "gamma-furnace-cannot-detect-energy-gain)."
+        )
+        return original_render(self, *args, **kwargs)
+
+    renderer_cls.render = guarded_render
+    try:
+        yield
+    finally:
+        renderer_cls.render = original_render

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,20 @@ from runtime_setup import (
 configure_test_temp_dir()
 BUILD_DIR = configure_test_imports()
 
+from _linear_render_guard import linear_render_guard, name_matches
+
+
+@pytest.fixture(autouse=True)
+def furnace_energy_linear_render_guard(request):
+    """pkg166: any test whose name matches *furnace* or *energy* MUST render
+    linear (apply_gamma=False). Enforced at the render call, not merely
+    documented — see tests/_linear_render_guard.py for the why."""
+    if not name_matches(request.node.name):
+        yield
+        return
+    with linear_render_guard(request.node.name):
+        yield
+
 
 @pytest.fixture(scope="session")
 def test_results_dir():

--- a/tests/test_dielectric_glass_furnace.py
+++ b/tests/test_dielectric_glass_furnace.py
@@ -47,7 +47,12 @@ def _furnace(ior: float, *, use_gpu: bool = False, spp: int = 64, depth: int = 3
         r.set_use_gpu(True)
     r.setup_camera([0, 0, 4], [0, 0, 0], [0, 1, 0], 40.0, 1.0, 0.0, 4.0, 80, 80)
     r.set_seed(7)
-    img = np.asarray(r.render(spp, depth, None, True), dtype=np.float32).reshape(80, 80, 3)
+    # pkg166: render LINEAR (4th arg apply_gamma=False). A gamma furnace clamps
+    # to [0,1] and can only ever detect energy LOSS, never GAIN. At albedo 1 in
+    # a radiance-1 field the target is 1.0, where gamma is a no-op, so the bands
+    # below are unchanged from the gamma pins — but the suite is no longer blind
+    # to an IOR-dependent energy GAIN above 1.0.
+    img = np.asarray(r.render(spp, depth, None, False), dtype=np.float32).reshape(80, 80, 3)
     return float(img[28:52, 28:52].mean())          # sphere-centre patch
 
 

--- a/tests/test_disney_energy_conservation.py
+++ b/tests/test_disney_energy_conservation.py
@@ -79,6 +79,12 @@ def test_disney_directional_hemispherical_reflectance_is_conserved(
     )
 
 
+# pkg166: measured-linear floor for the gray-furnace anti-glow test (below).
+# Measured mean luminance 0.2421 on cf67a92 (RTX 5070 Ti, linear); floor set
+# below it with margin so a near-black BSDF trips it while noise does not.
+_GRAY_FURNACE_FLOOR = 0.15
+
+
 def test_disney_mixed_metallic_sampler_does_not_glow_in_gray_furnace(
     astroray_module,
 ):
@@ -125,5 +131,15 @@ def test_disney_mixed_metallic_sampler_does_not_glow_in_gray_furnace(
         + 0.0722 * pixels[..., 2]
     )
 
-    assert float(np.mean(luminance[sphere])) <= 0.40
+    # Already linear (apply_gamma=False above). pkg166 adds the FLOOR half: the
+    # sphere is lit by a 0.45 gray field and must not read black, or "does not
+    # glow" would pass vacuously on a broken-dark BSDF. Ceiling 0.40 stays the
+    # anti-glow bound (mixed-lobe PDF must not overshoot the 0.45 environment).
+    mean_lum = float(np.mean(luminance[sphere]))
+    assert mean_lum <= 0.40
     assert float(np.percentile(luminance[sphere], 99.0)) <= 0.40
+    assert mean_lum >= _GRAY_FURNACE_FLOOR, (
+        f"gray-furnace sphere mean luminance {mean_lum:.4f} < {_GRAY_FURNACE_FLOOR} "
+        f"— the metallic Disney sphere reads near-black in a 0.45 field; the "
+        f"anti-glow ceiling would pass vacuously."
+    )

--- a/tests/test_disney_rough_glass_furnace.py
+++ b/tests/test_disney_rough_glass_furnace.py
@@ -45,7 +45,11 @@ def _furnace(roughness: float, *, use_gpu: bool = False, spp: int = 64, depth: i
         r.set_use_gpu(True)
     r.setup_camera([0, 0, 4], [0, 0, 0], [0, 1, 0], 40.0, 1.0, 0.0, 4.0, 80, 80)
     r.set_seed(7)
-    img = np.asarray(r.render(spp, depth, None, True), dtype=np.float32).reshape(80, 80, 3)
+    # pkg166: render LINEAR (4th arg apply_gamma=False). A gamma furnace clamps
+    # to [0,1] and is structurally blind to energy GAIN. Target is 1.0 (albedo 1
+    # in a radiance-1 field), where gamma is a no-op, so the conservation bands
+    # below are unchanged — but the ceilings can now actually catch a gain > 1.0.
+    img = np.asarray(r.render(spp, depth, None, False), dtype=np.float32).reshape(80, 80, 3)
     return float(img[28:52, 28:52].mean())          # sphere-centre patch
 
 
@@ -71,7 +75,26 @@ _SMOOTH = [0.0, 0.03]
 # gate; do not add R=0.05 here without first fixing that pre-existing gap.
 _ROUGH = [0.1, 0.3, 0.6, 1.0]
 
+# pkg166 REAL ENERGY-GAIN FINDING (2026-08-02). Converting this suite to linear
+# (apply_gamma=False) exposed that the Disney Principled transmission (glass)
+# lobe CREATES energy in the white furnace — hidden until now because gamma
+# clamps to [0,1] (the old bands passed on a clamped 1.000). Measured on
+# cf67a92, albedo=1, ior=1.5, patch mean, deterministic across 32/128/512 spp:
+#   CPU smooth R=0/0.03            -> 1.784
+#   CPU rough  R=0.1/0.3/0.6/1.0   -> 1.099 / 1.108 / 1.157 / 1.260
+#   GPU rough  R=0.1/0.3/0.6/1.0   -> 1.098 / 1.182 / 2.060 / 2.296
+# Controls conserve: plain `dielectric` furnace 0.994, opaque disney 0.958. The
+# GPU SMOOTH delta path is fine (0.993). Per pkg166's own contract these gains
+# are NOT pinned in and the bands are NOT widened: the conserving bands stay and
+# the failing cases are xfail'd pending the follow-up package (Disney glass
+# transmission energy gain, CPU+GPU). See team-lead 2026-08-02.
+_DISNEY_GLASS_ENERGY_GAIN = (
+    "pkg166 finding: Disney transmission (glass) lobe creates energy in the "
+    "white furnace (linear reveals >1.0; gamma hid it). Follow-up package TBD."
+)
 
+
+@pytest.mark.xfail(reason=_DISNEY_GLASS_ENERGY_GAIN, strict=False)
 def test_disney_smooth_glass_furnace_cpu():
     vals = {R: _furnace(R, spp=128) for R in _SMOOTH}
     bad = {R: v for R, v in vals.items() if not (0.95 <= v <= 1.02)}
@@ -86,8 +109,13 @@ def test_disney_rough_glass_furnace_converges():
     lo = _furnace(0.3, spp=256)
     hi = _furnace(0.3, spp=1024)
     assert abs(lo - hi) < 0.03, f"furnace not converged: 256spp={lo:.3f} 1024spp={hi:.3f}"
+    # pkg166: renders linear now (via _furnace). This is a CONVERGENCE property,
+    # orthogonal to the energy magnitude — the value bound lives in
+    # test_disney_rough_glass_furnace_energy_cpu (currently xfail'd for the
+    # Disney-glass energy-gain finding). Convergence itself holds regardless.
 
 
+@pytest.mark.xfail(reason=_DISNEY_GLASS_ENERGY_GAIN, strict=False)
 @pytest.mark.skipif(
     AVAILABLE and not astroray.__features__.get("cuda", False),
     reason="CUDA feature not in this build")
@@ -100,6 +128,7 @@ def test_disney_rough_glass_furnace_energy_gpu():
     assert not bad, f"GPU rough disney glass furnace not energy-conserving at roughness {bad}; all={vals}"
 
 
+@pytest.mark.xfail(reason=_DISNEY_GLASS_ENERGY_GAIN, strict=False)
 def test_disney_rough_glass_furnace_energy_cpu():
     # pkg118 FIXED 2026-06-08: the deficit was NOT missing multi-scatter — it was the
     # CPU analog of the #404 GPU glass-dark bug. The base Material::sampleSpectral wrapper

--- a/tests/test_disney_rough_glass_furnace.py
+++ b/tests/test_disney_rough_glass_furnace.py
@@ -86,11 +86,14 @@ _ROUGH = [0.1, 0.3, 0.6, 1.0]
 # Controls conserve: plain `dielectric` furnace 0.994, opaque disney 0.958. The
 # GPU SMOOTH delta path is fine (0.993). Per pkg166's own contract these gains
 # are NOT pinned in and the bands are NOT widened: the conserving bands stay and
-# the failing cases are xfail'd pending the follow-up package (Disney glass
-# transmission energy gain, CPU+GPU). See team-lead 2026-08-02.
+# the failing cases are xfail'd, owned by pkg169
+# (.astroray_plan/packages/pkg169-disney-transmission-energy-gain.md, HIGH).
+# pkg169's fix PR must REMOVE these markers and prove the cases green under
+# --runxfail — this is a quarantine of a known bug, not a permanent tolerance.
 _DISNEY_GLASS_ENERGY_GAIN = (
-    "pkg166 finding: Disney transmission (glass) lobe creates energy in the "
-    "white furnace (linear reveals >1.0; gamma hid it). Follow-up package TBD."
+    "energy gain under investigation, owned by pkg169: Disney transmission "
+    "(glass) lobe creates energy in the white furnace (linear reveals >1.0; "
+    "gamma hid it). Quarantine, not a tolerance — pkg169's fix must un-xfail."
 )
 
 

--- a/tests/test_linear_render_guard.py
+++ b/tests/test_linear_render_guard.py
@@ -1,0 +1,74 @@
+"""pkg166 — self-tests for the furnace/energy linear-render guard.
+
+These test the guard itself. Their own names deliberately contain neither
+"furnace" nor "energy", so the conftest autouse fixture is a no-op for them and
+they can exercise `linear_render_guard` directly.
+"""
+from __future__ import annotations
+
+import pytest
+
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+
+from _linear_render_guard import linear_render_guard, name_matches, renders_gamma
+
+try:
+    import astroray  # noqa: E402
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+
+def test_name_matches_selects_furnace_and_energy():
+    assert name_matches("test_dielectric_glass_furnace_cpu")
+    assert name_matches("test_disney_energy_conservation")
+    assert name_matches("test_metal_white_furnace_conserves_energy[0.3]")
+    assert not name_matches("test_glass_render")
+    assert not name_matches("test_scaled_mesh_visible")
+
+
+def test_renders_gamma_reads_the_apply_gamma_argument():
+    # apply_gamma defaults to True when omitted (the whole reason this guard exists)
+    assert renders_gamma((64, 32), {}) is True
+    assert renders_gamma((64, 32, None), {}) is True
+    # explicit positional 4th arg
+    assert renders_gamma((64, 32, None, True), {}) is True
+    assert renders_gamma((64, 32, None, False), {}) is False
+    # explicit keyword
+    assert renders_gamma((64, 32), {"apply_gamma": True}) is True
+    assert renders_gamma((64, 32), {"apply_gamma": False}) is False
+
+
+@pytest.mark.skipif(not AVAILABLE, reason="astroray not built")
+def test_guard_fires_on_gamma_and_is_silent_on_linear():
+    """The guard must FAIL a gamma render and PASS a linear one. A lightweight
+    stub stands in for the real render so this needs no GPU: the guard's
+    assertion runs before it ever delegates to the wrapped render."""
+    renderer_cls = astroray.Renderer
+    real_render = renderer_cls.render
+    renderer_cls.render = lambda self, *a, **k: "rendered"  # noqa: E731
+    try:
+        with linear_render_guard("test_fake_furnace"):
+            r = astroray.Renderer()
+            # Default gamma -> must fire.
+            with pytest.raises(AssertionError, match="apply_gamma"):
+                r.render(4, 2)
+            # Explicit gamma -> must fire.
+            with pytest.raises(AssertionError, match="apply_gamma"):
+                r.render(4, 2, None, True)
+            # Linear -> must be silent (delegates to the stub).
+            assert r.render(4, 2, None, False) == "rendered"
+            assert r.render(4, 2, apply_gamma=False) == "rendered"
+    finally:
+        renderer_cls.render = real_render
+
+
+@pytest.mark.skipif(not AVAILABLE, reason="astroray not built")
+def test_guard_restores_render_on_exit():
+    renderer_cls = astroray.Renderer
+    before = renderer_cls.render
+    with linear_render_guard("test_fake_furnace"):
+        assert renderer_cls.render is not before
+    assert renderer_cls.render is before

--- a/tests/test_material_plugins.py
+++ b/tests/test_material_plugins.py
@@ -44,24 +44,33 @@ def _renderer():
     return r
 
 
-def _render_mat(mat_id, renderer, samples=32):
+def _render_mat(mat_id, renderer, samples=32, apply_gamma=True):
     renderer.add_sphere([0, 0, 0], 1.0, mat_id)
-    pixels = np.array(renderer.render(samples_per_pixel=samples, max_depth=6), dtype=np.float32)
+    pixels = np.array(
+        renderer.render(samples, 6, None, apply_gamma), dtype=np.float32)
     return pixels
 
 
 def _reflectance(mat_type, color, params=None, samples=32):
-    """Estimate reflectance as mean pixel value relative to pure white lambertian."""
+    """Estimate reflectance as mean pixel value relative to pure white lambertian.
+
+    pkg166: rendered LINEAR (apply_gamma=False). Both the material and its white
+    lambertian reference share the same scene and the same linear transfer, so
+    the RATIO is unchanged in the conserving case — but a material that CREATES
+    energy now reads its true value > 1 instead of being clamped to 1 by gamma,
+    so the `mat_mean <= ref_mean * ceiling` gates below can finally catch a gain
+    (memory gamma-furnace-cannot-detect-energy-gain).
+    """
     params = params or {}
     # Reference: pure white lambertian in same scene
     r_ref = _renderer()
     ref_id = r_ref.create_material("lambertian", [1.0, 1.0, 1.0], {})
-    ref_pixels = _render_mat(ref_id, r_ref, samples)
+    ref_pixels = _render_mat(ref_id, r_ref, samples, apply_gamma=False)
     ref_mean = float(np.mean(ref_pixels))
 
     r = _renderer()
     mat_id = r.create_material(mat_type, color, params)
-    pixels = _render_mat(mat_id, r, samples)
+    pixels = _render_mat(mat_id, r, samples, apply_gamma=False)
     mat_mean = float(np.mean(pixels))
 
     # Non-emissive materials must not exceed white lambertian significantly
@@ -72,41 +81,52 @@ def _reflectance(mat_type, color, params=None, samples=32):
 # Energy conservation tests (reflectance ≤ 1.0 relative to white lambertian)
 # ---------------------------------------------------------------------------
 
+def _assert_conserving(label, mat_mean, ref_mean, floor_frac=0.85):
+    """pkg166 floor+ceiling pair on a linear white-furnace reflectance ratio.
+    The CEILING catches energy GAIN (a material reflecting MORE than the white
+    lambertian reference in the same field); the FLOOR catches gross energy LOSS
+    or a black/broken BRDF. Both halves are needed — gamma used to clamp the
+    ceiling to a passing 1.0. Ratios measured on cf67a92 (linear, RTX 5070 Ti)
+     range 0.83 (subsurface) to 1.00 (dielectric/mirror); floors are set below
+    the measured ratio with noise margin."""
+    assert mat_mean <= ref_mean * 1.1, \
+        f"{label} mean={mat_mean:.3f} exceeds white lambertian {ref_mean:.3f} (energy GAIN)"
+    assert mat_mean >= ref_mean * floor_frac, \
+        f"{label} mean={mat_mean:.3f} < {floor_frac:.2f}x white lambertian " \
+        f"{ref_mean:.3f} (energy LOSS / broken-dark BRDF)"
+
+
 def test_metal_energy_conservation():
     mat_mean, ref_mean = _reflectance("metal", [0.9, 0.9, 0.9], {"roughness": 0.3})
-    assert mat_mean <= ref_mean * 1.1, \
-        f"Metal mean={mat_mean:.3f} exceeds white lambertian {ref_mean:.3f}"
+    _assert_conserving("Metal", mat_mean, ref_mean)  # measured ratio 0.948
 
 
 def test_metal_smooth_energy_conservation():
     mat_mean, ref_mean = _reflectance("metal", [0.9, 0.9, 0.9], {"roughness": 0.02})
-    assert mat_mean <= ref_mean * 1.1, \
-        f"Metal (smooth) mean={mat_mean:.3f} exceeds white lambertian {ref_mean:.3f}"
+    _assert_conserving("Metal (smooth)", mat_mean, ref_mean)  # measured ratio 0.978
 
 
 def test_dielectric_energy_conservation():
     mat_mean, ref_mean = _reflectance("dielectric", [1.0, 1.0, 1.0], {"ior": 1.5})
-    assert mat_mean <= ref_mean * 1.1, \
-        f"Dielectric mean={mat_mean:.3f} exceeds white lambertian {ref_mean:.3f}"
+    _assert_conserving("Dielectric", mat_mean, ref_mean)  # measured ratio 1.002
 
 
 def test_glass_alias_energy_conservation():
     mat_mean, ref_mean = _reflectance("glass", [1.0, 1.0, 1.0], {"ior": 1.5})
-    assert mat_mean <= ref_mean * 1.1, \
-        f"Glass mean={mat_mean:.3f} exceeds white lambertian {ref_mean:.3f}"
+    _assert_conserving("Glass", mat_mean, ref_mean)  # measured ratio 1.000
 
 
 def test_phong_energy_conservation():
     for shininess in [8.0, 32.0, 100.0]:
         mat_mean, ref_mean = _reflectance("phong", [0.8, 0.8, 0.8], {"shininess": shininess})
-        assert mat_mean <= ref_mean * 1.1, \
-            f"Phong(shininess={shininess}) mean={mat_mean:.3f} exceeds white lambertian {ref_mean:.3f}"
+        _assert_conserving(f"Phong(shininess={shininess})", mat_mean, ref_mean)  # ratio 0.969-0.974
 
 
 def test_subsurface_energy_conservation():
     mat_mean, ref_mean = _reflectance("subsurface", [0.9, 0.6, 0.5])
-    assert mat_mean <= ref_mean * 1.1, \
-        f"Subsurface mean={mat_mean:.3f} exceeds white lambertian {ref_mean:.3f}"
+    # Subsurface is a colored ([0.9,0.6,0.5]) material, so it reflects less of
+    # the white field than an achromatic one — measured ratio 0.834; lower floor.
+    _assert_conserving("Subsurface", mat_mean, ref_mean, floor_frac=0.70)
 
 
 def test_disney_energy_conservation():
@@ -116,14 +136,12 @@ def test_disney_energy_conservation():
         {"clearcoat": 1.0, "clearcoat_gloss": 0.8},
     ]:
         mat_mean, ref_mean = _reflectance("disney", [0.8, 0.8, 0.8], params)
-        assert mat_mean <= ref_mean * 1.1, \
-            f"Disney({params}) mean={mat_mean:.3f} exceeds white lambertian {ref_mean:.3f}"
+        _assert_conserving(f"Disney({params})", mat_mean, ref_mean)  # ratio 0.960-0.969
 
 
 def test_mirror_energy_conservation():
     mat_mean, ref_mean = _reflectance("mirror", [1.0, 1.0, 1.0])
-    assert mat_mean <= ref_mean * 1.1, \
-        f"Mirror mean={mat_mean:.3f} exceeds white lambertian {ref_mean:.3f}"
+    _assert_conserving("Mirror", mat_mean, ref_mean)  # measured ratio 1.001
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_material_properties.py
+++ b/tests/test_material_properties.py
@@ -731,7 +731,7 @@ def test_metal_energy_conservation():
         setup_camera(r, look_from=[0, 0, 4], look_at=[0, 0, 0], width=W, height=H)
         mat = r.create_material('metal', [0.8, 0.3, 0.3], {'metallic': metallic})
         r.add_sphere([0, -0.5, 0], 1.0, mat)
-        pixels = render_image(r, samples=48)
+        pixels = render_image(r, samples=48, apply_gamma=False)  # pkg166: linear
         mean = np.mean(pixels, axis=(0, 1))
         return mean
 
@@ -758,7 +758,7 @@ def test_dielectric_energy_conservation():
             mat = r.create_material('dielectric', [1.0, 1.0, 1.0], params)
         _neutral_scene(r, mat)
         _cam_front(r)
-        pixels = render_image(r, samples=48)
+        pixels = render_image(r, samples=48, apply_gamma=False)  # pkg166: linear
         return float(np.mean(_center(pixels, frac=0.45)))
 
     lambertian_mean = render_mean('lambertian', {})
@@ -766,6 +766,10 @@ def test_dielectric_energy_conservation():
 
     assert dielectric_mean <= lambertian_mean * 1.05, \
         f"Dielectric ({dielectric_mean:.3f}) exceeds white Lambertian ({lambertian_mean:.3f}) — energy not conserved"
+    # pkg166 floor (linear): measured ratio 0.50 (glass refracts/transmits so it
+    # reads darker than lambertian); floor at 0.35x catches a black/broken glass.
+    assert dielectric_mean >= lambertian_mean * 0.35, \
+        f"Dielectric ({dielectric_mean:.3f}) < 0.35x white Lambertian ({lambertian_mean:.3f}) — glass reads near-black"
 
 
 # ===========================================================================
@@ -784,7 +788,7 @@ def test_phong_energy_conservation():
         mat = r.create_material('phong', albedo, {'shininess': 100.0})
         _neutral_scene(r, mat)
         _cam_front(r)
-        pixels = render_image(r, samples=48)
+        pixels = render_image(r, samples=48, apply_gamma=False)  # pkg166: linear
         scene_means[name] = float(np.mean(_center(pixels, frac=0.45)))
 
     white_mean = scene_means['white']
@@ -792,6 +796,11 @@ def test_phong_energy_conservation():
         assert scene_means[name] <= white_mean * 1.05, \
             f"Phong {name} ({scene_means[name]:.3f}) exceeds white ({white_mean:.3f}) " \
             f"— violates energy conservation"
+        # pkg166 floor (linear): a single-channel Phong still reflects its one
+        # channel of the white field — measured ratios 0.49-0.55; floor at 0.35x
+        # catches a black/broken colored BRDF without tripping on the color loss.
+        assert scene_means[name] >= white_mean * 0.35, \
+            f"Phong {name} ({scene_means[name]:.3f}) < 0.35x white ({white_mean:.3f}) — reads near-black"
 
 
 # ===========================================================================
@@ -808,10 +817,13 @@ def test_diffuse_light_energy_conservation():
     _cam_front(r)
     mat = r.create_material('light', [1.0, 1.0, 1.0], {'intensity': 0.5})
     r.add_sphere([0, 0, 0], 1.0, mat)
-    pixels = render_image(r, samples=48)
+    pixels = render_image(r, samples=48, apply_gamma=False)  # pkg166: linear
     mean_val = float(np.mean(pixels))
 
     assert mean_val <= 0.5 + 0.05, \
         f"DiffuseLight mean ({mean_val:.3f}) exceeds emission intensity 0.5 — energy not conserved"
-    assert mean_val > 0.0, \
-        f"DiffuseLight mean ({mean_val:.3f}) is zero — material not emitting"
+    # pkg166 floor (linear): measured 0.273; a real emitter fills a large frame
+    # fraction, so a floor at 0.15 catches a non-emitting/near-black material
+    # (stronger than the prior `> 0.0`).
+    assert mean_val >= 0.15, \
+        f"DiffuseLight mean ({mean_val:.3f}) < 0.15 — material barely emitting"

--- a/tests/test_python_bindings.py
+++ b/tests/test_python_bindings.py
@@ -632,6 +632,16 @@ def test_white_metal_roughness_one_not_dark():
     assert mean_center > 0.85, f"Rough white metal center too dark in furnace test ({mean_center:.3f})"
 
 
+# pkg166 linear re-pin (measured on cf67a92, RTX 5070 Ti, 64 spp, linear). The
+# old gamma floor was 0.78; in linear the same white-metal furnace reads lower
+# (gamma lifts mid-tones): mean_center = 0.994 / 0.841 / 0.806 / 0.928 at
+# roughness 0.1 / 0.3 / 0.6 / 1.0. The ceiling is the new half — a conductor with
+# albedo=1 in a radiance-1 field cannot exceed ~1.0 (pre-pkg160 it reflected up
+# to 1.77x); it now catches a gain instead of gamma clamping it to 1.0.
+_FURNACE_FLOOR = 0.70
+_FURNACE_CEILING = 1.02
+
+
 def test_metal_furnace_energy_above_threshold_all_roughness():
     """Furnace test: white metal should preserve high energy for all roughness values."""
     roughness_values = [0.1, 0.3, 0.6, 1.0]
@@ -641,12 +651,21 @@ def test_metal_furnace_energy_above_threshold_all_roughness():
         mat = r.create_material('metal', [1.0, 1.0, 1.0], {'roughness': roughness})
         r.add_sphere([0, 0, 0], 1.0, mat)
         setup_camera(r, look_from=[0, 0, 4], look_at=[0, 0, 0], vfov=35, width=W, height=H)
-        pixels = render_image(r, samples=SAMPLES_MED)
+        # pkg166: render LINEAR (apply_gamma=False). A gamma furnace clamps to
+        # [0,1] and can only detect energy LOSS; the ceiling below is what makes
+        # this catch a GAIN (white metal, albedo 1, in a radiance-1 field cannot
+        # exceed ~1.0 — pre-pkg160 plain metal reflected up to 1.77x).
+        pixels = render_image(r, samples=SAMPLES_MED, apply_gamma=False)
 
         crop = pixels[H // 2 - 20:H // 2 + 20, W // 2 - 20:W // 2 + 20, :]
         mean_center = float(np.mean(crop))
-        assert mean_center > 0.78, (
+        assert mean_center > _FURNACE_FLOOR, (
             f"Furnace energy too low for roughness={roughness:.2f}: center mean={mean_center:.3f}"
+        )
+        assert mean_center <= _FURNACE_CEILING, (
+            f"White metal furnace reflects {mean_center:.3f} > {_FURNACE_CEILING} at "
+            f"roughness={roughness:.2f} with albedo=1 in a radiance-1 field — the "
+            f"conductor lobe is CREATING energy (pre-pkg160 measured up to 1.77x)."
         )
 def test_glass_render():
     r = create_renderer()


### PR DESCRIPTION
## Summary

Furnace/energy tests rendered through `apply_gamma=True`, which clamps output to `[0,1]` and is **structurally blind to energy GAIN** â€” a gamma furnace can only ever detect LOSS. pkg160's conductor read 4.139 in linear yet 1.000000 through gamma; pkg120 added energy the same way and sailed through every shipped furnace suite. This converts every `*furnace*`/`*energy*`-named in-process render test to `apply_gamma=False`, adds floor+ceiling pairs, and enforces the rule at test time with an autouse guard.

## Deliverables

1. **Naming guard** (`tests/_linear_render_guard.py` + conftest autouse fixture): any test whose name matches `*furnace*`/`*energy*` fails **at the render call** if it requests gamma. Negative self-test (`tests/test_linear_render_guard.py`) proves it fires on gamma and is silent on linear.
2. **Converted + re-pinned suites** (linear, measured on cf67a92, RTX 5070 Ti):
   - `test_dielectric_glass_furnace` â€” CPU/GPU 0.993 (band [0.95,1.05] holds; already a pair)
   - `test_disney_rough_glass_furnace` â€” see finding below
   - `test_disney_energy_conservation` â€” gray-furnace anti-glow test gains a floor (mean_lum 0.242, floor 0.15)
   - `test_material_plugins` â€” 8 energy tests via a floor+ceiling helper (ratios 0.83â€“1.00)
   - `test_material_properties` â€” dielectric/phong/diffuse_light floors added
   - `test_python_bindings` â€” white-metal furnace gains a ceiling (measured 0.806â€“0.994; floor 0.70, ceiling 1.02)
3. **Doc note**: new `## Furnace/energy tests` section in `AGENTS.md`.

## REAL ENERGY-GAIN FINDING (not pinned in, bands not widened)

Converting the Disney rough-glass suite to linear exposed that the **Disney Principled transmission (glass) white furnace CREATES energy** â€” hidden until now because gamma clamped it to 1.000:

| case | linear reading |
|---|---|
| CPU smooth R=0/0.03 | 1.784 |
| CPU rough R=0.1/0.3/0.6/1.0 | 1.099 / 1.108 / 1.157 / 1.260 |
| GPU rough R=0.1/0.3/0.6/1.0 | 1.098 / 1.182 / 2.060 / 2.296 |

Deterministic (CPU R=0: 1.765/1.784/1.774 at 32/128/512 spp; GPU R=0.6: 2.081/2.060/2.053). Controls conserve: plain `dielectric` furnace 0.994, opaque disney (transmission=0) 0.958. GPU **smooth** delta path is fine (0.993). Per pkg166's own contract these gains are **not pinned in and bands are not widened**: `test_disney_smooth_glass_furnace_cpu`, `test_disney_rough_glass_furnace_energy_cpu`, `test_disney_rough_glass_furnace_energy_gpu` are `xfail(strict=False)` against the correct conserving band as a quarantine owned by **pkg169** (`pkg169-disney-transmission-energy-gain.md`, HIGH) — pkg169's fix PR must remove these markers and prove the cases green under `--runxfail` (not a permanent tolerance). `--runxfail` confirms all three genuinely fail with the >1.0 values.

## Mutation check (acceptance)

A deliberate `return result * 1.5f` on `MetalPlugin::evalSpectral` (scratch build, reverted; working tree clean of `plugins/`) was caught by the converted white-metal furnace case: **reflectance 1.156 > 1.02 ceiling at roughness 0.30**. Under gamma this would have clamped to ~1.0 and passed.

## Acceptance checklist

- [x] All converted suites green on the linear build with floor+ceiling pairs; no band widened to pass a gain (gains xfail'd instead)
- [x] Naming guard fires on a gamma furnace (negative self-test) and is silent on the full suite
- [x] Energy-gain mutation caught by a converted case (evidence above)
- [x] Doc note added (AGENTS.md)
- [x] Full converted-suite run: 315 passed, 5 xfailed; `test_python_bindings.py` 73 passed / 13 xfailed / 2 xpassed (pre-existing); collection clean across 1677 tests
- [x] Already-linear furnace/energy suites (pkg160, pkg144, pkg157) unaffected by the guard: 37 + 9 passed

## GPU-leg numbers (RTX 5070 Ti, CI is CPU-only)

- dielectric glass furnace GPU: 0.993 (all IOR)
- disney smooth glass GPU: 0.993 (conserving)
- disney rough glass GPU: 1.098â€“2.296 (**gain finding**, xfail'd)
- white-metal furnace: 0.994 / 0.841 / 0.806 / 0.928 at roughness 0.1/0.3/0.6/1.0

## Build

Test-only + doc change (`plugins/` reverted after the mutation check). Last 5 lines of the clean rebuild log:
```
[100%] Linking CXX shared module astroray.cp313-win_amd64.pyd
[100%] Built target astroray
[ 95%] Built target astroray_core_impl
[100%] Built target astroray_test_helpers
[build_cuda_worktree] Build succeeded
```

Spec status flipped to done in `.astroray_plan/packages/pkg166-furnace-suites-linear-rendering.md` (see follow-up commit).

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)

