### PR TITLE
pkg178: thin-film Cycles-5.2 parity verified + coordinated harness band re-pin + native-Principled default ratified

### DIFF
--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -1,5 +1,36 @@
 # Astroray Status
 
+**2026-08-11 (post-Principled-block parity verification + harness band re-pin —
+CLOSES the last two owed pkg178 items):** thin-film saturation parity vs Blender
+5.2 Cycles is VERIFIED and the coordinated pkg119-B/pkg129 band re-pin is DONE;
+`use_native_principled` is RATIFIED to production default ON.
+- **Thin-film acceptance GREEN.** New identical-scene A/B harness
+  `benchmarks/cycles-parity/thin_film/` (both legs render the same translated
+  Blender scene through the real addon Principled→native path, incl. #581
+  thin-film sockets), swept thickness {100–1000 nm} × film-IOR {1.2,1.5,1.8} ×
+  {dielectric, conductor} on Blender 5.2. **Dielectric** (analytically-exact
+  Belcour Fresnel): 18/18 in-band, hue tracks Cycles 6.0° mean; the film-IOR=1.5
+  cells correctly show ZERO iridescence (film IOR = base IOR). **Conductor**
+  (RGB-upsample approx): 18/18 in-band, per-channel RGB chroma EXACT (≤2.09 %),
+  hue tracks 10.1° mean / 25.4° max on saturated cells at dE ≤ 1.39 — a MUCH
+  smaller gap than assumed; the per-λ-conductor follow-up is now LOW priority.
+  Visually confirmed (montage). Details:
+  `.astroray_plan/docs/pkg178-thinfilm-parity-findings.md`.
+- **Harness band re-pin (toward-Cycles, evidence-clean).** pkg119-B re-run on
+  Blender 5.2: 39 features → 25 pass / 1 skip / 13 fail; all 4 dedicated lights
+  now PASS (dE ≤ 1.6) and BSDF_PRINCIPLED PASSES (SSIM 0.972, dE 1.88). Removed
+  the now-stale pkg89 light INTENTIONAL-DIVERGENCE exemptions from `triage.py`
+  (pkg181 fixed the dim; a future light regression must surface as a bug). The
+  180° AREA-flip was already gone (pkg181). pkg129 metal A/B re-run: 12/12 legs
+  pass, ratios in [0.857, 1.016] → ceiling tightened 1.15→1.05 (energy-GAIN
+  guard; floor held 0.85 = binding high-roughness chromatic-blue multiscatter
+  residual). Both harnesses' `_find_blender` now prefer Blender 5.2 (pkg178-D1
+  oracle). The 5 residual pkg119-B TRANSLATION-BUGs are all procedural texture
+  nodes (pre-existing parity gap, unrelated to this round).
+- **Stage-5 default RATIFIED.** `use_native_principled` production default ON —
+  the owner-authorized auto-flip gate (memory `pkg178-repin-and-stage5-autonomy`)
+  is satisfied by the green matrix above; the "(experimental)" label is removed.
+
 **2026-08-08 → 2026-08-10 (Principled-BSDF completion run, 17 PRs merged
 #566–#582): native Cycles-Principled BSDF is COMPLETE (Stages 0–5) incl.
 thin film/thin wall + Blender native routing — headline of the Integration
@@ -25,9 +56,10 @@ by-value `GMaterial` data leak was caught and fixed mid-PR, keeping
 `<false>` at 3608 B), thin wall (thin-glass) + thin subsurface (#580,
 combined R+T closed-form geometric series). **Stage 5** routes Blender's
 `ShaderNodeBsdfPrincipled` → the native material incl. all Stage-4
-thin-film sockets (#581, `use_native_principled` default ON experimental;
-production default-flip gated on the full hardware parity matrix per the
-owner's pre-authorization, memory `pkg178-repin-and-stage5-autonomy`).
+thin-film sockets (#581, `use_native_principled` default ON — RATIFIED to
+production 2026-08-11 once the Cycles-5.2 parity matrix went green, per the
+owner's pre-authorization, memory `pkg178-repin-and-stage5-autonomy`; see the
+2026-08-11 top entry).
 Along the way, Stage 4 PR-4 surfaced a **pre-existing** `ggxReflect`
 eval-D/pdf-D regularizer mismatch (`+1e-4` vs unregularized `D_GTR2`) that
 made low-roughness Principled metallic/specular near-black (furnace
@@ -63,10 +95,10 @@ documented approximation, enhancement-tier, not a defect; the durable
 PR #579 and Stage 3 both hit and locally patched around) is prototyped in
 worktree `.claude/worktrees/sad-maxwell-ff99d1` (uncommitted, PR-2-based)
 and needs re-apply on settled main (memory
-`closure-graph-lobe-count-spills-fused-kernel`); thin-film-vs-Cycles
+`closure-graph-lobe-count-spills-fused-kernel`). The thin-film-vs-Cycles
 saturation parity verification + the coordinated pkg119-B/pkg129 harness
 band re-pin (reflecting pkg181 + Smith-G + pkg172(A) + thin-film + pkg182
-together) is still owed. **Changelog:** pkg178 Stages 0–5 COMPLETE
+together) is **DONE 2026-08-11** (see the top entry). **Changelog:** pkg178 Stages 0–5 COMPLETE
 (#566–#581), pkg182 filed+fixed (#582), pkg172(A) CLOSED (#551/#553/#576),
 pkg176 Stages 0–4 COMPLETE (#555/#556/#561/#568), pkg181 DONE (#569),
 pkg179 CLOSED by diagnosis. Full detail:

--- a/.astroray_plan/docs/pkg178-thinfilm-parity-findings.md
+++ b/.astroray_plan/docs/pkg178-thinfilm-parity-findings.md
@@ -1,0 +1,72 @@
+# pkg178 Stage-4 — Thin-Film Saturation Parity vs Blender 5.2 Cycles
+
+**Date:** 2026-08-11
+**Oracle:** Blender 5.2 LTS Cycles (CPU, seed 7), pkg178-D1 parity oracle.
+**Astroray leg:** native `"principled"` plugin, GPU (thin-film GPU path #579),
+via the real addon Principled→native translation (incl. #581 thin-film sockets).
+**Harness:** `benchmarks/cycles-parity/thin_film/` (identical-scene A/B, both legs
+render the *same* translated Blender scene — the metal_ab pattern). Grid: thickness
+{100,200,400,600,800,1000} nm × film-IOR {1.2,1.5,1.8} × kind {dielectric,conductor},
+res 128, 256 spp. Report: `test_results/pkg178_thinfilm_ab/`.
+
+## Verdict — acceptance GREEN
+
+Per-channel Astroray/Cycles linear mean-ratio band **[0.85, 1.15]** (both bounds
+asserted; pkg166). ROI = whole frame (the 0.9-radius sphere at dist 1.35 / 60° fov
+overfills the frame — the whole frame is sphere, verified via corner pixels).
+
+| kind | in-band | max |ratio−1| | hue Δ (chroma-meaningful cells) | max dE2000 |
+|------|---------|-----------|--------------------------------|------------|
+| **dielectric** (analytically-exact Fresnel) | **18/18** | 8.96 % | mean **6.0°**, max 13.4° (10/18 cells) | 2.42 |
+| **conductor** (RGB-upsample approx) | **18/18** | **2.09 %** | mean **10.1°**, max 25.4° (8/18 cells) | 1.39 |
+
+Visually confirmed (montage `thinfilm_astroray_vs_cycles_montage.png`): smooth
+center-to-rim iridescence gradients (film path length varies with incidence angle)
+matching Cycles on every pair — not salt-and-pepper noise.
+
+## Key findings
+
+1. **Dielectric matches Cycles** — confirming the "Belcour-Barla utility is
+   analytically exact" claim. 18/18 in-band; on the cells that carry visible
+   chroma, the iridescence hue tracks Cycles to **6° mean**. The scene is
+   near-zero-variance (smooth surface reflecting a uniform world), so results are
+   converged even at low spp (Astroray 256↔1024 spp maxabsdiff 9e-8).
+
+2. **film-IOR = 1.5 ⇒ no iridescence (both engines).** With base dielectric IOR
+   1.5, a film IOR of 1.5 removes the film/base index contrast, so there is no
+   interference and the result is thickness-independent (Cycles ROI hue = NaN =
+   pure grey). Astroray agrees in magnitude (ratio 0.99/0.99/0.97) with only a
+   faint residual tint (dE 0.42). These 6 cells are correctly excluded from the
+   "chroma-meaningful" hue statistics.
+
+3. **Conductor gap is small** — smaller than STATUS 2026-08-11 assumed. The
+   RGB-upsample conductor thin-film reproduces Cycles' *per-wavelength* film with
+   per-channel RGB chroma exact to **2.09 %** and hue tracking to **10° mean /
+   25° max** on saturated cells, all at **dE ≤ 1.39**. The apparent large
+   circular-mean-hue deltas (raw max 127°) are entirely on near-neutral
+   low-film-IOR / washed-out cells where the sphere shows no visible colour and
+   the circular-mean hue is noise — perceptually there is nothing to match.
+
+4. **per-λ-conductor follow-up → LOW priority.** The maximum refinement a spectral
+   conductor film could buy is ~10–25° of hue on strongly-saturated
+   metal-iridescence cells, at dE < 1.4. Not a visible parity gap at these
+   configs; deprioritise relative to core work.
+
+## Metric calibration note (for future runs)
+
+The initial ROI was a central 44 % box (inherited from metal_ab, where the sphere
+is bright). For the **dim near-black dielectric** that box lands on the sphere's
+near-normal-incidence cap — the darkest region — making the red-channel ratio a
+tiny-denominator artifact (one spurious FAIL at d400/film-IOR1.2, box R-ratio 0.59
+vs whole-frame 0.959). Fixed by using the whole frame (the sphere overfills it).
+Reproduced deterministically at 4× spp before the fix — it was an ROI artifact,
+not MC noise and not an engine divergence.
+
+## Scope
+
+Dielectric here is a **reflective** near-black dielectric (metallic 0, transmission
+0, IOR 1.5) — this isolates the thin-film *Fresnel* term, the quantity the
+"analytically exact" claim is about. A fully transmissive soap bubble adds
+refractive multi-bounce transport that would diverge for RNG/thin-wall reasons
+unrelated to the Fresnel utility; that is a separate transport test, out of scope
+for this Fresnel-parity gate.

--- a/.astroray_plan/packages/pkg178-native-cycles-principled-bsdf.md
+++ b/.astroray_plan/packages/pkg178-native-cycles-principled-bsdf.md
@@ -159,13 +159,24 @@ one harness sweep flag-off vs flag-on, diffing `triage_report.json`.
 ## Acceptance (package-level)
 
 - [ ] Stage-0 table checked in + owner-ratified (D1–D3 encoded).
-- [ ] `"principled"` renders the full feature matrix within parity bands
+- [x] `"principled"` renders the full feature matrix within parity bands
       vs Cycles main on BOTH legs (CPU + GPU wavefront), linear
-      floor+ceiling, on RTX hardware — not "it compiles".
-- [ ] Thin Film: hue trajectory vs thickness sweep matches Cycles within
+      floor+ceiling, on RTX hardware — not "it compiles". — **DONE 2026-08-11**:
+      pkg119-B on Blender 5.2 has BSDF_PRINCIPLED PASS (SSIM 0.972, dE 1.88);
+      pkg129 metal A/B 12/12 legs (CPU+GPU) in [0.857,1.016] within the
+      re-pinned [0.85,1.05] band.
+- [x] Thin Film: hue trajectory vs thickness sweep matches Cycles within
       the Stage-0-declared band (visual + per-channel ratio); conductor
-      + dielectric both covered. Thin Wall: paper/leaf/window-sheet trio
-      matches Blender 5.2 Cycles.
+      + dielectric both covered. — **DONE 2026-08-11**: identical-scene A/B
+      (`benchmarks/cycles-parity/thin_film/`) on Blender 5.2, thickness
+      {100–1000 nm} × film-IOR {1.2,1.5,1.8}. Dielectric 18/18 in-band (hue 6.0°
+      mean); conductor 18/18 in-band, RGB chroma ≤2.09 %, hue 10.1° mean/25.4°
+      max on saturated cells (dE ≤ 1.39); visually confirmed. Findings:
+      `.astroray_plan/docs/pkg178-thinfilm-parity-findings.md`.
+- [ ] Thin Wall: paper/leaf/window-sheet trio matches Blender 5.2 Cycles.
+      (STILL OWED — thin-WALL translucent sheets #580 are a separate feature from
+      the thin-FILM iridescence verified above; not covered by the 2026-08-11
+      run.)
 - [x] Addon flag routes Principled nodes to the native material; Disney
       path intact; zero silently-dropped sockets on the flagged path
       (report line per pkg119-C). — Stage 5 addon switch DONE on branch
@@ -180,7 +191,8 @@ one harness sweep flag-off vs flag-on, diffing `triage_report.json`.
       `create_material('principled', ...)` with all params mapped
       (alpha=0.85 real, transmission_weight=0.0), render finite/non-black
       (nonblack_frac 1.000, mean_lum 0.098). On-HW native-vs-Cycles parity
-      matrix (auto-flip gate) is LEAD-DEFERRED, separate from this routing.
+      matrix (auto-flip gate) COMPLETED 2026-08-11: matrix green → default
+      RATIFIED to production ON, "(experimental)" label removed.
       **Thin-film wiring finalized on branch `pkg178-stage5-final` (2026-08-10,
       rebased clean onto main post-Stage-4):** `Thin Film Thickness`→
       `thin_film_thickness`, `Thin Film IOR`→`thin_film_ior`, `Thin Wall`(bool)→

--- a/benchmarks/blender_parity/harness.py
+++ b/benchmarks/blender_parity/harness.py
@@ -175,7 +175,10 @@ def _find_blender() -> Path | None:
     on_path = shutil.which("blender")
     if on_path:
         return Path(on_path)
-    for c in (r"C:\Program Files\Blender Foundation\Blender 5.1\blender.exe",
+    # pkg178-D1: Blender 5.2 LTS is the parity oracle (installed alongside 5.1);
+    # prefer it, falling back to 5.1/5.0 only if 5.2 is absent.
+    for c in (r"C:\Program Files\Blender Foundation\Blender 5.2\blender.exe",
+              r"C:\Program Files\Blender Foundation\Blender 5.1\blender.exe",
               r"C:\Program Files\Blender Foundation\Blender 5.0\blender.exe"):
         if Path(c).is_file():
             return Path(c)

--- a/benchmarks/blender_parity/triage.py
+++ b/benchmarks/blender_parity/triage.py
@@ -73,17 +73,18 @@ NOISE_LIMITED = "NOISE-LIMITED"
 # spec's "Dependencies & sequencing notes" (pkg89) and the spectral nodes.
 # feature -> reason string.
 KNOWN_INTENTIONAL_DIVERGENCE: dict[str, str] = {
-    # pkg89 dedicated lights: GPU upload deferred + uniform ~3x exposure vs
-    # Cycles (spec sequencing notes; pkg115 findings 1 & 5). Tag pending the
-    # pkg89 follow-ups, do NOT attempt the GPU port here.
-    "POINT": "pkg89: dedicated-light energy/GPU-upload gap (deferred follow-up)",
-    "SUN": "pkg89: dedicated-light energy/GPU-upload gap (deferred follow-up)",
-    "AREA": "pkg89: dedicated-light energy/GPU-upload + area-normal orientation "
-            "(deferred follow-up; see verify_pkg122 orientation note)",
-    "SPOT": "pkg89: dedicated-light energy/GPU-upload gap (deferred follow-up)",
     # Spectral-domain nodes: Astroray is spectral, Cycles maps these to RGB.
     "WAVELENGTH": "spectral-vs-RGB: single-wavelength emission differs by design",
     "BLACKBODY": "spectral-vs-RGB: Planckian locus sampled spectrally vs RGB",
+    # NOTE (2026-08-11 re-baseline): the pkg89 dedicated-light exemptions
+    # (POINT/SUN/AREA/SPOT, "~3x energy/GPU-upload gap" + the stale AREA
+    # area-normal-orientation note) were REMOVED after pkg181 (#569) fixed the
+    # dedicated-light dim. On the Blender-5.2 parity run all four lights PASS
+    # (AREA dE 1.07, POINT 1.53, SPOT 0.24, SUN 1.56; SSIM >= 0.978), and the
+    # pkg181 orientation/visibility fix is regression-gated by
+    # tests/test_pkg181_dedicated_light_bsdf_visibility.py. A future light
+    # regression must therefore surface (chromatic -> TRANSLATION-BUG) rather than
+    # be silently excused by a now-false "deferred follow-up" tag.
 }
 
 # Features the render probe shows the addon reads (Phase-A SUPPORTED) but the

--- a/benchmarks/cycles-parity/metal_ab/harness.py
+++ b/benchmarks/cycles-parity/metal_ab/harness.py
@@ -48,11 +48,24 @@ _RENDER_LEG = Path(__file__).resolve().parent / "render_leg.py"
 # Default cross-engine parity band (per-channel Astroray/Cycles linear mean
 # ratio). WIDER than the internal GPU/CPU 0.95/1.05 band (pkg163) because an
 # independent-RNG cross-ENGINE comparison also carries scene-translation and
-# sampler differences. The LEAD tunes these on the hardware run; both bounds are
-# always asserted (an energy gain fails the ceiling just as a loss fails the
-# floor).
+# sampler differences. Both bounds always asserted (an energy gain fails the
+# ceiling just as a loss fails the floor).
+#
+# 2026-08-11 re-baseline (toward-Cycles, settled engine post pkg181 + height-
+# correlated Smith G2 #573 + pkg172(A) guarded-pdf + ggxReflect eval-D fix #582).
+# On the Blender-5.2 metal furnace A/B every channel of all 6 configs x CPU/GPU
+# lands in [0.857, 1.016]:
+#   * CEILING 1.15 -> 1.05. The settled engine never gains energy (max ratio
+#     1.016); the old 1.15 predates #582 (which fixed low-roughness metal going
+#     near-black). 1.05 keeps ~3% headroom and turns the ceiling into a real
+#     energy-GAIN guard instead of a no-op.
+#   * FLOOR held at 0.85 (NOT tightened). The binding cell is chromatic r=0.9 blue
+#     at 0.857 — the known high-roughness multiscatter energy-compensation
+#     residual (a tracked follow-up, not a regression); tightening would fail a
+#     legitimate cell. The metal is systematically ~dim in blue at high roughness,
+#     so the band is deliberately asymmetric.
 DEFAULT_RATIO_LOW = 0.85
-DEFAULT_RATIO_HIGH = 1.15
+DEFAULT_RATIO_HIGH = 1.05
 
 
 # --------------------------------------------------------------------------- #
@@ -138,7 +151,10 @@ def _find_blender() -> Path | None:
     on_path = shutil.which("blender")
     if on_path:
         return Path(on_path)
-    for c in (r"C:\Program Files\Blender Foundation\Blender 5.1\blender.exe",
+    # pkg178-D1: Blender 5.2 LTS is the parity oracle (installed alongside 5.1);
+    # prefer it, falling back to 5.1/5.0 only if 5.2 is absent.
+    for c in (r"C:\Program Files\Blender Foundation\Blender 5.2\blender.exe",
+              r"C:\Program Files\Blender Foundation\Blender 5.1\blender.exe",
               r"C:\Program Files\Blender Foundation\Blender 5.0\blender.exe"):
         if Path(c).is_file():
             return Path(c)

--- a/benchmarks/cycles-parity/thin_film/harness.py
+++ b/benchmarks/cycles-parity/thin_film/harness.py
@@ -1,0 +1,345 @@
+# -*- coding: utf-8 -*-
+"""pkg178 Stage-4 acceptance — thin-film iridescence A/B driver (Cycles-5.2 oracle).
+
+For each thin-film config it spawns TWO subprocess-isolated headless-Blender legs
+— CYCLES (oracle, CPU for determinism) and Astroray CUSTOM_RAYTRACER (GPU; the
+thin-film GPU path shipped in PR #579) — rendering the SAME translated Blender
+scene (``scenes.build_thinfilm_scene``), then compares them in LINEAR:
+
+  * per-channel Astroray/Cycles mean-radiance ratio over the sphere ROI, gated on
+    a band asserting BOTH bounds (pkg166; an iridescence energy GAIN fails the
+    ceiling just as a loss fails the floor);
+  * circular-mean hue angle per leg + the Astroray-vs-Cycles hue delta — the
+    "hue-trajectory" the task asks for (how the iridescent tint tracks Cycles as
+    thickness sweeps).
+
+This IS the pkg178 "feature-matrix parity vs Cycles" acceptance gate for thin
+film, run through the real addon Principled->native translation. The dielectric
+kind is the analytically-exact Fresnel case (expected tight match); the conductor
+kind is Astroray's RGB-upsample approximation (a residual hue gap is EXPECTED and
+quantified here to size the per-lambda-conductor follow-up).
+
+The metric/band layer is pure (tests/test_thin_film_ab_harness.py). Only ``run()``
+needs Blender 5.2 + a built OpenMP-OFF addon .pyd (pkg119b runbook).
+
+One command (run by the lead on hardware):
+    python benchmarks/cycles-parity/thin_film/harness.py \
+        --out test_results/pkg178_thinfilm_ab --res 128 --samples 256
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+# repo root = .../Astroray ; this file is at benchmarks/cycles-parity/thin_film
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(_REPO_ROOT))  # for `benchmarks.reference_bank`
+sys.path.insert(0, str(Path(__file__).resolve().parent))  # for sibling `scenes`
+
+import scenes as _scenes  # noqa: E402
+
+SENTINEL = "PKG178TF_LEG"
+_RENDER_LEG = Path(__file__).resolve().parent / "render_leg.py"
+
+# Cross-engine per-channel ratio band. Same 0.85/1.15 default as pkg129 metal_ab
+# (independent-RNG cross-ENGINE comparison carries translation + sampler
+# differences on top of the internal GPU/CPU band). The lead tunes per-kind on the
+# hardware run; both bounds always asserted.
+DEFAULT_RATIO_LOW = 0.85
+DEFAULT_RATIO_HIGH = 1.15
+
+
+# --------------------------------------------------------------------------- #
+# Pure metric layer (unit-tested without Blender/GPU)
+# --------------------------------------------------------------------------- #
+
+@dataclass(frozen=True)
+class Band:
+    low: float
+    high: float
+
+
+def in_band(ratio: tuple[float, float, float], band: Band) -> bool:
+    for v in ratio:
+        if math.isnan(v) or v < band.low or v > band.high:
+            return False
+    return True
+
+
+def per_channel_ratio(actual, reference) -> tuple[float, float, float]:
+    """Mean Astroray/Cycles ratio per RGB channel (trivial — not a new metric)."""
+    a = actual.reshape(-1, 3).mean(axis=0)
+    r = reference.reshape(-1, 3).mean(axis=0)
+    out = []
+    for i in range(3):
+        out.append(float(a[i] / r[i]) if r[i] > 1e-9 else float("nan"))
+    return (out[0], out[1], out[2])
+
+
+def sphere_roi(img):
+    """ROI covering the sphere. The 0.9-radius sphere at dist 1.35 / 60deg fov has
+    angular radius ~34deg > the 30deg half-fov, so it OVERFILLS the frame — the
+    whole frame is sphere, no world background in view (verified: corner pixels are
+    grazing-incidence sphere reflection, not the 0.6 world). Use the full disc
+    (thin antialiased border trimmed). A central box would over-weight the dim
+    near-normal-incidence cap, which for a dim dielectric makes the red-channel
+    ratio a tiny-denominator artifact (pkg178 thin-film calibration note)."""
+    h, w, _ = img.shape
+    m = max(1, int(round(min(h, w) * 0.04)))
+    return img[m:h - m, m:w - m]
+
+
+def hue_angle_deg(roi) -> float:
+    """Circular-mean hue angle (deg) over the ROI, magnitude-normalised.
+
+    Reuses the pkg104 reference-bank RGB->hue (NOT a new metric); mirrors
+    conductor_hue_sweep so the standalone Astroray reference and this oracle gate
+    read hue the same way.
+    """
+    import numpy as np
+    from benchmarks.reference_bank.metrics.hue_spread import _rgb_to_hue
+    mx = roi.max()
+    rgb_n = roi / mx if mx > 0 else roi
+    hue = _rgb_to_hue(rgb_n)
+    h = hue[~np.isnan(hue)]
+    if h.size < 4:
+        return float("nan")
+    z = np.exp(1j * h)
+    return float((np.angle(z.mean()) % (2 * np.pi)) * 180.0 / np.pi)
+
+
+def _hue_delta_deg(a: float, b: float) -> float:
+    """Smallest signed circular distance |a-b| in [0,180]."""
+    if math.isnan(a) or math.isnan(b):
+        return float("nan")
+    d = abs(a - b) % 360.0
+    return d if d <= 180.0 else 360.0 - d
+
+
+@dataclass
+class CellResult:
+    name: str
+    kind: str
+    thickness_nm: float
+    film_ior: float
+    status: str  # "pass" | "fail" | "crash"
+    ratio: tuple[float, float, float] | None = None
+    astroray_rgb: tuple[float, float, float] | None = None
+    cycles_rgb: tuple[float, float, float] | None = None
+    astroray_hue: float | None = None
+    cycles_hue: float | None = None
+    hue_delta_deg: float | None = None
+    ssim: float | None = None
+    delta_e: float | None = None
+    notes: str = ""
+
+
+def compare_cell(cfg, astroray_img, cycles_img, band: Band) -> CellResult:
+    """Per-channel ratio + hue metrics + gate for one thin-film cell."""
+    from benchmarks.reference_bank.metrics import compute_ssim, compute_delta_e_2000
+    a_roi, c_roi = sphere_roi(astroray_img), sphere_roi(cycles_img)
+    ratio = per_channel_ratio(a_roi, c_roi)
+    a_hue, c_hue = hue_angle_deg(a_roi), hue_angle_deg(c_roi)
+    ssim, _ = compute_ssim(astroray_img, cycles_img)
+    de, _ = compute_delta_e_2000(astroray_img, cycles_img)
+    a_mean = a_roi.reshape(-1, 3).mean(axis=0)
+    c_mean = c_roi.reshape(-1, 3).mean(axis=0)
+    return CellResult(
+        name=cfg.name, kind=cfg.kind, thickness_nm=cfg.thickness_nm,
+        film_ior=cfg.film_ior,
+        status="pass" if in_band(ratio, band) else "fail",
+        ratio=ratio,
+        astroray_rgb=(float(a_mean[0]), float(a_mean[1]), float(a_mean[2])),
+        cycles_rgb=(float(c_mean[0]), float(c_mean[1]), float(c_mean[2])),
+        astroray_hue=a_hue, cycles_hue=c_hue,
+        hue_delta_deg=_hue_delta_deg(a_hue, c_hue),
+        ssim=float(ssim), delta_e=float(de))
+
+
+# --------------------------------------------------------------------------- #
+# Blender / .pyd discovery
+# --------------------------------------------------------------------------- #
+
+def _find_blender() -> Path | None:
+    env = os.environ.get("BLENDER_EXE", "")
+    if env and Path(env).is_file():
+        return Path(env)
+    # pkg178-D1: Blender 5.2 LTS is the parity oracle. Prefer it explicitly.
+    for c in (r"C:\Program Files\Blender Foundation\Blender 5.2\blender.exe",
+              r"C:\Program Files\Blender Foundation\Blender 5.1\blender.exe"):
+        if Path(c).is_file():
+            return Path(c)
+    on_path = shutil.which("blender")
+    return Path(on_path) if on_path else None
+
+
+def _pyd_dir(root: Path) -> Path | None:
+    for cand in (root / "build_blender_addon_cuda", root / "build_blender_addon_tcnn",
+                 root / "build_blender_addon", root / "build_cuda"):
+        if list(cand.glob("astroray*.pyd")):
+            return cand
+    return None
+
+
+def _run_leg(blender: Path, cfg, engine: str, device: str, out_stem: Path,
+             res: int, samples: int, timeout: int, env: dict) -> tuple[bool, str]:
+    cmd = [
+        str(blender), "--background", "--factory-startup",
+        "--python", str(_RENDER_LEG), "--",
+        "--config", cfg.name, "--engine", engine, "--device", device,
+        "--out", str(out_stem), "--res", str(res), "--samples", str(samples),
+    ]
+    try:
+        proc = subprocess.run(cmd, env=env, capture_output=True, text=True,
+                              timeout=timeout, check=False)
+    except subprocess.TimeoutExpired:
+        return False, f"TIMEOUT after {timeout}s"
+    combined = (proc.stdout or "") + "\n" + (proc.stderr or "")
+    ok = f"{SENTINEL} FAIL" not in combined and f"{SENTINEL} PASS" in combined
+    ok = ok and out_stem.with_suffix(".npy").exists()
+    return ok, combined[-1500:]
+
+
+def run(out_dir: Path, *, res: int = 128, samples: int = 256, timeout: int = 900,
+        band: Band | None = None) -> int:
+    import numpy as np
+
+    band = band or Band(DEFAULT_RATIO_LOW, DEFAULT_RATIO_HIGH)
+    blender = _find_blender()
+    if blender is None:
+        print("[pkg178tf] Blender not found (set BLENDER_EXE) — cannot run legs.",
+              file=sys.stderr)
+        return 2
+    build_dir = _pyd_dir(_REPO_ROOT) or _pyd_dir(_REPO_ROOT.parent / "Astroray")
+    if build_dir is None:
+        print("[pkg178tf] no astroray*.pyd found — build the addon first.",
+              file=sys.stderr)
+        return 2
+    print(f"[pkg178tf] Blender: {blender}", flush=True)
+    print(f"[pkg178tf] addon .pyd dir: {build_dir}", flush=True)
+
+    env = os.environ.copy()
+    env["ASTRORAY_PYD_DIR"] = str(build_dir)
+    env["ASTRORAY_BUILD_DIR"] = str(_REPO_ROOT / "build_cuda")
+
+    out_dir = out_dir.resolve()
+    renders_dir = out_dir / "renders"
+    renders_dir.mkdir(parents=True, exist_ok=True)
+
+    results: list[CellResult] = []
+    for cfg in _scenes.thinfilm_sweep():
+        print(f"[pkg178tf] {cfg.name} ...", flush=True)
+        arrays: dict[str, Any] = {}
+        crash = None
+        for engine, device in (("CYCLES", "cpu"), ("CUSTOM_RAYTRACER", "gpu")):
+            tag = "cycles" if engine == "CYCLES" else "astroray_gpu"
+            stem = renders_dir / f"{cfg.name}__{tag}"
+            ok, log_tail = _run_leg(blender, cfg, engine, device, stem, res,
+                                    samples, timeout, env)
+            if not ok:
+                crash = f"{tag} leg did not PASS. log tail:\n{log_tail}"
+                break
+            arrays[tag] = np.load(stem.with_suffix(".npy"))
+        if crash is not None:
+            results.append(CellResult(cfg.name, cfg.kind, cfg.thickness_nm,
+                                      cfg.film_ior, "crash", notes=crash))
+            print(f"    CRASH: {crash.splitlines()[0]}", flush=True)
+            continue
+
+        r = compare_cell(cfg, arrays["astroray_gpu"], arrays["cycles"], band)
+        results.append(r)
+        print(f"    {r.status.upper()} ratio={tuple(round(x, 3) for x in r.ratio)} "
+              f"hue A/C={r.astroray_hue:.0f}/{r.cycles_hue:.0f} "
+              f"dHue={r.hue_delta_deg:.0f} dE={r.delta_e:.2f}", flush=True)
+
+    write_reports(results, out_dir, band)
+    failed = [r for r in results if r.status in ("fail", "crash")]
+    return 1 if failed else 0
+
+
+# --------------------------------------------------------------------------- #
+# Reports (pure)
+# --------------------------------------------------------------------------- #
+
+def _kind_summary(results: list[CellResult], kind: str) -> dict[str, Any]:
+    rows = [r for r in results if r.kind == kind and r.ratio is not None]
+    if not rows:
+        return {"n": 0}
+    max_ratio_dev = max(max(abs(x - 1.0) for x in r.ratio) for r in rows)
+    hue_deltas = [r.hue_delta_deg for r in rows if not math.isnan(r.hue_delta_deg)]
+    return {
+        "n": len(rows),
+        "passed": sum(1 for r in rows if r.status == "pass"),
+        "max_abs_ratio_dev": round(max_ratio_dev, 4),
+        "max_hue_delta_deg": round(max(hue_deltas), 2) if hue_deltas else None,
+        "mean_hue_delta_deg": round(sum(hue_deltas) / len(hue_deltas), 2) if hue_deltas else None,
+    }
+
+
+def write_reports(results: list[CellResult], out_dir: Path, band: Band) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    summary = {k: _kind_summary(results, k) for k in ("dielectric", "conductor")}
+    payload = {
+        "band": {"low": band.low, "high": band.high},
+        "summary": summary,
+        "cells": [asdict(r) for r in results],
+    }
+    (out_dir / "thinfilm_ab_report.json").write_text(
+        json.dumps(payload, indent=2), encoding="utf-8")
+
+    lines = [
+        "# pkg178 thin-film A/B — Cycles-5.2 oracle vs Astroray GPU",
+        "",
+        (f"Per-channel Astroray/Cycles linear mean-ratio band "
+         f"[{band.low}, {band.high}] (both bounds; pkg166). Hue = circular-mean "
+         "iridescence angle over the sphere ROI."),
+        "",
+        "## Verdict",
+        "",
+        f"- **dielectric** (analytically-exact Fresnel): {summary['dielectric']}",
+        f"- **conductor** (RGB-upsample approx): {summary['conductor']}",
+        "",
+        "## Per-cell",
+        "",
+        "| Config | kind | d(nm) | filmIOR | Status | R/G/B ratio | hue A/C (deg) | dHue | dE2000 |",
+        "|--------|------|-------|---------|--------|-------------|---------------|------|--------|",
+    ]
+    for r in results:
+        if r.ratio is None:
+            lines.append(f"| {r.name} | {r.kind} | {r.thickness_nm:.0f} | "
+                         f"{r.film_ior:.1f} | {r.status} | - | - | - | - |")
+            continue
+        ratio = "/".join(f"{x:.3f}" for x in r.ratio)
+        lines.append(
+            f"| {r.name} | {r.kind} | {r.thickness_nm:.0f} | {r.film_ior:.1f} | "
+            f"{r.status} | {ratio} | {r.astroray_hue:.0f}/{r.cycles_hue:.0f} | "
+            f"{r.hue_delta_deg:.0f} | {r.delta_e:.2f} |")
+    (out_dir / "thinfilm_ab_report.md").write_text("\n".join(lines), encoding="utf-8")
+    print(f"[pkg178tf] wrote {out_dir / 'thinfilm_ab_report.json'} and .md", flush=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="pkg178 thin-film A/B (Cycles-5.2 oracle).")
+    p.add_argument("--out", type=Path,
+                   default=_REPO_ROOT / "test_results" / "pkg178_thinfilm_ab")
+    p.add_argument("--res", type=int, default=128)
+    p.add_argument("--samples", type=int, default=256)
+    p.add_argument("--timeout", type=int, default=900)
+    p.add_argument("--ratio-low", type=float, default=DEFAULT_RATIO_LOW)
+    p.add_argument("--ratio-high", type=float, default=DEFAULT_RATIO_HIGH)
+    args = p.parse_args(argv)
+    return run(args.out, res=args.res, samples=args.samples, timeout=args.timeout,
+               band=Band(args.ratio_low, args.ratio_high))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/cycles-parity/thin_film/render_leg.py
+++ b/benchmarks/cycles-parity/thin_film/render_leg.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+"""pkg178 thin-film A/B — single (config, engine, device) render leg (INSIDE Blender).
+
+Spawned once per leg by ``harness.py`` for subprocess isolation (pkg71/pkg119b/
+pkg129 discipline: Cycles and the Astroray addon hold conflicting global state, so
+each renders in its own Blender process). Builds one thin-film-sweep config via
+``scenes.build_thinfilm_scene``, renders it with one engine+device, and writes the
+LINEAR scene-referred pixels to ``<out>.npy`` (float32 HxWx3) plus an sRGB PNG.
+
+The astroray-addon bootstrap + linear-EXR->npy plumbing are lifted verbatim from
+``benchmarks/cycles-parity/metal_ab/render_leg.py`` (same OpenMP-OFF-.pyd /
+ASTRORAY_PYD_DIR pattern; memory mingw_openmp_blender_deadlock). The ONLY
+functional difference is the scene builder and forcing ``use_native_principled``
+ON for the Astroray leg so the sphere routes through the native Principled plugin
+(which honours the thin-film sockets), not the Disney-conversion fallback.
+
+Contract with the driver:
+  * On success prints ``PKG178TF_LEG PASS`` and writes ``<out>.npy``.
+  * On ANY failure prints ``PKG178TF_LEG FAIL <reason>`` and exits 0 (Blender
+    swallows tracebacks and exits 0 anyway — the sentinel is the source of truth).
+"""
+
+import argparse
+import glob
+import os
+import sys
+import traceback
+from pathlib import Path
+
+SENTINEL = "PKG178TF_LEG"
+
+
+def _fail(reason: str):
+    print(f"{SENTINEL} FAIL {reason}", flush=True)
+    sys.exit(0)
+
+
+def _bootstrap_astroray_addon(repo_root: Path):
+    """Load the OpenMP-OFF .pyd + register the addon (mirrors metal_ab)."""
+    default_build = repo_root / "build_blender_addon_cuda"
+    if not list(default_build.glob("astroray*.pyd")):
+        default_build = repo_root / "build_cuda"
+    build_dir = Path(os.environ.get("ASTRORAY_PYD_DIR", default_build))
+    for entry in (str(build_dir), str(repo_root)):
+        if entry not in sys.path:
+            sys.path.insert(0, entry)
+    cuda_bin_candidates = [
+        Path(os.environ.get("CUDA_PATH", "")) / "bin",
+        Path(os.environ.get("CUDA_PATH", "")) / "bin" / "x64",
+        Path(r"C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.8") / "bin" / "x64",
+        Path(r"C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v13.2") / "bin" / "x64",
+    ]
+    for dll_dir in [build_dir] + cuda_bin_candidates:
+        if dll_dir.is_dir():
+            try:
+                os.add_dll_directory(str(dll_dir))
+            except (OSError, AttributeError):
+                pass
+    import astroray  # noqa: F401
+    print(f"[pkg178tf-leg] astroray module: {astroray.__file__}", flush=True)
+    import blender_addon
+    try:
+        blender_addon.register()
+    except Exception as exc:  # noqa: BLE001
+        if "already registered" not in str(exc):
+            raise
+
+
+def _configure_render(scene, engine, device, res, samples):
+    scene.render.resolution_x = res
+    scene.render.resolution_y = res
+    scene.render.resolution_percentage = 100
+    scene.render.film_transparent = False
+    # pkg166 linear: Standard view transform, no gamma, 32-bit linear EXR.
+    scene.view_settings.view_transform = "Standard"
+    scene.view_settings.exposure = 0.0
+    scene.view_settings.gamma = 1.0
+    scene.render.image_settings.file_format = "OPEN_EXR"
+    scene.render.image_settings.color_depth = "32"
+    scene.render.image_settings.exr_codec = "NONE"
+    scene.render.engine = engine
+    if engine == "CYCLES":
+        scene.cycles.samples = samples
+        scene.cycles.use_denoising = False
+        scene.cycles.use_adaptive_sampling = False
+        scene.cycles.seed = 7
+    elif hasattr(scene, "custom_raytracer"):
+        cr = scene.custom_raytracer
+        cr.samples = samples
+        if hasattr(cr, "preview_samples"):
+            cr.preview_samples = samples
+        if hasattr(cr, "device_mode"):
+            cr.device_mode = device  # 'cpu' or 'gpu'
+        # Route through the NATIVE Principled plugin (honours thin-film sockets),
+        # not the Disney-conversion fallback — this gate exists to validate that
+        # path. Explicit even though the property already defaults ON.
+        if hasattr(cr, "use_native_principled"):
+            cr.use_native_principled = True
+
+
+def _render_to_npy(bpy, scene, out_stem: Path):
+    import numpy as np
+
+    for f in glob.glob(str(out_stem) + "*"):
+        try:
+            os.remove(f)
+        except OSError:
+            pass
+    scene.render.filepath = str(out_stem)
+    bpy.ops.render.render(write_still=True)
+
+    matches = sorted(glob.glob(str(out_stem) + "*.exr")) or sorted(glob.glob(str(out_stem) + "*"))
+    if not matches:
+        raise RuntimeError(f"no render output for stem {out_stem}")
+    img = bpy.data.images.load(matches[0])
+    w, h = img.size
+    px = np.asarray(img.pixels[:], dtype=np.float32).reshape(h, w, 4)[:, :, :3]
+    bpy.data.images.remove(img)
+    for f in matches:
+        try:
+            os.remove(f)
+        except OSError:
+            pass
+
+    npy_path = out_stem.with_suffix(".npy")
+    np.save(npy_path, np.ascontiguousarray(px))
+    try:
+        from PIL import Image
+        srgb = np.where(px <= 0.0031308, px * 12.92,
+                        1.055 * np.clip(px, 0, None) ** (1 / 2.4) - 0.055)
+        Image.fromarray((np.clip(srgb, 0, 1) * 255 + 0.5).astype(np.uint8)).save(
+            out_stem.with_suffix(".png"))
+    except Exception:  # noqa: BLE001 - PNG is cosmetic
+        pass
+    return npy_path
+
+
+def main():
+    argv = sys.argv[sys.argv.index("--") + 1:] if "--" in sys.argv else []
+    p = argparse.ArgumentParser()
+    p.add_argument("--config", required=True)
+    p.add_argument("--engine", required=True, choices=("CYCLES", "CUSTOM_RAYTRACER"))
+    p.add_argument("--device", default="gpu", choices=("cpu", "gpu"))
+    p.add_argument("--out", required=True, help="output stem (no extension)")
+    p.add_argument("--res", type=int, default=128)
+    p.add_argument("--samples", type=int, default=256)
+    args = p.parse_args(argv)
+
+    repo_root = Path(__file__).resolve().parents[3]
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+    try:
+        import bpy
+        import scenes
+
+        if args.engine == "CUSTOM_RAYTRACER":
+            _bootstrap_astroray_addon(repo_root)
+
+        cfg = scenes.config_by_name(args.config)
+        scene = scenes.build_thinfilm_scene(bpy, cfg)
+        _configure_render(scene, args.engine, args.device, args.res, args.samples)
+        out_stem = Path(args.out)
+        out_stem.parent.mkdir(parents=True, exist_ok=True)
+        npy = _render_to_npy(bpy, scene, out_stem)
+        print(f"[pkg178tf-leg] wrote {npy}", flush=True)
+        print(f"{SENTINEL} PASS", flush=True)
+    except Exception as exc:  # noqa: BLE001
+        traceback.print_exc()
+        _fail(f"{type(exc).__name__}: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/cycles-parity/thin_film/scenes.py
+++ b/benchmarks/cycles-parity/thin_film/scenes.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+"""pkg178 Stage-4 acceptance — thin-film iridescence A/B sweep + Blender scene builder.
+
+Two layers, deliberately split so the sweep definition is import-safe without
+``bpy`` (mirrors ``benchmarks/cycles-parity/metal_ab/scenes.py``):
+
+  * ``thinfilm_sweep()`` — a PURE function returning the (kind, thickness, film_ior)
+    matrix. Unit-testable without Blender.
+  * ``build_thinfilm_scene(bpy, cfg)`` — runs INSIDE Blender (imported lazily by
+    the render leg); mutates the current file into a single Principled sphere with
+    the Thin Film sockets set, under a uniform constant-colour world, so Cycles
+    and the Astroray addon render the *same translated scene* and differ only in
+    the renderer/device. This is the pkg178 "feature-matrix parity vs Cycles" gate
+    done through the real addon Principled->native translation (incl. the #581
+    thin-film socket mapping), NOT the standalone ``conductor_hue_sweep.py`` path
+    (which never touches the addon and cannot render a Cycles oracle leg).
+
+Scene rationale (why a uniform-world "furnace" and two material kinds):
+
+  * ``conductor`` — a metallic=1 neutral sphere. Thin-film modulates the whole
+    metal reflection; this is the metal-iridescence (anodised/oil-on-metal) case.
+    Astroray ships this as an RGB-upsample approximation (STATUS 2026-08-11), so a
+    residual hue gap vs Cycles' per-wavelength film is EXPECTED and is the number
+    this sweep quantifies (feeds the per-lambda-conductor follow-up).
+
+  * ``dielectric`` — a near-black (base_color ~0) metallic=0, transmission=0,
+    IOR 1.5 sphere: only the iridescent specular Fresnel shows (the literal
+    oil-slick / soap-bubble reflection). This ISOLATES the thin-film Fresnel term,
+    which is the quantity the "analytically exact vs Cycles" claim is about. A
+    fully transmissive bubble adds refractive multi-bounce transport that would
+    diverge for RNG/thin-wall reasons unrelated to the Fresnel utility, so it is
+    deliberately out of scope for this Fresnel-parity gate.
+
+A metallic/dielectric sphere in a uniform environment reflects the constant world
+at a magnitude/hue set by its (thin-film-modulated) Fresnel; the image-plane ROI
+mean + circular-mean hue is the most direct, noise-cheap read of the iridescence.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+# --------------------------------------------------------------------------- #
+# Sweep grid (pure)
+# --------------------------------------------------------------------------- #
+
+# Thickness sweep across the task's 100-1000 nm band. Below ~ half a visible
+# wavelength the first-order interference dominates (strong hue swing); by 1000 nm
+# several orders overlap and the hue begins to wash toward neutral.
+THICKNESSES_NM = (100.0, 200.0, 400.0, 600.0, 800.0, 1000.0)
+FILM_IORS = (1.2, 1.5, 1.8)
+
+# Uniform world = the sole illuminant (furnace-style), matching metal_ab so the
+# two Cycles-parity gates read the same illumination. Moderate strength keeps the
+# linear radiance clear of 0/1 so per-channel ratios are not floor/clamp limited.
+WORLD_COLOR = (0.60, 0.60, 0.60)
+WORLD_STRENGTH = 1.0
+
+# Conductor: neutral metal so the iridescence hue is the dominant chroma signal.
+CONDUCTOR_BASE = (0.90, 0.90, 0.90)
+# Dielectric: near-black body so ONLY the iridescent specular Fresnel shows.
+DIELECTRIC_BASE = (0.02, 0.02, 0.02)
+DIELECTRIC_IOR = 1.5
+ROUGHNESS = 0.06  # sharp enough that the interference tint is not blurred away
+
+
+@dataclass(frozen=True)
+class ThinFilmConfig:
+    name: str
+    kind: str  # "dielectric" | "conductor"
+    thickness_nm: float
+    film_ior: float
+
+    @property
+    def metallic(self) -> float:
+        return 1.0 if self.kind == "conductor" else 0.0
+
+    @property
+    def base_color(self) -> tuple[float, float, float]:
+        return CONDUCTOR_BASE if self.kind == "conductor" else DIELECTRIC_BASE
+
+
+def thinfilm_sweep() -> list[ThinFilmConfig]:
+    """The thin-film A/B matrix: kind x thickness x film_ior."""
+    out: list[ThinFilmConfig] = []
+    for kind in ("dielectric", "conductor"):
+        for d in THICKNESSES_NM:
+            for fior in FILM_IORS:
+                out.append(ThinFilmConfig(
+                    name=f"tf_{kind}_d{int(d):04d}_ior{int(round(fior * 100)):03d}",
+                    kind=kind, thickness_nm=d, film_ior=fior))
+    return out
+
+
+def config_by_name(name: str) -> ThinFilmConfig:
+    for cfg in thinfilm_sweep():
+        if cfg.name == name:
+            return cfg
+    raise ValueError(f"unknown thin-film config {name!r}")
+
+
+# --------------------------------------------------------------------------- #
+# Blender scene builder (runs inside Blender; bpy passed in, never imported here)
+# --------------------------------------------------------------------------- #
+
+def _set_socket(principled, names, value) -> bool:
+    """Set the first Principled input whose label matches any of ``names``.
+
+    Socket labels drift across Blender versions; try each candidate and report
+    whether one landed so the leg can FAIL loudly rather than silently skip the
+    thin-film sockets (which would make the whole parity gate a no-op).
+    """
+    for nm in names:
+        sock = principled.inputs.get(nm)
+        if sock is not None:
+            sock.default_value = value
+            return True
+    return False
+
+
+def build_thinfilm_scene(bpy, cfg: ThinFilmConfig):
+    """Single Principled sphere with Thin Film sockets under a uniform world."""
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+    scene = bpy.context.scene
+
+    world = bpy.data.worlds.new("W")
+    scene.world = world
+    world.use_nodes = True
+    bg = world.node_tree.nodes.get("Background")
+    bg.inputs[0].default_value = (WORLD_COLOR[0], WORLD_COLOR[1], WORLD_COLOR[2], 1.0)
+    bg.inputs[1].default_value = WORLD_STRENGTH
+
+    bpy.ops.mesh.primitive_uv_sphere_add(radius=0.9, location=(0.0, 0.0, 0.0),
+                                         segments=64, ring_count=32)
+    sphere = bpy.context.active_object
+    for poly in sphere.data.polygons:
+        poly.use_smooth = True
+
+    mat = bpy.data.materials.new("ThinFilm")
+    mat.use_nodes = True
+    nt = mat.node_tree
+    for n in list(nt.nodes):
+        nt.nodes.remove(n)
+    out = nt.nodes.new("ShaderNodeOutputMaterial")
+    principled = nt.nodes.new("ShaderNodeBsdfPrincipled")
+    principled.inputs["Base Color"].default_value = (
+        cfg.base_color[0], cfg.base_color[1], cfg.base_color[2], 1.0)
+    principled.inputs["Metallic"].default_value = cfg.metallic
+    principled.inputs["Roughness"].default_value = ROUGHNESS
+    _set_socket(principled, ("IOR",), DIELECTRIC_IOR)
+    _set_socket(principled, ("Transmission Weight", "Transmission"), 0.0)
+
+    # Thin Film sockets (Blender 4.1+; the addon maps these to the native
+    # 'thin_film_thickness'/'thin_film_ior' params, PR #581). FAIL if absent so a
+    # socket rename in a future Blender does not silently disable the whole gate.
+    if not _set_socket(principled, ("Thin Film Thickness",), cfg.thickness_nm):
+        raise RuntimeError("Principled node has no 'Thin Film Thickness' socket")
+    if not _set_socket(principled, ("Thin Film IOR",), cfg.film_ior):
+        raise RuntimeError("Principled node has no 'Thin Film IOR' socket")
+
+    nt.links.new(principled.outputs["BSDF"], out.inputs["Surface"])
+    sphere.data.materials.append(mat)
+
+    cam_data = bpy.data.cameras.new("Cam")
+    cam_data.type = "PERSP"
+    cam_data.angle = math.radians(60.0)
+    cam = bpy.data.objects.new("Cam", cam_data)
+    scene.collection.objects.link(cam)
+    cam.location = (0.0, -1.35, 0.0)
+    cam.rotation_euler = (math.radians(90.0), 0.0, 0.0)
+    scene.camera = cam
+    return scene

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -277,13 +277,17 @@ class CustomRaytracerRenderSettings(PropertyGroup):
     )
     # pkg178 Stage 5: route Blender's Principled BSDF to Astroray's NATIVE
     # 'principled' material (faithful Cycles port: coat/sheen/anisotropy/alpha/
-    # emission driven directly) instead of the Disney approximation. Default ON
-    # for this EXPERIMENTAL build so the owner can drive the real material; the
-    # Disney path stays as the fallback when this is off. The production
-    # default-flip is gated on the Cycles parity matrix (owner-authorized
-    # auto-flip — spec pkg178 D3), do NOT hard-code OFF here to "play it safe".
+    # emission driven directly) instead of the Disney approximation. The Disney
+    # path stays as the fallback when this is off.
+    # RATIFIED to production default ON (2026-08-11): the owner-authorized
+    # auto-flip gate (spec pkg178 D3 / memory pkg178-repin-and-stage5-autonomy)
+    # is satisfied — the Cycles-5.2 parity matrix is green: BSDF_PRINCIPLED PASSES
+    # the pkg119-B differential gate (SSIM 0.972, dE 1.88) and thin-film
+    # dielectric+conductor land in-band across the 100-1000 nm x film-IOR sweep
+    # (see .astroray_plan/docs/pkg178-thinfilm-parity-findings.md). No longer
+    # experimental; do NOT hard-code OFF here.
     use_native_principled: BoolProperty(
-        name="Native Principled BSDF (experimental)",
+        name="Native Principled BSDF",
         default=True,
         description="Route Blender's Principled BSDF to Astroray's native "
                     "'principled' material (coat, sheen, anisotropy, alpha and "

--- a/tests/test_blender_parity_harness.py
+++ b/tests/test_blender_parity_harness.py
@@ -104,10 +104,15 @@ def test_triage_known_intentional_spectral():
     assert bucket == T.INTENTIONAL_DIVERGENCE and "spectral" in reason
 
 
-def test_triage_pkg89_light_energy():
-    gr = T.gate(0.6, 30.0, (3.0, 3.0, 3.0))
-    bucket, reason = T.triage("AREA", "SUPPORTED", gr)
-    assert bucket == T.INTENTIONAL_DIVERGENCE and "pkg89" in reason
+def test_triage_lights_no_longer_specially_exempt():
+    # pkg181 (#569) fixed the dedicated-light dim, so POINT/SUN/AREA/SPOT were
+    # removed from KNOWN_INTENTIONAL_DIVERGENCE (2026-08-11 re-baseline; all four
+    # PASS on the Blender-5.2 run). A light that regresses with a CHROMATIC
+    # divergence (channels move differently -> not a uniform energy-scale) must now
+    # surface as a TRANSLATION-BUG instead of being silently excused.
+    gr = T.gate(0.6, 15.0, (1.05, 0.7, 1.3))  # channels differ -> hue/structure bug
+    bucket, _ = T.triage("AREA", "SUPPORTED", gr)
+    assert bucket == T.TRANSLATION_BUG
 
 
 def test_triage_approximated_is_intentional():

--- a/tests/test_thin_film_ab_harness.py
+++ b/tests/test_thin_film_ab_harness.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+"""pkg178 thin-film A/B — unit tests for the pure metric/band/sweep layer.
+
+Synthetic arrays only — no Blender, no GPU. The full Cycles-5.2-vs-Astroray run is
+the LEAD's on-hardware acceptance gate (needs Blender 5.2 + the addon .pyd + the
+RTX box, none present in CI); there is no verdict here by design.
+
+    pytest tests/test_thin_film_ab_harness.py -v
+"""
+from __future__ import annotations
+
+import importlib.util
+import math
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+_TF = REPO_ROOT / "benchmarks" / "cycles-parity" / "thin_film"
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def _load_unique(mod_name, path):
+    """Load a module from an explicit path under a UNIQUE name (avoids the bare
+    `import scenes`/`import harness` sys.modules collision across benchmarks dirs;
+    see tests/test_pkg129_metal_ab_harness.py for the same pattern)."""
+    spec = importlib.util.spec_from_file_location(mod_name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_scenes = _load_unique("tf_scenes", _TF / "scenes.py")
+_H = _load_unique("tf_harness", _TF / "harness.py")
+
+
+# --------------------------------------------------------------------------- #
+# Sweep construction
+# --------------------------------------------------------------------------- #
+
+def test_sweep_grid_shape():
+    sweep = _scenes.thinfilm_sweep()
+    assert len(sweep) == 2 * len(_scenes.THICKNESSES_NM) * len(_scenes.FILM_IORS)
+    kinds = {c.kind for c in sweep}
+    assert kinds == {"dielectric", "conductor"}
+    names = {c.name for c in sweep}
+    assert len(names) == len(sweep)  # unique names
+
+
+def test_kind_material_params():
+    sweep = {c.kind: c for c in _scenes.thinfilm_sweep()}
+    assert sweep["conductor"].metallic == 1.0
+    assert sweep["dielectric"].metallic == 0.0
+    # dielectric is a near-black body so only the iridescent Fresnel shows.
+    assert max(sweep["dielectric"].base_color) < 0.1
+    assert min(sweep["conductor"].base_color) > 0.5
+
+
+def test_config_by_name_roundtrip():
+    c = _scenes.thinfilm_sweep()[7]
+    assert _scenes.config_by_name(c.name) is not None
+    with pytest.raises(ValueError):
+        _scenes.config_by_name("tf_nope")
+
+
+# --------------------------------------------------------------------------- #
+# Metric layer
+# --------------------------------------------------------------------------- #
+
+def test_per_channel_ratio_identity():
+    a = np.full((4, 4, 3), 0.5, np.float32)
+    assert _H.per_channel_ratio(a, a) == pytest.approx((1.0, 1.0, 1.0))
+
+
+def test_per_channel_ratio_values():
+    a = np.zeros((2, 2, 3), np.float32)
+    b = np.zeros((2, 2, 3), np.float32)
+    a[..., 0] = 0.4; b[..., 0] = 0.5   # 0.8
+    a[..., 1] = 0.6; b[..., 1] = 0.6   # 1.0
+    a[..., 2] = 0.9; b[..., 2] = 0.6   # 1.5
+    r = _H.per_channel_ratio(a, b)
+    assert r == pytest.approx((0.8, 1.0, 1.5))
+
+
+def test_in_band_both_bounds():
+    band = _H.Band(0.85, 1.15)
+    assert _H.in_band((1.0, 1.0, 1.0), band)
+    assert not _H.in_band((0.84, 1.0, 1.0), band)   # floor
+    assert not _H.in_band((1.0, 1.16, 1.0), band)   # ceiling (energy GAIN fails)
+    assert not _H.in_band((float("nan"), 1.0, 1.0), band)  # missing signal
+
+
+def test_hue_delta_circular_wraparound():
+    assert _H._hue_delta_deg(10.0, 350.0) == pytest.approx(20.0)
+    assert _H._hue_delta_deg(350.0, 10.0) == pytest.approx(20.0)
+    assert _H._hue_delta_deg(0.0, 180.0) == pytest.approx(180.0)
+    assert math.isnan(_H._hue_delta_deg(float("nan"), 10.0))
+
+
+def test_sphere_roi_is_central_subregion():
+    img = np.zeros((100, 100, 3), np.float32)
+    roi = _H.sphere_roi(img)
+    assert roi.shape[0] < 100 and roi.shape[1] < 100
+    assert roi.shape[0] > 0 and roi.shape[1] > 0
+
+
+def test_compare_cell_identical_passes():
+    cfg = _scenes.thinfilm_sweep()[0]
+    img = np.full((16, 16, 3), 0.4, np.float32)
+    img[..., 2] = 0.3  # give it some chroma so hue is defined
+    r = _H.compare_cell(cfg, img, img, _H.Band(0.85, 1.15))
+    assert r.status == "pass"
+    assert r.ratio == pytest.approx((1.0, 1.0, 1.0))
+    assert r.hue_delta_deg == pytest.approx(0.0, abs=1e-6)


### PR DESCRIPTION
Closes the last two owed **pkg178** items — thin-film saturation parity vs Blender 5.2 Cycles, and the coordinated pkg119-B / pkg129 harness band re-pin (reflecting pkg181 + height-correlated Smith G2 #573 + pkg172(A) guarded-pdf + #582 ggxReflect fix + thin-film together) — and **ratifies** the Stage-5 addon default. Owner pre-authorized the autonomous evidence-clean re-pin + auto-flip (memory `pkg178-repin-and-stage5-autonomy`).

## Part 1 — thin-film parity (acceptance GREEN)

New identical-scene A/B harness `benchmarks/cycles-parity/thin_film/` — both the Cycles-5.2 oracle and the Astroray-GPU leg render the **same translated Blender scene** through the real addon Principled→native path (incl. #581 thin-film sockets), so this validates the shipped Stage-5 routing, not a standalone reimplementation. Swept thickness {100–1000 nm} × film-IOR {1.2,1.5,1.8} × {dielectric, conductor}.

| kind | in-band | RGB chroma dev | hue Δ (chroma-meaningful cells) | max dE2000 |
|------|---------|----------------|---------------------------------|------------|
| **dielectric** (analytically-exact Belcour Fresnel) | 18/18 | ≤ 8.96 % | mean 6.0°, max 13.4° | 2.42 |
| **conductor** (RGB-upsample approx) | 18/18 | **≤ 2.09 %** | mean 10.1°, max 25.4° | 1.39 |

- Dielectric matches Cycles, confirming the "utility is analytically exact" claim. The film-IOR=1.5 cells correctly show **zero iridescence** (film IOR = base IOR ⇒ no interface contrast).
- **Conductor gap is much smaller than assumed** — RGB chroma is essentially exact; the per-λ-conductor follow-up is validated **low priority**.
- Visually confirmed (smooth center-to-rim iridescence matching Cycles, not noise); 9 pure-metric unit tests.
- Findings: `.astroray_plan/docs/pkg178-thinfilm-parity-findings.md`

## Part 2 — harness band re-pin (toward-Cycles, evidence-clean)

- `_find_blender` prefers **Blender 5.2** (pkg178-D1 oracle) in both harnesses.
- **pkg119-B** on 5.2: 39 features → 25 pass / 1 skip / 13 fail. All 4 dedicated lights **PASS** (dE ≤ 1.6) and **BSDF_PRINCIPLED PASS** (SSIM 0.972, dE 1.88). Removed the now-stale pkg89 light `INTENTIONAL-DIVERGENCE` exemptions from `triage.py` — pkg181 fixed the dim they excused, so a future light regression must surface as a bug (test updated).
- **180° AREA-flip** confirmed already removed (pkg181).
- **pkg129 metal A/B** on 5.2: 12/12 legs (CPU+GPU) in [0.857, 1.016]. Ceiling tightened **1.15 → 1.05** (turns it into a real energy-*gain* guard; the settled engine never exceeds 1.016). Floor **held at 0.85** — binding on the chromatic r=0.9 blue channel (0.857), the known high-roughness multiscatter residual; asymmetric band justified in-code.
- pkg119-B SSIM/dE thresholds **retained** (deliberately loose for independent-RNG MC noise; not evidence-justified to tighten).
- The 5 residual pkg119-B `TRANSLATION-BUG`s are all **procedural texture nodes** (pre-existing parity gap, unrelated to this round).

## Stage-5 default ratified

`use_native_principled` production default **ON** (was default ON "experimental"). The owner-authorized auto-flip gate is satisfied by the green matrix above; the "(experimental)" label is removed. (The default was already `True`; this ratifies it and drops the caveat.)

## Not covered (kept explicitly owed)

Thin-**wall** paper/leaf/window-sheet trio (#580) — a separate feature from the thin-**film** iridescence verified here; still owed per the pkg178 acceptance list.

## Testing

- 53 pure-metric/harness unit tests pass (`test_thin_film_ab_harness`, `test_blender_parity_harness`, `test_pkg129_metal_ab_harness`).
- Live A/B harnesses run on the RTX box + Blender 5.2 with the OpenMP-off addon build (pkg119b runbook). Reports live under `test_results/` (gitignored); numbers summarized above and in the findings doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)