### PR TITLE
perf(pkg178 Stage-3b PR-1): template<bool HasPrincipled> shade-path isolation (D4 fix)

### DIFF
--- a/include/astroray/gpu_materials.h
+++ b/include/astroray/gpu_materials.h
@@ -2001,14 +2001,23 @@ __device__ inline float gpu_closure_pdf(
     }
 }
 
+// pkg178 Stage-3b D4: HasPrincipled compile-time isolation. Non-principled
+// scenes launch the <false> instantiation, in which the Principled arm and all
+// gpu_principled_* codegen are compiled out (if constexpr) — restoring main's
+// non-principled shade-kernel footprint. Default = true so every OTHER caller
+// (restir, snapshot intersect, sms, CPU-reachable) keeps today's behavior
+// verbatim. See .astroray_plan/docs/pkg178-stage3-d4-and-forks-decision.md §2b.
+template<bool HasPrincipled = true>
 __device__ inline GVec3 gpu_closure_graph_eval(
     const GMaterial& mat, GHitRecord& rec, const GVec3& wo, const GVec3& wi)
 {
     // pkg178 Stage 2: the Principled material is a monolithic single closure whose
     // eval IS its own view-dependent lobe mixture (gpu_principled_eval), not a sum
     // over independent graph closures — route it straight there.
-    if (gpu_closure_graph_is_principled(mat))
-        return gpu_principled_eval(mat.closures[0], rec, wo, wi);
+    if constexpr (HasPrincipled) {
+        if (gpu_closure_graph_is_principled(mat))
+            return gpu_principled_eval(mat.closures[0], rec, wo, wi);
+    }
     // pkg170: weight each lobe by its SELECTION probability (weight_i / totalWeight),
     // matching gpu_closure_graph_pdf's normalization, so the closure-graph sampler's
     // overwrite s.f = eval, s.pdf = pdf forms a correct one-sample-MIS estimator of
@@ -2080,6 +2089,7 @@ __device__ inline bool gpu_is_plain_diffuse(const GMaterial& mat) {
 // per-lambda via gpu_metal_eval_spectral (CPU-canonical colour space); any other
 // lobe keeps its existing per-lobe RGB eval then upsample. Non-metal graphs
 // never reach here, so their summed-then-upsampled behaviour is unchanged.
+template<bool HasPrincipled = true>  // pkg178 Stage-3b D4 (see gpu_closure_graph_eval)
 __device__ inline GSampledSpectrum gpu_closure_graph_eval_spectral(
     const GMaterial& mat, GHitRecord& rec, const GVec3& wo, const GVec3& wi,
     const GSampledWavelengths& wl)
@@ -2087,8 +2097,10 @@ __device__ inline GSampledSpectrum gpu_closure_graph_eval_spectral(
     // pkg178 Stage 2: native per-λ Principled mixture (per-lobe spectral eval,
     // NOT upsample-of-RGB — the pkg163/168 nonlinearity lesson is built into
     // gpu_pr_evalLobeSpectral, which upsamples reflectance colours only).
-    if (gpu_closure_graph_is_principled(mat))
-        return gpu_principled_eval_spectral(mat.closures[0], rec, wo, wi, wl);
+    if constexpr (HasPrincipled) {
+        if (gpu_closure_graph_is_principled(mat))
+            return gpu_principled_eval_spectral(mat.closures[0], rec, wo, wi, wl);
+    }
     // pkg170: same selection-probability normalization as the RGB
     // gpu_closure_graph_eval (see there) so f_total/pdf_total is a one-sample-MIS
     // estimator of the mixture BSDF. This spectral path is only reached for
@@ -2123,12 +2135,15 @@ __device__ inline GSampledSpectrum gpu_closure_graph_eval_spectral(
     return sum * (1.0f / totalWeight);
 }
 
+template<bool HasPrincipled = true>  // pkg178 Stage-3b D4 (see gpu_closure_graph_eval)
 __device__ inline float gpu_closure_graph_pdf(
     const GMaterial& mat, const GHitRecord& rec, const GVec3& wo, const GVec3& wi)
 {
     // pkg178 Stage 2: monolithic Principled mixture pdf (see gpu_closure_graph_eval).
-    if (gpu_closure_graph_is_principled(mat))
-        return gpu_principled_pdf(mat.closures[0], rec, wo, wi);
+    if constexpr (HasPrincipled) {
+        if (gpu_closure_graph_is_principled(mat))
+            return gpu_principled_pdf(mat.closures[0], rec, wo, wi);
+    }
     float totalWeight = 0.0f;
     int count = mat.closureCount < G_MAX_MATERIAL_CLOSURES ? mat.closureCount : G_MAX_MATERIAL_CLOSURES;
     for (int i = 0; i < count; ++i) {
@@ -2148,7 +2163,7 @@ __device__ inline float gpu_closure_graph_pdf(
     return sum;
 }
 
-template <typename TRng>
+template <bool HasPrincipled = true, typename TRng>  // pkg178 Stage-3b D4
 __device__ inline GBSDFSample gpu_closure_graph_sample(
     const GMaterial& mat, GHitRecord& rec, const GVec3& wo, TRng* rng)
 {
@@ -2163,8 +2178,10 @@ __device__ inline GBSDFSample gpu_closure_graph_sample(
     // sample (internal lobe choice + delta handling + mixture f/pdf recombination),
     // mirroring PrincipledPlugin::sample — do NOT route it through the generic
     // per-lobe switch + recompute below (its assembly is view-dependent).
-    if (gpu_closure_graph_is_principled(mat))
-        return gpu_principled_sample(mat.closures[0], rec, wo, rng);
+    if constexpr (HasPrincipled) {
+        if (gpu_closure_graph_is_principled(mat))
+            return gpu_principled_sample(mat.closures[0], rec, wo, rng);
+    }
 
     float totalWeight = 0.0f;
     int count = mat.closureCount < G_MAX_MATERIAL_CLOSURES ? mat.closureCount : G_MAX_MATERIAL_CLOSURES;
@@ -2204,8 +2221,8 @@ __device__ inline GBSDFSample gpu_closure_graph_sample(
     if (s.isDelta) {
         s.f *= closure.weight;
     } else {
-        s.f = gpu_closure_graph_eval(mat, rec, wo, s.wi);
-        s.pdf = gpu_closure_graph_pdf(mat, rec, wo, s.wi);
+        s.f = gpu_closure_graph_eval<HasPrincipled>(mat, rec, wo, s.wi);
+        s.pdf = gpu_closure_graph_pdf<HasPrincipled>(mat, rec, wo, s.wi);
     }
     return s;
 }
@@ -2221,6 +2238,7 @@ __device__ inline GVec3 gpu_closure_graph_emitted(const GMaterial& mat, bool fro
     return sum;
 }
 
+template<bool HasPrincipled = true>  // pkg178 Stage-3b D4 (see gpu_closure_graph_eval)
 __device__ inline GVec3 gpu_material_eval(
     const GMaterial& mat, GHitRecord& rec, const GVec3& wo, const GVec3& wi)
 {
@@ -2231,11 +2249,12 @@ __device__ inline GVec3 gpu_material_eval(
         case GMAT_DIFFUSE_LIGHT: return GVec3(0.f); // emissive only
         case GMAT_DISNEY:        return gpu_disney_eval(mat, rec, wo, wi);
         case GMAT_THIN_GLASS:    return GVec3(0.f); // mostly-delta pane
-        case GMAT_CLOSURE_GRAPH: return gpu_closure_graph_eval(mat, rec, wo, wi);
+        case GMAT_CLOSURE_GRAPH: return gpu_closure_graph_eval<HasPrincipled>(mat, rec, wo, wi);
         default:                 return GVec3(0.f);
     }
 }
 
+template<bool HasPrincipled = true>  // pkg178 Stage-3b D4 (see gpu_closure_graph_eval)
 __device__ inline GSampledSpectrum gpu_material_eval_spectral(
     const GMaterial& mat, GHitRecord& rec, const GVec3& wo, const GVec3& wi,
     const GSampledWavelengths& wl)
@@ -2247,10 +2266,12 @@ __device__ inline GSampledSpectrum gpu_material_eval_spectral(
     if (mat.type == GMAT_METAL)
         return gpu_metal_eval_spectral(mat, rec, wo, wi, wl);
     // pkg178 Stage 2: native per-λ Principled (its own spectral mixture path).
-    if (mat.type == GMAT_CLOSURE_GRAPH && gpu_closure_graph_is_principled(mat))
-        return gpu_closure_graph_eval_spectral(mat, rec, wo, wi, wl);
+    if constexpr (HasPrincipled) {
+        if (mat.type == GMAT_CLOSURE_GRAPH && gpu_closure_graph_is_principled(mat))
+            return gpu_closure_graph_eval_spectral<HasPrincipled>(mat, rec, wo, wi, wl);
+    }
     if (mat.type == GMAT_CLOSURE_GRAPH && gpu_closure_graph_has_metal(mat))
-        return gpu_closure_graph_eval_spectral(mat, rec, wo, wi, wl);
+        return gpu_closure_graph_eval_spectral<HasPrincipled>(mat, rec, wo, wi, wl);
     // pkg168 Step 2: plain diffuse (native GMAT_LAMBERTIAN or a diffuse-only
     // closure graph — the plain-Lambertian upload path) must upsample the pure
     // reflectance COLOUR, not the pre-scaled RGB eval baseColor*cos/pi. Jakob-
@@ -2266,7 +2287,7 @@ __device__ inline GSampledSpectrum gpu_material_eval_spectral(
     // no Hanrahan-Krueger mix is needed; the CPU oracle (Lambertian::evalSpectral)
     // applies none. The Disney diffuse lobe inside a metal-carrying graph keeps its
     // HK mix via gpu_closure_graph_eval_spectral above, unchanged.
-    GVec3 e = gpu_material_eval(mat, rec, wo, wi);
+    GVec3 e = gpu_material_eval<HasPrincipled>(mat, rec, wo, wi);
     float diffuseScale = 1.0f;
     if (gpu_is_plain_diffuse(mat)) {
         float NdotL = rec.normal.dot(wi);
@@ -2278,7 +2299,7 @@ __device__ inline GSampledSpectrum gpu_material_eval_spectral(
     return gpu_rgbToSampledSpectrum(e, wl, mat.spectralMode) * diffuseScale;
 }
 
-template <typename TRng>
+template <bool HasPrincipled = true, typename TRng>  // pkg178 Stage-3b D4
 __device__ inline GBSDFSample gpu_material_sample(
     const GMaterial& mat, GHitRecord& rec, const GVec3& wo, TRng* rng)
 {
@@ -2288,12 +2309,12 @@ __device__ inline GBSDFSample gpu_material_sample(
         case GMAT_DIELECTRIC:    return gpu_dielectric_sample(mat, rec, wo, rng);
         case GMAT_DISNEY:        return gpu_disney_sample(mat, rec, wo, rng);
         case GMAT_THIN_GLASS:    return gpu_thin_glass_sample(mat, rec, wo, rng);
-        case GMAT_CLOSURE_GRAPH: return gpu_closure_graph_sample(mat, rec, wo, rng);
+        case GMAT_CLOSURE_GRAPH: return gpu_closure_graph_sample<HasPrincipled>(mat, rec, wo, rng);
         default: { GBSDFSample s; s.f=GVec3(0); s.fSpectral=GSampledSpectrum(0.f); s.wi=GVec3(0,1,0); s.pdf=0; s.isDelta=false; return s; }
     }
 }
 
-template <typename TRng>
+template <bool HasPrincipled = true, typename TRng>  // pkg178 Stage-3b D4
 __device__ inline GBSDFSample gpu_material_sample_spectral(
     const GMaterial& mat, GHitRecord& rec, const GVec3& wo,
     GSampledWavelengths& wl, TRng* rng)
@@ -2302,7 +2323,7 @@ __device__ inline GBSDFSample gpu_material_sample_spectral(
     // sampler (it calls wl.terminateSecondary() on refraction — hero collapse).
     GBSDFSample s = (mat.type == GMAT_DIELECTRIC && mat.isDispersive)
         ? gpu_dielectric_sample_spectral(mat, rec, wo, wl, rng)
-        : gpu_material_sample(mat, rec, wo, rng);
+        : gpu_material_sample<HasPrincipled>(mat, rec, wo, rng);
 
     // Delta lobes (dielectric reflect/refract, smooth-glass disney/closure-graph
     // closures — a plain "dielectric" material lowers to GMAT_CLOSURE_GRAPH) carry a
@@ -2350,7 +2371,7 @@ __device__ inline GBSDFSample gpu_material_sample_spectral(
     if (metalSpectral && !s.isDelta && s.pdf > 0.0f && s.f.length2() > 0.0f) {
         s.fSpectral = (mat.type == GMAT_METAL)
             ? gpu_metal_eval_spectral(mat, rec, wo, s.wi, wl)
-            : gpu_closure_graph_eval_spectral(mat, rec, wo, s.wi, wl);
+            : gpu_closure_graph_eval_spectral<HasPrincipled>(mat, rec, wo, s.wi, wl);
         return s;
     }
 
@@ -2361,10 +2382,12 @@ __device__ inline GBSDFSample gpu_material_sample_spectral(
     // the generic eta²-clamp guard below, which factors the >1 magnitude and
     // upsamples the normalized tint — exactly PrincipledPlugin::sampleSpectral's
     // delta branch (principled.cpp:762-766, upsample(rgb/maxc)*maxc).
-    if (mat.type == GMAT_CLOSURE_GRAPH && gpu_closure_graph_is_principled(mat) &&
-        !s.isDelta && s.pdf > 0.0f && s.f.length2() > 0.0f) {
-        s.fSpectral = gpu_closure_graph_eval_spectral(mat, rec, wo, s.wi, wl);
-        return s;
+    if constexpr (HasPrincipled) {
+        if (mat.type == GMAT_CLOSURE_GRAPH && gpu_closure_graph_is_principled(mat) &&
+            !s.isDelta && s.pdf > 0.0f && s.f.length2() > 0.0f) {
+            s.fSpectral = gpu_closure_graph_eval_spectral<HasPrincipled>(mat, rec, wo, s.wi, wl);
+            return s;
+        }
     }
 
     // pkg168 Step 2: plain diffuse lobes (native GMAT_LAMBERTIAN or the plain-
@@ -2400,6 +2423,7 @@ __device__ inline GBSDFSample gpu_material_sample_spectral(
     return s;
 }
 
+template<bool HasPrincipled = true>  // pkg178 Stage-3b D4 (see gpu_closure_graph_eval)
 __device__ inline float gpu_material_pdf(
     const GMaterial& mat, const GHitRecord& rec, const GVec3& wo, const GVec3& wi)
 {
@@ -2407,7 +2431,7 @@ __device__ inline float gpu_material_pdf(
         case GMAT_LAMBERTIAN: return gpu_lambertian_pdf(mat, rec, wo, wi);
         case GMAT_METAL:      return gpu_metal_pdf(mat, rec, wo, wi);
         case GMAT_DISNEY:     return gpu_disney_pdf(mat, rec, wo, wi);
-        case GMAT_CLOSURE_GRAPH: return gpu_closure_graph_pdf(mat, rec, wo, wi);
+        case GMAT_CLOSURE_GRAPH: return gpu_closure_graph_pdf<HasPrincipled>(mat, rec, wo, wi);
         default:              return 0.f;
     }
 }

--- a/include/astroray/gpu_scene_upload.h
+++ b/include/astroray/gpu_scene_upload.h
@@ -12,6 +12,12 @@ struct SceneUploadResult {
     std::vector<GTriangle>  triangles;
     std::vector<GSphere>    spheres;
     std::vector<GMaterial>  materials;
+    // pkg178 Stage-3b D4: true when ANY uploaded material lowers to a
+    // closure-graph Principled (mirrors gpu_closure_graph_is_principled:
+    // type == GMAT_CLOSURE_GRAPH && closures[0].type == GCLOSURE_PRINCIPLED).
+    // The wavefront launchers pick the stageShade*<true/false> instantiation off
+    // this flag so non-principled scenes never compile in gpu_principled_* code.
+    bool hasPrincipled = false;
     std::vector<GLight>     lights;
     // pkg89-GPU / GAP 1 — dedicated lights (Blender POINT/SPOT/SUN/AREA lamps
     // routed through astroray::Light). Their cumulativePower continues the

--- a/include/astroray/gpu_wavefront_state.h
+++ b/include/astroray/gpu_wavefront_state.h
@@ -301,7 +301,8 @@ void launchStageAdvance(
     bool              useLuminanceOutput,  // pkg55-C3 (was missing)
     bool              enableNEE,           // pkg55-C3 (was missing)
     float             clampDirect, float clampIndirect,  // pkg157
-    bool              sync = true);  // N+7: render driver passes false, syncs once per render
+    bool              sync = true,  // N+7: render driver passes false, syncs once per render
+    bool              hasPrincipled = true);  // pkg178 Stage-3b D4 (caller-less; default keeps <true>)
 
 // Session N+7 part 2: queued advance + compaction. queue/count buffers are
 // device pointers; the host never reads the counters (zero-sync driver).
@@ -328,7 +329,8 @@ void launchStageAdvanceQueued(
     int               max_depth,
     bool              useLuminanceOutput,  // pkg55-C3 (was missing)
     bool              enableNEE,           // pkg55-C3 (was missing)
-    float             clampDirect, float clampIndirect);  // pkg157
+    float             clampDirect, float clampIndirect,  // pkg157
+    bool              hasPrincipled = true);  // pkg178 Stage-3b D4 (caller-less; default keeps <true>)
 
 // Fills d_queue with 0..n-1 and *d_count = n (bounce-0 population).
 void launchStageQueueIota(int* d_queue, int* d_count, int n);
@@ -399,7 +401,12 @@ void launchStageShadeBucketed(
     // cryptoDepth == 0 (or null pointers) = cryptomatte disabled, the default.
     // The shade stage inserts ATOMICALLY (crypto_insert_atomic, cryptomatte.h)
     // because path regeneration puts many concurrent slots on one pixel.
-    float* d_cryptoObjectRanks, float* d_cryptoMaterialRanks, int cryptoDepth);
+    float* d_cryptoObjectRanks, float* d_cryptoMaterialRanks, int cryptoDepth,
+    // pkg178 Stage-3b D4: scene-content flag from scene_upload. true selects the
+    // stageShadeBucketedKernel<true> (principled) instantiation; false selects
+    // <false>, which compiles out all gpu_principled_* codegen for the fleet-wide
+    // non-principled perf restore. See pkg178-stage3-d4-and-forks-decision.md §2b.
+    bool hasPrincipled);
 
 // pkg55-B' shadow stage: lean occlusion + lazy resolve over the NEE
 // samples parked by the deferring bucketed shade. nee_f/nee_i lane counts
@@ -496,7 +503,8 @@ void launchStageShadeNeeMis(
     int               max_depth,
     bool              useLuminanceOutput,  // pkg55-C3 (was missing)
     bool              enableNEE,           // pkg55-C3 (was missing)
-    float             clampDirect, float clampIndirect);  // pkg157
+    float             clampDirect, float clampIndirect,  // pkg157
+    bool              hasPrincipled);  // pkg178 Stage-3b D4 (snapshot launcher; passed res.hasPrincipled)
 
 // Session N+3 part 2: Hit record fields (extend GPUWavefrontState for intersect->shade flow).
 // These are passed as separate device pointers; will be folded into GPUWavefrontState

--- a/src/gpu/gpu_nee.cuh
+++ b/src/gpu/gpu_nee.cuh
@@ -510,6 +510,10 @@ __device__ inline GNEEOcclusion gpu_nee_occlude(
     return occ;
 }
 
+// pkg178 Stage-3b D4: HasPrincipled threads through to the material dispatch so
+// the immediate-NEE (dense/flat) shade path also compiles principled code out of
+// its <false> instantiation. Default = true keeps every other caller unchanged.
+template<bool HasPrincipled = true>
 __device__ inline GSampledSpectrum gpu_nee_resolve(
     const GHitRecord& rec, const GVec3& wo,
     const GSampledWavelengths& lambdas,
@@ -523,7 +527,7 @@ __device__ inline GSampledSpectrum gpu_nee_resolve(
     // Spectral BSDF and emission — mirrors CPU pathTraceSpectral lines
     // 2414-2421:  f_spec = evalSpectral ; L_spec = emission_spec (illuminant).
     GSampledSpectrum f_spec =
-        gpu_material_eval_spectral(mat, const_cast<GHitRecord&>(rec), wo, s.wi, lambdas);
+        gpu_material_eval_spectral<HasPrincipled>(mat, const_cast<GHitRecord&>(rec), wo, s.wi, lambdas);
     // pkg89-GPU / GAP 1 — dedicated lights carry their emission intrinsically
     // (no light material). The reference RGB is upsampled through the SAME
     // RGBIlluminant path the CPU uses (gpu_rgbSpectrumAt == CPU
@@ -539,7 +543,7 @@ __device__ inline GSampledSpectrum gpu_nee_resolve(
     }
     if (f_spec.maxValue() <= 0.f || L_spec.maxValue() <= 0.f) return direct;
 
-    float bsdfPdf = gpu_material_pdf(mat, rec, wo, s.wi);
+    float bsdfPdf = gpu_material_pdf<HasPrincipled>(mat, rec, wo, s.wi);
     // pkg140: delta-light samples (e.g. GDED_DISTANT angular_diameter == 0)
     // always get full MIS weight -- mirrors CPU pathTraceSpectral's
     // ls.isDelta check (raytracer.h). A BSDF-sampled ray has probability 0

--- a/src/gpu/scene_upload.cu
+++ b/src/gpu/scene_upload.cu
@@ -605,6 +605,14 @@ SceneUploadResult buildSceneArrays(const Renderer& cpu, const Camera* cam) {
         int id = (int)r.materials.size();
         matIdx[m.get()] = id;
         r.materials.push_back(convertMaterial(m));
+        // pkg178 Stage-3b D4: flag scenes carrying a closure-graph Principled
+        // material so the wavefront launchers select the <true> shade-kernel
+        // instantiation. The predicate mirrors gpu_closure_graph_is_principled
+        // (gpu_materials.h) exactly.
+        const GMaterial& g = r.materials.back();
+        if (g.type == GMAT_CLOSURE_GRAPH && g.closureCount >= 1 &&
+            g.closures[0].type == GCLOSURE_PRINCIPLED)
+            r.hasPrincipled = true;
         return id;
     };
 

--- a/src/gpu/wavefront/gpu_wavefront_snapshot.cu
+++ b/src/gpu/wavefront/gpu_wavefront_snapshot.cu
@@ -1201,7 +1201,8 @@ std::vector<float> cuda_wavefront_snapshot_post_nee_mis(
                                treeView, envMap, gbg, hasBg,
                                worldMaxBounces, /*max_depth=*/8,
                                /*useLuminanceOutput=*/false, /*enableNEE=*/true,
-                               renderer.getClampDirect(), renderer.getClampIndirect());  // pkg157
+                               renderer.getClampDirect(), renderer.getClampIndirect(),  // pkg157
+                               res.hasPrincipled);  // pkg178 Stage-3b D4
 
         cudaError_t se = cudaDeviceSynchronize();
         if (se != cudaSuccess)
@@ -1553,7 +1554,8 @@ std::vector<float> cuda_wavefront_render(
                                      caustic.grid, caustic.ready,  // pkg55-C5 / pkg113
                                      caustic.scale,
                                      d_cryptoObj, d_cryptoMat,     // pkg159
-                                     cryptoOn ? cryptoDepth : 0);
+                                     cryptoOn ? cryptoDepth : 0,
+                                     res.hasPrincipled);  // pkg178 Stage-3b D4
             launchStageShadow(state, hitBufs, d_neeF, d_neeI,
                               d_shadowQueue, d_shadowCount, total_paths,
                               d_tlas, d_instances, d_blas,  // pkg55-C4

--- a/src/gpu/wavefront/stage_advance.cu
+++ b/src/gpu/wavefront/stage_advance.cu
@@ -368,7 +368,12 @@ __device__ int intersectPathSlot(
 // live set in the REG:254-saturated shade kernel. Deferred=false keeps the
 // immediate path for advancePathSlot (the dense/flat reference schedulings).
 // PERF ONLY — the compiled-out branch is unreachable in the deferred callers.
-template<bool Deferred>
+// pkg178 Stage-3b D4: HasPrincipled is threaded into the material dispatch so
+// non-principled scenes launch a shade kernel with ZERO gpu_principled_* codegen
+// (if constexpr in gpu_materials.h), restoring main's footprint. The launchers
+// pick <true>/<false> off scene_upload's host-side flag. See
+// .astroray_plan/docs/pkg178-stage3-d4-and-forks-decision.md §2b.
+template<bool Deferred, bool HasPrincipled>
 __device__ bool shadePathSlot(
     int idx,
     GPUWavefrontState& state,
@@ -501,10 +506,10 @@ __device__ bool shadePathSlot(
                     // reorder: identical output, evals paid on occluded
                     // samples in exchange for a lean ~100-reg shadow kernel
                     // (measured tradeoff per the blueprint).
-                    GSampledSpectrum f_spec = gpu_material_eval_spectral(
+                    GSampledSpectrum f_spec = gpu_material_eval_spectral<HasPrincipled>(
                         mat, rec, wo, s.wi, lambdas);
                     if (f_spec.maxValue() > 0.f) {
-                        float bsdfPdf = gpu_material_pdf(mat, rec, wo, s.wi);
+                        float bsdfPdf = gpu_material_pdf<HasPrincipled>(mat, rec, wo, s.wi);
                         // Power heuristic (Veach 1997) — mirrors
                         // gpu_mw_powerHeuristic in the MW TU. Delta lights
                         // (pkg140, e.g. zero-diameter sun) force wt = 1
@@ -568,7 +573,7 @@ __device__ bool shadePathSlot(
                         s, tlas, instances, blas, bvhNodes, prims, tris, spheres,
                         ray.time, motionVerts);
                     if (!occ.occluded) {
-                        GSampledSpectrum nee = gpu_nee_resolve(
+                        GSampledSpectrum nee = gpu_nee_resolve<HasPrincipled>(
                             rec, wo, lambdas, materials, s,
                             s.isSphere ? (occ.frontFace != 0) : true);
                         // pkg157: direct/indirect clamp split (bounce is the
@@ -639,7 +644,7 @@ __device__ bool shadePathSlot(
     // ---- BSDF sampling via the templated megakernel material dispatch
     // (all 7 GMAT types + closure graphs), drawing directly from the
     // per-path PCG32 stream (template-RNG arc; see the NEE note above).
-    GBSDFSample bss = gpu_material_sample_spectral(mat, rec, wo, lambdas, &rng);
+    GBSDFSample bss = gpu_material_sample_spectral<HasPrincipled>(mat, rec, wo, lambdas, &rng);
     if (bss.pdf <= 0.0f) {
         state.color_0[idx] = color.v[0];
         state.color_1[idx] = color.v[1];
@@ -786,6 +791,8 @@ __device__ bool shadePathSlot(
 //
 // Composition wrapper -- the flat (unstaged) scheduling. Dense and
 // flat-queued kernels run EXACTLY intersect-half + shade-half back to back.
+// pkg178 Stage-3b D4: HasPrincipled forwards into the shade half.
+template<bool HasPrincipled>
 __device__ bool advancePathSlot(
     int idx,
     GPUWavefrontState& state,
@@ -821,7 +828,7 @@ __device__ bool advancePathSlot(
                                     lights, numLights, totalLightPower,
                                     dedLights, numDed, lightTree);  // pkg120+pkg181
     if (matType < 0) return false;
-    return shadePathSlot<false>(idx, state, hitBufs, tlas, instances, blas,
+    return shadePathSlot<false, HasPrincipled>(idx, state, hitBufs, tlas, instances, blas,
                          bvhNodes, prims, tris, spheres, motionVerts,
                          materials, lights, numLights, totalLightPower,
                          dedLights, numDed, lightTree, max_depth,
@@ -833,6 +840,7 @@ __device__ bool advancePathSlot(
                          photonGrid, hasPhotonGrid, photonScale);
 }
 
+template<bool HasPrincipled>  // pkg178 Stage-3b D4
 __global__ void stageAdvanceKernel(
     GPUWavefrontState state,
     GPUWavefrontHitBuffers hitBufs,
@@ -861,7 +869,7 @@ __global__ void stageAdvanceKernel(
     if (state.path_alive[idx] == 0) return;
     // Photon caustics run only on the bucketed production scheduling (C5);
     // the legacy dense path passes no grid (gather gated off).
-    advancePathSlot(idx, state, hitBufs, tlas, instances, blas,
+    advancePathSlot<HasPrincipled>(idx, state, hitBufs, tlas, instances, blas,
                     bvhNodes, prims, tris, spheres, motionVerts, materials,
                     lights, numLights, totalLightPower, dedLights, numDed,
                     lightTree, envMap,
@@ -881,6 +889,7 @@ __global__ void stageAdvanceKernel(
 // count retire immediately, so later bounces only pay for live paths
 // (Laine 2013 sec. 4: compaction keeps warps dense as paths die).
 // ---------------------------------------------------------------------------
+template<bool HasPrincipled>  // pkg178 Stage-3b D4
 __global__ void stageAdvanceQueuedKernel(
     GPUWavefrontState state,
     GPUWavefrontHitBuffers hitBufs,
@@ -909,7 +918,7 @@ __global__ void stageAdvanceQueuedKernel(
     int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= *count_in) return;
     int idx = queue_in[i];
-    bool alive = advancePathSlot(idx, state, hitBufs, tlas, instances, blas,
+    bool alive = advancePathSlot<HasPrincipled>(idx, state, hitBufs, tlas, instances, blas,
                                  bvhNodes, prims, tris, spheres, motionVerts,
                                  materials, lights, numLights, totalLightPower,
                                  dedLights, numDed,
@@ -1088,6 +1097,7 @@ __global__ void stageIntersectQueuedKernel(
     shade_queues[matType * capacity + slot] = idx;
 }
 
+template<bool HasPrincipled>  // pkg178 Stage-3b D4 (production perf vector)
 __global__ void stageShadeBucketedKernel(
     GPUWavefrontState state,
     GPUWavefrontHitBuffers hitBufs,
@@ -1120,7 +1130,7 @@ __global__ void stageShadeBucketedKernel(
     if (bucket >= G_WF_NUM_MAT_TYPES) return;
     if (pos >= shade_counts[bucket]) return;
     int idx = shade_queues[bucket * capacity + pos];
-    bool alive = shadePathSlot<true>(idx, state, hitBufs, tlas, instances, blas,
+    bool alive = shadePathSlot<true, HasPrincipled>(idx, state, hitBufs, tlas, instances, blas,
                                bvhNodes, prims, tris, spheres, motionVerts,
                                materials, lights, numLights,
                                totalLightPower, dedLights, numDed,
@@ -1253,23 +1263,38 @@ void launchStageAdvance(
     bool              useLuminanceOutput,
     bool              enableNEE,
     float             clampDirect, float clampIndirect,  // pkg157
-    bool              sync)
+    bool              sync,
+    bool              hasPrincipled)  // pkg178 Stage-3b D4
 {
     if (state.num_active <= 0) return;
     int threads = 256;
     int blocks  = (state.num_active + threads - 1) / threads;
     {
+        // pkg178 Stage-3b D4: pick the principled-isolated instantiation. Both
+        // are referenced here so both land in the cubin (cuobjdump gate parity).
+        const void* kptr = hasPrincipled
+            ? (const void*)stageAdvanceKernel<true>
+            : (const void*)stageAdvanceKernel<false>;
         astroray::gpu_profile::ScopedTimer _t(
-            "wavefront_stage_advance_n6",
-            (const void*)stageAdvanceKernel, blocks, threads);
-        stageAdvanceKernel<<<blocks, threads>>>(
-            state, hitBufs, d_tlas, d_instances, d_blas,
-            d_bvhNodes, d_prims, d_tris, d_spheres, d_motionVerts, d_materials,
-            d_lights, num_lights, total_light_power,
-            d_dedLights, num_ded, lightTree,
-            envMap, backgroundColor, hasBackgroundColor,
-            worldMaxBounces, max_depth, useLuminanceOutput, enableNEE,
-            clampDirect, clampIndirect);
+            "wavefront_stage_advance_n6", kptr, blocks, threads);
+        if (hasPrincipled)
+            stageAdvanceKernel<true><<<blocks, threads>>>(
+                state, hitBufs, d_tlas, d_instances, d_blas,
+                d_bvhNodes, d_prims, d_tris, d_spheres, d_motionVerts, d_materials,
+                d_lights, num_lights, total_light_power,
+                d_dedLights, num_ded, lightTree,
+                envMap, backgroundColor, hasBackgroundColor,
+                worldMaxBounces, max_depth, useLuminanceOutput, enableNEE,
+                clampDirect, clampIndirect);
+        else
+            stageAdvanceKernel<false><<<blocks, threads>>>(
+                state, hitBufs, d_tlas, d_instances, d_blas,
+                d_bvhNodes, d_prims, d_tris, d_spheres, d_motionVerts, d_materials,
+                d_lights, num_lights, total_light_power,
+                d_dedLights, num_ded, lightTree,
+                envMap, backgroundColor, hasBackgroundColor,
+                worldMaxBounces, max_depth, useLuminanceOutput, enableNEE,
+                clampDirect, clampIndirect);
         cudaError_t err = cudaGetLastError();
         if (err != cudaSuccess) {
             std::fprintf(stderr, "stage_advance launch error: %s\n",
@@ -1318,7 +1343,8 @@ void launchStageAdvanceQueued(
     int               max_depth,
     bool              useLuminanceOutput,
     bool              enableNEE,
-    float             clampDirect, float clampIndirect)  // pkg157
+    float             clampDirect, float clampIndirect,  // pkg157
+    bool              hasPrincipled)  // pkg178 Stage-3b D4
 {
     if (state.num_active <= 0) return;
     // Grid covers the worst case (all paths alive); the kernel early-outs
@@ -1327,18 +1353,33 @@ void launchStageAdvanceQueued(
     int threads = 256;
     int blocks  = (state.num_active + threads - 1) / threads;
     {
+        // pkg178 Stage-3b D4: pick the principled-isolated instantiation (both
+        // referenced so both land in the cubin for the cuobjdump gate).
+        const void* kptr = hasPrincipled
+            ? (const void*)stageAdvanceQueuedKernel<true>
+            : (const void*)stageAdvanceQueuedKernel<false>;
         astroray::gpu_profile::ScopedTimer _t(
-            "wavefront_stage_advance_queued_n7",
-            (const void*)stageAdvanceQueuedKernel, blocks, threads);
-        stageAdvanceQueuedKernel<<<blocks, threads>>>(
-            state, hitBufs, d_queue_in, d_count_in, d_queue_out, d_count_out,
-            d_tlas, d_instances, d_blas,
-            d_bvhNodes, d_prims, d_tris, d_spheres, d_motionVerts, d_materials,
-            d_lights, num_lights, total_light_power,
-            d_dedLights, num_ded, lightTree,
-            envMap, backgroundColor, hasBackgroundColor,
-            worldMaxBounces, max_depth, useLuminanceOutput, enableNEE,
-            clampDirect, clampIndirect);
+            "wavefront_stage_advance_queued_n7", kptr, blocks, threads);
+        if (hasPrincipled)
+            stageAdvanceQueuedKernel<true><<<blocks, threads>>>(
+                state, hitBufs, d_queue_in, d_count_in, d_queue_out, d_count_out,
+                d_tlas, d_instances, d_blas,
+                d_bvhNodes, d_prims, d_tris, d_spheres, d_motionVerts, d_materials,
+                d_lights, num_lights, total_light_power,
+                d_dedLights, num_ded, lightTree,
+                envMap, backgroundColor, hasBackgroundColor,
+                worldMaxBounces, max_depth, useLuminanceOutput, enableNEE,
+                clampDirect, clampIndirect);
+        else
+            stageAdvanceQueuedKernel<false><<<blocks, threads>>>(
+                state, hitBufs, d_queue_in, d_count_in, d_queue_out, d_count_out,
+                d_tlas, d_instances, d_blas,
+                d_bvhNodes, d_prims, d_tris, d_spheres, d_motionVerts, d_materials,
+                d_lights, num_lights, total_light_power,
+                d_dedLights, num_ded, lightTree,
+                envMap, backgroundColor, hasBackgroundColor,
+                worldMaxBounces, max_depth, useLuminanceOutput, enableNEE,
+                clampDirect, clampIndirect);
         cudaError_t err = cudaGetLastError();
         if (err != cudaSuccess) {
             std::fprintf(stderr, "stage_advance_queued launch error: %s\n",
@@ -1438,7 +1479,8 @@ void launchStageShadeBucketed(
     astroray::photon::gpu::GPhotonGrid photonGrid, bool hasPhotonGrid,
     float             photonScale,
     // pkg159: per-pixel cryptomatte rank arrays (driver-owned; null/0 = off).
-    float* d_cryptoObjectRanks, float* d_cryptoMaterialRanks, int cryptoDepth)
+    float* d_cryptoObjectRanks, float* d_cryptoMaterialRanks, int cryptoDepth,
+    bool              hasPrincipled)  // pkg178 Stage-3b D4
 {
     if (capacity <= 0) return;
     // One launch covers all buckets: grid = NUM_TYPES * capacity threads;
@@ -1449,21 +1491,42 @@ void launchStageShadeBucketed(
     int threads = 256;
     int blocks  = (int)((total + threads - 1) / threads);
     {
+        // pkg178 Stage-3b D4: select the HasPrincipled specialization off the
+        // host scene flag. The <false> instantiation carries zero gpu_principled_*
+        // codegen (restores main's ~4456 B stage-shade footprint); the <true>
+        // instantiation is byte-identical to today's kernel. Both are referenced
+        // so both appear in the cubin for the cuobjdump register report.
+        const void* kptr = hasPrincipled
+            ? (const void*)stageShadeBucketedKernel<true>
+            : (const void*)stageShadeBucketedKernel<false>;
         astroray::gpu_profile::ScopedTimer _t(
-            "wavefront_stage_shade_bucketed_n7",
-            (const void*)stageShadeBucketedKernel, blocks, threads);
-        stageShadeBucketedKernel<<<blocks, threads>>>(
-            state, hitBufs, d_shade_queues, d_shade_counts, capacity,
-            d_queue_out, d_count_out,
-            d_nee_f, d_nee_i, d_shadow_queue, d_shadow_count,
-            d_tlas, d_instances, d_blas,
-            d_bvhNodes, d_prims, d_tris, d_spheres, d_motionVerts, d_materials,
-            d_lights, num_lights, total_light_power,
-            d_dedLights, num_ded, lightTree, max_depth,
-            useLuminanceOutput, enableNEE,
-            clampDirect, clampIndirect,
-            photonGrid, hasPhotonGrid, photonScale,  // pkg55-C5 / pkg113
-            d_cryptoObjectRanks, d_cryptoMaterialRanks, cryptoDepth);  // pkg159
+            "wavefront_stage_shade_bucketed_n7", kptr, blocks, threads);
+        if (hasPrincipled)
+            stageShadeBucketedKernel<true><<<blocks, threads>>>(
+                state, hitBufs, d_shade_queues, d_shade_counts, capacity,
+                d_queue_out, d_count_out,
+                d_nee_f, d_nee_i, d_shadow_queue, d_shadow_count,
+                d_tlas, d_instances, d_blas,
+                d_bvhNodes, d_prims, d_tris, d_spheres, d_motionVerts, d_materials,
+                d_lights, num_lights, total_light_power,
+                d_dedLights, num_ded, lightTree, max_depth,
+                useLuminanceOutput, enableNEE,
+                clampDirect, clampIndirect,
+                photonGrid, hasPhotonGrid, photonScale,  // pkg55-C5 / pkg113
+                d_cryptoObjectRanks, d_cryptoMaterialRanks, cryptoDepth);  // pkg159
+        else
+            stageShadeBucketedKernel<false><<<blocks, threads>>>(
+                state, hitBufs, d_shade_queues, d_shade_counts, capacity,
+                d_queue_out, d_count_out,
+                d_nee_f, d_nee_i, d_shadow_queue, d_shadow_count,
+                d_tlas, d_instances, d_blas,
+                d_bvhNodes, d_prims, d_tris, d_spheres, d_motionVerts, d_materials,
+                d_lights, num_lights, total_light_power,
+                d_dedLights, num_ded, lightTree, max_depth,
+                useLuminanceOutput, enableNEE,
+                clampDirect, clampIndirect,
+                photonGrid, hasPhotonGrid, photonScale,  // pkg55-C5 / pkg113
+                d_cryptoObjectRanks, d_cryptoMaterialRanks, cryptoDepth);  // pkg159
         cudaError_t err = cudaGetLastError();
         if (err != cudaSuccess) {
             std::fprintf(stderr, "stage_shade_bucketed launch error: %s\n",
@@ -1696,6 +1759,7 @@ void launchStageShadow(
 // shadow buffers are throwaway parking scratch — the shadow trace is NOT run
 // here; the audit inspects the shade-time MIS weight, not the occlusion.
 // ---------------------------------------------------------------------------
+template<bool HasPrincipled>  // pkg178 Stage-3b D4
 __global__ void stageShadeNeeMisKernel(
     GPUWavefrontState state,
     GPUWavefrontHitBuffers hitBufs,
@@ -1733,7 +1797,7 @@ __global__ void stageShadeNeeMisKernel(
                                     lights, numLights, totalLightPower,
                                     dedLights, numDed, lightTree);  // pkg120+pkg181
     if (matType < 0) return;  // env miss / emissive hit: path died, no NEE.
-    shadePathSlot<true>(idx, state, hitBufs, tlas, instances, blas,
+    shadePathSlot<true, HasPrincipled>(idx, state, hitBufs, tlas, instances, blas,
                   bvhNodes, prims, tris, spheres, motionVerts,
                   materials, lights, numLights, totalLightPower,
                   dedLights, numDed, lightTree, max_depth,
@@ -1767,21 +1831,36 @@ void launchStageShadeNeeMis(
     int               max_depth,
     bool              useLuminanceOutput,
     bool              enableNEE,
-    float             clampDirect, float clampIndirect)  // pkg157
+    float             clampDirect, float clampIndirect,  // pkg157
+    bool              hasPrincipled)  // pkg178 Stage-3b D4
 {
     if (state.num_active <= 0) return;
     int threads = 256;
     int blocks  = (state.num_active + threads - 1) / threads;
-    stageShadeNeeMisKernel<<<blocks, threads>>>(
-        state, hitBufs, d_nee_f, d_nee_i,
-        d_shadow_queue, d_shadow_count, nee_capacity,
-        d_tlas, d_instances, d_blas,
-        d_bvhNodes, d_prims, d_tris, d_spheres, d_motionVerts, d_materials,
-        d_lights, num_lights, total_light_power,
-        d_dedLights, num_ded, lightTree,
-        envMap, backgroundColor, hasBackgroundColor, worldMaxBounces,
-        max_depth, useLuminanceOutput, enableNEE,
-        clampDirect, clampIndirect);
+    // pkg178 Stage-3b D4: select the HasPrincipled specialization (see
+    // launchStageShadeBucketed). Both referenced so both land in the cubin.
+    if (hasPrincipled)
+        stageShadeNeeMisKernel<true><<<blocks, threads>>>(
+            state, hitBufs, d_nee_f, d_nee_i,
+            d_shadow_queue, d_shadow_count, nee_capacity,
+            d_tlas, d_instances, d_blas,
+            d_bvhNodes, d_prims, d_tris, d_spheres, d_motionVerts, d_materials,
+            d_lights, num_lights, total_light_power,
+            d_dedLights, num_ded, lightTree,
+            envMap, backgroundColor, hasBackgroundColor, worldMaxBounces,
+            max_depth, useLuminanceOutput, enableNEE,
+            clampDirect, clampIndirect);
+    else
+        stageShadeNeeMisKernel<false><<<blocks, threads>>>(
+            state, hitBufs, d_nee_f, d_nee_i,
+            d_shadow_queue, d_shadow_count, nee_capacity,
+            d_tlas, d_instances, d_blas,
+            d_bvhNodes, d_prims, d_tris, d_spheres, d_motionVerts, d_materials,
+            d_lights, num_lights, total_light_power,
+            d_dedLights, num_ded, lightTree,
+            envMap, backgroundColor, hasBackgroundColor, worldMaxBounces,
+            max_depth, useLuminanceOutput, enableNEE,
+            clampDirect, clampIndirect);
     cudaError_t err = cudaGetLastError();
     if (err != cudaSuccess) {
         std::fprintf(stderr, "stage_shade_nee_mis launch error: %s\n",


### PR DESCRIPTION
## pkg178 Stage-3b PR-1 — D4 fix: compile Principled code out of the non-Principled kernel

Enabling refactor so Stage 3's added lobes never tax scenes that don't use Principled. Adds `template<bool HasPrincipled = true>` through the shade path; `if constexpr` compiles all `gpu_principled_*` out of the `<false>` instantiation. `scene_upload` sets a host `hasPrincipled` flag (mirrors `gpu_closure_graph_is_principled`); the four fused-kernel launchers dispatch `<true>`/`<false>`. Default-`true` keeps every non-shade caller byte-identical.

Why it matters (pkg180/pkg178 D4 analysis): a plain `dielectric` lowers to `GMAT_CLOSURE_GRAPH`, so "non-principled" scenes run the closure-graph arm and paid the Principled spill. Isolating at codegen (not an unlaunched bucket) is the only fix that helps them. This is a compatible **subset** of pkg174's `template<int MatType>` dispatch — not a dependency on it.

### Verified on RTX 5070 Ti (this is Stage-2 code; Stage 3 lobes rebase on top in PR-2)
| kernel | STACK |
|---|---|
| main `stageShadeBucketed` | 4456 B |
| `<true>` (principled) | 4456 B — identical to main |
| `<false>` (non-principled) | **3608 B** (−848 B) |

- **Non-principled perf: 634 ms vs main 651 ms** (min-of-7, identical config) — faster, no regression.
- **Non-principled output numerically equivalent:** max abs diff **2.86e-6** vs main (fast-math scheduling + atomic-accumulation class, ~5 orders below the parity bands; the `<false>` path is main's logic minus code unreachable for it). Not claimed bit-exact — the wavefront isn't self-byte-identical.
- Both instantiations land in the cubin (register report above).

When Stage 3's lobes rebase (PR-2), `<false>` stays ~3608 B / ~634 ms while `<true>` carries the lobe cost — the +52% fleet-wide regression becomes a Principled-only budget line. Closes the bug-class permanently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)