### PR TITLE
feat(pkg171): loud guard for CPU-only integrators on GPU

### DIFF
--- a/.astroray_plan/packages/pkg171-cpu-only-integrator-gpu-guard.md
+++ b/.astroray_plan/packages/pkg171-cpu-only-integrator-gpu-guard.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 3 (dispatch honesty / GPU pipeline health)
 **Track:** A (small; the guard is CPU-side dispatch logic, CI-testable; one RTX repro leg)
-**Status:** open — backlog (S, gap-filler tier — no user-facing defect today; the value is failing LOUDLY instead of silently black)
+**Status:** done (PR #PENDING, 2026-08-08 — raw-binding GPU dispatch now throws for all 4 CPU-only integrators (light_tracer_caustic / caustic_path_tracer / sms_caustic_path_tracer / neural-cache); no more silent near-black. RTX guard leg 5/5 green; full silent-black visual confirmation deferred to lead /verify)
 **Estimated effort:** S
 **Depends on:** nothing.
 

--- a/.astroray_plan/packages/pkg171-cpu-only-integrator-gpu-guard.md
+++ b/.astroray_plan/packages/pkg171-cpu-only-integrator-gpu-guard.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 3 (dispatch honesty / GPU pipeline health)
 **Track:** A (small; the guard is CPU-side dispatch logic, CI-testable; one RTX repro leg)
-**Status:** done (PR #PENDING, 2026-08-08 — raw-binding GPU dispatch now throws for all 4 CPU-only integrators (light_tracer_caustic / caustic_path_tracer / sms_caustic_path_tracer / neural-cache); no more silent near-black. RTX guard leg 5/5 green; full silent-black visual confirmation deferred to lead /verify)
+**Status:** done (PR #559, 2026-08-08 — raw-binding GPU dispatch now throws for all 4 CPU-only integrators (light_tracer_caustic / caustic_path_tracer / sms_caustic_path_tracer / neural-cache); no more silent near-black. RTX guard leg 5/5 green; full silent-black visual confirmation deferred to lead /verify)
 **Estimated effort:** S
 **Depends on:** nothing.
 

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -1681,6 +1681,30 @@ public:
 
 #ifdef ASTRORAY_CUDA_ENABLED
         if (useGPU && cudaRenderer && cudaRenderer->isAvailable()) {
+            // pkg171: a CPU-only integrator (no GPU kernel) would otherwise fall
+            // through to the generic wavefront route below, which renders it as if
+            // it were a plain path tracer — silently producing a NEAR-BLACK frame
+            // (#540 HW verification: light_tracer_caustic peak 0.019 vs CPU 0.500).
+            // Fail LOUDLY here instead of shipping a black render. The CPU-only set
+            // is enumerated by capabilities().gpuSupported == false — the same
+            // source integrator_capabilities() and the addon's configure_backend
+            // read — so no integrator name is hardcoded. This is the raw-binding
+            // backstop; the Blender addon already guards this at the Python layer
+            // (configure_backend: error on device_mode='gpu', CPU fallback on
+            // 'auto'), but direct PyRenderer callers (test scripts, HW verifiers)
+            // bypass it.
+            if (!integratorName_.empty()) {
+                auto probe = astroray::IntegratorRegistry::instance().create(
+                    integratorName_, integratorParams_);
+                const IntegratorCapabilities caps = probe->capabilities();
+                if (!caps.gpuSupported) {
+                    throw std::runtime_error(
+                        "Astroray: integrator '" + integratorName_ +
+                        "' has no GPU implementation (" + caps.gpuFallbackReason +
+                        ") and would render silently near-black on GPU. Render this "
+                        "integrator on CPU (set_use_gpu(false) / device_mode='cpu').");
+                }
+            }
             // GPU path: build BVH on CPU (needed for upload), then render on GPU.
             // pkg114 inc 3d: skipUpload renders from existing device state, so the
             // CPU BVH rebuild is unnecessary too (geometry is unchanged).

--- a/tests/test_blender_backend_policy.py
+++ b/tests/test_blender_backend_policy.py
@@ -230,6 +230,70 @@ def test_configure_backend_auto_logs_and_falls_back_for_unsupported_integrator(m
 
 
 # ---------------------------------------------------------------------------
+# pkg171 — CPU-only integrators must fail LOUDLY on GPU, not render near-black.
+# light_tracer_caustic (pkg106) has no GPU kernel; the #540 HW verification
+# forced it onto GPU and got a near-black frame (peak 0.019 vs CPU 0.500). The
+# dispatch-logic guard (this addon layer + the raw-binding backstop in
+# module/blender_module.cpp render()) is enumerated by capabilities()
+# .gpuSupported == false — no integrator name is hardcoded.
+# ---------------------------------------------------------------------------
+
+def _load_addon_with_cpu_only_caustic(monkeypatch, renderer_cls):
+    """Registry mock that includes light_tracer_caustic as a CPU-only plugin
+    (gpuSupported=False, with the real fallback reason)."""
+    gpu_set = {"path_tracer", "ambient_occlusion"}
+    return _load_blender_addon(monkeypatch, renderer_cls, extra_astroray_attrs={
+        "integrator_registry_names": lambda: [
+            "path_tracer", "ambient_occlusion", "light_tracer_caustic"],
+        "integrator_capabilities": lambda name: {
+            "gpuSupported": name in gpu_set,
+            "gpuFallbackReason": "" if name in gpu_set
+            else "forward light-tracer caustic (CPU-only)",
+        },
+    })
+
+
+def test_configure_backend_gpu_rejects_light_tracer_caustic(monkeypatch):
+    """pkg171: device_mode='gpu' + light_tracer_caustic must raise, not silently
+    render near-black (#540)."""
+    reports = []
+
+    class R:
+        gpu_available = True
+        def set_use_gpu(self, v):
+            raise AssertionError("set_use_gpu must not run for a CPU-only integrator")
+
+    addon = _load_addon_with_cpu_only_caustic(monkeypatch, R)
+    settings = _make_settings(device_mode="gpu", integrator_type="light_tracer_caustic")
+    try:
+        addon.configure_backend(R(), settings, lambda *args: reports.append(args))
+    except RuntimeError as exc:
+        assert "light_tracer_caustic" in str(exc)
+        assert "does not support GPU" in str(exc)
+    else:
+        raise AssertionError("forced GPU mode must raise for light_tracer_caustic")
+    assert reports and reports[0][0] == {'ERROR'}
+
+
+def test_configure_backend_auto_falls_back_for_light_tracer_caustic(monkeypatch):
+    """pkg171: device_mode='auto' + light_tracer_caustic falls back to CPU with a
+    visible INFO notice (never a silent GPU near-black)."""
+    reports = []
+
+    class R:
+        gpu_available = True
+        def set_use_gpu(self, v):
+            raise AssertionError("set_use_gpu must not run for a CPU-only integrator")
+
+    addon = _load_addon_with_cpu_only_caustic(monkeypatch, R)
+    settings = _make_settings(device_mode="auto", integrator_type="light_tracer_caustic")
+    result = addon.configure_backend(R(), settings, lambda *args: reports.append(args))
+    assert result == "cpu"
+    assert reports and reports[0][0] == {'INFO'}
+    assert "light_tracer_caustic" in reports[0][1]
+
+
+# ---------------------------------------------------------------------------
 # configure_backend is present as a module-level function
 # ---------------------------------------------------------------------------
 

--- a/tests/test_integrator_capabilities.py
+++ b/tests/test_integrator_capabilities.py
@@ -38,9 +38,17 @@ def test_integrator_gpu_support_matrix_matches_current_cuda_kernels():
     # C6 ReSTIR SoA port; the CPU frame history now lives in device SoA.
     expected_supported = {"path_tracer", "ambient_occlusion",
                           "multiwavelength_path_tracer", "restir-di"}
+    # pkg171: the CPU-only set is the enumeration the GPU-dispatch guard trusts
+    # (capabilities().gpuSupported == false). Requesting any of these on a GPU
+    # device would otherwise render silently near-black (#540: light_tracer_caustic
+    # peak 0.019 vs CPU 0.500); the guard in module/blender_module.cpp render()
+    # raises instead. Pin the full CPU-only list so a future GPU port must flip
+    # both the integrator's capabilities() AND this expectation deliberately.
     expected_unsupported = {
         "caustic_path_tracer",
         "neural-cache",
+        "light_tracer_caustic",
+        "sms_caustic_path_tracer",
     }
 
     assert expected_supported <= names

--- a/tests/test_pkg171_cpu_only_integrator_gpu_guard.py
+++ b/tests/test_pkg171_cpu_only_integrator_gpu_guard.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+"""pkg171 — CPU-only integrators must fail LOUDLY on GPU, not render near-black.
+
+The #540 HW verification forced `light_tracer_caustic` (pkg106, CPU-only, no GPU
+kernel) onto the GPU and got a near-black frame (peak 0.019 vs CPU 0.500) with NO
+error — the raw PyRenderer binding (set_use_gpu + set_integrator + render) bypasses
+the Blender addon's Python-layer guard (configure_backend).
+
+The fix is a backstop in module/blender_module.cpp render(): before dispatching to
+the wavefront pipeline, it queries the selected integrator's
+capabilities().gpuSupported (the same enumeration integrator_capabilities() and the
+addon read — no hardcoded name) and raises when it is False.
+
+GPU-gated: the guard only fires inside the `useGPU && cudaRenderer->isAvailable()`
+branch, so it needs a real CUDA device. This test skips on CI (no GPU) and is the
+one RTX leg /verify runs. The CI-runnable dispatch-logic legs live in
+tests/test_blender_backend_policy.py (addon) and tests/test_integrator_capabilities.py
+(enumeration).
+"""
+
+import pytest
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+
+try:
+    import astroray
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray module not available")
+
+
+def _gpu_renderer():
+    r = astroray.Renderer()
+    if not bool(astroray.__features__.get("cuda", False)) or not r.gpu_available:
+        pytest.skip("No CUDA GPU available — pkg171 guard runs on the RTX box (/verify).")
+    try:
+        r.set_use_gpu(True)
+    except Exception:  # noqa: BLE001 - any CUDA init failure means skip (cf. test_cuda_prewarm)
+        pytest.skip("CUDA initialization failed")
+    return r
+
+
+@pytest.mark.parametrize("name", [
+    "light_tracer_caustic",
+    "caustic_path_tracer",
+    "sms_caustic_path_tracer",
+    "neural-cache",
+])
+def test_cpu_only_integrator_on_gpu_raises(name):
+    """Every CPU-only integrator (gpuSupported == False) must raise on the raw
+    GPU render binding rather than silently rendering near-black."""
+    # Only exercise names that really are CPU-only in this build (the enumeration
+    # is authoritative — a future GPU port flips capabilities() and this skips).
+    if astroray.integrator_capabilities(name)["gpuSupported"]:
+        pytest.skip(f"{name} now reports GPU support — no longer a CPU-only guard case")
+
+    r = _gpu_renderer()
+    r.setup_camera(
+        look_from=[0, 0, 5], look_at=[0, 0, 0], vup=[0, 1, 0], vfov=40,
+        aspect_ratio=1.0, aperture=0.0, focus_dist=5.0, width=16, height=16,
+    )
+    r.set_integrator(name)
+    with pytest.raises(RuntimeError) as exc:
+        r.render(4, 4)
+    msg = str(exc.value)
+    assert name in msg, f"error must name the integrator, got: {msg}"
+    assert "GPU" in msg
+
+
+def test_gpu_supported_integrator_still_renders():
+    """Guardrail: the default path_tracer (gpuSupported == True) must NOT be
+    caught by the pkg171 guard — GPU rendering still works."""
+    r = _gpu_renderer()
+    r.setup_camera(
+        look_from=[0, 0, 5], look_at=[0, 0, 0], vup=[0, 1, 0], vfov=40,
+        aspect_ratio=1.0, aperture=0.0, focus_dist=5.0, width=16, height=16,
+    )
+    r.set_integrator("path_tracer")
+    img = r.render(4, 4)  # must not raise
+    assert img is not None


### PR DESCRIPTION
## Summary

CPU-only integrators (no GPU kernel) were being routed through the generic GPU wavefront path when forced onto GPU via the **raw `PyRenderer` binding**, rendering **silently near-black** (#540 HW verification: `light_tracer_caustic` peak 0.019 vs CPU 0.500) with **no error**. The Blender addon already guards this at the Python layer (`configure_backend`: error on `device_mode='gpu'`, CPU fallback on `'auto'`), but direct binding callers — test scripts, HW verifiers — bypass it. This adds the missing backstop and pins the enumeration contract.

## CPU-only integrators enumerated (how)

Enumerated by GREP + the authoritative `capabilities().gpuSupported == false` flag (queried from the built binary), **not hardcoded**:

| integrator | gpuSupported | reason |
|---|---|---|
| `caustic_path_tracer` | False | caustic chain connection integrator has no CUDA kernel |
| `light_tracer_caustic` | False | forward light-tracer caustic (CPU-only) |
| `neural-cache` | False | neural cache uses the CPU integrator interface... not the CUDA path-trace kernel |
| `sms_caustic_path_tracer` | False | SMS caustic integrator is CPU-only in Phase 1/2 |

GPU-supported (unaffected): `ambient_occlusion`, `multiwavelength_path_tracer`, `path_tracer`, `restir-di`, `wavefront_path_tracer`.

## Chosen behavior and why

**Raise an explicit `RuntimeError`** in `PyRenderer::render()`, at the top of the `useGPU && cudaRenderer->isAvailable()` branch. This is the spec's *preferred* option: the call site is the raw render binding (a direct, explicit GPU request), **not** the addon's auto-fallback path. The addon's `auto` warn+fallback and `gpu` error already exist at the Python layer (pkg37/53/80) — this PR does not change them. The guard reads `capabilities().gpuSupported` (same source `integrator_capabilities()` and the addon read), so no integrator name is hardcoded; a future GPU port only needs to flip the integrator's `capabilities()`.

## Tests

- **CI-runnable dispatch-logic (no GPU):**
  - `test_blender_backend_policy.py` — `light_tracer_caustic` + `device_mode='gpu'` raises (ERROR); + `'auto'` falls back to CPU with a visible INFO notice. Mocked; 17/17 pass.
  - `test_integrator_capabilities.py` — pinned the full CPU-only set (added `light_tracer_caustic`, `sms_caustic_path_tracer`). 3/3 pass against the real binary.
- **GPU-gated (RTX; the /verify leg):**
  - `test_pkg171_cpu_only_integrator_gpu_guard.py` — raw-binding `render()` raises on GPU for every CPU-only integrator, and `path_tracer` still renders. **5/5 pass on RTX 5070 Ti** with the freshly-built worktree `.pyd`.

## Measured

```
$ pytest test_pkg171_cpu_only_integrator_gpu_guard.py -v   (RTX 5070 Ti)
test_cpu_only_integrator_on_gpu_raises[light_tracer_caustic]   PASSED
test_cpu_only_integrator_on_gpu_raises[caustic_path_tracer]    PASSED
test_cpu_only_integrator_on_gpu_raises[sms_caustic_path_tracer] PASSED
test_cpu_only_integrator_on_gpu_raises[neural-cache]           PASSED
test_gpu_supported_integrator_still_renders                    PASSED
5 passed
```

## Build (last 5 lines — `blender_module.cpp` is in the CUDA build)

```
[113/115] Linking CUDA static library astroray_cuda.lib
[114/115] Linking CXX shared module astroray.cp313-win_amd64.pyd
[0/2] Re-checking globbed directories...
[1/3] Building CXX object CMakeFiles\astroray_test_helpers.dir\module\test_helpers_module.cpp.obj
[2/3] Linking CXX shared module astroray_test_helpers.cp313-win_amd64.pyd
[build_cuda_worktree] Build succeeded
```

## Acceptance criteria

- [x] Enumerate integrators by backend capability via the registry (not hardcoded) — via `capabilities().gpuSupported`.
- [x] CPU-only integrator + GPU raises an explicit error (raw binding); addon auto-fallback path unchanged (already warn+fallback).
- [x] CI-runnable dispatch-logic test asserting the guard.
- [x] Integrator itself unchanged; nothing ported to GPU (non-goals respected).

## Authorized surface

Spec Specification touches: integrator registry / capability enumeration / device-selection dispatch; tests. Files changed:
- `module/blender_module.cpp` — the device-selection dispatch guard (in scope).
- `tests/test_integrator_capabilities.py`, `tests/test_blender_backend_policy.py`, `tests/test_pkg171_cpu_only_integrator_gpu_guard.py` — tests (in scope).
- `.astroray_plan/packages/pkg171-cpu-only-integrator-gpu-guard.md` — status flip.

No addon code, disney/gpu_materials, benchmarks, or the integrator itself were touched.

## Deferred to lead

Full silent-black **visual** RTX confirmation (render a scene, confirm no black frame is reachable) is deferred to the lead's `/verify` leg per the dispatch. The guard-throw behavior is already confirmed green on RTX above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)