### PR TITLE
fix(pkg170): GPU opaque Disney closure-graph recombination energy gain

### DIFF
--- a/.astroray_plan/packages/pkg170-gpu-opaque-disney-closure-recombination-gain.md
+++ b/.astroray_plan/packages/pkg170-gpu-opaque-disney-closure-recombination-gain.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 2/3 (BSDF energy conservation, GPU parity)
 **Track:** A (RTX-gated — the defect is GPU-only; the new furnace legs are the lasting coverage)
-**Status:** done (PR #PENDING, 2026-08-02 — GPU opaque Disney furnace 1.975 flat → 0.986/0.987/0.987/0.979 at R∈{0,0.3,0.6,1.0}, all in [0.92,1.03]; CPU control unchanged 0.945–0.962; neighbours byte-unchanged (plain metal 0.9454, plain dielectric 0.9929); metallic=1 single-lobe unchanged 0.985/0.988. Fix: closure-graph eval now weights each lobe by its selection probability w_i/totalWeight, matching the pdf — one-sample MIS, RTX 5070 Ti)
+**Status:** done (PR #542, 2026-08-02 — GPU opaque Disney furnace 1.975 flat → 0.986/0.987/0.987/0.979 at R∈{0,0.3,0.6,1.0}, all in [0.92,1.03]; CPU control unchanged 0.945–0.962; neighbours byte-unchanged (plain metal 0.9454, plain dielectric 0.9929); metallic=1 single-lobe unchanged 0.985/0.988. Fix: closure-graph eval now weights each lobe by its selection probability w_i/totalWeight, matching the pdf — one-sample MIS, RTX 5070 Ti)
 **Estimated effort:** S–M (diagnosis mostly done — the seam is convicted; the work is the estimator-correct fix + the coverage gap + verification)
 **Depends on:** pkg169's fix PR (the one-sample-MIS-correct treatment this fix must mirror on the diffuse+conductor path, and the device-printf methodology to reuse). Related: memory `gpu-dielectric-lowers-to-closure-graph` (the closure-graph lowering is where this class of bug lives).
 

--- a/.astroray_plan/packages/pkg170-gpu-opaque-disney-closure-recombination-gain.md
+++ b/.astroray_plan/packages/pkg170-gpu-opaque-disney-closure-recombination-gain.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 2/3 (BSDF energy conservation, GPU parity)
 **Track:** A (RTX-gated — the defect is GPU-only; the new furnace legs are the lasting coverage)
-**Status:** open — dispatchable (HIGH priority: every opaque Disney material on GPU is affected — metallic=0/transmission=0 is the default material class; wider blast radius than pkg169's transmission bug)
+**Status:** done (PR #PENDING, 2026-08-02 — GPU opaque Disney furnace 1.975 flat → 0.986/0.987/0.987/0.979 at R∈{0,0.3,0.6,1.0}, all in [0.92,1.03]; CPU control unchanged 0.945–0.962; neighbours byte-unchanged (plain metal 0.9454, plain dielectric 0.9929); metallic=1 single-lobe unchanged 0.985/0.988. Fix: closure-graph eval now weights each lobe by its selection probability w_i/totalWeight, matching the pdf — one-sample MIS, RTX 5070 Ti)
 **Estimated effort:** S–M (diagnosis mostly done — the seam is convicted; the work is the estimator-correct fix + the coverage gap + verification)
 **Depends on:** pkg169's fix PR (the one-sample-MIS-correct treatment this fix must mirror on the diffuse+conductor path, and the device-printf methodology to reuse). Related: memory `gpu-dielectric-lowers-to-closure-graph` (the closure-graph lowering is where this class of bug lives).
 

--- a/include/astroray/gpu_materials.h
+++ b/include/astroray/gpu_materials.h
@@ -1350,14 +1350,38 @@ __device__ inline float gpu_closure_pdf(
 __device__ inline GVec3 gpu_closure_graph_eval(
     const GMaterial& mat, GHitRecord& rec, const GVec3& wo, const GVec3& wi)
 {
-    GVec3 sum(0.0f);
+    // pkg170: weight each lobe by its SELECTION probability (weight_i / totalWeight),
+    // matching gpu_closure_graph_pdf's normalization, so the closure-graph sampler's
+    // overwrite s.f = eval, s.pdf = pdf forms a correct one-sample-MIS estimator of
+    // the MIXTURE BSDF (Veach 1997 thesis Eq. 9.15 one-sample model / balance
+    // heuristic; PBRT-v4 §9.5 & §14.3.4 "BSDF::Sample_f" mixture sampling). The eval
+    // previously summed RAW weights (Sum w_i f_i) while the pdf summed NORMALIZED
+    // weights (Sum (w_i/W) pdf_i); f_total/pdf_total then estimated a W-inflated
+    // integrand. For opaque Disney (diffuse w=1 + GGX-conductor w=1, W=2, each lobe
+    // ~unit albedo in a white furnace) that is a flat ~1.975 energy gain across
+    // roughness (measured 78218f6 RTX 5070 Ti), while CPU's monolithic Disney
+    // conserves (~0.95). This is the opaque twin of pkg169's transmission-path
+    // recombination fix (which corrected the overwritten pdf's Fresnel orientation;
+    // this corrects the overwritten eval's lobe weighting). Single-lobe graphs
+    // (plain metal/dielectric, Disney glass, metallic=1 Disney) have W = weight_1 so
+    // (w_1/W) = 1 -> byte-unchanged. Normalize over the SAME sampleable set the pdf
+    // uses so the two are consistent.
+    float totalWeight = 0.0f;
     int count = mat.closureCount < G_MAX_MATERIAL_CLOSURES ? mat.closureCount : G_MAX_MATERIAL_CLOSURES;
+    for (int i = 0; i < count; ++i) {
+        const GMaterialClosure& closure = mat.closures[i];
+        if (gpu_closure_is_sampleable(closure.type))
+            totalWeight += fmaxf(closure.weight, 0.0f);
+    }
+    if (totalWeight <= 0.0f) return GVec3(0.0f);
+
+    GVec3 sum(0.0f);
     for (int i = 0; i < count; ++i) {
         const GMaterialClosure& closure = mat.closures[i];
         if (closure.type != GCLOSURE_EMISSION)
             sum += gpu_closure_eval(mat, closure, rec, wo, wi);
     }
-    return sum;
+    return sum * (1.0f / totalWeight);
 }
 
 // pkg163: does this closure graph carry a metal (non-Disney) conductor lobe?
@@ -1381,8 +1405,23 @@ __device__ inline GSampledSpectrum gpu_closure_graph_eval_spectral(
     const GMaterial& mat, GHitRecord& rec, const GVec3& wo, const GVec3& wi,
     const GSampledWavelengths& wl)
 {
-    GSampledSpectrum sum(0.0f);
+    // pkg170: same selection-probability normalization as the RGB
+    // gpu_closure_graph_eval (see there) so f_total/pdf_total is a one-sample-MIS
+    // estimator of the mixture BSDF. This spectral path is only reached for
+    // metal-carrying graphs (gpu_closure_graph_has_metal); those are single-lobe
+    // today (W = weight_1 -> unchanged), but the normalization is kept in lockstep
+    // with the RGB twin so a future multi-lobe metal graph cannot re-open this
+    // bug class.
+    float totalWeight = 0.0f;
     int count = mat.closureCount < G_MAX_MATERIAL_CLOSURES ? mat.closureCount : G_MAX_MATERIAL_CLOSURES;
+    for (int i = 0; i < count; ++i) {
+        const GMaterialClosure& closure = mat.closures[i];
+        if (gpu_closure_is_sampleable(closure.type))
+            totalWeight += fmaxf(closure.weight, 0.0f);
+    }
+    if (totalWeight <= 0.0f) return GSampledSpectrum(0.0f);
+
+    GSampledSpectrum sum(0.0f);
     for (int i = 0; i < count; ++i) {
         const GMaterialClosure& closure = mat.closures[i];
         if (closure.type == GCLOSURE_EMISSION || closure.weight <= 0.0f) continue;
@@ -1393,7 +1432,7 @@ __device__ inline GSampledSpectrum gpu_closure_graph_eval_spectral(
             sum += gpu_rgbToSampledSpectrum(
                 gpu_closure_eval(mat, closure, rec, wo, wi), wl, mat.spectralMode);
     }
-    return sum;
+    return sum * (1.0f / totalWeight);
 }
 
 __device__ inline float gpu_closure_graph_pdf(

--- a/tests/test_disney_opaque_furnace.py
+++ b/tests/test_disney_opaque_furnace.py
@@ -1,0 +1,136 @@
+"""Opaque Disney (metallic=0, transmission=0) must conserve energy on the GPU.
+
+The default Disney material class (metallic=0, transmission=0) lowers to a GPU
+closure graph carrying TWO sampleable lobes: a diffuse lobe (weight 1) and a GGX
+conductor lobe (weight 1), totalWeight W=2. Before pkg170 the closure-graph eval
+summed RAW lobe weights (Sum w_i f_i) while the pdf summed NORMALIZED selection
+weights (Sum (w_i/W) pdf_i); the one-sample-MIS estimator f_total/pdf_total then
+targeted a W-inflated integrand and the white furnace read a flat ~1.975 across
+all roughness (measured 78218f6, RTX 5070 Ti, linear) while CPU's monolithic
+Disney conserved (~0.95). pkg170 weights each lobe by its selection probability
+in the eval, matching the pdf (Veach 1997 §9.2.4 one-sample MIS / PBRT-v4 §9.5).
+
+pkg166's linear-furnace conversion did NOT cover opaque-Disney-on-GPU, which is
+why a ~2x gain on the DEFAULT material class survived unseen. These legs close
+that coverage gap (they are the lasting deliverable). Named `*furnace*` so the
+pkg166 autouse guard enforces linear rendering.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+
+try:
+    import astroray  # noqa: E402
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray not built")
+
+_gpu = pytest.mark.skipif(
+    AVAILABLE and not astroray.__features__.get("cuda", False),
+    reason="CUDA feature not in this build")
+
+_ROUGH = [0.0, 0.3, 0.6, 1.0]
+
+
+def _furnace(mat_type, params, *, use_gpu, spp=128, depth=32):
+    r = astroray.Renderer()
+    r.set_background_color([1.0, 1.0, 1.0])           # uniform white environment
+    m = r.create_material(mat_type, [1.0, 1.0, 1.0], dict(params))
+    r.add_sphere([0.0, 0.0, 0.0], 1.0, m)
+    r.set_integrator("path_tracer")
+    if use_gpu:
+        r.set_use_gpu(True)
+    r.setup_camera([0, 0, 4], [0, 0, 0], [0, 1, 0], 40.0, 1.0, 0.0, 4.0, 80, 80)
+    r.set_seed(7)
+    # LINEAR (apply_gamma=False): a gamma furnace clamps to [0,1] and is blind to
+    # energy GAIN — the exact reason this ~2x bug survived (pkg166; memory
+    # gamma-furnace-cannot-detect-energy-gain).
+    img = np.asarray(r.render(spp, depth, None, False), dtype=np.float32).reshape(80, 80, 3)
+    return float(img[28:52, 28:52].mean())
+
+
+def _opaque(roughness, metallic=0.0):
+    return {"metallic": metallic, "transmission": 0.0, "roughness": roughness}
+
+
+@_gpu
+def test_disney_opaque_furnace_energy_gpu():
+    if not astroray.Renderer().gpu_available:
+        pytest.skip("CUDA GPU not available")
+    vals = {R: _furnace("disney", _opaque(R), use_gpu=True) for R in _ROUGH}
+    bad = {R: v for R, v in vals.items() if not (0.92 <= v <= 1.03)}
+    assert not bad, f"GPU opaque Disney furnace not energy-conserving at roughness {bad}; all={vals}"
+
+
+def test_disney_opaque_furnace_energy_cpu():
+    # Control: CPU uses the monolithic Disney BSDF (no closure-graph recombination),
+    # already conserving pre- and post-pkg170. Guards that the GPU fix did not
+    # regress the CPU reference.
+    vals = {R: _furnace("disney", _opaque(R), use_gpu=False) for R in _ROUGH}
+    bad = {R: v for R, v in vals.items() if not (0.92 <= v <= 1.03)}
+    assert not bad, f"CPU opaque Disney furnace not energy-conserving at roughness {bad}; all={vals}"
+
+
+@_gpu
+def test_disney_metallic_furnace_energy_gpu():
+    # metallic=1 lowers to a SINGLE GGX-conductor lobe (W=weight_1), so the pkg170
+    # normalization is a no-op here — this leg pins that the single-lobe conductor
+    # path stays conserving and did not move.
+    if not astroray.Renderer().gpu_available:
+        pytest.skip("CUDA GPU not available")
+    vals = {R: _furnace("disney", _opaque(R, metallic=1.0), use_gpu=True) for R in [0.3, 0.6]}
+    bad = {R: v for R, v in vals.items() if not (0.92 <= v <= 1.03)}
+    assert not bad, f"GPU metallic Disney furnace not energy-conserving at roughness {bad}; all={vals}"
+
+
+@_gpu
+def test_closure_graph_neighbour_furnace_energy_gpu():
+    # Neighbour spot-check (spec acceptance): single-lobe closure graphs — plain
+    # `metal` (GGX conductor) and plain `dielectric` (delta transmission) — must be
+    # UNCHANGED by the recombination fix (W=weight_1 => (w_1/W)=1). Bands bracket
+    # the measured baselines (metal ~0.945, dielectric ~0.993) loosely enough to
+    # avoid noise flakes but far below the ~2x a leak would produce.
+    if not astroray.Renderer().gpu_available:
+        pytest.skip("CUDA GPU not available")
+    metal = _furnace("metal", {"roughness": 0.3}, use_gpu=True)
+    dielectric = _furnace("dielectric", {"ior": 1.5}, use_gpu=True)
+    assert 0.90 <= metal <= 1.06, f"plain metal furnace moved: {metal:.4f}"
+    assert 0.92 <= dielectric <= 1.05, f"plain dielectric furnace moved: {dielectric:.4f}"
+
+
+@_gpu
+def test_disney_opaque_gpu_does_not_glow_in_gray_furnace():
+    """Render-level appearance guard (memory pr-named-tests-insufficient): the
+    integral furnace above is necessary but not sufficient. A default opaque Disney
+    sphere lit by a uniform 0.45 gray field must reflect ~that field, not ~2x it.
+    Pre-pkg170 this GPU render glowed to ~0.9 (2x the environment); post-fix it sits
+    at the environment. Rendered LINEAR (the gain is invisible through gamma)."""
+    if not astroray.Renderer().gpu_available:
+        pytest.skip("CUDA GPU not available")
+    width = height = 64
+    r = astroray.Renderer()
+    r.set_integrator("path_tracer")
+    r.set_seed(77)
+    r.set_use_gpu(True)
+    r.set_background_color([0.45, 0.45, 0.45])
+    r.setup_camera([0.0, 0.0, 4.0], [0.0, 0.0, 0.0], [0.0, 1.0, 0.0],
+                   34.0, 1.0, 0.0, 4.0, width, height)
+    m = r.create_material("disney", [0.8, 0.8, 0.8], {"metallic": 0.0, "roughness": 0.4})
+    r.add_sphere([0.0, 0.0, 0.0], 0.85, m)
+    pixels = np.asarray(r.render(256, 16, None, False), dtype=np.float32)
+    yy, xx = np.mgrid[0:height, 0:width]
+    sphere = ((xx - (width - 1) * 0.5) ** 2 + (yy - (height - 1) * 0.5) ** 2) <= 19.0 ** 2
+    lum = 0.2126 * pixels[..., 0] + 0.7152 * pixels[..., 1] + 0.0722 * pixels[..., 2]
+    mean_lum = float(np.mean(lum[sphere]))
+    # A conserving gray surface in a 0.45 field reflects ~0.45. Ceiling 0.55 fails
+    # the pre-fix ~0.9 glow; floor 0.30 keeps "no glow" from passing on a black BSDF.
+    assert mean_lum <= 0.55, f"opaque Disney sphere glows in 0.45 field: mean_lum={mean_lum:.4f}"
+    assert mean_lum >= 0.30, f"opaque Disney sphere reads near-black: mean_lum={mean_lum:.4f}"


### PR DESCRIPTION
## Summary

GPU opaque Disney (`metallic=0, transmission=0` — the **default** material class) created a flat **~1.975× white-furnace energy gain** across all roughness, while CPU conserved (~0.95). Second member of the closure-graph re-eval-overwrite bug class (first: pkg169's transmission pdf orientation).

## Root cause (verified before fixing)

Opaque Disney lowers to a GPU closure graph with **two** sampleable lobes — diffuse (weight 1) + GGX conductor (weight 1), `totalWeight W=2`. `gpu_closure_graph_eval` summed **raw** lobe weights (`Σ wᵢfᵢ`) while `gpu_closure_graph_pdf` summed **normalized** selection weights (`Σ (wᵢ/W) pdfᵢ`). The sampler's one-sample-MIS overwrite (`s.f=eval`, `s.pdf=pdf`) then estimated a W-inflated integrand.

**Lobe-count arithmetic (spec's verify-before-fix clause):** each lobe ≈ unit albedo in a white furnace, so `Σ wᵢfᵢ ≈ diffuse(1.0)+conductor(0.987) ≈ 1.975`. Metallic-sweep cross-check: metallic=0 → 2 lobes → 1.975; metallic=1 → 1 lobe → 0.988; the **difference 0.987** is exactly the extra full-weight diffuse lobe. The measured factor is fully explained by the lobe count.

## Fix

Weight each lobe in the eval by its selection probability `wᵢ/totalWeight`, matching the pdf, so `f_total/pdf_total` is a correct one-sample-MIS estimator of the mixture BSDF (**Veach 1997 thesis §9.2.4** balance heuristic / one-sample model; **PBRT-v4 §9.5 & §14.3.4**). Applied to `gpu_closure_graph_eval` and its spectral twin `gpu_closure_graph_eval_spectral`. **Not** the diagnostic overwrite-skip (which changes estimator semantics for every closure-graph material). This is the opaque twin of pkg169's transmission-path fix.

Single-lobe graphs (plain metal/dielectric, Disney glass, metallic=1 Disney) have `W=weight₁` so `(w₁/W)=1` → **byte-unchanged**. GPU-only (CPU uses the monolithic Disney BSDF, no closure-graph recombination).

## Measured (128 spp, linear, RTX 5070 Ti, [0.92,1.03])

| config | before | after |
|---|---|---|
| GPU opaque Disney R=0/0.3/0.6/1.0 | 1.975/1.976/1.977/1.961 | **0.986/0.987/0.987/0.979** |
| CPU opaque Disney (control) | 0.953/0.958/0.962/0.945 | 0.953/0.958/0.962/0.945 |
| GPU metallic=1 (single lobe) | 0.988/0.985 | 0.988/0.985 |
| GPU plain metal / plain dielectric | 0.9454 / 0.9929 | 0.9454 / 0.9929 |

## Coverage gap closed (co-equal deliverable)

`tests/test_disney_opaque_furnace.py` adds the GPU opaque-Disney furnace legs pkg166 never had (R∈{0,0.3,0.6,1.0}, linear floor+ceiling, under the pkg166 naming guard), a metallic=1 single-lobe leg, a neighbour spot-check, and a render-level anti-glow appearance guard (memory `pr-named-tests-insufficient`). This bug survived precisely because that leg did not exist.

## Acceptance

- [x] GPU opaque Disney furnace in [0.92,1.03] at all four roughness; CPU unchanged
- [x] Estimator-correct one-sample-MIS recombination weight (cited); NOT the overwrite-skip
- [x] Overwrite-bypass diagnostic not in shipped code
- [x] New GPU furnace legs + guard
- [x] Closure-graph neighbours (plain dielectric, plain metal) byte-unchanged
- [x] Render-level appearance suite green (anti-glow guard + reflection_not_black + energy_conservation)

## Verification

`1562 passed / 69 skipped / 27 xfailed / 1 xpassed` on `tests/` (excl. wavefront_diff). The 1 xpassed is the pre-existing unrelated legacy prism PSNR gate. pkg169's Disney glass furnace and pkg123 metal parity green. Rebased onto main (78218f6) which includes pkg169/PR #540.

### Build log (last 5 lines)
```
[ 98%] Built target stb_impl
[100%] Linking CXX shared module astroray.cp313-win_amd64.pyd
[100%] Built target astroray
[ 95%] Built target astroray_core_impl
[build_cuda_worktree] Build succeeded
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)