### PR TITLE
feat(pkg175): one-command Blender dev loop (build->package->install->headless smoke)

### DIFF
--- a/.astroray_plan/packages/pkg175-blender-dev-loop-one-command.md
+++ b/.astroray_plan/packages/pkg175-blender-dev-loop-one-command.md
@@ -2,7 +2,7 @@
 
 **Pillar:** Integration Milestone (Blender/DCC integration — see ROADMAP "Integration Milestone")
 **Track:** A (tooling + real-host verification; smoke render needs the local RTX + Blender 5.1)
-**Status:** open — dispatchable at the start of the Integration Milestone (first package of the milestone; pkg176 consumes this loop on day one)
+**Status:** in review (PR pending, 2026-08-07 — script + guards + smoke landed; guard unit tests green (14/14), lint clean. On-hardware smoke `RESULT PASS`, `-Launch`, and loop timing pending parent RTX/Blender verification)
 **Estimated effort:** S–M (scripting + hardening of existing pieces, not new machinery)
 **Depends on:** nothing hard. Builds on: `build_blender_addon.py` + `ADDON_FILES` (packaging allow-list — memory `addon-packaging-file-list`), `scripts/verify_pkg88b_blender.py` / `verify_pkg114_*_blender.py` / `verify_pkg115_textures_blender.py` (the existing headless real-host patterns), the `-DASTRORAY_DISABLE_OPENMP=ON` addon-build constraint (memory `mingw_openmp_blender_deadlock`), the stale-`.pyd` discipline (memory `stale_pyd_locations`).
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,47 @@
+# Developing Astroray
+
+## Developing the Blender addon
+
+The whole build -> package -> install -> test loop is one command
+(`scripts/dev_addon.ps1`, PowerShell). It builds the engine `.pyd` (with
+OpenMP off, as Blender requires), packages the addon, runs the safety guards,
+installs into Blender 5.1, and then either smoke-tests it headlessly or opens
+Blender for you.
+
+```powershell
+# Owner: build the addon and open Blender with it enabled
+pwsh scripts\dev_addon.ps1 -Launch
+
+# Agent / CI-style: build, install, and headless smoke-render gate
+pwsh scripts\dev_addon.ps1 -Smoke
+
+# Fast Python-only iteration (reuse the already-built .pyd)
+pwsh scripts\dev_addon.ps1 -Smoke -SkipBuild
+```
+
+Useful options: `-Backend cpu|cuda|tcnn` (default `cuda`),
+`-Blender <path-to-blender.exe>`, `-Python <path-to-python.exe>`.
+
+### What the loop guards against
+
+Each guard encodes a failure mode this repo has actually shipped
+(`scripts/dev_loop_guards.py`):
+
+- **Stale `.pyd`** - refuses to package a compiled module older than `HEAD`
+  (you would otherwise test old code).
+- **OpenMP left on** - refuses an addon build not configured with
+  `-DASTRORAY_DISABLE_OPENMP=ON` (MinGW libgomp deadlocks inside Blender).
+- **Allow-list drift** - every `blender_addon/*.py` must be in `ADDON_FILES`
+  (in `scripts/build/build_blender_addon.py`) or explicitly excluded, so a new
+  module cannot silently fail to ship.
+- **Broken `register()`** - registers the *staged* addon in headless Blender
+  *before* copying it into Blender's extensions dir, so a broken package is
+  never installed.
+
+### Smoke gate
+
+`-Smoke` renders a fixed cheap scene (lit cube + Principled material + camera)
+at low spp and asserts the image is non-black, finite, and within a plausible
+mean-luminance band. It is a **liveness** gate, not a parity gate. Because
+Blender's `--python` exits 0 even on an uncaught traceback, the loop gates on a
+printed `PKG175_SMOKE_RESULT PASS` sentinel, never the exit code.

--- a/scripts/dev_addon.ps1
+++ b/scripts/dev_addon.ps1
@@ -1,0 +1,191 @@
+<#
+.SYNOPSIS
+    pkg175 - one-command Blender dev loop: build -> package -> guard -> install
+    -> (headless smoke | interactive launch).
+
+.DESCRIPTION
+    Composes the existing pieces (build_blender_addon.py for engine+staging,
+    the verify_pkg*_blender.py headless pattern) and wires in the four
+    memory-backed guards (scripts/dev_loop_guards.py) so the known footguns
+    are impossible, not merely documented.
+
+    Modes (pick one; -Smoke is the default and is the agent/CI-safe path):
+      -Smoke    build+package+install, then a headless liveness smoke render.
+                Gates on the printed "PKG175_SMOKE_RESULT PASS" sentinel,
+                NOT the exit code (Blender --python swallows tracebacks).
+      -Launch   build+package+install, then open interactive Blender with the
+                addon enabled and a test .blend (owner-facing).
+      -SkipBuild  re-stage the addon Python only (no C++ rebuild); iterate fast.
+
+.EXAMPLE
+    # Agent / CI: full loop, headless smoke gate
+    pwsh scripts/dev_addon.ps1 -Smoke
+
+.EXAMPLE
+    # Owner: build + open Blender with the fresh addon
+    pwsh scripts/dev_addon.ps1 -Launch
+
+.EXAMPLE
+    # Fast Python-only iteration (reuses the already-built .pyd)
+    pwsh scripts/dev_addon.ps1 -Smoke -SkipBuild
+#>
+[CmdletBinding()]
+param(
+    [switch]$Smoke,
+    [switch]$Launch,
+    [switch]$SkipBuild,
+    [ValidateSet('cpu', 'cuda', 'tcnn', 'auto')]
+    [string]$Backend = 'cuda',
+    [string]$Blender = 'C:/Program Files/Blender Foundation/Blender 5.1/blender.exe',
+    [string]$Python = 'python'
+)
+
+$ErrorActionPreference = 'Stop'
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+$RepoRoot   = Split-Path -Parent $PSScriptRoot
+$Guards     = Join-Path $PSScriptRoot 'dev_loop_guards.py'
+$BuildAddon = Join-Path $PSScriptRoot 'build/build_blender_addon.py'
+$SmokePy    = Join-Path $PSScriptRoot 'verify_pkg175_smoke_blender.py'
+$StageDir   = Join-Path $RepoRoot 'dist/astroray'
+$TestBlend  = Join-Path $RepoRoot 'blender_addon/Test_scene.blend'
+
+$BuildDirByBackend = @{
+    'cpu'  = Join-Path $RepoRoot 'build_blender_addon'
+    'cuda' = Join-Path $RepoRoot 'build_blender_addon_cuda'
+    'tcnn' = Join-Path $RepoRoot 'build_blender_addon_tcnn'
+    'auto' = Join-Path $RepoRoot 'build_blender_addon_tcnn'
+}
+$BuildDir = $BuildDirByBackend[$Backend]
+
+# -Launch wins if both are passed; default is Smoke.
+$Mode = if ($Launch) { 'launch' } else { 'smoke' }
+
+function Write-Section($text) {
+    Write-Host ''
+    Write-Host "=== $text ===" -ForegroundColor Cyan
+}
+
+function Invoke-Guard($guardArgs) {
+    Write-Host "> python dev_loop_guards.py $($guardArgs -join ' ')" -ForegroundColor DarkGray
+    & $Python $Guards @guardArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw "Guard failed: dev_loop_guards.py $($guardArgs -join ' ')"
+    }
+}
+
+function Invoke-BlenderSentinel($smokeMode, $addonDir, $token) {
+    # Run the headless smoke script and gate on the printed "<token> PASS"
+    # string (NOT the exit code - Blender --python exits 0 even on a traceback).
+    if (-not (Test-Path $Blender)) {
+        throw "Blender not found at: $Blender (pass -Blender <path>)"
+    }
+    $env:ASTRORAY_SMOKE_MODE = $smokeMode
+    $env:ASTRORAY_SMOKE_ADDON_DIR = $addonDir
+    Write-Host "> blender --background --factory-startup --python verify_pkg175_smoke_blender.py  (mode=$smokeMode)" -ForegroundColor DarkGray
+    $out = & $Blender --background --factory-startup --python $SmokePy 2>&1 | Out-String
+    Write-Host $out
+    if ($out -match "$token FAIL") { throw "$token FAIL (see output above)" }
+    if ($out -notmatch "$token PASS") {
+        throw "$token sentinel not found - Blender exited without reaching the PASS line"
+    }
+    Write-Host "$token PASS" -ForegroundColor Green
+}
+
+# --------------------------------------------------------------------------- #
+$total = [System.Diagnostics.Stopwatch]::StartNew()
+Write-Host "pkg175 dev loop  mode=$Mode  backend=$Backend  skip-build=$($SkipBuild.IsPresent)"
+
+# 1. BUILD + STAGE (engine .pyd with OpenMP OFF, staged into dist/astroray)
+$buildSecs = 0.0
+if ($SkipBuild) {
+    Write-Section "Re-stage addon Python only (-SkipBuild)"
+    if (-not (Test-Path (Join-Path $StageDir 'build_report.json'))) {
+        throw "No staged build at $StageDir - run a full build once before -SkipBuild"
+    }
+    # Reuse build_blender_addon's ADDON_FILES / STAGE_DIR / ADDON_SRC so the
+    # copied set stays in lockstep with the packaging allow-list.
+    $restage = @'
+import shutil, sys
+from pathlib import Path
+sys.path.insert(0, r"{0}")
+import build_blender_addon as b
+for name in b.ADDON_FILES:
+    src = b.ADDON_SRC / name
+    if src.exists():
+        shutil.copy2(src, b.STAGE_DIR / name)
+        print("restaged", name)
+'@ -f (Split-Path -Parent $BuildAddon)
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $restage | & $Python -
+    if ($LASTEXITCODE -ne 0) { throw "re-stage failed" }
+    $sw.Stop(); $buildSecs = $sw.Elapsed.TotalSeconds
+}
+else {
+    Write-Section "Build engine + package addon (backend=$Backend)"
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    & $Python $BuildAddon --backend $Backend --blender $Blender
+    if ($LASTEXITCODE -ne 0) { throw "build_blender_addon.py failed" }
+    $sw.Stop(); $buildSecs = $sw.Elapsed.TotalSeconds
+}
+
+# 2. GUARDS a/b/c on the freshly staged artifacts
+Write-Section "Guards"
+if (-not $SkipBuild) {
+    # (a) stale-.pyd: only meaningful right after a build.
+    Invoke-Guard @('pyd-fresh', '--build-dir', $BuildDir)
+}
+else {
+    Write-Host "[guard:pyd] skipped (-SkipBuild reuses the prior .pyd)" -ForegroundColor DarkGray
+}
+# (b) OpenMP off  (c) ADDON_FILES allow-list drift
+Invoke-Guard @('openmp', '--staged', $StageDir)
+Invoke-Guard @('addon-files', '--addon-dir', (Join-Path $RepoRoot 'blender_addon'))
+
+# 3. GUARD d: register the STAGED dir headless BEFORE copying into Blender
+Write-Section "Guard (d): headless register() of the staged addon (pre-install)"
+Invoke-BlenderSentinel 'register' $StageDir 'PKG175_REGISTER_RESULT'
+
+# 4. INSTALL staged -> Blender user_default extensions dir (reuses existing code)
+Write-Section "Install into Blender"
+$installPy = @'
+import sys
+from pathlib import Path
+sys.path.insert(0, r"{0}")
+import build_blender_addon as b
+ok = b.install_to_blender(Path(r"{1}"))
+sys.exit(0 if ok else 1)
+'@ -f (Split-Path -Parent $BuildAddon), $Blender
+$installPy | & $Python -
+if ($LASTEXITCODE -ne 0) { throw "install_to_blender failed" }
+
+# 5. SMOKE or LAUNCH
+if ($Mode -eq 'smoke') {
+    Write-Section "Headless smoke render (liveness gate)"
+    # Point the smoke at the installed extension dir so we exercise exactly
+    # what Blender will load. Fall back to the staged dir if the ext dir
+    # cannot be resolved.
+    $installPath = @'
+import sys
+from pathlib import Path
+sys.path.insert(0, r"{0}")
+import build_blender_addon as b
+d = b.blender_user_extensions_dir(Path(r"{1}"))
+print((d / "astroray") if d else "")
+'@ -f (Split-Path -Parent $BuildAddon), $Blender
+    $installed = ($installPath | & $Python -).Trim()
+    $addonDir = if ($installed -and (Test-Path $installed)) { $installed } else { $StageDir }
+    Write-Host "smoke addon dir: $addonDir" -ForegroundColor DarkGray
+    Invoke-BlenderSentinel 'render' $addonDir 'PKG175_SMOKE_RESULT'
+}
+else {
+    Write-Section "Launch interactive Blender"
+    $enable = "import bpy; bpy.ops.preferences.addon_enable(module='bl_ext.user_default.astroray'); bpy.ops.wm.save_userpref()"
+    $blendArg = if (Test-Path $TestBlend) { @($TestBlend) } else { @() }
+    Write-Host "Opening Blender with the addon enabled..." -ForegroundColor Green
+    & $Blender @blendArg --python-expr $enable
+}
+
+$total.Stop()
+Write-Section "Done"
+Write-Host ("build/stage: {0:N1}s   total: {1:N1}s" -f $buildSecs, $total.Elapsed.TotalSeconds)

--- a/scripts/dev_loop_guards.py
+++ b/scripts/dev_loop_guards.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""pkg175 dev-loop guards — the four memory-backed footguns, made impossible.
+
+These are plain, importable, unit-testable functions used by
+``scripts/dev_addon.ps1`` (the one-command Blender dev loop). Each encodes a
+failure mode this repo has actually shipped:
+
+  (a) pyd_is_stale            — stale-.pyd (memory: stale_pyd_locations). Refuse
+                                to package a ``.pyd`` older than HEAD.
+  (b) openmp_disabled_*       — MinGW libgomp deadlocks inside Blender
+                                (memory: mingw_openmp_blender_deadlock). Refuse
+                                an addon build that was not configured with
+                                ``-DASTRORAY_DISABLE_OPENMP=ON``.
+  (c) addon_files_drift       — the packaging allow-list drift trap
+                                (memory: addon-packaging-file-list). Every
+                                ``blender_addon/*.py`` on disk must be in
+                                ``ADDON_FILES`` (or explicitly excluded).
+  (d) sentinel_passed         — Blender ``--python`` swallows tracebacks and
+                                exits 0 (learned in the pkg88b harness). Gate on
+                                a printed ``<TOKEN> PASS`` string, never on exit
+                                code.
+
+The functions are pure/deterministic and take their inputs explicitly so they
+can be unit-tested without a GPU, a build, or Blender. A thin CLI at the bottom
+lets the PowerShell driver invoke them and branch on the exit code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# blender_addon/*.py files that intentionally do NOT ship in the addon zip.
+# Empty today — every top-level module is packaged. A new dev-only helper that
+# should not ship goes here (and the reason belongs in the commit message).
+ADDON_FILES_EXCLUDED: set[str] = set()
+
+
+# --------------------------------------------------------------------------- #
+# (a) stale .pyd guard
+# --------------------------------------------------------------------------- #
+
+def head_commit_epoch(repo_root: Path | str = REPO_ROOT) -> int:
+    """Return the committer-date (epoch seconds) of HEAD in ``repo_root``."""
+    out = subprocess.check_output(
+        ["git", "-C", str(repo_root), "log", "-1", "--format=%ct", "HEAD"],
+        text=True, timeout=15).strip()
+    return int(out)
+
+
+def pyd_is_stale(pyd_path: Path | str, head_epoch: int) -> tuple[bool, float]:
+    """Return (is_stale, pyd_mtime_epoch).
+
+    Stale == the compiled module predates the HEAD commit, i.e. it was built
+    from older source. A missing file is treated as stale.
+    """
+    p = Path(pyd_path)
+    if not p.exists():
+        return True, 0.0
+    mtime = p.stat().st_mtime
+    return (mtime < head_epoch), mtime
+
+
+def find_built_pyd(build_dir: Path | str) -> Path | None:
+    """Return the most-recently-built ``astroray*.pyd`` under ``build_dir``."""
+    root = Path(build_dir)
+    matches: list[Path] = []
+    for pattern in ("astroray.*.pyd", "astroray*.pyd", "astroray*.so",
+                    "Release/astroray*.pyd"):
+        matches += list(root.glob(pattern))
+    if not matches:
+        return None
+    matches.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    return matches[0]
+
+
+# --------------------------------------------------------------------------- #
+# (b) OpenMP-disabled guard
+# --------------------------------------------------------------------------- #
+
+def openmp_disabled_in_flags(cmake_flags: list[str]) -> bool:
+    """True iff the flag list carries ``-DASTRORAY_DISABLE_OPENMP=ON``."""
+    for flag in cmake_flags:
+        norm = flag.replace(" ", "").upper()
+        if norm == "-DASTRORAY_DISABLE_OPENMP=ON":
+            return True
+    return False
+
+
+def openmp_disabled_in_build_report(staged_dir: Path | str) -> bool:
+    """Read ``build_report.json`` written by build_blender_addon.py and confirm
+    the build was configured with OpenMP off."""
+    report = Path(staged_dir) / "build_report.json"
+    if not report.exists():
+        raise FileNotFoundError(f"no build_report.json in {staged_dir}")
+    flags = json.loads(report.read_text()).get("cmake_flags", [])
+    return openmp_disabled_in_flags(flags)
+
+
+# --------------------------------------------------------------------------- #
+# (c) ADDON_FILES allow-list drift guard
+# --------------------------------------------------------------------------- #
+
+def _load_addon_files(build_script: Path | str | None = None) -> list[str]:
+    """Import ADDON_FILES from scripts/build/build_blender_addon.py by path."""
+    path = Path(build_script) if build_script else (
+        REPO_ROOT / "scripts" / "build" / "build_blender_addon.py")
+    spec = importlib.util.spec_from_file_location("_bba_for_guard", path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return list(mod.ADDON_FILES)
+
+
+def addon_files_drift(addon_dir: Path | str,
+                      addon_files: list[str],
+                      excluded: set[str] | None = None) -> list[str]:
+    """Return top-level ``*.py`` files in ``addon_dir`` that are neither in the
+    packaging allow-list nor explicitly excluded. Empty list == no drift."""
+    excluded = excluded if excluded is not None else ADDON_FILES_EXCLUDED
+    allowed = set(addon_files) | set(excluded)
+    on_disk = sorted(p.name for p in Path(addon_dir).glob("*.py"))
+    return [name for name in on_disk if name not in allowed]
+
+
+# --------------------------------------------------------------------------- #
+# (d) headless-sentinel guard
+# --------------------------------------------------------------------------- #
+
+def sentinel_passed(output: str, token: str) -> bool:
+    """True iff ``<token> PASS`` appears in ``output`` and ``<token> FAIL`` does
+    not. Blender --python exits 0 even on an uncaught traceback, so the printed
+    sentinel — not the exit code — is the source of truth."""
+    if f"{token} FAIL" in output:
+        return False
+    return f"{token} PASS" in output
+
+
+# --------------------------------------------------------------------------- #
+# CLI (used by dev_addon.ps1; each subcommand exits 0 on pass, 1 on fail)
+# --------------------------------------------------------------------------- #
+
+def _cmd_pyd_fresh(args) -> int:
+    build_dir = Path(args.build_dir)
+    pyd = Path(args.pyd) if args.pyd else find_built_pyd(build_dir)
+    if pyd is None:
+        print(f"[guard:pyd] FAIL - no astroray*.pyd found under {build_dir}")
+        return 1
+    head = head_commit_epoch(args.repo)
+    stale, mtime = pyd_is_stale(pyd, head)
+    print(f"[guard:pyd] pyd={pyd}")
+    print(f"[guard:pyd] pyd_mtime={mtime:.0f}  head_commit_epoch={head}")
+    if stale:
+        print("[guard:pyd] FAIL - built .pyd is OLDER than HEAD; rebuild before packaging")
+        return 1
+    print("[guard:pyd] PASS - built .pyd is at/after HEAD")
+    return 0
+
+
+def _cmd_openmp(args) -> int:
+    try:
+        ok = openmp_disabled_in_build_report(args.staged)
+    except FileNotFoundError as exc:
+        print(f"[guard:openmp] FAIL - {exc}")
+        return 1
+    if not ok:
+        print("[guard:openmp] FAIL - build was NOT configured with "
+              "-DASTRORAY_DISABLE_OPENMP=ON (libgomp deadlocks in Blender)")
+        return 1
+    print("[guard:openmp] PASS - -DASTRORAY_DISABLE_OPENMP=ON")
+    return 0
+
+
+def _cmd_addon_files(args) -> int:
+    addon_dir = Path(args.addon_dir)
+    drift = addon_files_drift(addon_dir, _load_addon_files())
+    if drift:
+        print("[guard:addon-files] FAIL - these blender_addon/*.py are neither "
+              "in ADDON_FILES nor excluded:")
+        for name in drift:
+            print(f"    {name}")
+        print("  Add them to ADDON_FILES in scripts/build/build_blender_addon.py "
+              "or to ADDON_FILES_EXCLUDED in scripts/dev_loop_guards.py")
+        return 1
+    print("[guard:addon-files] PASS - every blender_addon/*.py is accounted for")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("pyd-fresh", help="(a) refuse a .pyd older than HEAD")
+    p.add_argument("--build-dir", required=True)
+    p.add_argument("--pyd", default=None, help="explicit .pyd (else newest in build-dir)")
+    p.add_argument("--repo", default=str(REPO_ROOT))
+    p.set_defaults(func=_cmd_pyd_fresh)
+
+    p = sub.add_parser("openmp", help="(b) refuse a build without OpenMP off")
+    p.add_argument("--staged", required=True, help="staged addon dir (has build_report.json)")
+    p.set_defaults(func=_cmd_openmp)
+
+    p = sub.add_parser("addon-files", help="(c) ADDON_FILES allow-list drift")
+    p.add_argument("--addon-dir", default=str(REPO_ROOT / "blender_addon"))
+    p.set_defaults(func=_cmd_addon_files)
+
+    args = ap.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_pkg175_smoke_blender.py
+++ b/scripts/verify_pkg175_smoke_blender.py
@@ -1,0 +1,209 @@
+"""pkg175 dev-loop smoke — headless liveness gate for the freshly built addon.
+
+Run inside Blender (headless):
+
+    "C:/Program Files/Blender Foundation/Blender 5.1/blender.exe" \
+        --background --factory-startup \
+        --python scripts/verify_pkg175_smoke_blender.py
+
+Two modes, selected by the ASTRORAY_SMOKE_MODE env var:
+
+  register  — load the staged/installed addon and call register(). Proves the
+              package imports (its bundled .pyd + DLLs) and its render engine
+              registers. This is dev-loop guard (d): run against the STAGED dir
+              BEFORE the install copy. Prints PKG175_REGISTER_RESULT PASS/FAIL.
+
+  render    — everything register does, plus build a fixed, cheap scene
+              (lit cube + Principled material + camera), render it at low spp
+              through the Astroray engine, and assert the image is non-black,
+              finite, and within a plausible mean-luminance band. This is a
+              LIVENESS gate, not a parity gate (parity is pkg119-B). Prints
+              PKG175_SMOKE_RESULT PASS/FAIL and PKG175_SMOKE_STATS.
+
+Env vars:
+  ASTRORAY_SMOKE_MODE      register | render   (default: render)
+  ASTRORAY_SMOKE_ADDON_DIR directory holding the addon __init__.py + astroray*.pyd
+                           (staged dir or the installed extension dir). When
+                           unset, falls back to tests/runtime_setup discovery of
+                           the dev build_cuda tree + blender_addon source.
+
+Blender's --python swallows unhandled exceptions and still exits 0, so a bare
+crash would look like success. The bottom of this file converts any exception
+into an explicit FAIL line + nonzero exit. Callers MUST gate on the printed
+"... PASS" string, never on the exit code alone.
+"""
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import bpy  # type: ignore
+
+MODE = os.environ.get("ASTRORAY_SMOKE_MODE", "render").strip().lower()
+REGISTER_TOKEN = "PKG175_REGISTER_RESULT"
+SMOKE_TOKEN = "PKG175_SMOKE_RESULT"
+
+W = H = 96
+SAMPLES = 16
+MAX_DEPTH = 3
+SEED = 175175
+
+
+def _bootstrap():
+    """Put the addon dir + engine .pyd on sys.path, register the addon, and
+    return (astroray_module, addon_module)."""
+    repo_root = Path(__file__).resolve().parents[1]
+    addon_dir = os.environ.get("ASTRORAY_SMOKE_ADDON_DIR")
+
+    if addon_dir:
+        addon_dir = Path(addon_dir)
+        # The staged/installed dir is self-contained: astroray*.pyd, its bundled
+        # MinGW/CUDA/OIDN DLLs, and the addon Python all live here.
+        if str(addon_dir) not in sys.path:
+            sys.path.insert(0, str(addon_dir))
+        if sys.platform == "win32" and hasattr(os, "add_dll_directory"):
+            for d in (addon_dir, addon_dir / "oidn"):
+                if d.is_dir():
+                    os.add_dll_directory(str(d))
+            # CUDA runtime DLLs may live in the toolkit rather than the package.
+            cuda_root = Path(os.environ.get(
+                "CUDA_PATH",
+                r"C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.8"))
+            for d in (cuda_root / "bin", cuda_root / "bin" / "x64"):
+                if d.is_dir():
+                    os.add_dll_directory(str(d))
+        init_path = addon_dir / "__init__.py"
+    else:
+        # Fallback: dev tree. Reuse the shared test bootstrap (build_cuda +
+        # runtime DLL dirs) and the blender_addon source.
+        sys.path.insert(0, str(repo_root / "tests"))
+        import runtime_setup  # type: ignore
+        runtime_setup.configure_test_imports(include_blender_addon=True)
+        init_path = repo_root / "blender_addon" / "__init__.py"
+
+    import astroray
+    print("engine:", astroray.__file__)
+
+    spec = importlib.util.spec_from_file_location("astroray_addon", init_path)
+    addon = importlib.util.module_from_spec(spec)
+    sys.modules["astroray_addon"] = addon
+    spec.loader.exec_module(addon)
+    print("addon :", init_path)
+    addon.register()  # let it raise — a failed register IS a guard-(d) failure
+    return astroray, addon
+
+
+def _engine_standin(addon):
+    """A bpy RenderEngine subclass cannot be instantiated outside the render
+    pipeline, so mirror its plain-Python methods onto a standalone object
+    (same technique as scripts/verify_pkg88b_blender.py)."""
+    Engine = addon.CustomRaytracerRenderEngine
+
+    class _S:
+        def report(self, *a, **k):
+            pass
+
+    for name, fn in Engine.__dict__.items():
+        if callable(fn) and not name.startswith("__"):
+            setattr(_S, name, fn)
+    return _S()
+
+
+def _build_scene():
+    """Fixed cheap scene: one lit cube with a Principled material + a camera,
+    black world so the mean-luminance band is meaningful."""
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+    scene = bpy.context.scene
+
+    bpy.ops.mesh.primitive_cube_add(size=1.5, location=(0.0, 0.0, 0.0))
+    cube = bpy.context.object
+    mat = bpy.data.materials.new("SmokeMat")
+    mat.use_nodes = True
+    bsdf = mat.node_tree.nodes.get("Principled BSDF")
+    if bsdf is not None:
+        bsdf.inputs["Base Color"].default_value = (0.8, 0.3, 0.2, 1.0)
+        bsdf.inputs["Roughness"].default_value = 0.5
+    cube.data.materials.append(mat)
+
+    world = bpy.data.worlds.new("W")
+    world.use_nodes = False
+    world.color = (0.0, 0.0, 0.0)
+    scene.world = world
+
+    light_data = bpy.data.lights.new("L", type='POINT')
+    light_data.energy = 3000.0
+    light = bpy.data.objects.new("L", light_data)
+    light.location = (2.5, -3.0, 4.0)
+    scene.collection.objects.link(light)
+
+    cam_data = bpy.data.cameras.new("C")
+    cam = bpy.data.objects.new("C", cam_data)
+    cam.location = (0.0, -6.0, 0.0)
+    cam.rotation_euler = (1.5708, 0.0, 0.0)
+    scene.collection.objects.link(cam)
+    scene.camera = cam
+    scene.render.resolution_x = W
+    scene.render.resolution_y = H
+    return scene
+
+
+def _render(astroray, addon):
+    import numpy as np
+    _build_scene()
+    st = _engine_standin(addon)
+    r = astroray.Renderer()
+    depsgraph = bpy.context.evaluated_depsgraph_get()
+    st.convert_scene(depsgraph, r, W, H)   # (self, depsgraph, renderer, w, h)
+    r.set_seed(SEED)
+    img = np.asarray(r.render(SAMPLES, MAX_DEPTH, None, False), dtype=np.float32)
+    return img
+
+
+def _check_image(img) -> tuple[bool, dict]:
+    import numpy as np
+    lum = 0.2126 * img[..., 0] + 0.7152 * img[..., 1] + 0.0722 * img[..., 2]
+    stats = {
+        "shape": list(img.shape),
+        "mean_lum": float(lum.mean()),
+        "max_lum": float(lum.max()),
+        "nonblack_frac": float((lum > 1e-4).mean()),
+        "finite": bool(np.isfinite(img).all()),
+    }
+    ok = (
+        stats["finite"]
+        and stats["max_lum"] > 0.0
+        and stats["nonblack_frac"] > 0.01     # the cube is visible
+        and 1e-4 < stats["mean_lum"] < 100.0  # plausible band, not blown out
+    )
+    return ok, stats
+
+
+def main():
+    astroray, addon = _bootstrap()
+
+    if MODE == "register":
+        assert hasattr(addon, "CustomRaytracerRenderEngine"), \
+            "addon registered but CustomRaytracerRenderEngine is missing"
+        print(f"{REGISTER_TOKEN} PASS")
+        return
+
+    img = _render(astroray, addon)
+    ok, stats = _check_image(img)
+    print(f"PKG175_SMOKE_STATS {stats!r}")
+    print(f"{SMOKE_TOKEN} {'PASS' if ok else 'FAIL'}")
+    if not ok:
+        sys.exit(1)
+
+
+try:
+    main()
+except SystemExit:
+    raise
+except BaseException as exc:  # noqa: BLE001
+    import traceback
+    traceback.print_exc()
+    token = REGISTER_TOKEN if MODE == "register" else SMOKE_TOKEN
+    print()
+    print(f"{token} FAIL")
+    print(f"PKG175_ERROR {type(exc).__name__}: {exc}")
+    sys.exit(1)

--- a/tests/test_dev_loop_smoke.py
+++ b/tests/test_dev_loop_smoke.py
@@ -1,0 +1,167 @@
+"""pkg175 - unit tests for the dev-loop guards + a local-host smoke gate.
+
+The guard tests are pure (no GPU, no build, no Blender) and always run - they
+are the real regression coverage for the four footguns. The smoke test drives
+the full ``scripts/dev_addon.ps1 -Smoke -SkipBuild`` loop and SKIPS CLEANLY
+when Blender, PowerShell, a prior staged build, or the GPU is absent, so CI
+(which has none of those) stays green. This is a local-host gate.
+"""
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = REPO_ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import dev_loop_guards as g
+
+BLENDER = Path("C:/Program Files/Blender Foundation/Blender 5.1/blender.exe")
+STAGE_DIR = REPO_ROOT / "dist" / "astroray"
+
+
+# --------------------------------------------------------------------------- #
+# (a) stale-.pyd guard
+# --------------------------------------------------------------------------- #
+
+def test_pyd_is_stale_flags_old_module(tmp_path):
+    pyd = tmp_path / "astroray.cp313-win_amd64.pyd"
+    pyd.write_bytes(b"x")
+    mtime = pyd.stat().st_mtime
+    # HEAD committed AFTER the .pyd was built -> stale.
+    stale, reported = g.pyd_is_stale(pyd, head_epoch=int(mtime) + 1000)
+    assert stale is True
+    assert reported == pytest.approx(mtime)
+
+
+def test_pyd_is_stale_passes_fresh_module(tmp_path):
+    pyd = tmp_path / "astroray.cp313-win_amd64.pyd"
+    pyd.write_bytes(b"x")
+    mtime = pyd.stat().st_mtime
+    stale, _ = g.pyd_is_stale(pyd, head_epoch=int(mtime) - 1000)
+    assert stale is False
+
+
+def test_pyd_is_stale_missing_is_stale(tmp_path):
+    stale, mtime = g.pyd_is_stale(tmp_path / "nope.pyd", head_epoch=0)
+    assert stale is True
+    assert mtime == 0.0
+
+
+def test_find_built_pyd_picks_newest(tmp_path):
+    old = tmp_path / "astroray.old.pyd"
+    new = tmp_path / "astroray.new.pyd"
+    old.write_bytes(b"o")
+    new.write_bytes(b"n")
+    os.utime(old, (1000, 1000))
+    os.utime(new, (2000, 2000))
+    assert g.find_built_pyd(tmp_path) == new
+
+
+def test_find_built_pyd_none_when_absent(tmp_path):
+    assert g.find_built_pyd(tmp_path) is None
+
+
+# --------------------------------------------------------------------------- #
+# (b) OpenMP-disabled guard
+# --------------------------------------------------------------------------- #
+
+def test_openmp_disabled_positive():
+    assert g.openmp_disabled_in_flags(
+        ["-DUSE_FAST_MATH=ON", "-DASTRORAY_DISABLE_OPENMP=ON"]) is True
+
+
+def test_openmp_disabled_negative():
+    assert g.openmp_disabled_in_flags(["-DUSE_FAST_MATH=ON"]) is False
+    assert g.openmp_disabled_in_flags(
+        ["-DASTRORAY_DISABLE_OPENMP=OFF"]) is False
+
+
+def test_openmp_disabled_in_build_report(tmp_path):
+    (tmp_path / "build_report.json").write_text(
+        '{"cmake_flags": ["-DASTRORAY_DISABLE_OPENMP=ON"]}')
+    assert g.openmp_disabled_in_build_report(tmp_path) is True
+
+    (tmp_path / "build_report.json").write_text('{"cmake_flags": []}')
+    assert g.openmp_disabled_in_build_report(tmp_path) is False
+
+    with pytest.raises(FileNotFoundError):
+        g.openmp_disabled_in_build_report(tmp_path / "missing")
+
+
+# --------------------------------------------------------------------------- #
+# (c) ADDON_FILES allow-list drift guard
+# --------------------------------------------------------------------------- #
+
+def test_addon_files_drift_detects_unlisted(tmp_path):
+    (tmp_path / "__init__.py").write_text("")
+    (tmp_path / "shipped.py").write_text("")
+    (tmp_path / "rogue.py").write_text("")
+    drift = g.addon_files_drift(
+        tmp_path, addon_files=["__init__.py", "shipped.py"], excluded=set())
+    assert drift == ["rogue.py"]
+
+
+def test_addon_files_drift_respects_exclusions(tmp_path):
+    (tmp_path / "devonly.py").write_text("")
+    drift = g.addon_files_drift(
+        tmp_path, addon_files=[], excluded={"devonly.py"})
+    assert drift == []
+
+
+def test_repo_blender_addon_has_no_drift():
+    """The real regression: every blender_addon/*.py must be in ADDON_FILES.
+    Memory: addon-packaging-file-list - a new module silently missing from the
+    allow-list ships a broken addon."""
+    addon_files = g._load_addon_files()
+    drift = g.addon_files_drift(REPO_ROOT / "blender_addon", addon_files)
+    assert drift == [], (
+        f"blender_addon/*.py not in ADDON_FILES (add to ADDON_FILES in "
+        f"build_blender_addon.py or ADDON_FILES_EXCLUDED): {drift}")
+
+
+# --------------------------------------------------------------------------- #
+# (d) headless-sentinel guard
+# --------------------------------------------------------------------------- #
+
+def test_sentinel_passed_true():
+    assert g.sentinel_passed("...\nPKG175_SMOKE_RESULT PASS\n", "PKG175_SMOKE_RESULT") is True
+
+
+def test_sentinel_passed_false_on_fail():
+    assert g.sentinel_passed("PKG175_SMOKE_RESULT FAIL\n", "PKG175_SMOKE_RESULT") is False
+
+
+def test_sentinel_passed_false_when_absent():
+    # Exit-0-with-no-sentinel (Blender swallowed a traceback) must NOT pass.
+    assert g.sentinel_passed("engine crashed silently\n", "PKG175_SMOKE_RESULT") is False
+
+
+# --------------------------------------------------------------------------- #
+# Local-host smoke gate (skips cleanly without Blender / pwsh / staged build)
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.serial
+@pytest.mark.gpu
+def test_dev_loop_smoke_local_host():
+    if not BLENDER.exists():
+        pytest.skip("Blender 5.1 not installed - local-host gate")
+    pwsh = shutil.which("pwsh") or shutil.which("powershell")
+    if pwsh is None:
+        pytest.skip("PowerShell not found")
+    if not (STAGE_DIR / "build_report.json").exists():
+        pytest.skip("no prior staged build (run scripts/dev_addon.ps1 -Smoke once)")
+
+    script = SCRIPTS / "dev_addon.ps1"
+    proc = subprocess.run(
+        [pwsh, "-NoProfile", "-File", str(script), "-Smoke", "-SkipBuild"],
+        cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=900,
+        check=False)
+    combined = proc.stdout + "\n" + proc.stderr
+    assert g.sentinel_passed(combined, "PKG175_SMOKE_RESULT"), (
+        "smoke did not report PKG175_SMOKE_RESULT PASS:\n" + combined[-3000:])


### PR DESCRIPTION
## pkg175 — one-command Blender dev loop

Turns the manual build -> package -> install -> launch -> test cycle into a
single command (`scripts/dev_addon.ps1`). Composes the existing pieces
(`build_blender_addon.py`, the `verify_pkg*_blender.py` headless pattern);
new code is glue + guards only.

### Modes
- `-Smoke` (default; agent/CI-safe): build engine `.pyd` (OpenMP OFF) -> stage/package -> guards -> register-check -> install -> headless smoke render -> gate on `PKG175_SMOKE_RESULT PASS`.
- `-Launch` (owner): same build/install, then open interactive Blender with the addon enabled + `Test_scene.blend`.
- `-SkipBuild`: re-stage addon Python only (reuse the built `.pyd`) for fast iteration.

### The four guards (`scripts/dev_loop_guards.py`, unit-testable)
- **(a) stale-.pyd** — refuses to package a `.pyd` older than HEAD (`pyd_is_stale`). Memory `stale_pyd_locations`.
- **(b) OpenMP left on** — refuses a build not configured with `-DASTRORAY_DISABLE_OPENMP=ON`, read from the staged `build_report.json` (`openmp_disabled_*`). Memory `mingw_openmp_blender_deadlock`.
- **(c) allow-list drift** — every top-level `blender_addon/*.py` must be in `ADDON_FILES` or `ADDON_FILES_EXCLUDED` (`addon_files_drift`). Memory `addon-packaging-file-list`.
- **(d) broken register()** — registers the *staged* addon in headless Blender *before* the install copy, so a broken package never lands in Blender's extensions dir.

### Smoke sentinel
Blender `--python` exits 0 even on an uncaught traceback (learned in the pkg88b harness), so the loop gates on the printed string `PKG175_SMOKE_RESULT PASS` (and treats `... FAIL` / absence as failure), never the exit code. `sentinel_passed()` encodes this and is unit-tested including the "exit-0 with no sentinel" case.

### Verification done here (no GPU used — parent owns the RTX this session)
- Guard unit tests: **14 passed, 1 skipped** (`pytest tests/test_dev_loop_smoke.py`). The skip is the local-host smoke, which skips cleanly with no staged build — CI stays green.
- Lint differential vs `origin/main`: **0 new findings** (ruff/markdownlint/codespell/git-diff-check).
- PowerShell parse-check: no errors; `.ps1` is ASCII-only.
- Each guard demonstrably fires: (a) stale-.pyd and (c) rogue-module via the CLI; (b) missing/OpenMP-off and (d) FAIL/absent-sentinel via unit tests.

### Pending parent hardware verification (NOT verified here)
- [ ] Full `-Smoke` loop source -> installed -> headless `PKG175_SMOKE_RESULT PASS` on RTX 5070 Ti + Blender 5.1.
- [ ] `-Launch` opens Blender with the addon enabled and `CUSTOM_RAYTRACER` selectable (screenshot/log).
- [ ] Loop timing recorded (full rebuild vs `-SkipBuild`).

### Authorized surface
Spec intended: `scripts/dev_addon.ps1`, guard functions, `tests/test_dev_loop_smoke.py`, `DEVELOPMENT.md`. Files actually changed:
- `scripts/dev_addon.ps1` (new — orchestrator)
- `scripts/dev_loop_guards.py` (new — guard functions + CLI)
- `scripts/verify_pkg175_smoke_blender.py` (new — headless smoke/register, follows the `verify_pkg*_blender.py` pattern the spec cites)
- `tests/test_dev_loop_smoke.py` (new)
- `DEVELOPMENT.md` (new)
- `.astroray_plan/packages/pkg175-blender-dev-loop-one-command.md` (status flip)

No engine/addon source touched; no `.cu/.cpp/.h/CMakeLists.txt` changed (no CUDA build required). `build_blender_addon.py` is reused unmodified (imported for `ADDON_FILES`/`install_to_blender`/`blender_user_extensions_dir`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
