### PR TITLE
feat(pkg176): Stage 0 Cycles-settings -> Astroray mapping table (owner-review artifact)

### DIFF
--- a/.astroray_plan/packages/pkg176-blender-native-steering-wheel.md
+++ b/.astroray_plan/packages/pkg176-blender-native-steering-wheel.md
@@ -2,7 +2,7 @@
 
 **Pillar:** Integration Milestone (Blender/DCC integration — see ROADMAP "Integration Milestone")
 **Track:** A (addon-heavy Python + real-host verification; render legs RTX)
-**Status:** open — dispatchable after pkg175 (the dev loop is this package's iteration vehicle); staged, expect multiple PRs
+**Status:** Stage 0 done (owner-review artifact — mapping table `docs/blender_parity/pkg176_stage0_mapping.md` + machine-readable `blender_addon/settings_map.py`; 58 direct / 4 approximated / 19 dropped / 9 astroray-only across 90 settings-level rows; Route-2 §6 five hard rules honoured). Stages 1–4 open — dispatchable after pkg175 (the dev loop is this package's iteration vehicle); staged, expect multiple PRs
 **Estimated effort:** L, staged (Stage 1 render/sampling settings; Stage 2 panel adoption; Stage 3 world/light/camera property completion; Stage 4 custom-UI retirement)
 **Depends on:** pkg175 (dev loop). Cross-links: **pkg119** (Phase A matrix enumerates exactly the native surface this package must consume; Phases B/C are this package's verification layer — see pkg119's refreshed Status), **pkg103** (the earlier feature-wiring audit this supersedes in approach), **pkg115** (native shader-node adoption — the precedent: we already adopted Blender's node surface for textures; this package extends that philosophy from nodes to settings/UI), research note `.astroray_plan/docs/dcc-integration-research-2026-08.md`.
 

--- a/blender_addon/settings_map.py
+++ b/blender_addon/settings_map.py
@@ -1,0 +1,367 @@
+"""pkg176 Stage 0 — Cycles-settings -> Astroray-parameter mapping table.
+
+This module is the SINGLE SOURCE OF TRANSLATION POLICY for the "Blender as the
+steering wheel" work (pkg176). It records, for every native Blender/Cycles
+setting the steering wheel needs, which host-neutral engine/session parameter it
+drives, and whether the mapping is direct, approximated, dropped, or has no
+native home (ASTRORAY-ONLY).
+
+Route-2 session-boundary discipline (dcc-integration-decision-2026-08 §6):
+  * This module lives on the TRANSLATOR side and is pure DATA — it MUST NOT
+    ``import bpy`` and MUST NOT call the engine. (Rule 1, Rule 3.)
+  * ``neutral_param`` names the HOST-NEUTRAL session target (a pybind
+    ``Renderer`` setter or a ``render()`` argument), never a Blender datablock.
+    A second host (Houdini adapter / hdAstroray) reads THIS table to learn what
+    Blender's steering wheel *meant*, then maps its own controls to the same
+    neutral values. (Rule 2, Rule 3.)
+  * It is inert in Stage 0: nothing imports it yet. Stage 1 makes the exporter
+    read native properties per this table; Stage 4 collapses the custom_prop
+    duplicates into the native read *above* the boundary without removing any
+    neutral_param capability below it. (Rule 4.)
+  * No framework, no C API — this is a data module and a naming rule only.
+    (Rule 5.)
+
+Grounding: the ``status`` / ``pkg119a`` columns reuse the pkg119 Phase A
+coverage matrix (docs/blender_parity/coverage_matrix.json — 117 SUPPORTED /
+22 APPROXIMATED / 385 DROPPED-SILENT as of PR #487). Where the current addon
+has since diverged from the matrix (some native reads were added by later
+packages, e.g. pkg88/pkg103b wired ``scene.cycles.seed`` / ``film_exposure`` /
+``filter_width`` natively), the ``note`` says so — the matrix classification is
+kept verbatim in ``pkg119a`` as the audit anchor, and ``status`` reflects the
+current translation reality the owner is asked to ratify.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+# Mapping status vocabulary (opinionated, owner-ratified in Stage 0 review):
+#   "direct"        - native value drives the neutral param 1:1 (unit-exact or
+#                     documented trivial conversion).
+#   "approximated"  - native value drives a nearest engine behaviour; lossy or
+#                     semantically narrower/wider. MUST warn (pkg119-C) once wired.
+#   "dropped"       - native value has no engine target today; DROPPED-SILENT in
+#                     pkg119-A. The steering wheel must stop dropping these
+#                     silently (Stage 1/3 + pkg119-C).
+#   "astroray-only" - genuinely engine-unique control with no native Blender
+#                     home; stays on the one custom "Astroray" panel (Stage 4).
+STATUS_VALUES = ("direct", "approximated", "dropped", "astroray-only")
+
+# pkg119-A classification vocabulary, reused verbatim as the audit anchor.
+PKG119A_VALUES = ("SUPPORTED", "APPROXIMATED", "DROPPED-SILENT", "n/a")
+
+
+class MappingEntry(NamedTuple):
+    category: str        # render/sampling/light_paths/film/color_mgmt/world/camera/light/material
+    native_prop: str     # Blender/Cycles property id (matches pkg119-A socket_or_prop for settings)
+    cycles_path: str     # full native access path, e.g. "scene.cycles.samples"
+    custom_prop: str     # current shadowing custom prop, "" if native-only / ASTRORAY-ONLY
+    neutral_param: str   # host-neutral session target (Renderer setter / render() arg / "(none)")
+    status: str          # one of STATUS_VALUES
+    pkg119a: str         # one of PKG119A_VALUES
+    note: str            # one-line note where non-obvious or lossy
+
+
+# ---------------------------------------------------------------------------
+# Render / sampling  (scene.cycles.* + scene.render.*)
+# ---------------------------------------------------------------------------
+_RENDER_SAMPLING = [
+    MappingEntry("render", "resolution_x", "scene.render.resolution_x", "",
+                 "render(width=...)", "direct", "n/a",
+                 "Read natively today (x resolution_percentage); not a custom duplicate."),
+    MappingEntry("render", "resolution_y", "scene.render.resolution_y", "",
+                 "render(height=...)", "direct", "n/a",
+                 "Read natively today (x resolution_percentage)."),
+    MappingEntry("sampling", "samples", "scene.cycles.samples", "custom_raytracer.samples",
+                 "render(samples=...)", "direct", "SUPPORTED",
+                 "Custom duplicate shadows native; Stage 1 reads scene.cycles.samples."),
+    MappingEntry("sampling", "preview_samples", "scene.cycles.preview_samples",
+                 "custom_raytracer.preview_samples", "render(samples=...) [viewport]",
+                 "direct", "n/a", "Viewport spp; native Cycles preview_samples is the counterpart."),
+    MappingEntry("sampling", "use_adaptive_sampling", "scene.cycles.use_adaptive_sampling",
+                 "custom_raytracer.use_adaptive_sampling", "(none)", "dropped", "DROPPED-SILENT",
+                 "Custom toggle exists but is not plumbed to the engine; no adaptive-sampling session arg yet."),
+    MappingEntry("sampling", "adaptive_threshold", "scene.cycles.adaptive_threshold",
+                 "custom_raytracer.adaptive_threshold", "(none)", "dropped", "DROPPED-SILENT",
+                 "Noise threshold; no engine target (adaptive sampling not wired)."),
+    MappingEntry("sampling", "adaptive_min_samples", "scene.cycles.adaptive_min_samples", "",
+                 "(none)", "dropped", "DROPPED-SILENT", "No custom prop and no engine target."),
+    MappingEntry("sampling", "seed", "scene.cycles.seed", "",
+                 "renderer.set_seed", "direct", "DROPPED-SILENT",
+                 "pkg119-A marked DROPPED; addon NOW reads scene.cycles.seed natively (+use_animated_seed). "
+                 "Seed 0 = engine random sentinel (raytracer.h)."),
+    MappingEntry("sampling", "sample_offset", "scene.cycles.sample_offset", "",
+                 "(none)", "dropped", "DROPPED-SILENT", "Sample-offset for tiled/distributed render; no engine target."),
+    MappingEntry("sampling", "pixel_filter_type", "scene.cycles.pixel_filter_type", "",
+                 "renderer.set_pixel_filter", "direct", "n/a",
+                 "Read natively today; BOX/GAUSSIAN/BLACKMAN_HARRIS -> 0/1/2."),
+    MappingEntry("sampling", "filter_width", "scene.cycles.filter_width", "",
+                 "renderer.set_pixel_filter", "direct", "DROPPED-SILENT",
+                 "pkg119-A marked DROPPED; addon NOW reads scene.cycles.filter_width natively."),
+    MappingEntry("sampling", "light_sampling", "scene.cycles.use_light_tree",
+                 "custom_raytracer.light_sampler", "renderer.set_light_sampler", "approximated", "n/a",
+                 "SEMANTIC MISMATCH: Astroray has uniform/power/light_tree tri-state; Cycles exposes only a "
+                 "use_light_tree bool (+light_sampling_threshold). Stays custom-only until reconciled (Stage 1 rule)."),
+]
+
+# ---------------------------------------------------------------------------
+# Light paths / bounces  (scene.cycles.*_bounces)
+# ---------------------------------------------------------------------------
+_LIGHT_PATHS = [
+    MappingEntry("light_paths", "max_bounces", "scene.cycles.max_bounces",
+                 "custom_raytracer.max_bounces", "render(max_bounces=...)", "direct", "DROPPED-SILENT",
+                 "Custom duplicate shadows native; Stage 1 reads scene.cycles.max_bounces."),
+    MappingEntry("light_paths", "diffuse_bounces", "scene.cycles.diffuse_bounces",
+                 "custom_raytracer.diffuse_bounces", "render(diffuse_bounces=...)", "direct", "DROPPED-SILENT",
+                 "Custom duplicate shadows native."),
+    MappingEntry("light_paths", "glossy_bounces", "scene.cycles.glossy_bounces",
+                 "custom_raytracer.glossy_bounces", "render(glossy_bounces=...)", "direct", "DROPPED-SILENT",
+                 "Custom duplicate shadows native."),
+    MappingEntry("light_paths", "transmission_bounces", "scene.cycles.transmission_bounces",
+                 "custom_raytracer.transmission_bounces", "render(transmission_bounces=...)", "direct", "DROPPED-SILENT",
+                 "Custom duplicate shadows native."),
+    MappingEntry("light_paths", "volume_bounces", "scene.cycles.volume_bounces",
+                 "custom_raytracer.volume_bounces", "render(volume_bounces=...)", "direct", "DROPPED-SILENT",
+                 "Custom duplicate shadows native; volume transport is itself only partially implemented."),
+    MappingEntry("light_paths", "transparent_max_bounces", "scene.cycles.transparent_max_bounces",
+                 "custom_raytracer.transparent_bounces", "render(transparent_bounces=...)", "direct", "DROPPED-SILENT",
+                 "NAME MISMATCH: custom prop is 'transparent_bounces', Cycles is 'transparent_max_bounces'."),
+    MappingEntry("light_paths", "sample_clamp_direct", "scene.cycles.sample_clamp_direct",
+                 "custom_raytracer.clamp_direct", "renderer.set_clamp_direct", "direct", "n/a",
+                 "Cycles prop is 'sample_clamp_direct'; 0 disables. Custom duplicate shadows it."),
+    MappingEntry("light_paths", "sample_clamp_indirect", "scene.cycles.sample_clamp_indirect",
+                 "custom_raytracer.clamp_indirect", "renderer.set_clamp_indirect", "direct", "n/a",
+                 "Cycles prop is 'sample_clamp_indirect'; 0 disables. Custom duplicate shadows it."),
+    MappingEntry("light_paths", "blur_glossy", "scene.cycles.blur_glossy",
+                 "custom_raytracer.filter_glossy", "renderer.set_filter_glossy", "direct", "n/a",
+                 "Cycles 'Filter Glossy' is the 'blur_glossy' prop. Custom duplicate shadows it."),
+    MappingEntry("light_paths", "caustics_reflective", "scene.cycles.caustics_reflective",
+                 "custom_raytracer.use_reflective_caustics", "renderer.set_use_reflective_caustics",
+                 "direct", "DROPPED-SILENT", "Custom duplicate shadows native."),
+    MappingEntry("light_paths", "caustics_refractive", "scene.cycles.caustics_refractive",
+                 "custom_raytracer.use_refractive_caustics", "renderer.set_use_refractive_caustics",
+                 "direct", "DROPPED-SILENT", "Custom duplicate shadows native."),
+    MappingEntry("light_paths", "use_fast_gi", "scene.cycles.use_fast_gi", "",
+                 "(none)", "dropped", "DROPPED-SILENT",
+                 "Fast GI approximation not implemented; no engine target."),
+    MappingEntry("light_paths", "world_max_bounces", "scene.world.light_settings.max_bounces", "",
+                 "renderer.set_world_max_bounces", "direct", "n/a",
+                 "Read natively today from world.light_settings.max_bounces."),
+]
+
+# ---------------------------------------------------------------------------
+# Film / color management  (scene.render.* + scene.cycles.film_* + scene.view_settings.*)
+# ---------------------------------------------------------------------------
+_FILM_COLOR = [
+    MappingEntry("film", "film_exposure", "scene.cycles.film_exposure", "",
+                 "renderer.set_film_exposure", "direct", "DROPPED-SILENT",
+                 "pkg119-A marked DROPPED; addon NOW reads scene.cycles.film_exposure natively."),
+    MappingEntry("film", "film_transparent", "scene.render.film_transparent", "",
+                 "renderer.set_use_transparent_film", "direct", "SUPPORTED",
+                 "Read natively from scene.render.film_transparent."),
+    MappingEntry("film", "film_transparent_glass", "scene.cycles.film_transparent_glass", "",
+                 "renderer.set_transparent_glass", "direct", "n/a",
+                 "Read natively from scene.cycles.film_transparent_glass."),
+    MappingEntry("color_mgmt", "view_transform", "scene.view_settings.view_transform", "",
+                 "(none)", "dropped", "n/a",
+                 "GAP: engine applies its own gamma (render applyGamma) and ignores AgX/Filmic view "
+                 "transforms. Not in pkg119-A allow-list; steering wheel needs it (Stage 3 + pkg119-C)."),
+    MappingEntry("color_mgmt", "look", "scene.view_settings.look", "",
+                 "(none)", "dropped", "n/a", "Color-management 'look' contrast presets ignored."),
+    MappingEntry("color_mgmt", "exposure", "scene.view_settings.exposure", "",
+                 "(none)", "dropped", "n/a",
+                 "View-transform exposure (stops) is distinct from cycles.film_exposure; currently ignored."),
+    MappingEntry("color_mgmt", "gamma", "scene.view_settings.gamma", "",
+                 "(none)", "dropped", "n/a", "Color-management gamma ignored (engine gamma is fixed)."),
+]
+
+# ---------------------------------------------------------------------------
+# Denoising  (scene.cycles.*)
+# ---------------------------------------------------------------------------
+_DENOISING = [
+    MappingEntry("denoising", "use_denoising", "scene.cycles.use_denoising",
+                 "custom_raytracer.use_denoising", "render_denoise_pass", "direct", "SUPPORTED",
+                 "Custom duplicate shadows native final-render denoise toggle."),
+    MappingEntry("denoising", "denoiser", "scene.cycles.denoiser",
+                 "custom_raytracer.denoiser_backend", "resolve_denoiser_pass", "approximated", "SUPPORTED",
+                 "Cycles enum OPTIX/OPENIMAGEDENOISE maps to Astroray auto/optix/oidn; Astroray adds 'auto'."),
+    MappingEntry("denoising", "use_preview_denoising", "scene.cycles.use_preview_denoising",
+                 "custom_raytracer.viewport_oidn", "viewport denoise", "approximated", "n/a",
+                 "Viewport denoise toggle; native counterpart is use_preview_denoising."),
+    MappingEntry("denoising", "denoising_input_passes", "scene.cycles.denoising_input_passes", "",
+                 "(none)", "dropped", "DROPPED-SILENT",
+                 "Albedo/normal guide-pass selection not exposed to the denoiser call."),
+]
+
+# ---------------------------------------------------------------------------
+# World  (scene.world node tree)
+# ---------------------------------------------------------------------------
+_WORLD = [
+    MappingEntry("world", "use_nodes", "scene.world.use_nodes", "",
+                 "setup_world (node walk)", "direct", "SUPPORTED",
+                 "World node tree is the sole source; TEX_ENVIRONMENT/BACKGROUND/MAPPING walked (pkg63)."),
+    MappingEntry("world", "background_strength", "world BACKGROUND node Strength", "",
+                 "load_environment_map / set_background_color", "direct", "n/a",
+                 "Read from the world node tree, not a datablock prop."),
+    MappingEntry("world", "background_color", "world BACKGROUND node Color", "",
+                 "set_background_color / HDRI tint", "direct", "n/a",
+                 "Solid bg when no HDRI; multiplicative tint when HDRI present."),
+    MappingEntry("world", "mapping_rotation", "world MAPPING node Rotation", "",
+                 "load_environment_map (baked rotation)", "direct", "n/a",
+                 "XYZ Euler baked into HDRI rotation matrix."),
+]
+
+# ---------------------------------------------------------------------------
+# Camera datablock  (scene.camera.data.*)
+# ---------------------------------------------------------------------------
+_CAMERA = [
+    MappingEntry("camera", "lens", "camera.data.lens", "", "setup_camera(vfov)", "direct", "SUPPORTED",
+                 "Focal length -> vertical FOV via sensor fit."),
+    MappingEntry("camera", "sensor_width", "camera.data.sensor_width", "", "setup_camera", "direct", "SUPPORTED", ""),
+    MappingEntry("camera", "sensor_height", "camera.data.sensor_height", "", "setup_camera", "direct", "SUPPORTED", ""),
+    MappingEntry("camera", "shift_x", "camera.data.shift_x", "", "setup_camera", "direct", "SUPPORTED", ""),
+    MappingEntry("camera", "shift_y", "camera.data.shift_y", "", "setup_camera", "direct", "SUPPORTED", ""),
+    MappingEntry("camera", "aperture_fstop", "camera.data.dof.aperture_fstop", "",
+                 "setup_camera (DoF)", "direct", "SUPPORTED", "Thin-lens f-stop -> aperture radius."),
+    MappingEntry("camera", "aperture_blades", "camera.data.dof.aperture_blades", "",
+                 "(none)", "dropped", "DROPPED-SILENT", "Bokeh blade count ignored (circular aperture only)."),
+    MappingEntry("camera", "aperture_rotation", "camera.data.dof.aperture_rotation", "",
+                 "(none)", "dropped", "DROPPED-SILENT", "Bokeh rotation ignored."),
+    MappingEntry("camera", "aperture_ratio", "camera.data.dof.aperture_ratio", "",
+                 "(none)", "dropped", "DROPPED-SILENT", "Anamorphic bokeh ratio ignored."),
+    MappingEntry("camera", "type", "camera.data.type", "",
+                 "(none)", "dropped", "DROPPED-SILENT",
+                 "PERSP/ORTHO/PANO ignored; engine assumes perspective."),
+    MappingEntry("camera", "clip_start", "camera.data.clip_start", "",
+                 "(none)", "dropped", "DROPPED-SILENT", "Near clip ignored."),
+    MappingEntry("camera", "clip_end", "camera.data.clip_end", "",
+                 "(none)", "dropped", "DROPPED-SILENT", "Far clip ignored."),
+]
+
+# ---------------------------------------------------------------------------
+# Light datablocks  (one row per distinct property; applies across light types)
+# ---------------------------------------------------------------------------
+_LIGHT = [
+    MappingEntry("light", "energy", "light.data.energy", "", "add_*_light (power)", "direct", "SUPPORTED",
+                 "Applies to POINT/SUN/SPOT/AREA. Known ~3x energy-scale divergence vs Cycles (pkg89/pkg115)."),
+    MappingEntry("light", "color", "light.data.color", "", "add_*_light", "direct", "SUPPORTED",
+                 "All light types."),
+    MappingEntry("light", "use_temperature", "light.data.use_temperature", "", "add_*_light", "direct", "SUPPORTED",
+                 "Blackbody toggle; all types."),
+    MappingEntry("light", "temperature", "light.data.temperature", "", "add_*_light", "direct", "SUPPORTED",
+                 "Blackbody Kelvin; all types."),
+    MappingEntry("light", "shadow_soft_size", "light.data.shadow_soft_size", "", "add_point_light (radius)",
+                 "direct", "SUPPORTED", "POINT soft size."),
+    MappingEntry("light", "angle", "light.data.angle", "", "add_sun_light (angular radius)", "direct", "SUPPORTED",
+                 "SUN angular diameter."),
+    MappingEntry("light", "spot_size", "light.data.spot_size", "", "add_spot_light", "direct", "SUPPORTED", "SPOT cone."),
+    MappingEntry("light", "spot_blend", "light.data.spot_blend", "", "add_spot_light", "direct", "SUPPORTED", "SPOT falloff."),
+    MappingEntry("light", "shape", "light.data.shape", "", "add_area_light", "direct", "SUPPORTED", "AREA shape."),
+    MappingEntry("light", "size", "light.data.size", "", "add_area_light", "direct", "SUPPORTED", "AREA size."),
+    MappingEntry("light", "size_y", "light.data.size_y", "", "add_area_light", "direct", "SUPPORTED", "AREA size Y."),
+    MappingEntry("light", "spread", "light.data.spread", "", "add_area_light", "direct", "SUPPORTED", "AREA spread."),
+    MappingEntry("light", "specular_factor", "light.data.specular_factor", "",
+                 "(none)", "dropped", "DROPPED-SILENT",
+                 "Per-light specular multiplier ignored; all light types (POINT/SUN/SPOT/AREA)."),
+    MappingEntry("light", "show_cone", "light.data.show_cone", "",
+                 "(none)", "dropped", "DROPPED-SILENT", "SPOT viewport-only gizmo; not render-relevant."),
+]
+
+# ---------------------------------------------------------------------------
+# Material / socket layer (steering wheel = Principled BSDF sockets).
+# The FULL socket-level classification (461 shader-node rows) is the pkg119-A
+# matrix (docs/blender_parity/coverage_matrix.json / report.md) — the authoritative
+# source; it is NOT re-typed here. Below is the primary material steering wheel:
+# the Principled BSDF sockets Astroray honours, plus the notable dropped ones.
+# ---------------------------------------------------------------------------
+_MATERIAL_PRINCIPLED = [
+    MappingEntry("material", "Base Color", "Principled BSDF: Base Color", "",
+                 "material spec base_color", "direct", "SUPPORTED", ""),
+    MappingEntry("material", "Metallic", "Principled BSDF: Metallic", "",
+                 "material spec metallic", "direct", "SUPPORTED", ""),
+    MappingEntry("material", "Roughness", "Principled BSDF: Roughness", "",
+                 "material spec roughness", "direct", "SUPPORTED", ""),
+    MappingEntry("material", "IOR", "Principled BSDF: IOR", "",
+                 "material spec ior", "direct", "SUPPORTED", ""),
+    MappingEntry("material", "Normal", "Principled BSDF: Normal", "",
+                 "material spec normal map", "direct", "SUPPORTED", ""),
+    MappingEntry("material", "Anisotropic", "Principled BSDF: Anisotropic", "",
+                 "material spec anisotropy", "direct", "SUPPORTED", ""),
+    MappingEntry("material", "Subsurface Weight", "Principled BSDF: Subsurface Weight", "",
+                 "material spec subsurface", "direct", "SUPPORTED", ""),
+    MappingEntry("material", "Transmission Weight", "Principled BSDF: Transmission Weight", "",
+                 "material spec transmission", "direct", "SUPPORTED", ""),
+    MappingEntry("material", "Coat Weight", "Principled BSDF: Coat Weight", "",
+                 "material spec coat", "direct", "SUPPORTED", ""),
+    MappingEntry("material", "Coat Roughness", "Principled BSDF: Coat Roughness", "",
+                 "material spec coat_roughness", "direct", "SUPPORTED", ""),
+    MappingEntry("material", "Sheen Weight", "Principled BSDF: Sheen Weight", "",
+                 "material spec sheen", "direct", "SUPPORTED", ""),
+    MappingEntry("material", "Emission Color", "Principled BSDF: Emission Color", "",
+                 "material spec emission", "direct", "SUPPORTED", ""),
+    MappingEntry("material", "Emission Strength", "Principled BSDF: Emission Strength", "",
+                 "material spec emission_strength", "direct", "SUPPORTED", ""),
+    MappingEntry("material", "Alpha", "Principled BSDF: Alpha", "",
+                 "(none)", "dropped", "DROPPED-SILENT",
+                 "Alpha transparency socket ignored; representative of the DROPPED Principled sockets "
+                 "(Specular IOR Level, Coat IOR/Tint/Normal, Sheen Roughness/Tint, Thin Film, "
+                 "Subsurface Radius/Scale/IOR/Anisotropy, Anisotropic Rotation, Diffuse Roughness). "
+                 "See pkg119-A matrix for the full per-socket list."),
+]
+
+# ---------------------------------------------------------------------------
+# ASTRORAY-ONLY  (genuinely engine-unique; no native Blender home; stays on the
+# single custom 'Astroray' panel after Stage 4 retirement).
+# ---------------------------------------------------------------------------
+_ASTRORAY_ONLY = [
+    MappingEntry("astroray_only", "wavelength_preset", "", "custom_raytracer.wavelength_preset",
+                 "wavelength band + integrator selection", "astroray-only", "n/a",
+                 "Spectral render band (visible/near_ir/uv/custom); no Cycles equivalent."),
+    MappingEntry("astroray_only", "wavelength_min", "", "custom_raytracer.wavelength_min",
+                 "wavelength band min (nm)", "astroray-only", "n/a", "Custom spectral band lower bound."),
+    MappingEntry("astroray_only", "wavelength_max", "", "custom_raytracer.wavelength_max",
+                 "wavelength band max (nm)", "astroray-only", "n/a", "Custom spectral band upper bound."),
+    MappingEntry("astroray_only", "colourmap", "", "custom_raytracer.colourmap",
+                 "output colourmap", "astroray-only", "n/a", "False-colour palette for non-visible renders."),
+    MappingEntry("astroray_only", "integrator_type", "", "custom_raytracer.integrator_type",
+                 "render(integrator=...)", "astroray-only", "n/a",
+                 "Plugin-registry integrator selector; Cycles has no equivalent (progressive/branched removed)."),
+    MappingEntry("astroray_only", "device_mode", "scene.cycles.device", "custom_raytracer.device_mode",
+                 "renderer.set_use_gpu", "astroray-only", "n/a",
+                 "SEMANTIC MISMATCH: native scene.cycles.device is CPU/GPU only; Astroray adds an 'auto' "
+                 "safe-fallback tri-state. Kept custom until reconciled (Stage 1 mismatch rule)."),
+    MappingEntry("astroray_only", "viewport_display_pass", "", "custom_raytracer.viewport_display_pass",
+                 "viewport pass selector", "astroray-only", "n/a", "Which AOV to show in the viewport; engine-specific."),
+    MappingEntry("astroray_only", "cryptomatte_depth", "view_layer.pass_cryptomatte_depth",
+                 "custom_raytracer.cryptomatte_depth", "cryptomatte depth", "approximated", "n/a",
+                 "Native counterpart exists (view_layer.pass_cryptomatte_depth); currently a custom duplicate."),
+    MappingEntry("astroray_only", "black_hole", "", "object.astroray_black_hole (PropertyGroup)",
+                 "GR/accretion object params", "astroray-only", "n/a",
+                 "GR/Kerr black-hole objects (mass/spin/accretion model/jets); wholly engine-unique."),
+    MappingEntry("astroray_only", "is_caustic_caster", "", "object.astroray (is_caustic_caster)",
+                 "SMS caustic caster opt-in", "astroray-only", "n/a",
+                 "Loosely mirrors Cycles is_caustics_caster but is an Astroray SMS opt-in (behaviour only)."),
+]
+
+
+MAPPING: list[MappingEntry] = (
+    _RENDER_SAMPLING
+    + _LIGHT_PATHS
+    + _FILM_COLOR
+    + _DENOISING
+    + _WORLD
+    + _CAMERA
+    + _LIGHT
+    + _MATERIAL_PRINCIPLED
+    + _ASTRORAY_ONLY
+)
+
+
+def by_status(status: str) -> list[MappingEntry]:
+    """All mapping entries with the given translation status."""
+    return [e for e in MAPPING if e.status == status]
+
+
+def by_category(category: str) -> list[MappingEntry]:
+    """All mapping entries in the given category."""
+    return [e for e in MAPPING if e.category == category]

--- a/docs/blender_parity/pkg176_stage0_mapping.md
+++ b/docs/blender_parity/pkg176_stage0_mapping.md
@@ -6,6 +6,24 @@ This is the **owner-review anchor** for pkg176. It records, for every native Ble
 
 **Grounding:** the `status` / `pkg119a` columns reuse the pkg119 Phase A coverage matrix (`docs/blender_parity/coverage_matrix.json` — 117 SUPPORTED / 22 APPROXIMATED / 385 DROPPED-SILENT). `pkg119a` is kept verbatim as the audit anchor; `status` reflects current translation reality (some natives were wired after PR #487 — noted per-row).
 
+## Stage-1 retirement policy — OWNER RATIFIED 2026-08-08
+
+The owner ratified the direction for Stage 1 (consistent with the pkg177
+Route-1 "Cycles-as-steering-wheel" charter):
+
+> **Adopt native and retire custom for every setting that has a Cycles
+> equivalent.** Where a `scene.cycles.*` / `scene.render.*` native control
+> exists, Stage 1 reads it directly and the duplicate `custom_raytracer.*`
+> prop is retired (its durable value preserved at the neutral target — Route-2
+> rule). **Astroray-only settings** (spectral pipeline, GR, device/backend,
+> integrator choice — the `astroray-only` rows) keep their own custom panel;
+> they have no native home and are NOT candidates for retirement.
+
+Practical read of the table under this policy: every `direct`/`approximated`
+row whose **Current custom prop** column names a `custom_raytracer.*` duplicate
+is a **Stage-1 retire-and-adopt-native** item; every `astroray-only` row stays
+custom. This is the charter Stage 1 executes against.
+
 ## Summary
 
 - **direct**: 58

--- a/docs/blender_parity/pkg176_stage0_mapping.md
+++ b/docs/blender_parity/pkg176_stage0_mapping.md
@@ -1,0 +1,182 @@
+# pkg176 Stage 0 — Cycles-settings -> Astroray mapping table (owner-review artifact)
+
+**Human-readable mirror of** `blender_addon/settings_map.py` — that module is the machine-readable single source of truth. Edit the `.py` and re-mirror; do not hand-edit the rows below.
+
+This is the **owner-review anchor** for pkg176. It records, for every native Blender/Cycles setting the steering wheel needs, the host-neutral Astroray engine/session target and whether the mapping is **direct**, **approximated**, **dropped**, or has no native home (**astroray-only**). No silent mapping decisions: every opinionated call (which `scene.cycles.*` props Astroray may read; every semantic mismatch) is a row here for the owner to ratify.
+
+**Grounding:** the `status` / `pkg119a` columns reuse the pkg119 Phase A coverage matrix (`docs/blender_parity/coverage_matrix.json` — 117 SUPPORTED / 22 APPROXIMATED / 385 DROPPED-SILENT). `pkg119a` is kept verbatim as the audit anchor; `status` reflects current translation reality (some natives were wired after PR #487 — noted per-row).
+
+## Summary
+
+- **direct**: 58
+- **approximated**: 4
+- **dropped**: 19
+- **astroray-only**: 9
+- **total rows**: 90
+
+The full 461-row shader-node socket classification is NOT duplicated here; it is the pkg119-A matrix (`docs/blender_parity/report.md`). The Material section below is the primary material steering wheel (Principled BSDF).
+
+## Status vocabulary
+
+| status | meaning |
+|---|---|
+| `direct` | native value drives the neutral param 1:1 (unit-exact / trivial conversion). |
+| `approximated` | drives a nearest engine behaviour; lossy or semantically narrower/wider — must warn (pkg119-C) once wired. |
+| `dropped` | no engine target today; DROPPED-SILENT in pkg119-A. Steering wheel must stop dropping silently (Stage 1/3 + pkg119-C). |
+| `astroray-only` | engine-unique control, no native Blender home; stays on the single custom Astroray panel (Stage 4). |
+
+## Render (scene.render.*)
+
+| Native Blender/Cycles | Current custom prop | Astroray target (neutral) | Status | pkg119-A | Note |
+|---|---|---|---|---|---|
+| `scene.render.resolution_x` | `—` | `render(width=...)` | direct | n/a | Read natively today (x resolution_percentage); not a custom duplicate. |
+| `scene.render.resolution_y` | `—` | `render(height=...)` | direct | n/a | Read natively today (x resolution_percentage). |
+
+## Sampling (scene.cycles.* / scene.render.*)
+
+| Native Blender/Cycles | Current custom prop | Astroray target (neutral) | Status | pkg119-A | Note |
+|---|---|---|---|---|---|
+| `scene.cycles.samples` | `custom_raytracer.samples` | `render(samples=...)` | direct | SUPPORTED | Custom duplicate shadows native; Stage 1 reads scene.cycles.samples. |
+| `scene.cycles.preview_samples` | `custom_raytracer.preview_samples` | `render(samples=...) [viewport]` | direct | n/a | Viewport spp; native Cycles preview_samples is the counterpart. |
+| `scene.cycles.use_adaptive_sampling` | `custom_raytracer.use_adaptive_sampling` | `(none)` | dropped | DROPPED-SILENT | Custom toggle exists but is not plumbed to the engine; no adaptive-sampling session arg yet. |
+| `scene.cycles.adaptive_threshold` | `custom_raytracer.adaptive_threshold` | `(none)` | dropped | DROPPED-SILENT | Noise threshold; no engine target (adaptive sampling not wired). |
+| `scene.cycles.adaptive_min_samples` | `—` | `(none)` | dropped | DROPPED-SILENT | No custom prop and no engine target. |
+| `scene.cycles.seed` | `—` | `renderer.set_seed` | direct | DROPPED-SILENT | pkg119-A marked DROPPED; addon NOW reads scene.cycles.seed natively (+use_animated_seed). Seed 0 = engine random sentinel (raytracer.h). |
+| `scene.cycles.sample_offset` | `—` | `(none)` | dropped | DROPPED-SILENT | Sample-offset for tiled/distributed render; no engine target. |
+| `scene.cycles.pixel_filter_type` | `—` | `renderer.set_pixel_filter` | direct | n/a | Read natively today; BOX/GAUSSIAN/BLACKMAN_HARRIS -> 0/1/2. |
+| `scene.cycles.filter_width` | `—` | `renderer.set_pixel_filter` | direct | DROPPED-SILENT | pkg119-A marked DROPPED; addon NOW reads scene.cycles.filter_width natively. |
+| `scene.cycles.use_light_tree` | `custom_raytracer.light_sampler` | `renderer.set_light_sampler` | approximated | n/a | SEMANTIC MISMATCH: Astroray has uniform/power/light_tree tri-state; Cycles exposes only a use_light_tree bool (+light_sampling_threshold). Stays custom-only until reconciled (Stage 1 rule). |
+
+## Light Paths & Clamping (scene.cycles.*)
+
+| Native Blender/Cycles | Current custom prop | Astroray target (neutral) | Status | pkg119-A | Note |
+|---|---|---|---|---|---|
+| `scene.cycles.max_bounces` | `custom_raytracer.max_bounces` | `render(max_bounces=...)` | direct | DROPPED-SILENT | Custom duplicate shadows native; Stage 1 reads scene.cycles.max_bounces. |
+| `scene.cycles.diffuse_bounces` | `custom_raytracer.diffuse_bounces` | `render(diffuse_bounces=...)` | direct | DROPPED-SILENT | Custom duplicate shadows native. |
+| `scene.cycles.glossy_bounces` | `custom_raytracer.glossy_bounces` | `render(glossy_bounces=...)` | direct | DROPPED-SILENT | Custom duplicate shadows native. |
+| `scene.cycles.transmission_bounces` | `custom_raytracer.transmission_bounces` | `render(transmission_bounces=...)` | direct | DROPPED-SILENT | Custom duplicate shadows native. |
+| `scene.cycles.volume_bounces` | `custom_raytracer.volume_bounces` | `render(volume_bounces=...)` | direct | DROPPED-SILENT | Custom duplicate shadows native; volume transport is itself only partially implemented. |
+| `scene.cycles.transparent_max_bounces` | `custom_raytracer.transparent_bounces` | `render(transparent_bounces=...)` | direct | DROPPED-SILENT | NAME MISMATCH: custom prop is 'transparent_bounces', Cycles is 'transparent_max_bounces'. |
+| `scene.cycles.sample_clamp_direct` | `custom_raytracer.clamp_direct` | `renderer.set_clamp_direct` | direct | n/a | Cycles prop is 'sample_clamp_direct'; 0 disables. Custom duplicate shadows it. |
+| `scene.cycles.sample_clamp_indirect` | `custom_raytracer.clamp_indirect` | `renderer.set_clamp_indirect` | direct | n/a | Cycles prop is 'sample_clamp_indirect'; 0 disables. Custom duplicate shadows it. |
+| `scene.cycles.blur_glossy` | `custom_raytracer.filter_glossy` | `renderer.set_filter_glossy` | direct | n/a | Cycles 'Filter Glossy' is the 'blur_glossy' prop. Custom duplicate shadows it. |
+| `scene.cycles.caustics_reflective` | `custom_raytracer.use_reflective_caustics` | `renderer.set_use_reflective_caustics` | direct | DROPPED-SILENT | Custom duplicate shadows native. |
+| `scene.cycles.caustics_refractive` | `custom_raytracer.use_refractive_caustics` | `renderer.set_use_refractive_caustics` | direct | DROPPED-SILENT | Custom duplicate shadows native. |
+| `scene.cycles.use_fast_gi` | `—` | `(none)` | dropped | DROPPED-SILENT | Fast GI approximation not implemented; no engine target. |
+| `scene.world.light_settings.max_bounces` | `—` | `renderer.set_world_max_bounces` | direct | n/a | Read natively today from world.light_settings.max_bounces. |
+
+## Film (scene.render.* / scene.cycles.film_*)
+
+| Native Blender/Cycles | Current custom prop | Astroray target (neutral) | Status | pkg119-A | Note |
+|---|---|---|---|---|---|
+| `scene.cycles.film_exposure` | `—` | `renderer.set_film_exposure` | direct | DROPPED-SILENT | pkg119-A marked DROPPED; addon NOW reads scene.cycles.film_exposure natively. |
+| `scene.render.film_transparent` | `—` | `renderer.set_use_transparent_film` | direct | SUPPORTED | Read natively from scene.render.film_transparent. |
+| `scene.cycles.film_transparent_glass` | `—` | `renderer.set_transparent_glass` | direct | n/a | Read natively from scene.cycles.film_transparent_glass. |
+
+## Color Management (scene.view_settings.*)  — GAP class
+
+| Native Blender/Cycles | Current custom prop | Astroray target (neutral) | Status | pkg119-A | Note |
+|---|---|---|---|---|---|
+| `scene.view_settings.view_transform` | `—` | `(none)` | dropped | n/a | GAP: engine applies its own gamma (render applyGamma) and ignores AgX/Filmic view transforms. Not in pkg119-A allow-list; steering wheel needs it (Stage 3 + pkg119-C). |
+| `scene.view_settings.look` | `—` | `(none)` | dropped | n/a | Color-management 'look' contrast presets ignored. |
+| `scene.view_settings.exposure` | `—` | `(none)` | dropped | n/a | View-transform exposure (stops) is distinct from cycles.film_exposure; currently ignored. |
+| `scene.view_settings.gamma` | `—` | `(none)` | dropped | n/a | Color-management gamma ignored (engine gamma is fixed). |
+
+## Denoising (scene.cycles.*)
+
+| Native Blender/Cycles | Current custom prop | Astroray target (neutral) | Status | pkg119-A | Note |
+|---|---|---|---|---|---|
+| `scene.cycles.use_denoising` | `custom_raytracer.use_denoising` | `render_denoise_pass` | direct | SUPPORTED | Custom duplicate shadows native final-render denoise toggle. |
+| `scene.cycles.denoiser` | `custom_raytracer.denoiser_backend` | `resolve_denoiser_pass` | approximated | SUPPORTED | Cycles enum OPTIX/OPENIMAGEDENOISE maps to Astroray auto/optix/oidn; Astroray adds 'auto'. |
+| `scene.cycles.use_preview_denoising` | `custom_raytracer.viewport_oidn` | `viewport denoise` | approximated | n/a | Viewport denoise toggle; native counterpart is use_preview_denoising. |
+| `scene.cycles.denoising_input_passes` | `—` | `(none)` | dropped | DROPPED-SILENT | Albedo/normal guide-pass selection not exposed to the denoiser call. |
+
+## World (scene.world node tree)
+
+| Native Blender/Cycles | Current custom prop | Astroray target (neutral) | Status | pkg119-A | Note |
+|---|---|---|---|---|---|
+| `scene.world.use_nodes` | `—` | `setup_world (node walk)` | direct | SUPPORTED | World node tree is the sole source; TEX_ENVIRONMENT/BACKGROUND/MAPPING walked (pkg63). |
+| `world BACKGROUND node Strength` | `—` | `load_environment_map / set_background_color` | direct | n/a | Read from the world node tree, not a datablock prop. |
+| `world BACKGROUND node Color` | `—` | `set_background_color / HDRI tint` | direct | n/a | Solid bg when no HDRI; multiplicative tint when HDRI present. |
+| `world MAPPING node Rotation` | `—` | `load_environment_map (baked rotation)` | direct | n/a | XYZ Euler baked into HDRI rotation matrix. |
+
+## Camera datablock (camera.data.*)
+
+| Native Blender/Cycles | Current custom prop | Astroray target (neutral) | Status | pkg119-A | Note |
+|---|---|---|---|---|---|
+| `camera.data.lens` | `—` | `setup_camera(vfov)` | direct | SUPPORTED | Focal length -> vertical FOV via sensor fit. |
+| `camera.data.sensor_width` | `—` | `setup_camera` | direct | SUPPORTED |  |
+| `camera.data.sensor_height` | `—` | `setup_camera` | direct | SUPPORTED |  |
+| `camera.data.shift_x` | `—` | `setup_camera` | direct | SUPPORTED |  |
+| `camera.data.shift_y` | `—` | `setup_camera` | direct | SUPPORTED |  |
+| `camera.data.dof.aperture_fstop` | `—` | `setup_camera (DoF)` | direct | SUPPORTED | Thin-lens f-stop -> aperture radius. |
+| `camera.data.dof.aperture_blades` | `—` | `(none)` | dropped | DROPPED-SILENT | Bokeh blade count ignored (circular aperture only). |
+| `camera.data.dof.aperture_rotation` | `—` | `(none)` | dropped | DROPPED-SILENT | Bokeh rotation ignored. |
+| `camera.data.dof.aperture_ratio` | `—` | `(none)` | dropped | DROPPED-SILENT | Anamorphic bokeh ratio ignored. |
+| `camera.data.type` | `—` | `(none)` | dropped | DROPPED-SILENT | PERSP/ORTHO/PANO ignored; engine assumes perspective. |
+| `camera.data.clip_start` | `—` | `(none)` | dropped | DROPPED-SILENT | Near clip ignored. |
+| `camera.data.clip_end` | `—` | `(none)` | dropped | DROPPED-SILENT | Far clip ignored. |
+
+## Lights (light.data.*, across POINT/SUN/SPOT/AREA)
+
+| Native Blender/Cycles | Current custom prop | Astroray target (neutral) | Status | pkg119-A | Note |
+|---|---|---|---|---|---|
+| `light.data.energy` | `—` | `add_*_light (power)` | direct | SUPPORTED | Applies to POINT/SUN/SPOT/AREA. Known ~3x energy-scale divergence vs Cycles (pkg89/pkg115). |
+| `light.data.color` | `—` | `add_*_light` | direct | SUPPORTED | All light types. |
+| `light.data.use_temperature` | `—` | `add_*_light` | direct | SUPPORTED | Blackbody toggle; all types. |
+| `light.data.temperature` | `—` | `add_*_light` | direct | SUPPORTED | Blackbody Kelvin; all types. |
+| `light.data.shadow_soft_size` | `—` | `add_point_light (radius)` | direct | SUPPORTED | POINT soft size. |
+| `light.data.angle` | `—` | `add_sun_light (angular radius)` | direct | SUPPORTED | SUN angular diameter. |
+| `light.data.spot_size` | `—` | `add_spot_light` | direct | SUPPORTED | SPOT cone. |
+| `light.data.spot_blend` | `—` | `add_spot_light` | direct | SUPPORTED | SPOT falloff. |
+| `light.data.shape` | `—` | `add_area_light` | direct | SUPPORTED | AREA shape. |
+| `light.data.size` | `—` | `add_area_light` | direct | SUPPORTED | AREA size. |
+| `light.data.size_y` | `—` | `add_area_light` | direct | SUPPORTED | AREA size Y. |
+| `light.data.spread` | `—` | `add_area_light` | direct | SUPPORTED | AREA spread. |
+| `light.data.specular_factor` | `—` | `(none)` | dropped | DROPPED-SILENT | Per-light specular multiplier ignored; all light types (POINT/SUN/SPOT/AREA). |
+| `light.data.show_cone` | `—` | `(none)` | dropped | DROPPED-SILENT | SPOT viewport-only gizmo; not render-relevant. |
+
+## Material — Principled BSDF steering wheel (full socket list: pkg119-A matrix)
+
+| Native Blender/Cycles | Current custom prop | Astroray target (neutral) | Status | pkg119-A | Note |
+|---|---|---|---|---|---|
+| `Principled BSDF: Base Color` | `—` | `material spec base_color` | direct | SUPPORTED |  |
+| `Principled BSDF: Metallic` | `—` | `material spec metallic` | direct | SUPPORTED |  |
+| `Principled BSDF: Roughness` | `—` | `material spec roughness` | direct | SUPPORTED |  |
+| `Principled BSDF: IOR` | `—` | `material spec ior` | direct | SUPPORTED |  |
+| `Principled BSDF: Normal` | `—` | `material spec normal map` | direct | SUPPORTED |  |
+| `Principled BSDF: Anisotropic` | `—` | `material spec anisotropy` | direct | SUPPORTED |  |
+| `Principled BSDF: Subsurface Weight` | `—` | `material spec subsurface` | direct | SUPPORTED |  |
+| `Principled BSDF: Transmission Weight` | `—` | `material spec transmission` | direct | SUPPORTED |  |
+| `Principled BSDF: Coat Weight` | `—` | `material spec coat` | direct | SUPPORTED |  |
+| `Principled BSDF: Coat Roughness` | `—` | `material spec coat_roughness` | direct | SUPPORTED |  |
+| `Principled BSDF: Sheen Weight` | `—` | `material spec sheen` | direct | SUPPORTED |  |
+| `Principled BSDF: Emission Color` | `—` | `material spec emission` | direct | SUPPORTED |  |
+| `Principled BSDF: Emission Strength` | `—` | `material spec emission_strength` | direct | SUPPORTED |  |
+| `Principled BSDF: Alpha` | `—` | `(none)` | dropped | DROPPED-SILENT | Alpha transparency socket ignored; representative of the DROPPED Principled sockets (Specular IOR Level, Coat IOR/Tint/Normal, Sheen Roughness/Tint, Thin Film, Subsurface Radius/Scale/IOR/Anisotropy, Anisotropic Rotation, Diffuse Roughness). See pkg119-A matrix for the full per-socket list. |
+
+## ASTRORAY-ONLY (no native home; stays on the one custom panel)
+
+| Native Blender/Cycles | Current custom prop | Astroray target (neutral) | Status | pkg119-A | Note |
+|---|---|---|---|---|---|
+| `wavelength_preset` | `custom_raytracer.wavelength_preset` | `wavelength band + integrator selection` | astroray-only | n/a | Spectral render band (visible/near_ir/uv/custom); no Cycles equivalent. |
+| `wavelength_min` | `custom_raytracer.wavelength_min` | `wavelength band min (nm)` | astroray-only | n/a | Custom spectral band lower bound. |
+| `wavelength_max` | `custom_raytracer.wavelength_max` | `wavelength band max (nm)` | astroray-only | n/a | Custom spectral band upper bound. |
+| `colourmap` | `custom_raytracer.colourmap` | `output colourmap` | astroray-only | n/a | False-colour palette for non-visible renders. |
+| `integrator_type` | `custom_raytracer.integrator_type` | `render(integrator=...)` | astroray-only | n/a | Plugin-registry integrator selector; Cycles has no equivalent (progressive/branched removed). |
+| `scene.cycles.device` | `custom_raytracer.device_mode` | `renderer.set_use_gpu` | astroray-only | n/a | SEMANTIC MISMATCH: native scene.cycles.device is CPU/GPU only; Astroray adds an 'auto' safe-fallback tri-state. Kept custom until reconciled (Stage 1 mismatch rule). |
+| `viewport_display_pass` | `custom_raytracer.viewport_display_pass` | `viewport pass selector` | astroray-only | n/a | Which AOV to show in the viewport; engine-specific. |
+| `view_layer.pass_cryptomatte_depth` | `custom_raytracer.cryptomatte_depth` | `cryptomatte depth` | approximated | n/a | Native counterpart exists (view_layer.pass_cryptomatte_depth); currently a custom duplicate. |
+| `black_hole` | `object.astroray_black_hole (PropertyGroup)` | `GR/accretion object params` | astroray-only | n/a | GR/Kerr black-hole objects (mass/spin/accretion model/jets); wholly engine-unique. |
+| `is_caustic_caster` | `object.astroray (is_caustic_caster)` | `SMS caustic caster opt-in` | astroray-only | n/a | Loosely mirrors Cycles is_caustics_caster but is an Astroray SMS opt-in (behaviour only). |
+
+## Route-2 session-boundary compliance (dcc-integration-decision-2026-08 §6)
+
+The Stage-0 design was checked against all five owner-ratified (2026-08-08) hard rules:
+
+1. **No `bpy` below the translation line.** `settings_map.py` is pure data and imports no `bpy`; enforced by `test_source_has_no_bpy_import`.
+2. **Session surface stays host-neutral.** The `Astroray target` column names Renderer setters / `render()` args / neutral phrases — never a `scene.cycles.*` property group or datablock; spot-checked by `test_neutral_targets_are_host_neutral`.
+3. **The mapping table is the single source of translation policy, on the translator side.** It lives in `blender_addon/settings_map.py` (translator side); later stages import it. A second host reads this table to learn what Blender's steering wheel meant.
+4. **Retirement preserves neutral values.** Every `direct`/`approximated` row already names a durable `neutral_param`; Stage 4 collapses the `custom_prop` duplicate into the native read *above* the boundary without removing any engine capability below it.
+5. **No standalone C API / second-consumer framework.** Stage 0 adds a data module, a doc, and a test — no framework, no C API.
+

--- a/scripts/build/build_blender_addon.py
+++ b/scripts/build/build_blender_addon.py
@@ -73,7 +73,8 @@ BUILD_DIR: Path = REPO_ROOT / "build_blender_addon"  # overwritten in main()
 # ignored — test scenes, backups, __pycache__, ...).
 ADDON_FILES = ["__init__.py", "blender_manifest.toml", "shader_blending.py",
                "_bulk_geometry.py",   # pkg112 batched geometry upload
-               "exporter.py"]         # pkg116 viewport-sync exporter
+               "exporter.py",         # pkg116 viewport-sync exporter
+               "settings_map.py"]     # pkg176 Stage-0 mapping data (inert; Stage 1 consumes it)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_pkg176_settings_map.py
+++ b/tests/test_pkg176_settings_map.py
@@ -1,0 +1,119 @@
+"""pkg176 Stage 0 — validate the settings mapping table's shape and coverage.
+
+CPU/collection-level only: this exercises the inert data module
+``blender_addon/settings_map.py`` and cross-checks it against the pkg119 Phase A
+coverage matrix. No Blender, no engine, no GPU.
+
+It also mechanically enforces the two Route-2 hard rules the table itself must
+honour (dcc-integration-decision-2026-08 §6): the translator-side data module
+must NOT import ``bpy`` (rule 1), and its neutral targets must not name Blender
+datablocks (rule 2, spot-checked).
+"""
+
+import json
+import pathlib
+
+import pytest
+
+_ADDON = pathlib.Path(__file__).resolve().parents[1] / "blender_addon"
+_MATRIX = pathlib.Path(__file__).resolve().parents[1] / "docs" / "blender_parity" / "coverage_matrix.json"
+
+
+def _load_module():
+    """Import settings_map.py directly from blender_addon/ without importing the
+    addon package (which would pull in bpy)."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "pkg176_settings_map", _ADDON / "settings_map.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+sm = _load_module()
+
+
+def test_table_nonempty():
+    assert len(sm.MAPPING) >= 60, "steering-wheel table should cover the core native surface"
+
+
+def test_every_row_shape_valid():
+    for e in sm.MAPPING:
+        assert e.status in sm.STATUS_VALUES, f"{e.native_prop}: bad status {e.status!r}"
+        assert e.pkg119a in sm.PKG119A_VALUES, f"{e.native_prop}: bad pkg119a {e.pkg119a!r}"
+        assert e.category, f"{e.native_prop}: empty category"
+        # A row must name at least one side of the correspondence.
+        assert e.native_prop or e.cycles_path or e.custom_prop, "row names nothing"
+        # astroray-only rows have no direct/approximated engine claim of a native
+        # 1:1; every non-dropped, non-astroray row must name a neutral target.
+        if e.status in ("direct", "approximated"):
+            assert e.neutral_param and e.neutral_param != "(none)", (
+                f"{e.native_prop}: {e.status} row must name a neutral engine target"
+            )
+        if e.status == "dropped":
+            assert e.neutral_param == "(none)", (
+                f"{e.native_prop}: dropped row must have no engine target"
+            )
+
+
+def test_source_has_no_bpy_import():
+    """Route-2 rule 1: the translator-side data module must not import bpy."""
+    src = (_ADDON / "settings_map.py").read_text(encoding="utf-8")
+    for line in src.splitlines():
+        stripped = line.strip()
+        assert not stripped.startswith("import bpy"), "settings_map must not import bpy"
+        assert not stripped.startswith("from bpy"), "settings_map must not import bpy"
+
+
+def test_neutral_targets_are_host_neutral():
+    """Route-2 rule 2 (spot-check): neutral targets name engine session surface
+    (Renderer setters / render() args / neutral phrases), never a bpy datablock."""
+    for e in sm.MAPPING:
+        if e.status in ("direct", "approximated"):
+            assert "scene.cycles" not in e.neutral_param, e.native_prop
+            assert "custom_raytracer" not in e.neutral_param, e.native_prop
+
+
+def test_status_counts_reported(capsys):
+    counts = {s: len(sm.by_status(s)) for s in sm.STATUS_VALUES}
+    total = sum(counts.values())
+    assert total == len(sm.MAPPING)
+    print(f"pkg176 Stage-0 mapping status counts: {counts} (total {total})")
+
+
+@pytest.mark.skipif(not _MATRIX.exists(), reason="pkg119-A coverage matrix not present")
+def test_render_settings_fully_covered_vs_pkg119a():
+    """Every allow-listed render_settings row in the pkg119-A matrix must be
+    represented in the mapping table (the render/sampling/light_paths/film/
+    denoising steering wheel). This is the coverage contract for Stage 1."""
+    matrix = json.loads(_MATRIX.read_text(encoding="utf-8"))
+    native_props_in_map = {e.native_prop for e in sm.MAPPING}
+
+    missing = []
+    for row in matrix:
+        if row.get("category") != "render_settings":
+            continue
+        prop = row.get("socket_or_prop")
+        if prop not in native_props_in_map:
+            missing.append(prop)
+
+    assert not missing, f"render_settings props not in mapping table: {missing}"
+
+
+@pytest.mark.skipif(not _MATRIX.exists(), reason="pkg119-A coverage matrix not present")
+def test_settings_natives_covered_vs_pkg119a():
+    """Camera / light / world native props from pkg119-A are represented too."""
+    matrix = json.loads(_MATRIX.read_text(encoding="utf-8"))
+    native_props_in_map = {e.native_prop for e in sm.MAPPING}
+
+    missing = []
+    for row in matrix:
+        if row.get("category") not in ("camera", "light", "world"):
+            continue
+        prop = row.get("socket_or_prop")
+        if prop not in native_props_in_map:
+            missing.append((row.get("category"), prop))
+
+    assert not missing, f"camera/light/world props not in mapping table: {missing}"


### PR DESCRIPTION
## pkg176 Stage 0 — OWNER-REVIEW ARTIFACT

This PR delivers **only Stage 0** of pkg176: the authoritative Cycles-settings -> Astroray-parameter mapping table. It is the **review anchor** the spec requires before any settings plumbing (Stage 1), panel adoption (Stage 2), or engine wiring. No behaviour change — data, a doc, and a collect-clean test.

**Owner review asked for:** ratify the opinionated calls encoded here — which `scene.cycles.*` props Astroray may legitimately read, and every semantic/name mismatch flagged in the table.

### Deliverables
- **`blender_addon/settings_map.py`** — inert, host-neutral data module; the single source of translation policy (translator side). Imports no `bpy`; `neutral_param` names the pybind session surface (Renderer setters / `render()` args), never a Blender datablock. Nothing imports it yet (Stage 1+ will).
- **`docs/blender_parity/pkg176_stage0_mapping.md`** — human-readable owner-review table (mirror of the module).
- **`tests/test_pkg176_settings_map.py`** — validates row shape/status enums, cross-checks render/light/camera/world coverage against the pkg119-A matrix, and mechanically enforces Route-2 rules 1 & 2.

### Coverage summary (90 settings-level rows)
- **direct**: 58
- **approximated**: 4
- **dropped**: 19
- **astroray-only**: 9

Grounded in the pkg119 Phase A matrix (`docs/blender_parity/coverage_matrix.json` — 117 SUPPORTED / 22 APPROXIMATED / 385 DROPPED-SILENT). `pkg119a` column kept verbatim as the audit anchor; `status` reflects current translation reality (e.g. `scene.cycles.seed` / `film_exposure` / `filter_width` were marked DROPPED in pkg119-A but the addon now reads them natively post-#487 — noted per-row). The full 461-row shader-node socket classification is NOT duplicated; the matrix remains the authoritative socket-level source. The Material section captures the primary Principled BSDF steering wheel.

### Notable opinionated calls for the owner
- Custom `CustomRaytracerRenderSettings` props (samples, all bounces, clamps, filter_glossy, caustics) are **duplicates that shadow native `scene.cycles.*`** — Stage 1 flips the exporter to the native read.
- **Semantic mismatches kept custom-only** (per spec Stage-1 rule): `light_sampler` (Astroray uniform/power/light_tree tri-state vs Cycles `use_light_tree` bool), `device_mode` (Astroray adds `auto` vs native CPU/GPU).
- **Name mismatch**: custom `transparent_bounces` vs Cycles `transparent_max_bounces`.
- **Color-management is a whole GAP class** (`view_transform`/`look`/`exposure`/`gamma`): the engine applies its own gamma and ignores AgX/Filmic — not in pkg119-A's allow-list, surfaced here because the steering wheel needs it (Stage 3 + pkg119-C).

### Route-2 session-boundary compliance (dcc-integration-decision-2026-08 §6, owner-ratified 2026-08-08)
Checked the Stage-0 design against all five hard rules:
1. **No `bpy` below the translation line** — `settings_map.py` is pure data, no `bpy` import; enforced by `test_source_has_no_bpy_import`.
2. **Session surface host-neutral** — `neutral_param` names engine setters/`render()` args, never `scene.cycles.*`/datablocks; spot-checked by `test_neutral_targets_are_host_neutral`.
3. **Mapping table is the single source of translation policy, translator side** — lives in `blender_addon/settings_map.py`; later stages and any future second host read it.
4. **Retirement preserves neutral values** — every direct/approximated row already names a durable `neutral_param`; Stage 4 collapses the custom duplicate into the native read above the boundary.
5. **No standalone C API / framework** — data module + doc + test only.

### Authorized surface (scope gate)
Spec Stage 0 intends: a checked-in mapping table (+ optional minimal inert scaffold + a collect-clean test). Files actually changed:
- `blender_addon/settings_map.py` — new (the minimal inert scaffold the spec permits).
- `docs/blender_parity/pkg176_stage0_mapping.md` — new (the table).
- `tests/test_pkg176_settings_map.py` — new (collect-clean validation).
- `.astroray_plan/packages/pkg176-blender-native-steering-wheel.md` — Status line flipped to Stage 0 done.

Nothing outside the spec's Stage-0 scope: no exporter/panel/engine changes, no `.cu/.cpp/.h`, no GPU build (parent session owns the GPU).

### Verification
- `pytest tests/test_pkg176_settings_map.py -v` — 7 passed.
- Lint gate: 0 new findings (ruff / markdownlint / codespell / git-diff-check).
- No C++/CUDA touched, so no build required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
