### PR TITLE
fix(pkg172A follow-up): guarded-pdf in neural_cache + restir_di

### DIFF
--- a/plugins/integrators/neural_cache.cpp
+++ b/plugins/integrators/neural_cache.cpp
@@ -155,7 +155,7 @@ class NeuralCacheIntegrator : public Integrator {
         // pkg140: see raytracer.h pathTraceSpectral's identical comment --
         // delta-light NEE samples always get full MIS weight.
         float wt = ls.isDelta ? 1.0f : (a * a) / (a * a + b * b + 1e-8f);
-        return f * L * (wt / (ls.pdf + 0.001f));
+        return f * L * (ls.pdf > 1e-8f ? wt / ls.pdf : 0.0f);
     }
 
     bool backendReady() {
@@ -434,7 +434,7 @@ public:
         if (warmup || !enableInference_) {
             astroray::SampledSpectrum tail =
                 renderer_->pathTraceSpectral(next, std::max(1, maxDepth_ - 1), lambdas, gen);
-            astroray::SampledSpectrum indirect = f * tail * (1.0f / (bss.pdf + 0.001f));
+            astroray::SampledSpectrum indirect = f * tail * (bss.pdf > 1e-8f ? 1.0f / bss.pdf : 0.0f);
             if (trainThisSample) {
                 astroray::XYZ xyz = indirect.toXYZ(lambdas);
                 Vec3 rgb = xyzToLinearSRGB(Vec3(xyz.X, xyz.Y, xyz.Z));

--- a/plugins/integrators/restir_di.cpp
+++ b/plugins/integrators/restir_di.cpp
@@ -366,7 +366,7 @@ public:
                                                0, cryptoDepth, objectId, materialId, weight);
             }
 
-            throughput *= bss.f_spectral * (1.0f / (bss.pdf + 0.001f));
+            throughput *= bss.f_spectral * (bss.pdf > 1e-8f ? 1.0f / bss.pdf : 0.0f);
 
             Ray next(rec.point, bss.wi, pathRay.time, pathRay.screenU, pathRay.screenV);
             next.hasCameraFrame = pathRay.hasCameraFrame;


### PR DESCRIPTION
Applies the pkg172(A) guarded-pdf fix (#551) to the two specialized integrators left out of that PR's convicted-three-leg scope, per owner direction to fix them too.

**Sites:** `neural_cache.cpp:158` (NEE), `neural_cache.cpp:437` (throughput), `restir_di.cpp:369` (throughput) — same `f/(pdf+1e-3)` → `pdf>1e-8f ? f/pdf : 0` transform (exact division, reject-at-site; pbrt-v4).

**Verification:** 90 restir/neural tests pass, 0 failures, no re-pin needed. No signature changes. Rationale/citation in `.astroray_plan/docs/pkg172a-guarded-pdf.md` (landed with #551).

🤖 Generated with [Claude Code](https://claude.com/claude-code)