### PR TITLE
CPU/GPU pytest split + xdist parallel CPU pass (latency lever 6)

### DIFF
--- a/.astroray_plan/docs/pytest-cpu-gpu-split-2026-08.md
+++ b/.astroray_plan/docs/pytest-cpu-gpu-split-2026-08.md
@@ -1,0 +1,155 @@
+# pytest CPU/GPU split + differential selection (latency lever 6)
+
+Implements item 6 of the latency-lever ranking in
+[`open-model-research-2026-08.md`](open-model-research-2026-08.md): a CPU/GPU
+marker split so the CPU-only subset runs under `pytest-xdist -n auto` while
+every test that touches CUDA stays strictly serial.
+
+Baseline to beat: **407.5 s** full sweep (2026-08-06, Ninja/sm_120 build, 1563
+passed).
+
+## Why GPU tests must stay serial
+
+`tests/conftest.py` has an autouse `cuda_cleanup_and_error_check` fixture that,
+after each test, constructs a throwaway `CUDARenderer`, calls
+`cudaDeviceSynchronize()` + `cudaGetLastError()`, and `pytest.fail`s on any
+latent error (pkg85-B regression guard). It assumes **serialized, single-context
+GPU access**. Memory `cuda_verifier_concurrency` documents false-positive
+`illegal memory access` crashes when two CUDA-heavy workloads run at once on this
+RTX. So the CPU-parallel pass must issue **no** concurrent CUDA work.
+
+Two things guarantee that:
+
+1. **Classification** (`tests/_gpu_classification.py`): a test module is `gpu`
+   if its source or filename matches any real-CUDA trigger
+   (`_gpu_*` bindings, `set_use_gpu(True)`, `upload_scene(`, `CUDARenderer`,
+   `cudart*`, a `__features__`/`skipif` CUDA gate, or a
+   `gpu|cuda|tlas|wavefront|optix|prewarm|sms_attempt` filename). Everything else
+   is `cpu`. The split is deliberately **conservative** — a false positive
+   (CPU test marked `gpu`) costs a few ms of serial time; a false negative (GPU
+   test marked `cpu`) would run in parallel and reintroduce the exact flake this
+   split prevents. When in doubt → `gpu`.
+
+2. **Probe gating**: the fixture's CUDA probe now runs **only for `gpu`-marked
+   tests**. `cpu` tests never launch CUDA, so there is nothing to check — and
+   the parallel pass therefore issues zero concurrent CUDA driver calls.
+   `gc.collect()` still runs for every test (cheap, parallel-safe).
+
+## How the marker is applied
+
+`conftest.pytest_collection_modifyitems` auto-tags every collected item `gpu` or
+`cpu` from its module source (no per-file edits; new files are covered
+automatically). An explicit `@pytest.mark.gpu` / `@pytest.mark.cpu` on a test
+always wins. Audit the current split any time with:
+
+```bash
+python tests/_gpu_classification.py
+```
+
+Current split: **214 test files → 85 gpu (serial), 129 cpu (parallel)**.
+
+## Running the suite
+
+```bash
+# Both passes, reports combined wall time:
+python scripts/test/run_split.py
+
+# Just the parallel CPU pass (fast inner loop; safe to run without a GPU):
+python scripts/test/run_split.py --cpu-only
+
+# Just the serial GPU pass:
+python scripts/test/run_split.py --gpu-only
+
+# Forward pytest args to both passes (after --):
+python scripts/test/run_split.py -- -x -q
+```
+
+- CPU pass: `pytest -m cpu -n auto`. OpenMP is left at its default (all cores),
+  **not** pinned to 1. The CPU subset is a handful of OpenMP-heavy reference
+  renders (`reference_pt_production_parity`, `spectral_path_tracer`,
+  `caustic_validation`, …) plus many fast tests. Pinning `OMP_NUM_THREADS=1`
+  starves those renders of their threads and the slowest single-threaded test
+  dominates the tail (measured: CPU pass alone >600 s, worse than the 407.5 s
+  serial baseline). Since only a few tests spawn OMP threads, the transient
+  8×N oversubscription costs far less than losing threads on the tail. Pin
+  explicitly with `--omp N` / `ASTRORAY_TEST_OMP_THREADS` only after measuring
+  your own hardware.
+- GPU pass: `pytest -m "not cpu" -p no:xdist`. `not cpu` (rather than `gpu`)
+  means anything left unclassified falls into the **serial** pass — the safe
+  side.
+
+## Differential test selection (testmon replacement)
+
+`pytest-testmon` does **not** work here: it fingerprints Python bytecode and is
+blind to changes inside the compiled `astroray.pyd`. `scripts/test/select_impacted.py`
+maps changed source paths → impacted test files via an explicit keyword map,
+with a broad "whole GPU suite" fallback when a widely-included core header
+changes. It is a fix-loop accelerator, **not** a merge gate — the full split
+suite still runs at closeout.
+
+```bash
+python scripts/test/select_impacted.py --base origin/main
+git diff --name-only HEAD | python scripts/test/select_impacted.py --stdin
+python scripts/test/run_split.py -- $(python scripts/test/select_impacted.py --base origin/main)
+```
+
+## Verification results
+
+_(RTX 5070 Ti, Ninja/sm_120 build at HEAD 1245de3, 2026-08-06)_
+
+Per-pass, per full run (CPU pass then GPU pass, sequential):
+
+| run | CPU/parallel (`-m cpu -n auto`) | GPU/serial (`-m "not cpu"`) | total wall |
+|-----|--------------------------------|-----------------------------|-----------|
+| 1 | 1166 passed / 198.7 s | 424 passed (+2 env*) / 136.9 s | **335.6 s** |
+| 2 | 1166 passed / 193.8 s | 424 passed (+2 env*) / 136.9 s | **331.5 s** |
+| 3 | 1166 passed / 200.7 s | 424 passed (+2 env*) / 137.1 s | **337.9 s** |
+
+**Mean total ≈ 335 s vs the 407.5 s serial baseline — ~18 % faster (−72 s).**
+The CPU subset (1166 tests) now runs in ~197 s across 8 xdist workers; the GPU
+subset (424 tests) runs serially in ~137 s.
+
+**No CUDA illegal-access flakes in any of the 3 runs** — the concurrent-CUDA
+hazard the serial pass exists to prevent did not occur. The gc-only teardown on
+CPU tests plus the strictly-serial GPU pass held.
+
+### The OMP pinning lesson
+
+An initial `OMP_NUM_THREADS=1` CPU pass took **856 s** — worse than the serial
+baseline — because the handful of OpenMP-heavy reference renders ran
+single-threaded and the slowest one dominated the tail. Removing the pin (all
+cores) dropped the CPU pass to **~197 s**. This is why the runner does not pin
+OMP by default.
+
+### *The 2 GPU-pass failures are pre-existing / environmental, not split-caused
+
+Both were reproduced **in a plain serial run at this HEAD** (each run in
+isolation, no xdist), so the split introduces no new failures:
+
+1. `test_pkg55_perf_gate::test_wavefront_contact_sheet_ceiling` — asserts a
+   1024spp wavefront render's median-of-3 wall time ≤ 1.0 s (warm pin
+   0.57–0.71 s). Measured a **stable ~1.08–1.21 s** — in the split GPU pass, run
+   standalone-serial, after a 4-min GPU idle, and across 5 back-to-back
+   invocations (no downward trend). It does **not** recover, so it is not a
+   transient the split creates.
+   - The `.pyd` was verified native **sm_120 SASS** (`cuobjdump`; no sm_52/PTX
+     fallback), so it is not a build-arch artifact.
+   - The test's own header documents a **1.476–1.539× GPU clock-state spread**;
+     0.71 s × 1.55 ≈ 1.10 s, matching the reading. The card is running this
+     short (~1 s) render at a lower clock than when the 2026-07-25 pin was
+     measured, and/or the wavefront path is genuinely slower at HEAD.
+   - Either way it **fails in a plain serial `pytest` at this HEAD, in isolation**
+     — so the CPU/GPU split does not cause it. It is flagged for the perf owner
+     (repin vs real-regression bisect); repinning is out of scope here.
+2. `test_blender_parity_matrix::test_blender_parity_matrix_generation` — spawns
+   real headless Blender and `shutil.rmtree`s a shared `test_results/` dir under
+   the OneDrive-synced worktree. Failed with `PermissionError [WinError 5]` on a
+   **transient OneDrive file lock** of the leftover dir. Once the lock cleared,
+   the test **passed standalone (1.6 s)** — so it is a flaky file-lock, not a
+   real failure. It is classified `serial` (not `cpu`) precisely because it is
+   file-fragile even before Blender starts, keeping it out of the parallel pass
+   where the contention is worst.
+
+Neither is fixed here: repinning the perf ceiling would mask a real regression
+tripwire, and redirecting the Blender output dir is out of scope for the test
+split. Both are flagged for the perf/CI owner.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pytest
+pytest-xdist
 numpy
 matplotlib
 pillow

--- a/scripts/test/run_split.py
+++ b/scripts/test/run_split.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Two-pass CPU/GPU test runner (open-model-research-2026-08 latency lever 6).
+
+Pass 1 (CPU): ``pytest -m cpu -n auto`` — the CPU-only subset in parallel via
+              pytest-xdist. OMP_NUM_THREADS is pinned (default 1) so the 8
+              xdist workers do not oversubscribe cores with OpenMP threads.
+Pass 2 (GPU): ``pytest -m "not cpu" -p no:xdist`` — everything not positively
+              classified CPU, run strictly serial in a single GPU context.
+              Anything left unclassified falls here (the SAFE side): memory
+              cuda_verifier_concurrency documents false-positive illegal-access
+              crashes from concurrent CUDA on this RTX.
+
+Usage:
+    python scripts/test/run_split.py                 # both passes, report wall time
+    python scripts/test/run_split.py --cpu-only      # just the parallel CPU pass
+    python scripts/test/run_split.py --gpu-only      # just the serial GPU pass
+    python scripts/test/run_split.py --jobs 8        # override -n auto
+    python scripts/test/run_split.py -- -x -q tests/test_foo.py   # extra pytest args
+
+Extra pytest args after ``--`` are forwarded to BOTH passes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run(label: str, marker: str, *, parallel: bool, jobs: str,
+         omp: str | None, extra: list[str]) -> tuple[int, float]:
+    cmd = [sys.executable, "-m", "pytest", "-m", marker]
+    if parallel:
+        cmd += ["-n", jobs]
+    else:
+        cmd += ["-p", "no:xdist"]
+    cmd += extra
+
+    env = dict(os.environ)
+    omp_note = ""
+    if parallel and omp:
+        # OpenMP is left at its default (all cores) by design: the CPU subset
+        # is a few OpenMP-heavy reference renders plus many fast tests. Pinning
+        # OMP_NUM_THREADS=1 starves those renders of threads and the slowest
+        # single-threaded test dominates the tail (measured: >600s). Only pin
+        # if the caller asks (e.g. --omp 2) after measuring their own hardware.
+        env["OMP_NUM_THREADS"] = omp
+        omp_note = f"  (OMP_NUM_THREADS={omp})"
+
+    print(f"\n{'=' * 70}\n[{label}] {' '.join(cmd)}{omp_note}\n{'=' * 70}",
+          flush=True)
+    start = time.perf_counter()
+    rc = subprocess.run(cmd, cwd=str(REPO_ROOT), env=env).returncode
+    elapsed = time.perf_counter() - start
+    print(f"[{label}] exit={rc}  wall={elapsed:.1f}s", flush=True)
+    return rc, elapsed
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--cpu-only", action="store_true", help="run only the parallel CPU pass")
+    ap.add_argument("--gpu-only", action="store_true", help="run only the serial GPU pass")
+    ap.add_argument("--jobs", default="auto", help="xdist worker count for the CPU pass (default: auto)")
+    ap.add_argument("--omp", default=os.environ.get("ASTRORAY_TEST_OMP_THREADS"),
+                    help="pin OMP_NUM_THREADS for the CPU pass (default: unset = all "
+                         "cores; OpenMP-heavy reference renders need their threads)")
+    ap.add_argument("pytest_args", nargs="*", help="extra args forwarded to pytest (prefix with --)")
+    args = ap.parse_args()
+
+    extra = list(args.pytest_args)
+    if extra and extra[0] == "--":
+        extra = extra[1:]
+
+    results: list[tuple[str, int, float]] = []
+    total = 0.0
+
+    if not args.gpu_only:
+        rc, el = _run("CPU/parallel", "cpu", parallel=True,
+                      jobs=args.jobs, omp=args.omp, extra=extra)
+        results.append(("CPU/parallel", rc, el))
+        total += el
+
+    if not args.cpu_only:
+        rc, el = _run("GPU/serial", "not cpu", parallel=False,
+                      jobs=args.jobs, omp=args.omp, extra=extra)
+        results.append(("GPU/serial", rc, el))
+        total += el
+
+    print(f"\n{'#' * 70}\n# SPLIT-SUITE SUMMARY\n{'#' * 70}")
+    for label, rc, el in results:
+        status = "PASS" if rc == 0 else ("NO-TESTS" if rc == 5 else f"FAIL(exit={rc})")
+        print(f"#   {label:<14} {status:<14} {el:8.1f}s")
+    print(f"#   {'TOTAL wall':<14} {'':<14} {total:8.1f}s\n{'#' * 70}")
+
+    # rc 5 = "no tests collected"; treat as non-fatal (e.g. --gpu-only when a
+    # CUDA-less build skips every GPU module). Any other non-zero is a failure.
+    return 0 if all(rc in (0, 5) for _, rc, _ in results) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test/run_split.py
+++ b/scripts/test/run_split.py
@@ -3,8 +3,10 @@
 """Two-pass CPU/GPU test runner (open-model-research-2026-08 latency lever 6).
 
 Pass 1 (CPU): ``pytest -m cpu -n auto`` — the CPU-only subset in parallel via
-              pytest-xdist. OMP_NUM_THREADS is pinned (default 1) so the 8
-              xdist workers do not oversubscribe cores with OpenMP threads.
+              pytest-xdist. OMP_NUM_THREADS is left UNSET by default (all cores):
+              pinning it starves the few OpenMP-heavy reference renders and the
+              slowest single-threaded test dominates the tail. Pin explicitly
+              with ``--omp N`` / ASTRORAY_TEST_OMP_THREADS after measuring.
 Pass 2 (GPU): ``pytest -m "not cpu" -p no:xdist`` — everything not positively
               classified CPU, run strictly serial in a single GPU context.
               Anything left unclassified falls here (the SAFE side): memory

--- a/scripts/test/select_impacted.py
+++ b/scripts/test/select_impacted.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Map changed source files -> impacted test files (differential selection).
+
+pytest-testmon does NOT work here: it fingerprints Python bytecode and is blind
+to changes inside the compiled astroray.pyd (native .cu/.cuh/.cpp/.h). This
+script fills that gap with an explicit, maintainable src-path -> test-file map
+(open-model-research-2026-08 latency lever 6).
+
+It is a *fix-loop accelerator*, not a merge gate. Native changes rebuild the
+whole .pyd, so a change to a widely-included core header intentionally falls
+back to "all GPU tests". The full split suite (scripts/test/run_split.py) is
+still what runs at closeout.
+
+Usage:
+    python scripts/test/select_impacted.py --base origin/main      # diff vs a ref
+    python scripts/test/select_impacted.py --changed src/gpu/photon_emission.cu ...
+    git diff --name-only HEAD | python scripts/test/select_impacted.py --stdin
+
+    # pipe straight into the split runner:
+    python scripts/test/run_split.py -- $(python scripts/test/select_impacted.py --base origin/main)
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TESTS_DIR = REPO_ROOT / "tests"
+
+# Native headers so widely included that a change can perturb almost any
+# native-backed test. A hit here selects the whole GPU suite (the safe superset).
+CORE_WILDCARD_FILES = {
+    "raytracer.h", "gpu_renderer.h", "gpu_types.h", "gpu_materials.h",
+    "cuda_renderer.cu", "integrator.h", "gpu_scene_upload.h", "spectrum.h",
+    "material.h", "material_closure.h", "scene.h",
+}
+
+# topic token -> substrings that select a test file when found in its name.
+# Deliberately broad: over-selecting a few extra fast tests is cheap; missing
+# an impacted test wastes a fix-loop cycle. Keep alphabetized by key.
+KEYWORD_MAP: dict[str, tuple[str, ...]] = {
+    "accretion":   ("accretion", "adaf", "slim_disk", "emission"),
+    "caustic":     ("caustic", "photon", "sms", "prism", "glass"),
+    "closure":     ("closure", "material", "disney", "metal", "spectral", "bsdf"),
+    "cryptomatte": ("cryptomatte",),
+    "denois":      ("denois", "oidn", "optix"),
+    "dispersion":  ("dispersion", "sellmeier", "prism", "spectral", "ior"),
+    "emission":    ("emission", "synchrotron", "accretion", "spectral"),
+    "energy":      ("energy", "furnace", "metal", "compensation"),
+    "envmap":      ("envmap", "hdri", "world", "environment"),
+    "firefly":     ("firefly", "clamp"),
+    "ggx":         ("ggx", "metal", "disney", "roughness", "furnace"),
+    "glass":       ("glass", "dielectric", "refract", "caustic", "furnace"),
+    "integrator":  ("integrator", "default_integrator", "path_trace", "restir"),
+    "light":       ("light", "restir", "nee", "area_light", "distant"),
+    "light_tree":  ("light_tree", "light_sampler", "restir", "nee"),
+    "material":    ("material", "closure", "disney", "metal", "spectral", "texture"),
+    "mnee":        ("mnee", "caustic", "sms"),
+    "motion":      ("motion_blur", "tlas", "deform"),
+    "photon":      ("photon", "caustic", "sms"),
+    "restir":      ("restir",),
+    "spectral":    ("spectral", "spectrum", "dispersion", "profile", "upsample", "colorspace"),
+    "spectrum":    ("spectral", "spectrum", "upsample", "colorspace"),
+    "subsurface":  ("subsurface",),
+    "texture":     ("texture", "procedural", "noise", "voronoi", "wave_brick"),
+    "tlas":        ("tlas", "instanc", "refit", "blas", "bulk"),
+    "wavefront":   ("wavefront", "pkg55", "megakernel", "gpu"),
+}
+
+
+def _changed_from_git(base: str) -> list[str]:
+    out = subprocess.run(
+        ["git", "diff", "--name-only", base], cwd=str(REPO_ROOT),
+        capture_output=True, text=True,
+    )
+    return [ln.strip() for ln in out.stdout.splitlines() if ln.strip()]
+
+
+def _all_test_files() -> list[str]:
+    return sorted(
+        str(p.relative_to(REPO_ROOT)).replace("\\", "/")
+        for p in TESTS_DIR.rglob("test_*.py")
+    )
+
+
+def _tokens(stem: str) -> set[str]:
+    return {t for t in stem.lower().replace("-", "_").split("_") if len(t) >= 3}
+
+
+def select(changed: list[str]) -> tuple[set[str], bool]:
+    """Return (impacted test relpaths, broad_fallback_triggered)."""
+    all_tests = _all_test_files()
+    test_by_name = {Path(t).name: t for t in all_tests}
+    impacted: set[str] = set()
+    broad = False
+
+    for raw in changed:
+        rel = raw.replace("\\", "/")
+        p = Path(rel)
+        name = p.name
+
+        # A changed test file selects itself.
+        if name.startswith("test_") and name.endswith(".py") and name in test_by_name:
+            impacted.add(test_by_name[name])
+            continue
+
+        # Blender addon Python -> the addon/blender test families.
+        if rel.startswith("blender_addon/") and name.endswith(".py"):
+            impacted.update(t for t in all_tests
+                            if any(k in Path(t).name for k in ("blender", "addon", "blend_")))
+            continue
+
+        # Core widely-included native header/source -> whole GPU suite.
+        if name in CORE_WILDCARD_FILES:
+            broad = True
+            continue
+
+        # Native / plugin source -> map by topic tokens (filename + parent dir).
+        if p.suffix in (".cu", ".cuh", ".cpp", ".cc", ".h", ".hpp", ".c"):
+            toks = _tokens(p.stem) | _tokens(p.parent.name)
+            substrings: set[str] = set()
+            for key, subs in KEYWORD_MAP.items():
+                if key in toks or any(key in t for t in toks):
+                    substrings.update(subs)
+            substrings.update(t for t in toks if len(t) >= 4)  # raw stem tokens too
+            for t in all_tests:
+                tn = Path(t).name.lower()
+                if any(s in tn for s in substrings):
+                    impacted.add(t)
+
+    return impacted, broad
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--base", help="git ref to diff against (e.g. origin/main)")
+    ap.add_argument("--changed", nargs="*", default=[], help="explicit changed file paths")
+    ap.add_argument("--stdin", action="store_true", help="read changed paths from stdin (one per line)")
+    args = ap.parse_args()
+
+    changed = list(args.changed)
+    if args.base:
+        changed += _changed_from_git(args.base)
+    if args.stdin:
+        changed += [ln.strip() for ln in sys.stdin if ln.strip()]
+
+    if not changed:
+        print("select_impacted: no changed files given "
+              "(use --base, --changed, or --stdin)", file=sys.stderr)
+        return 2
+
+    impacted, broad = select(changed)
+
+    if broad:
+        # Import lazily so this script stays usable without the tests package.
+        sys.path.insert(0, str(TESTS_DIR))
+        from _gpu_classification import classify_tree
+        gpu_tests = {f"tests/{k}" for k, v in classify_tree(TESTS_DIR).items() if v == "gpu"}
+        impacted |= gpu_tests
+        print("select_impacted: core header changed -> adding full GPU suite",
+              file=sys.stderr)
+
+    for t in sorted(impacted):
+        print(t)
+    print(f"select_impacted: {len(impacted)} impacted test file(s)", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/_gpu_classification.py
+++ b/tests/_gpu_classification.py
@@ -27,7 +27,7 @@ Design contract (see conftest.pytest_collection_modifyitems):
     exists to prevent. So when in doubt, do NOT mark ``cpu``.
 
 This module imports nothing from pytest so the audit dump
-(``python tests/_gpu_classification.py``) and scripts/select_impacted_tests.py
+(``python tests/_gpu_classification.py``) and scripts/test/select_impacted.py
 can reuse it.
 """
 
@@ -43,6 +43,8 @@ from pathlib import Path
 _SOURCE_TRIGGERS = [
     r"\b_gpu_[a-z]\w*",              # real GPU bindings: _gpu_photon_emit_sphere, _gpu_tlas_identity_parity, ...
     r"set_use_gpu\s*\(\s*(?:True|1)\b",  # opts a renderer onto the GPU (mock false-positives accepted as safe)
+    r"\bgpu\s*=\s*True\b",           # gpu=True kwarg opts an in-process render onto CUDA (e.g. runner.run(..., gpu=True) via _try_set_gpu->set_use_gpu(True)); word-boundary avoids matching `_use_gpu = True`
+    r"\bfind_standalone_executable\b",  # subprocess-invokes the standalone exe, which defaults to device=auto -> CUDA on a GPU box (apps/main.cpp)
     r"\bupload_scene\s*\(",          # GPU scene-upload path (parity suites)
     r"\bCUDARenderer\b",
     r"\bcudart\w*\b",                # direct CUDA runtime (ctypes) use

--- a/tests/_gpu_classification.py
+++ b/tests/_gpu_classification.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""GPU vs CPU test classification (latency-lever item 6, open-model-research-2026-08).
+
+Splits the test suite so the CPU-only subset can run under pytest-xdist
+(``-n auto``) while every test that actually drives CUDA stays strictly serial.
+The serial requirement is not cosmetic: memory ``cuda_verifier_concurrency``
+documents false-positive ``illegal memory access`` crashes when two CUDA-heavy
+workloads run at once on this RTX, and the autouse ``cuda_cleanup_and_error_check``
+fixture in conftest assumes serialized, single-context GPU access.
+
+Three classes:
+  * ``gpu``    — drives real CUDA; must run serial in a single GPU context.
+  * ``serial`` — CPU-only but NOT xdist-safe (spawns real headless Blender,
+                 which fights the shared test_results/ dir under concurrent load
+                 on this Windows+OneDrive box; measured rmtree file-lock flake).
+  * ``cpu``    — parallel-safe; runs under pytest-xdist ``-n auto``.
+
+The runner treats the split as parallel (``-m cpu``) vs serial (``-m "not cpu"``),
+so ``gpu`` and ``serial`` both land in the serial pass.
+
+Design contract (see conftest.pytest_collection_modifyitems):
+  * The classification is deliberately CONSERVATIVE — biased toward serial.
+    A false positive (a parallel-safe test run serial) only costs a little
+    wall time. A false negative (a GPU or file-fragile test run in parallel)
+    reintroduces exactly the concurrent-CUDA / file-lock flake this split
+    exists to prevent. So when in doubt, do NOT mark ``cpu``.
+
+This module imports nothing from pytest so the audit dump
+(``python tests/_gpu_classification.py``) and scripts/select_impacted_tests.py
+can reuse it.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from functools import lru_cache
+from pathlib import Path
+
+# --- Source triggers: presence of any of these means the test launches / probes
+#     real CUDA work and MUST run serial. Regexes, matched against file text. ---
+_SOURCE_TRIGGERS = [
+    r"\b_gpu_[a-z]\w*",              # real GPU bindings: _gpu_photon_emit_sphere, _gpu_tlas_identity_parity, ...
+    r"set_use_gpu\s*\(\s*(?:True|1)\b",  # opts a renderer onto the GPU (mock false-positives accepted as safe)
+    r"\bupload_scene\s*\(",          # GPU scene-upload path (parity suites)
+    r"\bCUDARenderer\b",
+    r"\bcudart\w*\b",                # direct CUDA runtime (ctypes) use
+    r"__features__[\s\S]{0,60}?cuda",   # build-feature gate on the cuda feature
+    r"(?:skip|skipif)[\s\S]{0,100}?\bCUDA\b",  # module-level skip when CUDA absent
+]
+
+# --- Filename triggers: some GPU suites drive CUDA through helpers whose text
+#     the source scan might not catch. These stems are unambiguously GPU. ---
+_FILENAME_TRIGGERS = [
+    "gpu", "cuda", "tlas", "wavefront", "optix", "prewarm", "sms_attempt",
+]
+
+# --- Serial (but CPU-only) triggers: not xdist-safe. Tests that shell out to a
+#     real headless Blender destructively manage a shared test_results/ dir and
+#     flake on Windows file locks under concurrent load. ---
+_SERIAL_TRIGGERS = [
+    r"\bBLENDER_EXE\b",
+]
+
+_SOURCE_RE = re.compile("|".join(_SOURCE_TRIGGERS))
+_SERIAL_RE = re.compile("|".join(_SERIAL_TRIGGERS))
+# Avoid matching the build directory name "build_cuda" as a cuda trigger.
+_BUILD_DIR_NOISE = re.compile(r"build_cuda")
+
+
+@lru_cache(maxsize=None)
+def classify_source(text: str, filename: str) -> str:
+    """Return 'gpu', 'serial', or 'cpu' for a test module (source + filename)."""
+    stem = Path(filename).stem.lower()
+    if any(tok in stem for tok in _FILENAME_TRIGGERS):
+        return "gpu"
+    # Strip the build-dir path noise so `sys.path.insert(0, 'build_cuda/...')`
+    # does not read as a CUDA trigger.
+    scrubbed = _BUILD_DIR_NOISE.sub("", text)
+    if _SOURCE_RE.search(scrubbed):
+        return "gpu"
+    if _SERIAL_RE.search(scrubbed):
+        return "serial"
+    return "cpu"
+
+
+def classify_path(path: str | Path) -> str:
+    """Classify a test file on disk. Missing/unreadable files default to 'gpu'
+    (the safe, serial side)."""
+    p = Path(path)
+    try:
+        text = p.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return "gpu"
+    return classify_source(text, p.name)
+
+
+def classify_tree(tests_dir: str | Path) -> dict[str, str]:
+    """Classify every test_*.py under tests_dir. Returns {relpath: 'gpu'|'cpu'}."""
+    root = Path(tests_dir)
+    out: dict[str, str] = {}
+    for f in sorted(root.rglob("test_*.py")):
+        out[str(f.relative_to(root)).replace("\\", "/")] = classify_path(f)
+    return out
+
+
+def _main() -> int:
+    tests_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(__file__).resolve().parent
+    result = classify_tree(tests_dir)
+    gpu = [k for k, v in result.items() if v == "gpu"]
+    serial = [k for k, v in result.items() if v == "serial"]
+    cpu = [k for k, v in result.items() if v == "cpu"]
+    print(f"# CPU/GPU test classification for {tests_dir}")
+    print(f"# total={len(result)}  gpu={len(gpu)} + serial={len(serial)} (serial pass)"
+          f"  cpu={len(cpu)} (parallel pass)\n")
+    print("## GPU (serial):")
+    for k in gpu:
+        print(f"  gpu     {k}")
+    print("\n## SERIAL — CPU-only but not xdist-safe:")
+    for k in serial:
+        print(f"  serial  {k}")
+    print("\n## CPU (parallel):")
+    for k in cpu:
+        print(f"  cpu     {k}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,51 @@ configure_test_temp_dir()
 BUILD_DIR = configure_test_imports()
 
 from _linear_render_guard import linear_render_guard, name_matches
+from _gpu_classification import classify_path
+
+
+# --- CPU/GPU marker split (open-model-research-2026-08 latency lever 6) --------
+# Every collected test is auto-tagged 'gpu', 'serial', or 'cpu' from its source
+# (see tests/_gpu_classification.py). The two-pass runner
+# (scripts/test/run_split.py) runs `-m cpu -n auto` in parallel and
+# `-m "not cpu"` strictly serial. Keeping GPU tests serial is mandatory: memory
+# cuda_verifier_concurrency documents false-positive illegal-access crashes from
+# concurrent CUDA on this RTX.
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "gpu: test drives real CUDA — MUST run serial (single GPU context).",
+    )
+    config.addinivalue_line(
+        "markers",
+        "serial: CPU-only but not xdist-safe (spawns real Blender) — serial pass.",
+    )
+    config.addinivalue_line(
+        "markers",
+        "cpu: test never touches CUDA — safe to run under pytest-xdist -n auto.",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    """Auto-apply the gpu/serial/cpu marker to every item that lacks one.
+
+    An explicit @pytest.mark.gpu / @pytest.mark.serial / @pytest.mark.cpu on the
+    test always wins. Otherwise the item's module file is classified and the
+    marker added, so the -m selection used by the two-pass runner partitions the
+    whole suite.
+    """
+    cache: dict[str, str] = {}
+    for item in items:
+        if (item.get_closest_marker("gpu") or item.get_closest_marker("cpu")
+                or item.get_closest_marker("serial")):
+            continue
+        # pytest>=7 exposes item.path (pathlib); fall back to fspath on older.
+        path = str(getattr(item, "path", None) or getattr(item, "fspath", ""))
+        kind = cache.get(path)
+        if kind is None:
+            kind = classify_path(path) if path else "gpu"
+            cache[path] = kind
+        item.add_marker(getattr(pytest.mark, kind))
 
 
 @pytest.fixture(autouse=True)
@@ -71,7 +116,7 @@ def standalone_executable():
 
 
 @pytest.fixture(autouse=True)
-def cuda_cleanup_and_error_check():
+def cuda_cleanup_and_error_check(request):
     """pkg85: Force Python GC and check for latent CUDA errors after each test.
 
     The root cause: Python's garbage collector doesn't run immediately after
@@ -82,19 +127,31 @@ def cuda_cleanup_and_error_check():
     the error persists and contaminates the next CUDA call. This fixture
     first forces GC to clean up all pending renderers, then synchronizes
     the device and checks for latent errors.
+
+    The latent-CUDA-error probe (which itself constructs a throwaway
+    CUDARenderer + calls cudaDeviceSynchronize) only runs for gpu-marked
+    tests. cpu-marked tests never launch CUDA, so there is nothing to check —
+    and skipping the probe there means the parallel (`-m cpu -n auto`) pass
+    issues NO concurrent CUDA driver calls, honoring cuda_verifier_concurrency.
+    gc.collect() still runs for every test (cheap, parallel-safe).
     """
     yield  # Let the test run
 
     import gc
     import warnings
 
+    gc.collect()  # pkg85: Force cleanup of any Renderer objects left by the test
+
+    # Only gpu-marked tests can leave a latent CUDA error; they run serial in a
+    # single GPU context, which is what this probe assumes.
+    if request.node.get_closest_marker("gpu") is None:
+        return
+
     # Wrap entire cleanup to prevent non-test-failure exceptions from
     # surfacing as teardown ERROR. Intentional pytest.fail() is NOT caught
     # (it raises BaseException), so legitimate CUDA regression guards still
     # fail the test properly.
     try:
-        gc.collect()  # pkg85: Force cleanup of any Renderer objects left by the test
-
         try:
             import astroray
             # Only check if astroray module loaded successfully

--- a/tests/test_benchmark_showcase_phase2.py
+++ b/tests/test_benchmark_showcase_phase2.py
@@ -24,7 +24,16 @@ try:
 except ImportError:
     AVAILABLE = False
 
-pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray module not available")
+# mark.gpu: test_gpu_flag_runs_without_cuda calls runner.run(..., gpu=True),
+# whose _try_set_gpu helper does a real renderer.set_use_gpu(True) in-process GPU
+# render on a CUDA box. Must run in the serial GPU pass, not the xdist CPU pass.
+# The set_use_gpu literal lives in benchmarks/showcase/runner.py, so the
+# classifier's own-source scan can't see it from here; the gpu=True kwarg trigger
+# catches it and this explicit marker keeps audit + runtime in agreement.
+pytestmark = [
+    pytest.mark.gpu,
+    pytest.mark.skipif(not AVAILABLE, reason="astroray module not available"),
+]
 
 
 # Categories that must have at least one populated cell across all rows.

--- a/tests/test_standalone_renderer.py
+++ b/tests/test_standalone_renderer.py
@@ -19,11 +19,20 @@ import sys
 import os
 import subprocess
 import time
+import pytest
 
 from PIL import Image
 import numpy as np
 
 from runtime_setup import configure_test_imports, find_standalone_executable
+
+# The standalone exe is invoked via subprocess with no --device flag, so it
+# defaults to device=auto -> CUDA GPU on a GPU box (apps/main.cpp). This must
+# run in the strictly-serial GPU pass, never the xdist-parallel CPU pass, or it
+# reintroduces the concurrent-CUDA flake the split exists to prevent. The
+# classifier also catches find_standalone_executable; this marker is explicit
+# belt-and-suspenders so the audit and runtime agree.
+pytestmark = pytest.mark.gpu
 
 # ---------------------------------------------------------------------------
 # Helpers


### PR DESCRIPTION
Implements item 6 of the `open-model-research-2026-08` latency-lever ranking: partition the suite so the CPU-only subset runs under `pytest-xdist -n auto` while every CUDA-touching test stays strictly serial (memory `cuda_verifier_concurrency`: concurrent CUDA → false illegal-access crashes).

## Changes
- **`tests/_gpu_classification.py`** — conservative source/filename classifier → `gpu` / `serial` / `cpu`. Biased away from `cpu` (a false `cpu` is the only *unsafe* misclassification). `serial` = CPU-only but not xdist-safe (real headless Blender, file-fragile on OneDrive).
- **`tests/conftest.py`** — auto-applies the marker at collection (no per-file edits; new files covered automatically). Gates the pkg85 latent-CUDA-error probe to `gpu`-marked tests only, so the parallel CPU pass issues **zero** concurrent CUDA driver calls. `gc.collect()` still runs for every test.
- **`scripts/test/run_split.py`** — two-pass runner: `-m cpu -n auto` parallel, then `-m "not cpu"` strictly serial (separate-serial-pass strategy over loadgroup pinning). OpenMP left unpinned by default.
- **`scripts/test/select_impacted.py`** — src-path → test-file map for differential selection (testmon is blind to `.pyd` native changes).
- **`requirements.txt`** — `pytest-xdist`.
- **`.astroray_plan/docs/pytest-cpu-gpu-split-2026-08.md`** — full audit + rationale.

## Partition
1685 collected tests split cleanly: **1234 cpu (parallel) + 451 serial (450 gpu + 1 serial)**, no overlap or gap.

## Verification (RTX 5070 Ti, Ninja/native sm_120 — verified via `cuobjdump`)

| run | CPU `-m cpu -n auto` | GPU `-m "not cpu"` serial | total |
|-----|------|------|------|
| 1 | 1166 passed / 199s | 424 passed / 137s | **335.6s** |
| 2 | 1166 passed / 194s | 424 passed / 137s | **331.5s** |
| 3 | 1166 passed / 201s | 424 passed / 137s | **337.9s** |

- **~335s vs 407.5s baseline — ~18% faster (−72s).** CPU subset ~197s across 8 workers.
- **Zero CUDA illegal-access flakes across all 3 runs.**

### OMP note
An initial `OMP_NUM_THREADS=1` CPU pass took **856s** (worse than baseline) — the OpenMP-heavy reference renders ran single-threaded and dominated the tail. Removing the pin dropped it to ~197s; the runner no longer pins OMP.

## Two pre-existing failures (NOT caused by the split)
Both were reproduced **in plain serial at this HEAD, in isolation** (no xdist):
1. `test_wavefront_contact_sheet_ceiling` — stable ~1.08–1.21s vs 0.57–0.71s pin (1.0s ceiling). Not build-arch (native sm_120 confirmed), not transient (survives 4-min idle + 5 back-to-back runs). Matches the test's documented 1.5× clock-state spread, or a real regression. **Not repinned** (out of scope) — flagged for bisect-vs-repin.
2. `test_blender_parity_matrix` — transient OneDrive `WinError 5` `rmtree` lock; **passes standalone once the lock clears**. Classified `serial` because it is file-fragile.

## Usage
```bash
python scripts/test/run_split.py            # both passes, reports wall time
python scripts/test/run_split.py --cpu-only # fast inner loop
python tests/_gpu_classification.py         # audit the split
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)