### PR TITLE
fix(pkg178 PR-4a): height-correlated Smith G for Principled GGX (Cycles parity)

### DIFF
--- a/include/astroray/gpu_materials.h
+++ b/include/astroray/gpu_materials.h
@@ -1327,9 +1327,20 @@ __device__ inline float gpu_pr_smithG1(float NdotV, float alphaG) {
     float b = NdotV * NdotV;
     return 2.f * NdotV / (NdotV + sqrtf(a + b - a * b) + 0.001f);
 }
-__device__ inline float gpu_pr_smithG_k(float NdotL, float NdotV, float roughness) {
-    float k = (roughness + 1.f) * (roughness + 1.f) / 8.f;
-    return (NdotL / (NdotL * (1.f - k) + k)) * (NdotV / (NdotV * (1.f - k) + k));
+// Height-correlated Smith masking-shadowing (pkg178 Stage-3b PR-4a) — GPU twin of
+// principled.cpp smithLambda/smithG2_GGX. Replaces the former Disney/UE4 Schlick-k
+// approximation with the EXACT Cycles form (Heitz 2014, JCGT Vol.3 No.2 §3.2
+// Eq. 72; Cycles intern/cycles/kernel/closure/bsdf_microfacet.h, BSD-3-Clause:
+// bsdf_lambda_from_sqr_alpha_tan_n / bsdf_lambda / bsdf_microfacet_eval). ISOTROPIC
+// only (αx=αy → α=roughness²); anisotropy is PR-4b.
+__device__ inline float gpu_pr_smithLambda(float cosTheta, float alpha) {
+    float a2 = alpha * alpha;  // sqr_alpha (Cycles alpha2)
+    float c2 = fmaxf(cosTheta * cosTheta, 1e-7f);
+    float t = a2 * fmaxf(1.f / c2 - 1.f, 0.f);  // sqr_alpha * tan^2
+    return 0.5f * (sqrtf(1.f + t) - 1.f);
+}
+__device__ inline float gpu_pr_smithG2(float NdotL, float NdotV, float alpha) {
+    return 1.f / (1.f + gpu_pr_smithLambda(NdotV, alpha) + gpu_pr_smithLambda(NdotL, alpha));
 }
 __device__ inline float gpu_pr_F0_from_ior(float ior) {
     float f = (ior - 1.f) / (ior + 1.f);
@@ -1618,7 +1629,7 @@ __device__ inline GVec3 gpu_pr_ggxReflect(const GVec3& Fhalf, const GVec3& compF
     float a = fmaxf(roughness * roughness, 0.0064f), a2 = a * a;
     float denom = NdotH * NdotH * (a2 - 1.f) + 1.f;
     float D = a2 / (M_PI_F * denom * denom + 1e-4f);
-    float G = gpu_pr_smithG_k(nl, nv, roughness);
+    float G = gpu_pr_smithG2(nl, nv, a);  // height-correlated Smith (Cycles parity)
     GVec3 single = Fhalf * (D * G / (4.f * nv + 1e-4f));
     return single * gpu_ggxCompensationFactor(compFss, roughness, nv);
 }
@@ -1632,7 +1643,7 @@ __device__ inline GSampledSpectrum gpu_pr_ggxReflectSpectral(const GSampledSpect
     float a = fmaxf(roughness * roughness, 0.0064f), a2 = a * a;
     float denom = NdotH * NdotH * (a2 - 1.f) + 1.f;
     float D = a2 / (M_PI_F * denom * denom + 1e-4f);
-    float G = gpu_pr_smithG_k(nl, nv, roughness);
+    float G = gpu_pr_smithG2(nl, nv, a);  // height-correlated Smith (Cycles parity)
     GSampledSpectrum single = Fhalf * (D * G / (4.f * nv + 1e-4f));
     if (!g_ggxE || !g_ggxEavg) return single;
     float E = fmaxf(gpu_ggxE(roughness, nv), 1e-4f);
@@ -1657,7 +1668,8 @@ __device__ inline GVec3 gpu_pr_transmissionEval(const GPrincipledClosure& c, con
         float HdotO = wo.dot(wm);
         if (HdotO <= 1e-10f) return GVec3(0.f);
         float D = gpu_pr_D_GTR2(wm.dot(rec.normal), alpha);
-        float G = gpu_pr_smithG1(cosO, alpha) * gpu_pr_smithG1(cosI, alpha);
+        // Height-correlated Smith G2 for the external-reflection sub-lobe (Cycles).
+        float G = gpu_pr_smithG2(cosI, cosO, alpha);
         float F = gpu_pr_fresnelDielectric(HdotO, 1.f, L.ior);
         float fr = D * G * F / (4.f * cosO * cosI + 1e-8f) * cosI;
         return L.weight * c.specularTint * fr;
@@ -1668,7 +1680,8 @@ __device__ inline GVec3 gpu_pr_transmissionEval(const GPrincipledClosure& c, con
     if (wm.dot(rec.normal) < 0.f) wm = -wm;
     if (wm.dot(wi) * cosI < 0.f || wm.dot(wo) * cosO < 0.f) return GVec3(0.f);
     float D = gpu_pr_D_GTR2(fabsf(wm.dot(rec.normal)), alpha);
-    float G = gpu_pr_smithG1(fabsf(cosO), alpha) * gpu_pr_smithG1(fabsf(cosI), alpha);
+    // Height-correlated Smith G2 for the refraction sub-lobe (Cycles parity).
+    float G = gpu_pr_smithG2(fabsf(cosI), fabsf(cosO), alpha);
     float F = gpu_pr_fresnelDielectric(fabsf(wo.dot(wm)), etaI, etaT);
     float den = wi.dot(wm) + wo.dot(wm) / etap;
     den = den * den * cosI * cosO;

--- a/plugins/materials/principled.cpp
+++ b/plugins/materials/principled.cpp
@@ -91,10 +91,24 @@ class PrincipledPlugin : public Material {
         float b = NdotV * NdotV;
         return 2.0f * NdotV / (NdotV + std::sqrt(a + b - a * b) + 0.001f);
     }
-    // Schlick-GGX combined G (metal.cpp): G1(L)·G1(V) with k = (r+1)²/8.
-    static float smithG_k(float NdotL, float NdotV, float roughness) {
-        float k = (roughness + 1) * (roughness + 1) / 8.0f;
-        return (NdotL / (NdotL * (1 - k) + k)) * (NdotV / (NdotV * (1 - k) + k));
+    // Height-correlated Smith masking-shadowing (pkg178 Stage-3b PR-4a). Replaces
+    // the former Disney/UE4 Schlick-k approximation with the EXACT form Cycles
+    // uses for BOTH reflection and transmission — Heitz 2014 "Understanding the
+    // Masking-Shadowing Function in Microfacet-Based BRDFs" (JCGT Vol.3 No.2,
+    // §3.2, Eq. 72) — mirrored from Cycles
+    // intern/cycles/kernel/closure/bsdf_microfacet.h (BSD-3-Clause):
+    // bsdf_lambda_from_sqr_alpha_tan_n / bsdf_lambda / bsdf_microfacet_eval.
+    // ISOTROPIC only (αx=αy → α=roughness²); anisotropy is the PR-4b follow-up.
+    // λ(θ) = ½(√(1 + α²·tan²θ) − 1); alpha arg = α (Cycles alpha2 = αx·αy).
+    static float smithLambda(float cosTheta, float alpha) {
+        float a2 = alpha * alpha;  // sqr_alpha (Cycles alpha2)
+        float c2 = std::max(cosTheta * cosTheta, 1e-7f);
+        float t = a2 * std::max(1.0f / c2 - 1.0f, 0.0f);  // sqr_alpha · tan²θ
+        return 0.5f * (std::sqrt(1.0f + t) - 1.0f);
+    }
+    // Height-correlated Smith G2 = 1 / (1 + λO + λI) (Cycles bsdf_microfacet_eval).
+    static float smithG2_GGX(float NdotL, float NdotV, float alpha) {
+        return 1.0f / (1.0f + smithLambda(NdotV, alpha) + smithLambda(NdotL, alpha));
     }
 
     // Cycles bsdf_util.h: F0_from_ior.
@@ -528,7 +542,7 @@ class PrincipledPlugin : public Material {
         float a = std::max(roughness * roughness, 0.0064f), a2 = a * a;
         float denom = NdotH * NdotH * (a2 - 1.0f) + 1.0f;
         float D = a2 / (float(M_PI) * denom * denom + 1e-4f);
-        float G = smithG_k(nl, nv, roughness);
+        float G = smithG2_GGX(nl, nv, a);  // height-correlated Smith (Cycles parity)
         Vec3 single = Fhalf * (D * G / (4.0f * nv + 1e-4f));  // brdf·NdotL
         return single * ggxCompFactor(compFss, roughness, nv);
     }
@@ -550,7 +564,9 @@ class PrincipledPlugin : public Material {
             float HdotO = wo.dot(wm);
             if (HdotO <= 1e-10f) return Vec3(0);
             float D = D_GTR2(wm.dot(rec.normal), alpha);
-            float G = smithG1_GGX(cosO, alpha) * smithG1_GGX(cosI, alpha);
+            // Height-correlated Smith G2 for the external-reflection sub-lobe
+            // (Cycles bsdf_microfacet_eval uses 1/(1+λI+λO) for reflection too).
+            float G = smithG2_GGX(cosI, cosO, alpha);
             float F = fresnelDielectric(HdotO, 1.0f, L.ior);
             float fr = D * G * F / (4.0f * cosO * cosI + 1e-8f) * cosI;  // brdf·cosI
             return L.weight * specularTint_ * fr;
@@ -562,7 +578,8 @@ class PrincipledPlugin : public Material {
         if (wm.dot(rec.normal) < 0.0f) wm = -wm;
         if (wm.dot(wi) * cosI < 0.0f || wm.dot(wo) * cosO < 0.0f) return Vec3(0);
         float D = D_GTR2(std::abs(wm.dot(rec.normal)), alpha);
-        float G = smithG1_GGX(std::abs(cosO), alpha) * smithG1_GGX(std::abs(cosI), alpha);
+        // Height-correlated Smith G2 for the refraction sub-lobe (Cycles parity).
+        float G = smithG2_GGX(std::abs(cosI), std::abs(cosO), alpha);
         float F = fresnelDielectric(std::abs(wo.dot(wm)), etaI, etaT);
         float den = wi.dot(wm) + wo.dot(wm) / etap;
         den = den * den * cosI * cosO;
@@ -919,7 +936,7 @@ public:
         float a = std::max(roughness * roughness, 0.0064f), a2 = a * a;
         float denom = NdotH * NdotH * (a2 - 1.0f) + 1.0f;
         float D = a2 / (float(M_PI) * denom * denom + 1e-4f);
-        float G = smithG_k(nl, nv, roughness);
+        float G = smithG2_GGX(nl, nv, a);  // height-correlated Smith (Cycles parity)
         astroray::SampledSpectrum single = Fhalf * (D * G / (4.0f * nv + 1e-4f));
         const auto& t = astroray::DisneyEnergyCompensationTables::instance();
         if (!t.loaded()) return single;


### PR DESCRIPTION
## pkg178 Stage-3b PR-4a — height-correlated Smith G2 (isotropic)

The Principled reflect lobes used a Disney/UE4 **Schlick-k** Smith G, which is off Cycles parity; Cycles uses **height-correlated** `G2 = 1/(1+λI+λO)` (Heitz 2014) for reflection and transmission. This swaps to the Cycles-exact form. Isotropic only — anisotropy (αx≠αy) is the follow-up. Sets the isotropic case exact so the aniso generalization is a clean α-branch.

Swapped 4 sites each in `principled.cpp` (CPU) and `gpu_materials.h` (GPU twin), byte-mirrored: metallic/specular/coat reflect + both transmission sub-lobes. VNDF sampling/pdf untouched (already Cycles-exact via `smithG1`=1/(1+λ)) → **no RNG-stream change**. Cites Heitz 2014 §3.2 + Cycles `bsdf_microfacet.h` (BSD-3).

### Every gate moved TOWARD 1.0 (parity, not masking) — no re-blessing needed
CPU linear furnace, Schlick-k → height-correlated (all in-band):
| config | old → new |
|---|---|
| metallic r0.3 | 0.929 → 0.960 |
| metallic r0.6 | 0.942 → 0.978 |
| coat r0.3 | 0.986 → 0.994 |
| glass r0.4 | 0.953 → 0.954 |

Schlick-k systematically over-shadowed; height-correlated is the exact energy-conserving form. Largest movers are the pure-GGX metallic lobes, as expected.

### Verified
- CPU: `test_principled_bsdf` 13/13, `test_chi2_principled --runxfail` 12/12 (transmission chi² unchanged = eval-only swap, sampler untouched), plugins + bindings 89 passed/1 skip/15 pre-existing xfail.
- **GPU (RTX): `test_pkg178_principled_gpu_furnace` + `_gpu_cpu_parity` 10 passed.**
- **Register-neutral:** `stageShadeBucketed<true>` STACK 5136 B (= Stage 3; G2 has fewer temps than G1·G1). Non-principled `<false>` untouched.

pkg129 rough-metal live-Cycles A/B bands expected to tighten toward Cycles — folds into the final coordinated re-pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)