### PR TITLE
spec(pkg178): native Cycles Principled BSDF port for true parity

### DIFF
--- a/.astroray_plan/docs/cycles-principled-port-research-2026-08.md
+++ b/.astroray_plan/docs/cycles-principled-port-research-2026-08.md
@@ -112,11 +112,24 @@ F82-tint; OpenPBR spec (EON diffuse).
   string-keyed `MaterialRegistry`. `disney.cpp:918` registers `"disney"`.
 - Build: `CMakeLists.txt:303` `file(GLOB_RECURSE ASTRORAY_PLUGIN_SOURCES
   CONFIGURE_DEPENDS ...)` — a new `plugins/materials/principled.cpp` needs
-  **zero CMake edits**.
+  **zero CMake edits** (plugins build as an OBJECT library so the
+  registration static-initializers survive).
 - Interface (`include/raytracer.h:424`): `sample/eval/pdf/emitted` +
-  spectral (`evalSpectral:485`, `sampleSpectral:494`, `Ext` variants for
-  pkg39 profiles) + `closureGraph():437` (the GPU lowering) +
-  `backendCapabilities():438` (validates the graph for GPU reachability).
+  spectral — **`evalSpectral` (`:485`) is the one PURE-VIRTUAL hard
+  requirement**; `sampleSpectral:494` has an upsampling default with the
+  eta²-clamp guard; `Ext` variants for pkg39 profiles — +
+  `closureGraph():437` (the GPU lowering) + `backendCapabilities():438`
+  (validates the graph for GPU reachability) + ~14 scalar getters that form
+  the `scene_upload.cu` upload ABI.
+- Binding gotchas (`module/blender_module.cpp:477-505`
+  `PyRenderer::createMaterial`): NO prefixed-key map or `enable_*` branch
+  for materials (blanket ParamDict pass-through — the GR-emission wiring
+  checklist does not apply here), BUT (a) a ctor exception is swallowed and
+  silently falls back to a legacy material — test the registry name
+  explicitly; (b) `params.contains("texture")` bypasses the registry
+  entirely (the root cause of the addon's textured-basecolor→lambertian
+  downgrade); (c) `ParamDict` float/int stores are type-segregated — use
+  `getFloat` only.
 - Reusable subsystems already in place: `energy_compensation.h` (Cycles
   `table_ggx_E`/`Eavg` + glass tables, Kulla-Conty layering — pkg60/151/
   160/163 lineage), VNDF sampling (pkg149), `RGBAlbedoSpectrum`
@@ -147,18 +160,38 @@ file + registration, no core edits.
   ior+tint absorption, LTC sheen, thin-film fresnel params on conductor +
   dielectric closures, thin-subsurface/translucent), per-closure param
   fields, possibly `G_MAX_MATERIAL_CLOSURES` 8→10 (the full stack can
-  allocate up to 9 closures incl. transparent+emission), upload plumbing,
-  and eval/sample/pdf/spectral switch arms.
+  allocate up to 9 closures incl. transparent+emission; CPU-side cap
+  `material_closure.h:40` moves in lockstep), upload plumbing
+  (`scene_upload.cu:108-148` closure path preferred over a new
+  `GMAT_PRINCIPLED` string arm), and eval/sample/pdf/spectral switch arms.
+- **Known traps if a new `GMaterialType` is added instead of riding
+  `GMAT_CLOSURE_GRAPH`:** `stage_advance.cu:109` `G_WF_NUM_MAT_TYPES = 7`
+  with a SILENT clamp at `:1034-1036` (an out-of-range type shades in the
+  wrong bucket, no error), duplicated as `kNumMatTypes = 7` at
+  `gpu_wavefront_snapshot.cu:1412`; and `photon_caustic.cu:116-124`
+  `isTransmissive` must learn any new transmissive type or caustics
+  silently skip it. The closure-graph route avoids the first two entirely
+  — a strong argument for it.
 - LTC sheen and thin-film sensitivity data need table uploads — precedent
   exists (Cycles `shader.tables` GGX E/Eavg already ship on both legs,
   `gpu_ggx_tables.cu`, `gpu_glass_tables.cu`).
+- **Extensibility unlock (design-only today):**
+  `.astroray_plan/docs/pkg174-per-material-kernel-dispatch-design.md` —
+  `template<int MatType>` per-bucket shade kernels off the already-sorted
+  shade queues. Measured perf-neutral; its justification is exactly this
+  package's problem (adding materials without growing one shared kernel's
+  spill). Stage 2 should decide whether to land it as its vehicle.
 
 ### 2.3 Register-pressure risk (the known ceiling)
 
 `stageAdvance`/`stageShadeBucketed` are pinned at 254 regs; any extra
 per-hit live state spills ~2KB and tanks wavefront perf (memory
 `wavefront-shade-kernels-register-saturated`; pkg168/pkg174 history; pkg174
-just recovered the ceiling to owner-accepted levels). The thin-film Airy
+just recovered the ceiling to owner-accepted levels). Measured attribution
+(pkg174 design doc, `cuobjdump`): NEE and BSDF legs are two independent
+~160-reg consumers on a ~95-reg base — new material arms inlined into
+`gpu_material_sample_spectral` grow STACK spill, not REG, so the damage is
+invisible to a REG-only check; watch STACK. The thin-film Airy
 summation (complex phasors, per-channel loop) and LTC sheen fetch are
 exactly the kind of code that spills. Mitigations, in preference order:
 1. Evaluate new closures in a **dedicated shade bucket/kernel** for
@@ -173,30 +206,73 @@ scenes unconditionally; principled-scene perf gets its own measured budget.
 
 ### 2.4 Blender addon seam
 
-`blender_addon/__init__.py:3358` `convert_principled_bsdf_v2` maps
-Principled→`'disney'` today, dropping/approximating: coat ior/tint/normal,
-sheen tint/roughness, specular_ior_level/tint (partially), diffuse
+**Two parallel Principled translation paths — both must switch together:**
+the live spec-based path (`_principled_shader_spec:3055` →
+`_create_material_from_shader_spec:3189`, `'disney'` literal at `:3237`
+plus the `'transparent'`-kind lowering at `:3241`) and the semi-orphaned
+`convert_principled_bsdf_v2:3358` (`'disney'` at `:3437`). Three literals →
+one flag-aware helper. Today's mapping drops/approximates: coat
+ior/tint/normal, sheen tint/roughness, specular_ior_level/tint, diffuse
 roughness, SSS radius/scale/anisotropy/method, anisotropic rotation/tangent,
-thin film (entirely), thin wall (entirely); emission is heuristically
-promoted to a `'light'` material; **textured base color downgrades the whole
-material to textured-lambertian** (`:3425` — a known wart, adjacent scope).
-The switch point for pkg178 Stage 5 is exactly this function: route to
-`'principled'` behind a flag, keep `'disney'` as fallback. `shader_blending.py`
-normalizes principled specs and must learn the new params too.
+thin film + thin wall (entirely); **alpha is folded into
+`transmission = max(transmission, 1-alpha)`** (opacity/refraction
+conflation — same family as the convicted BSDF_TRANSPARENT
+TRANSLATION-BUG, SSIM 0.44, which lowers transparent to a Disney ior=1.0
+dielectric at `:3239-3241`); emission is heuristically promoted to a
+`'light'` material; **textured base color downgrades the whole material to
+textured-lambertian** (`:3227-3235` — root cause is the
+`params.contains("texture")` registry bypass in `createMaterial`).
+The manual-override dropdown (`CustomRaytracerMaterialSettings:705`)
+enumerates `material_registry_names()` — a new registered material appears
+there automatically. `shader_blending.py` normalizes principled specs and
+must learn the new params too. `dist/astroray/__init__.py` is a build
+artifact — never edit.
 
 ### 2.5 Verification infrastructure (exists, reusable)
 
-- pkg119-B differential harness (Cycles-vs-Astroray, PR #550; runbook in
-  memory `pkg119b-harness-runbook`) — per-feature scene pairs, the natural
-  home for a Principled feature-matrix leg.
+- pkg119-B differential harness (Cycles-vs-Astroray, PR #550,
+  `benchmarks/blender_parity/{harness,render_leg,scene_library,triage}.py`;
+  runbook in memory `pkg119b-harness-runbook`) — per-feature scene pairs;
+  current gates SSIM≥0.90 / mean ΔE2000≤8.0, per-channel ratio for triage
+  only. A native Principled needs NO harness code change: flip the flag,
+  re-run, diff `triage_report.json` flag-off vs flag-on; new rows (thin
+  film, thin wall) enter by reclassifying their `coverage_matrix.json`
+  cells from DROPPED-SILENT. Note these package-level gates are looser
+  than pkg178's per-feature parity bands — the harness locates
+  divergence, the per-lobe gates convict it.
 - `benchmarks/reference_bank/` (pkg104) Cycles-as-oracle blessing + metrics;
   `benchmarks/cycles-parity/` (pkg71) paired render legs.
 - pkg166 conventions: linear rendering (`apply_gamma=False`), floor AND
   ceiling bands (gamma furnaces cannot detect energy gain).
 - pkg129 (narrowed) live-Cycles rough-metal A/B — composes with Stage-1
-  metal-lobe acceptance.
+  metal-lobe acceptance (spec only, no code shipped yet; the closest
+  substrate is `benchmarks/cycles-parity/` from pkg71).
+- **pkg128 (thin-film iridescence) — pre-existing open spec, reconciled:**
+  pkg128 already specifies Belcour-Barla thin film across
+  metal/dielectric/disney + GPU + the six DROPPED-SILENT addon sockets,
+  with the key design insight that **Astroray's spectral core can evaluate
+  the Airy term per sampled wavelength directly** (no RGB
+  sensitivity-curve fit — simpler than Cycles' own implementation).
+  pkg178 Stage 4 adopts pkg128's per-λ design and implements the
+  thin-film Fresnel layer ONCE as a shared utility; pkg128's residual
+  charter narrows to the standalone Glass/Metallic node cells + the
+  spectral showcase visuals, riding the same utility.
 - Gate style: per-channel mean-ratio bands, not SSIM, for independent RNG
   streams (memory `ssim-wrong-gate-for-independent-rng`).
+
+---
+
+### 2.6 Highest-value design decision: spectrally native from day one
+
+Disney's `evalSpectral` is the pkg13 shortcut — upsample the post-scale RGB
+eval (`disney.cpp:700-706`). Jakob-Hanika upsampling is nonlinear in
+magnitude (`upsample(k·c) != k·upsample(c)`), and this exact shortcut has
+already produced three separate bug classes (pkg118/#404 eta² clamp, pkg163
+metal colour-space seam, pkg168 diffuse upsample-shape). The new material
+must be per-λ native in `evalSpectral`/`sampleSpectral` (upsample
+reflectance COLOURS, apply scalars per-λ), matching the pattern
+`gpu_metal_eval_spectral`/`MetalPlugin::evalSpectral` established. This is
+the single largest correctness improvement over porting Disney's shape.
 
 ---
 

--- a/.astroray_plan/docs/cycles-principled-port-research-2026-08.md
+++ b/.astroray_plan/docs/cycles-principled-port-research-2026-08.md
@@ -1,0 +1,246 @@
+# Research note — Native Cycles Principled BSDF port (pkg178)
+
+**Date:** 2026-08-08. **Author:** architect (goal-capture). **Owner request:**
+a faithful native copy of Cycles' Principled BSDF — the LATEST version,
+including the thin translucent / thin-film material — replacing the current
+Principled→Disney approximation for true parity. This note records the
+external reference pin, the Astroray extension-point analysis, and the
+swarm-decomposition assessment behind pkg178.
+
+---
+
+## 1. Reference pin: Cycles main (Blender 5.2-era Principled BSDF)
+
+The post-4.0 rewrite timeline (what "latest" means):
+
+| Version | Feature | Reference |
+|---|---|---|
+| 4.0 (2023) | Full rewrite: Coat (GGX, `coat_ior`+`coat_tint` Beer absorption, sits above emission), Sheen (Zeltner/Burley/Chiang LTC "microfiber"), multiscatter GGX by default, IOR-driven specular (`specular_ior_level` remaps F0), emission inside the node | [4.0 release notes](https://developer.blender.org/docs/release_notes/4.0/shading/) |
+| 4.2 | **Thin Film** iridescence (Belcour-Barla 2017), dielectric specular + transmission | [PR #118477](https://projects.blender.org/blender/blender/pulls/118477) |
+| 4.3 | Diffuse Roughness (energy-preserving multiscatter Oren-Nayar, OpenPBR/EON behaviour); Physical Conductor (complex-IOR) + F82-tint metal Fresnel | [PR #123345](https://projects.blender.org/blender/blender/pulls/123345), [PR #123616](https://projects.blender.org/blender/blender/pulls/123616) |
+| 5.0 | Thin Film extended to **conductors** (metallic lobe) | [5.0 Cycles notes](https://developer.blender.org/docs/release_notes/5.0/cycles/) |
+| 5.2 | **Thin Wall** mode (bool): thin sheet — combined reflection+transmission thin glass, diffuse+translucent thin subsurface ("paper, leaves, window sheets"); also negative SSS anisotropy | [PR #157469](https://projects.blender.org/blender/blender/pulls/157469) |
+
+The owner's "thin translucent / thin-film material" is BOTH features: Thin
+Film (interference iridescence, 4.2/5.0) and Thin Wall translucency (5.2).
+
+**Oracle implication:** the local Blender is 5.1 — it has dielectric+conductor
+thin film but NOT Thin Wall. Stage-4 thin-wall parity legs need a Blender
+5.2 LTS install as the Cycles oracle (owner decision D1 in pkg178).
+
+### 1.1 Full parameter list (SVM stack reads, `svm_node_closure_bsdf`,
+`CLOSURE_BSDF_PRINCIPLED_ID`, cycles `src/kernel/svm/closure.h`)
+
+`base_color, metallic, roughness, ior, alpha, normal; diffuse_roughness;
+subsurface_weight, subsurface_radius (RGB), subsurface_scale, subsurface_ior,
+subsurface_anisotropy, subsurface_method; specular_ior_level, specular_tint,
+anisotropic, anisotropic_rotation, tangent_offset; transmission_weight;
+coat_weight, coat_roughness, coat_ior, coat_tint, coat_normal_offset;
+sheen_weight, sheen_roughness, sheen_tint; emission_color, emission_strength;
+thin_film_thickness (nm), thin_film_ior; thin_wall (bool)`.
+
+### 1.2 Closure stack and layering (the structure to replicate)
+
+Weight flow: `weight = mix_weight`; `weight *= alpha` (a Transparent closure
+takes `1-alpha`); then top-down:
+
+1. **Emission** — attenuated by the layers stacked above it.
+2. **Sheen** (LTC microfiber): `weight = closure_layering_weight(sheen_albedo, weight)`.
+3. **Coat**: GGX dielectric microfacet, `fresnel_dielectric`; layer albedo
+   attenuates below; underlying weight further
+   `*= mix(1, coat_tint^optical_depth, coat_weight)` with
+   `optical_depth = 1/cos(theta_refracted)` (Beer's law).
+4. **Metallic**: GGX + `FresnelF82Tint` or `FresnelConductor`; thin-film
+   params forwarded (5.0). Afterwards `weight *= (1-metallic)`.
+5. **Transmission**: thick → GGX glass closure +
+   `FresnelGeneralizedSchlick(ior, tint=specular_tint, sqrt(base_color),
+   thin_film)`; thin_wall → `bsdf_thin_glass_setup` (single closure,
+   combined R+T, no refraction offset). Afterwards
+   `weight *= (1-transmission_weight)`.
+6. **Specular dielectric** (if `eta != 1` or thin film): GGX +
+   `FresnelGeneralizedSchlick` (`f0` from `specular_ior_level`, `f90 = 1`,
+   `exponent = -eta`); layering weight via GGX directional albedo (E lookup).
+7. **Subsurface**: thick → `Bssrdf` (random-walk); thin_wall →
+   `bsdf_thin_subsurface_setup` (diffuse + translucent);
+   `diffuse_weight = base_color * (1-subsurface_weight) * weight`.
+8. **Diffuse**: `bsdf_diffuse_setup`, or `bsdf_oren_nayar_setup` when
+   `diffuse_roughness > 0` (energy-preserving multiscatter Oren-Nayar / EON,
+   OpenPBR behaviour).
+
+Multiscatter GGX energy compensation rides the fresnel-setup variants
+(`is_multiggx`). Backface handling adjusts the film IOR:
+`adjust_thin_film_ior_at_backface(thinfilm.ior, bsdf->ior)`.
+
+### 1.3 Thin-film model (cycles `src/kernel/closure/bsdf_util.h`)
+
+Belcour & Barla, *A Practical Extension to Microfacet Theory for the
+Modeling of Varying Iridescence*, ACM TOG 36(4), SIGGRAPH 2017. Cycles
+implements the Airy-reflectance summation truncated at m=3 with complex
+phasors; `OPD = -2 * film_ior * thickness * cos_theta_2`; evaluated
+**per RGB channel** through a CIE sensitivity LUT
+(`iridescence_lookup_sensitivity_channel`); `template<bool conductive>
+fresnel_iridescence_channel(kg, channel, ambient_ior, thin_film{thickness,
+ior}, substrate_n, substrate_k, F82, cos_theta_1, *r_cos_theta_3)` covers
+dielectric AND conductor substrates. Thickness in nm (LUT range 0–60 µm).
+Astroray note: our spectral integrator can evaluate the Airy reflectance
+directly per sampled wavelength (potentially *more* faithful than Cycles'
+3-channel sensitivity-LUT approach); the RGB legs should mirror Cycles'
+per-channel LUT for parity. Keep both in mind at Stage-4 spec time.
+
+### 1.4 Reference files and licenses
+
+Cycles standalone mirror `github.com/blender/cycles` (Apache-2.0; several
+closure headers carry BSD-3-Clause — both compatible, follow the existing
+in-repo citation pattern used by `disney.cpp`/`energy_compensation.h`):
+`src/kernel/svm/closure.h` (closure assembly + layering — the canonical
+structure), `src/kernel/closure/bsdf_microfacet.h` (GGX + fresnel setups +
+energy preservation), `bsdf_util.h` (fresnel + iridescence), `bsdf_sheen.h`
+(LTC tables + fetch), `bsdf_oren_nayar.h` (EON), `bsdf_transparent.h`,
+`bssrdf.h` (random-walk profiles). Papers: Belcour-Barla 2017; Zeltner,
+Burley, Chiang, *Practical Multiple-Scattering Sheen Using Linearly
+Transformed Cosines* (SIGGRAPH 2022 talk); Kulla & Conty 2017; Kutz/Hoffman
+F82-tint; OpenPBR spec (EON diffuse).
+
+---
+
+## 2. Astroray extension-point analysis (grep-verified on main `736cd75`)
+
+### 2.1 CPU — genuinely pluggable, low friction
+
+- Registry: `include/astroray/register.h:26` —
+  `ASTRORAY_REGISTER_MATERIAL(name, T)` installs a `ParamDict` factory in a
+  string-keyed `MaterialRegistry`. `disney.cpp:918` registers `"disney"`.
+- Build: `CMakeLists.txt:303` `file(GLOB_RECURSE ASTRORAY_PLUGIN_SOURCES
+  CONFIGURE_DEPENDS ...)` — a new `plugins/materials/principled.cpp` needs
+  **zero CMake edits**.
+- Interface (`include/raytracer.h:424`): `sample/eval/pdf/emitted` +
+  spectral (`evalSpectral:485`, `sampleSpectral:494`, `Ext` variants for
+  pkg39 profiles) + `closureGraph():437` (the GPU lowering) +
+  `backendCapabilities():438` (validates the graph for GPU reachability).
+- Reusable subsystems already in place: `energy_compensation.h` (Cycles
+  `table_ggx_E`/`Eavg` + glass tables, Kulla-Conty layering — pkg60/151/
+  160/163 lineage), VNDF sampling (pkg149), `RGBAlbedoSpectrum`
+  Jakob-Hanika upsampling (beware the nonlinearity: upsample reflectance
+  colour only — memory `spectral-upsample-nonlinearity-scaled-bsdf`),
+  `thin_glass.cpp` (a 122-line thin-glass plugin — a starting precedent for
+  Thin Wall), `oren_nayar.cpp` (qualitative O-N; EON is new),
+  `subsurface.cpp` (64-line approximation — NOT a random-walk BSSRDF).
+
+Verdict: the owner's hope holds on the CPU side — a new material is a new
+file + registration, no core edits.
+
+### 2.2 GPU — closure-graph, NOT pluggable; core edits required
+
+- `gpu_types.h:364` `GMaterialType` enum; modern materials lower to
+  `GMAT_CLOSURE_GRAPH` (dielectric and Disney already do — memory
+  `gpu-dielectric-lowers-to-closure-graph`).
+- `material_closure.h:15` `MaterialClosureType`: today `Diffuse,
+  GGXConductor, DielectricTransmission, Clearcoat, Sheen, Emission,
+  ThinGlass`. `GMaterialClosure closures[G_MAX_MATERIAL_CLOSURES]` with
+  `G_MAX_MATERIAL_CLOSURES = 8` (`gpu_types.h:391,468`).
+- Evaluation: `gpu_materials.h` (1769 lines) — `gpu_closure_graph_eval/
+  pdf/sample/eval_spectral` (`:1379–1568`) with one-sample-MIS lobe
+  recombination (pkg170's `wᵢ/W` fix lives here). Upload:
+  `src/gpu/scene_upload.cu`.
+- Required core edits for a faithful Principled: new/extended closure types
+  (EON diffuse, F82-tint conductor, generalized-Schlick specular, coat with
+  ior+tint absorption, LTC sheen, thin-film fresnel params on conductor +
+  dielectric closures, thin-subsurface/translucent), per-closure param
+  fields, possibly `G_MAX_MATERIAL_CLOSURES` 8→10 (the full stack can
+  allocate up to 9 closures incl. transparent+emission), upload plumbing,
+  and eval/sample/pdf/spectral switch arms.
+- LTC sheen and thin-film sensitivity data need table uploads — precedent
+  exists (Cycles `shader.tables` GGX E/Eavg already ship on both legs,
+  `gpu_ggx_tables.cu`, `gpu_glass_tables.cu`).
+
+### 2.3 Register-pressure risk (the known ceiling)
+
+`stageAdvance`/`stageShadeBucketed` are pinned at 254 regs; any extra
+per-hit live state spills ~2KB and tanks wavefront perf (memory
+`wavefront-shade-kernels-register-saturated`; pkg168/pkg174 history; pkg174
+just recovered the ceiling to owner-accepted levels). The thin-film Airy
+summation (complex phasors, per-channel loop) and LTC sheen fetch are
+exactly the kind of code that spills. Mitigations, in preference order:
+1. Evaluate new closures in a **dedicated shade bucket/kernel** for
+   closure-graph materials carrying the new closure types, so register cost
+   is isolated from the existing hot kernels (bucketing machinery exists).
+2. `__noinline__` boundaries around thin-film fresnel (pkg174 measured this
+   lever; mind the clock-drift protocol, memory `gpu-perf-ab-clock-drift`).
+3. Precompute what is angle-independent per material (film OPD prefactor).
+Protocol: `cuobjdump` per-kernel reg/spill counts before/after at every GPU
+stage, and the wavefront perf gate must stay green on **non-principled**
+scenes unconditionally; principled-scene perf gets its own measured budget.
+
+### 2.4 Blender addon seam
+
+`blender_addon/__init__.py:3358` `convert_principled_bsdf_v2` maps
+Principled→`'disney'` today, dropping/approximating: coat ior/tint/normal,
+sheen tint/roughness, specular_ior_level/tint (partially), diffuse
+roughness, SSS radius/scale/anisotropy/method, anisotropic rotation/tangent,
+thin film (entirely), thin wall (entirely); emission is heuristically
+promoted to a `'light'` material; **textured base color downgrades the whole
+material to textured-lambertian** (`:3425` — a known wart, adjacent scope).
+The switch point for pkg178 Stage 5 is exactly this function: route to
+`'principled'` behind a flag, keep `'disney'` as fallback. `shader_blending.py`
+normalizes principled specs and must learn the new params too.
+
+### 2.5 Verification infrastructure (exists, reusable)
+
+- pkg119-B differential harness (Cycles-vs-Astroray, PR #550; runbook in
+  memory `pkg119b-harness-runbook`) — per-feature scene pairs, the natural
+  home for a Principled feature-matrix leg.
+- `benchmarks/reference_bank/` (pkg104) Cycles-as-oracle blessing + metrics;
+  `benchmarks/cycles-parity/` (pkg71) paired render legs.
+- pkg166 conventions: linear rendering (`apply_gamma=False`), floor AND
+  ceiling bands (gamma furnaces cannot detect energy gain).
+- pkg129 (narrowed) live-Cycles rough-metal A/B — composes with Stage-1
+  metal-lobe acceptance.
+- Gate style: per-channel mean-ratio bands, not SSIM, for independent RNG
+  streams (memory `ssim-wrong-gate-for-independent-rng`).
+
+---
+
+## 3. Swarm-decomposition assessment (honest)
+
+The closure architecture does decompose by lobe, but NOT flat-parallel from
+day one:
+
+- **Serial spine (cannot be swarmed):** Stage 0 mapping table; the Stage-1
+  scaffold — parameter dict, closure-stack assembly, the
+  `closure_layering_weight` chain, lobe-selection/one-sample-MIS pdf
+  recombination. This is the part where every historical Disney defect
+  lived (pkg169/pkg170) and it defines the internal lobe interface.
+- **Parallel-by-lobe (after the scaffold):** metal F82(+tint), transmission
+  glass, coat, sheen LTC, EON diffuse, thin-film fresnel, thin-wall
+  closures are separable implementation units against the scaffold's lobe
+  interface, each with its own furnace + Cycles single-lobe parity gate.
+  Realistic width: **3–4 lobe agents concurrently**, not a large swarm —
+  beyond that they contend on shared headers and on review bandwidth.
+- **Hard constraint:** delegated subagents cannot build CUDA on this
+  machine (memory `delegated-agents-cant-build-cuda`) — lobe agents are
+  implement-only; the lead builds, runs gates, and owns every GPU merge
+  serially. GPU register budget is a global resource: one gatekeeper.
+- **Bounded grunt (delegate-skill tier):** table conversion (LTC/CIE data →
+  headers), scene-pair generation for the feature matrix, mapping-table
+  transcription — all evidence-verified per the cost-routing policy.
+
+Net: "a swarm of low-level agents" ≈ 1 scaffold implementer (serial), then
+3–4 parallel lobe implementers + grunt delegation, converging through one
+building/verifying lead. Coupling is real but the staged spec is shaped to
+maximize the parallel window (Stages 3–4 lobes are independent of each
+other).
+
+---
+
+## 4. Sources
+
+- https://developer.blender.org/docs/release_notes/4.0/shading/
+- https://developer.blender.org/docs/release_notes/5.0/cycles/
+- https://projects.blender.org/blender/blender/pulls/118477 (thin film)
+- https://projects.blender.org/blender/blender/pulls/157469 (thin wall, 5.2)
+- https://projects.blender.org/blender/blender/pulls/123345, /123616 (EON)
+- https://docs.blender.org/manual/en/latest/render/shader_nodes/shader/principled.html
+- https://github.com/blender/cycles — `src/kernel/svm/closure.h`,
+  `src/kernel/closure/{bsdf_microfacet,bsdf_util,bsdf_sheen,bsdf_oren_nayar,bssrdf}.h`
+- Belcour & Barla 2017 (TOG 36(4)); Zeltner/Burley/Chiang 2022; Kulla &
+  Conty 2017; OpenPBR specification.

--- a/.astroray_plan/packages/pkg128-thin-film-iridescence.md
+++ b/.astroray_plan/packages/pkg128-thin-film-iridescence.md
@@ -3,7 +3,7 @@
 **Pillar:** 2 (materials / BSDF) + 5 (spectral showcase)
 **Track:** A (CPU-first spectral BSDF layer with numerical + visual gates; GPU spectral-closure mirror RTX-verified; Blender addon parity cells closed)
 **Codex-paste-ready:** no (a physically-based interference model re-derived from the paper, applied across three closures + the GPU mirror, plus a spectral-showcase visual bar and addon socket wiring — needs judgment, not a mechanical patch)
-**Status:** open — self-contained material feature; the recommended "good medium package after Phase C" in the research adoption plan
+**Status:** open — self-contained material feature; the recommended "good medium package after Phase C" in the research adoption plan. **Cross-ref 2026-08-08:** pkg178 (native Cycles Principled BSDF) Stage 4 adopts this spec's per-λ Belcour-Barla design and builds the shared thin-film Fresnel utility; this package's residual charter is the standalone Glass/Metallic node cells + the spectral showcase, riding that utility — coordinate at dispatch time.
 **Estimated effort:** M–L (a self-contained interference term is moderate, but it attaches to metal/dielectric/Disney Fresnel on both CPU and GPU, needs a spectral-native evaluation the RGB references don't, and closes three DROPPED-SILENT addon parity cells with a visual showcase gate)
 **Depends on:** none hard. Composes with the spectral material path (pkg30/pkg35 spectral BSDF interface) and the Fresnel evaluation in `plugins/materials/{metal,dielectric,disney}.cpp` + `include/astroray/gpu_materials.h`. Best sequenced after pkg55 Phase C so the GPU mirror lands in the single surviving wavefront closure rather than the doomed megakernel.
 

--- a/.astroray_plan/packages/pkg178-native-cycles-principled-bsdf.md
+++ b/.astroray_plan/packages/pkg178-native-cycles-principled-bsdf.md
@@ -4,7 +4,7 @@
 **Track:** A (core BSDF + GPU closure work + RTX-verified Cycles parity — last-line-of-defense judgment; bounded sub-tasks delegated per the cost-routing policy)
 **Status:** open — Stage 0 dispatchable now; Stages 1–5 gated on the prior stage's acceptance
 **Estimated effort:** XL, staged across multiple rounds (each stage is its own PR set)
-**Depends on / composes with:** `disney.cpp` (the closest analog and the thing this eventually supersedes in the addon path — NOT deleted), `energy_compensation.h` (pkg60/151/160/163 Cycles-table lineage — reuse, do not fork), pkg163 spectral per-λ discipline, pkg149 VNDF, pkg176 (native settings/steering-wheel — Stage 5 rides its translation layer), pkg119-B differential harness (PR #550) + pkg104 reference bank + pkg71 cycles-parity benches (verification layer), pkg129-narrowed (rough-metal live-Cycles A/B composes with Stage 1), pkg174 (register-pressure ceiling — Stage 2's hard constraint).
+**Depends on / composes with:** `disney.cpp` (the closest analog and the thing this eventually supersedes in the addon path — NOT deleted), `energy_compensation.h` (pkg60/151/160/163 Cycles-table lineage — reuse, do not fork), pkg163 spectral per-λ discipline, pkg149 VNDF, pkg176 (native settings/steering-wheel — Stage 5 rides its translation layer), pkg119-B differential harness (PR #550) + pkg104 reference bank + pkg71 cycles-parity benches (verification layer), pkg129-narrowed (rough-metal live-Cycles A/B composes with Stage 1), pkg174 (register-pressure ceiling — Stage 2's hard constraint; its per-material-kernel-dispatch DESIGN doc `.astroray_plan/docs/pkg174-per-material-kernel-dispatch-design.md` is Stage 2's candidate vehicle), **pkg128 (thin-film iridescence — pre-existing open spec: Stage 4 adopts its per-λ Belcour-Barla design and builds the shared thin-film Fresnel utility; pkg128's residual charter narrows to standalone Glass/Metallic nodes + showcase, riding that utility)**.
 **Research note (read first):** `.astroray_plan/docs/cycles-principled-port-research-2026-08.md` — reference pin (Cycles main / Blender 5.2-era), full parameter + closure-stack breakdown, Astroray extension-point analysis, swarm assessment, citations.
 
 ## Goal (owner request, 2026-08-08 — provenance)
@@ -66,23 +66,36 @@ matched eval/pdf normalization (the pkg170 lesson, in from day one).
 Lobes: diffuse (Lambert + EON at `diffuse_roughness>0`), specular GGX with
 generalized-Schlick Fresnel (`specular_ior_level`/`specular_tint`),
 metallic F82-tint conductor, transmission rough glass — all reusing
-`energy_compensation.h` tables and VNDF sampling. Spectral legs via
-`evalSpectral`/`sampleSpectral` (upsample reflectance colour ONLY —
-memory `spectral-upsample-nonlinearity-scaled-bsdf`).
+`energy_compensation.h` tables and VNDF sampling. **Spectrally NATIVE
+from day one**: `evalSpectral` (the interface's one pure virtual) and
+`sampleSpectral` evaluate per-λ; do NOT copy Disney's
+upsample-the-RGB-eval shortcut (`disney.cpp:700-706` — the pkg118/163/168
+bug-class source; upsample reflectance colours only, scalars per-λ).
 Registration `ASTRORAY_REGISTER_MATERIAL("principled", ...)`; zero core
-edits expected on this stage (CMake auto-globs plugins).
+edits expected on this stage (CMake auto-globs plugins; add the name to
+`tests/test_material_plugins.py:20`). Binding gotcha: `createMaterial`
+swallows ctor exceptions into a silent legacy fallback — a
+registry-name-resolves test is mandatory.
 
-**Stage 2 — GPU twin (closure-graph extension).** Extend
-`MaterialClosureType`/`GMaterialClosure` (+ params), `scene_upload.cu`,
-and `gpu_materials.h` eval/sample/pdf/spectral for the Stage-1 lobe set;
-`G_MAX_MATERIAL_CLOSURES` 8→10 if the audit confirms the full stack needs
-it. **Register-pressure protocol is part of acceptance:** `cuobjdump`
-per-kernel reg/spill before/after; wavefront perf gate unchanged on
-non-principled scenes (hard); principled scenes get their own measured
-budget; if the existing shade kernels can't absorb the new closures,
-isolate them in a dedicated shade bucket rather than raising the ceiling
-(pkg174's recovery is not to be re-spent silently; ceiling changes are an
-owner call).
+**Stage 2 — GPU twin (closure-graph extension).** Lower via
+`GMAT_CLOSURE_GRAPH` (the `scene_upload.cu:108-148` preferred path), NOT a
+new `GMaterialType` — the enum route carries known silent traps
+(`G_WF_NUM_MAT_TYPES=7` clamp at `stage_advance.cu:1034-1036`, duplicated
+at `gpu_wavefront_snapshot.cu:1412`; `photon_caustic.cu:116` transmissive
+list). Extend `MaterialClosureType`/`GMaterialClosure` (+ params),
+`scene_upload.cu`, and `gpu_materials.h` eval/sample/pdf/spectral for the
+Stage-1 lobe set; closure caps (`material_closure.h:40` +
+`G_MAX_MATERIAL_CLOSURES`) 8→10 in lockstep if the audit confirms need.
+**Register-pressure protocol is part of acceptance:** `cuobjdump`
+per-kernel REG **and STACK** before/after (new arms inline into
+`gpu_material_sample_spectral` and grow spill/STACK, not REG — a REG-only
+check is blind); wavefront perf gate unchanged on non-principled scenes
+(hard); principled scenes get their own measured budget. Stage 2 opens
+with a sizing decision: absorb the closures into the existing bucketed
+shade kernel vs land pkg174's designed `template<int MatType>` per-bucket
+dispatch as the isolation vehicle; if neither fits without re-spending
+pkg174's recovered ceiling, that fork goes to the owner (D4), never
+silently.
 
 **Stage 3 — advanced layers.** Coat (GGX + `coat_ior`, `coat_tint` Beer
 absorption `tint^(1/cosθ_refracted)`, `coat_normal_offset`); Sheen LTC
@@ -92,24 +105,36 @@ the addon's promote-to-light heuristic for the flagged path); subsurface
 per decision D2. CPU+GPU per lobe (each lobe lands with both legs + its
 parity gate; Stage-2's register protocol applies to every GPU merge).
 
-**Stage 4 — Thin Film + Thin Wall.** Thin film: Belcour-Barla Airy
-reflectance on the specular/transmission dielectric closures AND the
-conductor closure (5.0 semantics), backface film-IOR adjustment; RGB legs
-mirror Cycles' CIE-sensitivity-LUT per-channel evaluation; the spectral
-integrator MAY evaluate Airy per sampled λ (flag the divergence in gates
-if used — parity legs compare like-for-like). Thin wall: combined-R+T
-thin-glass closure (seed from existing `thin_glass.cpp` +
-`MaterialClosureType::ThinGlass`, reconciled against Cycles
-`bsdf_thin_glass_setup`) + thin-subsurface (diffuse+translucent). Oracle
-needs Blender 5.2 (D1).
+**Stage 4 — Thin Film + Thin Wall.** Thin film: build the Belcour-Barla
+Airy-reflectance Fresnel layer ONCE as a shared utility **per pkg128's
+pre-existing design** — per sampled λ on the spectral core (no RGB
+sensitivity fit needed there; simpler than Cycles' own path), with the RGB
+legs mirroring Cycles' CIE-sensitivity-LUT per-channel evaluation for
+like-for-like parity gates. Apply to the specular/transmission dielectric
+closures AND the conductor closure (5.0 semantics), with backface film-IOR
+adjustment. pkg128's residual charter (standalone Glass/Metallic nodes +
+spectral showcase) rides the same utility — coordinate, don't duplicate.
+Thin wall: combined-R+T thin-glass closure (seed from existing
+`thin_glass.cpp` + `MaterialClosureType::ThinGlass`, reconciled against
+Cycles `bsdf_thin_glass_setup`) + thin-subsurface (diffuse+translucent).
+Oracle needs Blender 5.2 (D1).
 
-**Stage 5 — addon switch (flag, not replace).**
-`convert_principled_bsdf_v2` routes `ShaderNodeBsdfPrincipled` →
-`'principled'` behind an addon option (default OFF until the Stage-5
-parity matrix is green; flip-default is an owner sign-off). Full socket
-map incl. renamed-input fallbacks; `shader_blending.py` learns the new
-spec kind; Disney path preserved untouched as fallback. Per-render
-one-line report of any still-approximated socket (pkg119-C policy).
+**Stage 5 — addon switch (flag, not replace).** Route
+`ShaderNodeBsdfPrincipled` → `'principled'` behind an addon option
+(default OFF until the Stage-5 parity matrix is green; flip-default is an
+owner sign-off). **BOTH translation paths switch together** via one
+flag-aware helper replacing the three `'disney'` literals: the live
+spec-based path (`_principled_shader_spec:3055` /
+`_create_material_from_shader_spec:3237,:3241`) and the semi-orphaned
+`convert_principled_bsdf_v2:3437`. Full socket map incl. renamed-input
+fallbacks; alpha routes through a real transparent lobe on the flagged
+path (retiring the `transmission=max(transmission,1-alpha)` conflation —
+the convicted BSDF_TRANSPARENT bug family); `shader_blending.py` learns
+the new spec kind; Disney path preserved byte-identical as fallback.
+Per-render one-line report of any still-approximated socket (pkg119-C
+policy). `coverage_matrix.json` cells for newly-honoured sockets flip
+DROPPED-SILENT→SUPPORTED so the pkg119-B harness picks them up; the A/B is
+one harness sweep flag-off vs flag-on, diffing `triage_report.json`.
 
 ## Verification plan (every stage; Cycles is the oracle)
 

--- a/.astroray_plan/packages/pkg178-native-cycles-principled-bsdf.md
+++ b/.astroray_plan/packages/pkg178-native-cycles-principled-bsdf.md
@@ -1,0 +1,198 @@
+# pkg178 — Native Cycles Principled BSDF ("principled" material): faithful port incl. Thin Film + Thin Wall
+
+**Pillar:** 2 (materials) + Integration Milestone (it exists FOR Blender parity)
+**Track:** A (core BSDF + GPU closure work + RTX-verified Cycles parity — last-line-of-defense judgment; bounded sub-tasks delegated per the cost-routing policy)
+**Status:** open — Stage 0 dispatchable now; Stages 1–5 gated on the prior stage's acceptance
+**Estimated effort:** XL, staged across multiple rounds (each stage is its own PR set)
+**Depends on / composes with:** `disney.cpp` (the closest analog and the thing this eventually supersedes in the addon path — NOT deleted), `energy_compensation.h` (pkg60/151/160/163 Cycles-table lineage — reuse, do not fork), pkg163 spectral per-λ discipline, pkg149 VNDF, pkg176 (native settings/steering-wheel — Stage 5 rides its translation layer), pkg119-B differential harness (PR #550) + pkg104 reference bank + pkg71 cycles-parity benches (verification layer), pkg129-narrowed (rough-metal live-Cycles A/B composes with Stage 1), pkg174 (register-pressure ceiling — Stage 2's hard constraint).
+**Research note (read first):** `.astroray_plan/docs/cycles-principled-port-research-2026-08.md` — reference pin (Cycles main / Blender 5.2-era), full parameter + closure-stack breakdown, Astroray extension-point analysis, swarm assessment, citations.
+
+## Goal (owner request, 2026-08-08 — provenance)
+
+*"A 'copy' of the Principled BSDF that Cycles has as its primary shader,
+available natively in Astroray. [...] because they [Principled and Disney]
+are fundamentally different they will never quite match. For true parity
+with Cycles, a faithful Principled BSDF port is the way to go — the LATEST
+updated version that includes the thin translucent / thin-film material."*
+
+Deliverable: a new `"principled"` material plugin whose closure stack,
+layering math, Fresnel models, and energy compensation mirror Cycles main
+(Blender 5.2-era) — Base/Metallic/Roughness, IOR-based Specular,
+Transmission, Coat (ior+tint), Sheen (LTC microfiber), EON diffuse
+roughness, Emission/Alpha, Anisotropy, **Thin Film iridescence**
+(dielectric 4.2 + conductor 5.0, Belcour-Barla) and **Thin Wall**
+translucency (5.2) — CPU + GPU, driven from the Blender addon in place of
+the current Principled→Disney approximation (behind a flag first).
+Subsurface is in scope with an explicit approximation decision (D2 below).
+
+**Architect's framing:** this is the right call, not just transcription —
+the Disney↔Principled mismatch is structural (layering weights, Fresnel
+models, coat absorption, missing lobes), so per-bug parity patches on
+Disney converge slowly. A faithful port with Cycles as reference kills the
+whole class. The plugin architecture DOES make the CPU side clean; the GPU
+closure layer is the honest cost (core edits + register-pressure risk —
+see Feasibility).
+
+## Reference & license (CLAUDE.md §6 — no invention)
+
+Canonical structure: Cycles `src/kernel/svm/closure.h`
+(`CLOSURE_BSDF_PRINCIPLED_ID` — closure assembly + `closure_layering_weight`
+chain) and `src/kernel/closure/{bsdf_microfacet,bsdf_util,bsdf_sheen,
+bsdf_oren_nayar,bssrdf}.h` (Apache-2.0 / BSD-3-Clause — compatible; cite
+per-function in code exactly as `disney.cpp`/`energy_compensation.h`
+already do). Papers: Belcour-Barla 2017 (thin film), Zeltner/Burley/Chiang
+2022 (sheen LTC), Kulla & Conty 2017 (multiscatter), OpenPBR/EON (diffuse
+roughness). Full list in the research note. **Borrow Cycles' math verbatim
+wherever possible; every non-trivial formula carries a citation.**
+
+## Staged specification
+
+**Stage 0 — closure/parameter mapping table (blocking, cheap, owner-review
+artifact — pkg176 Stage-0 discipline).** A checked-in table
+`docs/blender_parity/pkg178_stage0_closure_map.md` + machine-readable twin:
+every Cycles Principled input and every closure in the stack → its Astroray
+realization — `DIRECT` (existing closure/table reused), `NEW-CLOSURE`
+(exact port), `APPROXIMATED` (state the delta + the gate band it implies),
+or `DEFERRED` (with owning follow-up). Includes the lobe-interface contract
+the Stage-1 scaffold will expose (the seam the parallel lobe agents code
+against) and the per-lobe acceptance-gate matrix. No silent mapping
+decisions; the table encodes owner decisions D1–D3.
+
+**Stage 1 — CPU core lobes (`plugins/materials/principled.cpp`).**
+Scaffold: ParamDict surface (Cycles socket names), closure-stack assembly
+in Cycles' order, `closure_layering_weight` chain, coat/metallic/
+transmission weight attenuation, one-sample-MIS lobe selection with
+matched eval/pdf normalization (the pkg170 lesson, in from day one).
+Lobes: diffuse (Lambert + EON at `diffuse_roughness>0`), specular GGX with
+generalized-Schlick Fresnel (`specular_ior_level`/`specular_tint`),
+metallic F82-tint conductor, transmission rough glass — all reusing
+`energy_compensation.h` tables and VNDF sampling. Spectral legs via
+`evalSpectral`/`sampleSpectral` (upsample reflectance colour ONLY —
+memory `spectral-upsample-nonlinearity-scaled-bsdf`).
+Registration `ASTRORAY_REGISTER_MATERIAL("principled", ...)`; zero core
+edits expected on this stage (CMake auto-globs plugins).
+
+**Stage 2 — GPU twin (closure-graph extension).** Extend
+`MaterialClosureType`/`GMaterialClosure` (+ params), `scene_upload.cu`,
+and `gpu_materials.h` eval/sample/pdf/spectral for the Stage-1 lobe set;
+`G_MAX_MATERIAL_CLOSURES` 8→10 if the audit confirms the full stack needs
+it. **Register-pressure protocol is part of acceptance:** `cuobjdump`
+per-kernel reg/spill before/after; wavefront perf gate unchanged on
+non-principled scenes (hard); principled scenes get their own measured
+budget; if the existing shade kernels can't absorb the new closures,
+isolate them in a dedicated shade bucket rather than raising the ceiling
+(pkg174's recovery is not to be re-spent silently; ceiling changes are an
+owner call).
+
+**Stage 3 — advanced layers.** Coat (GGX + `coat_ior`, `coat_tint` Beer
+absorption `tint^(1/cosθ_refracted)`, `coat_normal_offset`); Sheen LTC
+(port Cycles' LTC table — table-shipping precedent: `gpu_ggx_tables.cu`);
+anisotropy + rotation/tangent; emission + alpha inside the node (retiring
+the addon's promote-to-light heuristic for the flagged path); subsurface
+per decision D2. CPU+GPU per lobe (each lobe lands with both legs + its
+parity gate; Stage-2's register protocol applies to every GPU merge).
+
+**Stage 4 — Thin Film + Thin Wall.** Thin film: Belcour-Barla Airy
+reflectance on the specular/transmission dielectric closures AND the
+conductor closure (5.0 semantics), backface film-IOR adjustment; RGB legs
+mirror Cycles' CIE-sensitivity-LUT per-channel evaluation; the spectral
+integrator MAY evaluate Airy per sampled λ (flag the divergence in gates
+if used — parity legs compare like-for-like). Thin wall: combined-R+T
+thin-glass closure (seed from existing `thin_glass.cpp` +
+`MaterialClosureType::ThinGlass`, reconciled against Cycles
+`bsdf_thin_glass_setup`) + thin-subsurface (diffuse+translucent). Oracle
+needs Blender 5.2 (D1).
+
+**Stage 5 — addon switch (flag, not replace).**
+`convert_principled_bsdf_v2` routes `ShaderNodeBsdfPrincipled` →
+`'principled'` behind an addon option (default OFF until the Stage-5
+parity matrix is green; flip-default is an owner sign-off). Full socket
+map incl. renamed-input fallbacks; `shader_blending.py` learns the new
+spec kind; Disney path preserved untouched as fallback. Per-render
+one-line report of any still-approximated socket (pkg119-C policy).
+
+## Verification plan (every stage; Cycles is the oracle)
+
+- **Feature-matrix image-plane parity** via the pkg119-B differential
+  harness + pkg104 reference-bank metrics: one scene pair per feature axis
+  (metallic sweep, roughness sweep, IOR/specular level, transmission,
+  coat w/ tint, sheen, diffuse roughness, anisotropy, thin-film thickness
+  sweep 100–3000nm × film IOR, thin-wall glass + translucent, alpha,
+  emission) + curated composites. **Linear output, floor AND ceiling
+  bands (pkg166), per-channel mean-ratio gates not SSIM (independent RNG
+  streams)** — target band `[0.95,1.05]` per lit region, documented
+  exceptions only via the Stage-0 `APPROXIMATED` table.
+- **Furnace/energy conservation** per lobe and stacked, CPU+GPU, linear
+  with upper bounds (energy gain must be detectable).
+- **Sampler correctness:** chi² (pkg121 harness) for each new sampled lobe.
+- **CPU↔GPU parity** per lobe on landing (the pkg119b runbook build).
+- **Perf:** wavefront gate green on non-principled scenes at every GPU
+  merge; `cuobjdump` reg/spill deltas recorded in each PR.
+- Render-level suites, not just consistency gates (memory
+  `pr-named-tests-insufficient`); implementer test lists are a floor.
+
+## Acceptance (package-level)
+
+- [ ] Stage-0 table checked in + owner-ratified (D1–D3 encoded).
+- [ ] `"principled"` renders the full feature matrix within parity bands
+      vs Cycles main on BOTH legs (CPU + GPU wavefront), linear
+      floor+ceiling, on RTX hardware — not "it compiles".
+- [ ] Thin Film: hue trajectory vs thickness sweep matches Cycles within
+      the Stage-0-declared band (visual + per-channel ratio); conductor
+      + dielectric both covered. Thin Wall: paper/leaf/window-sheet trio
+      matches Blender 5.2 Cycles.
+- [ ] Addon flag routes Principled nodes to the native material; Disney
+      path intact; zero silently-dropped sockets on the flagged path
+      (report line per pkg119-C).
+- [ ] No wavefront perf regression on non-principled scenes; register
+      report attached to every GPU-stage PR.
+- [ ] Every ported formula cites its Cycles file/function or paper.
+
+## Non-goals
+
+- Deleting/deprecating `disney.cpp` (default flip is a later owner call).
+- Hair/toon/ray-portal/volume closures; OSL.
+- Full random-walk BSSRDF parity if D2 selects the approximation path
+  (then a named follow-up owns it).
+- The textured-base-color→lambertian downgrade wart
+  (`__init__.py:3425`) — adjacent, surfaced for a follow-up package; the
+  native material SHOULD accept a base-color texture but the socket→
+  texture plumbing beyond what Disney's path has today is not this
+  package's scope.
+- Matching Cycles' internal RNG/noise (expectation parity only).
+
+## Owner decisions needed (blocking the stages named)
+
+- **D1 (Stage 4):** install Blender 5.2 LTS alongside 5.1 as the parity
+  oracle (5.1 lacks Thin Wall; 5.0+ needed for conductor thin film).
+  Recommended: yes, keep 5.1 for existing refbank baselines until
+  re-blessed.
+- **D2 (Stage 3):** subsurface scope — (a) approximate SSS (existing
+  diffusion-style plugin lineage, wider declared band vs Cycles
+  random-walk) with full random-walk BSSRDF as a follow-up package, or
+  (b) full random-walk in-scope now (adds a volume-walk subsystem to both
+  integrator legs; significant scope growth). Architect recommends (a).
+- **D3 (Stage 5):** confirm flag-first (default OFF) rollout, default
+  flip only after the parity matrix is green. Architect recommends yes.
+- **D4 (Stage 2, conditional):** IF the new closures cannot fit the
+  existing shade kernels' register budget even bucketed, the
+  ceiling/bucketing tradeoff comes back as a fork — not decided silently.
+
+## Feasibility & decomposition (summary; full analysis in research note §2–3)
+
+CPU: clean plugin add (new file + macro, zero core edits). GPU: core edits
+to `material_closure.h`/`gpu_types.h`/`gpu_materials.h`/`scene_upload.cu`
+are unavoidable (closure enum is not pluggable) — contained but shared, and
+carry the register-pressure risk above. Swarm: serial spine (Stage 0 table
++ Stage 1 scaffold) THEN 3–4 parallel lobe implementers (metal/transmission/
+coat/sheen/EON/thin-film as independent units against the scaffold's lobe
+contract) + delegate-tier grunt (table conversion, scene-pair generation);
+all GPU merges serialize through the building/verifying lead (subagents
+cannot build CUDA on this machine). A "large swarm" is not realistic; a
+disciplined 4–6-agent pipeline is.
+
+## Provenance
+
+Filed by the architect 2026-08-08 from the owner's verbatim request (native
+Cycles Principled copy, latest version incl. thin translucent/thin film).
+Research note: `.astroray_plan/docs/cycles-principled-port-research-2026-08.md`.


### PR DESCRIPTION
## Summary

Architect goal-capture deliverable (owner request 2026-08-08): a staged package spec for a **faithful native port of Cycles' latest Principled BSDF** (Blender 5.2-era: core lobes, coat/sheen-LTC/EON, **Thin Film iridescence** dielectric+conductor, **Thin Wall** translucency), replacing the Principled->Disney approximation for true parity — plus the research note pinning the Cycles reference, the Astroray extension-point analysis, and the swarm-decomposition assessment.

- `.astroray_plan/packages/pkg178-native-cycles-principled-bsdf.md` — Stage 0 (closure/param mapping table, owner-review artifact) -> Stage 1 (CPU core lobes, spectrally native) -> Stage 2 (GPU closure-graph twin, register-pressure protocol) -> Stage 3 (coat/sheen/SSS) -> Stage 4 (Thin Film + Thin Wall) -> Stage 5 (addon flag switch, Disney preserved). Acceptance = image-plane parity vs Cycles across a feature matrix, linear floor+ceiling (pkg166), via the pkg119-B harness.
- `.astroray_plan/docs/cycles-principled-port-research-2026-08.md` — citations (Cycles svm/closure.h stack, Belcour-Barla 2017, Zeltner sheen LTC, EON/OpenPBR), grep-verified extension points, known GPU traps, feasibility + 4-6-agent decomposition.
- `.astroray_plan/packages/pkg128-thin-film-iridescence.md` — one-line cross-ref (pkg178 Stage 4 adopts its per-wavelength design; pkg128 narrows to Glass/Metallic nodes + showcase).

## Owner decisions flagged in the spec

- **D1:** Blender 5.2 LTS as thin-wall/conductor-thin-film oracle (5.1 lacks Thin Wall)
- **D2:** subsurface scope — approximate first (recommended) vs full random-walk now
- **D3:** flag-first addon rollout, default flip only after parity matrix green
- **D4:** register-budget fork escalation path (conditional)

Docs-only; no engine code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)