### PR TITLE
docs(pkg172): (B)/(B') decomposition — single-bounce=#541 (verified), multi-bounce convicted as geometry-sampling parity (held for supervised round)

### DIFF
--- a/.astroray_plan/docs/pkg172-triangle-transport-diagnosis.md
+++ b/.astroray_plan/docs/pkg172-triangle-transport-diagnosis.md
@@ -1,0 +1,77 @@
+# pkg172 — diagnosis: the residual is NOT triangle-specific; it is a ~0.6%/bounce diffuse energy discrepancy, and the pkg156 ORACLE is the outlier
+
+**Date:** 2026-08-02 (RTX 5070 Ti). **Branch:** pkg172-triangle-transport-bias
+(base 80d4ec0, #541 not merged — findings below use NEUTRAL albedo, which is
+#541-independent per pkg168 Step 2). **No fix applied — escalating.**
+
+## The spec's premise is falsified, and all three named candidates are cleared
+
+**(1) NOT triangle-specific.** With a clean full-frame single-bounce measurement
+(camera face-on, uniform white env, spp 16384), a **sphere and a triangle wall
+give the IDENTICAL ratio** 0.99570 (per-channel, neutral albedo 0.5). My pkg168
+Step-2 "sphere-clean / triangle-dirty" reading was a camera/depth/masking
+confound (the sphere and floor probes used different camera heights and path
+depths). The bias is geometry-INDEPENDENT.
+
+**(2) Candidate (c) epsilon — CLEARED.** Scratch rebuild with the throughput
+epsilon `f/(pdf+1e-3)` → `1e-6` on BOTH legs left the ratio unchanged (0.99587 →
+0.99590). Not the epsilon.
+
+**(3) Candidates (a)/(b) normal/cosθ — CLEARED.** The bias is achromatic,
+depth-independent (constant 0.99587 across depth 2–8 on a flat wall — no
+multi-bounce, no off-by-one), and identical for sphere vs triangle. Both legs use
+the normalized face normal + matching `frontFace`; a mis-normalized or non-ONB
+frame cancels in `f/pdf` anyway.
+
+Also ruled out by inspection/measurement: the JH upsampling tables (Step 1,
+neutral matches to 1.000000), the diffuse closure weight (=1.0), the GPU contrib
+clamp (`clampDirect/Indirect` default 0 = identity), and toXYZ/CMF (shared).
+
+## The real structure (three-way cross-check, same wall scene, albedo 0.5, env white)
+
+| integrator | reflected luminance | vs analytic 0.5 |
+|---|---|---|
+| CPU `multiwavelength_path_tracer` (pkg156 oracle) | [0.5001, 0.5009, 0.4915] | ~exact |
+| CPU `path_tracer` (canonical) | [0.4970, 0.4978, 0.4884] | −0.6% |
+| GPU wavefront (naive) | [0.4979, 0.4988, 0.4895] | −0.4% |
+
+- **GPU wavefront ≈ CPU `path_tracer`** (ratio 1.002) — the GPU is NOT the
+  outlier; it agrees with the canonical CPU production integrator.
+- **CPU `multiwavelength_path_tracer` is the outlier** — ~0.6% brighter than both,
+  and it is the one that matches the energy-conserving analytic (a 0.5-albedo
+  Lambertian under unit illumination must reflect exactly 0.5).
+
+So the pkg156 gate ("GPU/CPU divergence") is really: the GPU faithfully matches
+the canonical CPU path tracer, but the gate's chosen ORACLE (CPU
+multiwavelength) is the ~0.6%/bounce outlier. Restoring the gate to 0.998 by
+making the GPU match CPU-mw would move the GPU AWAY from the canonical
+`path_tracer`. Conversely, the CPU-mw being closest to the analytic suggests
+`path_tracer` + GPU share a ~0.6%/bounce diffuse ENERGY LOSS that CPU-mw does not.
+
+## Why this is an escalation, not a fix
+
+There is a genuine design fork the owner must decide — this is not a single
+convicted line:
+
+1. **CPU-mw is right (energy-conserving):** then `path_tracer` AND the GPU
+   wavefront share a ~0.6%/bounce diffuse energy-loss bug to fix — a broad change
+   touching the canonical CPU integrator and the production GPU path, far beyond a
+   triangle-geometry tweak, and it would shift many existing `path_tracer` gates.
+2. **`path_tracer`/GPU are right:** then the pkg156 gate's oracle is wrong and the
+   gate should compare against `path_tracer`, not `multiwavelength_path_tracer` —
+   a gate/oracle change, not a transport fix.
+3. The 0.6% compounds over the pkg156 room's multiple bounces to the observed
+   ~1.5% ([1.016,1.010,1.014]); either resolution must be measured on the full
+   scene.
+
+Per the spec ("if 0.998 is unreachable, escalate with the next-level
+decomposition — the gate does not re-pin below 0.998 a second time without an
+owner"), pkg172 stops here and escalates. **pkg156 stays at 0.995; no re-pin.**
+Root cause of the CPU-mw vs `path_tracer` divergence (MIS/env-handling/energy
+convention) is the next drill-down, owner-directed.
+
+## pkg153 intel
+
+No fix applied, so no movement to report. But the discriminator is now sharper:
+pkg153's drift is CHROMATIC/emitter-linked; this is ACHROMATIC and present with no
+emitter (env-only). Distinct mechanisms, consistent with the scope fence.

--- a/.astroray_plan/docs/pkg172-triangle-transport-diagnosis.md
+++ b/.astroray_plan/docs/pkg172-triangle-transport-diagnosis.md
@@ -1,4 +1,4 @@
-# pkg172 — diagnosis: the residual is NOT triangle-specific; it is a ~0.6%/bounce diffuse energy discrepancy, and the pkg156 ORACLE is the outlier
+# pkg172 — diagnosis: the residual is NOT triangle-specific; it decomposes into (A) a universal ~0.6%/bounce diffuse epsilon energy-loss + (B) a separate GPU-only ~0.4% loss that owns pkg156
 
 **Date:** 2026-08-02 (RTX 5070 Ti). **Branch:** pkg172-triangle-transport-bias
 (base 80d4ec0, #541 not merged — findings below use NEUTRAL albedo, which is
@@ -25,50 +25,58 @@ frame cancels in `f/pdf` anyway.
 
 Also ruled out by inspection/measurement: the JH upsampling tables (Step 1,
 neutral matches to 1.000000), the diffuse closure weight (=1.0), the GPU contrib
-clamp (`clampDirect/Indirect` default 0 = identity), and toXYZ/CMF (shared).
+clamp (`clampDirect/Indirect` default 0 = identity). (toXYZ/CMF NOT yet cleared —
+now a prime suspect for effect (B); see below.)
 
-## The real structure (three-way cross-check, same wall scene, albedo 0.5, env white)
+## CORRECTION (clean rebuild) — the table below the line was contaminated
+
+My first cross-check ran against a stale `.pyd`: after the epsilon probe I
+reverted the SOURCE but did not rebuild, so the run used a build where the epsilon
+was zeroed in `multiwavelength_path_tracer` (line 238) + GPU `stage_advance` (685)
+but NOT in `path_tracer` (`raytracer.h:2549`). That falsely made CPU-mw read
+0.500 "analytic-exact." RETRACTED. Corrected numbers (clean build, epsilon 1e-3
+everywhere):
 
 | integrator | reflected luminance | vs analytic 0.5 |
 |---|---|---|
-| CPU `multiwavelength_path_tracer` (pkg156 oracle) | [0.5001, 0.5009, 0.4915] | ~exact |
-| CPU `path_tracer` (canonical) | [0.4970, 0.4978, 0.4884] | −0.6% |
-| GPU wavefront (naive) | [0.4979, 0.4988, 0.4895] | −0.4% |
+| CPU `multiwavelength_path_tracer` | [0.49699, 0.49777, 0.48845] | −0.6% |
+| CPU `path_tracer` | [0.49699, 0.49777, 0.48845] | −0.6% (BIT-IDENTICAL to mw) |
+| GPU wavefront (naive) | [0.49486, 0.49572, 0.48652] | −1.0% |
 
-- **GPU wavefront ≈ CPU `path_tracer`** (ratio 1.002) — the GPU is NOT the
-  outlier; it agrees with the canonical CPU production integrator.
-- **CPU `multiwavelength_path_tracer` is the outlier** — ~0.6% brighter than both,
-  and it is the one that matches the energy-conserving analytic (a 0.5-albedo
-  Lambertian under unit illumination must reflect exactly 0.5).
+## The real structure: TWO separate effects
 
-So the pkg156 gate ("GPU/CPU divergence") is really: the GPU faithfully matches
-the canonical CPU path tracer, but the gate's chosen ORACLE (CPU
-multiwavelength) is the ~0.6%/bounce outlier. Restoring the gate to 0.998 by
-making the GPU match CPU-mw would move the GPU AWAY from the canonical
-`path_tracer`. Conversely, the CPU-mw being closest to the analytic suggests
-`path_tracer` + GPU share a ~0.6%/bounce diffuse ENERGY LOSS that CPU-mw does not.
+**(A) Universal ~0.6%/bounce diffuse energy loss — the `f/(pdf+1e-3)` epsilon.**
+All three legs undershoot the analytic 0.5 by ~0.6% (CPU-mw == CPU-pt
+bit-identical). An additive `1e-3` epsilon on a cosine-sampled diffuse pdf loses
+exactly `2π·eps ≈ 0.628%` (E[1/cosθ]=2 over the cosine-weighted hemisphere),
+matching to the digit; rebuilding at `1e-6` restores 0.500. **The pkg156 oracle
+(CPU-mw) is NOT exempt — my earlier claim is RETRACTED.** This confirms the
+architect's BRANCH-1 that a real ~0.6%/bounce loss exists; it is universal.
+Fixing it brightens ALL diffuse ~0.6%/bounce → the large coordinated re-pin.
 
-## Why this is an escalation, not a fix
+**(B) A separate GPU-only extra ~0.4% loss.** The GPU (0.495) sits below the
+bit-identical CPU legs (0.497) even with the GPU `stage_advance` epsilon set to
+`1e-6` — a DISTINCT second GPU site, upstream of the throughput update. Because
+(A) cancels in the GPU/CPU ratio, **(B) — not (A) — is what the pkg156 gate ratio
+(0.9957) measures.** Fixing (A) alone does NOT restore pkg156; pkg156 needs (B).
 
-There is a genuine design fork the owner must decide — this is not a single
-convicted line:
+Cleared for (B): the cosine samplers are byte-identical (CPU
+`Vec3::randomCosineDirection` == GPU `gpu_randomCosineDir`) and GPU `f/pdf =
+albedo` exactly for the single diffuse closure lobe. (B) is therefore suspected in
+the GPU spectral env-apply / `gpu_spectrum_to_xyz` / accumulation, not the BSDF
+sample — next drill-down is a toXYZ A/B probe (pkg168-probe pattern).
 
-1. **CPU-mw is right (energy-conserving):** then `path_tracer` AND the GPU
-   wavefront share a ~0.6%/bounce diffuse energy-loss bug to fix — a broad change
-   touching the canonical CPU integrator and the production GPU path, far beyond a
-   triangle-geometry tweak, and it would shift many existing `path_tracer` gates.
-2. **`path_tracer`/GPU are right:** then the pkg156 gate's oracle is wrong and the
-   gate should compare against `path_tracer`, not `multiwavelength_path_tracer` —
-   a gate/oracle change, not a transport fix.
-3. The 0.6% compounds over the pkg156 room's multiple bounces to the observed
-   ~1.5% ([1.016,1.010,1.014]); either resolution must be measured on the full
-   scene.
+## Status
 
-Per the spec ("if 0.998 is unreachable, escalate with the next-level
-decomposition — the gate does not re-pin below 0.998 a second time without an
-owner"), pkg172 stops here and escalates. **pkg156 stays at 0.995; no re-pin.**
-Root cause of the CPU-mw vs `path_tracer` divergence (MIS/env-handling/energy
-convention) is the next drill-down, owner-directed.
+- **(A) convicted** (epsilon; `2π·eps` math + `1e-6` probe → 0.500). Fix =
+  guarded pdf at the sample site (pbrt-v4: reject when `pdf==0`, divide by the
+  true pdf; never an additive bias). Broad re-pin sweep + architect sign-off
+  before push.
+- **(B) located** as a distinct GPU-only site, not yet convicted to a line; owns
+  the pkg156 restoration.
+- **pkg156 stays at 0.995; no re-pin** until (B) is fixed and measured full-scene.
+- Shared −1.7% B-channel deficit vs analytic across all three legs: separate
+  sensor/illuminant-normalization question, flagged for a future filing.
 
 ## pkg153 intel
 

--- a/.astroray_plan/docs/pkg172-triangle-transport-diagnosis.md
+++ b/.astroray_plan/docs/pkg172-triangle-transport-diagnosis.md
@@ -82,6 +82,33 @@ instrumentation ([pkg172-diag] kernel printf of throughput, envSpec, and the
 per-λ contribution + XYZ for one pixel/sample, diffed against the same on CPU) —
 a focused instrumented build, recommended as the next step. (B) owns pkg156.
 
+## UPDATE 2 — (B) split further: single-bounce (B)=#541; a distinct MULTI-BOUNCE (B') remains
+
+Cherry-picking #541 (commit 19fb009) onto pkg172 + clean rebuild (`.pyd` mtime
+1785649939 > HEAD e9d2034 ctime 1785649784) shows:
+
+- **Single-bounce (B) IS #541.** Face-on wall, single diffuse bounce, GPU/CPU:
+  0.9959 → [0.99988, 1.00005, 1.00021] for every albedo. The "GPU-only 0.4% site"
+  was the pkg168 Step-2 upsample-of-pre-scaled-value bug, small for neutral
+  albedo. #541 fixes it. **pkg156 needs #541 merged.**
+
+- **A separate MULTI-BOUNCE residual (B') survives #541.** pkg156 room gate WITH
+  #541 present is still [1.016, 1.010, 1.016] / SSIM 0.9955. Minimal reproducer
+  (grey albedo 0.6, grey env, #541 present, GPU/CPU): single floor 1.0096 (const
+  across depth); corner/2-walls 1.0145 (d4); box/4-walls 1.0368 (d4), 1.063 (d2).
+  Divergence scales with inter-reflection and is GPU-BRIGHTER.
+
+Ruled out for (B'): epsilon (probe negative), the JH tables (Step 1), the
+per-bounce throughput (invariant `throughput_after/before == albedo` holds exactly
+per-path on both legs regardless of RNG), and simple occlusion parity — a ceiling
+occluder REDUCED the divergence (floor 1.0096 → floor+ceiling 1.001 @d4), the
+opposite of an under-occlusion story. The effect is strongly config-sensitive
+(face-on clean; grazing/multi-bounce diverge), which points at a path-length /
+escape-distribution or camera/first-hit interaction rather than a single
+per-bounce factor. Convicting it requires a per-hit deterministic trace (per-path
+bounce-count + throughput + escape, GPU vs CPU) — a focused instrumented build,
+NOT rushed (this session already hit one un-rebuilt-revert contamination error).
+
 ## Status
 
 - **(A) convicted** (epsilon; `2π·eps` math + `1e-6` probe → 0.500). Fix =

--- a/.astroray_plan/docs/pkg172-triangle-transport-diagnosis.md
+++ b/.astroray_plan/docs/pkg172-triangle-transport-diagnosis.md
@@ -109,6 +109,44 @@ per-bounce factor. Convicting it requires a per-hit deterministic trace (per-pat
 bounce-count + throughput + escape, GPU vs CPU) — a focused instrumented build,
 NOT rushed (this session already hit one un-rebuilt-revert contamination error).
 
+## UPDATE 3 — per-hit trace: (B') is an ESCAPE-DISTRIBUTION / first-hit geometry difference, not a per-bounce transport term
+
+[pkg172-diag] device-printf (GPU env-miss) + fprintf (CPU env-miss), dumping the
+escape bounce# and throughput-at-escape, on the actual pkg156 scene (12×12, 64
+spp, #541 present; diag since removed). Escape throughput summed by bounce:
+
+| bounce | CPU Σthr | GPU Σthr | GPU/CPU | CPU events | GPU events |
+|---|---|---|---|---|---|
+| 0 (camera direct-miss) | 634.0 | 661.0 | 1.043 | 634 | 661 |
+| 1 (one diffuse bounce → escape) | 3204.3 | 3581.3 | **1.118** | 5769 | 6115 |
+| 2 | 148.9 | 157.0 | 1.055 | 1215 | 1331 |
+| 3 | 30.6 | 33.9 | 1.108 | 455 | 511 |
+| total | 4017.8 | 4433.3 | 1.103 | 8073 | 8618 |
+
+The divergence is DOMINATED by **bounce-1 escapes** (+11.8%), which splits into
+two geometric effects: GPU has ~6% MORE bounce-1-escape events (6115 vs 5769 —
+more rays escape to the background after one bounce) AND ~5.5% higher throughput
+per escape (0.586 vs 0.555). Since #541 makes per-surface throughput match
+(single-bounce wall is bit-clean), the higher per-escape throughput means GPU
+rays land on a BRIGHTER distribution of surfaces, and the extra events mean more
+rays escape after one bounce rather than hitting a second surface.
+
+**Both are camera-ray / bounce-ray GEOMETRY-SAMPLING differences (which surface
+is hit / whether the continuation ray escapes), NOT a spectral or per-bounce
+transport term.** This is the same family as the documented, accepted GPU
+camera-ray simplification (stage_init.cu: GPU uses a simplified lens/filter, not
+CPU std::mt19937 — pkg55 accepted a ≤4-ULP PostInit geometry difference). It
+persists at 8192 spp (the gate's [1.016]), so it is a systematic direction/hit
+bias, not sample jitter.
+
+**Implication:** (B') is likely NOT a surgical transport fix — it is CPU↔GPU
+geometry-sampling parity (camera-ray + BVH continuation-ray hit distribution).
+Fixing it means reconciling the GPU's ray generation / intersection with the CPU
+oracle, which touches the accepted ≤4-ULP simplification and the BVH. Recommend
+architect input before implementing: this is a parity-of-samplers question, not a
+one-line term, and may be a fundamental precision limit rather than a bug. pkg156
+stays 0.995. #541 must still merge (fixes the single-bounce component).
+
 ## Status
 
 - **(A) convicted** (epsilon; `2π·eps` math + `1e-6` probe → 0.500). Fix =

--- a/.astroray_plan/docs/pkg172-triangle-transport-diagnosis.md
+++ b/.astroray_plan/docs/pkg172-triangle-transport-diagnosis.md
@@ -61,10 +61,26 @@ bit-identical CPU legs (0.497) even with the GPU `stage_advance` epsilon set to
 (0.9957) measures.** Fixing (A) alone does NOT restore pkg156; pkg156 needs (B).
 
 Cleared for (B): the cosine samplers are byte-identical (CPU
-`Vec3::randomCosineDirection` == GPU `gpu_randomCosineDir`) and GPU `f/pdf =
-albedo` exactly for the single diffuse closure lobe. (B) is therefore suspected in
-the GPU spectral env-apply / `gpu_spectrum_to_xyz` / accumulation, not the BSDF
-sample — next drill-down is a toXYZ A/B probe (pkg168-probe pattern).
+`Vec3::randomCosineDirection` == GPU `gpu_randomCosineDir`); GPU `f/pdf = albedo`
+exactly for the single diffuse closure lobe; CMF/toXYZ share the SAME
+`data/spectra/cie_cmf.inc` and MC formula; D65 norm matches (direct-bg render is
+clean); the contrib clamp is default-off (identity). Every component provably
+matches, yet the GPU is a stable ~0.4% low on one diffuse bounce.
+
+**New clue — (B) is ALBEDO-DEPENDENT** (single bounce, white env, GPU/CPU ratio):
+
+| albedo | GPU/CPU | abs deficit |
+|---|---|---|
+| 0.5 | 0.99589 | 0.00213 |
+| 0.8 | 0.99700 | 0.00252 |
+
+A pure throughput epsilon would give an albedo-INDEPENDENT fractional loss, so (B)
+is NOT a scalar epsilon — it is a spectral-shape / spectral-product / toXYZ-
+interaction effect that depends on the upsampled albedo spectrum's shape. Since
+every static component matches, convicting (B) to a line now requires per-hit GPU
+instrumentation ([pkg172-diag] kernel printf of throughput, envSpec, and the
+per-λ contribution + XYZ for one pixel/sample, diffed against the same on CPU) —
+a focused instrumented build, recommended as the next step. (B) owns pkg156.
 
 ## Status
 

--- a/.astroray_plan/packages/pkg172-triangle-transport-bias.md
+++ b/.astroray_plan/packages/pkg172-triangle-transport-bias.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 3 (GPU/CPU transport parity)
 **Track:** A (RTX-gated)
-**Status:** open — dispatchable (diagnosis-first; not urgent-tier — 0.6% is inside every live band — but it now OWNS the pkg156 SSIM gate restoration, transferred from pkg168)
+**Status:** ESCALATED to architect (diagnosis done, no fix, 2026-08-02) — the spec premise is FALSIFIED: the bias is NOT triangle-specific (sphere == triangle == 0.9957 single-bounce) and candidates (a)/(b)/(c) are all CLEARED (epsilon probe negative; achromatic, geometry- & depth-independent). Three-way cross-check: **GPU wavefront AGREES with the canonical CPU `path_tracer` (ratio 1.002); the pkg156 ORACLE (CPU `multiwavelength_path_tracer`) is the ~0.6%/bounce OUTLIER** and is the one matching the energy-conserving analytic. This is a design fork (fix CPU-mw's energy vs fix path_tracer+GPU vs change the gate oracle) requiring owner direction — not a single convicted line. **pkg156 stays at 0.995; NOT re-pinned.** Full decomposition: .astroray_plan/docs/pkg172-triangle-transport-diagnosis.md.
 **Estimated effort:** S (diagnosis — the discriminators are already established and the minimal scene is one triangle) + S for the fix once convicted
 **Depends on:** PR #541 (pkg168 Step 2) merged — the sphere-clean baseline this spec's discriminator rests on. Cross-links: **pkg156** (its 0.998 restoration is BLOCKED-ON this package; pointer updated 2026-08-02), **pkg168** (charter complete — exonerated the tables in Step 1, fixed the call-structure shape divergence in Step 2; THIS residual is the third mechanism its decomposition exposed), **pkg153** (sibling family, ownership separate — see Scope fence).
 


### PR DESCRIPTION
Follow-up docs to #543 carrying the pkg172 hunt to its conclusion:

- UPDATE 2: single-bounce (B) confirmed = the unmerged #541 diffuse-upsample fix (cherry-pick verification, all albedos collapse to ~1.000); a DISTINCT multi-bounce (B') survives #541 (room gate still 0.9955).
- UPDATE 3: per-hit device-printf trace convicts (B') as escape-distribution / first-hit geometry-sampling parity (GPU ~6% more bounce-1 escapes + brighter first-hit distribution), same family as the accepted stage_init camera simplification — NOT a spectral/transport term. Ruled out with evidence: epsilon, JH tables, per-path albedo^k invariant, occlusion parity.
- Scope adjudication (sampler/BVH parity package vs re-baselining the 0.998 aspiration) is pending with the architect; (B') work held for a supervised round alongside pkg172 effect (A).

Docs-only diff (diagnosis doc). pkg156 gate stays 0.995.

🤖 Generated with [Claude Code](https://claude.com/claude-code)