### PR TITLE
feat(pkg178 Stage 5): Blender Principled node → native material, incl. thin-film sockets

### DIFF
--- a/.astroray_plan/packages/pkg178-native-cycles-principled-bsdf.md
+++ b/.astroray_plan/packages/pkg178-native-cycles-principled-bsdf.md
@@ -166,9 +166,21 @@ one harness sweep flag-off vs flag-on, diffing `triage_report.json`.
       the Stage-0-declared band (visual + per-channel ratio); conductor
       + dielectric both covered. Thin Wall: paper/leaf/window-sheet trio
       matches Blender 5.2 Cycles.
-- [ ] Addon flag routes Principled nodes to the native material; Disney
+- [x] Addon flag routes Principled nodes to the native material; Disney
       path intact; zero silently-dropped sockets on the flagged path
-      (report line per pkg119-C).
+      (report line per pkg119-C). — Stage 5 addon switch DONE on branch
+      `pkg178-stage5` (2026-08-09): `use_native_principled` bool (default ON,
+      experimental), one flag-aware helper replaces both `'disney'` literals
+      (live spec path + `convert_principled_bsdf_v2`); 22-socket Blender→native
+      map incl. renamed-input fallbacks; alpha routes to the native `alpha`
+      param (transmission conflation retired on the flagged path);
+      `shader_blending` carries native_params through Mix/Add; pkg119-C gap
+      report for thin-film/thin-wall/subsurface. Verified headless on Blender
+      5.2: a metallic+coat+sheen+aniso+alpha Principled node routes to
+      `create_material('principled', ...)` with all params mapped
+      (alpha=0.85 real, transmission_weight=0.0), render finite/non-black
+      (nonblack_frac 1.000, mean_lum 0.098). On-HW native-vs-Cycles parity
+      matrix (auto-flip gate) is LEAD-DEFERRED, separate from this routing.
 - [ ] No wavefront perf regression on non-principled scenes; register
       report attached to every GPU-stage PR.
 - [ ] Every ported formula cites its Cycles file/function or paper.

--- a/.astroray_plan/packages/pkg178-native-cycles-principled-bsdf.md
+++ b/.astroray_plan/packages/pkg178-native-cycles-principled-bsdf.md
@@ -181,6 +181,17 @@ one harness sweep flag-off vs flag-on, diffing `triage_report.json`.
       (alpha=0.85 real, transmission_weight=0.0), render finite/non-black
       (nonblack_frac 1.000, mean_lum 0.098). On-HW native-vs-Cycles parity
       matrix (auto-flip gate) is LEAD-DEFERRED, separate from this routing.
+      **Thin-film wiring finalized on branch `pkg178-stage5-final` (2026-08-10,
+      rebased clean onto main post-Stage-4):** `Thin Film Thickness`→
+      `thin_film_thickness`, `Thin Film IOR`→`thin_film_ior`, `Thin Wall`(bool)→
+      `thin_wall`, `Subsurface Anisotropy`→`subsurface_anisotropy` now mapped
+      (socket names read off live Blender 5.2); removed from the dropped list
+      (only `Subsurface IOR`, `Coat Normal`, `Tangent` remain, reported per
+      pkg119-C when linked). Verified headless on Blender 5.2: a Principled node
+      with thin_film_thickness=550nm + thin_film_ior=1.4 + thin_wall + subsurface
+      anisotropy=0.3 routes to `create_material('principled', ...)` with the four
+      native params present (thin_film/thin_wall no longer gap-reported), render
+      finite/non-black (nonblack_frac 1.000, mean_lum 0.046).
 - [ ] No wavefront perf regression on non-principled scenes; register
       report attached to every GPU-stage PR.
 - [ ] Every ported formula cites its Cycles file/function or paper.

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -3121,12 +3121,14 @@ class CustomRaytracerRenderEngine(RenderEngine):
         return spec
 
     # pkg178 Stage 5: Blender Principled sockets present on 5.x but NOT honoured
-    # by the native 'principled' material (thin-film is Stage 4 CPU-only, not yet
-    # wired to the addon; thin-wall + the extra subsurface controls are unmapped).
+    # by the native 'principled' material. Thin Film (thickness/IOR), Thin Wall and
+    # Subsurface Anisotropy are now wired (pkg178 Stage 4 on main) and no longer
+    # listed here. What remains genuinely unmapped: Subsurface IOR (native material
+    # has no per-medium IOR knob), and the per-lobe normal/tangent vector sockets
+    # (Coat Normal, Tangent — native uses the shading/UV normal + UV tangent).
     # Reported per-render via the pkg119-C degradation policy, never dropped silently.
     _NATIVE_PRINCIPLED_UNMAPPED = (
-        'Thin Wall', 'Thin Film Thickness', 'Thin Film IOR',
-        'Subsurface IOR', 'Subsurface Anisotropy',
+        'Subsurface IOR', 'Coat Normal', 'Tangent',
     )
 
     def _use_native_principled(self):
@@ -3185,6 +3187,16 @@ class CustomRaytracerRenderEngine(RenderEngine):
         put_float('subsurface_weight', 'Subsurface Weight', 'Subsurface')
         put_float('subsurface_scale', 'Subsurface Scale')
         put_vec('subsurface_radius', 'Subsurface Radius')
+        # Subsurface anisotropy (thin-subsurface diffuse/translucent split; Cycles
+        # bsdf_thin_subsurface_setup). Now honoured by the native material (pkg178
+        # Stage 4 on main); previously in _NATIVE_PRINCIPLED_UNMAPPED.
+        put_float('subsurface_anisotropy', 'Subsurface Anisotropy')
+        # Thin Film iridescence (Belcour-Barla) + Thin Wall translucency — pkg178
+        # Stage 4, now on main. Thin Wall is a boolean socket; get_float_input
+        # returns 1.0/0.0 which the engine reads as thin_wall>0.5.
+        put_float('thin_film_thickness', 'Thin Film Thickness')
+        put_float('thin_film_ior', 'Thin Film IOR')
+        put_float('thin_wall', 'Thin Wall')
         # Alpha — a REAL value routed to the native transparent lobe; NOT folded
         # into transmission (that conflation is the convicted BSDF_TRANSPARENT
         # bug family the Disney path still carries).
@@ -3193,9 +3205,10 @@ class CustomRaytracerRenderEngine(RenderEngine):
 
     def _native_principled_gaps(self, node, native_params):
         """pkg119-C: sockets the native Principled path does not honour, surfaced
-        per-render so nothing is dropped silently. Linked unmapped sockets, a
-        typed-in thin-film thickness, a set Thin-Wall flag, and the approximate
-        subsurface model all get a report line."""
+        per-render so nothing is dropped silently. Linked unmapped sockets
+        (Subsurface IOR, Coat Normal, Tangent) and the approximate subsurface
+        model get a report line. Thin Film, Thin Wall and Subsurface Anisotropy
+        are now wired (pkg178 Stage 4) and no longer reported as gaps."""
         gaps = []
         for nm in self._NATIVE_PRINCIPLED_UNMAPPED:
             inp = node.inputs.get(nm)
@@ -3204,22 +3217,6 @@ class CustomRaytracerRenderEngine(RenderEngine):
             if getattr(inp, 'is_linked', False):
                 gaps.append(f"Principled socket '{nm}' is linked but not honoured "
                             f"by the native material (dropped)")
-                continue
-            try:
-                val = inp.default_value
-            except AttributeError:
-                continue
-            if nm == 'Thin Wall':
-                if bool(val):
-                    gaps.append("Principled 'Thin Wall' is set but not wired to the "
-                                "native material (dropped)")
-            elif nm == 'Thin Film Thickness':
-                try:
-                    if float(val) > 0.0:
-                        gaps.append("Principled Thin Film (thickness>0) is not wired "
-                                    "to the native addon path yet (dropped)")
-                except (TypeError, ValueError):
-                    pass
         if float(native_params.get('subsurface_weight', 0.0)) > 0.0:
             gaps.append("Principled Subsurface uses the approximate diffusion model "
                         "(D2(a), not the Cycles random-walk BSSRDF)")

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -275,6 +275,21 @@ class CustomRaytracerRenderSettings(PropertyGroup):
         description="Light transport integrator (from plugin registry)",
         items=_integrator_type_items,
     )
+    # pkg178 Stage 5: route Blender's Principled BSDF to Astroray's NATIVE
+    # 'principled' material (faithful Cycles port: coat/sheen/anisotropy/alpha/
+    # emission driven directly) instead of the Disney approximation. Default ON
+    # for this EXPERIMENTAL build so the owner can drive the real material; the
+    # Disney path stays as the fallback when this is off. The production
+    # default-flip is gated on the Cycles parity matrix (owner-authorized
+    # auto-flip — spec pkg178 D3), do NOT hard-code OFF here to "play it safe".
+    use_native_principled: BoolProperty(
+        name="Native Principled BSDF (experimental)",
+        default=True,
+        description="Route Blender's Principled BSDF to Astroray's native "
+                    "'principled' material (coat, sheen, anisotropy, alpha and "
+                    "emission driven directly) instead of the Disney "
+                    "approximation. Disney remains the fallback when off",
+    )
     # pkg39: wavelength / multi-spectral settings
     wavelength_preset: EnumProperty(
         name="Preset",
@@ -1940,6 +1955,13 @@ class CustomRaytracerRenderEngine(RenderEngine):
         # and always True), so we always go through the node tree conversion.
         material_map = {}
         self._volume_material_map = {}
+        # pkg178 Stage 5: resolve the Principled routing flag once per conversion
+        # (default ON — see use_native_principled). Stored on the engine so the
+        # per-material helpers reach it without re-plumbing the scene through
+        # every call site.
+        _settings = getattr(depsgraph.scene, "custom_raytracer", None)
+        self._use_native_principled_flag = bool(
+            getattr(_settings, "use_native_principled", True))
         # pkg115 generated-coords: textures created in GENERATED mode while
         # converting a material are recorded per material name so
         # convert_objects can bake each using object's bounding box onto them
@@ -3068,6 +3090,12 @@ class CustomRaytracerRenderEngine(RenderEngine):
             'emission_color': self.get_color_input(node, 'Emission Color', [0.0, 0.0, 0.0]),
             'emission_strength': self.get_float_input(node, 'Emission Strength', 0.0),
         }
+        # pkg178 Stage 5: carry the FULL native-socket map alongside the Disney
+        # 'params' above. The Disney fallback path reads 'params' (byte-unchanged);
+        # the native 'principled' path reads 'native_params'. 'native_gaps' records
+        # any socket the native path does not honour (pkg119-C — never a silent drop).
+        spec['native_params'] = self._principled_native_params(node)
+        spec['native_gaps'] = self._native_principled_gaps(node, spec['native_params'])
         # Carry texture-name references through the spec when a renderer is
         # available (i.e. during real conversion, not unit-tests of the spec
         # shape). Without this, an Image Texture connected to Base Color was
@@ -3091,6 +3119,188 @@ class CustomRaytracerRenderEngine(RenderEngine):
                     spec['bump_strength'] = normal_inputs['bump_strength']
                     spec['bump_distance'] = normal_inputs['bump_distance']
         return spec
+
+    # pkg178 Stage 5: Blender Principled sockets present on 5.x but NOT honoured
+    # by the native 'principled' material (thin-film is Stage 4 CPU-only, not yet
+    # wired to the addon; thin-wall + the extra subsurface controls are unmapped).
+    # Reported per-render via the pkg119-C degradation policy, never dropped silently.
+    _NATIVE_PRINCIPLED_UNMAPPED = (
+        'Thin Wall', 'Thin Film Thickness', 'Thin Film IOR',
+        'Subsurface IOR', 'Subsurface Anisotropy',
+    )
+
+    def _use_native_principled(self):
+        """pkg178 Stage 5 routing flag. Defaults ON (experimental build) so
+        direct helper calls outside a full convert_materials() lifecycle (unit
+        tests, previews) match the shipped default; convert_materials resolves
+        the real per-scene value onto self._use_native_principled_flag."""
+        return bool(getattr(self, "_use_native_principled_flag", True))
+
+    def _principled_native_params(self, node):
+        """Map EVERY Blender Principled socket the native 'principled' material
+        accepts onto its Cycles/native param name (plugins/materials/principled.cpp).
+        Sockets absent on this Blender version are skipped (renamed-input
+        fallbacks cover 3.x/4.x/5.x drift). Colours are read only from RGBA/VECTOR
+        sockets so 3.x float Specular-Tint / Sheen-Tint don't poison the colour
+        params. pkg178 Stage 5. Emission + base colour are carried at the spec
+        top level, not here."""
+        p = {}
+
+        def put_float(dst, *names):
+            for nm in names:
+                if node.inputs.get(nm) is not None:
+                    p[dst] = self.get_float_input(node, nm, 0.0)
+                    return
+
+        def put_vec(dst, *names):
+            for nm in names:
+                inp = node.inputs.get(nm)
+                if inp is not None and getattr(inp, 'type', 'RGBA') in ('RGBA', 'VECTOR'):
+                    p[dst] = self.get_color_input(node, nm, [1.0, 1.0, 1.0])
+                    return
+
+        # Core
+        put_float('metallic', 'Metallic')
+        put_float('roughness', 'Roughness')
+        put_float('ior', 'IOR')
+        put_float('diffuse_roughness', 'Diffuse Roughness')
+        # Specular (Cycles: Specular IOR Level + Specular Tint; 3.x 'Specular' float)
+        put_float('specular_ior_level', 'Specular IOR Level', 'Specular')
+        put_vec('specular_tint', 'Specular Tint')
+        # Transmission
+        put_float('transmission_weight', 'Transmission Weight', 'Transmission')
+        # Coat (4.x+: weight/roughness/ior/tint; 3.x 'Clearcoat' pair)
+        put_float('coat_weight', 'Coat Weight', 'Clearcoat')
+        put_float('coat_roughness', 'Coat Roughness', 'Clearcoat Roughness')
+        put_float('coat_ior', 'Coat IOR')
+        put_vec('coat_tint', 'Coat Tint')
+        # Sheen (4.x+: weight/roughness/tint; 3.x 'Sheen' float)
+        put_float('sheen_weight', 'Sheen Weight', 'Sheen')
+        put_float('sheen_roughness', 'Sheen Roughness')
+        put_vec('sheen_tint', 'Sheen Tint')
+        # Anisotropy
+        put_float('anisotropic', 'Anisotropic')
+        put_float('anisotropic_rotation', 'Anisotropic Rotation')
+        # Subsurface (approximate D2(a) diffusion in the native material)
+        put_float('subsurface_weight', 'Subsurface Weight', 'Subsurface')
+        put_float('subsurface_scale', 'Subsurface Scale')
+        put_vec('subsurface_radius', 'Subsurface Radius')
+        # Alpha — a REAL value routed to the native transparent lobe; NOT folded
+        # into transmission (that conflation is the convicted BSDF_TRANSPARENT
+        # bug family the Disney path still carries).
+        put_float('alpha', 'Alpha')
+        return p
+
+    def _native_principled_gaps(self, node, native_params):
+        """pkg119-C: sockets the native Principled path does not honour, surfaced
+        per-render so nothing is dropped silently. Linked unmapped sockets, a
+        typed-in thin-film thickness, a set Thin-Wall flag, and the approximate
+        subsurface model all get a report line."""
+        gaps = []
+        for nm in self._NATIVE_PRINCIPLED_UNMAPPED:
+            inp = node.inputs.get(nm)
+            if inp is None:
+                continue
+            if getattr(inp, 'is_linked', False):
+                gaps.append(f"Principled socket '{nm}' is linked but not honoured "
+                            f"by the native material (dropped)")
+                continue
+            try:
+                val = inp.default_value
+            except AttributeError:
+                continue
+            if nm == 'Thin Wall':
+                if bool(val):
+                    gaps.append("Principled 'Thin Wall' is set but not wired to the "
+                                "native material (dropped)")
+            elif nm == 'Thin Film Thickness':
+                try:
+                    if float(val) > 0.0:
+                        gaps.append("Principled Thin Film (thickness>0) is not wired "
+                                    "to the native addon path yet (dropped)")
+                except (TypeError, ValueError):
+                    pass
+        if float(native_params.get('subsurface_weight', 0.0)) > 0.0:
+            gaps.append("Principled Subsurface uses the approximate diffusion model "
+                        "(D2(a), not the Cycles random-walk BSSRDF)")
+        return gaps
+
+    # pkg178 Stage 5: Disney param name -> native 'principled' param name, for
+    # 'principled'-kind specs that only carry Disney-named params (standalone
+    # BSDF nodes, Mix/Add blends). clearcoat_gloss inverts to coat_roughness.
+    _DISNEY_TO_NATIVE_PARAM = {
+        'metallic': 'metallic',
+        'roughness': 'roughness',
+        'ior': 'ior',
+        'transmission': 'transmission_weight',
+        'clearcoat': 'coat_weight',
+        'anisotropic': 'anisotropic',
+        'sheen': 'sheen_weight',
+        'subsurface': 'subsurface_weight',
+    }
+
+    def _disney_params_to_native(self, params):
+        """Translate a Disney-named param dict to native 'principled' names.
+        Non-material keys (textures, alpha) are left for the caller to handle."""
+        native = {}
+        for dk, nk in self._DISNEY_TO_NATIVE_PARAM.items():
+            if dk in params:
+                native[nk] = params[dk]
+        if 'clearcoat_gloss' in params:
+            native['coat_roughness'] = 1.0 - float(params['clearcoat_gloss'])
+        return native
+
+    def _create_native_principled_material(self, spec, renderer, color, params,
+                                           emission_color, emission_strength):
+        """pkg178 Stage 5 — route a Blender Principled node to the NATIVE
+        'principled' material. Alpha routes through the native 'alpha' param (NOT
+        the transmission conflation the Disney path uses); emission lives inside
+        the node (the promote-to-light heuristic is retired on this path). A
+        textured base colour still routes through textured-lambertian because
+        neither material has a base-colour texture slot (spec Non-goal)."""
+        # Standalone BSDF nodes (Glass/Metallic/Glossy/...) and Mix/Add blends
+        # produce a 'principled' spec whose 'params' use Disney names but carry
+        # NO native_params. Translate those to native names first so their
+        # metallic/transmission/roughness are not lost, then overlay the richer
+        # native_params (the Principled-node parse) which wins where present.
+        native = self._disney_params_to_native(params)
+        native.update(spec.get('native_params', {}))
+
+        # Alpha may also arrive from a Mix-with-Transparent (shader_blending sets
+        # params['alpha']); an explicit native alpha wins, else honour that.
+        if 'alpha' not in native and 'alpha' in params:
+            native['alpha'] = float(params['alpha'])
+
+        # Emission inside the node (native material emits directly).
+        native['emission_color'] = list(emission_color)
+        native['emission_strength'] = float(emission_strength)
+
+        # Normal/bump textures plumb through to the native material.
+        for key in ('normal_map_texture', 'normal_strength',
+                    'bump_map_texture', 'bump_strength', 'bump_distance'):
+            if key in spec:
+                native[key] = spec[key]
+
+        # pkg119-C: surface every socket the native path does not honour.
+        for msg in spec.get('native_gaps', []):
+            self._warn_shader_fallback('BSDF_PRINCIPLED', msg)
+
+        # Textured base colour → textured-lambertian (Non-goal: base-colour
+        # texture slot on the native material). Mirrors the Disney path.
+        base_tex = spec.get('base_color_texture')
+        if base_tex is not None:
+            self._warn_shader_fallback(
+                'BSDF_PRINCIPLED',
+                'textured Base Color routes through lambertian (native material '
+                'has no base-color texture slot yet)')
+            lambert_params = {'texture': base_tex}
+            for key in ('normal_map_texture', 'normal_strength',
+                        'bump_map_texture', 'bump_strength', 'bump_distance'):
+                if key in native:
+                    lambert_params[key] = native[key]
+            return renderer.create_material('lambertian', color, lambert_params)
+
+        return renderer.create_material('principled', color, native)
 
     def _degradation_report(self):
         """pkg119 Phase C: the per-render degradation policy accumulator. Lazily
@@ -3199,6 +3409,14 @@ class CustomRaytracerRenderEngine(RenderEngine):
             params = dict(spec.get('params', {}))
             emission_strength = float(spec.get('emission_strength', 0.0))
             emission_color = list(spec.get('emission_color', [0.0, 0.0, 0.0]))
+
+            # pkg178 Stage 5: flag-aware routing. When native Principled is on,
+            # drive the faithful 'principled' material (coat/sheen/aniso/alpha/
+            # emission direct); otherwise fall through to the Disney path below,
+            # which is preserved byte-for-byte as the fallback.
+            if self._use_native_principled():
+                return self._create_native_principled_material(
+                    spec, renderer, color, params, emission_color, emission_strength)
 
             # Renderer has no explicit alpha channel; approximate transparency.
             alpha = params.pop('alpha', None)
@@ -3395,7 +3613,11 @@ class CustomRaytracerRenderEngine(RenderEngine):
         # a pure light until DisneyBRDF gains an emission term) ---
         emission_color    = self.get_color_input(node, 'Emission Color', [0, 0, 0])
         emission_strength = self.get_float_input(node, 'Emission Strength', 0.0)
-        if emission_strength > 0.0 and any(c > 0 for c in emission_color):
+        # pkg178 Stage 5: the promote-to-light heuristic is a Disney-path
+        # workaround (Disney has no emission term). On the native path emission
+        # lives inside the material, so skip the promotion when the flag is on.
+        if (not self._use_native_principled()
+                and emission_strength > 0.0 and any(c > 0 for c in emission_color)):
             # Heuristic: treat as a dedicated light material when emission
             # dominates the surface response.
             if emission_strength >= 1.0 and metallic == 0.0 and transmission == 0.0:
@@ -3442,6 +3664,21 @@ class CustomRaytracerRenderEngine(RenderEngine):
                     lambert_params[key] = params[key]
             return renderer.create_material('lambertian', base_color,
                                             lambert_params)
+
+        # pkg178 Stage 5: flag-aware routing (mirrors _create_material_from_shader_spec).
+        # When native Principled is on, drive the faithful 'principled' material;
+        # otherwise keep the Disney fallback below byte-unchanged.
+        if self._use_native_principled():
+            native = self._principled_native_params(node)
+            native['emission_color'] = list(emission_color)
+            native['emission_strength'] = float(emission_strength)
+            for key in ('normal_map_texture', 'normal_strength',
+                        'bump_map_texture', 'bump_strength', 'bump_distance'):
+                if key in params:
+                    native[key] = params[key]
+            for msg in self._native_principled_gaps(node, native):
+                self._warn_shader_fallback('BSDF_PRINCIPLED', msg)
+            return renderer.create_material('principled', base_color, native)
 
         return renderer.create_material('disney', base_color, params)
 
@@ -4579,6 +4816,10 @@ class RENDER_PT_custom_raytracer_performance(AstrorayPanelBase, Panel):
 
         col = layout.column(align=True)
         col.prop(settings, "device_mode", expand=True)
+
+        # pkg178 Stage 5 (experimental): native Principled BSDF routing toggle.
+        layout.separator()
+        layout.prop(settings, "use_native_principled")
 
         if RAYTRACER_AVAILABLE:
             try:

--- a/blender_addon/shader_blending.py
+++ b/blender_addon/shader_blending.py
@@ -15,6 +15,26 @@ def _lerp_vec3(a, b, fac):
     return [_lerp_float(a[0], b[0], fac), _lerp_float(a[1], b[1], fac), _lerp_float(a[2], b[2], fac)]
 
 
+def _blend_params(pa, pb, fac):
+    """Lerp two Principled param dicts key-wise. Scalars lerp; 3-vectors
+    (colours such as coat_tint / sheen_tint / subsurface_radius) lerp
+    component-wise. A key set on only one side survives (blended against the
+    other side's value, which falls back to its own)."""
+    keys = set(pa.keys()) | set(pb.keys())
+    out = {}
+    for k in keys:
+        va = pa.get(k)
+        vb = pb.get(k)
+        if isinstance(va, (list, tuple)) or isinstance(vb, (list, tuple)):
+            va = va if isinstance(va, (list, tuple)) else vb
+            vb = vb if isinstance(vb, (list, tuple)) else va
+            out[k] = _lerp_vec3(va, vb, fac)
+        else:
+            out[k] = _lerp_float(va if va is not None else 0.0,
+                                 vb if vb is not None else 0.0, fac)
+    return out
+
+
 def _normalized_principled(spec):
     out = deepcopy(spec)
     out.setdefault("kind", "principled")
@@ -29,6 +49,11 @@ def _normalized_principled(spec):
     out["params"].setdefault("anisotropic", 0.0)
     out["params"].setdefault("sheen", 0.0)
     out["params"].setdefault("subsurface", 0.0)
+    # pkg178 Stage 5: the native 'principled' routing reads native_params; carry
+    # it through blending so a Mix/Add of Principled nodes still drives the native
+    # material. native_gaps (pkg119-C report lines) are unioned.
+    out.setdefault("native_params", {})
+    out.setdefault("native_gaps", [])
     out.setdefault("emission_color", [0.0, 0.0, 0.0])
     out.setdefault("emission_strength", 0.0)
     return out
@@ -54,6 +79,8 @@ def blend_shader_specs(fac, a, b):
             "kind": "principled",
             "base_color": _lerp_vec3(pa["base_color"], pb["base_color"], fac),
             "params": params,
+            "native_params": _blend_params(pa["native_params"], pb["native_params"], fac),
+            "native_gaps": list(dict.fromkeys(pa["native_gaps"] + pb["native_gaps"])),
             "emission_color": _lerp_vec3(pa["emission_color"], pb["emission_color"], fac),
             "emission_strength": _lerp_float(pa["emission_strength"], pb["emission_strength"], fac),
         }
@@ -61,10 +88,12 @@ def blend_shader_specs(fac, a, b):
     if ka == "principled" and kb == "transparent":
         out = _normalized_principled(a)
         out["params"]["alpha"] = 1.0 - fac
+        out["native_params"]["alpha"] = 1.0 - fac
         return out
     if ka == "transparent" and kb == "principled":
         out = _normalized_principled(b)
         out["params"]["alpha"] = fac
+        out["native_params"]["alpha"] = fac
         return out
 
     if ka == "principled" and kb == "emission":

--- a/scripts/verify_pkg175_smoke_blender.py
+++ b/scripts/verify_pkg175_smoke_blender.py
@@ -103,9 +103,12 @@ def _engine_standin(addon):
         def report(self, *a, **k):
             pass
 
-    for name, fn in Engine.__dict__.items():
-        if callable(fn) and not name.startswith("__"):
-            setattr(_S, name, fn)
+    # Mirror BOTH methods AND class-level constants (e.g. pkg178 Stage-5's
+    # _NATIVE_PRINCIPLED_UNMAPPED, read via self. during material conversion) —
+    # copying callables only left the stand-in missing class attributes.
+    for name, val in Engine.__dict__.items():
+        if not name.startswith("__"):
+            setattr(_S, name, val)
     return _S()
 
 

--- a/tests/test_blender_native_nodes.py
+++ b/tests/test_blender_native_nodes.py
@@ -340,9 +340,15 @@ def _principled_node():
 
 
 def test_cycles_principled_path_unchanged(monkeypatch):
-    """Tree with only OUTPUT_MATERIAL → BsdfPrincipled must still hit the
-    existing _principled_shader_spec → 'disney' branch — no Astroray
-    intercept when no AstrorayOutputNode is present."""
+    """Tree with only OUTPUT_MATERIAL → BsdfPrincipled must hit the standard
+    _principled_shader_spec conversion — no AstrorayOutputNode intercept.
+
+    Original intent (pkg57): assert the standard Principled path runs, not the
+    Astroray-node intercept. pkg178 Stage 5 flipped the standard path's DEFAULT
+    to the native 'principled' material (was the Disney approximation), so the
+    non-intercept path now produces 'principled'. The intercept case would give
+    'dielectric' (see the Sellmeier test below) — 'principled' still proves no
+    intercept fired."""
     addon = _load_blender_addon(monkeypatch)
 
     p = _principled_node()
@@ -364,8 +370,9 @@ def test_cycles_principled_path_unchanged(monkeypatch):
     assert mat_id == 1
     assert len(renderer.created_materials) == 1
     mat_type, color, params = renderer.created_materials[0]
-    assert mat_type == "disney", (
-        f"Cycles BsdfPrincipled fallback must produce 'disney'; got {mat_type!r}")
+    assert mat_type == "principled", (
+        f"standard BsdfPrincipled path must produce the native 'principled' "
+        f"material (pkg178 Stage 5 default); got {mat_type!r}")
     assert abs(color[0] - 0.6) < 1e-5
 
 

--- a/tests/test_blender_principled_texture.py
+++ b/tests/test_blender_principled_texture.py
@@ -212,15 +212,19 @@ def test_principled_with_image_texture_routes_to_textured_lambertian(monkeypatch
 
 
 def test_principled_without_texture_still_renders_disney(monkeypatch):
-    """Regression guard: a Principled BSDF with NO texture link must still
-    create a 'disney' material. Don't accidentally route every Principled
-    BSDF through the lambertian path."""
+    """Regression guard: a Principled BSDF with NO texture link must NOT be
+    routed through the lambertian (textured) path. This exercises the Disney
+    fallback explicitly (pkg178 Stage 5's native default is covered separately
+    in test_pkg178_stage5_native_routing.py); with native routing off, a
+    non-textured Principled must produce 'disney', never 'lambertian'."""
     addon = _load_blender_addon(monkeypatch)
 
     node = _principled_node(base_color_default=(0.7, 0.2, 0.2, 1.0))
 
     renderer = _RecordingRenderer()
     engine = addon.CustomRaytracerRenderEngine()
+    # pkg178 Stage 5: pin the Disney fallback for this guard.
+    engine._use_native_principled_flag = False
     spec = engine._principled_shader_spec(node, renderer)
 
     assert 'base_color_texture' not in spec

--- a/tests/test_pkg178_stage5_native_routing.py
+++ b/tests/test_pkg178_stage5_native_routing.py
@@ -136,6 +136,10 @@ def _principled_node():
             'Sheen Weight':        _Socket(default=0.6),
             'Sheen Roughness':     _Socket(default=0.3),
             'Sheen Tint':          _Socket(default=(1.0, 0.5, 0.5, 1.0), socket_type="RGBA"),
+            'Subsurface Anisotropy': _Socket(default=0.0),
+            'Thin Film Thickness': _Socket(default=0.0),
+            'Thin Film IOR':       _Socket(default=1.33),
+            'Thin Wall':           _Socket(default=False, socket_type="VALUE"),
             'Emission Color':      _Socket(default=(0.0, 0.0, 0.0, 1.0), socket_type="RGBA"),
             'Emission Strength':   _Socket(default=0.0),
             'Normal':              _Socket(socket_type="VECTOR"),
@@ -223,6 +227,42 @@ def test_default_flag_is_native_on(monkeypatch):
     mat_type, _color, _params = renderer.created_materials[0]
     assert mat_type == "principled", (
         f"default (unset) flag must be native ON; got {mat_type!r}")
+
+
+def test_thin_film_thin_wall_route_native(monkeypatch):
+    """pkg178 Stage 4/5: Thin Film Thickness/IOR, Thin Wall and Subsurface
+    Anisotropy are wired to the native material (engine gained them on main).
+    A Principled node with those set routes to create_material('principled', ...)
+    with the four native params present and NOT reported as gaps."""
+    addon = _load_blender_addon(monkeypatch)
+    engine = _engine(addon, native_flag=True)
+    engine._degradation = None  # fresh report accumulator
+
+    node = _principled_node()
+    node.inputs['Thin Film Thickness'].default_value = 550.0
+    node.inputs['Thin Film IOR'].default_value = 1.4
+    node.inputs['Thin Wall'].default_value = True
+    node.inputs['Subsurface Anisotropy'].default_value = 0.3
+
+    spec = engine._principled_shader_spec(node, renderer=None)
+    renderer = _RecordingRenderer()
+    engine._create_material_from_shader_spec(spec, renderer)
+
+    assert len(renderer.created_materials) == 1
+    mat_type, _color, params = renderer.created_materials[0]
+    assert mat_type == "principled", f"flag ON must route to native; got {mat_type!r}"
+
+    assert abs(params["thin_film_thickness"] - 550.0) < 1e-4
+    assert abs(params["thin_film_ior"] - 1.4) < 1e-6
+    # Thin Wall boolean -> 1.0 float (engine reads thin_wall>0.5).
+    assert abs(params["thin_wall"] - 1.0) < 1e-6
+    assert abs(params["subsurface_anisotropy"] - 0.3) < 1e-6
+
+    # These four are no longer pkg119-C gaps.
+    report = engine._degradation_report()
+    text = " ".join(report.messages())
+    assert "Thin Film" not in text and "Thin Wall" not in text, (
+        f"thin-film/thin-wall must NOT be reported as dropped now; got {report.messages()!r}")
 
 
 def test_subsurface_gap_reported_on_native_path(monkeypatch):

--- a/tests/test_pkg178_stage5_native_routing.py
+++ b/tests/test_pkg178_stage5_native_routing.py
@@ -1,0 +1,245 @@
+"""pkg178 Stage 5 — Blender Principled BSDF -> native 'principled' routing.
+
+Stub-Blender tests (no live Blender process). Assert:
+  * flag ON (default) -> a Principled node produces a create_material(
+    'principled', ...) call with the mapped native params (coat/sheen/aniso/
+    alpha present, Cycles socket names).
+  * flag OFF -> the Disney path is unchanged (create_material('disney', ...)
+    with the historical alpha->transmission conflation).
+  * alpha routes through the native 'alpha' param on the flagged path (NOT the
+    transmission conflation — the BSDF_TRANSPARENT bug family this stage retires).
+
+Shape mirrors tests/test_blender_native_nodes.py.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_blender_addon(monkeypatch):
+    bpy_module = types.ModuleType("bpy")
+    bpy_types_module = types.ModuleType("bpy.types")
+    bpy_props_module = types.ModuleType("bpy.props")
+
+    class _Base:
+        pass
+
+    class _RenderEngineBase:
+        def report(self, *a, **k): return None
+        def update_progress(self, *a, **k): return None
+        def test_break(self): return False
+
+    bpy_types_module.Panel = _Base
+    bpy_types_module.Operator = _Base
+    bpy_types_module.AddonPreferences = _Base
+    bpy_types_module.PropertyGroup = _Base
+    bpy_types_module.RenderEngine = _RenderEngineBase
+    bpy_module.types = bpy_types_module
+
+    for name in ("BoolProperty", "IntProperty", "FloatProperty", "StringProperty",
+                 "PointerProperty", "FloatVectorProperty", "EnumProperty"):
+        setattr(bpy_props_module, name, lambda **_kwargs: None)
+    bpy_module.props = bpy_props_module
+    bpy_module.path = types.SimpleNamespace(abspath=lambda p: p)
+
+    # Use the real shader_blending module (native_params blending is exercised
+    # indirectly by the addon import; the mix path is not under test here).
+    sys.path.insert(0, str(REPO_ROOT / "blender_addon"))
+
+    mathutils_module = types.ModuleType("mathutils")
+    mathutils_module.Vector = lambda values: values
+
+    astroray_module = types.ModuleType("astroray")
+    astroray_module.__version__ = "test"
+    astroray_module.__features__ = {"cuda": False, "spectral": True}
+    astroray_module.__file__ = "/fake/astroray.pyd"
+    astroray_module.integrator_registry_names = lambda: ["path_tracer"]
+    astroray_module.material_registry_names = lambda: ["lambertian", "disney", "principled"]
+    astroray_module.pass_registry_names = lambda: []
+
+    monkeypatch.setitem(sys.modules, "bpy", bpy_module)
+    monkeypatch.setitem(sys.modules, "bpy.types", bpy_types_module)
+    monkeypatch.setitem(sys.modules, "bpy.props", bpy_props_module)
+    monkeypatch.setitem(sys.modules, "mathutils", mathutils_module)
+    monkeypatch.setitem(sys.modules, "astroray", astroray_module)
+
+    sys.modules.pop("astroray_blender_addon_test", None)
+    module_path = REPO_ROOT / "blender_addon" / "__init__.py"
+    spec = importlib.util.spec_from_file_location("astroray_blender_addon_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+# --- Stub Blender data primitives ---
+
+class _Socket:
+    def __init__(self, default=0.0, socket_type="VALUE"):
+        self.default_value = default
+        self.is_linked = False
+        self.links = []
+        self.type = socket_type
+
+
+class _Node:
+    def __init__(self, ntype="", bl_idname="", inputs=None):
+        self.type = ntype
+        self.bl_idname = bl_idname
+        self.inputs = inputs or {}
+
+
+class _RecordingRenderer:
+    def __init__(self):
+        self.created_materials = []
+        self._next_id = 1
+
+    def create_material(self, mat_type, color, params):
+        self.created_materials.append((mat_type, list(color), dict(params)))
+        mid = self._next_id
+        self._next_id += 1
+        return mid
+
+    def set_material_spectral_profile(self, *a, **k): pass
+    def clear_material_spectral_profile(self, *a, **k): pass
+
+
+def _principled_node():
+    """A Blender-5.2-shaped Principled node with coat/sheen/aniso/alpha set."""
+    return _Node(
+        ntype="BSDF_PRINCIPLED",
+        bl_idname="ShaderNodeBsdfPrincipled",
+        inputs={
+            'Base Color':          _Socket(default=(0.6, 0.3, 0.2, 1.0), socket_type="RGBA"),
+            'Metallic':            _Socket(default=0.25),
+            'Roughness':           _Socket(default=0.4),
+            'IOR':                 _Socket(default=1.5),
+            'Alpha':               _Socket(default=0.7),
+            'Diffuse Roughness':   _Socket(default=0.1),
+            'Subsurface Weight':   _Socket(default=0.0),
+            'Subsurface Radius':   _Socket(default=(1.0, 0.2, 0.1), socket_type="VECTOR"),
+            'Subsurface Scale':    _Socket(default=0.05),
+            'Specular IOR Level':  _Socket(default=0.5),
+            'Specular Tint':       _Socket(default=(1.0, 1.0, 1.0, 1.0), socket_type="RGBA"),
+            'Anisotropic':         _Socket(default=0.8),
+            'Anisotropic Rotation':_Socket(default=0.25),
+            'Transmission Weight': _Socket(default=0.0),
+            'Coat Weight':         _Socket(default=0.9),
+            'Coat Roughness':      _Socket(default=0.15),
+            'Coat IOR':            _Socket(default=1.5),
+            'Coat Tint':           _Socket(default=(0.8, 0.9, 1.0, 1.0), socket_type="RGBA"),
+            'Sheen Weight':        _Socket(default=0.6),
+            'Sheen Roughness':     _Socket(default=0.3),
+            'Sheen Tint':          _Socket(default=(1.0, 0.5, 0.5, 1.0), socket_type="RGBA"),
+            'Emission Color':      _Socket(default=(0.0, 0.0, 0.0, 1.0), socket_type="RGBA"),
+            'Emission Strength':   _Socket(default=0.0),
+            'Normal':              _Socket(socket_type="VECTOR"),
+        },
+    )
+
+
+def _engine(addon, native_flag):
+    engine = addon.CustomRaytracerRenderEngine()
+    engine._use_native_principled_flag = native_flag
+    return engine
+
+
+def test_flag_on_routes_to_native_with_mapped_params(monkeypatch):
+    addon = _load_blender_addon(monkeypatch)
+    engine = _engine(addon, native_flag=True)
+
+    node = _principled_node()
+    spec = engine._principled_shader_spec(node, renderer=None)
+    renderer = _RecordingRenderer()
+    engine._create_material_from_shader_spec(spec, renderer)
+
+    assert len(renderer.created_materials) == 1
+    mat_type, color, params = renderer.created_materials[0]
+    assert mat_type == "principled", f"flag ON must route to native; got {mat_type!r}"
+    assert abs(color[0] - 0.6) < 1e-5
+
+    # Native Cycles socket names present with the mapped values.
+    assert abs(params["metallic"] - 0.25) < 1e-6
+    assert abs(params["coat_weight"] - 0.9) < 1e-6
+    assert abs(params["coat_roughness"] - 0.15) < 1e-6
+    assert abs(params["coat_ior"] - 1.5) < 1e-6
+    assert params["coat_tint"] == [0.8, 0.9, 1.0]
+    assert abs(params["sheen_weight"] - 0.6) < 1e-6
+    assert abs(params["sheen_roughness"] - 0.3) < 1e-6
+    assert params["sheen_tint"] == [1.0, 0.5, 0.5]
+    assert abs(params["anisotropic"] - 0.8) < 1e-6
+    assert abs(params["anisotropic_rotation"] - 0.25) < 1e-6
+    assert abs(params["specular_ior_level"] - 0.5) < 1e-6
+    assert params["specular_tint"] == [1.0, 1.0, 1.0]
+    assert abs(params["diffuse_roughness"] - 0.1) < 1e-6
+    assert params["subsurface_radius"] == [1.0, 0.2, 0.1]
+
+    # Alpha is a REAL native param, NOT folded into transmission.
+    assert abs(params["alpha"] - 0.7) < 1e-6
+    assert abs(params.get("transmission_weight", 0.0)) < 1e-6, (
+        "native path must NOT conflate alpha into transmission")
+    assert "transmission" not in params, (
+        "native path must not emit the Disney 'transmission' key")
+
+
+def test_flag_off_disney_path_unchanged(monkeypatch):
+    addon = _load_blender_addon(monkeypatch)
+    engine = _engine(addon, native_flag=False)
+
+    node = _principled_node()
+    spec = engine._principled_shader_spec(node, renderer=None)
+    renderer = _RecordingRenderer()
+    engine._create_material_from_shader_spec(spec, renderer)
+
+    assert len(renderer.created_materials) == 1
+    mat_type, _color, params = renderer.created_materials[0]
+    assert mat_type == "disney", f"flag OFF must keep the Disney path; got {mat_type!r}"
+    # Disney param names (byte-unchanged fallback). The Disney parse historically
+    # never read the Alpha socket at all (alpha only entered via a Mix-with-
+    # Transparent), so a plain Principled leaves transmission at 0 and carries no
+    # 'alpha' key — the native path is what finally honours the Alpha socket.
+    assert "clearcoat" in params
+    assert "coat_weight" not in params
+    assert abs(params.get("transmission", 0.0)) < 1e-6
+    assert "alpha" not in params
+
+
+def test_default_flag_is_native_on(monkeypatch):
+    """The experimental build ships native Principled ON by default: a fresh
+    engine with no convert_materials() call routes to 'principled'."""
+    addon = _load_blender_addon(monkeypatch)
+    engine = addon.CustomRaytracerRenderEngine()  # no flag set
+
+    node = _principled_node()
+    spec = engine._principled_shader_spec(node, renderer=None)
+    renderer = _RecordingRenderer()
+    engine._create_material_from_shader_spec(spec, renderer)
+
+    mat_type, _color, _params = renderer.created_materials[0]
+    assert mat_type == "principled", (
+        f"default (unset) flag must be native ON; got {mat_type!r}")
+
+
+def test_subsurface_gap_reported_on_native_path(monkeypatch):
+    """pkg119-C: an active subsurface weight is reported as approximated on the
+    native path (never silently dropped)."""
+    addon = _load_blender_addon(monkeypatch)
+    engine = _engine(addon, native_flag=True)
+    engine._degradation = None  # fresh report accumulator
+
+    node = _principled_node()
+    node.inputs['Subsurface Weight'].default_value = 0.5
+    spec = engine._principled_shader_spec(node, renderer=None)
+    renderer = _RecordingRenderer()
+    engine._create_material_from_shader_spec(spec, renderer)
+
+    report = engine._degradation_report()
+    text = " ".join(report.messages())
+    assert "Subsurface" in text or "subsurface" in text, (
+        "an active subsurface weight must surface a pkg119-C approximation line; "
+        f"got {report.messages()!r}")


### PR DESCRIPTION
## pkg178 Stage 5 — native Principled routing (Blender integration, complete)

Routes Blender's `ShaderNodeBsdfPrincipled` → the native `'principled'` material (instead of the Disney conversion) behind a `use_native_principled` flag, with the full socket map now including the Stage-4 thin-film sockets. Both translation paths (`_create_material_from_shader_spec` + `convert_principled_bsdf_v2`) route through one helper; Disney path preserved as fallback.

### Socket map (verified off a live Blender 5.2 node)
Core + coat/sheen/anisotropy/subsurface/emission/**alpha** (real transparent lobe, retiring the transmission conflation), plus the new **Thin Film Thickness/IOR, Thin Wall, Subsurface Anisotropy** → native params. Genuinely-unmapped sockets (`Subsurface IOR`, `Coat Normal`, `Tangent`) still surfaced per-render (pkg119-C — never a silent drop).

### Verified
- 15/15 Stage-5 routing tests (incl. thin-film routing) + 39 addon-regression green.
- **Live Blender 5.2 headless:** a Principled node with `thin_film_thickness=550 + thin_film_ior=1.4 + thin_wall=True + subsurface_anisotropy=0.3` → routes native with all four params, renders finite/non-black (`STAGE5_ROUTING PASS` + `STAGE5_RENDER PASS`).
- Includes the dev-loop smoke-harness fix (stand-in mirrors engine class constants, not just methods).

`use_native_principled` default **ON** (experimental). The production default-flip is gated on the full native-vs-Cycles parity matrix on hardware (the lead's Phase-2 check, per the owner's auto-flip authorization). Pure addon Python — no engine change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)