### PR TITLE
docs(pkg172): diagnosis — residual is NOT triangle-specific; pkg156 oracle is the outlier (escalate)

### DIFF
--- a/.astroray_plan/docs/pkg172-triangle-transport-diagnosis.md
+++ b/.astroray_plan/docs/pkg172-triangle-transport-diagnosis.md
@@ -1,0 +1,77 @@
+# pkg172 — diagnosis: the residual is NOT triangle-specific; it is a ~0.6%/bounce diffuse energy discrepancy, and the pkg156 ORACLE is the outlier
+
+**Date:** 2026-08-02 (RTX 5070 Ti). **Branch:** pkg172-triangle-transport-bias
+(base 80d4ec0, #541 not merged — findings below use NEUTRAL albedo, which is
+#541-independent per pkg168 Step 2). **No fix applied — escalating.**
+
+## The spec's premise is falsified, and all three named candidates are cleared
+
+**(1) NOT triangle-specific.** With a clean full-frame single-bounce measurement
+(camera face-on, uniform white env, spp 16384), a **sphere and a triangle wall
+give the IDENTICAL ratio** 0.99570 (per-channel, neutral albedo 0.5). My pkg168
+Step-2 "sphere-clean / triangle-dirty" reading was a camera/depth/masking
+confound (the sphere and floor probes used different camera heights and path
+depths). The bias is geometry-INDEPENDENT.
+
+**(2) Candidate (c) epsilon — CLEARED.** Scratch rebuild with the throughput
+epsilon `f/(pdf+1e-3)` → `1e-6` on BOTH legs left the ratio unchanged (0.99587 →
+0.99590). Not the epsilon.
+
+**(3) Candidates (a)/(b) normal/cosθ — CLEARED.** The bias is achromatic,
+depth-independent (constant 0.99587 across depth 2–8 on a flat wall — no
+multi-bounce, no off-by-one), and identical for sphere vs triangle. Both legs use
+the normalized face normal + matching `frontFace`; a mis-normalized or non-ONB
+frame cancels in `f/pdf` anyway.
+
+Also ruled out by inspection/measurement: the JH upsampling tables (Step 1,
+neutral matches to 1.000000), the diffuse closure weight (=1.0), the GPU contrib
+clamp (`clampDirect/Indirect` default 0 = identity), and toXYZ/CMF (shared).
+
+## The real structure (three-way cross-check, same wall scene, albedo 0.5, env white)
+
+| integrator | reflected luminance | vs analytic 0.5 |
+|---|---|---|
+| CPU `multiwavelength_path_tracer` (pkg156 oracle) | [0.5001, 0.5009, 0.4915] | ~exact |
+| CPU `path_tracer` (canonical) | [0.4970, 0.4978, 0.4884] | −0.6% |
+| GPU wavefront (naive) | [0.4979, 0.4988, 0.4895] | −0.4% |
+
+- **GPU wavefront ≈ CPU `path_tracer`** (ratio 1.002) — the GPU is NOT the
+  outlier; it agrees with the canonical CPU production integrator.
+- **CPU `multiwavelength_path_tracer` is the outlier** — ~0.6% brighter than both,
+  and it is the one that matches the energy-conserving analytic (a 0.5-albedo
+  Lambertian under unit illumination must reflect exactly 0.5).
+
+So the pkg156 gate ("GPU/CPU divergence") is really: the GPU faithfully matches
+the canonical CPU path tracer, but the gate's chosen ORACLE (CPU
+multiwavelength) is the ~0.6%/bounce outlier. Restoring the gate to 0.998 by
+making the GPU match CPU-mw would move the GPU AWAY from the canonical
+`path_tracer`. Conversely, the CPU-mw being closest to the analytic suggests
+`path_tracer` + GPU share a ~0.6%/bounce diffuse ENERGY LOSS that CPU-mw does not.
+
+## Why this is an escalation, not a fix
+
+There is a genuine design fork the owner must decide — this is not a single
+convicted line:
+
+1. **CPU-mw is right (energy-conserving):** then `path_tracer` AND the GPU
+   wavefront share a ~0.6%/bounce diffuse energy-loss bug to fix — a broad change
+   touching the canonical CPU integrator and the production GPU path, far beyond a
+   triangle-geometry tweak, and it would shift many existing `path_tracer` gates.
+2. **`path_tracer`/GPU are right:** then the pkg156 gate's oracle is wrong and the
+   gate should compare against `path_tracer`, not `multiwavelength_path_tracer` —
+   a gate/oracle change, not a transport fix.
+3. The 0.6% compounds over the pkg156 room's multiple bounces to the observed
+   ~1.5% ([1.016,1.010,1.014]); either resolution must be measured on the full
+   scene.
+
+Per the spec ("if 0.998 is unreachable, escalate with the next-level
+decomposition — the gate does not re-pin below 0.998 a second time without an
+owner"), pkg172 stops here and escalates. **pkg156 stays at 0.995; no re-pin.**
+Root cause of the CPU-mw vs `path_tracer` divergence (MIS/env-handling/energy
+convention) is the next drill-down, owner-directed.
+
+## pkg153 intel
+
+No fix applied, so no movement to report. But the discriminator is now sharper:
+pkg153's drift is CHROMATIC/emitter-linked; this is ACHROMATIC and present with no
+emitter (env-only). Distinct mechanisms, consistent with the scope fence.

--- a/.astroray_plan/packages/pkg172-triangle-transport-bias.md
+++ b/.astroray_plan/packages/pkg172-triangle-transport-bias.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 3 (GPU/CPU transport parity)
 **Track:** A (RTX-gated)
-**Status:** open — dispatchable (diagnosis-first; not urgent-tier — 0.6% is inside every live band — but it now OWNS the pkg156 SSIM gate restoration, transferred from pkg168)
+**Status:** ESCALATED to architect (diagnosis done, no fix, 2026-08-02) — the spec premise is FALSIFIED: the bias is NOT triangle-specific (sphere == triangle == 0.9957 single-bounce) and candidates (a)/(b)/(c) are all CLEARED (epsilon probe negative; achromatic, geometry- & depth-independent). Three-way cross-check: **GPU wavefront AGREES with the canonical CPU `path_tracer` (ratio 1.002); the pkg156 ORACLE (CPU `multiwavelength_path_tracer`) is the ~0.6%/bounce OUTLIER** and is the one matching the energy-conserving analytic. This is a design fork (fix CPU-mw's energy vs fix path_tracer+GPU vs change the gate oracle) requiring owner direction — not a single convicted line. **pkg156 stays at 0.995; NOT re-pinned.** Full decomposition: .astroray_plan/docs/pkg172-triangle-transport-diagnosis.md.
 **Estimated effort:** S (diagnosis — the discriminators are already established and the minimal scene is one triangle) + S for the fix once convicted
 **Depends on:** PR #541 (pkg168 Step 2) merged — the sphere-clean baseline this spec's discriminator rests on. Cross-links: **pkg156** (its 0.998 restoration is BLOCKED-ON this package; pointer updated 2026-08-02), **pkg168** (charter complete — exonerated the tables in Step 1, fixed the call-structure shape divergence in Step 2; THIS residual is the third mechanism its decomposition exposed), **pkg153** (sibling family, ownership separate — see Scope fence).
 


### PR DESCRIPTION
## Diagnosis only (no code fix) — escalating a design fork

Ran the spec's three-probe protocol. The spec's premise is **falsified** and all three named candidates are cleared.

### Findings
- **NOT triangle-specific.** Full-frame single-bounce, uniform white env, neutral albedo: a **sphere and a triangle wall give the identical ratio 0.9957**. The pkg168 Step-2 "sphere-clean/triangle-dirty" reading was a camera/depth/masking confound.
- **(c) epsilon — CLEARED.** Scratch rebuild with `f/(pdf+1e-3)`→`1e-6` on both legs: ratio unchanged (0.99587→0.99590).
- **(a)/(b) normal/cosθ — CLEARED.** Achromatic, depth-independent (constant across depth 2–8 on a flat wall = pure single bounce), geometry-identical. Both legs use the normalized face normal + matching `frontFace`.
- Also ruled out: JH tables (Step 1), diffuse closure weight (=1.0), GPU contrib clamp (default 0 = identity), toXYZ/CMF (shared).

### The real structure (three-way cross-check, wall, albedo 0.5, white env, reflected luminance)
| integrator | luminance | vs analytic 0.5 |
|---|---|---|
| CPU `multiwavelength_path_tracer` (pkg156 **oracle**) | 0.5001 | ~exact |
| CPU `path_tracer` (canonical) | 0.4970 | −0.6% |
| GPU wavefront (naive) | 0.4979 | −0.4% |

**GPU ≈ CPU `path_tracer` (ratio 1.002).** The GPU is *not* the outlier — it matches the canonical CPU integrator. The pkg156 gate's **oracle** (CPU multiwavelength) is the ~0.6%/bounce outlier, and it is the one matching the energy-conserving analytic (a 0.5-albedo Lambertian under unit env must reflect exactly 0.5).

### Why escalate rather than fix
A genuine design fork the owner must decide (not a single convicted line):
1. **CPU-mw is right (energy-conserving):** then `path_tracer` AND the GPU share a ~0.6%/bounce diffuse energy-loss bug — a broad change to the canonical CPU integrator + production GPU path that would shift many existing `path_tracer` gates.
2. **`path_tracer`/GPU are right:** then the pkg156 gate's oracle is wrong; the gate should compare against `path_tracer`.
3. Either way the 0.6% compounds over the pkg156 room to the observed ~1.5%, so the resolution must be measured on the full scene.

Per the spec ("gate does not re-pin below 0.998 without an owner"), **pkg156 stays at 0.995; not re-pinned.** Root cause of the CPU-mw vs `path_tracer` divergence (MIS/env-handling/energy convention) is the owner-directed next drill-down.

### pkg153 intel
No fix applied → no movement. Discriminator sharpened: this is **achromatic** and present with **no emitter** (env-only); pkg153's drift is chromatic/emitter-linked. Distinct.

Note: `.astroray_plan/docs/pkg172-triangle-transport-diagnosis.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)