### PR TITLE
feat(pkg176 Stage 4): retire custom UI — native Blender settings are the only steering wheel

### DIFF
--- a/benchmarks/viewport_parity/blender_driver.py
+++ b/benchmarks/viewport_parity/blender_driver.py
@@ -260,7 +260,11 @@ def run_offline(args) -> dict:
         gpu_note = _enable_cycles_gpu()
         print(f"[pkg81-driver] cycles device: {gpu_note}")
     elif hasattr(scene, "custom_raytracer"):
-        scene.custom_raytracer.preview_samples = args.chunk_spp
+        # pkg176 Stage 4: samples come from native Cycles props now (the exporter
+        # reads them via resolve_native_settings); the custom preview_samples
+        # alias was retired.
+        scene.cycles.samples = args.chunk_spp
+        scene.cycles.preview_samples = args.chunk_spp
         if hasattr(scene.custom_raytracer, "viewport_chunk_spp"):
             scene.custom_raytracer.viewport_chunk_spp = args.chunk_spp
         if hasattr(scene.custom_raytracer, "viewport_oidn"):

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -210,16 +210,17 @@ _VIEWPORT_DISPLAY_PASS_ITEMS = [
 ]
 
 class CustomRaytracerRenderSettings(PropertyGroup):
-    # pkg176 Stage 1: the properties tagged "[Deprecated alias]" below now shadow
-    # a native Blender/Cycles control (see blender_addon/settings_map.py). The
-    # exporter reads the native value unless one of these was explicitly set in a
-    # saved .blend, in which case it wins for one release and logs a migration
-    # note per render (native_settings.resolve_native_settings). Set the value in
-    # Blender's native panel instead; these duplicates are removed in a later stage.
-    samples: IntProperty(name="Samples", min=1, max=65536, default=2,
-        description="[Deprecated alias] Superseded by native scene.cycles.samples")
-    preview_samples: IntProperty(name="Viewport Samples", min=1, max=1024, default=1,
-        description="[Deprecated alias] Superseded by native scene.cycles.preview_samples")
+    # pkg176 Stage 4: the DIRECT-mapped custom duplicates (samples,
+    # preview_samples, the light-path depths, clamp direct/indirect, filter
+    # glossy, reflective/refractive caustics, use_denoising) were RETIRED here.
+    # Their one-release back-compat window (Stage 1) is closed: the exporter now
+    # reads the native Blender/Cycles value for every `direct` row via
+    # native_settings.resolve_native_settings (see blender_addon/settings_map.py).
+    # An old .blend that saved one of the removed props degrades gracefully -
+    # Blender drops the unknown member on load and the native value is used.
+    # Only genuinely engine-unique / semantically-mismatched controls remain
+    # below (spectral band, device tri-state, integrator, denoiser backend, the
+    # not-yet-plumbed adaptive-sampling / light-sampler controls).
     viewport_display_pass: EnumProperty(
         name="Viewport Pass",
         description="Render pass shown in the rendered-shading viewport",
@@ -246,31 +247,9 @@ class CustomRaytracerRenderSettings(PropertyGroup):
         ],
         default='auto',
     )
-    max_bounces: IntProperty(name="Max Bounces", min=0, max=1024, default=10,
-        description="[Deprecated alias] Superseded by native scene.cycles.max_bounces")
-    diffuse_bounces: IntProperty(name="Diffuse", min=0, max=1024, default=4,
-        description="[Deprecated alias] Superseded by native scene.cycles.diffuse_bounces")
-    glossy_bounces: IntProperty(name="Glossy", min=0, max=1024, default=4,
-        description="[Deprecated alias] Superseded by native scene.cycles.glossy_bounces")
-    transmission_bounces: IntProperty(name="Transmission", min=0, max=1024, default=12,
-        description="[Deprecated alias] Superseded by native scene.cycles.transmission_bounces")
-    volume_bounces: IntProperty(name="Volume", min=0, max=1024, default=0,
-        description="[Deprecated alias] Superseded by native scene.cycles.volume_bounces")
-    transparent_bounces: IntProperty(name="Transparent", min=0, max=1024, default=8,
-        description="[Deprecated alias] Superseded by native scene.cycles.transparent_max_bounces")
     use_adaptive_sampling: BoolProperty(name="Adaptive Sampling", default=True,
         description="Stop sampling pixels that have already converged")
     adaptive_threshold: FloatProperty(name="Noise Threshold", min=0.001, max=1.0, default=0.01)
-    clamp_direct: FloatProperty(name="Clamp Direct", min=0.0, max=100.0, default=0.0,
-        description="[Deprecated alias] Superseded by native scene.cycles.sample_clamp_direct (0 disables)")
-    clamp_indirect: FloatProperty(name="Clamp Indirect", min=0.0, max=100.0, default=0.0,
-        description="[Deprecated alias] Superseded by native scene.cycles.sample_clamp_indirect (0 disables)")
-    filter_glossy: FloatProperty(name="Filter Glossy", min=0.0, max=10.0, default=0.0,
-        description="[Deprecated alias] Superseded by native scene.cycles.blur_glossy")
-    use_reflective_caustics: BoolProperty(name="Reflective Caustics", default=True,
-        description="[Deprecated alias] Superseded by native scene.cycles.caustics_reflective")
-    use_refractive_caustics: BoolProperty(name="Refractive Caustics", default=True,
-        description="[Deprecated alias] Superseded by native scene.cycles.caustics_refractive")
     light_sampler: EnumProperty(
         name="Light Sampler",
         description="Strategy for sampling lights in Next Event Estimation (Conty et al. 2018 Light Tree)",
@@ -296,8 +275,6 @@ class CustomRaytracerRenderSettings(PropertyGroup):
         description="Light transport integrator (from plugin registry)",
         items=_integrator_type_items,
     )
-    use_denoising: BoolProperty(name="Denoise", default=False,
-        description="[Deprecated alias] Superseded by native scene.cycles.use_denoising")
     # pkg39: wavelength / multi-spectral settings
     wavelength_preset: EnumProperty(
         name="Preset",
@@ -4549,9 +4526,18 @@ class RENDER_PT_custom_raytracer_sampling(AstrorayPanelBase, Panel):
 
         settings = context.scene.custom_raytracer
 
+        # pkg176 Stage 4: samples/preview_samples are `direct` rows read natively
+        # (native_settings.DIRECT_ALIASES). Cycles bundles them with dropped
+        # adaptive/time_limit controls, so the native Sampling panel is NOT
+        # adopted (see ADOPTED_NATIVE_PANELS); instead we draw the honest native
+        # scene.cycles.samples / preview_samples directly on this custom panel.
+        cycles = getattr(context.scene, "cycles", None)
         col = layout.column(align=True)
-        col.prop(settings, "samples", text="Render")
-        col.prop(settings, "preview_samples", text="Viewport")
+        if cycles is not None:
+            col.prop(cycles, "samples", text="Render")
+            col.prop(cycles, "preview_samples", text="Viewport")
+        else:
+            col.label(text="Enable the Cycles add-on for sample counts", icon='INFO')
 
         layout.separator()
         col = layout.column(align=True)

--- a/blender_addon/native_settings.py
+++ b/blender_addon/native_settings.py
@@ -1,20 +1,24 @@
-"""pkg176 Stage 1 - native Blender/Cycles settings resolution (translation layer).
+"""pkg176 Stage 4 - native Blender/Cycles settings resolution (translation layer).
 
 The exporter drives Astroray from Blender's NATIVE controls. For every setting
-the Stage-0 contract (``blender_addon/settings_map.py``) marks ``direct`` and
-that still has a shadowing ``custom_raytracer.*`` duplicate, this module resolves
-the value the engine session should use:
+the Stage-0 contract (``blender_addon/settings_map.py``) marks ``direct``, this
+module resolves the value the engine session should use:
 
-  1. If the legacy custom duplicate is explicitly set in a saved ``.blend``
-     (``is_property_set``), honour it for one release of back-compat and log a
-     one-line deprecation/migration note per render.
-  2. Otherwise read the native ``scene.cycles.*`` / ``scene.render.*`` property.
-  3. If neither is available (a non-Cycles scene / a unit-test stub), leave the
-     setting unresolved so behaviour is unchanged (the custom prop is used).
+  1. Read the native ``scene.cycles.*`` / ``scene.render.*`` property.
+  2. If it is unavailable (a non-Cycles scene - e.g. the Cycles add-on is
+     disabled - or a unit-test stub), fall back to ``DIRECT_DEFAULTS`` (the
+     engine defaults the retired custom props used to carry) so resolution never
+     raises. A test stub that still carries the old custom attribute is left
+     unresolved so the proxy falls through to it unchanged.
+
+Stage 4 retired the ``custom_raytracer.*`` duplicates for the ``direct`` rows;
+their one-release Stage-1 back-compat window is closed. An old ``.blend`` that
+saved one of those props degrades gracefully - Blender drops the unknown member
+on load and the native value (or default) is used; nothing hard-crashes.
 
 Semantic mismatches (table status ``approximated`` / ``dropped`` / ``astroray-only``)
 are deliberately NOT resolved here - they stay custom-only until the engine
-honours the native meaning (Stage 1 rule).
+honours the native meaning.
 
 Route-2 discipline (dcc-integration-decision-2026-08 §6): this module is the
 bpy-facing TRANSLATOR. It reads Blender datablocks and returns a plain read-only
@@ -51,34 +55,26 @@ def _direct_aliases():
 DIRECT_ALIASES = _direct_aliases()
 
 
-def _custom_is_set(settings, custom_attr):
-    """True if the legacy custom duplicate was explicitly written (a saved
-    ``.blend`` override). Uses Blender's ``is_property_set`` (the canonical way
-    to distinguish an authored value from a registered default); returns False
-    under test stubs that don't provide it."""
-    is_set = getattr(settings, "is_property_set", None)
-    if not callable(is_set):
-        return False
-    try:
-        return bool(is_set(custom_attr))
-    except (TypeError, RuntimeError):
-        return False
-
-
-def _log_migration(report, custom_attr, native_attr):
-    msg = (
-        f"Astroray: legacy custom setting 'custom_raytracer.{custom_attr}' is set "
-        f"and overrides native 'scene.cycles.{native_attr}'; this alias is "
-        f"deprecated and will be removed - set the value in Blender's native "
-        f"panel instead."
-    )
-    if report is not None:
-        try:
-            report({'WARNING'}, msg)
-            return
-        except (TypeError, RuntimeError):
-            pass
-    print(msg)
+# pkg176 Stage 4: last-resort fallback for the retired direct aliases, used ONLY
+# when the scene carries no ``cycles`` datablock (Cycles add-on disabled / a
+# unit-test stub) so resolution never raises. Values mirror the engine defaults
+# the removed custom props used to carry. Keyed by the (former) custom attr name.
+DIRECT_DEFAULTS = {
+    "samples": 2,
+    "preview_samples": 1,
+    "max_bounces": 10,
+    "diffuse_bounces": 4,
+    "glossy_bounces": 4,
+    "transmission_bounces": 12,
+    "volume_bounces": 0,
+    "transparent_bounces": 8,
+    "clamp_direct": 0.0,
+    "clamp_indirect": 0.0,
+    "filter_glossy": 0.0,
+    "use_reflective_caustics": True,
+    "use_refractive_caustics": True,
+    "use_denoising": False,
+}
 
 
 class ResolvedSettings:
@@ -200,19 +196,20 @@ def resolve_native_settings(scene, report=None):
     """Resolve the DIRECT-mapped settings for ``scene`` and return a
     :class:`ResolvedSettings` view.
 
-    ``report`` is an optional Blender ``self.report``-style callback used to
-    surface the per-render deprecation note; pass ``None`` on hot paths
-    (per-frame viewport draw) to keep resolution silent.
+    ``report`` is retained for call-site compatibility (final render / viewport
+    paths pass ``self.report``) but is unused since Stage 4 removed the
+    deprecation/migration note along with the custom aliases it warned about.
     """
     settings = scene.custom_raytracer
     cycles = getattr(scene, "cycles", None)
     resolved = {}
     for native_attr, custom_attr in DIRECT_ALIASES:
-        if _custom_is_set(settings, custom_attr):
-            _log_migration(report, custom_attr, native_attr)
-            resolved[custom_attr] = getattr(settings, custom_attr)
-        elif cycles is not None and hasattr(cycles, native_attr):
+        if cycles is not None and hasattr(cycles, native_attr):
             resolved[custom_attr] = getattr(cycles, native_attr)
-        # else: leave unresolved -> the proxy falls through to the custom prop,
-        # keeping behaviour unchanged on non-Cycles / stub scenes.
+        elif not hasattr(settings, custom_attr):
+            # Retired custom prop AND no native source (Cycles-less scene):
+            # fall back to the engine default so nothing hard-crashes.
+            resolved[custom_attr] = DIRECT_DEFAULTS[custom_attr]
+        # else: settings still carries the attr (a pre-retirement object / test
+        # stub) -> leave unresolved so the proxy falls through to it unchanged.
     return ResolvedSettings(settings, resolved)

--- a/scripts/dev/render_test_scene.py
+++ b/scripts/dev/render_test_scene.py
@@ -88,11 +88,14 @@ def main():
         print(f"FAIL: couldn't set render engine to CUSTOM_RAYTRACER: {e}")
         sys.exit(3)
 
-    # Engine-side sampling settings (we registered these as scene.custom_raytracer)
+    # pkg176 Stage 4: samples / max_bounces are read from the native Cycles props.
+    cyc = getattr(scene, "cycles", None)
+    if cyc is not None:
+        cyc.samples = args.samples
+        cyc.max_bounces = args.max_bounces
+    # Adaptive sampling stays an astroray-only custom control.
     cr = getattr(scene, "custom_raytracer", None)
     if cr is not None:
-        cr.samples = args.samples
-        cr.max_bounces = args.max_bounces
         # Keep adaptive sampling off for deterministic timings in tests
         cr.use_adaptive_sampling = False
 

--- a/scripts/verify_pkg108_bug09_bug14_blender.py
+++ b/scripts/verify_pkg108_bug09_bug14_blender.py
@@ -74,7 +74,7 @@ def main():
     scene.render.resolution_x = 64
     scene.render.resolution_y = 64
     scene.render.resolution_percentage = 100
-    scene.custom_raytracer.samples = 2
+    scene.cycles.samples = 2  # pkg176 Stage 4: samples read from native Cycles
 
     # Camera + light so the engine has a complete scene.
     cam_data = bpy.data.cameras.new("Cam")

--- a/scripts/verify_pkg115_textures_blender.py
+++ b/scripts/verify_pkg115_textures_blender.py
@@ -188,8 +188,9 @@ def main():
         scene.cycles.samples = args.spp
         scene.cycles.use_denoising = False
     elif hasattr(scene, "custom_raytracer"):
-        scene.custom_raytracer.samples = args.spp  # the F12 property
-        scene.custom_raytracer.preview_samples = args.spp
+        # pkg176 Stage 4: samples/preview_samples read from native Cycles props.
+        scene.cycles.samples = args.spp
+        scene.cycles.preview_samples = args.spp
         if hasattr(scene.custom_raytracer, "device_mode"):
             scene.custom_raytracer.device_mode = args.device
 

--- a/scripts/verify_pkg122_cycles_oracle.py
+++ b/scripts/verify_pkg122_cycles_oracle.py
@@ -149,8 +149,9 @@ def render_engine(scene, engine, spp, out_stem):
         scene.cycles.use_denoising = False
         scene.cycles.use_adaptive_sampling = False
     elif hasattr(scene, "custom_raytracer"):
-        scene.custom_raytracer.samples = spp
-        scene.custom_raytracer.preview_samples = spp
+        # pkg176 Stage 4: samples/preview_samples read from native Cycles props.
+        scene.cycles.samples = spp
+        scene.cycles.preview_samples = spp
         if hasattr(scene.custom_raytracer, "device_mode"):
             scene.custom_raytracer.device_mode = "gpu"
 

--- a/scripts/verify_pkg139_area_orientation_oracle.py
+++ b/scripts/verify_pkg139_area_orientation_oracle.py
@@ -132,8 +132,9 @@ def render_engine(scene, engine, spp, out_stem):
         scene.cycles.use_denoising = False
         scene.cycles.use_adaptive_sampling = False
     elif hasattr(scene, "custom_raytracer"):
-        scene.custom_raytracer.samples = spp
-        scene.custom_raytracer.preview_samples = spp
+        # pkg176 Stage 4: samples/preview_samples read from native Cycles props.
+        scene.cycles.samples = spp
+        scene.cycles.preview_samples = spp
         if hasattr(scene.custom_raytracer, "device_mode"):
             scene.custom_raytracer.device_mode = "gpu"
 

--- a/tests/test_pkg176_stage1_native_settings.py
+++ b/tests/test_pkg176_stage1_native_settings.py
@@ -1,15 +1,17 @@
-"""pkg176 Stage 1 - native-settings resolution (translation layer) unit tests.
+"""pkg176 Stage 1/4 - native-settings resolution (translation layer) unit tests.
 
 Pure Python, no Blender / engine / GPU. Exercises
 ``blender_addon/native_settings.py`` with a stub ``scene`` mirroring the Blender
-datablock shape (``scene.cycles.*`` native props + ``scene.custom_raytracer.*``
-deprecated custom duplicates).
+datablock shape (``scene.cycles.*`` native props + ``scene.custom_raytracer.*``).
 
 Acceptance covered:
   (a) each DIRECT-mapped native prop flows to the resolved setting (correct
       native source + name/unit mapping);
-  (b) a set legacy custom prop still wins, with a logged migration note;
-  (c) an approximated/dropped setting is NOT read from native (stays custom).
+  (b) Stage 4 retired the custom duplicates: the native value ALWAYS wins and no
+      migration note is emitted, even if a stale custom attribute is present;
+  (c) an approximated/dropped setting is NOT read from native (stays custom);
+  (d) a Cycles-less scene falls back gracefully (default / stale custom) and
+      never raises.
 """
 
 import importlib.util
@@ -161,36 +163,30 @@ def test_no_migration_note_when_no_legacy_override():
 
 
 # --------------------------------------------------------------------------- #
-# (b) a set legacy custom prop wins, and logs a migration note
+# (b) Stage 4 retirement: the custom duplicates no longer override native, and
+#     no migration note is emitted even for a stale explicitly-set custom value.
 # --------------------------------------------------------------------------- #
 
-def test_legacy_custom_override_wins_and_logs():
+def test_native_wins_over_stale_custom_and_emits_no_note():
     reports = []
+    # even a stale explicitly-set custom value must NOT win any more.
     scene = _scene(_native_cycles(), explicitly_set=("max_bounces", "clamp_direct"))
     resolved = ns.resolve_native_settings(scene, report=lambda t, m: reports.append((t, m)))
 
-    # overridden props take the CUSTOM value, not native
-    assert resolved.max_bounces == 10
-    assert resolved.clamp_direct == 0.0
-    # non-overridden direct props still read native
+    assert resolved.max_bounces == 24    # native, not the custom 10
+    assert resolved.clamp_direct == 2.5  # native, not the custom 0.0
     assert resolved.samples == 64
     assert resolved.glossy_bounces == 6
 
-    # exactly one migration note per overridden alias, tagged WARNING
-    assert len(reports) == 2
-    joined = " ".join(m for _, m in reports)
-    assert "custom_raytracer.max_bounces" in joined
-    assert "custom_raytracer.clamp_direct" in joined
-    assert all(t == {'WARNING'} for t, _ in reports)
+    # the deprecation/migration note is retired along with the aliases.
+    assert reports == []
 
 
-def test_legacy_override_falls_back_to_print_without_report(capsys):
+def test_report_none_is_silent(capsys):
     scene = _scene(_native_cycles(), explicitly_set=("samples",))
     resolved = ns.resolve_native_settings(scene, report=None)
-    assert resolved.samples == 2  # custom value wins
-    out = capsys.readouterr().out
-    assert "custom_raytracer.samples" in out
-    assert "deprecated" in out.lower()
+    assert resolved.samples == 64  # native wins
+    assert capsys.readouterr().out == ""
 
 
 # --------------------------------------------------------------------------- #
@@ -214,15 +210,31 @@ def test_approximated_and_dropped_stay_custom():
 
 
 # --------------------------------------------------------------------------- #
-# fallback: non-Cycles / stub scene keeps custom values (behaviour unchanged)
+# (d) fallback: Cycles-less scene never raises
 # --------------------------------------------------------------------------- #
 
-def test_non_cycles_scene_uses_custom_values_unchanged():
+def test_non_cycles_scene_falls_through_to_stale_custom_if_present():
+    # a pre-retirement object / stub that still carries the custom attr is honoured
+    # as a graceful read back-compat path (no native source, attr present).
     resolved = ns.resolve_native_settings(_scene(cycles=None))
     assert resolved.samples == 2
     assert resolved.max_bounces == 10
     assert resolved.clamp_direct == 0.0
     assert resolved.light_sampler == 'power'
+
+
+def test_non_cycles_scene_without_custom_attrs_uses_defaults():
+    """Real Stage-4 shape: the retired custom props are GONE from the settings
+    object and there is no Cycles datablock -> DIRECT_DEFAULTS, never a raise."""
+    bare = types.SimpleNamespace()  # no direct-alias attrs at all
+    scene = types.SimpleNamespace(custom_raytracer=bare, cycles=None)
+    resolved = ns.resolve_native_settings(scene)
+    for custom_attr, expected in ns.DIRECT_DEFAULTS.items():
+        assert getattr(resolved, custom_attr) == expected
+
+
+def test_direct_defaults_cover_every_alias():
+    assert set(ns.DIRECT_DEFAULTS) == {c for _, c in ns.DIRECT_ALIASES}
 
 
 def test_attribute_write_reaches_underlying_settings():

--- a/tests/test_pkg176_stage4_retirement.py
+++ b/tests/test_pkg176_stage4_retirement.py
@@ -1,0 +1,233 @@
+"""pkg176 Stage 4 - custom-UI retirement unit tests.
+
+Pure Python, no live Blender / engine / GPU. Loads ``blender_addon/__init__.py``
+under a stub ``bpy`` (same monkeypatch pattern as test_pkg176_stage2_panel_adoption.py)
+extended with a ``bpy.utils`` class-registration recorder and Scene/Material/Object
+id-types so ``register()`` / ``unregister()`` can be driven end-to-end.
+
+Acceptance covered:
+  (a) the 14 DIRECT-mapped custom alias properties are GONE from
+      CustomRaytracerRenderSettings, while the genuinely engine-unique /
+      semantically-mismatched props remain;
+  (b) no retired custom panel/property-group class lingers in ``classes``; the
+      single object-level "Astroray" panel and the astroray-only render panels
+      are still registered;
+  (c) register()/unregister() are consistent - every class registered is
+      unregistered exactly once, and nothing is unregistered that was never
+      registered;
+  (d) after register() the adopted native Cycles Light Paths panels honour
+      CUSTOM_RAYTRACER, and after unregister() they no longer do.
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from typing import ClassVar
+
+import pytest
+
+_ADDON = Path(__file__).resolve().parents[1] / "blender_addon"
+
+# The retired DIRECT-mapped custom duplicates (former custom_raytracer.* attrs).
+RETIRED_ALIAS_ATTRS = {
+    "samples", "preview_samples",
+    "max_bounces", "diffuse_bounces", "glossy_bounces",
+    "transmission_bounces", "volume_bounces", "transparent_bounces",
+    "clamp_direct", "clamp_indirect", "filter_glossy",
+    "use_reflective_caustics", "use_refractive_caustics", "use_denoising",
+}
+
+# Genuinely engine-unique / mismatched props that MUST survive retirement.
+KEPT_ASTRORAY_ONLY_ATTRS = {
+    "wavelength_preset", "wavelength_min", "wavelength_max", "colourmap",
+    "device_mode", "integrator_type", "viewport_display_pass",
+    "denoiser_backend", "cryptomatte_depth",
+    # not-yet-plumbed native controls kept custom-only (approximated / dropped):
+    "light_sampler", "use_adaptive_sampling", "adaptive_threshold",
+}
+
+ADOPTED = (
+    "CYCLES_RENDER_PT_light_paths",
+    "CYCLES_RENDER_PT_light_paths_max_bounces",
+    "CYCLES_RENDER_PT_light_paths_clamping",
+    "CYCLES_RENDER_PT_light_paths_caustics",
+)
+
+
+def _make_cycles_types(bpy_types_module):
+    """Fake Cycles panels sharing ONE inherited COMPAT_ENGINES set (as in real
+    Blender), so an in-place mutation leak would be detectable."""
+
+    class CyclesButtonsPanel:
+        COMPAT_ENGINES: ClassVar[set] = {'CYCLES'}
+
+    for name in (*ADOPTED, "CYCLES_RENDER_PT_sampling_render"):
+        setattr(bpy_types_module, name, type(name, (CyclesButtonsPanel,), {}))
+
+
+def _load_addon(monkeypatch):
+    bpy_module = types.ModuleType("bpy")
+    bpy_types_module = types.ModuleType("bpy.types")
+    bpy_props_module = types.ModuleType("bpy.props")
+    bpy_utils_module = types.ModuleType("bpy.utils")
+
+    class _Base:
+        pass
+
+    class _RenderEngineBase:
+        def report(self, *_a, **_k):
+            return None
+
+        def update_progress(self, *_a, **_k):
+            return None
+
+        def test_break(self):
+            return False
+
+    bpy_types_module.Panel = _Base
+    bpy_types_module.Operator = _Base
+    bpy_types_module.AddonPreferences = _Base
+    bpy_types_module.PropertyGroup = _Base
+    bpy_types_module.RenderEngine = _RenderEngineBase
+
+    # id-types register() attaches PointerProperties to.
+    class _Scene: pass
+    class _Material: pass
+    class _Object: pass
+    bpy_types_module.Scene = _Scene
+    bpy_types_module.Material = _Material
+    bpy_types_module.Object = _Object
+
+    # bpy.utils.register_class / unregister_class recorder.
+    registered = []
+    unregistered = []
+    bpy_utils_module.register_class = lambda cls: registered.append(cls)
+    bpy_utils_module.unregister_class = lambda cls: unregistered.append(cls)
+
+    bpy_module.types = bpy_types_module
+    bpy_module.utils = bpy_utils_module
+
+    for name in ("BoolProperty", "IntProperty", "FloatProperty", "StringProperty",
+                 "PointerProperty", "FloatVectorProperty", "EnumProperty"):
+        setattr(bpy_props_module, name, lambda **_k: None)
+    bpy_module.props = bpy_props_module
+    bpy_module.path = types.SimpleNamespace(abspath=lambda p: p)
+
+    shader_blending_module = types.ModuleType("shader_blending")
+    shader_blending_module.blend_shader_specs = {}
+    shader_blending_module.add_shader_specs = {}
+
+    mathutils_module = types.ModuleType("mathutils")
+    mathutils_module.Vector = lambda values: values
+
+    astroray_module = types.ModuleType("astroray")
+    astroray_module.__version__ = "test"
+    astroray_module.__features__ = {"cuda": False, "spectral": True}
+    astroray_module.__file__ = "/fake/astroray.pyd"
+
+    _make_cycles_types(bpy_types_module)
+
+    monkeypatch.setitem(sys.modules, "bpy", bpy_module)
+    monkeypatch.setitem(sys.modules, "bpy.types", bpy_types_module)
+    monkeypatch.setitem(sys.modules, "bpy.props", bpy_props_module)
+    monkeypatch.setitem(sys.modules, "bpy.utils", bpy_utils_module)
+    monkeypatch.setitem(sys.modules, "shader_blending", shader_blending_module)
+    monkeypatch.setitem(sys.modules, "mathutils", mathutils_module)
+    monkeypatch.setitem(sys.modules, "astroray", astroray_module)
+
+    spec = importlib.util.spec_from_file_location(
+        "astroray_addon_pkg176s4_test", _ADDON / "__init__.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module, bpy_types_module, registered, unregistered
+
+
+# --------------------------------------------------------------------------- #
+# (a) the retired alias props are gone; astroray-only props remain
+# --------------------------------------------------------------------------- #
+
+def test_retired_alias_props_removed_kept_ones_remain(monkeypatch):
+    addon, _bt, _reg, _unreg = _load_addon(monkeypatch)
+    ann = set(addon.CustomRaytracerRenderSettings.__annotations__)
+
+    leaked = RETIRED_ALIAS_ATTRS & ann
+    assert not leaked, f"retired alias props still declared: {sorted(leaked)}"
+
+    missing = KEPT_ASTRORAY_ONLY_ATTRS - ann
+    assert not missing, f"engine-unique props wrongly removed: {sorted(missing)}"
+
+
+def test_retired_set_equals_stage0_direct_aliases(monkeypatch):
+    """The props removed here are EXACTLY the direct-mapped custom duplicates the
+    Stage-0 contract / Stage-1 resolver enumerate - the retirement stays tied to
+    the single source of truth (native_settings.DIRECT_ALIASES)."""
+    _addon, _bt, _reg, _unreg = _load_addon(monkeypatch)
+    spec = importlib.util.spec_from_file_location(
+        "pkg176s4_native_settings", _ADDON / "native_settings.py")
+    ns = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(ns)
+    assert {c for _, c in ns.DIRECT_ALIASES} == RETIRED_ALIAS_ATTRS
+
+
+# --------------------------------------------------------------------------- #
+# (b) no retired panel/property-group class lingers; the kept ones remain
+# --------------------------------------------------------------------------- #
+
+def test_no_retired_panel_classes_kept_ones_present(monkeypatch):
+    addon, _bt, _reg, _unreg = _load_addon(monkeypatch)
+    class_names = {c.__name__ for c in addon.classes}
+
+    # Stage 2 already retired the custom Light Paths panel; it must stay gone.
+    assert "RENDER_PT_custom_raytracer_light_paths" not in class_names
+    assert not hasattr(addon, "RENDER_PT_custom_raytracer_light_paths")
+
+    # single object-level "Astroray" panel + astroray-only render panels remain.
+    assert "OBJECT_PT_astroray_object" in class_names
+    for kept in ("RENDER_PT_custom_raytracer_sampling",
+                 "RENDER_PT_custom_raytracer_performance",
+                 "RENDER_PT_custom_raytracer_wavelength",
+                 "RENDER_PT_custom_raytracer_diagnostics"):
+        assert kept in class_names, kept
+
+
+def test_classes_list_has_no_duplicates(monkeypatch):
+    addon, _bt, _reg, _unreg = _load_addon(monkeypatch)
+    assert len(addon.classes) == len(set(addon.classes))
+
+
+# --------------------------------------------------------------------------- #
+# (c)+(d) register()/unregister() are consistent and drive panel adoption
+# --------------------------------------------------------------------------- #
+
+def test_register_unregister_consistent_and_adopts_panels(monkeypatch):
+    addon, bt, registered, unregistered = _load_addon(monkeypatch)
+
+    addon.register()
+
+    # every declared class was registered exactly once, in order.
+    assert registered == list(addon.classes)
+    # adopted native panels now honour our engine.
+    for name in ADOPTED:
+        assert 'CUSTOM_RAYTRACER' in getattr(bt, name).COMPAT_ENGINES, name
+    # pointer properties attached.
+    assert hasattr(bt.Scene, "custom_raytracer")
+    assert hasattr(bt.Object, "astroray_object")
+
+    addon.unregister()
+
+    # nothing unregistered that was never registered, and all are torn down.
+    assert set(unregistered) == set(registered)
+    assert len(unregistered) == len(registered)
+    # adopted panels released.
+    for name in ADOPTED:
+        assert 'CUSTOM_RAYTRACER' not in getattr(bt, name).COMPAT_ENGINES, name
+    # pointer properties removed.
+    assert not hasattr(bt.Scene, "custom_raytracer")
+    assert not hasattr(bt.Object, "astroray_object")
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])


### PR DESCRIPTION
## pkg176 Stage 4 — custom-UI retirement (integration milestone point-of-no-return)

Owner approved proceeding 2026-08-09. Stages 0–3 (native settings plumbing, panel adoption, world/light/camera completion) are merged; this closes the loop: **native Blender/Cycles panels are the only steering wheel**, plus the one astroray-only panel for genuinely-astroray controls.

### What changed
- Removed the 14 Stage-1 deprecated-alias custom props from `CustomRaytracerRenderSettings` (samples, preview_samples, the 6 bounce counts, clamp_direct/indirect, filter_glossy, the 2 caustics toggles, use_denoising). The exporter already reads native via `resolve_native_settings` (Stage 1), so no read-site changed.
- `native_settings.py`: dropped the legacy-override + migration-note machinery; `resolve_native_settings` now reads native → stale-custom fallback (graceful read back-compat for old .blend) → `DIRECT_DEFAULTS`.
- Custom Sampling panel draws native `scene.cycles.samples`/`preview_samples` (that panel stays custom because Cycles bundles dropped adaptive/time_limit controls).
- Call-site sweep: migrated `scripts/*` and `benchmarks/viewport_parity/blender_driver.py` off the retired props to `scene.cycles.*`.

### Verification
- 45 pkg176 unit tests pass (incl. new `test_pkg176_stage4_retirement.py`: retired props gone, kept props survive, register/unregister consistency, single Astroray panel).
- **Blender 5.2 real-host: register PASS + headless smoke render PASS** (`dev_addon.ps1 -Smoke`, OpenMP-OFF addon .pyd; guards pyd-fresh/openmp/addon-files all PASS).
- Graceful degradation: removing a saved custom prop does not crash load — Blender drops the unknown member; value reverts to native Cycles (or DIRECT_DEFAULTS).

Deferred to a later addon HW session: deep per-setting F12 pixel-honour matrix (bundle with the accumulated Stage 1–3 HW debt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)