### PR TITLE
build: force CRLF checkout for .bat/.cmd via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Windows batch scripts must be checked out with CRLF line endings.
+# cmd.exe mis-parses LF-only .bat files: it joins lines and mangles the
+# `^` continuation, producing errors like "'5-B'' is not recognized" and
+# "< was unexpected at this time", and can falsely exit 0 having done nothing.
+# git still stores these as LF internally; `eol=crlf` forces CRLF on checkout.
+*.bat text eol=crlf
+*.cmd text eol=crlf


### PR DESCRIPTION
## Problem

All tracked Windows batch scripts were committed **LF-only** (verified with `git cat-file blob` — CR=0 on all 5), there is **no `.gitattributes`**, and local `core.autocrlf=false` (overriding the system-level `true`). So `.bat` files check out **LF-only on disk** — confirmed CR=0 on all 5 working-tree files.

cmd.exe can mis-parse LF-only `.bat` files: it joins lines and mangles `^` continuations (parse-sensitive constructs live in `scripts/build/build_cuda_worktree.bat` and `scripts/build/build_cuda.bat`). This broke a direct `build_cuda_worktree.bat` invocation on 2026-08-10 (had to run a CRLF-converted copy). Matches the `bat-files-need-crlf` memory.

## Fix

Add `.gitattributes`:
```
*.bat text eol=crlf
*.cmd text eol=crlf
```

Git keeps LF internally (**blobs unchanged → zero content churn**, diff is the one new file) but now checks out **CRLF on disk** across all worktrees regardless of `core.autocrlf`.

## Verification

- `git check-attr text eol` confirms `text=set eol=crlf` applies to `.bat`.
- After renormalize + re-checkout, all 5 working-tree `.bat` files are CRLF (CR == LF line count); index blobs remain LF; `git status` shows only `.gitattributes` added.
- Real, now-CRLF `scripts/build/build_cuda_worktree.bat` parses correctly under a direct `cmd /c` (no-args path exercises its multi-line `if`/`^<` blocks → clean Usage output, exit 1).

**Honest caveat:** I could not synthetically reproduce the LF-only break on this Windows 11 box — cmd.exe parsed LF-only caret, flat-`if`, and nested-`if` blocks correctly in isolated A/B tests. The documented failure is intermittent / construct- or invocation-specific. CRLF remains the correct, safe standard for Windows `.bat` regardless; this PR just guarantees it on every future checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)