### PR TITLE
fix: ggxReflect low-roughness metal/specular dimming (eval-D/pdf-D consistency)

### DIFF
--- a/include/astroray/gpu_materials.h
+++ b/include/astroray/gpu_materials.h
@@ -1378,7 +1378,8 @@ __device__ inline float gpu_pr_smithG2Aniso(const GVec3& I, const GVec3& O, floa
     return 1.f / (1.f + gpu_pr_smithLambdaAniso(O, ax, ay) + gpu_pr_smithLambdaAniso(I, ax, ay));
 }
 // alpha2/(π·(alpha2·len2)² + reg): at ax==ay reduces exactly to a²/(π·denom²+reg)
-// (the iso forms). reg=1e-4 matches the eval-side inline D; ~0 matches D_GTR2 (pdf).
+// (the iso forms). reg is now 1e-12 everywhere (eval + pdf) so eval and pdf share
+// the same D (pkg182); ~0 recovers the pure D_GTR2 form.
 __device__ inline float gpu_pr_ggxAnisoD(const GVec3& H, float ax, float ay, float reg) {
     float hx = H.x / ax, hy = H.y / ay, hz = H.z;
     float len2 = hx * hx + hy * hy + hz * hz;
@@ -1938,9 +1939,11 @@ __device__ inline GVec3 gpu_pr_ggxReflect(const GVec3& Fhalf, const GVec3& compF
     float D, G, roughComp;
     if (anisotropic <= 0.f) {  // PR-4a isotropic (bit-identical)
         float NdotH = fmaxf(rec.normal.dot(h), 1e-4f);
-        float a = fmaxf(roughness * roughness, 0.0064f), a2 = a * a;
-        float denom = NdotH * NdotH * (a2 - 1.f) + 1.f;
-        D = a2 / (M_PI_F * denom * denom + 1e-4f);
+        float a = fmaxf(roughness * roughness, 0.0064f);
+        // pkg182: eval D must EQUAL the NDF-sampling pdf's D (gpu_pr_pdfLobe:
+        // gpu_pr_D_GTR2). The former a2/(π·denom²+1e-4) collapsed eval D ~1e4×
+        // below the pdf D at low roughness → f/pdf→0 → metal/specular near-black.
+        D = gpu_pr_D_GTR2(NdotH, a);
         G = gpu_pr_smithG2(nl, nv, a);  // height-correlated Smith (Cycles parity)
         roughComp = roughness;
     } else {  // PR-4b anisotropic (Cycles bsdf_aniso_D / bsdf_aniso_lambda)
@@ -1949,7 +1952,7 @@ __device__ inline GVec3 gpu_pr_ggxReflect(const GVec3& Fhalf, const GVec3& compF
         GVec3 Hl(X.dot(h), Y.dot(h), fmaxf(rec.normal.dot(h), 1e-4f));
         GVec3 Il(X.dot(wi), Y.dot(wi), nl);
         GVec3 Ol(X.dot(wo), Y.dot(wo), nv);
-        D = gpu_pr_ggxAnisoD(Hl, ax, ay, 1e-4f);
+        D = gpu_pr_ggxAnisoD(Hl, ax, ay, 1e-12f);  // pkg182: match aniso pdf reg
         G = gpu_pr_smithG2Aniso(Il, Ol, ax, ay);
         roughComp = sqrtf(sqrtf(ax * ay));
     }
@@ -1966,9 +1969,9 @@ __device__ inline GSampledSpectrum gpu_pr_ggxReflectSpectral(const GSampledSpect
     float D, G, roughComp;
     if (anisotropic <= 0.f) {  // PR-4a isotropic (bit-identical)
         float NdotH = fmaxf(rec.normal.dot(h), 1e-4f);
-        float a = fmaxf(roughness * roughness, 0.0064f), a2 = a * a;
-        float denom = NdotH * NdotH * (a2 - 1.f) + 1.f;
-        D = a2 / (M_PI_F * denom * denom + 1e-4f);
+        float a = fmaxf(roughness * roughness, 0.0064f);
+        // pkg182: eval D == pdf D (gpu_pr_D_GTR2); see gpu_pr_ggxReflect rationale.
+        D = gpu_pr_D_GTR2(NdotH, a);
         G = gpu_pr_smithG2(nl, nv, a);  // height-correlated Smith (Cycles parity)
         roughComp = roughness;
     } else {  // PR-4b anisotropic
@@ -1977,7 +1980,7 @@ __device__ inline GSampledSpectrum gpu_pr_ggxReflectSpectral(const GSampledSpect
         GVec3 Hl(X.dot(h), Y.dot(h), fmaxf(rec.normal.dot(h), 1e-4f));
         GVec3 Il(X.dot(wi), Y.dot(wi), nl);
         GVec3 Ol(X.dot(wo), Y.dot(wo), nv);
-        D = gpu_pr_ggxAnisoD(Hl, ax, ay, 1e-4f);
+        D = gpu_pr_ggxAnisoD(Hl, ax, ay, 1e-12f);  // pkg182: match aniso pdf reg
         G = gpu_pr_smithG2Aniso(Il, Ol, ax, ay);
         roughComp = sqrtf(sqrtf(ax * ay));
     }
@@ -1992,12 +1995,10 @@ __device__ inline GSampledSpectrum gpu_pr_ggxReflectSpectral(const GSampledSpect
 }
 
 // pkg178 Stage 4 PR-4 — isotropic GGX reflection whose eval D matches the pdf's D
-// EXACTLY (both D_GTR2), for the thin-glass lobes only. gpu_pr_ggxReflect above
-// regularizes eval D with +1e-4 (absent from the pdf's D_GTR2), collapsing the
-// near-specular eval → a smooth thin sheet renders BLACK. Twin of
-// principled.cpp::ggxReflectConsistent. (Same +1e-4 mismatch dims the Principled
-// metallic/specular lobes at low roughness — pre-existing gpu_pr_ggxReflect bug,
-// out of PR-4 scope; flagged to the lead.)
+// EXACTLY (both D_GTR2), for the thin-glass lobes only (iso). gpu_pr_ggxReflect
+// above now shares the same D-consistency (pkg182 fixed its former +1e-4 eval
+// regularizer, which had collapsed the metallic/specular lobes at low roughness).
+// Twin of principled.cpp::ggxReflectConsistent; kept as the lean iso-only entry.
 __device__ inline GVec3 gpu_pr_ggxReflectConsistent(const GVec3& Fhalf, const GVec3& compFss,
                                                     float roughness, const GHitRecord& rec,
                                                     const GVec3& wo, const GVec3& wi) {

--- a/plugins/materials/principled.cpp
+++ b/plugins/materials/principled.cpp
@@ -190,8 +190,8 @@ class PrincipledPlugin : public Material {
     // bsdf_aniso_D: Hloc = microfacet normal in (X,Y,N); z = NdotH.
     // Written as alpha2/(π·(alpha2·len2)² + reg) so that at ax==ay==a it is
     // ALGEBRAICALLY a²/(π·denom² + reg), denom = 1+(a²-1)NdotH² — i.e. it reduces
-    // exactly to the isotropic forms. `reg` selects which iso form: 1e-4 matches
-    // the eval-side inline D (ggxReflectRGB), ~0 matches the pdf-side D_GTR2.
+    // exactly to the isotropic forms. `reg` is now 1e-12 everywhere (eval + pdf)
+    // so eval and pdf share the same D (pkg182); ~0 recovers the pure D_GTR2 form.
     static float ggxAnisoD(const Vec3& Hloc, float ax, float ay, float reg) {
         float hx = Hloc.x / ax, hy = Hloc.y / ay, hz = Hloc.z;
         float len2 = hx * hx + hy * hy + hz * hz;
@@ -999,9 +999,13 @@ class PrincipledPlugin : public Material {
         float D, G, roughComp;
         if (anisotropic <= 0.0f) {
             float NdotH = std::max(rec.normal.dot(h), 1e-4f);
-            float a = std::max(roughness * roughness, 0.0064f), a2 = a * a;
-            float denom = NdotH * NdotH * (a2 - 1.0f) + 1.0f;
-            D = a2 / (float(M_PI) * denom * denom + 1e-4f);
+            float a = std::max(roughness * roughness, 0.0064f);
+            // pkg182: eval D must EQUAL the NDF-sampling pdf's D (pdfLobe: D_GTR2).
+            // The former a2/(π·denom²+1e-4) regularizer collapsed the eval D ~1e4×
+            // below the pdf D at the specular peak for roughness≲0.2 → f/pdf→0 →
+            // metal/specular rendered near-black. Same D-consistency discipline the
+            // Transmission / thin-glass (ggxReflectConsistent) lobes already use.
+            D = D_GTR2(NdotH, a);
             G = smithG2_GGX(nl, nv, a);  // height-correlated Smith (Cycles parity)
             roughComp = roughness;
         } else {
@@ -1010,7 +1014,9 @@ class PrincipledPlugin : public Material {
             Vec3 Hl(X.dot(h), Y.dot(h), std::max(rec.normal.dot(h), 1e-4f));
             Vec3 Il(X.dot(wi), Y.dot(wi), nl);
             Vec3 Ol(X.dot(wo), Y.dot(wo), nv);
-            D = ggxAnisoD(Hl, ax, ay, 1e-4f);
+            // pkg182: match the aniso pdf's reg (pdfLobe: ggxAnisoD(...,1e-12f)); the
+            // former 1e-4f caused the same low-roughness eval/pdf-D mismatch.
+            D = ggxAnisoD(Hl, ax, ay, 1e-12f);
             G = smithG2Aniso(Il, Ol, ax, ay);
             roughComp = std::sqrt(std::sqrt(ax * ay));
         }
@@ -1020,14 +1026,10 @@ class PrincipledPlugin : public Material {
 
     // pkg178 Stage 4 PR-4 — isotropic GGX reflection whose eval D matches the
     // pdf's D EXACTLY (both D_GTR2), used ONLY by the thin-glass reflect/transmit
-    // lobes. ggxReflectRGB (above) regularizes its eval D with +1e-4, which the
-    // NDF-sampling pdf (pdfLobe: D_GTR2) does NOT — for near-specular alpha the
-    // +1e-4 term dominates and the eval D collapses (~1e4× too small vs the pdf),
-    // so f/pdf → 0 and a smooth thin sheet renders BLACK. The regular Transmission
-    // lobe already sidesteps this by using D_GTR2 in both eval and pdf; the thin
-    // glass follows the same discipline here. (The SAME +1e-4 mismatch makes the
-    // Principled metallic/specular lobes lose energy at roughness ≲ 0.2 — a
-    // PRE-EXISTING ggxReflectRGB bug, out of PR-4 scope; flagged to the lead.)
+    // lobes (iso, no aniso / no anisoRotation). ggxReflectRGB/Spectral now share
+    // the same D-consistency (pkg182 fixed their former +1e-4 eval regularizer,
+    // which had collapsed the metallic/specular lobes at roughness ≲ 0.2); this
+    // helper stays as the lean iso-only entry point the thin-glass lobes call.
     Vec3 ggxReflectConsistent(const Vec3& Fhalf, const Vec3& compFss, float roughness,
                               const HitRecord& rec, const Vec3& wo, const Vec3& wi) const {
         float nl = rec.normal.dot(wi), nv = rec.normal.dot(wo);
@@ -1698,9 +1700,9 @@ public:
         float D, G, roughComp;
         if (anisotropic <= 0.0f) {
             float NdotH = std::max(rec.normal.dot(h), 1e-4f);
-            float a = std::max(roughness * roughness, 0.0064f), a2 = a * a;
-            float denom = NdotH * NdotH * (a2 - 1.0f) + 1.0f;
-            D = a2 / (float(M_PI) * denom * denom + 1e-4f);
+            float a = std::max(roughness * roughness, 0.0064f);
+            // pkg182: eval D == pdf D (D_GTR2); see ggxReflectRGB for the rationale.
+            D = D_GTR2(NdotH, a);
             G = smithG2_GGX(nl, nv, a);  // height-correlated Smith (Cycles parity)
             roughComp = roughness;
         } else {
@@ -1709,7 +1711,7 @@ public:
             Vec3 Hl(X.dot(h), Y.dot(h), std::max(rec.normal.dot(h), 1e-4f));
             Vec3 Il(X.dot(wi), Y.dot(wi), nl);
             Vec3 Ol(X.dot(wo), Y.dot(wo), nv);
-            D = ggxAnisoD(Hl, ax, ay, 1e-4f);
+            D = ggxAnisoD(Hl, ax, ay, 1e-12f);  // pkg182: match aniso pdf reg
             G = smithG2Aniso(Il, Ol, ax, ay);
             roughComp = std::sqrt(std::sqrt(ax * ay));
         }

--- a/tests/test_principled_reflection_not_black.py
+++ b/tests/test_principled_reflection_not_black.py
@@ -1,0 +1,117 @@
+"""Principled metallic + dielectric-specular REFLECTION must not render black at
+LOW roughness, CPU and GPU.
+
+Regression guard for the eval-D vs pdf-D regularizer mismatch (fixed pkg182): the
+Principled reflect lobes (ggxReflectRGB/Spectral + gpu_pr_ggxReflect*) evaluated D
+as `a2/(π·denom²+1e-4)` while the NDF-sampling pdf (pdfLobe) used the unregularized
+`D_GTR2`. At roughness ≲ 0.2 the `+1e-4` term dominates the eval denominator and
+collapses the eval D ~1e4× below the pdf D at the specular peak (measured ~19000×
+at r=0.02), so f/pdf → 0 and the metallic / specular lobe rendered NEAR-BLACK. The
+fix uses D_GTR2 in BOTH eval and pdf (the discipline the Transmission / thin-glass
+`ggxReflectConsistent` lobes already followed).
+
+A Principled metallic (or dielectric-specular) sphere in a uniform grey [0.5]
+environment must reflect that environment — its centre luminance must be a
+substantial fraction of what the plain `metal` material produces at the same
+roughness, and must NOT be ~0. The plain `metal` material uses a self-consistent
+eval/pdf D (both `+0.001f`), so it reflects correctly at low roughness and is a
+valid reference. The white-furnace glass gate does NOT catch this (it exercises
+the transmission path, not reflection) — pkg PR-named-tests-insufficient.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+
+try:
+    import astroray
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray not built")
+
+_ROUGHNESS = [0.02, 0.05, 0.1]
+_GOLD = [0.9, 0.68, 0.25]
+
+
+def _centre_lum(mat_type: str, base, params: dict, *, use_gpu: bool = False) -> float:
+    r = astroray.Renderer()
+    r.set_background_color([0.5, 0.5, 0.5])           # uniform grey environment
+    m = r.create_material(mat_type, list(base), dict(params))
+    r.add_sphere([0.0, 0.0, 0.0], 1.0, m)
+    r.set_integrator("path_tracer")
+    if use_gpu:
+        r.set_use_gpu(True)
+    r.setup_camera([0, 0, 4], [0, 0, 0], [0, 1, 0], 40.0, 1.0, 0.0, 4.0, 96, 96)
+    r.set_seed(7)
+    img = np.asarray(r.render(64, 8, None, True), dtype=np.float32).reshape(96, 96, 3)
+    lum = 0.2126 * img[:, :, 0] + 0.7152 * img[:, :, 1] + 0.0722 * img[:, :, 2]
+    return float(lum[36:60, 36:60].mean())
+
+
+def _check_metallic(use_gpu: bool):
+    """Full metallic mirror: reflects ~all of the grey env. Compared to the plain
+    `metal` material (self-consistent eval/pdf D → correct at low roughness).
+    Pre-fix (measured, CPU): 0.067/0.067/0.112 at r=0.02/0.05/0.10 vs metal ~0.60."""
+    bad = {}
+    for R in _ROUGHNESS:
+        pr = _centre_lum("principled", _GOLD, {"metallic": 1.0, "roughness": R}, use_gpu=use_gpu)
+        metal = _centre_lum("metal", _GOLD, {"roughness": R}, use_gpu=use_gpu)
+        # F82 vs GGX + energy comp differ slightly; require it be REFLECTING, i.e.
+        # a substantial fraction of the metal material (not the ~0.1x collapse).
+        if pr < 0.30 or pr < 0.5 * metal:
+            bad[R] = (round(pr, 4), round(metal, 4))
+    assert not bad, (
+        f"Principled metallic reflection too dark vs metal material at low "
+        f"roughness {{R:(principled,metal)}}={bad}")
+
+
+def _check_specular(use_gpu: bool):
+    """Isolate the dielectric-specular reflect lobe: BLACK base color kills the
+    diffuse lobe (which would otherwise mask the specular collapse), metallic=0,
+    no transmission. Only the specular GGX reflection of the grey env remains.
+    Pre-fix (measured, CPU): 0.025/0.025/0.042; post-fix flat ~0.231. A flat,
+    clearly-positive value across roughness is the smoking gun that the eval/pdf-D
+    mismatch (which grew as roughness→0) is gone."""
+    bad = {}
+    for R in _ROUGHNESS:
+        pr = _centre_lum("principled", [0.0, 0.0, 0.0],
+                         {"metallic": 0.0, "roughness": R, "specular_ior_level": 1.0},
+                         use_gpu=use_gpu)
+        # Post-fix ~0.23; pre-fix max 0.042. 0.12 cleanly separates (~3x margin).
+        if pr < 0.12:
+            bad[R] = round(pr, 4)
+    assert not bad, (
+        f"Principled dielectric-specular reflection collapsed at low roughness "
+        f"(black-base isolation) {{R:centre_lum}}={bad}; expected ~0.23")
+
+
+def test_principled_metallic_reflection_not_black_low_roughness_cpu():
+    _check_metallic(use_gpu=False)
+
+
+def test_principled_specular_reflection_not_black_low_roughness_cpu():
+    _check_specular(use_gpu=False)
+
+
+@pytest.mark.skipif(
+    AVAILABLE and not astroray.__features__.get("cuda", False),
+    reason="CUDA feature not in this build")
+def test_principled_metallic_reflection_not_black_low_roughness_gpu():
+    if not astroray.Renderer().gpu_available:
+        pytest.skip("CUDA GPU not available")
+    _check_metallic(use_gpu=True)
+
+
+@pytest.mark.skipif(
+    AVAILABLE and not astroray.__features__.get("cuda", False),
+    reason="CUDA feature not in this build")
+def test_principled_specular_reflection_not_black_low_roughness_gpu():
+    if not astroray.Renderer().gpu_available:
+        pytest.skip("CUDA GPU not available")
+    _check_specular(use_gpu=True)


### PR DESCRIPTION
## Fix: low-roughness Principled metallic/specular rendered near-black

Pre-existing defect (surfaced during thin-wall PR-4): the reflect **eval** D used `a2/(π·denom²+1e-4)` while the NDF-sampling **pdf** used unregularized `D_GTR2`. At the specular peak the `+1e-4` collapses eval-D **~19000× at r=0.02**, driving `f/pdf→0`. The aniso path had the twin (`ggxAnisoD` eval reg 1e-4 vs pdf 1e-12).

Fix: make eval-D **equal** pdf-D (`D_GTR2`; aniso reg → 1e-12) in the metallic + specular + anisotropic reflect evaluators, CPU + GPU byte-mirrored. **Eval-only — sampler/pdf untouched** (they were already `D_GTR2`). Same discipline as the Transmission and (PR-4) thin-glass lobes. Heitz 2014.

### Measured (grey-furnace centre luminance, before → after)
| config | r=0.02 | r=0.05 | r=0.10 | r=0.30 |
|---|---|---|---|---|
| metallic | 0.067 → **0.604** | 0.067 → **0.604** | 0.112 → **0.604** | 0.567 → 0.603 |
| dielectric-spec | 0.025 → **0.231** | 0.025 → **0.231** | 0.042 → **0.231** | 0.217 → 0.230 |

Metallic now matches the `metal` reference (0.604). Converges to negligible by r=0.3, so existing furnace gates are unaffected.

### Verified (RTX 5070 Ti)
- New `test_principled_reflection_not_black` (metallic + specular at r∈{0.02,0.05,0.1}) + GPU furnace + GPU/CPU parity: **14 passed**.
- **Register-neutral** (`<false>` 3608 / `<true>` 6592 unchanged — D-expression swap, one fewer temp).
- chi² invariant (eval-only); 73 regression tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)