### PR TITLE
feat(pkg178 Stage 4 PR-3): GPU twin of thin-film (dielectric + conductor)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -480,6 +480,7 @@ if(ASTRORAY_CUDA_FOUND)
         src/gpu/gpu_spectral_tables.cu   # pkg55-C1: shared CMF/D65/JH/profile tables
         src/gpu/gpu_glass_tables.cu      # pkg151: rough-transmission glass multiscatter tables
         src/gpu/gpu_ggx_tables.cu        # pkg152: reflection-lobe multiscatter/layering compensation tables
+        src/gpu/gpu_thin_film_table.cu   # pkg178 Stage 4 PR-3: thin-film CIE sensitivity LUT upload
         src/gpu/light_tree_probe.cu      # pkg55-C1: pkg86-B light-tree pick probe
         src/gpu/scene_upload.cu
         src/gpu/pkg64_sms_probe.cu

--- a/include/astroray/gpu_materials.h
+++ b/include/astroray/gpu_materials.h
@@ -1514,16 +1514,35 @@ __device__ inline GVec3 gpu_pr_thinFilmF0RescaleRGB(GVec3 F, const GVec3& f0, fl
                  gpu_pr_thinFilmF0RescaleChannel(F.y, f0.y, F0real),
                  gpu_pr_thinFilmF0RescaleChannel(F.z, f0.z, F0real));
 }
+// Per-channel Gulbrandsen conductor (n,k) + F82 value g from (f0, specular_tint) —
+// exact mirror of principled.cpp::precomputeConductorNK ("Artist Friendly Metallic
+// Fresnel", Gulbrandsen JCGT 2014; Cycles bsdf_microfacet.h:365-383). On the CPU
+// this is a per-material ctor precompute; on the GPU it is recomputed PER HIT here
+// (only reached on the metallic thin-film path, <true> only) so the 9 floats do
+// NOT bloat GPrincipledClosure/GMaterial and leak STACK into the shared <false>
+// kernel via its by-value copy (see gpu_types.h). g reuses the metallic lobe's own
+// F82 eval at cosθ=1/7 (gpu_pr_f82Channel == principled.cpp::f82Channel).
+__device__ inline void gpu_pr_conductorNK(float f0, float tint, float& n, float& k, float& g) {
+    const float r = fminf(f0, 0.999f);
+    g = gpu_pr_f82Channel(1.f / 7.f, f0, tint);
+    const float sqrtR = sqrtf(r);
+    const float nLo = (1.f + sqrtR) / (1.f - sqrtR);
+    const float nHi = (1.f - r) / (1.f + r);
+    n = nLo + (nHi - nLo) * g;
+    const float kNum = r * (n + 1.f) * (n + 1.f) - (n - 1.f) * (n - 1.f);
+    k = sqrtf(fmaxf(0.f, kNum / (1.f - r)));
+}
 // principled.cpp::thinFilmConductorRGB — per-RGB-channel conductor iridescence F
-// with the HOST-precomputed (n,k,g) (c.filmMetalN/K/G) + the CIE LUT.
+// with the PER-HIT-computed (n,k,g) + the CIE LUT.
 __device__ inline GVec3 gpu_pr_thinFilmConductorRGB(const GPrincipledClosure& c, float cosI) {
     namespace tf = astroray::thinfilm;
     GVec3 out;
     for (int ch = 0; ch < 3; ++ch) {
+        float n, k, g;
+        gpu_pr_conductorNK((&c.color.x)[ch], (&c.specularTint.x)[ch], n, k, g);
         auto S = [ch](float argOPD) { return gpu_pr_sensitivityRGB(argOPD, ch); };
         (&out.x)[ch] = tf::fresnelIridescenceChannel<true>(
-            1.f, c.thinFilmThickness, c.thinFilmIor, c.filmMetalN[ch], c.filmMetalK[ch],
-            c.filmMetalG[ch], cosI, nullptr, S);
+            1.f, c.thinFilmThickness, c.thinFilmIor, n, k, g, cosI, nullptr, S);
     }
     return out;
 }

--- a/include/astroray/gpu_materials.h
+++ b/include/astroray/gpu_materials.h
@@ -8,6 +8,8 @@
 #include "gpu_glass_tables.cuh"  // pkg151: rough-transmission multiscatter compensation
 #include "gpu_ggx_tables.cuh"    // pkg152: reflection-lobe multiscatter/layering compensation
 #include "sheen_ltc_table.h"     // pkg178 Stage 3: sheen LTC table (host/device)
+#include "thin_film_fresnel.h"       // pkg178 Stage 4: shared Belcour-Barla iridescence core
+#include "gpu_thin_film_table.cuh"   // pkg178 Stage 4 PR-3: device CIE sensitivity LUT + gpu_pr_sensitivityRGB
 #include <curand_kernel.h>
 
 #ifndef M_PI_F
@@ -1459,6 +1461,82 @@ __device__ inline GVec3 gpu_pr_sqrtColor(const GVec3& c) {
     return GVec3(sqrtf(fmaxf(0.f, c.x)), sqrtf(fmaxf(0.f, c.y)), sqrtf(fmaxf(0.f, c.z)));
 }
 
+// ==========================================================================
+// pkg178 Stage 4 PR-3 — thin-film iridescence (GPU twin of principled.cpp
+// PR-1/PR-2). SAME shared core (thin_film_fresnel.h fresnelIridescenceChannel)
+// as the CPU — byte-identical math, one body, two legs. The film only OVERRIDES
+// the single-scatter Fresnel F at the specular/transmission/metallic eval sites,
+// gated on gpu_pr_filmActive; thickness ≤ cutoff → these are NEVER called, so
+// thickness-0 renders are byte-identical to PR-6 (the load-bearing no-op).
+// energy-comp (compFss) stays FILM-FREE (no double-count), exactly as CPU/Cycles.
+// ==========================================================================
+__device__ inline bool gpu_pr_filmActive(const GPrincipledClosure& c) {
+    return c.thinFilmThickness > astroray::thinfilm::kThinFilmThicknessCutoff;
+}
+// principled.cpp::thinFilmFresnelRGB — per-RGB-channel dielectric iridescence F,
+// RGB sensitivity via the device CIE LUT (gpu_pr_sensitivityRGB).
+__device__ inline GVec3 gpu_pr_thinFilmFresnelRGB(const GPrincipledClosure& c, float cosI,
+                                                  float iorArg, float filmIor) {
+    namespace tf = astroray::thinfilm;
+    GVec3 out;
+    for (int ch = 0; ch < 3; ++ch) {
+        auto S = [ch](float argOPD) { return gpu_pr_sensitivityRGB(argOPD, ch); };
+        (&out.x)[ch] = tf::fresnelIridescenceChannel<false>(
+            1.f, c.thinFilmThickness, filmIor, iorArg, 0.f, -1.f, cosI, nullptr, S);
+    }
+    return out;
+}
+// principled.cpp::thinFilmFresnelSpectral — per-λ analytic sensitivity (no LUT).
+__device__ inline GSampledSpectrum gpu_pr_thinFilmFresnelSpectral(
+        const GPrincipledClosure& c, float cosI, float iorArg, float filmIor,
+        const GSampledWavelengths& wl) {
+    namespace tf = astroray::thinfilm;
+    GSampledSpectrum out(0.f);
+    for (int i = 0; i < G_SPECTRUM_SAMPLES; ++i) {
+        float lambda = wl.lambda[i];
+        auto S = [lambda](float argOPD) { return tf::sensitivitySpectral(argOPD, lambda); };
+        out[i] = tf::fresnelIridescenceChannel<false>(
+            1.f, c.thinFilmThickness, filmIor, iorArg, 0.f, -1.f, cosI, nullptr, S);
+    }
+    return out;
+}
+// principled.cpp::thinFilmF0RescaleChannel / thinFilmF0RescaleRGB — Cycles
+// generalized_schlick_fresnel thin-film F0-rescale (bsdf_microfacet.h:284-297).
+__device__ inline float gpu_pr_thinFilmF0RescaleChannel(float Fc, float f0c, float F0real) {
+    float s = fminf(fmaxf((Fc - 1.f) / (F0real - 1.f), 0.f), 1.f);
+    float factor = f0c / F0real;
+    return Fc * (1.f + (factor - 1.f) * s);
+}
+__device__ inline GVec3 gpu_pr_thinFilmF0RescaleRGB(GVec3 F, const GVec3& f0, float iorArg) {
+    float F0real = gpu_pr_F0_from_ior(iorArg);
+    if (F0real <= 1e-5f || (F.x == 1.f && F.y == 1.f && F.z == 1.f)) return F;
+    return GVec3(gpu_pr_thinFilmF0RescaleChannel(F.x, f0.x, F0real),
+                 gpu_pr_thinFilmF0RescaleChannel(F.y, f0.y, F0real),
+                 gpu_pr_thinFilmF0RescaleChannel(F.z, f0.z, F0real));
+}
+// principled.cpp::thinFilmConductorRGB — per-RGB-channel conductor iridescence F
+// with the HOST-precomputed (n,k,g) (c.filmMetalN/K/G) + the CIE LUT.
+__device__ inline GVec3 gpu_pr_thinFilmConductorRGB(const GPrincipledClosure& c, float cosI) {
+    namespace tf = astroray::thinfilm;
+    GVec3 out;
+    for (int ch = 0; ch < 3; ++ch) {
+        auto S = [ch](float argOPD) { return gpu_pr_sensitivityRGB(argOPD, ch); };
+        (&out.x)[ch] = tf::fresnelIridescenceChannel<true>(
+            1.f, c.thinFilmThickness, c.thinFilmIor, c.filmMetalN[ch], c.filmMetalK[ch],
+            c.filmMetalG[ch], cosI, nullptr, S);
+    }
+    return out;
+}
+// principled.cpp::thinFilmConductorSpectral — RGB-channel conductor F upsampled
+// to spectral (Cycles has no spectral n,k; plan §0.5 APPROXIMATED-equal-to-Cycles).
+__device__ inline GSampledSpectrum gpu_pr_thinFilmConductorSpectral(
+        const GPrincipledClosure& c, float cosI, const GSampledWavelengths& wl) {
+    GVec3 rgb = gpu_pr_thinFilmConductorRGB(c, cosI);
+    float maxc = fmaxf(fmaxf(fmaxf(rgb.x, rgb.y), rgb.z), 1.f);
+    GVec3 tint = rgb * (1.f / maxc);
+    return gpu_rgbToSampledSpectrum(tint, wl, GSPEC_RGB_ALBEDO) * maxc;
+}
+
 // --- VNDF sampling + micro-refraction (principled.cpp:187-229) -------------
 __device__ inline float gpu_pr_vndfPdf(const GVec3& N, const GVec3& wo, const GVec3& wm, float roughness) {
     float absCosO = fabsf(wo.dot(N));
@@ -1785,6 +1863,17 @@ __device__ inline GVec3 gpu_pr_transmissionEval(const GPrincipledClosure& c, con
         float D = gpu_pr_D_GTR2(wm.dot(rec.normal), alpha);
         // Height-correlated Smith G2 for the external-reflection sub-lobe (Cycles).
         float G = gpu_pr_smithG2(cosI, cosO, alpha);
+        if (gpu_pr_filmActive(c)) {
+            // pkg178 Stage 4 PR-3: thin-film iridescence F (Cycles single
+            // microfacet_fresnel at bsdf->ior = etap; specular_tint folded into f0
+            // via the F0-rescale, not a post-multiply).
+            float etapR = entering ? L.ior : (1.f / L.ior);
+            float filmIor = entering ? c.thinFilmIor : c.thinFilmIor / L.ior;
+            GVec3 F = gpu_pr_thinFilmFresnelRGB(c, HdotO, etapR, filmIor);
+            F = gpu_pr_thinFilmF0RescaleRGB(F, GVec3(gpu_pr_F0_from_ior(etapR)) * c.specularTint, etapR);
+            float geom = D * G / (4.f * cosO * cosI + 1e-8f) * cosI;
+            return L.weight * F * geom;
+        }
         float F = gpu_pr_fresnelDielectric(HdotO, 1.f, L.ior);
         float fr = D * G * F / (4.f * cosO * cosI + 1e-8f) * cosI;
         return L.weight * c.specularTint * fr;
@@ -1797,6 +1886,20 @@ __device__ inline GVec3 gpu_pr_transmissionEval(const GPrincipledClosure& c, con
     float D = gpu_pr_D_GTR2(fabsf(wm.dot(rec.normal)), alpha);
     // Height-correlated Smith G2 for the refraction sub-lobe (Cycles parity).
     float G = gpu_pr_smithG2(fabsf(cosI), fabsf(cosO), alpha);
+    if (gpu_pr_filmActive(c)) {
+        // pkg178 Stage 4 PR-3: transmittance = (1-F)·transmission_tint with the
+        // same iridescence F; film IOR backface-adjusted (÷bulk IOR).
+        float filmIor = entering ? c.thinFilmIor : c.thinFilmIor / L.ior;
+        GVec3 Fv = gpu_pr_thinFilmFresnelRGB(c, fabsf(wo.dot(wm)), etap, filmIor);
+        Fv = gpu_pr_thinFilmF0RescaleRGB(Fv, GVec3(gpu_pr_F0_from_ior(etap)) * c.specularTint, etap);
+        float den = wi.dot(wm) + wo.dot(wm) / etap;
+        den = den * den * cosI * cosO;
+        float ft = D * G * fabsf(wi.dot(wm) * wo.dot(wm) / (den + 1e-10f));
+        ft /= (etap * etap);
+        float scale = ft * fabsf(cosI) * gpu_ggxGlassCompensationFactor(L.roughness, etap, fabsf(cosO));
+        GVec3 res = L.weight * gpu_pr_sqrtColor(c.color) * (GVec3(1.f) - Fv) * scale;
+        return gvec3_max(res, GVec3(0.f));
+    }
     float F = gpu_pr_fresnelDielectric(fabsf(wo.dot(wm)), etaI, etaT);
     float den = wi.dot(wm) + wo.dot(wm) / etap;
     den = den * den * cosI * cosO;
@@ -1832,6 +1935,65 @@ __device__ inline float gpu_pr_transmissionPdf(const GPrincipledLobe& L, const G
     return (1.f - F) * gpu_pr_vndfPdf(rec.normal, wo, wm, L.roughness) * fabsf(HdotI) / d2;
 }
 
+// pkg178 Stage 4 PR-3 — per-λ native thin-film glass eval (film ONLY; the film-
+// free spectral path stays the Stage-3b upsample-of-RGB in gpu_pr_evalLobeSpectral).
+// Achromatic geometry × per-λ iridescence F (both faces; backface film-IOR adjust
+// ÷ bulk IOR). Exact mirror of principled.cpp::transmissionEvalSpectral.
+__device__ inline GSampledSpectrum gpu_pr_transmissionEvalSpectral(
+        const GPrincipledClosure& c, const GPrincipledLobe& L, const GHitRecord& rec,
+        const GVec3& wo, const GVec3& wi, const GSampledWavelengths& wl) {
+    if (L.isDelta) return GSampledSpectrum(0.f);
+    float cosO = rec.normal.dot(wo), cosI = rec.normal.dot(wi);
+    bool entering = rec.frontFace;
+    float alpha = fmaxf(L.roughness * L.roughness, 0.0064f);
+    float etap = entering ? L.ior : (1.f / L.ior);
+    float filmIor = entering ? c.thinFilmIor : c.thinFilmIor / L.ior;
+    float F0real = gpu_pr_F0_from_ior(etap);
+    GSampledSpectrum wSpec = gpu_rgbToSampledSpectrum(L.weight, wl, GSPEC_RGB_ALBEDO);
+    GSampledSpectrum tintSpec = gpu_rgbToSampledSpectrum(c.specularTint, wl, GSPEC_RGB_ALBEDO);
+    if (cosO > 0.f && cosI > 0.f) {  // reflection sub-lobe
+        GVec3 wm = (wo + wi).normalized();
+        if (wm.dot(rec.normal) < 0.f) wm = -wm;
+        float HdotO = wo.dot(wm);
+        if (HdotO <= 1e-10f) return GSampledSpectrum(0.f);
+        float D = gpu_pr_D_GTR2(wm.dot(rec.normal), alpha);
+        float G = gpu_pr_smithG2(cosI, cosO, alpha);
+        float geom = D * G / (4.f * cosO * cosI + 1e-8f) * cosI;
+        GSampledSpectrum F = gpu_pr_thinFilmFresnelSpectral(c, HdotO, etap, filmIor, wl);
+        GSampledSpectrum out(0.f);
+        for (int i = 0; i < G_SPECTRUM_SAMPLES; ++i) {
+            float Fi = (F0real > 1e-5f)
+                           ? gpu_pr_thinFilmF0RescaleChannel(F[i], F0real * tintSpec[i], F0real)
+                           : F[i];
+            out[i] = wSpec[i] * Fi * geom;
+        }
+        return out;
+    }
+    if (cosO * cosI >= 0.f) return GSampledSpectrum(0.f);
+    // transmission sub-lobe
+    GVec3 wm = (wi * etap + wo).normalized();
+    if (wm.dot(rec.normal) < 0.f) wm = -wm;
+    if (wm.dot(wi) * cosI < 0.f || wm.dot(wo) * cosO < 0.f) return GSampledSpectrum(0.f);
+    float D = gpu_pr_D_GTR2(fabsf(wm.dot(rec.normal)), alpha);
+    float G = gpu_pr_smithG2(fabsf(cosI), fabsf(cosO), alpha);
+    float den = wi.dot(wm) + wo.dot(wm) / etap;
+    den = den * den * cosI * cosO;
+    float ft = D * G * fabsf(wi.dot(wm) * wo.dot(wm) / (den + 1e-10f));
+    ft /= (etap * etap);
+    float scale = ft * fabsf(cosI) * gpu_ggxGlassCompensationFactor(L.roughness, etap, fabsf(cosO));
+    GSampledSpectrum F = gpu_pr_thinFilmFresnelSpectral(c, fabsf(wo.dot(wm)), etap, filmIor, wl);
+    GSampledSpectrum baseSpec = gpu_rgbToSampledSpectrum(gpu_pr_sqrtColor(c.color), wl, GSPEC_RGB_ALBEDO);
+    GSampledSpectrum out(0.f);
+    for (int i = 0; i < G_SPECTRUM_SAMPLES; ++i) {
+        float Fi = (F0real > 1e-5f)
+                       ? gpu_pr_thinFilmF0RescaleChannel(F[i], F0real * tintSpec[i], F0real)
+                       : F[i];
+        float v = wSpec[i] * baseSpec[i] * (1.f - Fi) * scale;
+        out[i] = v > 0.f ? v : 0.f;
+    }
+    return out;
+}
+
 // --- Per-lobe eval / pdf (principled.cpp:355-461) --------------------------
 __device__ inline GVec3 gpu_pr_evalLobe(const GPrincipledClosure& c, const GPrincipledLobe& L,
                                         const GHitRecord& rec, const GVec3& wo, const GVec3& wi) {
@@ -1857,8 +2019,17 @@ __device__ inline GVec3 gpu_pr_evalLobe(const GPrincipledClosure& c, const GPrin
         case GPR_SPECULAR: {
             if (nl <= 0.f || nv <= 0.f) return GVec3(0.f);
             GVec3 h = (wo + wi).normalized();
+            // Film-OFF statements FIRST, textually unchanged (byte-identical
+            // codegen + thickness-0 render); the film only OVERRIDES F afterward.
             float sHalf = gpu_pr_generalizedSchlickS(fabsf(wo.dot(h)), L.ior);
             GVec3 F = L.color + (GVec3(1.f) - L.color) * sHalf;
+            if (L.kind == GPR_SPECULAR && gpu_pr_filmActive(c)) {
+                // pkg178 Stage 4 PR-3: thin-film iridescence replaces the single-
+                // scatter Fresnel (Cycles generalized_schlick_fresnel thin-film
+                // branch). compFss stays FILM-FREE (L.color = specF0).
+                GVec3 Fraw = gpu_pr_thinFilmFresnelRGB(c, fabsf(wo.dot(h)), L.ior, c.thinFilmIor);
+                F = gpu_pr_thinFilmF0RescaleRGB(Fraw, L.color, L.ior);
+            }
             return L.weight * gpu_pr_ggxReflect(F, L.color, L.roughness,
                                                 L.anisotropic, L.anisoRotation, rec, wo, wi);
         }
@@ -1866,9 +2037,17 @@ __device__ inline GVec3 gpu_pr_evalLobe(const GPrincipledClosure& c, const GPrin
             if (nl <= 0.f || nv <= 0.f) return GVec3(0.f);
             GVec3 h = (wo + wi).normalized();
             float ci = fminf(fmaxf(wo.dot(h), 0.f), 1.f);
+            // Film-OFF statements FIRST, textually unchanged (thickness-0 bit-
+            // equality); the film only OVERRIDES F.
             GVec3 F(gpu_pr_f82Channel(ci, L.color.x, c.specularTint.x),
                     gpu_pr_f82Channel(ci, L.color.y, c.specularTint.y),
                     gpu_pr_f82Channel(ci, L.color.z, c.specularTint.z));
+            if (gpu_pr_filmActive(c)) {
+                // pkg178 Stage 4 PR-3: thin-film iridescence over the conductor
+                // substrate replaces the single-scatter F82. compFss (L.color)
+                // stays FILM-FREE.
+                F = gpu_pr_thinFilmConductorRGB(c, ci);
+            }
             return L.weight * gpu_pr_ggxReflect(F, L.color, L.roughness,
                                                 L.anisotropic, L.anisoRotation, rec, wo, wi);
         }
@@ -1940,9 +2119,19 @@ __device__ inline GSampledSpectrum gpu_pr_evalLobeSpectral(const GPrincipledClos
         case GPR_SPECULAR: {
             if (nl <= 0.f || nv <= 0.f) return GSampledSpectrum(0.f);
             GVec3 h = (wo + wi).normalized();
+            // Film-OFF statements FIRST, textually unchanged; the film only OVERRIDES F.
             float sHalf = gpu_pr_generalizedSchlickS(fabsf(wo.dot(h)), L.ior);
             GSampledSpectrum f0 = gpu_rgbToSampledSpectrum(L.color, wl, GSPEC_RGB_ALBEDO);
             GSampledSpectrum F = f0 + (GSampledSpectrum(1.f) - f0) * sHalf;
+            if (L.kind == GPR_SPECULAR && gpu_pr_filmActive(c)) {
+                // pkg178 Stage 4 PR-3: per-λ native thin-film iridescence (analytic
+                // sensitivity, no LUT). compFss (f0) stays film-free.
+                F = gpu_pr_thinFilmFresnelSpectral(c, fabsf(wo.dot(h)), L.ior, c.thinFilmIor, wl);
+                float F0real = gpu_pr_F0_from_ior(L.ior);
+                if (F0real > 1e-5f)
+                    for (int i = 0; i < G_SPECTRUM_SAMPLES; ++i)
+                        F[i] = gpu_pr_thinFilmF0RescaleChannel(F[i], f0[i], F0real);
+            }
             return wSpec * gpu_pr_ggxReflectSpectral(F, f0, L.roughness,
                                                      L.anisotropic, L.anisoRotation, rec, wo, wi);
         }
@@ -1951,14 +2140,24 @@ __device__ inline GSampledSpectrum gpu_pr_evalLobeSpectral(const GPrincipledClos
             GVec3 h = (wo + wi).normalized();
             float ci = fminf(fmaxf(wo.dot(h), 0.f), 1.f);
             GSampledSpectrum f0 = gpu_rgbToSampledSpectrum(L.color, wl, GSPEC_RGB_ALBEDO);
+            // Film-OFF statements FIRST, textually unchanged; the film only OVERRIDES F.
             GSampledSpectrum tint = gpu_rgbToSampledSpectrum(c.specularTint, wl, GSPEC_RGB_ALBEDO);
             GSampledSpectrum F(0.f);
             for (int i = 0; i < G_SPECTRUM_SAMPLES; ++i)
                 F[i] = gpu_pr_f82Channel(ci, f0[i], tint[i]);
+            if (gpu_pr_filmActive(c)) {
+                // pkg178 Stage 4 PR-3: conductor thin-film F (RGB-channel n,k
+                // upsampled — plan §0.5 APPROXIMATED-equal-to-Cycles). compFss
+                // (f0) stays film-free.
+                F = gpu_pr_thinFilmConductorSpectral(c, ci, wl);
+            }
             return wSpec * gpu_pr_ggxReflectSpectral(F, f0, L.roughness,
                                                      L.anisotropic, L.anisoRotation, rec, wo, wi);
         }
         case GPR_TRANSMISSION: {
+            // pkg178 Stage 4 PR-3: with the film ON, evaluate F per-λ natively
+            // (pkg163 discipline); OFF path is the exact Stage-3b upsample hack.
+            if (gpu_pr_filmActive(c)) return gpu_pr_transmissionEvalSpectral(c, L, rec, wo, wi, wl);
             // Colour upsampled; achromatic geometry/Fresnel scalar per-λ (principled.cpp:664-672).
             GVec3 rgb = gpu_pr_transmissionEval(c, L, rec, wo, wi);
             if (rgb.x <= 0.f && rgb.y <= 0.f && rgb.z <= 0.f) return GSampledSpectrum(0.f);

--- a/include/astroray/gpu_thin_film_table.cuh
+++ b/include/astroray/gpu_thin_film_table.cuh
@@ -1,0 +1,37 @@
+#pragma once
+// pkg178 Stage 4 PR-3 — GPU upload of the Rec.709-baked thin-film CIE
+// sensitivity LUT (astroray::thinfilm::kThinFilmCieTable, thin_film_cie_table.h).
+//
+// The RGB legs of the thin-film iridescence Fresnel (gpu_materials.h
+// gpu_pr_thinFilm*RGB / *Spectral-conductor) need the [512][6] CIE sensitivity
+// table on-device. It lives in device GLOBAL memory (not __constant__), uploaded
+// once by uploadThinFilmTable() — mirrors the pkg151 glass / pkg152 ggx table
+// pattern in gpu_ggx_tables.cuh/.cu EXACTLY (same rationale: gpu_materials.h is
+// included by many .cu translation units, so a single extern global pointer
+// avoids constant-memory duplication / device-linker multiple-definition errors).
+//
+// Same data + citations as include/astroray/thin_film_cie_table.h (Cycles
+// table_thin_film_cmf, Apache-2.0; Belcour & Barla 2017). Layout [512][6] =
+// {re_R, re_G, re_B, im_R, im_G, im_B}, flattened row-major for the device copy.
+//
+// Only include this from .cu files compiled by nvcc.
+
+#include "gpu_types.h"
+#include "thin_film_fresnel.h"
+#include <cuda_runtime.h>
+
+// Defined once in gpu_thin_film_table.cu; populated by uploadThinFilmTable().
+// Flat [512*6] row-major (== kThinFilmCieTable[512][6]).
+extern __device__ const float* g_thinFilmCie;
+
+// Host-callable one-time upload (defined in gpu_thin_film_table.cu); copies the
+// same host-side kThinFilmCieTable data the CPU sensitivityRGB reads.
+void uploadThinFilmTable();
+
+// Device sensitivity provider (RGB leg) — reinterprets the flat device pointer
+// back into [.][6] and forwards to the SHARED core (thin_film_fresnel.h
+// sensitivityRGB), so the GPU RGB leg is byte-identical to the CPU one.
+__device__ inline astroray::thinfilm::TFComplex gpu_pr_sensitivityRGB(float argOPD, int channel) {
+    return astroray::thinfilm::sensitivityRGB(
+        argOPD, channel, reinterpret_cast<const float (*)[6]>(g_thinFilmCie));
+}

--- a/include/astroray/gpu_types.h
+++ b/include/astroray/gpu_types.h
@@ -468,6 +468,18 @@ struct GPrincipledClosure {
     float anisotropicRotation;
     // pkg178 Stage-3b PR-6 — alpha transparency (1 → opaque, no transparent lobe).
     float alpha;
+    // pkg178 Stage 4 PR-3 — thin-film iridescence (GPU twin of the CPU work in
+    // principled.cpp PR-1/PR-2; Belcour-Barla 2017, see thin_film_fresnel.h).
+    // thickness ≤ 0.1nm cutoff → film OFF, byte-identical to PR-6. The per-RGB-
+    // channel conductor (n,k) + F82 value g are HOST-precomputed at upload
+    // (scene_upload.cu) from (base_color, specular_tint) via the Gulbrandsen
+    // inversion — exact mirror of principled.cpp::precomputeConductorNK (never
+    // recomputed per hit; plan §0 decision 5).
+    float thinFilmThickness = 0.f;      // Cycles thin_film_thickness (nm)
+    float thinFilmIor = 1.33f;          // Cycles thin_film_ior
+    float filmMetalN[3] = {0.f, 0.f, 0.f};  // conductor n per RGB channel
+    float filmMetalK[3] = {0.f, 0.f, 0.f};  // conductor k per RGB channel
+    float filmMetalG[3] = {0.f, 0.f, 0.f};  // F82 reflectance g = fresnel_f82(1/7)
 };
 
 // pkg54a: layout for the device-side spectral profile table. Profiles are

--- a/include/astroray/gpu_types.h
+++ b/include/astroray/gpu_types.h
@@ -470,16 +470,18 @@ struct GPrincipledClosure {
     float alpha;
     // pkg178 Stage 4 PR-3 — thin-film iridescence (GPU twin of the CPU work in
     // principled.cpp PR-1/PR-2; Belcour-Barla 2017, see thin_film_fresnel.h).
-    // thickness ≤ 0.1nm cutoff → film OFF, byte-identical to PR-6. The per-RGB-
-    // channel conductor (n,k) + F82 value g are HOST-precomputed at upload
-    // (scene_upload.cu) from (base_color, specular_tint) via the Gulbrandsen
-    // inversion — exact mirror of principled.cpp::precomputeConductorNK (never
-    // recomputed per hit; plan §0 decision 5).
+    // thickness ≤ 0.1nm cutoff → film OFF, byte-identical to PR-6. Only two floats
+    // (+8 B): the metallic-lobe conductor (n,k,g) are recomputed ON-DEVICE per hit
+    // inside the thin-film path (gpu_pr_thinFilmConductorRGB, <true> only), NOT
+    // stored here. Storing 9 more floats inflated GMaterial, which the SHARED
+    // closure-graph path stack-copies by value, so the non-principled <false>
+    // kernel paid +320 B STACK for data it never reads (measured regression:
+    // 3608→3928 B, +6.1% perf; same data-leak class as the Stage-3 data-iso
+    // finding). The per-hit Gulbrandsen inversion now lands only in <true> (which
+    // has budget). CPU (PR-2) keeps its plugin-stored precompute — this is a
+    // GPU-only trade-off (register/stack over a per-hit recompute).
     float thinFilmThickness = 0.f;      // Cycles thin_film_thickness (nm)
     float thinFilmIor = 1.33f;          // Cycles thin_film_ior
-    float filmMetalN[3] = {0.f, 0.f, 0.f};  // conductor n per RGB channel
-    float filmMetalK[3] = {0.f, 0.f, 0.f};  // conductor k per RGB channel
-    float filmMetalG[3] = {0.f, 0.f, 0.f};  // F82 reflectance g = fresnel_f82(1/7)
 };
 
 // pkg54a: layout for the device-side spectral profile table. Profiles are

--- a/src/gpu/gpu_thin_film_table.cu
+++ b/src/gpu/gpu_thin_film_table.cu
@@ -1,0 +1,47 @@
+// gpu_thin_film_table.cu — pkg178 Stage 4 PR-3.
+//
+// Definition + one-time upload for the thin-film CIE sensitivity table declared
+// in include/astroray/gpu_thin_film_table.cuh. Copies the Rec.709-baked
+// astroray::thinfilm::kThinFilmCieTable ([512][6], thin_film_cie_table.h) into
+// device global memory, mirroring the pkg152 gpu_ggx_tables.cu upload pattern
+// exactly (same data/citations: Cycles table_thin_film_cmf, Apache-2.0;
+// Belcour & Barla 2017).
+
+#include "astroray/gpu_thin_film_table.cuh"
+#include "astroray/thin_film_cie_table.h"
+
+#include <cuda_runtime.h>
+#include <cstddef>
+#include <cstdio>
+#include <stdexcept>
+
+__device__ const float* g_thinFilmCie = nullptr;
+
+// Host-side ownership of the device allocation; freed only on process exit
+// (read-only table, re-uploading would be wasteful) — same lifetime policy as
+// gpu_ggx_tables.cu's s_ggxEDev.
+static float* s_thinFilmCieDev = nullptr;
+
+void uploadThinFilmTable() {
+    static bool uploaded = false;
+    if (uploaded) return;
+
+    constexpr int kCount = astroray::thinfilm::kThinFilmTableSize * 6;  // 512*6
+    const size_t bytes = size_t(kCount) * sizeof(float);
+    // kThinFilmCieTable is [512][6] contiguous — flatten row-major.
+    const float* host = &astroray::thinfilm::kThinFilmCieTable[0][0];
+
+    cudaError_t e = cudaMalloc(reinterpret_cast<void**>(&s_thinFilmCieDev), bytes);
+    if (e == cudaSuccess) {
+        e = cudaMemcpy(s_thinFilmCieDev, host, bytes, cudaMemcpyHostToDevice);
+    }
+    if (e == cudaSuccess) {
+        e = cudaMemcpyToSymbol(g_thinFilmCie, &s_thinFilmCieDev, sizeof(float*));
+    }
+    if (e != cudaSuccess) {
+        fprintf(stderr, "uploadThinFilmTable failed: %s\n", cudaGetErrorString(e));
+        throw std::runtime_error(cudaGetErrorString(e));
+    }
+
+    uploaded = true;
+}

--- a/src/gpu/scene_upload.cu
+++ b/src/gpu/scene_upload.cu
@@ -175,6 +175,43 @@ static GMaterial convertMaterial(const std::shared_ptr<Material>& mat) {
                 gp.anisotropic = c.anisotropic;                 // pkg178 PR-4b
                 gp.anisotropicRotation = c.anisotropicRotation;
                 gp.alpha = c.alpha;                             // pkg178 PR-6
+                // pkg178 Stage 4 PR-3 — thin-film iridescence params + HOST
+                // precompute of the metallic-lobe conductor (n,k,g). EXACT mirror
+                // of principled.cpp::precomputeConductorNK (Gulbrandsen "Artist
+                // Friendly Metallic Fresnel", JCGT 2014; Cycles bsdf_microfacet.h
+                // :365-383). Depends only on per-material constants (base_color,
+                // specular_tint) → computed ONCE here, never per hit (plan §0.5).
+                gp.thinFilmThickness = c.thinFilmThickness;
+                gp.thinFilmIor = c.thinFilmIor;
+                for (int ch = 0; ch < 3; ++ch) {
+                    const float f0 = (&c.color.x)[ch];
+                    const float tint = (&c.specularTint.x)[ch];
+                    const float r = std::min(f0, 0.999f);
+                    // g = f82Channel(1/7, f0, tint) — the metallic lobe's own F82
+                    // evaluation at cosθ=1/7 (principled.cpp::f82Channel/f82BChannel).
+                    const float ff = 6.0f / 7.0f;
+                    const float f5 = (ff * ff) * (ff * ff) * ff;
+                    const float FsB = f0 + (1.0f - f0) * f5;           // mix(F0,1,f5)
+                    const float B = FsB * (7.0f / (f5 * ff)) * (1.0f - tint);
+                    const float cosi = 1.0f / 7.0f;
+                    float sC = 1.0f - cosi;
+                    sC = sC < 0.0f ? 0.0f : (sC > 1.0f ? 1.0f : sC);
+                    const float s5 = (sC * sC) * (sC * sC) * sC;
+                    const float FsS = f0 + (1.0f - f0) * s5;           // mix(F0,1,s5)
+                    float g = FsS - B * cosi * s5 * sC;
+                    g = g < 0.0f ? 0.0f : (g > 1.0f ? 1.0f : g);
+                    // n = mix((1+√r)/(1−√r), (1−r)/(1+r), g);
+                    // k = safe_sqrt((r(n+1)²−(n−1)²)/(1−r)).
+                    const float sqrtR = std::sqrt(r);
+                    const float nLo = (1.0f + sqrtR) / (1.0f - sqrtR);
+                    const float nHi = (1.0f - r) / (1.0f + r);
+                    const float n = nLo + (nHi - nLo) * g;
+                    const float kNum = r * (n + 1.0f) * (n + 1.0f) - (n - 1.0f) * (n - 1.0f);
+                    const float k = std::sqrt(std::max(0.0f, kNum / (1.0f - r)));
+                    gp.filmMetalN[ch] = n;
+                    gp.filmMetalK[ch] = k;
+                    gp.filmMetalG[ch] = g;
+                }
             }
             g.closures[i] = gc;
         }

--- a/src/gpu/scene_upload.cu
+++ b/src/gpu/scene_upload.cu
@@ -175,43 +175,15 @@ static GMaterial convertMaterial(const std::shared_ptr<Material>& mat) {
                 gp.anisotropic = c.anisotropic;                 // pkg178 PR-4b
                 gp.anisotropicRotation = c.anisotropicRotation;
                 gp.alpha = c.alpha;                             // pkg178 PR-6
-                // pkg178 Stage 4 PR-3 — thin-film iridescence params + HOST
-                // precompute of the metallic-lobe conductor (n,k,g). EXACT mirror
-                // of principled.cpp::precomputeConductorNK (Gulbrandsen "Artist
-                // Friendly Metallic Fresnel", JCGT 2014; Cycles bsdf_microfacet.h
-                // :365-383). Depends only on per-material constants (base_color,
-                // specular_tint) → computed ONCE here, never per hit (plan §0.5).
+                // pkg178 Stage 4 PR-3 — thin-film iridescence params. Only the two
+                // scalars are uploaded; the metallic-lobe conductor (n,k,g) are
+                // recomputed ON-DEVICE per hit inside gpu_pr_thinFilmConductorRGB
+                // (<true> only) rather than stored in GPrincipledClosure — storing
+                // them inflated GMaterial and leaked +320 B STACK into the shared
+                // non-principled <false> kernel via its by-value copy. See the
+                // GPrincipledClosure comment in gpu_types.h.
                 gp.thinFilmThickness = c.thinFilmThickness;
                 gp.thinFilmIor = c.thinFilmIor;
-                for (int ch = 0; ch < 3; ++ch) {
-                    const float f0 = (&c.color.x)[ch];
-                    const float tint = (&c.specularTint.x)[ch];
-                    const float r = std::min(f0, 0.999f);
-                    // g = f82Channel(1/7, f0, tint) — the metallic lobe's own F82
-                    // evaluation at cosθ=1/7 (principled.cpp::f82Channel/f82BChannel).
-                    const float ff = 6.0f / 7.0f;
-                    const float f5 = (ff * ff) * (ff * ff) * ff;
-                    const float FsB = f0 + (1.0f - f0) * f5;           // mix(F0,1,f5)
-                    const float B = FsB * (7.0f / (f5 * ff)) * (1.0f - tint);
-                    const float cosi = 1.0f / 7.0f;
-                    float sC = 1.0f - cosi;
-                    sC = sC < 0.0f ? 0.0f : (sC > 1.0f ? 1.0f : sC);
-                    const float s5 = (sC * sC) * (sC * sC) * sC;
-                    const float FsS = f0 + (1.0f - f0) * s5;           // mix(F0,1,s5)
-                    float g = FsS - B * cosi * s5 * sC;
-                    g = g < 0.0f ? 0.0f : (g > 1.0f ? 1.0f : g);
-                    // n = mix((1+√r)/(1−√r), (1−r)/(1+r), g);
-                    // k = safe_sqrt((r(n+1)²−(n−1)²)/(1−r)).
-                    const float sqrtR = std::sqrt(r);
-                    const float nLo = (1.0f + sqrtR) / (1.0f - sqrtR);
-                    const float nHi = (1.0f - r) / (1.0f + r);
-                    const float n = nLo + (nHi - nLo) * g;
-                    const float kNum = r * (n + 1.0f) * (n + 1.0f) - (n - 1.0f) * (n - 1.0f);
-                    const float k = std::sqrt(std::max(0.0f, kNum / (1.0f - r)));
-                    gp.filmMetalN[ch] = n;
-                    gp.filmMetalK[ch] = k;
-                    gp.filmMetalG[ch] = g;
-                }
             }
             g.closures[i] = gc;
         }

--- a/src/gpu/wavefront/gpu_wavefront_snapshot.cu
+++ b/src/gpu/wavefront/gpu_wavefront_snapshot.cu
@@ -38,6 +38,11 @@ void uploadProfileTable(const float* host, int count);
 // gpu_ggxCompensationFactor/DirectionalAlbedo/sheen/clearcoat lookups.
 void uploadGgxTables();
 
+// pkg178 Stage 4 PR-3: thin-film CIE sensitivity LUT (gpu_thin_film_table.cu) —
+// required by the principled thin-film RGB legs (gpu_pr_thinFilm*RGB / conductor
+// spectral). No-op unless a principled material has thin_film_thickness > 0.1nm.
+void uploadThinFilmTable();
+
 // pkg55-C5 / pkg113: photon caustic grid structures.
 #include "astroray/gpu_photon_caustic.h"
 #include "astroray/gpu_photon_store.h"
@@ -1467,6 +1472,7 @@ std::vector<float> cuda_wavefront_render(
     // silently off; pkg54a NIR/UV profile override broken).
     uploadGgxGlassTables();
     uploadGgxTables();  // pkg152 (#523) — re-homed from the deleted render()
+    uploadThinFilmTable();  // pkg178 Stage 4 PR-3 — thin-film CIE sensitivity LUT
     if (res.profileCount > 0)
         uploadProfileTable(res.profileTable.data(), res.profileCount);
 
@@ -1814,6 +1820,7 @@ std::vector<float> cuda_wavefront_render_restir(
     uploadJakobHanikaLut();
     uploadGgxGlassTables();  // pkg55-C7: see cuda_wavefront_render note
     uploadGgxTables();       // pkg152 (#523)
+    uploadThinFilmTable();   // pkg178 Stage 4 PR-3 — thin-film CIE sensitivity LUT
 
     // ReSTIR-DI is visible-band spectral (matches the CPU restir_di).
     const float lambdaMin = 380.0f, lambdaMax = 780.0f;

--- a/tests/test_pkg178_thinfilm_gpu_cpu_parity.py
+++ b/tests/test_pkg178_thinfilm_gpu_cpu_parity.py
@@ -124,10 +124,15 @@ def test_thinfilm_zero_thickness_bit_identity(params):
     off = _render(use_gpu=True, params=params)
     zero = _render(use_gpu=True, params={**params, "thin_film_thickness": 0.0,
                                          "thin_film_ior": FILM_IOR})
-    assert np.array_equal(off, zero), (
-        "pkg178 PR-3 thickness-0 GPU bit-identity FAILED: film-off and "
-        "thickness=0 renders differ (max abs diff "
-        f"{np.max(np.abs(off - zero)):.3e}) -- the film no-op guard is broken.")
+    # Two SEPARATE GPU renders are not byte-identical to each other (atomic
+    # accumulation ordering, ~1.2e-7 floor -- the wavefront isn't self-identical,
+    # memory pkg157). The no-op guard is that thickness=0 stays AT that floor,
+    # not above it (verified: off-vs-off == off-vs-thickness0 == 1.19e-7).
+    diff = float(np.max(np.abs(off - zero)))
+    assert diff <= 1e-6, (
+        "pkg178 PR-3 thickness-0 GPU no-op FAILED: film-off and thickness=0 "
+        f"renders differ by {diff:.3e} > 1e-6 (atomic floor ~1.2e-7) -- the "
+        "film no-op guard is broken.")
 
 
 @pytest.mark.parametrize("label,params", CASES, ids=[c[0] for c in CASES])

--- a/tests/test_pkg178_thinfilm_gpu_cpu_parity.py
+++ b/tests/test_pkg178_thinfilm_gpu_cpu_parity.py
@@ -1,0 +1,172 @@
+"""pkg178 Stage 4 PR-3 — thin-film iridescence GPU(wavefront) <-> CPU parity
+plus the thickness-0 GPU bit-identity no-op guard.
+
+DRAFTED by the package-implementer, NOT YET RUN: subagents on this machine
+cannot build CUDA, so the GPU leg has never executed. The building/verifying
+LEAD must run this after `build_cuda_worktree.bat` and record the measured
+per-channel numbers in the PR. See the module footer for the exact commands.
+
+Why this file exists
+--------------------
+PR-3 lands the GPU twin of the CPU thin-film work (PR-1 dielectric, PR-2
+conductor). The device code (gpu_pr_thinFilm* in include/astroray/gpu_materials.h)
+calls the SAME shared Belcour-Barla core (include/astroray/thin_film_fresnel.h)
+as plugins/materials/principled.cpp, with the conductor (n,k,g) host-precomputed
+at upload (scene_upload.cu) exactly as principled.cpp::precomputeConductorNK. So
+CPU<->GPU should match TIGHTLY — this is the gate that proves the two legs agree.
+
+Two gates here:
+  1. test_thinfilm_zero_thickness_bit_identity — the load-bearing no-op: a GPU
+     render with thin_film_thickness=0 must be BYTE-identical to the same GPU
+     render with no thin-film param at all (film gated OFF below the 0.1nm
+     cutoff, so the eval path is textually unchanged from PR-6).
+  2. test_thinfilm_gpu_cpu_parity — dielectric specular / glass transmission /
+     metallic spheres across a thickness sweep, per-channel mean + ratio-of-
+     medians inside the band (ratio-of-medians, not median-of-ratios, because the
+     backends draw independent MC streams; memory
+     ssim-wrong-gate-for-independent-rng).
+
+Bands are PROVISIONAL scaffolding: [0.95, 1.05] is the target for a genuinely
+matched material (same math both legs). The lead re-measures on RTX and either
+confirms the band or documents a per-row exception with a cause (do NOT loosen
+silently). The RGB<->spectral hue difference is by construction and NOT gated
+here (pkg128 §B); this test renders RGB on both legs.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+
+try:
+    import astroray
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray not built")
+
+if AVAILABLE and not astroray.__features__.get("cuda", False):
+    pytest.skip(
+        "CUDA feature not in this build -- pkg178 thin-film GPU/CPU parity "
+        "needs the RTX box (LEAD runs this).",
+        allow_module_level=True,
+    )
+
+WIDTH = HEIGHT = 48
+SAMPLES = 256
+MAX_DEPTH = 6
+SEED = 178403
+
+ALBEDO = [0.82, 0.66, 0.34]
+BACKGROUND = [0.35, 0.45, 0.60]
+
+RATIO_LOW = 0.95
+RATIO_HIGH = 1.05
+
+# thin_film_ior 1.4 (soap-ish); thickness sweep in nm. Each base material gets
+# the same sweep so a lobe-specific divergence shows as a whole-column failure.
+FILM_IOR = 1.4
+THICKNESSES = [200.0, 550.0, 1200.0]
+
+BASE_CASES = [
+    ("dielectric_spec", {"metallic": 0.0, "roughness": 0.25}),
+    ("glass_r0.2", {"metallic": 0.0, "transmission_weight": 1.0, "ior": 1.5, "roughness": 0.2}),
+    ("metallic_r0.3", {"metallic": 1.0, "roughness": 0.3}),
+]
+
+CASES = []
+for _label, _base in BASE_CASES:
+    for _d in THICKNESSES:
+        _p = dict(_base)
+        _p["thin_film_thickness"] = _d
+        _p["thin_film_ior"] = FILM_IOR
+        CASES.append((f"{_label}_d{int(_d)}", _p))
+
+
+def _make_scene(use_gpu: bool, params: dict):
+    r = astroray.Renderer()
+    r.set_background_color(BACKGROUND)
+    mat = r.create_material("principled", ALBEDO, params)
+    r.add_sphere([0.0, 0.0, 0.0], 0.9, mat)
+    r.setup_camera([0.0, 0.0, 1.35], [0.0, 0.0, 0.0], [0.0, 1.0, 0.0],
+                   60.0, WIDTH / HEIGHT, 0.0, 1.35, WIDTH, HEIGHT)
+    r.set_integrator("path_tracer")
+    r.set_integrator_param("max_depth", MAX_DEPTH)
+    if use_gpu:
+        r.set_use_gpu(True)
+    return r
+
+
+def _render(use_gpu: bool, params: dict) -> np.ndarray:
+    r = _make_scene(use_gpu=use_gpu, params=params)
+    r.set_seed(SEED)
+    # 4th positional arg is applyGamma -- False keeps both sides linear
+    # (memory gamma-vs-linear-comparison-artifact).
+    return np.asarray(r.render(SAMPLES, MAX_DEPTH, None, False), dtype=np.float64)
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"metallic": 0.0, "roughness": 0.25},
+        {"metallic": 1.0, "roughness": 0.3},
+        {"metallic": 0.0, "transmission_weight": 1.0, "ior": 1.5, "roughness": 0.2},
+    ],
+    ids=["dielectric_spec", "metallic", "glass"],
+)
+def test_thinfilm_zero_thickness_bit_identity(params):
+    """The load-bearing no-op: GPU with thin_film_thickness=0 == GPU with no
+    thin-film param at all (film gated off below the 0.1nm cutoff)."""
+    off = _render(use_gpu=True, params=params)
+    zero = _render(use_gpu=True, params={**params, "thin_film_thickness": 0.0,
+                                         "thin_film_ior": FILM_IOR})
+    assert np.array_equal(off, zero), (
+        "pkg178 PR-3 thickness-0 GPU bit-identity FAILED: film-off and "
+        "thickness=0 renders differ (max abs diff "
+        f"{np.max(np.abs(off - zero)):.3e}) -- the film no-op guard is broken.")
+
+
+@pytest.mark.parametrize("label,params", CASES, ids=[c[0] for c in CASES])
+def test_thinfilm_gpu_cpu_parity(label, params):
+    gpu = _render(use_gpu=True, params=params)
+    cpu = _render(use_gpu=False, params=params)
+
+    assert gpu.shape == (HEIGHT, WIDTH, 3)
+    assert cpu.shape == (HEIGHT, WIDTH, 3)
+    assert np.all(np.isfinite(gpu)), "GPU render produced NaN/Inf"
+    assert np.all(np.isfinite(cpu)), "CPU render produced NaN/Inf"
+
+    rows = []
+    for c, ch in enumerate("RGB"):
+        cpu_mean, gpu_mean = float(cpu[..., c].mean()), float(gpu[..., c].mean())
+        cpu_med, gpu_med = float(np.median(cpu[..., c])), float(np.median(gpu[..., c]))
+        mr = gpu_mean / cpu_mean if cpu_mean > 1e-8 else float("nan")
+        medr = gpu_med / cpu_med if cpu_med > 1e-8 else float("nan")
+        rows.append((ch, cpu_mean, gpu_mean, mr, cpu_med, gpu_med, medr))
+
+    print(f"\n[pkg178 thin-film GPU/CPU parity] case={label} "
+          f"band=[{RATIO_LOW}, {RATIO_HIGH}]")
+    for ch, cm, gm, mr, cmed, gmed, medr in rows:
+        print(f"  {ch}: mean cpu={cm:.5f} gpu={gm:.5f} ratio={mr:.4f} | "
+              f"median cpu={cmed:.5f} gpu={gmed:.5f} ratio={medr:.4f}")
+
+    for ch, cm, gm, mr, cmed, gmed, medr in rows:
+        assert RATIO_LOW <= mr <= RATIO_HIGH, (
+            f"pkg178 thin-film GPU/CPU MEAN parity FAILED case={label} "
+            f"channel {ch}: ratio {mr:.4f} outside [{RATIO_LOW}, {RATIO_HIGH}] "
+            f"(cpu={cm:.5f}, gpu={gm:.5f})")
+        assert RATIO_LOW <= medr <= RATIO_HIGH, (
+            f"pkg178 thin-film GPU/CPU MEDIAN parity FAILED case={label} "
+            f"channel {ch}: ratio {medr:.4f} outside [{RATIO_LOW}, {RATIO_HIGH}] "
+            f"(cpu={cmed:.5f}, gpu={gmed:.5f})")
+
+
+# ===========================================================================
+# LEAD RUN COMMANDS (after build_cuda_worktree.bat, on the RTX box):
+#   pytest tests/test_pkg178_thinfilm_gpu_cpu_parity.py -v -s
+# The -s flag surfaces the per-channel measured ratios to paste into the PR.
+# ===========================================================================


### PR DESCRIPTION
## pkg178 Stage 4 PR-3 — GPU thin-film (dielectric + conductor)

Byte-mirrors the CPU thin-film (PR-1 dielectric + PR-2 conductor) onto the GPU wavefront: same shared `thin_film_fresnel.h` device functions, CIE LUT uploaded like `gpu_ggx_tables`, all inside the `template<bool HasPrincipled>` `<true>` instantiation. Conductor (n,k) recomputed **on-GPU per-hit** (Gulbrandsen) rather than stored — see below.

### Register/perf — non-principled pays nothing
Initial impl stored 9 conductor floats in `GPrincipledClosure`, which inflated the by-value `GMaterial` copy in the shared path → `<false>` 3608→3928 B, +6% non-principled regression. **Fixed** by recomputing (n,k) on-GPU in `<true>`:
- `<false>` STACK **3608 B** (baseline, leak eliminated); non-principled perf **639 ms** (~baseline, +0.7% noise).
- `<true>` STACK **6816 B** (thin-film, principled-only; *lower* than the pre-fix 7072, well under 7696).

### Verified (RTX 5070 Ti)
- First device compilation of `thin_film_fresnel.h` — compiles clean.
- thickness-0 GPU no-op: off vs thickness=0 diff **1.19e-7 = the atomic floor** (== off-vs-off), i.e. a true no-op (test assertion corrected from `array_equal` to the atomic tolerance — the wavefront isn't self-byte-identical, pkg157).
- CPU↔GPU parity sweep (dielectric/glass/metallic × thickness): **12 passed**; GPU furnace green.
- Visual: iridescence present + hue cycles with thickness (subtle under flat standalone lighting; the vivid HDRI showcase comes via Blender after PR-5).

Follow-up (filed): the by-value `GMaterial` copy in the shared closure-graph loop is the recurring data-leak (Stage-3, GTriangle, this) — killing it permanently belongs in Phase-2 stabilization. PR-4 = thin wall; PR-5 = addon sockets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)