### PR TITLE
pkg174: wavefront register-pressure recovery (owner-accepted ceiling)

### DIFF
--- a/.astroray_plan/docs/pkg174-per-material-kernel-dispatch-design.md
+++ b/.astroray_plan/docs/pkg174-per-material-kernel-dispatch-design.md
@@ -1,0 +1,164 @@
+# pkg174 — per-material shade-kernel dispatch: extensibility foundation
+
+**Status:** design (2026-08-08). Companion to
+`pkg174-stage-split-design.md` (perf) and `pkg174-register-pressure-ledger.md`
+(levers). **This document is scoped to EXTENSIBILITY, not perf.** The measured
+finding below is that per-material kernel dispatch does **not** move the ≤1.0s
+number — it is proposed for the plugin-material roadmap, and sized as
+architecture.
+
+**Machine/toolchain:** RTX 5070 Ti, Ninja + CUDA 12.8 + native sm_120. Every
+REG/STACK below is `cuobjdump --dump-resource-usage` on the linked `.pyd`.
+
+## Measured attribution that frames this design (2026-08-08 session)
+
+Nsight Compute source attribution was unavailable (`ncu` → `ERR_NVGPUCTRPERM`,
+no perf-counter permission, same missing elevation as clock-lock). Targeted
+stub-and-rebuild on `stageShadeBucketedKernel` gave:
+
+| Config | REG | STACK |
+| --- | --- | --- |
+| baseline (NEE on, BSDF on) | 254 | 2576 |
+| NEE section OFF, BSDF on | 254 | 2064 |
+| NEE on, BSDF sampler bypassed | 255 | 2320 |
+| NEE OFF **and** BSDF bypassed | **95** | 584 |
+
+**Interpretation (this corrects `pkg174-stage-split-design.md`'s headline).**
+The REG:254 ceiling is held by **two independent ~160-register consumers** on a
+**~95-register irreducible state-marshalling base**:
+
+- the NEE light-sampling section (`gpu_nee_sample` light-tree descent +
+  `gpu_material_eval_spectral`/`_pdf` + shadow-ray park), and
+- the BSDF material union (`gpu_material_sample_spectral` → the 7-way
+  `gpu_material_sample` switch + spectral upsampling).
+
+**Either one alone saturates the 254 cap**; only removing *both* drops to 95.
+ptxas caps at 254 and spills the combined ~415-register want to local memory
+(STACK 2576 B). This is why every single removal moves only STACK (spill), never
+REG.
+
+The earlier design doc concluded "material code is NOT the register bottleneck"
+after stubbing the **non-spectral** `gpu_material_sample/_eval/_pdf` (thin
+wrappers). Its own note #3 flagged that the `_spectral` variants — the ones
+actually on the wavefront hot path — were never isolated. They are, in fact, a
+~160-register consumer.
+
+### Consequence for perf (measured, not hypothesized)
+
+Per-material kernel dispatch **cannot raise the shade kernel's occupancy**:
+
+- Every bucket's shade kernel still runs the **NEE** section (all non-delta
+  hits do NEE), and NEE alone pins REG at 254 (measured: "NEE on, BSDF
+  bypassed" = 255). Slicing only the BSDF union per material leaves NEE holding
+  the ceiling.
+- Even slicing *both* (per-material BSDF **and** NEE moved to its own stage),
+  the perf-gate scene (`disney_contact_sheet`) is dominated by heavy buckets —
+  `GMAT_DISNEY`, `GMAT_THIN_GLASS`, `GMAT_CLOSURE_GRAPH` — whose individual
+  samplers, on the ~95 base, stay above the 128-register threshold needed for
+  2 blocks/SM. The light buckets (`GMAT_LAMBERTIAN`, `GMAT_DIFFUSE_LIGHT`)
+  would gain occupancy, but they are not the bottleneck.
+
+So this design is justified by the **plugin roadmap**, not the ≤1.0s ceiling.
+Do not re-pin the perf gate on the strength of it.
+
+## Why it is still worth building (extensibility)
+
+The owner will add many material families through the plugin architecture —
+diffraction gratings, thin films, thin translucents (Blender 5.x), astro
+materials. Each new family today must be added **into the shared switch** in
+`gpu_material_sample` / `gpu_material_eval_spectral` / `gpu_material_pdf`
+(`include/astroray/gpu_materials.h`). That has three costs that compound with
+material count:
+
+1. **Megakernel growth.** Every family's sampler inlines into the one union that
+   `stageShadeBucketedKernel` compiles. Heavy future families (multilayer
+   thin-film interference, dispersive gratings) are large; the union's
+   ~160-register contribution and the kernel's compile time both grow with the
+   roster, even though a given *path* only ever needs one arm.
+2. **Compile time & code size** scale with the roster, not with what any launch
+   uses.
+3. **It is at odds with the plugin design** — a plugin should add a
+   self-contained unit, not edit a shared switch in a core header.
+
+The already-sorted per-type shade queues are the dispatch substrate:
+`stageQueueScatterKernel` buckets each surviving path by `matType` (0..6) into
+`shade_queues[matType * capacity + slot]` (`stage_advance.cu:~1027`), and
+`stageShadeBucketedKernel` launches `G_WF_NUM_MAT_TYPES * capacity` threads with
+`bucket = i / capacity` (`stage_advance.cu:1058`). **Bucket m already contains
+only material type m** — the launch just doesn't exploit it: it runs the same
+megakernel body for every bucket.
+
+## The design: `template<int MatType>` per-bucket shade kernels
+
+Specialize the shade kernel on the compile-time material type, dispatched off the
+existing buckets. Concretely:
+
+1. **Add a `template<int MatType>` overload of `gpu_material_sample_spectral`
+   (and `_eval_spectral` / `_pdf`)** whose body is the current one with the
+   runtime `switch (mat.type)` replaced by `if constexpr (MatType == GMAT_X)`.
+   For a concrete `MatType`, the compiler keeps exactly one arm; the other six
+   samplers are never instantiated into that kernel. The `GMAT_CLOSURE_GRAPH`
+   arm stays general (it is itself an interpreter), so it specializes least —
+   which is fine; the concrete families (0..5) are where slicing pays.
+
+2. **`template<int MatType> __global__ void stageShadeBucketedKernelT(...)`** —
+   the body of today's `stageShadeBucketedKernel` (still `shadePathSlot<true>`,
+   i.e. keeping ALL shared features: NEE/MIS/photon/crypto — this is the point of
+   difference from the feature-incomplete relic kernels), calling the
+   `template<MatType>` material fns. Grid covers one bucket's `capacity`, not
+   `NUM_TYPES * capacity`.
+
+3. **A dispatch table + launcher**: `launchStageShadeBucketed` iterates material
+   types, and for each **non-empty** bucket (`shade_counts[m] > 0`, already
+   resident) launches `stageShadeBucketedKernelT<m>` on that bucket's slice. A
+   `constexpr` type-list drives the instantiation; a plugin material family adds
+   (a) its enum value, (b) its `if constexpr` arm (or, longer-term, a registered
+   specialization), and (c) a type-list entry — **not** an edit to a shared
+   runtime switch.
+
+### Rejected alternative: device function-pointer registry
+
+A `__device__` function-pointer table indexed by material type (the most
+"plugin-native" shape) is **rejected for the hot path**: indirect `__device__`
+calls defeat inlining and cross-function register/scheduling optimization on
+CUDA, and would *regress* the shade path. Compile-time specialization keeps the
+inlined codegen while still giving each family its own kernel. Plugin
+registration can live at the *host* launch-table level (which
+`stageShadeBucketedKernelT<m>` to launch), not as device indirect calls.
+
+### The relic kernels are a pattern, not a target
+
+`stageShadeLambertianKernel` / `stageShadeMetalKernel`
+(`src/gpu/wavefront/stage_shade_lambertian.cu`, `stage_shade_metal.cu`) are
+N+3-era per-type kernels that predate NEE/MIS/photon/cryptomatte and are
+feature-incomplete. **Do not route production paths into them.** The
+`template<int MatType>` kernel grows from the full `shadePathSlot<true>`, so it
+carries every feature. The relics should be deleted or converted to the
+templated form in the same change.
+
+## Cost axis to measure (not assume)
+
+The dispatch trades **1 launch/bounce for up-to-7 launches/bounce**. Launching
+only non-empty buckets bounds this, but a scene exercising all families pays the
+extra launch overhead every bounce. Because this is an **extensibility** change,
+its acceptance bar is **no wall-time regression** on the perf-gate scene (burn-in
+P0 + min-of-N, per the ledger protocol), not a speedup. If per-bucket launch
+overhead measurably regresses, fall back to launching the concrete families
+(0..5) individually while keeping `GMAT_CLOSURE_GRAPH` (and any residual
+low-population buckets) merged in one general kernel.
+
+## Scope / sequencing
+
+- Independent of the ≤1.0s perf question — it can land whenever the plugin
+  roadmap needs it, gated on bit-identity (`tests/wavefront_diff/`) + the perf
+  gate as a no-regression tripwire.
+- Correctness-frozen while pkg174 is open: this design is **not** implemented in
+  the pkg174 perf PR (which is Exp1 only). Filed as a follow-up for the plugin
+  arc.
+
+## Citations
+
+- Laine, Karras & Aila 2013, "Megakernels Considered Harmful: Wavefront Path
+  Tracing on GPUs" — the wavefront/stage-split argument the codebase already
+  cites from pkg55. Note this design applies its *material-coherence* half
+  (already realized by the buckets) to codegen, not to occupancy.

--- a/.astroray_plan/docs/pkg174-register-pressure-ledger.md
+++ b/.astroray_plan/docs/pkg174-register-pressure-ledger.md
@@ -107,3 +107,81 @@ applied. Reverted.
 **Net for the settlement round:** pkg174 remains **in progress**. The micro-lever
 avenue is closed with evidence; the ceiling raise correctly persists; the
 structural stage-split is the remaining path and is routed to supervised work.
+
+---
+
+## Supervised session 2026-08-08 — stage-split executed + register attribution
+
+**Base:** `pkg174-stage-split` off `origin/main` `b4a80d9`. Same machine /
+toolchain / protocol (burn-in 15 → 2887 MHz P0, min-of-10). Fresh baseline
+reproduced the pinned numbers exactly: shade REG:254 STACK:2576, perf min 1.1446 /
+median 1.1458 s.
+
+### Lever 3 — `template<bool Deferred>`, compile out the dead immediate-NEE branch — **KEEP (−1.1%)**
+
+The design doc's cheapest suspect (#2). `shadePathSlot` is now
+`template<bool Deferred>`; the immediate-NEE `else` (inline `gpu_nee_occlude`
+shadow-ray BVH/TLAS traversal) is `if constexpr`'d out of the deferred
+(bucketed + NeeMis) instantiations, where it is dead (`nee_f` always non-null).
+`advancePathSlot` keeps it (`Deferred=false`).
+
+| Metric | Baseline | Lever 3 |
+| --- | --- | --- |
+| `stageShadeBucketedKernel` REG / STACK | 254 / 2576 | 254 / **2256** |
+| `stageShadeNeeMisKernel` STACK | 3168 | **2848** |
+| perf min / median (2887 MHz P0, N=10) | 1.1446 / 1.1458 | **1.1318 / 1.1330** |
+
+Clean separation (every Lever-3 run < baseline's minimum), so the −1.1% is real,
+not clock drift. REG stays at the 254 ceiling (occupancy unchanged); the win is
+the −320 B spill-traffic reduction. Bit-identity green
+(`test_pkg55_cuda_threshold_gate`, `pkg89_dedicated_nee`, `gpu_wavefront_image`;
+full `wavefront_diff` 29 passed); `mean_img` byte-identical. **Committed; this is
+the shippable pkg174 change.**
+
+### Register attribution — ncu blocked, stub-and-rebuild fallback
+
+`ncu` unusable: `ERR_NVGPUCTRPERM` (no perf-counter permission — same missing
+elevation as clock-lock). Targeted stub-and-rebuild on `stageShadeBucketedKernel`:
+
+| Config | REG | STACK |
+| --- | --- | --- |
+| baseline (NEE on, BSDF on) | 254 | 2576 |
+| NEE section OFF, BSDF on | 254 | 2064 |
+| NEE on, BSDF sampler bypassed | 255 | 2320 |
+| NEE OFF **and** BSDF bypassed | **95** | 584 |
+
+**This corrects the stage-split design doc's headline.** The 254 ceiling is held
+by **two independent ~160-register consumers** on a **~95-register irreducible
+state-marshalling base**: the NEE light-sampling section and the BSDF material
+union (`gpu_material_sample_spectral`, the *spectral* variant the earlier
+experiments never isolated — its own note #3). **Either alone saturates 254**;
+only removing both reaches 95. ptxas caps at 254 and spills the combined ~415-reg
+want — which is why every single removal moves only STACK (spill), never REG, and
+why Lever 3's dead-branch removal bought spill-traffic (−1.1%) but no occupancy.
+
+### Why ≤1.0s is unreachable via stage-split (measured, not asserted)
+
+- Extract NEE → shade keeps BSDF → still 254. Extract BSDF → shade keeps NEE →
+  still 255. The extracted kernel itself carries the ~95 base + its ~160 work
+  ≈ 254. A split trades one 254-kernel for two 254-kernels + extra path-state
+  global round-trips = **net-negative** (Laine 2013 in reverse; the addendum's
+  exact warning). **Exp3 was therefore NOT implemented — the measurement shows
+  it cannot help.**
+- Per-material specialization can't help this scene either: NEE (needed by every
+  bucket) independently pins 254, and the perf-gate's heavy buckets
+  (disney/glass/closure) have individually large samplers (>128, the 2-blocks/SM
+  threshold). Filed as extensibility only —
+  `pkg174-per-material-kernel-dispatch-design.md`.
+- The only remaining lever is shrinking the **shared state** (fewer spectral
+  samples / fewer kernel params), which is a correctness/precision change —
+  **out of pkg174's PERF-ONLY, correctness-frozen scope.**
+
+### Definition-of-done status
+
+Scene measures **1.132 s** (Lever 3, best case) — still **> 1.0 s**. The
+temporary 1.5 s ceiling in `test_pkg55_perf_gate.py` is therefore **NOT
+reverted** (reverting is valid only at a true ≤1.0 s — spec acceptance). Held for
+owner review with this evidence: the ≤1.0 s target is not reachable under the
+package's PERF-ONLY + correctness-frozen constraints, and needs an owner decision
+(accept the raised ceiling, or authorize a shared-state / precision change that
+leaves PERF-ONLY scope).

--- a/.astroray_plan/packages/pkg174-wavefront-register-pressure-recovery.md
+++ b/.astroray_plan/packages/pkg174-wavefront-register-pressure-recovery.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 3 (GPU wavefront performance)
 **Track:** A (RTX-gated; every measurement is hardware)
-**Status:** in progress — dispatched 2026-08-07 (worktree .claude/worktrees/pkg174, branch pkg174-register-pressure); #541 precondition satisfied (merged 2026-08-06, bbf2d8c). **2026-08-07 overnight update:** micro-lever avenue closed with evidence — see `.astroray_plan/docs/pkg174-register-pressure-ledger.md`. Baseline 1.145s @ 2887MHz P0; `__noinline__` fence REJECTED (+2.7%), `__launch_bounds__(256,2)` NULL (ptxas ignored on sm_120). Ceiling raise NOT reverted (target ≤1.0s unmet). Remaining path = structural stage-split, routed to SUPERVISED (correctness-frozen serialization-point kernel; occupancy-cliff-bounded). This is the companion package that option A creates: #541 ships the correctness fix v4 with a TEMPORARY raise of the wavefront perf ceiling; this package restores the ceiling and reverts the raise.
+**Status:** RESOLVED 2026-08-08 (owner accepted the raised ceiling; PR #554, branch pkg174-stage-split). Shipped `template<bool Deferred>` dead-NEE-branch compile-out (−1.1%); ≤1.0s measured UNREACHABLE in PERF-ONLY scope (two independent ~160-reg consumers on a ~95-reg base — see Acceptance + ledger). Originally dispatched 2026-08-07 (worktree .claude/worktrees/pkg174, branch pkg174-register-pressure); #541 precondition satisfied (merged 2026-08-06, bbf2d8c). **2026-08-07 overnight update:** micro-lever avenue closed with evidence — see `.astroray_plan/docs/pkg174-register-pressure-ledger.md`. Baseline 1.145s @ 2887MHz P0; `__noinline__` fence REJECTED (+2.7%), `__launch_bounds__(256,2)` NULL (ptxas ignored on sm_120). Ceiling raise NOT reverted (target ≤1.0s unmet). Remaining path = structural stage-split, routed to SUPERVISED (correctness-frozen serialization-point kernel; occupancy-cliff-bounded). This is the companion package that option A creates: #541 ships the correctness fix v4 with a TEMPORARY raise of the wavefront perf ceiling; this package restores the ceiling and reverts the raise.
 **Estimated effort:** M (kernel-architecture work, measured at every step; no correctness surface should move)
 **Depends on:** PR #541 merged (option A — owner CONFIRMED 2026-08-03). Cross-links: **pkg155** (Phase 1 conviction: shade stage 221 regs/thread, 1 block/SM, sm_120 AOT ruled out with numbers — the register problem is intrinsic to the kernel, not a build artifact; its recovery target ≤128 regs is this package's inherited north star), **pkg168** (whose #541 fix is the per-hit state that tipped the stage over), **pkg172(A)** (the epsilon fix ships in the same supervised round; run this package's final perf measurement on a build containing BOTH).
 
@@ -41,20 +41,28 @@ recorded in **PR #541's comment thread** and preserved commit **`6ef2c11`**):
    any stage-splitting design change (CLAUDE.md §6); the repo's pkg55 docs
    already carry the citation — extend, don't re-derive.
 
-## Acceptance
+## Acceptance — RESOLVED 2026-08-08 (owner accepted raised ceiling; PR #554)
 
-- [ ] Perf-gate scene ≤ **1.0s** median-of-3 on RTX 5070 Ti **with the #541
-      correctness fix present** (and pkg172(A)'s epsilon fix if already
-      merged — measure on the real settlement-round main, not a curated
-      branch).
-- [ ] **The temporary ceiling raise from #541 is REVERTED in this package's
-      PR** — the gate goes back to its pre-#541 bound. That revert is the
-      definition of done; leaving the raised ceiling in place is a FAIL
-      even if the measured time improves.
-- [ ] REG/spill/occupancy ledger for every lever tried (including rejected
-      ones) recorded in a research note under `.astroray_plan/docs/`.
-- [ ] Bit-identity/parity gates green; no material-eval code moved in ways
-      that change results (REG work only).
+- [~] Perf-gate scene ≤ **1.0s**: **UNREACHABLE under PERF-ONLY + correctness-
+      frozen scope, measured.** The shade kernel's REG:254 ceiling is two
+      independent ~160-reg consumers (NEE light-sampling + spectral BSDF union)
+      on a ~95-reg irreducible state base — either alone saturates the cap, so
+      no stage-split or per-material split raises occupancy. Best correct form
+      now 1.132s (Lever 3 below). Full mechanism + attribution table:
+      `pkg174-register-pressure-ledger.md` (supervised section).
+- [x] **Ceiling raise: owner ACCEPTED 2026-08-08** as the permanent post-
+      settlement ceiling (1.5s, ~31% headroom over 1.132s) — the revert was
+      contingent on a true ≤1.0s, which is unreachable in scope. Superseded the
+      "revert = definition of done" criterion. `test_pkg55_perf_gate.py` comment
+      updated to reflect acceptance.
+- [x] REG/spill ledger for every lever (including rejected + the stub-and-
+      rebuild attribution) recorded: `pkg174-register-pressure-ledger.md`.
+- [x] Bit-identity/parity gates green (full `tests/wavefront_diff/` 29 passed);
+      PERF ONLY, no material-eval math moved. Shipped win: `template<bool
+      Deferred>` dead-branch compile-out, −1.1%, REG unchanged (spill-traffic).
+- [x] Extensibility follow-up filed:
+      `pkg174-per-material-kernel-dispatch-design.md` (per-material kernel
+      dispatch — scoped as plugin architecture, measured NOT to move ≤1.0s).
 
 ## Scope fence
 

--- a/src/gpu/wavefront/stage_advance.cu
+++ b/src/gpu/wavefront/stage_advance.cu
@@ -313,6 +313,15 @@ __device__ int intersectPathSlot(
 // trace + resolve to the dedicated shadow stage (park the sample + wo +
 // throughput, enqueue the slot). Null => immediate occlude+resolve inline
 // (the flat/dense schedulings keep their original single-kernel behavior).
+// pkg174: template on Deferred. The production bucketed/NeeMis schedulings
+// always park NEE work to the deferred shadow stage (nee_f != nullptr), so the
+// immediate-NEE `else` branch (inline gpu_nee_occlude shadow-ray BVH/TLAS
+// traversal) is DEAD in those instantiations. Compiling it out with
+// `if constexpr (Deferred)` frees ptxas from allocating for its shadow-traversal
+// live set in the REG:254-saturated shade kernel. Deferred=false keeps the
+// immediate path for advancePathSlot (the dense/flat reference schedulings).
+// PERF ONLY — the compiled-out branch is unreachable in the deferred callers.
+template<bool Deferred>
 __device__ bool shadePathSlot(
     int idx,
     GPUWavefrontState& state,
@@ -437,7 +446,7 @@ __device__ bool shadePathSlot(
                                           dedLights, numDed,
                                           lightTree, &rng);
             if (s.valid) {
-                if (nee_f != nullptr) {
+                if constexpr (Deferred) {
                     // Defer the TRACE + emission to the shadow stage; the
                     // BSDF eval/pdf/MIS happen HERE where the material code
                     // already lives (Cycles shade_surface.h ordering). The
@@ -764,7 +773,7 @@ __device__ bool advancePathSlot(
                                     clampDirect, clampIndirect,
                                     lights, numLights, totalLightPower, lightTree);  // pkg120
     if (matType < 0) return false;
-    return shadePathSlot(idx, state, hitBufs, tlas, instances, blas,
+    return shadePathSlot<false>(idx, state, hitBufs, tlas, instances, blas,
                          bvhNodes, prims, tris, spheres, motionVerts,
                          materials, lights, numLights, totalLightPower,
                          dedLights, numDed, lightTree, max_depth,
@@ -1060,7 +1069,7 @@ __global__ void stageShadeBucketedKernel(
     if (bucket >= G_WF_NUM_MAT_TYPES) return;
     if (pos >= shade_counts[bucket]) return;
     int idx = shade_queues[bucket * capacity + pos];
-    bool alive = shadePathSlot(idx, state, hitBufs, tlas, instances, blas,
+    bool alive = shadePathSlot<true>(idx, state, hitBufs, tlas, instances, blas,
                                bvhNodes, prims, tris, spheres, motionVerts,
                                materials, lights, numLights,
                                totalLightPower, dedLights, numDed,
@@ -1669,7 +1678,7 @@ __global__ void stageShadeNeeMisKernel(
                                     clampDirect, clampIndirect,
                                     lights, numLights, totalLightPower, lightTree);  // pkg120
     if (matType < 0) return;  // env miss / emissive hit: path died, no NEE.
-    shadePathSlot(idx, state, hitBufs, tlas, instances, blas,
+    shadePathSlot<true>(idx, state, hitBufs, tlas, instances, blas,
                   bvhNodes, prims, tris, spheres, motionVerts,
                   materials, lights, numLights, totalLightPower,
                   dedLights, numDed, lightTree, max_depth,

--- a/tests/wavefront_diff/test_pkg55_perf_gate.py
+++ b/tests/wavefront_diff/test_pkg55_perf_gate.py
@@ -59,10 +59,16 @@ WIDTH = HEIGHT = 256
 SPP = 1024
 MAX_DEPTH = 8
 SEED = 424242
-CEILING_S = 1.5  # TEMPORARY raise (owner decision 2026-08-03, PR #541 option A):
-# the pkg168 correctness fix v4 measures 1.222s (best correct form; REG:254
-# blocks in-kernel recovery). Owned by pkg174 — restoring 1.0 and reverting
-# this raise is pkg174's definition of done. Original pin: 1.0 (2026-07-25).
+CEILING_S = 1.5  # ACCEPTED post-settlement ceiling (owner decision 2026-08-08,
+# pkg174 / PR #554). The ≤1.0s restore target is UNREACHABLE under a PERF-ONLY,
+# correctness-frozen scope: pkg174 measured the shade kernel's REG:254 ceiling as
+# TWO independent ~160-reg consumers (NEE light-sampling + the spectral BSDF union)
+# on a ~95-reg irreducible state base — either alone saturates the cap, so no
+# stage-split or per-material split raises occupancy (full evidence:
+# .astroray_plan/docs/pkg174-register-pressure-ledger.md). Best correct form now
+# measures 1.132s (pkg174's template<bool Deferred> dead-branch removal, -1.1%);
+# 1.5s keeps ~31% headroom as a gross-regression tripwire. Original pin: 1.0
+# (2026-07-25, pre-accretion); superseded by feature-cost reality (addendum 1.156s).
 
 
 def _build():


### PR DESCRIPTION
## pkg174 — wavefront register-pressure recovery (supervised session)

**HELD FOR OWNER REVIEW — do not merge.** PERF-ONLY; correctness frozen; bit-identity gated.

### What landed
`shadePathSlot` is now `template<bool Deferred>`. The dead immediate-NEE `else`
branch (inline `gpu_nee_occlude` shadow-ray BVH/TLAS traversal) is `if constexpr`'d
out of the production deferred (bucketed + NeeMis) instantiations where it is
unreachable (`nee_f` always non-null); `advancePathSlot` keeps it (`Deferred=false`).

**Measured (RTX 5070 Ti, 2887 MHz P0, burn-in + min-of-10, `disney_contact_sheet` 1024spp):**
| | baseline | this PR |
| --- | --- | --- |
| `stageShadeBucketedKernel` REG / STACK | 254 / 2576 | 254 / **2256** |
| `stageShadeNeeMisKernel` STACK | 3168 | **2848** |
| perf min / median | 1.1446 / 1.1458 s | **1.1318 / 1.1330 s** (**−1.1%**) |

Every run below baseline's minimum → real, not clock drift. Bit-identity: full
`tests/wavefront_diff/` **29 passed** (CPU↔GPU per-stage snapshot gate + dedicated-NEE +
image); `mean_img` byte-identical.

### The ≤1.0s target is NOT met — and is unreachable via stage-split (measured)
Nsight Compute was blocked (`ERR_NVGPUCTRPERM`, no perf-counter permission). Stub-and-rebuild
attribution on the shade kernel:

| Config | REG | STACK |
| --- | --- | --- |
| baseline (NEE on, BSDF on) | 254 | 2576 |
| NEE OFF, BSDF on | 254 | 2064 |
| NEE on, BSDF bypassed | 255 | 2320 |
| NEE OFF **and** BSDF bypassed | **95** | 584 |

**This corrects the merged stage-split design doc's headline.** The 254 ceiling is **two
independent ~160-reg consumers** (NEE light-sampling; the *spectral* BSDF union
`gpu_material_sample_spectral` — never isolated before) on a **~95-reg irreducible
state-marshalling base**. Either alone saturates 254; only removing both reaches 95. So:
- Extracting NEE **or** BSDF into its own stage leaves the other pinning 254 → **no
  occupancy gain**. A split trades one 254-kernel for two 254-kernels + extra state
  round-trips = net-negative. **Exp3 was therefore not implemented — the measurement shows
  it cannot help.**
- Per-material specialization can't help this scene either (NEE pins every bucket; heavy
  buckets' samplers exceed the 128-reg 2-blocks/SM threshold). Filed as **extensibility
  only** — `pkg174-per-material-kernel-dispatch-design.md`.
- The only remaining lever is shrinking shared state (fewer spectral samples / params) — a
  correctness/precision change, **out of this package's PERF-ONLY scope.**

### Definition-of-done: ceiling NOT reverted (correct)
Scene measures **1.132 s > 1.0 s**, so the temporary 1.5 s ceiling in
`test_pkg55_perf_gate.py` **stays** (reverting is valid only at a true ≤1.0 s). 

**Owner decision needed:** accept the raised ceiling as the new floor (feature-cost reality
per the addendum), or authorize a shared-state / precision change that steps outside
PERF-ONLY scope. Full evidence: `pkg174-register-pressure-ledger.md` (supervised-session section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
