### PR TITLE
docs: file pkg167-Part2 + systemic-dim follow-ups; pkg165 verify-and-close

### DIFF
--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -1,5 +1,26 @@
 # Astroray Status
 
+**2026-08-08 (run — dielectric energy chain + Cycles-parity harnesses):**
+Landed this run: **pkg167 Part 1** (PR #562, MERGED) — Disney dielectric
+REFLECTION-lobe multiscatter compensation CPU+GPU, furnace in-band
+0.99/0.94/0.93 at r=0.3/0.6/1.0, pkg169 xfail retired. **pkg119 Phase B**
+differential parity harness landed + HARDWARE-VALIDATED (PR #550, 26/12/1;
+`world:World` + `BSDF_TRANSPARENT` flagged as TRANSLATION-BUG follow-ups).
+**pkg129 metal A/B** run on current main (research doc §5) — **A/B CLEAN, no
+application-form divergence; GPU ≈ CPU (marginally brighter)**; conviction-path
+LUT port does NOT fire. Two escalations surfaced and filed by the architect this
+date: **pkg167 Part 2 was applied, measured, REVERTED, premise falsified** —
+reflection compensation recovers only +0.009 at r=1.0 (0.476→0.485); the masked
+~23% below-horizon energy belongs in the TRANSMISSION lobe and the dead-sample
+rate is ~3× pkg150's documented figure → filed as **pkg179**
+(sampler-diagnosis-then-transmission-redistribution, Track A). A **systemic
+~12–20% Astroray-vs-Cycles dim** (pkg119-B cells ~0.88, pkg129 metal neutral
+r0.9 ~0.93, plain diffuse backdrop ~0.79–0.82; uniform + chromatically uniform)
+→ filed as **pkg180** (diagnosis-first; prime suspect a view-transform-vs-linear
+comparison artifact). **pkg165** (Disney-metal GPU-dim) flipped to
+**verify-and-close** — its premise does not reproduce on current main per the
+pkg129 A/B.
+
 **2026-08-06 → 2026-08-07 (workflow restructure + settlement round opens):**
 **PR #541 (pkg168 Step 2) MERGED 2026-08-06 (`bbf2d8c`) — option A** (owner
 confirmed 2026-08-03): correctness v4 shipped with the wavefront perf

--- a/.astroray_plan/docs/reflection-multiscatter-turquin-research.md
+++ b/.astroray_plan/docs/reflection-multiscatter-turquin-research.md
@@ -135,7 +135,7 @@ any — is attributable to the application form and to nothing else.
 > `test_results/pkg129_metal_ab/metal_ab_report.md`) here and record the verdict
 > (parity within band → close; divergence → conviction-path sizing).
 >
-> _(verdict pending)_
+> _(verdict recorded above, 2026-08-08: A/B CLEAN — no divergence; pkg129 closes on the harness + this note; pkg165 → verify-and-close.)_
 
 ---
 

--- a/.astroray_plan/packages/pkg165-disney-metal-uniform-dim-residual.md
+++ b/.astroray_plan/packages/pkg165-disney-metal-uniform-dim-residual.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 3 (GPU/CPU parity)
 **Track:** A (RTX-gated)
-**Status:** open — dispatchable (diagnosis-first; NOT urgent-tier — every reading is inside the current `[0.90, 1.10]` Disney-metal band, nothing is red)
+**Status:** verify-and-close (2026-08-08) — **the GPU-dim premise DOES NOT REPRODUCE on current main.** The pkg129 metal A/B (research doc `reflection-multiscatter-turquin-research.md` §5, lead HW lane, RTX 5070 Ti + Blender 5.1, Disney metallic=1) measures **GPU ≈ CPU with GPU marginally BRIGHTER (≤~1%), not dimmer**, at every roughness — the opposite sign of this package's "uniform ~5–8% GPU-dim" finding, which was measured on the old SHA `b036ac93`. Likely resolved by pkg170's opaque-Disney 2× gain fix (PR #542) + intervening work. **Disposition:** recommend verify-and-close — a focused confirm on pkg158's exact Step-0 scene at r ∈ {0.0, 0.3, 0.6, 0.9} would fully close it, but it is non-urgent, in-band, and below the Integration Milestone. Spec retained (not deleted) for the finding + disposition record. *(Superseded original status: open — dispatchable, diagnosis-first, NOT urgent-tier — every reading inside the `[0.90, 1.10]` band.)*
 **Estimated effort:** S (diagnosis/localization) + S–M only if a material-side defect is convicted
 **Depends on:** pkg158 closed (PR #535, Outcome A — reconciliation table is this package's baseline). pkg163 done (PR #533, `b036ac9` — the plain-metal per-λ spectral path; its gate numbers are the cross-datapoint below). Reads: pkg158 Step-0 reconciliation table, `.astroray_plan/docs/pkg141-gpu-metal-near-delta-research.md` (per-event instrumentation pattern).
 
@@ -83,8 +83,29 @@ Lessons, 2026-06-11; at 5–8% it is not the prime suspect, but state it anyway)
   1.10]` band stays until an owner decision on project-wide tightening (open
   item since 2026-07-26); do not tighten it "while here."
 
+## Disposition (2026-08-08) — premise not reproducing; verify-and-close
+
+The pkg129-narrowed live-Cycles metal A/B ran this date on current main (lead HW
+lane; verdict recorded in `.astroray_plan/docs/reflection-multiscatter-turquin-research.md`
+§5). Disney metallic=1, r ∈ {0.3, 0.6, 0.9} × {chromatic, neutral}, CPU + GPU:
+**GPU ≈ CPU, with GPU marginally BRIGHTER (≤~1%)** at every roughness (e.g. r=0.9
+neutral CPU 0.936/0.939/0.923 vs GPU 0.946/0.948/0.930). This is the **opposite
+sign** of this package's Step-0 finding — the "uniform ~5–8% GPU-dim, R>G>B" does
+NOT reproduce on current main. It was measured on the old SHA `b036ac93`; the
+most likely resolver is pkg170's opaque-Disney closure-recombination 2× gain fix
+(PR #542, which reached the Disney closure path) plus intervening spectral work.
+
+**Recommendation:** verify-and-close. Step 1's 2×2 localization is NOT needed —
+the premise it would localize is gone. A single focused confirm on pkg158's exact
+Step-0 scene (r ∈ {0.0, 0.3, 0.6, 0.9}, per-channel GPU/CPU linear ratio, `[0.95,
+1.05]`) would fully close the package with a clean datapoint, but it is
+non-urgent (in-band, no red gate) and sits below the Integration Milestone; run
+it opportunistically the next time that scene is on the GPU lane. Do NOT reopen
+Step 1's full fork or touch Disney code — there is no convicted defect.
+
 ## Provenance
 
 Filed by the architect 2026-08-02 at team-lead request, from the pkg158 Step-0
 out-of-scope finding (PR #535) plus pkg163's same-night opposite-sign gate
-reading (PR #533).
+reading (PR #533). **Disposition update 2026-08-08:** premise not reproducing on
+current main per the pkg129 metal A/B (research doc §5) → verify-and-close.

--- a/.astroray_plan/packages/pkg179-dielectric-transmission-energy-redistribution.md
+++ b/.astroray_plan/packages/pkg179-dielectric-transmission-energy-redistribution.md
@@ -1,0 +1,170 @@
+# pkg179 — Disney dielectric dead-sample fix, Part 2: diagnose the 3× dead-sample rate, then redistribute the masked energy into the TRANSMISSION lobe
+
+**Pillar:** 2 (materials / BSDF energy correctness)
+**Track:** A (CPU furnace gates on CI; GPU twin RTX-verified)
+**Status:** open — dispatchable (Phase 1 diagnosis-first; Phase 2 gated on Phase 1's finding)
+**Estimated effort:** M–L (Phase 1 is S diagnosis; Phase 2 is the hard part — a transmission-lobe redistribution mechanism or a combined-closure treatment, CPU+GPU, holding the furnace at all roughnesses WITH the dead-sample fix in)
+**Depends on:** pkg167 Part 1 landed (PR #562, `b4f8376` era — Disney dielectric reflection-lobe multiscatter compensation CPU+GPU, furnace in-band 0.99/0.94/0.93 at r=0.3/0.6/1.0, pkg169 xfail retired). The pkg151→pkg154→pkg149 sampler chain is on main. **Composes with:** pkg149 (VNDF sampler — Phase 1 audits its below-horizon reflection accounting), pkg118 (`ggxGlassCompensationFactor`, rough-dielectric transmission multiscatter — the existing transmission-side term this package extends), pkg178 (native Principled port — see Relationship note; the combined-closure question this package answers directly informs Stage 1/3 there).
+
+**Origin:** pkg167 Part 2 escalation (lead, 2026-08-08). pkg167 shipped Part 1
+(reflection-lobe compensation) but **Part 2 — the pkg150 pbrt-v4 dead-sample
+fix (below-horizon VNDF reflection → `pdf=0`, delete the smooth-mirror delta
+fallback) — was applied, measured, REVERTED, and its guiding premise
+FALSIFIED.** The bundled two-commit plan of pkg167 assumed reflection-lobe
+compensation would let the dead-sample fix ship without furnace regression. It
+does not. This package owns what the measurement proved is actually required.
+
+---
+
+## The falsified premise (cite this; full detail in memory `dielectric-dead-sample-needs-transmission-redistribution` and PR #562's body)
+
+Measured 2026-08-08 (lead HW lane) with pkg167 Part 1's reflection compensation
+IN and the dead-sample fix re-applied on top:
+
+- **Reflection compensation cannot rescue the dead-sample fix.** With the delta
+  fallback removed, reflection-lobe compensation recovers only **+0.009** at
+  r=1.0 (furnace **0.476 → 0.485**, still ❌ vs the 0.92 floor). A dielectric's
+  `Fss ≈ 0.09` makes the Kulla-Conty compensation factor **≈1.05** —
+  near-identity — so a reflection-lobe multiply has almost no energy to give.
+- **The masked energy belongs in the TRANSMISSION lobe.** For a low-Fresnel
+  dielectric the ~23% below-horizon reflection energy physically re-enters the
+  surface and mostly transmits. **Cycles redistributes it for free inside ONE
+  combined closure**; Astroray's SPLIT reflection/transmission lobes + pbrt-v4
+  dead-sample termination structurally cannot recover it via a reflection-lobe
+  multiply. The fix needs a transmission-lobe energy-redistribution mechanism
+  (or Cycles' combined-closure treatment), not more reflection compensation.
+- **Red flag — the dead-sample rate is ~3× the documented figure.** Measured
+  below-horizon dead fraction is **22.9% at r=1.0** vs pkg150's documented
+  **7.1%** (spec table `pkg150`, Finding 2). That 3× discrepancy is unexplained
+  and may be a residual VNDF sampler bug introduced or exposed since pkg150's
+  measurement — NOT physics. Diagnose it FIRST; the excess dead samples might
+  be the whole story, and no redistribution term should be built on top of a
+  broken sampler.
+
+## Phase 1 — diagnose the 3× dead-sample-rate discrepancy (blocking; no Phase-2 work before it resolves)
+
+All on ONE recorded post-#562 main SHA, LINEAR (`apply_gamma=False`), the exact
+config pkg150 used (`debug_bsdf_sample_batch`, glass metallic=0 / transmission=1
+/ ior=1.5, N≥300k).
+
+1. **Reproduce and localize the rate.** Re-run pkg150's dead-fraction histogram
+   across the roughness × incidence grid on current main. Confirm 22.9% @
+   r=1.0-θ0 vs pkg150's 7.1%; establish whether the gap is uniform or
+   corner-specific.
+2. **Bisect the cause.** Candidates, in order of cheapness: (a) a sampler
+   regression between pkg150's SHA (`d02fe07`) and current main — `git log` the
+   VNDF path (`sampleGgxVNDF`, the reflect/refract branch) and A/B the
+   dead-fraction across that range; (b) a measurement-methodology difference
+   (spp, seed, which candidate counts as "dead") between pkg150's harness and
+   the pkg167 measurement; (c) a genuine VNDF azimuth/hemisphere-orientation
+   bug in the below-horizon accounting (the pkg149 class of defect — Lerp arg
+   order, oriented-normal vs geometric-normal for the enter/exit side; memory
+   `photon-caustic-exit-refraction-oriented-normal`).
+3. **Fork on the finding.** If a sampler bug is convicted → fix it (cite the
+   reference form, CLAUDE.md §6), re-measure the dead-fraction, and re-test
+   whether the dead-sample fix + pkg167 compensation now holds the furnace on
+   its own. If it does, Phase 2 may not be needed — CLOSE with the diagnosis.
+   If the rate is legitimate physics (~23% really is below-horizon at r=1.0),
+   proceed to Phase 2.
+
+## Phase 2 — transmission-lobe energy redistribution (only if Phase 1 shows the dead-sample rate is real)
+
+The below-horizon reflection energy that the dead-sample fix correctly refuses
+to emit as a spurious smooth-mirror delta must be re-routed to where it
+physically goes: the transmission lobe. Two candidate constructions — pick one
+with citations, do not invent a hybrid:
+
+- **Combined-closure redistribution (Cycles' approach).** Treat the dielectric
+  reflection+transmission as one closure whose lobe-selection and throughput
+  bookkeeping conserve the below-horizon energy into transmission, matching how
+  Cycles' `bsdf_microfacet` dielectric handles the shared microfacet. This is
+  the structurally-correct answer and directly informs pkg178's port; it may be
+  larger than a term.
+- **Transmission-lobe multiscatter extension.** Extend the existing
+  `ggxGlassCompensationFactor` (pkg118, from `fresnelDielectricFss(etap)`) so
+  the transmission lobe absorbs the reflected-below-horizon energy budget the
+  dead-sample fix releases. Document precisely how this composes with pkg167's
+  reflection-lobe term so the two never double-compensate and never
+  double-count the same photons.
+
+**Cite — no inventions (CLAUDE.md §6; invoke `cite-algorithm` before coding):**
+
+- **Cycles `bsdf_microfacet.h`** (BSD-3-Clause) — the combined dielectric
+  closure's below-horizon / total-internal-reflection energy bookkeeping. This
+  is the production cross-check and the "one combined closure" the escalation
+  names.
+- **pbrt-v4 `DielectricBxDF`** (`src/pbrt/bxdfs.cpp`, Apache-2.0) — the
+  dead-sample `pdf=0` semantics being ported (the coverage half, preserved at
+  `.astroray_plan/docs/pkg150-deadsample-fix.patch`), and how pbrt keeps
+  reflection/transmission lobe selection energy-consistent under that
+  termination.
+- **Heitz 2018 VNDF** (JCGT 7:4) + **Kulla & Conty 2017** / **Turquin 2019**
+  for the multiscatter-compensation family already in-repo
+  (`energy_compensation.h`), if Phase 2 takes the transmission-extension route.
+- **In-repo composition partners:** pkg118's `ggxGlassCompensationFactor`
+  (`disney.cpp`) and pkg167's new reflection-lobe term — the research note MUST
+  state the composition rule across all three.
+
+**CPU/GPU mirrored in the same package.** The term/closure lands in `disney.cpp`
+eval/sampleSpectral AND its exact GPU twin in the closure-graph path
+(`gpu_materials.h` / wavefront shade), the pkg160→pkg163 discipline. A CPU-only
+land repeats the four-week divergence; do not split.
+
+## Acceptance criteria
+
+- [ ] **Phase 1 diagnosis recorded** with the dead-fraction grid on current
+      main, the bisect verdict (sampler bug / methodology / real physics), and
+      — if a sampler bug — the fix with its reference citation, re-measured
+      dead-fraction, and un-`--runxfail`-proven gates.
+- [ ] **The dead-sample fix ships** (delta fallback removed, below-horizon VNDF
+      reflection returns `pdf=0` per pbrt-v4) — this is the binding deliverable
+      that pkg150/pkg167 could not land.
+- [ ] **White furnace in-band at ALL of r ∈ {0.3, 0.6, 1.0}, CPU AND GPU, in
+      LINEAR with floor+ceiling** (pkg166 rules: `apply_gamma=False` explicit,
+      upper bound asserted — a gamma furnace cannot see this failure mode), WITH
+      the dead-sample fix IN. Target band `[0.92, 1.03]` unless the architect
+      signs off otherwise. This is the pass/fail pkg167 Part 2 failed at 0.485.
+- [ ] The pkg167-inherited quarantine cell (CPU Disney transmission furnace,
+      ior 1.5, R=1.0) returns to the standard band and any residual xfail marker
+      is removed, proven under `--runxfail` (memory `xfail-gated-features-must-unxfail`).
+- [ ] CPU and GPU are the same construction (spectral handling per pkg163's
+      class rule); a plain GPU/CPU parity check on a rough dielectric sphere
+      stays in the standard band.
+- [ ] **chi² caveat encoded:** do NOT pin any gate on a raw `ires=4` chi²
+      number — that reading is ~90% a quadrature artifact (pkg150 Finding 3).
+      Re-run at higher `ires` before citing or gating any chi² result.
+- [ ] Research note
+      `.astroray_plan/docs/pkg179-dielectric-transmission-redistribution-research.md`
+      with the citations above, the Phase-1 verdict, the combined-closure
+      vs transmission-extension decision, and the three-way composition rule
+      (reflection pkg167 / transmission-multiscatter pkg118 / this
+      redistribution).
+
+## Relationship note — pkg178 (native Principled port)
+
+The "one combined closure vs split lobes" question this package answers is the
+same structural fork pkg178 confronts: Cycles' Principled dielectric is a
+combined closure by construction. If Phase 2 lands a combined-closure
+redistribution for the Disney dielectric, record the design in the research note
+so pkg178 Stage 1/3 can adopt (not re-derive) it — but do NOT expand this
+package into the full Principled port. This is the Disney dielectric only.
+
+## Non-goals
+
+- Not the reflection lobe (pkg167 Part 1 shipped that; do not re-tune it —
+  extend/compose with it).
+- Not the metal lobes (pkg60/pkg160/pkg163 shipped; pkg129 owns unification).
+- Not reopening pkg150/pkg149/pkg151/pkg154 as charters — this package consumes
+  their sampler and the preserved dead-sample patch.
+- No gate-band changes without architect sign-off; no LUT regeneration from
+  scratch — borrow license-clean tables (CLAUDE.md §6).
+
+## Provenance
+
+Filed by the architect 2026-08-08 at lead request, from pkg167 Part 2's
+escalation (PR #562): reflection-lobe compensation recovers only +0.009 at
+r=1.0 (furnace 0.476→0.485), the masked ~23% below-horizon energy belongs in
+transmission, and the measured dead-sample rate is ~3× pkg150's documented
+figure (possible sampler bug). Fourth+ member of the dielectric energy-accounting
+chain: pkg150 (coverage STOP) → pkg149 (sampler) → pkg167 (reflection comp) →
+**pkg179 (sampler diagnosis + transmission redistribution)**.

--- a/.astroray_plan/packages/pkg180-systemic-cycles-dim-diagnosis.md
+++ b/.astroray_plan/packages/pkg180-systemic-cycles-dim-diagnosis.md
@@ -1,0 +1,131 @@
+# pkg180 — systemic ~12–20% Astroray-vs-Cycles dim: is it a comparison-methodology artifact or a real engine energy offset? (diagnosis-first, do NOT fix until localized)
+
+**Pillar:** 3 (GPU/CPU + Cycles parity) / Integration Milestone verification layer
+**Track:** A (RTX + headless-Blender/Cycles; render legs serialize on the GPU lane per repo rule)
+**Status:** open — dispatchable (DIAGNOSIS-FIRST; no fix work until the offset is localized to a mechanism)
+**Estimated effort:** S–M (Phase 1 is a cheap methodology check; a real-engine conviction only then sizes into further work with architect sign-off)
+**Depends on:** pkg119-B differential harness landed + HW-validated (PR #550 — the passing-cell ratio cluster is this package's primary evidence), pkg129-narrowed metal A/B (research doc §5, run 2026-08-08 — the metal cross-datapoint), pkg104 reference bank + pkg71 cycles-parity benches (oracle blessing + metrics). Reads: memory `pkg119b-harness-runbook`, `ssim-wrong-gate-for-independent-rng`, `gamma-vs-linear-comparison-artifact`, `mc-noise-vs-deterministic`.
+
+**Origin:** lead cross-harness measurement, 2026-08-08. The pkg119-B differential
+harness and the pkg129 metal A/B, run independently on current main, BOTH show
+Astroray rendering **systemically dimmer than Cycles at equal settings** on
+diffuse/metal scenes. This is filed so the offset has an owner and a
+diagnosis-first charter instead of living as scattered "INTENTIONAL-DIVERGENCE"
+triage lines across two harnesses.
+
+---
+
+## Finding (baseline — cite this, do not re-derive casually)
+
+Across three independent measurements on current main (RTX 5070 Ti + Blender
+5.1, linear ratio statistic):
+
+1. **pkg119-B differential harness:** passing cells cluster at Astroray/Cycles
+   ratio **~0.88** (the harness correctly routes this to a parity-band /
+   INTENTIONAL-DIVERGENCE signal rather than a per-feature bug — PR #550).
+2. **pkg129 metal A/B** (research doc §5, 2026-08-08): neutral-albedo Disney
+   metal reads ~1.00 at r=0.3 falling to ~**0.93** at r=0.9 vs Cycles — a mild
+   roughness-dependent dim on top of a baseline offset.
+3. **Plain solid-diffuse backdrop probe:** ratio **~0.79–0.82** — the largest
+   reading, on the simplest possible scene.
+
+The signature: a **UNIFORM, chromatically-uniform energy-scale offset** of
+**~12–20%** — NOT a per-feature bug, NOT channel-ordered, NOT
+roughness-gated (the roughness term in (2) rides on top of it). A uniform
+achromatic scale factor across unrelated materials and scenes is the fingerprint
+of a **comparison-methodology or global-exposure** difference far more than an
+engine transport defect — which is exactly what Phase 1 checks, cheaply, first.
+
+**Why it matters:** it is directly relevant to pkg178's Principled-BSDF
+true-parity goal and the owner's standing parity ambitions. A ~15% global dim
+would swamp every per-lobe parity delta pkg178 tries to measure; this offset
+must be characterized (and, if real, owned) before "true Cycles parity" is a
+measurable claim.
+
+## Phase 1 — is it a comparison-methodology artifact? (blocking; cheapest check first)
+
+A uniform achromatic scale is most likely NOT in the engine. Rule the
+methodology out before touching any transport code. All on ONE recorded main
+SHA, every leg's `apply_gamma` / color-management state stated explicitly.
+
+1. **View transform / color management.** Cycles applies a view transform
+   (Filmic / AgX in Blender 5.x) and display color management by default;
+   Astroray outputs linear. If the harness compares Cycles' **view-transformed**
+   output against Astroray's **linear** output, a systemic offset is guaranteed
+   and is an artifact, not a defect. Confirm each harness reads Cycles in the
+   **same** transform space as Astroray (Standard/Raw view transform, or both
+   compared in scene-linear before any display transform). This is the prime
+   suspect — the gamma-vs-linear comparison artifact has burned this project
+   before (memory `gamma-vs-linear-comparison-artifact`,
+   `mc-noise-vs-deterministic`).
+2. **Exposure / film settings.** Check Cycles `Film > Exposure`, the scene
+   `View Layer` exposure, and any tonemap the harness applies to one leg but not
+   the other. A stray exposure≠0 or an implicit filmic curve reproduces a
+   uniform scale exactly.
+3. **Sample/normalization convention.** Confirm both engines normalize
+   accumulated radiance identically (per-sample average vs sum), and that the
+   background/world contribution is present and identical in both legs (a missing
+   or half-strength world uniformly dims the whole frame — cf. pkg119-B's
+   `world:World` SSIM 0.62 finding).
+
+**Phase 1 exit:** if the offset collapses into band once the comparison is put
+in a common linear space with matched exposure/world → it is a
+**methodology artifact**. Record the corrected comparison protocol (feed it back
+to the pkg119-B harness and pkg129 A/B so their ratio bands are honest), close
+this package with no engine change, and note whatever residual remains for
+pkg178's baseline.
+
+## Phase 2 — only if a REAL engine offset survives Phase 1
+
+If the offset persists with the comparison provably in a common linear space,
+matched exposure, and matched world — THEN it is an engine energy difference.
+Localize before proposing any fix:
+
+1. Bisect by scene minimalism: single diffuse surface + single known-radiance
+   light, no world, delta-ish — compute the expected radiance analytically and
+   see which engine is off the analytic truth (Cycles is the oracle for
+   *parity*, but an analytic scene tells you WHICH engine is wrong).
+2. Decompose direct vs indirect: does the dim appear at max_depth=1 (a
+   direct-lighting / light-normalization / solid-angle factor) or only with
+   bounces (an indirect-throughput / russian-roulette / clamp difference)?
+3. Report the localized mechanism to the architect. **Do NOT ship a global
+   brightness multiply** — a uniform fudge factor is a CLAUDE.md §6 violation and
+   would mask whatever the real cause is. A fix, if any, sizes into its own spec
+   with architect sign-off.
+
+## Acceptance criteria
+
+- [ ] **Phase 1 verdict recorded:** the comparison protocol audited leg-by-leg
+      (view transform, exposure, normalization, world), with a same-linear-space
+      re-measurement of the ~0.88 / ~0.93 / ~0.79–0.82 readings. Verdict:
+      artifact (→ close with corrected protocol) or real (→ Phase 2).
+- [ ] If artifact: the corrected comparison protocol is documented and the
+      pkg119-B harness + pkg129 A/B ratio bands are updated/annotated to reflect
+      it (so future runs don't re-file this).
+- [ ] If real: a localization table (which engine, direct vs indirect, analytic
+      vs oracle) and an architect hand-off — NOT a fix in this package.
+- [ ] Research note
+      `.astroray_plan/docs/pkg180-systemic-cycles-dim-diagnosis.md` with the
+      measurements, the Phase-1 methodology audit, and the disposition.
+
+## Non-goals
+
+- **No fix until localized.** This is diagnosis-first; a uniform brightness
+  multiply is explicitly forbidden (CLAUDE.md §6).
+- **Not a per-feature parity bug.** The pkg119-B TRANSLATION-BUG cells
+  (`BSDF_TRANSPARENT`, `world:World`) are their own follow-ups; this package
+  owns the UNIFORM offset underneath them, not the per-feature divergences.
+- **Not reopening pkg129, pkg163, or pkg165.** Their metal-specific readings are
+  cross-datapoints for the uniform offset, not defect claims here.
+- **No parity-band change without architect sign-off.** The `[0.90,1.10]`
+  history stays; this package explains the offset, it does not widen the band to
+  hide it.
+
+## Provenance
+
+Filed by the architect 2026-08-08 at lead request, from the cross-harness
+measurement this run: pkg119-B passing cells ~0.88, pkg129 metal neutral r0.9
+~0.93, plain solid-diffuse backdrop ~0.79–0.82 — a uniform chromatically-uniform
+~12–20% Astroray-vs-Cycles dim. Diagnosis-first; prime suspect is a Cycles
+view-transform-vs-Astroray-linear comparison artifact (check cheaply, first)
+rather than an engine energy bug. Directly relevant to pkg178's true-parity goal.


### PR DESCRIPTION
Bookkeeping from the lead's 2026-08-08 run findings. Docs-only; no code touched.

## pkg179 — Disney dielectric dead-sample fix Part 2 (pkg167 Part 2 escalation)
pkg167 (PR #562, MERGED) shipped Part 1 (reflection-lobe multiscatter comp, CPU+GPU, furnace in-band, pkg169 xfail retired). **Part 2 — the pkg150 pbrt-v4 dead-sample fix — was applied, measured, REVERTED, premise falsified:** reflection compensation recovers only +0.009 at r=1.0 (furnace 0.476→0.485, still fails the 0.92 floor) because a dielectric's Fss≈0.09 makes the K&C factor ≈1.05. The masked ~23% below-horizon energy belongs in the TRANSMISSION lobe (Cycles redistributes it in one combined closure; Astroray's split lobes cannot via a reflection multiply). Also: measured dead-sample rate is ~3× pkg150's documented figure (22.9% vs 7.1% @ r=1.0) → possible sampler bug. pkg179 scope: **(Phase 1)** diagnose the 3× discrepancy (sampler bug?), **(Phase 2)** transmission-lobe redistribution so the dead-sample fix ships without furnace regression. Track A, CPU furnace + GPU twin.

## pkg180 — systemic ~12–20% Astroray-vs-Cycles dim (diagnosis-first)
Across pkg119-B (passing cells ~0.88), pkg129 metal A/B (neutral r0.9 ~0.93), and a plain diffuse backdrop probe (~0.79–0.82), Astroray renders a **uniform, chromatically-uniform ~12–20% dimmer** than Cycles at equal settings. Filed diagnosis-first; prime suspect is a Cycles view-transform-vs-Astroray-linear **comparison-methodology artifact** (check cheaply, first), not an engine bug. Directly relevant to pkg178's true-parity goal. Track A. No fix until localized.

## pkg165 — verify-and-close
Its "uniform ~5–8% Disney-metal GPU-dim" premise (measured on old SHA b036ac93) does **not reproduce on current main**: the pkg129 metal A/B shows GPU ≈ CPU (marginally *brighter*, not dimmer) at every roughness — opposite sign. Likely resolved by pkg170's opaque-Disney fix + intervening work. Status flipped to verify-and-close; spec retained (not deleted); disposition cited in reflection-multiscatter-turquin-research.md §5.

## Also
STATUS.md top section: 2026-08-08 run note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)