### PR TITLE
feat(pkg178 Stage 4 PR-2): CPU conductor thin-film iridescence (metallic lobe)

### DIFF
--- a/.astroray_plan/docs/pkg178-stage4-plan.md
+++ b/.astroray_plan/docs/pkg178-stage4-plan.md
@@ -236,10 +236,18 @@ local Blender 5.2 python API before hardcoding (5.x renamed sockets before).
   analytic-phase check vs exact Airy (Δ~1e-6); furnace no-gain sweep; chi² film-ON.
   LEAD-DEFERRED: dielectric/glass hue-trajectory sweep vs Blender 5.2 Cycles (harness
   scene author + comparison run).
-- **PR-2 — CPU conductor thin film.** Host Gulbrandsen n,k precompute,
-  `fresnelIridescence<true>` on the metallic lobe, spectral + RGB legs.
-  Gates: thickness-0 bit-equality; conductor hue sweep vs 5.2; furnace; metallic
-  chi² unchanged.
+- **PR-2 — CPU conductor thin film.** Status: DONE on branch
+  `pkg178-thinfilm-pr2` (stacked on pkg178-thinfilm-pr1; commit 7cff9af, 2026-08-10;
+  not yet PR'd/merged — lead rebases onto main + runs the vs-5.2 conductor hue
+  sweep). Host Gulbrandsen n,k precompute (per-RGB-channel, ctor-time, never
+  per-hit), `fresnelIridescenceChannel<true>` on the metallic lobe (RGB leg =
+  precomputed n,k + CIE LUT; spectral leg = RGB reflectance upsampled per plan §0.5).
+  Sampler/pdf unchanged; energy comp left film-free. Gates met (CPU, RTX build):
+  thickness-0 metallic bit-equality byte-identical (maxΔ 0.0); metallic chi² film-ON
+  (θ=0,45); furnace no-gain sweep (thickness×film-IOR). LEAD-DEFERRED: conductor
+  hue-trajectory sweep vs Blender 5.2 Cycles (harness authored:
+  benchmarks/cycles-parity/thin_film/conductor_hue_sweep.py; comparison run needs the
+  oracle).
 - **PR-3 — GPU twin of PR-1+2.** `GPrincipledClosure` params + upload, LUT upload
   unit, `gpu_pr_*` call sites in `<true>`. Gates: CPU↔GPU per-lobe parity;
   cuobjdump REG+STACK report; non-principled wavefront perf hard gate;

--- a/benchmarks/cycles-parity/thin_film/conductor_hue_sweep.py
+++ b/benchmarks/cycles-parity/thin_film/conductor_hue_sweep.py
@@ -1,0 +1,144 @@
+"""pkg178 Stage 4 PR-2 — conductor (metallic) thin-film hue-sweep harness.
+
+Renders the Astroray-CPU leg of the conductor iridescence hue trajectory: a
+metallic Principled sphere under a uniform environment, swept over
+thin_film_thickness x thin_film_ior. For each cell it records the per-channel
+LINEAR mean radiance over the sphere ROI and the circular-mean hue angle
+(benchmarks.reference_bank.metrics.hue_spread), then writes a JSON + CSV table
+and a hue-angle-vs-thickness curve the LEAD diffs against Blender 5.2 Cycles.
+
+LEAD-DEFERRED: this authors the ASTRORAY side only. The vs-Cycles-5.2 verdict
+(rendering the Cycles oracle leg, the per-channel mean-ratio bands, and the
+refbank 5.2-blessed refs for these scenes) is the lead's on-hardware step — it
+needs the oracle, which is not available to the PR-2 implementer. The scene here
+is the plan §4 "conductor" row of the hue-trajectory sweep (thickness {100, 200,
+400, 800, 1500, 3000}nm x film IOR {1.2, 1.5, 1.8}).
+
+One command:
+    python benchmarks/cycles-parity/thin_film/conductor_hue_sweep.py \
+        --out test_results/pkg178_conductor_hue --res 128 --samples 256
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+
+# repo root = .../Astroray ; this file is at benchmarks/cycles-parity/thin_film
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(_REPO_ROOT))
+sys.path.insert(0, str(_REPO_ROOT / "tests"))
+
+# Imports below run AFTER the sys.path setup above (build-dir bootstrap), so the
+# module block is intentionally interleaved with configure_test_imports().
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+
+import astroray
+from benchmarks.reference_bank.metrics.hue_spread import _rgb_to_hue
+
+# plan §4 conductor hue-trajectory grid.
+THICKNESSES_NM = [100.0, 200.0, 400.0, 800.0, 1500.0, 3000.0]
+FILM_IORS = [1.2, 1.5, 1.8]
+# Neutral-ish metal base so the iridescence hue is the dominant chroma signal.
+BASE_COLOR = [0.9, 0.9, 0.9]
+
+
+def _render(thickness_nm: float, film_ior: float, res: int, samples: int, seed: int) -> np.ndarray:
+    r = astroray.Renderer()
+    r.set_use_gpu(False)  # CPU leg — GPU thin film is PR-3
+    r.set_background_color([1.0, 1.0, 1.0])
+    params = {
+        "ior": 1.5,
+        "roughness": 0.08,
+        "metallic": 1.0,
+        "transmission_weight": 0.0,
+        "thin_film_thickness": thickness_nm,
+        "thin_film_ior": film_ior,
+    }
+    mid = r.create_material("principled", list(BASE_COLOR), params)
+    r.add_sphere([0.0, 0.0, 0.0], 1.0, mid)
+    r.set_integrator("path_tracer")
+    r.setup_camera([0, 0, 4], [0, 0, 0], [0, 1, 0], 40.0, 1.0, 0.0, 4.0, res, res)
+    r.set_seed(seed)
+    # render(spp, depth, denoiser, apply_gamma) — LINEAR (apply_gamma=False).
+    img = np.asarray(r.render(samples, 16, None, False), dtype=np.float32).reshape(res, res, 3)
+    return img
+
+
+def _sphere_roi(img: np.ndarray) -> np.ndarray:
+    """Central square ROI covering the sphere (camera is centered on it)."""
+    h, w, _ = img.shape
+    y0, y1 = int(h * 0.25), int(h * 0.75)
+    x0, x1 = int(w * 0.25), int(w * 0.75)
+    return img[y0:y1, x0:x1]
+
+
+def _hue_angle_deg(roi: np.ndarray) -> float:
+    mx = roi.max()
+    rgb_n = roi / mx if mx > 0 else roi
+    hue = _rgb_to_hue(rgb_n)
+    h = hue[~np.isnan(hue)]
+    if h.size < 4:
+        return float("nan")
+    z = np.exp(1j * h)
+    return float((np.angle(z.mean()) % (2 * np.pi)) * 180.0 / np.pi)
+
+
+def run(out_dir: str, res: int, samples: int) -> dict:
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    rows = []
+    seed = 7
+    for d in THICKNESSES_NM:
+        for fior in FILM_IORS:
+            img = _render(d, fior, res, samples, seed)
+            roi = _sphere_roi(img)
+            mean_rgb = roi.reshape(-1, 3).mean(axis=0)
+            rows.append({
+                "thickness_nm": d,
+                "film_ior": fior,
+                "mean_r": float(mean_rgb[0]),
+                "mean_g": float(mean_rgb[1]),
+                "mean_b": float(mean_rgb[2]),
+                "hue_angle_deg": _hue_angle_deg(roi),
+            })
+            np.save(out / f"astroray_cpu_d{int(d)}_ior{fior}.npy", img)
+
+    result = {
+        "engine": "astroray_cpu",
+        "note": "vs-Cycles-5.2 comparison is LEAD-DEFERRED (needs the oracle)",
+        "base_color": BASE_COLOR,
+        "res": res,
+        "samples": samples,
+        "rows": rows,
+    }
+    (out / "conductor_hue_sweep.json").write_text(json.dumps(result, indent=2))
+    with (out / "conductor_hue_sweep.csv").open("w", newline="") as f:
+        wr = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        wr.writeheader()
+        wr.writerows(rows)
+    return result
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out", default="test_results/pkg178_conductor_hue")
+    ap.add_argument("--res", type=int, default=128)
+    ap.add_argument("--samples", type=int, default=256)
+    args = ap.parse_args()
+    result = run(args.out, args.res, args.samples)
+    print(f"[pkg178-conductor-hue] wrote {len(result['rows'])} cells to {args.out}")
+    for row in result["rows"]:
+        print("  d={thickness_nm:>6.0f}nm ior={film_ior:.1f}  "
+              "RGB=({mean_r:.4f},{mean_g:.4f},{mean_b:.4f})  hue={hue_angle_deg:.1f}deg".format(**row))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/materials/principled.cpp
+++ b/plugins/materials/principled.cpp
@@ -45,6 +45,14 @@ class PrincipledPlugin : public Material {
     // specular/transmission Fresnel takes the exact Stage-3b path, byte-identical.
     float thinFilmThickness_;  // Cycles thin_film_thickness (nm)
     float thinFilmIor_;        // Cycles thin_film_ior
+    // pkg178 Stage 4 PR-2 — per-RGB-channel conductor (n,k) + F82 value g for the
+    // metallic lobe's thin-film Fresnel, host-PRECOMPUTED at ctor from (base_color,
+    // specular_tint) via the Gulbrandsen inversion (Cycles bsdf_microfacet.h:365-383,
+    // "Artist Friendly Metallic Fresnel", Gulbrandsen JCGT 2014). These depend only
+    // on per-material constants, so they are computed ONCE here — never per hit.
+    float filmMetalN_[3] = {0.0f, 0.0f, 0.0f};
+    float filmMetalK_[3] = {0.0f, 0.0f, 0.0f};
+    float filmMetalG_[3] = {0.0f, 0.0f, 0.0f};
     // pkg178 Stage-3b PR-4b — Cycles anisotropic + anisotropic_rotation sockets.
     // Default 0 → isotropic (alpha_x==alpha_y), Stage-1/2 behavior byte-for-byte.
     float anisotropic_, anisotropicRotation_;
@@ -296,6 +304,70 @@ class PrincipledPlugin : public Material {
         return Vec3(thinFilmF0RescaleChannel(F.x, f0.x, F0real),
                     thinFilmF0RescaleChannel(F.y, f0.y, F0real),
                     thinFilmF0RescaleChannel(F.z, f0.z, F0real));
+    }
+
+    // ==================================================================
+    // pkg178 Stage 4 PR-2 — CONDUCTOR thin-film iridescence (metallic lobe).
+    // Bottom interface is a conductor whose (n,k) come from the artist F82 model
+    // via the Gulbrandsen inversion (JCGT 2014); the film Airy summation is the
+    // shared Belcour-Barla core (thin_film_fresnel.h). Cycles reference:
+    // bsdf_microfacet.h:365-383 (F82_TINT thin-film branch) +
+    // bsdf_util.h:200 fresnel_conductor_polarized + :499
+    // fresnel_iridescence_channel<true>.
+    // ==================================================================
+    // Host-precompute the per-RGB-channel conductor (n,k) + F82 value g from a
+    // per-material (f0, F82-tint) pair. Called ONCE from the ctor — this is the
+    // per-hit-inversion optimization the plan mandates (plan §0 decision 5;
+    // Cycles re-inverts per shade only because its fresnel structs are per-hit).
+    void precomputeConductorNK() {
+        for (int c = 0; c < 3; ++c) {
+            const float f0 = (&baseColor_.x)[c];
+            const float tint = (&specularTint_.x)[c];
+            const float r = std::min(f0, 0.999f);
+            // g = fresnel_f82(1/7, f0, b) with b = f82tint_B(f0, tint) — exactly the
+            // metallic lobe's own F82 evaluation at cosθ=1/7 (bsdf_util.h:186).
+            const float g = f82Channel(1.0f / 7.0f, f0, tint);
+            const float sqrtR = std::sqrt(r);
+            // n = mix((1+√r)/(1−√r), (1−r)/(1+r), g); k = safe_sqrt((r(n+1)²−(n−1)²)/(1−r)).
+            const float nLo = (1.0f + sqrtR) / (1.0f - sqrtR);
+            const float nHi = (1.0f - r) / (1.0f + r);
+            const float n = nLo + (nHi - nLo) * g;
+            const float kNum = r * (n + 1.0f) * (n + 1.0f) - (n - 1.0f) * (n - 1.0f);
+            const float k = std::sqrt(std::max(0.0f, kNum / (1.0f - r)));
+            filmMetalN_[c] = n;
+            filmMetalK_[c] = k;
+            filmMetalG_[c] = g;
+        }
+    }
+    // Per-RGB-channel conductor iridescence F at half-vector cosine `cosI`, using
+    // the precomputed (n,k,g) + the Rec.709-baked CIE sensitivity LUT — Cycles
+    // fresnel_iridescence_channel<true> (bsdf_util.h:499).
+    Vec3 thinFilmConductorRGB(float cosI) const {
+        namespace tf = astroray::thinfilm;
+        Vec3 out;
+        for (int c = 0; c < 3; ++c) {
+            auto S = [c](float argOPD) {
+                return tf::sensitivityRGB(argOPD, c, tf::kThinFilmCieTable);
+            };
+            (&out.x)[c] = tf::fresnelIridescenceChannel<true>(
+                1.0f, thinFilmThickness_, thinFilmIor_, filmMetalN_[c], filmMetalK_[c],
+                filmMetalG_[c], cosI, nullptr, S);
+        }
+        return out;
+    }
+    // Spectral leg. Cycles has no spectral n,k for the F82 conductor, so the plan
+    // (§0 decision 5) evaluates the RGB-channel conductor iridescence and upsamples
+    // the resulting reflectance to spectral — APPROXIMATED-equal-to-Cycles, and the
+    // sanctioned "upsample a reflectance colour" JH usage (memory
+    // spectral-upsample-nonlinearity-scaled-bsdf; same trick as the film-free
+    // transmission spectral fallback below). Documented RGB↔spectral hue difference
+    // by construction (pkg128 §B; recorded, not gated).
+    astroray::SampledSpectrum thinFilmConductorSpectral(
+            float cosI, const astroray::SampledWavelengths& lam) const {
+        Vec3 rgb = thinFilmConductorRGB(cosI);
+        float maxc = std::max({rgb.x, rgb.y, rgb.z, 1.0f});
+        Vec3 tint = rgb * (1.0f / maxc);
+        return upsample(tint, lam) * maxc;
     }
 
     // Multiscatter GGX energy compensation (Kulla & Conty 2017 / Cycles
@@ -690,9 +762,17 @@ class PrincipledPlugin : public Material {
                 if (nl <= 0.0f || nv <= 0.0f) return Vec3(0);
                 Vec3 h = (wo + wi).normalized();
                 float ci = std::clamp(wo.dot(h), 0.0f, 1.0f);
+                // Film-OFF statements FIRST, textually unchanged (byte-identical
+                // codegen + thickness-0 render); the film only OVERRIDES F.
                 Vec3 F(f82Channel(ci, L.color.x, specularTint_.x),
                        f82Channel(ci, L.color.y, specularTint_.y),
                        f82Channel(ci, L.color.z, specularTint_.z));
+                if (filmActive()) {
+                    // pkg178 Stage 4 PR-2: thin-film iridescence over the conductor
+                    // substrate replaces the single-scatter F82 Fresnel. compFss
+                    // (L.color) stays FILM-FREE so energy comp is not double-counted.
+                    F = thinFilmConductorRGB(ci);
+                }
                 return L.weight * ggxReflectRGB(F, L.color, L.roughness,
                                                 L.anisotropic, L.anisoRotation, rec, wo, wi);
             }
@@ -1084,7 +1164,12 @@ public:
           emissionStrength_(std::max(0.0f, p.getFloat("emission_strength", 1.0f))),
           emissionSpec_({emissionColor_.x * emissionStrength_,
                          emissionColor_.y * emissionStrength_,
-                         emissionColor_.z * emissionStrength_}) {}
+                         emissionColor_.z * emissionStrength_}) {
+        // pkg178 Stage 4 PR-2: host-precompute the metallic-lobe conductor (n,k,g)
+        // once (per-material constant; never per hit). No-op for the render unless
+        // the film is active on the metallic lobe.
+        precomputeConductorNK();
+    }
 
     Vec3 getAlbedo() const override { return baseColor_; }
     float getAnisotropic() const override { return anisotropic_; }  // pkg178 PR-4b
@@ -1235,10 +1320,18 @@ public:
                 Vec3 h = (wo + wi).normalized();
                 float ci = std::clamp(wo.dot(h), 0.0f, 1.0f);
                 astroray::SampledSpectrum f0 = upsample(L.color, lam);
+                // Film-OFF statements FIRST, textually unchanged (thickness-0
+                // bit-equality); the film (rare path) only OVERRIDES F.
                 astroray::SampledSpectrum tint = upsample(specularTint_, lam);
                 astroray::SampledSpectrum F(0.0f);
                 for (int i = 0; i < astroray::kSpectrumSamples; ++i)
                     F[i] = f82Channel(ci, f0[i], tint[i]);
+                if (filmActive()) {
+                    // pkg178 Stage 4 PR-2: conductor thin-film F (RGB-channel n,k
+                    // upsampled — plan §0.5 APPROXIMATED-equal-to-Cycles). compFss
+                    // (f0) stays film-free.
+                    F = thinFilmConductorSpectral(ci, lam);
+                }
                 return wSpec * ggxReflectSpectral(F, f0, L.roughness, L.anisotropic,
                                                   L.anisoRotation, rec, wo, wi);
             }

--- a/tests/statistical/test_chi2_principled.py
+++ b/tests/statistical/test_chi2_principled.py
@@ -63,6 +63,18 @@ def test_chi2_principled_metallic(theta_deg, roughness):
     assert ok, f"principled metallic chi² FAILED (r={roughness}, θ={theta_deg}) p={t.p_value:.6f}"
 
 
+@pytest.mark.parametrize("theta_deg", [0, 45])
+def test_chi2_principled_metallic_thin_film(theta_deg):
+    # pkg178 Stage 4 PR-2: conductor thin-film iridescence changes only the eval
+    # Fresnel MAGNITUDE of the metallic lobe — the sampler/pdf (GGX NDF sampling,
+    # Fresnel-independent) is byte-unchanged. This gate proves chi² stays valid
+    # with the film ON (the "metallic sampler/pdf unchanged" claim).
+    ok, t = _run({"base_color": [0.95, 0.64, 0.54], "metallic": 1.0, "roughness": 0.5,
+                  "thin_film_thickness": 500.0, "thin_film_ior": 1.4},
+                 theta_deg, HemisphericalDomain(), seed=950 + theta_deg)
+    assert ok, f"principled thin-film metallic chi² FAILED (θ={theta_deg}) p={t.p_value:.6f}"
+
+
 # pkg178 Stage-3b PR-4b — anisotropic GGX (αx≠αy). Validates that the aniso NDF
 # half-vector sampler (slope stretch) is matched by the aniso pdf() in the
 # one-sample MIS. The rotation exercises the UV-aligned frame path. The frame in

--- a/tests/test_thin_film_pr2.py
+++ b/tests/test_thin_film_pr2.py
@@ -1,0 +1,95 @@
+"""pkg178 Stage 4 PR-2 — CPU conductor (metallic) thin-film (Belcour-Barla) gates.
+
+CPU-only (GPU is PR-3): every test forces set_use_gpu(False). PR-1 covers the
+dielectric specular/transmission legs; here we gate the CONDUCTOR path — the
+Principled metallic (F82) lobe whose thin-film bottom interface is a conductor
+whose (n,k) come from the Gulbrandsen inversion (host-precomputed at ctor):
+
+  * thickness-0 BIT-EQUALITY (load-bearing): a metallic Principled render with
+    thin_film_thickness ∈ {absent, 0, 0.05nm ≤ cutoff} is byte-identical — the
+    conductor film is a true no-op when off.
+  * film ON actually changes the metallic image, chromatically (wired, not dead).
+  * furnace (LINEAR ceiling, memory gamma-furnace-cannot-detect-energy-gain): the
+    conductor film creates no net energy across a thickness × film-IOR sweep.
+"""
+import numpy as np
+import pytest
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+
+try:
+    import astroray
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray not built")
+
+_W = 64
+_SEED = 7
+
+
+def _render(params, *, color=(0.9, 0.6, 0.2), spp=48, depth=16, bg=1.0):
+    """Metallic sphere (metallic=1) under a uniform white environment — the
+    conductor lobe reflects the background so the F82/film Fresnel is exercised."""
+    r = astroray.Renderer()
+    r.set_use_gpu(False)  # CPU only — GPU thin film is PR-3
+    r.set_background_color([bg, bg, bg])
+    p = {"ior": 1.5, "roughness": 0.12, "metallic": 1.0, "transmission_weight": 0.0}
+    p.update(params)
+    mid = r.create_material("principled", list(color), p)
+    r.add_sphere([0.0, 0.0, 0.0], 1.0, mid)
+    r.set_integrator("path_tracer")
+    r.setup_camera([0, 0, 4], [0, 0, 0], [0, 1, 0], 40.0, 1.0, 0.0, 4.0, _W, _W)
+    r.set_seed(_SEED)
+    img = np.asarray(r.render(spp, depth, None, False), dtype=np.float32).reshape(_W, _W, 3)
+    return img
+
+
+# ---------------------------------------------------------------------------
+# thickness-0 bit-equality (load-bearing no-op guard for the metallic lobe)
+# ---------------------------------------------------------------------------
+def test_metallic_thin_film_thickness0_bit_equality():
+    base = _render({})                              # param absent
+    zero = _render({"thin_film_thickness": 0.0})
+    subc = _render({"thin_film_thickness": 0.05})   # ≤ 0.1nm cutoff
+    assert np.array_equal(base, zero), (
+        "metallic: thin_film_thickness=0 not byte-identical to absent "
+        f"(max Δ={np.abs(base - zero).max():.3e})")
+    assert np.array_equal(base, subc), (
+        "metallic: thin_film_thickness=0.05 (≤cutoff) not byte-identical to off "
+        f"(max Δ={np.abs(base - subc).max():.3e})")
+
+
+# ---------------------------------------------------------------------------
+# film ON changes the metallic image, chromatically (iridescence, not dead code)
+# ---------------------------------------------------------------------------
+def test_metallic_thin_film_on_changes_image():
+    off = _render({"thin_film_thickness": 0.0})
+    on = _render({"thin_film_thickness": 400.0, "thin_film_ior": 1.4})
+    diff = float(np.abs(on - off).mean())
+    assert diff > 1e-3, f"metallic thin film (400nm) did not change the image (mean Δ={diff:.3e})"
+    dr, dg, db = (on - off).reshape(-1, 3).mean(axis=0)
+    spread = max(abs(dr - dg), abs(dg - db), abs(dr - db))
+    assert spread > 1e-4, (
+        f"metallic film change is achromatic (no hue shift): {dr:.4f},{dg:.4f},{db:.4f}")
+
+
+# ---------------------------------------------------------------------------
+# furnace: the conductor film creates NO net energy across a thickness × film-IOR
+# sweep. A metallic sphere in a white environment reflects but never amplifies —
+# the whole-image mean must stay in a tight band around the film-OFF mean, LINEAR
+# (memory gamma-furnace-cannot-detect-energy-gain). Neutral base color keeps the
+# F82 reflectance high so a spurious energy GAIN would be unmistakable.
+# ---------------------------------------------------------------------------
+def test_metallic_thin_film_furnace_no_energy_gain():
+    off_mean = float(_render({"thin_film_thickness": 0.0}, color=(0.9, 0.9, 0.9), spp=64).mean())
+    for d in (100.0, 300.0, 600.0, 1500.0, 3000.0):
+        for fior in (1.2, 1.5, 1.8):
+            m = float(_render({"thin_film_thickness": d, "thin_film_ior": fior},
+                              color=(0.9, 0.9, 0.9), spp=64).mean())
+            assert m <= off_mean * 1.06 + 0.02, (
+                f"metallic d={d} fior={fior}: mean {m:.4f} > off {off_mean:.4f} x1.06 (energy GAIN)")
+            assert m >= off_mean * 0.90 - 0.02, (
+                f"metallic d={d} fior={fior}: mean {m:.4f} < off {off_mean:.4f} x0.90 (energy LOSS)")


### PR DESCRIPTION
## pkg178 Stage 4 PR-2 — CPU conductor thin-film

Applies the PR-1 Belcour-Barla utility to the **metallic/conductor** lobe. Host-precomputes conductor (n,k) from (base_color, specular_tint) via the Gulbrandsen F82→(n,k) inversion — a per-material constant at ctor, never per-hit. Metallic Fresnel is overridden with the conductor Airy iridescence when `thin_film_thickness > 0` (default 0 = off → metallic lobe byte-unchanged). Energy comp left film-free (no double-count); sampler/pdf untouched.

Cites Belcour-Barla 2017, Cycles `bsdf_util.h:200` `fresnel_conductor_polarized` + `bsdf_microfacet.h` F82 thin-film branch (BSD-3), Gulbrandsen 2014.

### Verified (CPU, rebased onto main)
- **Metallic thickness-0 bit-equality: exact** (thickness ∈ {absent,0,0.05nm} byte-identical, maxΔ 0.0).
- Furnace (linear) no energy gain across thickness × film-IOR; chi² metallic film-ON θ=0,45 pass (sampler/pdf unchanged).
- Full suite on the rebased build: **45 passed, 1 xfailed** (pre-existing); GPU untouched (conductor GPU is PR-3).

### Note (Stage-0 APPROXIMATED table)
Per plan §0.5 (RGB n,k, no per-hit inversion): the metallic **spectral** leg upsamples the RGB conductor iridescence rather than computing per-λ-native iridescence (there is no spectral (n,k); only 3 RGB channels). This is a by-construction RGB↔spectral difference (the dielectric spectral leg *is* per-λ-native since its substrate is achromatic). A per-λ-native conductor path is a one-function swap if ever wanted (at the per-hit-inversion cost the plan warned against).

vs-Blender-5.2 conductor hue sweep harness authored (LEAD-DEFERRED — pixel-matched parity runs at the GPU stage, PR-3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)