### PR TITLE
fix(pkg172A): align two GPU NEE light-pdf sites to the CPU guarded-pdf (parity)

### DIFF
--- a/src/gpu/gpu_nee.cuh
+++ b/src/gpu/gpu_nee.cuh
@@ -550,7 +550,11 @@ __device__ inline GSampledSpectrum gpu_nee_resolve(
     // of reproducing a delta direction, so power-heuristic-combining against
     // bsdfPdf would incorrectly discount it.
     float wt = s.isDeltaLight ? 1.0f : gpu_mw_powerHeuristic(s.lightPdf, bsdfPdf);
-    // color += throughput * f_spec * L_spec * (wt / (ls.pdf + 0.001f))
-    return f_spec * L_spec * (wt / (s.lightPdf + 0.001f));
+    // color += throughput * f_spec * L_spec * (wt / ls.pdf)
+    // pkg172(A) secondary: guarded light-pdf (pbrt-v4 convention) — was
+    // wt/(lightPdf+1e-3), a biasing additive-epsilon under-weighting of NEE.
+    // Mirrors the CPU NEE twin (raytracer.h:2558) already guarded on main
+    // (#551); brings the immediate GPU NEE leg back into CPU parity.
+    return f_spec * L_spec * (s.lightPdf > 1e-8f ? wt / s.lightPdf : 0.0f);
 }
 

--- a/src/gpu/wavefront/stage_advance.cu
+++ b/src/gpu/wavefront/stage_advance.cu
@@ -549,7 +549,13 @@ __device__ bool shadePathSlot(
                         float b2 = bsdfPdf * bsdfPdf;
                         float wt = s.isDeltaLight ? 1.0f
                                                   : a2 / (a2 + b2 + 1e-8f);
-                        float scale = wt / (s.lightPdf + 0.001f);
+                        // pkg172(A) secondary: guarded light-pdf (pbrt-v4
+                        // convention) — was wt/(lightPdf+1e-3), a biasing
+                        // additive-epsilon under-weighting of NEE. Mirrors the
+                        // CPU NEE twin (raytracer.h:2558, path_kernel.cpp:290)
+                        // already guarded on main (#551); brings the deferred
+                        // GPU NEE leg back into CPU parity.
+                        float scale = s.lightPdf > 1e-8f ? wt / s.lightPdf : 0.0f;
                         // pkg89-wavefront: dedicated emission is
                         // rgbAt(dedEmissionRGB, λ)·dedGeoScale (gpu_nee_resolve);
                         // dedGeoScale is λ-independent, so fold it into the


### PR DESCRIPTION
## pkg172(A) — GPU NEE light-pdf parity cleanup (completes pkg172A)

The pkg172(A) primary fix (guarded-pdf BSDF throughput, the 0.628%/bounce epsilon) already landed CPU+GPU via PR #551. This aligns the two remaining GPU NEE light-pdf sites whose CPU twins #551 guarded but whose GPU legs still divided by `(lightPdf + 1e-3)`:
- `src/gpu/wavefront/stage_advance.cu:552` (deferred/bucketed NEE)
- `src/gpu/gpu_nee.cuh:554` (immediate `gpu_nee_resolve`)

Both → `s.lightPdf > 1e-8f ? wt / s.lightPdf : 0.0f` (pbrt-v4 guarded form, matching `raytracer.h:2558`). Left `gpu_nee.cuh:90` (solid-angle pdf `+0.001f`) untouched — its CPU twins still carry it, so a GPU-only change there would *break* parity; that's a separate coordinated CPU+GPU follow-up.

### Verified (RTX 5070 Ti)
- GPU furnace + CPU/GPU parity: **10 passed** (parity now tighter — both legs guarded).
- Firefly check (area + mesh lights): E1 area 1.16/1.23, E4 mirror max_lum 7.22 — **no fireflies**; values unchanged (the 1e-3 light-pdf eps was negligible), so no gate shifts / no re-pin.
- Register-neutral (guarded reciprocal, no new state).

Cites pbrt-v4 guarded-pdf (`.astroray_plan/docs/pkg172a-guarded-pdf.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)