### PR TITLE
fix(pkg169): Disney transmission energy conservation (CPU delta Fresnel + rough |cosI|; GPU closure-graph pdf orientation)

### DIFF
--- a/.astroray_plan/docs/pkg169-transmission-energy-gain-findings.md
+++ b/.astroray_plan/docs/pkg169-transmission-energy-gain-findings.md
@@ -1,0 +1,128 @@
+# pkg169 — Disney transmission energy-gain findings
+
+**Status:** diagnosis complete; fix landed for both convictions; one residual cell
+(CPU ior 1.5, R=1.0) pending an architect scope decision (multiscatter comp is a
+spec non-goal, band-widening forbidden).
+
+Base SHA for all measurements below: `e2bfd84` (current main; spec baseline was
+`cf67a92`, re-confirmed to reproduce — CPU delta 1.784, GPU rough → 2.296,
+controls conserve). RTX 5070 Ti, linear render (`apply_gamma=False`), albedo=1,
+white env, deterministic across 256↔1024 spp.
+
+## Repo radiance-transport convention (stated per the spec's contract)
+
+Astroray is a **radiance** path tracer. Under refraction, radiance scales by the
+inverse-squared relative IOR: a ray crossing into a medium of relative IOR
+`etap = etaT/etaI` carries radiance multiplied by `1/etap²` (PBRT-v4 §9.5.2,
+"Radiance along rays that do refract must increase so that energy is preserved").
+In the code `eta = etaI/etaT`, so the delta-transmission factor `eta² = 1/etap²`
+is the correct radiance factor: `0.444` on enter (etap=1.5), `2.25` on exit
+(etap=1/1.5); the pair telescopes to 1.0 over a closed enter→exit path.
+
+The integrator forms throughput as `f_spectral / (pdf + eps)` with **no separate
+cosine multiply** for any BSDF sample (raytracer.h ~2714). The convention is
+therefore that `eval()` returns the BSDF value **with the incident cosine folded
+in** (disney.cpp eval() ends with `result * NdotL`), and delta events fold the
+cosine away analytically. Any lobe that returns a per-steradian BSDF without the
+cosine is inconsistent with this convention — that is Conviction A bug #2.
+
+## Conviction A — CPU, two single-scatter weight defects
+
+### A1. Delta glass dropped the Fresnel common factor (furnace 1.784 at R=0)
+
+`disney.cpp` sample() delta branch set:
+- reflection `s.f = Vec3(1)` with `s.pdf = fresnel·transmission_`  → `f/pdf = 1/R`
+- transmission `s.f = baseColor·eta²` with `s.pdf = (1-fresnel)·transmission_` → `f/pdf = eta²/T`
+
+PBRT-v4 DielectricBxDF::Sample_f (smooth case): reflection `f = R/|cosθi|`,
+`pdf = pr/(pr+pt) = R`; transmission `f = T/|cosθi| /etap²`, `pdf = pt/(pr+pt) = T`.
+The book states the value and pdf "contain the common factor R or T, which cancels
+when their ratio is taken." Astroray kept R/T in the pdf but dropped it from f, so
+each interface behaved lossless-in-expectation and created energy.
+
+**Fix:** reflection `s.f = Vec3(cannotRefract ? 1 : fresnel)` (TIR ⇒ R=1);
+transmission `s.f = baseColor·eta²·(1-fresnel)`. → R=0 furnace 1.784 → 0.990.
+
+### A2. Rough transmission missing the incident cosine (furnace ~1.10 at R≥0.1)
+
+`roughTransmissionEval` returns the PBRT-v4 per-steradian BTDF
+`D·(1-F)·G·|HdotI·HdotO|/(|cosI·cosO|·denom²)/etap²` and, being reached via an
+early return in eval(), never gets eval()'s trailing `* NdotL`. The integrator
+adds no cosine, so throughput was inflated by `1/|cosI|` (E[1/|cosI|] > 1 over the
+furnace cone). Correct VNDF weight is `f·|cosI|/pdf = G1(cosI)/etap²`
+(Heitz 2018 / PBRT-v4 DielectricBxDF).
+
+**Fix:** fold `|cosI|` into the transmission scale. → R=0.1 furnace 1.099 → 0.993.
+
+## Conviction B — GPU, closure-graph reflection-pdf Fresnel orientation
+
+Disney glass lowers to `GMAT_CLOSURE_GRAPH` (scene_upload.cu). The closure-graph
+sampler (`gpu_closure_graph_sample`) samples a direction via the disney sampler
+(correct inline f/pdf) then **overwrites** `s.f`/`s.pdf` with a re-evaluated
+`gpu_closure_graph_eval` / `gpu_closure_graph_pdf` — the standard one-sample-MIS
+`f_total/pdf_total` estimator, which is legitimate.
+
+A device-printf trace of sampled-vs-overwritten weights showed the overwrite is a
+no-op for transmission samples but diverges by up to ~20× on **internal-reflection
+events** (`frontFace=false`, same-hemisphere `cosO·cosI>0`): `pdfOvr` was far
+smaller than `pdfSamp`. Root cause: `gpu_disney_pdf`'s reflection-branch Fresnel
+used `entering = rec.normal.dot(wo) > 0` — **always true**, because `rec.normal` is
+the front-facing (reoriented) normal. For an exit event it computed the air→glass
+Fresnel (small) instead of glass→air (≈1 near TIR), so the reflection-branch pdf
+was too small and `f/pdf` inflated. The sampler itself uses `rec.frontFace` for
+etaI/etaT, so the overwrite disagreed with how the sample was drawn. The gain rises
+with roughness because the internal-reflection fraction rises with roughness.
+
+**Fix:** `entering = rec.frontFace` in `gpu_disney_pdf` (mirroring the sampler and
+the pkg154 `roughTransmission{Eval,Pdf}` convention). The identical latent bug in
+the CPU `disney.cpp pdf()` (line ~908) was fixed too — it does not affect the CPU
+furnace (no closure-graph overwrite; the furnace uses the sampler's inline pdf) but
+is wrong for NEE/MIS and must stay in parity with the GPU twin. The GPU delta
+Fresnel fix (A1) and cosine fold (A2) were also mirrored into `gpu_materials.h`.
+→ GPU R=1.0 furnace 2.296 → 0.930.
+
+I did **not** skip the closure-graph overwrite (a superficially-working but broad
+change that also masks the separate opaque-Disney defect below); the pdf-orientation
+was the actual bug.
+
+## Citation-to-line mapping
+
+| Fix | File / function | Citation |
+|---|---|---|
+| A1 delta Fresnel | `plugins/materials/disney.cpp` sample() delta branch | PBRT-v4 §9.5 DielectricBxDF::Sample_f |
+| A2 cosine fold | `plugins/materials/disney.cpp` roughTransmissionEval | Heitz 2018 VNDF; PBRT-v4 DielectricBxDF |
+| B pdf orientation | `plugins/materials/disney.cpp` pdf(); `include/astroray/gpu_materials.h` gpu_disney_pdf | pkg154 frontFace convention; PBRT-v4 |
+| A1/A2/B GPU mirror | `include/astroray/gpu_materials.h` gpu_disney_sample / gpu_disney_roughTransmissionEval | CPU twins above |
+
+## Furnace results after fix (256 spp, linear, band [0.92,1.03])
+
+```
+ior 1.5   R= 0    0.03   0.1    0.3    0.6    1.0
+  CPU     0.990  0.990  0.993  0.980  0.926  0.902   ← R=1.0 below 0.92 floor
+  GPU     0.992  0.992  0.992  0.986  0.970  0.930   all in band
+ior 1.33  CPU    0.991  0.991  0.993  0.989  0.980  0.980   all in band
+ior 1.33  GPU    0.993  0.993  0.992  0.989  0.992  0.988   all in band
+controls: plain dielectric 0.993 CPU / 0.992 GPU; opaque disney 0.959 CPU
+```
+
+`--runxfail` on `tests/test_disney_rough_glass_furnace.py`: 4 passed, 1 failed —
+only `test_disney_rough_glass_furnace_energy_cpu` at R=1.0=0.9017.
+
+## Residual (pending architect decision)
+
+CPU ior 1.5 R=1.0 converges to 0.903 (256/1024 agree). Single-scatter alone is
+0.717; pkg151 `ggxGlassCompensationFactor` recovers it to 0.903 but not to ≥0.92.
+This is the **multiscatter/compensation family the spec lists as a non-goal**, and
+band-widening is forbidden — so it is not touched here. GPU lands at 0.930 (in
+band) via the closure-graph one-sample-MIS estimator; the CPU direct estimator
+converges ~3% lower — a residual CPU/GPU parity nuance, vastly improved from the
+baseline 1.260 vs 2.296.
+
+## Separate out-of-scope finding
+
+GPU **opaque** Disney (metallic=0, transmission=0) furnaces at 1.975 — a flat ~2×
+gain across all roughness, present on base main independent of pkg169. It also
+stems from the closure-graph re-eval overwrite, but on the diffuse+conductor lobe
+recombination (skipping the overwrite drops it to 0.987). CPU opaque conserves
+(0.959). A real GPU energy-conservation bug in non-transmissive Disney, outside
+pkg169's transmission scope — recommend a new spec.

--- a/.astroray_plan/packages/pkg169-disney-transmission-energy-gain.md
+++ b/.astroray_plan/packages/pkg169-disney-transmission-energy-gain.md
@@ -114,3 +114,104 @@ implementation, so impl-pkg166 can cite the number in its quarantine xfails.
 Discovery is itself the pkg166 thesis validated: a gamma furnace structurally
 cannot see energy gain; the first linear run found a shipped lobe creating up
 to 2.3× energy.
+
+## Hardware verification 2026-08-02
+
+**Hardware/software:** RTX 5070 Ti, driver 610.47, Windows 11 (10.0.26200), CUDA
+12.8, OptiX 9.1.0, OIDN 2.4.1. Worktree HEAD pinned at `945e9b8493281687b2c14d159951193b69d171e2` (PR #540), verified before build (contamination guard).
+
+### Gate results (verbatim)
+
+**tests/test_disney_rough_glass_furnace.py --runxfail** (forces the pkg167-owned
+quarantine cell to actually run): 5 passed, 1 failed exactly as documented —
+`test_disney_rough_glass_furnace_energy_cpu_r1_ior15` measured **0.9017**
+(doc says ~0.90/0.903; xfail(strict=False) citing pkg167, not this PR's scope).
+
+Measured values (ior 1.5, direct script call matching the test's `_furnace`):
+
+| roughness | CPU | GPU |
+|---|---|---|
+| 0.0 (delta) | 0.9897 | 0.9929 |
+| 0.03 (delta) | 0.9897 | 0.9929 |
+| 0.1 | 0.9930 | 0.9923 |
+| 0.3 | 0.9799 | 0.9857 |
+| 0.6 | 0.9259 | 0.9699 |
+| 1.0 | 0.9017 (quarantined, owned by pkg167) | 0.9298 |
+
+All within claimed bands: CPU 0.9259-0.9930 (spec claimed 0.926-0.993), GPU
+0.9298-0.9929 (spec claimed 0.930-0.992).
+
+**Second ior point (1.33), delta + one rough value, both legs:**
+
+| config | value |
+|---|---|
+| ior 1.33 delta CPU (R=0) | 0.9920 |
+| ior 1.33 delta GPU (R=0) | 0.9932 |
+| ior 1.33 rough CPU (R=0.6) | 0.9795 |
+| ior 1.33 rough GPU (R=0.6) | 0.9921 |
+
+All ≥ 0.980 as required.
+
+**tests/test_dielectric_glass_furnace.py** (plain-dielectric control): 2 passed.
+Measured CPU ior {1.0,1.1,1.5,2.0} = 0.9950/0.9958/0.9938/0.9927; GPU =
+0.9930/0.9935/0.9930/0.9926. Unchanged from the ~0.993 baseline — the fix did
+not leak into the plain-dielectric path.
+
+**tests/statistical/test_chi2_bsdf.py -k disney_glass** (no `--runxfail`):
+1 xfailed as documented — `test_chi2_disney_glass[0.3-45]` chi²=34987.970271
+(1025 dof), identical to the pre-existing pkg150 quadrature-artifact xfail
+reason string. Unaffected by this PR.
+
+**Regression set** (`test_disney_transmission_peak_alignment.py`,
+`test_disney_energy_conservation.py`, `test_disney_reflection_not_black.py`,
+`test_glass_sphere_caustic.py`): 275 passed, 0 failed.
+
+**tests/test_material_properties.py -k glass**: 3 passed
+(`test_glass_transmits_background_color`, `test_glass_ior_changes_appearance`,
+`test_glass_less_opaque_than_black`).
+
+**pkg64 prism/GPU-CPU-parity gates** (6 files): 9 passed, 2 xfailed
+(pre-existing, undisturbed), 1 xpassed. No new failures.
+
+**pkg160/pkg163 metal parity gates** (closure-graph `pdf()` shared with the
+GPU frontFace fix in this PR): 34 passed, 0 failed.
+`test_pkg163_metal_spectral_colorspace_parity` GPU/CPU ratios R/G/B =
+1.0164/1.0204/1.0159 (neutral), seed-averaged spread 0.0025 (chromatic) — same
+shape of numbers as the prior #533 verification; metal path untouched.
+
+### Visual inspection
+
+- `tests/test_glass_sphere_caustic.py` scene (plain dielectric sphere,
+  `light_tracer_caustic`, **CPU-only per the test's own docstring**): rendered
+  CPU — bright focused caustic spot on the floor, peak luminance 0.500 (gate
+  measures ≥0.25), sphere itself dark/near-black from this angle (expected:
+  the scene is deliberately dim overall so the caustic dominates). No
+  fireflies, no banding. GPU render of this specific CPU-only integrator was
+  attempted for completeness and produced a near-black result with no caustic
+  spot (max luminance 0.019 vs CPU's 0.500) — this integrator is documented
+  CPU-only and is not part of this PR's gate surface; flagging only as a
+  known non-target rather than a pkg169 regression.
+- Disney glass sphere (`path_tracer`, the code path this PR actually
+  touches), rendered CPU vs GPU at roughness {0.0 delta, 0.6, 1.0}, ad-hoc
+  scene (sun + floor): CPU and GPU visually match at each roughness — clear
+  refraction with a dim specular highlight at R=0 (no black glass), frosted
+  transmission at R=0.6, near-fully-diffuse at R=1.0. No fireflies, no
+  banding/quantization artifacts, no NaN pixels (checked numerically:
+  `np.isnan(img).any() == False` at all 6 renders), no mode regressions.
+- `test_results/mat_glass_*.png`, `mat_overexposure_glass.png`,
+  `mat_overexposure_disney_glass.png` (from the material-properties test run):
+  clean MC noise only, no fireflies, no black glass, consistent transmission
+  across IOR 1.2/1.5/2.0.
+
+### Anomalies worth watching
+
+- The `light_tracer_caustic` GPU near-black result above is worth a follow-up
+  ticket if GPU support for that integrator is ever claimed — it is currently
+  undocumented as GPU-supported and this session found no evidence it works,
+  but it is out of scope for pkg169 (which never touches that integrator).
+
+**Verdict: PASS**, bound to `945e9b8493281687b2c14d159951193b69d171e2`. All
+declared gates green (matching or better than claimed bands); the one
+documented multiscatter quarantine cell measured within the documented ~0.90
+value; controls, chi2 xfail, and the metal-parity path are undisturbed;
+visual inspection found no regressions on the code path this PR touches.

--- a/.astroray_plan/packages/pkg169-disney-transmission-energy-gain.md
+++ b/.astroray_plan/packages/pkg169-disney-transmission-energy-gain.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 2 (BSDF energy conservation — correctness wins over both fidelity and perf)
 **Track:** A (RTX-gated for the GPU leg; CPU leg CI-runnable in linear)
-**Status:** open — dispatchable (HIGH priority: an energy-GAIN defect in a shipped lobe, invisible until pkg166's linear conversion; pkg166 is xfail-quarantining the affected furnace cases pending this package)
+**Status:** in review (PR #540, 2026-08-02) — both convictions fixed CPU+GPU. Conviction A: delta glass dropped the Fresnel common factor R/T (PBRT-v4 §9.5) + rough transmission missing the incident cosine |N·wi| (Heitz-2018 VNDF). Conviction B: GPU closure-graph reflection-pdf used sign(normal·wo) not rec.frontFace for the exit-side Fresnel → internal-reflection pdf up to ~20× too small (fixed both legs). Furnace after fix (ior 1.5): CPU 0.990/0.990/0.993/0.980/0.926/0.902, GPU 0.992/0.992/0.992/0.986/0.970/0.930; ior 1.33 both legs 0.98–0.99. pkg166's 3 xfails removed. One residual cell (CPU ior1.5 R=1.0 ≈0.90, multiscatter) quarantined to pkg167 per architect verdict. GPU opaque-Disney 2× filed as pkg170.
 **Estimated effort:** M (two independent convictions + mirrored fix + un-xfail)
 **Depends on:** nothing open. pkg166 (linear furnace conversion, in flight) discovered it and quarantines the affected cases as `xfail(strict=False)` citing **pkg169** — this package MUST remove those markers in its fix PR (memory `xfail-gated-features-must-unxfail`; verify with `--runxfail`).
 

--- a/include/astroray/gpu_materials.h
+++ b/include/astroray/gpu_materials.h
@@ -793,7 +793,14 @@ __device__ inline GVec3 gpu_disney_roughTransmissionEval(
     // PBRT-v4: radiance transport correction (Astroray is a radiance path tracer)
     ft /= (etap * etap);
 
-    float scale = (1.f - mat.metallic) * mat.transmission * ft;
+    // pkg169: fold in the incident cosine |N.wi| (CPU twin: disney.cpp
+    // roughTransmissionEval). The integrator forms throughput as f/pdf with no
+    // separate cosine multiply; the reflection lobes supply it via `* NdotL` in
+    // eval(), but this transmission branch never gets one and `ft` is the
+    // per-steradian PBRT-v4 BTDF (no cosine). Omitting |cosI| inflated rough
+    // transmission by 1/|cosI| (energy gain; gamma clamped it). With it, the
+    // weight collapses to the Heitz-2018 VNDF form G1(cosI)/etap^2.
+    float scale = (1.f - mat.metallic) * mat.transmission * ft * fabsf(cosI);
     GVec3 result = mat.baseColor * scale;
 
     // pkg151: rough-transmission multi-scatter compensation (Cycles glass
@@ -1092,7 +1099,15 @@ __device__ inline GBSDFSample gpu_disney_sample(
 
         if (cannotRef || gpu_rng_uniform(rng) < fresnel) {
             s.wi  = n * (2.f * wo.dot(n)) - wo;
-            s.f   = GVec3(1.f);
+            // pkg169: the delta-reflection BSDF value must carry the Fresnel
+            // reflectance R so it cancels the R in the pdf (PBRT-v4 §9.5
+            // DielectricBxDF::Sample_f). Setting f = 1 dropped R from f while the
+            // pdf kept it, over-counting reflection by 1/R. This delta branch is
+            // the fallthrough target for rough-glass VNDF samples that fail (near
+            // 100% at high roughness -- pkg138), so the omission created energy in
+            // the GPU rough furnace, rising with roughness. TIR is deterministic
+            // (R=1), so f = 1 there. CPU twin: disney.cpp sample() delta branch.
+            s.f   = GVec3(cannotRef ? 1.f : fresnel);
             // pkg118 Part A: forced-TIR reflection is deterministic (selection prob 1),
             // so pdf = transmission (not fresnel*transmission). PBRT-v4 §9.5. Mirrors CPU
             // disney.cpp forced-TIR fix; keeps the bespoke RGB GPU path in lockstep.
@@ -1101,7 +1116,10 @@ __device__ inline GBSDFSample gpu_disney_sample(
             GVec3 perp = (wo - n*cosTheta) * (-eta);
             GVec3 para = n * (-sqrtf(fabsf(1.f - perp.length2())));
             s.wi  = (perp + para).normalized();
-            s.f   = mat.baseColor * (eta*eta);
+            // pkg169: delta-transmission f must carry T = (1 - fresnel) so it
+            // cancels the T in the pdf (PBRT-v4 §9.5; eta*eta is the radiance
+            // factor 1/etap^2). CPU twin: disney.cpp sample() delta branch.
+            s.f   = mat.baseColor * (eta*eta) * (1.f - fresnel);
             s.pdf = (1.f - fresnel) * mat.transmission;
         }
         s.isDelta = true;
@@ -1182,7 +1200,17 @@ __device__ inline float gpu_disney_pdf(
         }
     }
     if (mat.transmission > 0.f && mat.roughness > 0.03f) {
-        bool entering = rec.normal.dot(wo) > 0.f;
+        // pkg169: entering MUST come from rec.frontFace, not sign(rec.normal.dot(wo))
+        // (which is always > 0 -- rec.normal is the front-facing normal). For an
+        // EXIT event (frontFace=false) the old test computed the air->glass Fresnel
+        // (small) instead of glass->air (~1 near TIR), so this reflection-branch pdf
+        // was far too small for internal reflections. The delta/eval path already
+        // uses frontFace (sample()'s etaI/etaT; roughTransmission{Eval,Pdf} per
+        // pkg154). The closure-graph sampler OVERWRITES the correct sampler pdf with
+        // this gpu_disney_pdf, so the too-small internal-reflection pdf inflated
+        // f/pdf up to ~20x per event -> the GPU rough-glass furnace energy gain.
+        // CPU twin: disney.cpp pdf().
+        bool entering = rec.frontFace;
         float etaI = entering ? 1.f : mat.ior;
         float etaT = entering ? mat.ior : 1.f;
         // fabsf() matches gpu_disney_sample's inline computation and CPU pdf()

--- a/plugins/materials/disney.cpp
+++ b/plugins/materials/disney.cpp
@@ -365,7 +365,17 @@ class DisneyPlugin : public Material {
         // PBRT-v4: radiance transport correction (Astroray is a radiance path tracer)
         ft /= (etap * etap);
 
-        float scale = (1.0f - metallic_) * transmission_ * ft;
+        // pkg169: fold in the incident cosine |N.wi|. The integrator forms the
+        // throughput as f/pdf WITHOUT a separate cosine multiply (delta events
+        // fold it away; the diffuse/specular reflection lobes in eval() below
+        // supply it via the `* NdotL` at the end of eval()). This transmission
+        // branch returns early from eval() and never reached that multiply, and
+        // `ft` is the PBRT-v4 per-steradian BTDF D(1-F)G|HdotI HdotO|/(|cosI cosO|
+        // denom^2)/etap^2 (no cosine). The rendering-equation |cosI| was therefore
+        // missing, inflating rough-transmission throughput by 1/|cosI| (E[1/|cosI|]
+        // > 1 over the furnace cone => energy gain; gamma clamped it to 1.0). With
+        // it, f*|cosI|/pdf collapses to the Heitz-2018 VNDF weight G1(cosI)/etap^2.
+        float scale = (1.0f - metallic_) * transmission_ * ft * std::abs(cosI);
         Vec3 result = baseColor_ * scale;
 
         // pkg151: rough-transmission multi-scatter compensation (Cycles glass
@@ -771,7 +781,16 @@ public:
 
             if (cannotRefract || dist(gen) < fresnel) {
                 s.wi = n * (2 * wo.dot(n)) - wo;
-                s.f = Vec3(1);
+                // pkg169: the delta-reflection BSDF value must carry the Fresnel
+                // reflectance R so it cancels the R in the pdf (PBRT-v4 §9.5
+                // DielectricBxDF::Sample_f: reflection f = R/|cosThetaI|,
+                // pdf = pr/(pr+pt) = R; "the BSDF value and sample probability
+                // contain the common factor R ... which cancels when their ratio
+                // is taken"). Setting f = 1 dropped R from f while the pdf kept it,
+                // over-counting reflection throughput by 1/R and creating energy in
+                // the white furnace (linear 1.784 at R=0; gamma clamped it to 1.0).
+                // TIR is deterministic (R=1), so f = 1 there.
+                s.f = Vec3(cannotRefract ? 1.0f : fresnel);
                 // pkg118 Part A: a forced-TIR reflection is deterministic (selection
                 // probability 1), so pdf = transmission_; only a Fresnel-roulette-selected
                 // reflection keeps the `fresnel` factor. PBRT-v4 §9.5 DielectricBxDF::Sample_f:
@@ -783,7 +802,13 @@ public:
                 Vec3 perp = (wo - n * cosTheta) * (-eta);
                 Vec3 para = n * (-std::sqrt(std::abs(1 - perp.length2())));
                 s.wi = (perp + para).normalized();
-                s.f = baseColor_ * (eta * eta);
+                // pkg169: the delta-transmission BSDF value must carry the Fresnel
+                // transmittance T = (1 - fresnel) so it cancels the T in the pdf
+                // (PBRT-v4 §9.5: transmission f = T/|cosThetaI| /etap^2 (radiance),
+                // pdf = pt/(pr+pt) = T). `eta*eta` is the radiance factor 1/etap^2
+                // (eta = etaI/etaT). Dropping the (1-fresnel) factor over-counted
+                // transmission throughput by 1/T.
+                s.f = baseColor_ * (eta * eta) * (1.0f - fresnel);
                 s.pdf = (1 - fresnel) * transmission_;
             }
             // Smooth/failed rough samples use a delta glass event so spectral
@@ -861,7 +886,15 @@ public:
             }
         }
         if (transmission_ > 0.0f && roughness_ > kDeltaTransmissionRoughness) {
-            bool entering = rec.normal.dot(wo) > 0.0f;
+            // pkg169: entering MUST come from rec.frontFace, not sign(rec.normal.dot(wo))
+            // (always > 0 -- rec.normal is the front-facing normal). For an EXIT event
+            // this computed the air->glass Fresnel (small) instead of glass->air (~1
+            // near TIR), so the reflection-branch pdf was far too small for internal
+            // reflections. Mirrors the pkg154 frontFace fix in roughTransmission{Eval,
+            // Pdf} and sample()'s own etaI/etaT. The CPU furnace uses sample()'s inline
+            // pdf directly (no closure-graph overwrite) so this did not affect it, but
+            // it is wrong for NEE/MIS and must match the GPU twin (gpu_disney_pdf).
+            bool entering = rec.frontFace;
             float etaI = entering ? 1.0f : ior_;
             float etaT = entering ? ior_ : 1.0f;
             // std::abs() matches sample()'s inline computation (disney.cpp ~431:

--- a/tests/test_disney_rough_glass_furnace.py
+++ b/tests/test_disney_rough_glass_furnace.py
@@ -75,25 +75,22 @@ _SMOOTH = [0.0, 0.03]
 # gate; do not add R=0.05 here without first fixing that pre-existing gap.
 _ROUGH = [0.1, 0.3, 0.6, 1.0]
 
-# pkg166 REAL ENERGY-GAIN FINDING (2026-08-02). Converting this suite to linear
-# (apply_gamma=False) exposed that the Disney Principled transmission (glass)
-# lobe CREATES energy in the white furnace — hidden until now because gamma
-# clamps to [0,1] (the old bands passed on a clamped 1.000). Measured on
-# cf67a92, albedo=1, ior=1.5, patch mean, deterministic across 32/128/512 spp:
-#   CPU smooth R=0/0.03            -> 1.784
-#   CPU rough  R=0.1/0.3/0.6/1.0   -> 1.099 / 1.108 / 1.157 / 1.260
-#   GPU rough  R=0.1/0.3/0.6/1.0   -> 1.098 / 1.182 / 2.060 / 2.296
-# Controls conserve: plain `dielectric` furnace 0.994, opaque disney 0.958. The
-# GPU SMOOTH delta path is fine (0.993). Per pkg166's own contract these gains
-# are NOT pinned in and the bands are NOT widened: the conserving bands stay and
-# the failing cases are xfail'd, owned by pkg169
-# (.astroray_plan/packages/pkg169-disney-transmission-energy-gain.md, HIGH).
-# pkg169's fix PR must REMOVE these markers and prove the cases green under
-# --runxfail — this is a quarantine of a known bug, not a permanent tolerance.
-_DISNEY_GLASS_ENERGY_GAIN = (
-    "energy gain under investigation, owned by pkg169: Disney transmission "
-    "(glass) lobe creates energy in the white furnace (linear reveals >1.0; "
-    "gamma hid it). Quarantine, not a tolerance — pkg169's fix must un-xfail."
+# pkg169 (2026-08-02) fixed the Disney transmission energy GAIN that pkg166's
+# linear conversion exposed (baseline on cf67a92: CPU smooth 1.784, CPU rough
+# 1.099-1.260, GPU rough 1.098-2.296). The three pkg166 xfail(strict=False)
+# markers are removed; all cases conserve EXCEPT the single cell below.
+#
+# CPU rough glass at ior=1.5, R=1.0 converges to ~0.90 (below the 0.92 floor):
+# a residual MULTI-SCATTER under-compensation, not a single-scatter weight defect
+# (single-scatter alone is 0.717; pkg151's ggxGlassCompensationFactor recovers it
+# to 0.90 but not fully). Architect-approved (2026-08-02) single-cell quarantine
+# owned by pkg167 (dielectric-reflection multiscatter, "Inherited quarantine"
+# section) — NOT a band widening; the cell stays measured and pkg167's PR must
+# retire this xfail under --runxfail. GPU passes the same cell (0.930, [0.90,1.06]).
+_PKG167_MULTISCATTER_R1_IOR15 = (
+    "CPU rough Disney glass ior=1.5 R=1.0 residual multiscatter under-compensation "
+    "(~0.90 vs 0.92 floor); owned by pkg167 (Inherited quarantine). pkg167's PR "
+    "must retire this xfail under --runxfail. Not a band widening; single cell only."
 )
 
 
@@ -118,8 +115,8 @@ def test_disney_rough_glass_furnace_converges():
     assert abs(lo - hi) < 0.03, f"furnace not converged: 256spp={lo:.3f} 1024spp={hi:.3f}"
     # pkg166: renders linear now (via _furnace). This is a CONVERGENCE property,
     # orthogonal to the energy magnitude — the value bound lives in
-    # test_disney_rough_glass_furnace_energy_cpu (currently xfail'd for the
-    # Disney-glass energy-gain finding). Convergence itself holds regardless.
+    # test_disney_rough_glass_furnace_energy_cpu (un-xfail'd by pkg169).
+    # Convergence itself holds regardless.
 
 
 # pkg169 (2026-08-02) un-xfail: the GPU rough-glass energy gain (up to 2.296) is
@@ -142,22 +139,32 @@ def test_disney_rough_glass_furnace_energy_gpu():
     assert not bad, f"GPU rough disney glass furnace not energy-conserving at roughness {bad}; all={vals}"
 
 
-@pytest.mark.xfail(reason=_DISNEY_GLASS_ENERGY_GAIN, strict=False)
+# pkg169 (2026-08-02) un-xfail: the CPU rough-glass energy gain is fixed by two
+# single-scatter weight corrections — rough transmission was missing the incident
+# cosine |N.wi| (eval() folds it via *NdotL, but the transmission path returns
+# early with the PBRT per-steradian BTDF and the integrator adds no cosine), and
+# the delta fallthrough dropped the Fresnel factor (see the module docstring /
+# findings doc). R=0.1/0.3/0.6 -> 0.993/0.980/0.926, all in [0.92,1.03]. R=1.0 is
+# carved out below (multiscatter, pkg167).
+_ROUGH_CPU_CONSERVING = [0.1, 0.3, 0.6]
+
+
 def test_disney_rough_glass_furnace_energy_cpu():
-    # pkg118 FIXED 2026-06-08: the deficit was NOT missing multi-scatter — it was the
-    # CPU analog of the #404 GPU glass-dark bug. The base Material::sampleSpectral wrapper
-    # upsampled the delta/rough glass throughput `bs.f` through RGBAlbedoSpectrum, whose
-    # Jakob-Hanika ALBEDO LUT clamps rgb>1 to 1 — clipping the exit refraction's eta^2=2.25
-    # radiance recovery and darkening all transmissive glass (furnace R=0.05 0.77, R=0.1
-    # 0.81). The fix factors any >1 magnitude out as a flat spectral scalar (raytracer.h
-    # sampleSpectral), exactly as PR #404 did on the GPU. The CPU furnace now conserves:
-    # R=0.3/0.6/1.0 -> ~1.00, R=0.1 -> 0.94 (matching the GPU's own low-alpha-boundary
-    # residual 0.956; the GPU gate above accepts [0.90,1.06]). Root cause + the full
-    # diagnosis trail (5 ruled-out approaches, per-bounce ray trace) is in
-    # .astroray_plan/docs/pkg118-multiscatter-energy-research.md.
-    vals = {R: _furnace(R, spp=256) for R in _ROUGH}
+    vals = {R: _furnace(R, spp=256) for R in _ROUGH_CPU_CONSERVING}
     bad = {R: v for R, v in vals.items() if not (0.92 <= v <= 1.03)}
     assert not bad, f"rough disney glass furnace not energy-conserving at roughness {bad}; all={vals}"
+
+
+@pytest.mark.xfail(reason=_PKG167_MULTISCATTER_R1_IOR15, strict=False)
+def test_disney_rough_glass_furnace_energy_cpu_r1_ior15():
+    # Single-cell quarantine kept in the grid so it stays MEASURED (architect
+    # verdict 2026-08-02). CPU rough Disney glass at ior=1.5, R=1.0 converges to
+    # ~0.90 — a residual multiscatter under-compensation owned by pkg167, NOT the
+    # pkg169 single-scatter defect (which is fixed). No band widening: same
+    # [0.92,1.03] gate as the conserving cells above; pkg167's PR must retire this
+    # xfail under --runxfail.
+    v = _furnace(1.0, spp=256)  # ior 1.5 (default)
+    assert 0.92 <= v <= 1.03, f"CPU rough disney glass R=1.0 ior1.5 furnace = {v:.4f}"
 
 
 @pytest.mark.skipif(

--- a/tests/test_disney_rough_glass_furnace.py
+++ b/tests/test_disney_rough_glass_furnace.py
@@ -97,7 +97,11 @@ _DISNEY_GLASS_ENERGY_GAIN = (
 )
 
 
-@pytest.mark.xfail(reason=_DISNEY_GLASS_ENERGY_GAIN, strict=False)
+# pkg169 (2026-08-02) un-xfail: the delta-glass energy gain is fixed. The delta
+# reflection/transmission f dropped the Fresnel common factor R/T (kept in the pdf,
+# so f/pdf did not cancel) — PBRT-v4 §9.5 DielectricBxDF::Sample_f. Fixed in
+# disney.cpp sample(); R=0 furnace 1.784 -> 0.990. See
+# .astroray_plan/docs/pkg169-transmission-energy-gain-findings.md.
 def test_disney_smooth_glass_furnace_cpu():
     vals = {R: _furnace(R, spp=128) for R in _SMOOTH}
     bad = {R: v for R, v in vals.items() if not (0.95 <= v <= 1.02)}
@@ -118,7 +122,14 @@ def test_disney_rough_glass_furnace_converges():
     # Disney-glass energy-gain finding). Convergence itself holds regardless.
 
 
-@pytest.mark.xfail(reason=_DISNEY_GLASS_ENERGY_GAIN, strict=False)
+# pkg169 (2026-08-02) un-xfail: the GPU rough-glass energy gain (up to 2.296) is
+# fixed. Root cause was NOT the transmission weight formula: disney glass lowers to
+# a closure graph whose sampler overwrites the correct sampler pdf with
+# gpu_disney_pdf, whose reflection-branch Fresnel used entering = normal.dot(wo) > 0
+# (always true) instead of rec.frontFace — computing air->glass F instead of
+# glass->air (~1 at TIR) for internal reflections, so the pdf was up to ~20x too
+# small and f/pdf inflated. Fixed to rec.frontFace (+ mirrored delta/cosine fixes).
+# GPU R=1.0 furnace 2.296 -> 0.930. See the findings doc.
 @pytest.mark.skipif(
     AVAILABLE and not astroray.__features__.get("cuda", False),
     reason="CUDA feature not in this build")


### PR DESCRIPTION
## Summary

The Disney Principled transmission lobe **created energy** in the linear white furnace (CPU 1.784 at delta, GPU up to 2.296 at R=1.0), exposed when pkg166 converted the furnace suites from gamma to linear (gamma clamped the gain to 1.000). Two independent convictions, diagnosed per-event and fixed CPU+GPU in this PR, both cited to canonical references.

## Conviction A — CPU, two single-scatter weight defects

**A1. Delta glass dropped the Fresnel common factor** (furnace 1.784 at R=0). The delta branch set reflection `f=1` (should be R) and transmission `f=baseColor·eta²` (should be ×T=(1−fresnel)), while the pdf kept R/T — so `f/pdf` did not cancel and each interface acted lossless-in-expectation. PBRT-v4 §9.5 DielectricBxDF::Sample_f: reflection `f=R/|cosθi|, pdf=R`; transmission `f=T/|cosθi|/etap², pdf=T` — "the BSDF value and sample probability contain the common factor R or T, which cancels when their ratio is taken." Fixed in `disney.cpp` sample() delta branch.

**A2. Rough transmission missing the incident cosine** `|N·wi|` (furnace ~1.10 at R≥0.1). `eval()` folds the cosine via `*NdotL` at its end, but the transmission path returns early via `roughTransmissionEval` (the PBRT per-steradian BTDF, no cosine) and the integrator adds no separate cosine — so throughput was inflated by `1/|cosI|` (E[1/|cosI|]>1). Folded `|cosI|` in; the weight collapses to the Heitz-2018 VNDF form `G1(cosI)/etap²`.

## Conviction B — GPU, closure-graph reflection-pdf Fresnel orientation

Root cause is **not** a transmission weight formula. Disney glass lowers to `GMAT_CLOSURE_GRAPH`; the closure-graph sampler overwrites the (correct) sampler pdf with `gpu_disney_pdf` (a valid one-sample-MIS `f_total/pdf_total`). A device-printf trace showed the divergence is entirely on internal-reflection events (`frontFace=false`, same hemisphere): `gpu_disney_pdf`'s reflection Fresnel used `entering = rec.normal.dot(wo) > 0` — **always true** after normal reorientation — computing air→glass Fresnel (small) instead of glass→air (≈1 near TIR), so the reflection-branch pdf was up to ~20× too small and `f/pdf` inflated (rises with roughness as internal-reflection fraction rises). Fixed to `entering = rec.frontFace` (matching the sampler and the pkg154 `roughTransmission{Eval,Pdf}` convention) in both `gpu_disney_pdf` and the CPU twin `disney.cpp pdf()`. The A1/A2 fixes were mirrored into `gpu_materials.h`. (I did **not** skip the overwrite — that masks the separate pkg170 opaque-Disney defect; the pdf orientation was the actual bug.)

## Before / after furnace (256 spp, linear, floor+ceiling [0.92,1.03])

| ior 1.5 | R=0 | 0.03 | 0.1 | 0.3 | 0.6 | 1.0 |
|---|---|---|---|---|---|---|
| CPU before | 1.784 | 1.784 | 1.099 | 1.108 | 1.157 | 1.260 |
| **CPU after** | 0.990 | 0.990 | 0.993 | 0.980 | 0.926 | 0.902* |
| GPU before | 0.993 | 0.993 | 1.098 | 1.182 | 2.060 | 2.296 |
| **GPU after** | 0.992 | 0.992 | 0.992 | 0.986 | 0.970 | 0.930 |

| ior 1.33 | R=0 | 0.03 | 0.1 | 0.3 | 0.6 | 1.0 |
|---|---|---|---|---|---|---|
| **CPU after** | 0.991 | 0.991 | 0.993 | 0.989 | 0.980 | 0.980 |
| **GPU after** | 0.993 | 0.993 | 0.992 | 0.989 | 0.992 | 0.988 |

Controls unchanged: plain dielectric 0.993 (CPU) / 0.992 (GPU); opaque disney 0.959 (CPU). \*CPU ior1.5 R=1.0 = 0.902 — see quarantine note.

## Acceptance checklist

- [x] Furnace conserving at ior 1.5 AND 1.33, CPU and GPU, all roughness, linear with floor+ceiling — except the one carved cell below.
- [x] Controls unchanged (plain dielectric, opaque Disney stay conserving on CPU).
- [x] Second IOR (1.33) at delta + rough, both legs — conserves.
- [x] pkg166's 3 `xfail(strict=False)` markers removed; fixed cases prove green under `--runxfail`.
- [x] cite-algorithm discipline (PBRT-v4 §9.5, Heitz 2018 VNDF, pkg154 frontFace convention).
- [x] CPU and GPU fixed in the same PR.
- [x] Findings doc `.astroray_plan/docs/pkg169-transmission-energy-gain-findings.md` (both conviction traces, radiance-transport convention, citation-to-line map).

## Single-cell quarantine (architect verdict, 2026-08-02)

CPU rough glass at **ior 1.5, R=1.0** converges to ~0.902 (256/1024 spp agree) — a residual **multiscatter** under-compensation (single-scatter alone 0.717; pkg151's comp recovers to 0.90 but not to 0.92), **not** the single-scatter defect this PR fixes. Per architect verdict it is a single-cell `xfail(strict=False)` (`test_disney_rough_glass_furnace_energy_cpu_r1_ior15`) owned by **pkg167** (dielectric-reflection multiscatter, "Inherited quarantine"); pkg167's PR must retire it under `--runxfail`. No band widening — same [0.92,1.03] gate; the cell stays measured. GPU passes the same cell (0.930).

## --runxfail evidence

```
tests/test_disney_rough_glass_furnace.py  (normal)   : 5 passed, 1 xfailed
tests/test_disney_rough_glass_furnace.py --runxfail  : 5 passed, 1 failed
  (only test_disney_rough_glass_furnace_energy_cpu_r1_ior15 — the pkg167-owned cell)
```
Regression sweep green: reflection/energy/dielectric/caustic 276 passed; chi² BSDF consistency 131 passed / 4 pre-existing xfail; closure-graph + disney/material 304 passed / 2 pre-existing xfail (incl. pkg108 tinted glass, pkg123 metal parity).

## Out of scope (filed as pkg170)

GPU **opaque** Disney (metallic=0, transmission=0) furnaces at ~1.975 (flat 2× gain, pre-existing) from the same closure-graph re-eval overwrite on the diffuse+conductor recombination — a separate bug, not touched here.

## Build log (last 5 lines, rebased HEAD d00f633, exit 0)

```
[100%] Linking CXX shared module astroray.cp313-win_amd64.pyd
[100%] Built target astroray
[ 95%] Built target astroray_core_impl
[100%] Built target astroray_test_helpers
[build_cuda_worktree] Build succeeded
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)