### PR TITLE
fix(pkg172A): guarded-pdf throughput/NEE — remove universal ~0.628%/bounce energy loss

### DIFF
--- a/.astroray_plan/docs/pkg172a-guarded-pdf.md
+++ b/.astroray_plan/docs/pkg172a-guarded-pdf.md
@@ -1,0 +1,61 @@
+# pkg172(A) — guarded-pdf fix for the universal ~0.628%/bounce energy loss
+
+## The defect (convicted 2026-08-02, architect verdict in the pkg172 spec)
+
+Every throughput/NEE estimator divided by an **additive** pdf epsilon:
+
+```
+throughput *= f_spectral * (1.0f / (pdf + 0.001f));      // BSDF throughput
+nee += f * L * (wt / (ls.pdf + 0.001f));                  // NEE
+```
+
+An additive `+ε` in the denominator is a systematic **under-weighting** of
+every estimate. Under cosine-sampled diffuse (`f = albedo·cosθ/π`,
+`pdf = cosθ/π`, so `f/pdf = albedo` exactly, zero-variance per sample), the
+analytic loss is exactly **`2π·ε = 0.628%` per bounce** for `ε = 1e-3`. A
+0.5-albedo Lambertian wall under a unit white env must reflect exactly 0.5
+(Veach 1997; the scene is zero-variance), so this deterministic deficit is a
+defect, not a convention. Confirmed by the spec's probe: dropping ε to `1e-6`
+reads the wall at exactly 0.500.
+
+## The fix (pbrt-v4 convention — cited, not invented)
+
+pbrt-v4 never biases the estimate with a denominator epsilon; it **rejects the
+sample at the source** when the pdf is degenerate and otherwise divides by the
+**exact** pdf (see *Physically Based Rendering* 4e, §13.3 "The Light Transport
+Equation" / the `SampleLd` and path-throughput updates: `if (bs->pdf == 0)
+break;` then `beta *= bs->f * AbsDot(...) / bs->pdf`). Expressed as the local
+guarded reciprocal used here:
+
+```
+f_spectral * (pdf > 1e-8f ? 1.0f / pdf : 0.0f)
+```
+
+- Degenerate pdf (`≤ 1e-8`, i.e. a sample essentially at the horizon, measure
+  ~zero and with `f→0` too) contributes zero — equivalent to pbrt's
+  `break`/terminate, with no NaN/Inf risk.
+- Every real sample divides by the **true** pdf → the estimator is now
+  unbiased; the furnace wall reads the analytic value.
+
+Applied to the three convicted legs (CPU path_tracer + CPU wavefront, CPU
+multiwavelength, GPU wavefront) — `include/raytracer.h`,
+`src/cpu/wavefront/{path_kernel,reference_pt_production}.cpp`,
+`plugins/integrators/multiwavelength_path_tracer.cpp`,
+`src/gpu/wavefront/{stage_advance,stage_light_sample,stage_shade_lambertian,stage_shade_metal}.{cu}`.
+
+## Deliberately NOT fixed here (surgical scope)
+
+`plugins/integrators/neural_cache.cpp` and `plugins/integrators/restir_di.cpp`
+carry the **same** additive-epsilon bias but are specialized integrators
+outside the convicted three legs; their gates are already pinned to the biased
+value. Left as a noted follow-up so this PR's re-pin batch stays attributable
+to the analytic 0.628%/bounce prediction. (The `gpu_nee.cuh:439` occurrence is
+commented-out dead code.)
+
+## Consequence: coordinated re-pin
+
+The fix **brightens every diffuse bounce** toward the true value on all three
+legs. Any furnace/parity/reference gate pinned to the old (dark) value shifts
+up by ~0.628%/bounce (compounding with depth). Each re-pin in this PR is
+justified against that analytic prediction and the furnace-analytic oracle
+(0.5 wall → 0.5), never re-pinned to "whatever the new number is."

--- a/include/raytracer.h
+++ b/include/raytracer.h
@@ -2481,7 +2481,7 @@ public:
                         // angle == 0, undercounting the delta sun's energy.
                         float wt = ls.isDelta ? 1.0f : (a * a) / (a * a + b * b + 1e-8f);
                         astroray::SampledSpectrum neeContrib =
-                            throughput * f_spec * L_spec * (wt / (ls.pdf + 0.001f));
+                            throughput * f_spec * L_spec * (ls.pdf > 1e-8f ? wt / ls.pdf : 0.0f);
                         color += clampContribSpectral(neeContrib, lambdas, bounce);
                     }
                 }
@@ -2546,7 +2546,12 @@ public:
                                                0, cryptoDepth, objectId, materialId, weight);
             }
 
-            throughput *= bss.f_spectral * (1.0f / (bss.pdf + 0.001f));
+            // pkg172(A): guarded-pdf throughput update (pbrt-v4 convention —
+            // reject the sample when pdf is degenerate, else divide by the
+            // EXACT pdf). The former `1/(pdf+1e-3)` additive epsilon was a
+            // universal 2π·ε=0.628%/bounce energy loss. See
+            // .astroray_plan/docs/pkg172a-guarded-pdf.md.
+            throughput *= bss.f_spectral * (bss.pdf > 1e-8f ? 1.0f / bss.pdf : 0.0f);
 
             Ray next(rec.point, bss.wi, ray.time, ray.screenU, ray.screenV);
             next.hasCameraFrame = ray.hasCameraFrame;
@@ -2674,7 +2679,7 @@ public:
                         // delta-light NEE samples always get full MIS weight.
                         float wt = ls.isDelta ? 1.0f : (a * a) / (a * a + b * b + 1e-8f);
                         astroray::SampledSpectrum neeContrib =
-                            throughput * f_spec * L_spec * (wt / (ls.pdf + 0.001f));
+                            throughput * f_spec * L_spec * (ls.pdf > 1e-8f ? wt / ls.pdf : 0.0f);
                         color += clampContribSpectral(neeContrib, lambdas, bounce);
                     }
                 }
@@ -2711,7 +2716,7 @@ public:
             }
 
             astroray::SampledSpectrum nextThroughput =
-                throughput * bss.f_spectral * (1.0f / (bss.pdf + 0.001f));
+                throughput * bss.f_spectral * (bss.pdf > 1e-8f ? 1.0f / bss.pdf : 0.0f);
 
             if (bss.isDelta) {
                 LightSample ls;
@@ -2763,7 +2768,7 @@ public:
                                 float geom = std::max(0.0f, std::abs(ls.normal.dot(-wiToLight))) /
                                              std::max(dist2, 1e-4f);
                                 astroray::SampledSpectrum contribution =
-                                    walkThroughput * f_spec * Li * (geom / (ls.pdf + 0.001f));
+                                    walkThroughput * f_spec * Li * (ls.pdf > 1e-8f ? geom / ls.pdf : 0.0f);
                                 causticConnections += 1;
                                 causticEnergy += contribution.maxValue();
                                 // pkg144: same indirect classification as the emissive
@@ -2776,7 +2781,7 @@ public:
                         Vec3 wwo = -walkRay.direction.normalized();
                         BSDFSampleSpectral step = wrec.material->sampleSpectral(wrec, wwo, gen, walkLambdas);
                         if (!step.isDelta || step.pdf <= 0.0f) break;
-                        walkThroughput *= step.f_spectral * (1.0f / (step.pdf + 0.001f));
+                        walkThroughput *= step.f_spectral * (step.pdf > 1e-8f ? 1.0f / step.pdf : 0.0f);
                         Ray next(wrec.point, step.wi, walkRay.time, walkRay.screenU, walkRay.screenV);
                         next.hasCameraFrame = walkRay.hasCameraFrame;
                         next.cameraOrigin = walkRay.cameraOrigin;

--- a/plugins/integrators/multiwavelength_path_tracer.cpp
+++ b/plugins/integrators/multiwavelength_path_tracer.cpp
@@ -235,7 +235,7 @@ private:
                                                0, cryptoDepth, objectId, materialId, weight);
             }
 
-            throughput *= bss.f_spectral * (1.0f / (bss.pdf + 0.001f));
+            throughput *= bss.f_spectral * (bss.pdf > 1e-8f ? 1.0f / bss.pdf : 0.0f);
 
             Ray next(rec.point, bss.wi, ray.time, ray.screenU, ray.screenV);
             next.hasCameraFrame = ray.hasCameraFrame;

--- a/src/cpu/wavefront/path_kernel.cpp
+++ b/src/cpu/wavefront/path_kernel.cpp
@@ -258,7 +258,7 @@ bool advance_one_bounce(PathState& ps, HitRecord& rec,
                 // pkg140: see raytracer.h pathTraceSpectral's identical comment
                 // -- delta-light NEE samples always get full MIS weight.
                 float wt = ls.isDelta ? 1.0f : (a * a) / (a * a + b * b + 1e-8f);
-                SampledSpectrum nee_contribution = f_spec * L_spec * (wt / (ls.pdf + 0.001f));
+                SampledSpectrum nee_contribution = f_spec * L_spec * (ls.pdf > 1e-8f ? wt / ls.pdf : 0.0f);
                 ps.color += ps.throughput * nee_contribution;
 
                 if (sink) {
@@ -333,7 +333,7 @@ bool advance_one_bounce(PathState& ps, HitRecord& rec,
     if (bss.pdf <= 0.0f) { ps.alive = false; return false; }
     ps.wasSpecular = bss.isDelta;
     ps.bsdfPdfPrev = bss.pdf;  // pkg120: carry for next-bounce two-sided MIS
-    ps.throughput *= bss.f_spectral * (1.0f / (bss.pdf + 0.001f));
+    ps.throughput *= bss.f_spectral * (bss.pdf > 1e-8f ? 1.0f / bss.pdf : 0.0f);
 
     // ---- PostShade snapshot.
     if (sink) {

--- a/src/cpu/wavefront/reference_pt_production.cpp
+++ b/src/cpu/wavefront/reference_pt_production.cpp
@@ -160,7 +160,7 @@ SampledSpectrum tracePathSpectral(
                     // pkg140: see raytracer.h pathTraceSpectral's identical comment
                     // -- delta-light NEE samples always get full MIS weight.
                     float wt = ls.isDelta ? 1.0f : (a * a) / (a * a + b * b + 1e-8f);
-                    SampledSpectrum nee_contribution = f_spec * L_spec * (wt / (ls.pdf + 0.001f));
+                    SampledSpectrum nee_contribution = f_spec * L_spec * (ls.pdf > 1e-8f ? wt / ls.pdf : 0.0f);
                     color += throughput * nee_contribution;
 
                     // PostLightSample snapshot.
@@ -220,7 +220,7 @@ SampledSpectrum tracePathSpectral(
         if (bss.pdf <= 0.0f) break;
         wasSpecular = bss.isDelta;
         bsdfPdfPrev = bss.pdf;  // pkg120: carry for next-bounce two-sided MIS
-        throughput *= bss.f_spectral * (1.0f / (bss.pdf + 0.001f));
+        throughput *= bss.f_spectral * (bss.pdf > 1e-8f ? 1.0f / bss.pdf : 0.0f);
 
         // PostShade snapshot.
         if (sink) {

--- a/src/gpu/wavefront/stage_advance.cu
+++ b/src/gpu/wavefront/stage_advance.cu
@@ -682,7 +682,7 @@ __device__ bool shadePathSlot(
             state.pixel_index[idx], cryptoDepth, objectId, materialId, weight);
     }
 
-    throughput *= bss.fSpectral * (1.0f / (bss.pdf + 0.001f));
+    throughput *= bss.fSpectral * (bss.pdf > 1e-8f ? 1.0f / bss.pdf : 0.0f);
 
     // ---- Throughput clamp (CPU: maxC > 10 -> scale to 10).
     float maxC = throughput.maxValue();

--- a/src/gpu/wavefront/stage_light_sample.cu
+++ b/src/gpu/wavefront/stage_light_sample.cu
@@ -315,7 +315,7 @@ __global__ void stageLightSampleKernel(
         // NEE contribution: f * L * (wt / pdf).
         // Mirrors CPU line 246.
         GSampledSpectrum L_spec = ls.emission;
-        GSampledSpectrum nee_contribution = f_spec * L_spec * (wt / (ls.pdf + 0.001f));
+        GSampledSpectrum nee_contribution = f_spec * L_spec * (ls.pdf > 1e-8f ? wt / ls.pdf : 0.0f);
 
         // Accumulate to path color: color += throughput * nee_contribution.
         GSampledSpectrum color_update = throughput * nee_contribution;

--- a/src/gpu/wavefront/stage_shade_lambertian.cu
+++ b/src/gpu/wavefront/stage_shade_lambertian.cu
@@ -214,7 +214,7 @@ __global__ void stageShadeLambertianKernel(
 
     // Update throughput: throughput *= f_spectral / pdf
     // Add small epsilon to pdf to avoid division by zero (matches CPU path_kernel.cpp line 298).
-    throughput = throughput * bss.f_spectral * (1.0f / (bss.pdf + 0.001f));
+    throughput = throughput * bss.f_spectral * (bss.pdf > 1e-8f ? 1.0f / bss.pdf : 0.0f);
 
     // Write updated throughput back to SoA.
     state.throughput_0[idx] = throughput[0];

--- a/src/gpu/wavefront/stage_shade_metal.cu
+++ b/src/gpu/wavefront/stage_shade_metal.cu
@@ -341,7 +341,7 @@ __global__ void stageShadeMetalKernel(
 
     // Update throughput: throughput *= f_spectral / pdf
     // Add small epsilon to pdf to avoid division by zero (matches CPU path_kernel.cpp line 320).
-    throughput = throughput * bss.f_spectral * (1.0f / (bss.pdf + 0.001f));
+    throughput = throughput * bss.f_spectral * (bss.pdf > 1e-8f ? 1.0f / bss.pdf : 0.0f);
 
     // Write updated throughput back to SoA.
     state.throughput_0[idx] = throughput[0];

--- a/tests/test_material_properties.py
+++ b/tests/test_material_properties.py
@@ -550,7 +550,15 @@ def test_disney_clearcoat_adds_gloss():
         f"({bright_mean_no_coat:.3f}) by at least {min_bright_mean_delta:.3f}"
 
     mse = float(np.mean((rgb_no_coat - rgb_coat) ** 2))
-    assert mse > 5e-5, \
+    # pkg172(A) re-pin (2026-08-08): the guarded-pdf fix removed the universal
+    # ~0.6%/bounce throughput under-weighting; under the now-unbiased estimator
+    # the whole-sphere coat-vs-no-coat MSE differential moved 5.76e-5 -> 4.92e-5
+    # (clean-build A/B on this scene). The primary clearcoat signals — the
+    # p99.5 and bright-mean deltas asserted above — still pass, so clearcoat is
+    # verifiably contributing; this coarse aggregate floor was calibrated to the
+    # old (biased, darker) renders. Floor lowered to 3.5e-5 (keeps a real guard
+    # against a clearcoat that contributes nothing, MSE->~0).
+    assert mse > 3.5e-5, \
         f"Clearcoat has no visible effect on sphere pixels (MSE={mse:.6f})"
 
     fig, axes = plt.subplots(1, 2, figsize=(8, 4))


### PR DESCRIPTION
## What

Replaces the biased additive-epsilon estimator `f / (pdf + 1e-3)` with the **pbrt-v4 guarded-pdf form** (`pdf > 1e-8f ? 1.0f/pdf : 0.0f` — exact division, reject the sample at source when the pdf is degenerate) across the **three convicted legs** (pkg172 effect (A), architect-convicted 2026-08-02):

- CPU path_tracer + CPU wavefront — `include/raytracer.h`, `src/cpu/wavefront/{path_kernel,reference_pt_production}.cpp`
- CPU multiwavelength — `plugins/integrators/multiwavelength_path_tracer.cpp`
- GPU wavefront — `src/gpu/wavefront/{stage_advance,stage_light_sample,stage_shade_lambertian,stage_shade_metal}`

15 sites, **identical transform CPU+GPU** so CPU/GPU leg parity is preserved. Citation + analytic derivation: `.astroray_plan/docs/pkg172a-guarded-pdf.md`.

## Why

An additive pdf epsilon systematically under-weights every estimate. Under cosine-sampled diffuse the loss is exactly **2π·ε = 0.628%/bounce** — a 0.5-albedo wall under unit env reads 0.497 not the analytic 0.500. This is a deterministic defect, not a convention (Veach 1997; pbrt-v4).

## ⚠️ Owner: one coordinated re-pin (please eyeball)

`tests/test_material_properties.py::test_disney_clearcoat_adds_gloss` — its coarse **whole-sphere MSE floor** was the only gate that shifted. Clean-build A/B on the exact scene:

| build | coat-vs-no-coat MSE | vs 5e-5 floor |
|---|---|---|
| clean main | **5.76e-5** | pass |
| this fix | **4.92e-5** | fail |

The fix's unbiased estimator lowers the whole-sphere differential ~15%. **The two *primary* clearcoat asserts (p99.5 peak delta, bright-mean delta) still pass** — clearcoat verifiably still contributes; the MSE floor was calibrated to the old (biased, darker) renders. Floor lowered **5e-5 → 3.5e-5** with in-test justification (still guards against a clearcoat that contributes nothing → MSE→0).

## Verification

- Full split suite: GPU-serial pass **green**; 344 furnace/energy green; all parity/reference/wavefront-diff green; the only real shift is the clearcoat re-pin above (verified passing post-re-pin). One transient OneDrive dir-lock flake on `test_blender_parity_matrix` (WinError 5, unrelated to this change — passes after clearing; CI is Linux so N/A).
- No signature changes → no stale call sites.

## Scope note

`neural_cache.cpp` and `restir_di.cpp` carry the **same** additive epsilon but are outside the convicted three legs (their gates are pinned to the biased value). Left as a documented follow-up so this PR's re-pin stays attributable. The pkg156 0.998 SSIM restoration is **pkg173's** scope per the 2026-08-02 correction, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)