### PR TITLE
feat(pkg182): per-λ-native Principled conductor thin-film (supersede RGB-upsample)

### DIFF
--- a/.astroray_plan/packages/pkg182-ggxreflect-eval-d-pdf-d-consistency.md
+++ b/.astroray_plan/packages/pkg182-ggxreflect-eval-d-pdf-d-consistency.md
@@ -61,3 +61,67 @@ pkg178 Stage-4 thin-glass lobe. Cites Heitz 2014 (GGX D term).
 
 Filed by the lead 2026-08-10, discovered during pkg178 Stage 4 PR-4 review
 (thin-glass black-render blocker); fixed and merged the same day as PR #582.
+
+## Hardware verification 2026-08-12 (PR #586 — per-λ-native conductor thin-film follow-up)
+
+**Scope note:** PR #586 is the pkg182 follow-up leg (per-λ-native Principled
+metallic/conductor F82 thin-film, superseding the PR-2/PR-3 RGB-upsample
+approximation). Its own gate list lives in the PR body, not restated as
+spec acceptance criteria here — this section records the independent
+hardware re-measurement.
+
+**Hardware:** NVIDIA GeForce RTX 5070 Ti, driver 610.47, compute capability
+12.0. CUDA 12.8 (`nvcc` V12.8.61, `CMAKE_CUDA_COMPILER` =
+`CUDA/v12.8/bin/nvcc.exe`; `ASTRORAY_CUDA_ARCHS=native` local-dev build).
+Windows 11 Enterprise 10.0.26200. Worktree
+`.claude/worktrees/awesome-morse-c232d1`, HEAD
+`3425afeb9256a850779ea367e60a2c13cb71997e`, clean rebuild
+(`build_cuda_worktree.bat`), `.pyd` mtime 2026-08-12 09:17 (post-HEAD-commit,
+non-stale), `astroray.__file__` confirmed pointing at the worktree's own
+`build_cuda/astroray.cp313-win_amd64.pyd`.
+
+| Gate | Claimed | Measured | Result |
+|---|---|---|---|
+| cuobjdump `stageShadeBucketedKernel<false>` | STACK 3608 / REG 254, unchanged | STACK 3608 / REG 254 (identical to current-main baseline: STACK 3608/REG 254) | PASS |
+| cuobjdump `stageShadeBucketedKernel<true>` | STACK 6592 / REG 254, unchanged, only CONSTANT[2] +40 B | STACK 6592 / REG 254; CONSTANT[2] 208→248 B (main baseline 208, branch 248 = +40 B exactly) | PASS |
+| Thickness-0 bit-equality (CPU, metallic) | PASS | `test_metallic_thin_film_thickness0_bit_equality` PASSED (np.array_equal true for both absent-vs-0.0 and 0.05nm-sub-cutoff) | PASS |
+| Thickness-0 bit-equality (CPU+GPU ×3, pkg178 harness) | PASS | `test_thinfilm_zero_thickness_bit_identity[dielectric_spec\|metallic\|glass]` — 3/3 PASSED | PASS |
+| CPU/GPU conductor thin-film spectral parity | 12/12, metallic within 0.7% | 12/12 PASSED (`test_thinfilm_gpu_cpu_parity` × 9 cases + `test_thinfilm_zero_thickness_bit_identity` × 3); metallic cases max deviation: mean-ratio ≤1.0016 (0.16%), median-ratio up to 1.0071 (metallic_r0.3_d550, R channel, 0.71%) — consistent with the claimed "within 0.7%" | PASS |
+| Furnace no-energy-gain (LINEAR, `apply_gamma=False`) | PASS | `test_metallic_thin_film_furnace_no_energy_gain` PASSED — 15-case thickness×film-IOR sweep held within `[off_mean×0.90-0.02, off_mean×1.06+0.02]`; render call confirmed `apply_gamma=False` at the call site (line 46 of `tests/test_thin_film_pr2.py`) | PASS |
+| Full gate suite (`test_thin_film_pr2` + `test_pkg182_conductor_spectral_native` + `test_pkg178_thinfilm_gpu_cpu_parity`) | 17/17 | 17/17 PASSED (`10.70s`) — first attempt showed 1 failure (`UnicodeEncodeError` on `λ` glyph under the shell's cp1252 console codepage inside a `print()`, not a logic failure); re-ran with `PYTHONIOENCODING=utf-8`, all 17 green | PASS |
+| Saturation washout guard (`test_conductor_spectral_stays_chromatic`) | mean 0.0488→0.0499, max 0.1842→0.2045 | mean_sat=0.0499, max_sat=0.2045 (exact match to claimed) | PASS |
+| Hue trajectory moves with thickness | — | `test_conductor_spectral_hue_moves_with_thickness` PASSED | PASS |
+
+**Visual inspection:** rendered a 384×384 metallic Principled sphere
+(thickness 500 nm, film IOR 1.5, base_color 0.9/0.9/0.9, white background,
+256 spp, GPU path) on this branch and on a freshly-rebuilt current-`main`
+(24106ca) baseline for the same scene/seed. Both show the same iridescent
+banding pattern (yellow rim → magenta band → cyan/green core, growing
+toward grazing angle) at comparable noise level (mean|on−off| = 0.00898
+branch vs 0.00955 main). A saturation-boosted (×6 chroma) crop and a ×10
+absolute-difference heatmap confirm: no fireflies/single-pixel spikes, no
+banding/quantization artifacts, no NaN pixels (magenta/black), no mode
+regression (thin-film-off renders a clean uniform-white sphere on both
+builds). The branch-vs-main diff is smooth and ring-shaped (concentrated at
+the grazing rim, consistent with the physics), not noisy or structurally
+different — matches the PR's own "not the visible saturation jump the
+ticket implied" finding. No visual regression found.
+
+**Anomalies worth watching:** none blocking. Both this worktree's and
+current-main's `build_cuda/CMakeCache.txt` still carry a stale cached
+`CMAKE_CUDA_ARCHITECTURES:STRING=52` alongside `ASTRORAY_CUDA_ARCHS=native`;
+confirmed this is shadowed at configure time by the CMakeLists.txt
+unconditional `set(CMAKE_CUDA_ARCHITECTURES "${ASTRORAY_CUDA_ARCHS}")` (a
+non-cache variable), and the actually-compiled kernels correctly target
+this machine's `native` SM (RTX 5070 Ti, CC 12.0) — not a live bug, but the
+cache entry should eventually be cleaned so it stops looking like drift on
+every worktree-cache audit. Main's `.pyd` was found stale (older than its
+own HEAD commit) at verification start and was rebuilt as the comparison
+baseline; this was pre-existing main-branch build-cache staleness, unrelated
+to PR #586's own gate results.
+
+**Overall verdict:** mergeable-on-HW-evidence: yes. All 17/17 gate tests
+pass, the cuobjdump structural claims measure exactly as stated including
+the precise +40 B CONSTANT[2] delta, and visual inspection found no
+regression. This is a numbers report, not a merge authorization — gate/merge
+decisions remain with the architect dialogue.

--- a/include/astroray/gpu_materials.h
+++ b/include/astroray/gpu_materials.h
@@ -1547,14 +1547,31 @@ __device__ inline GVec3 gpu_pr_thinFilmConductorRGB(const GPrincipledClosure& c,
     }
     return out;
 }
-// principled.cpp::thinFilmConductorSpectral — RGB-channel conductor F upsampled
-// to spectral (Cycles has no spectral n,k; plan §0.5 APPROXIMATED-equal-to-Cycles).
+// principled.cpp::thinFilmConductorSpectral — PER-λ NATIVE (pkg182). Upsample f0 +
+// specular-tint per sampled λ, invert the conductor (n,k,g) per-λ via
+// gpu_pr_conductorNK (Gulbrandsen JCGT 2014), and run the analytic Belcour-Barla
+// Airy per-λ (sensitivitySpectral) — mirror of the dielectric spectral leg;
+// supersedes PR-3's RGB-upsample with the exact per-λ evaluation (no Jakob-Hanika
+// round-trip). The per-hit per-λ inversion lands ONLY in the <true> HasPrincipled
+// instantiation (which already recomputes conductor n,k per hit — see
+// gpu_pr_conductorNK / gpu_types.h data-isolation note), so the shared <false>
+// kernel's STACK is unchanged. Cycles bsdf_util.h:499
+// fresnel_iridescence_channel<true> over :200 fresnel_conductor_polarized.
 __device__ inline GSampledSpectrum gpu_pr_thinFilmConductorSpectral(
         const GPrincipledClosure& c, float cosI, const GSampledWavelengths& wl) {
-    GVec3 rgb = gpu_pr_thinFilmConductorRGB(c, cosI);
-    float maxc = fmaxf(fmaxf(fmaxf(rgb.x, rgb.y), rgb.z), 1.f);
-    GVec3 tint = rgb * (1.f / maxc);
-    return gpu_rgbToSampledSpectrum(tint, wl, GSPEC_RGB_ALBEDO) * maxc;
+    namespace tf = astroray::thinfilm;
+    GSampledSpectrum f0 = gpu_rgbToSampledSpectrum(c.color, wl, GSPEC_RGB_ALBEDO);
+    GSampledSpectrum tint = gpu_rgbToSampledSpectrum(c.specularTint, wl, GSPEC_RGB_ALBEDO);
+    GSampledSpectrum out(0.f);
+    for (int i = 0; i < G_SPECTRUM_SAMPLES; ++i) {
+        float n, k, g;
+        gpu_pr_conductorNK(f0[i], tint[i], n, k, g);
+        float lambda = wl.lambda[i];
+        auto S = [lambda](float argOPD) { return tf::sensitivitySpectral(argOPD, lambda); };
+        out[i] = tf::fresnelIridescenceChannel<true>(
+            1.f, c.thinFilmThickness, c.thinFilmIor, n, k, g, cosI, nullptr, S);
+    }
+    return out;
 }
 
 // ==========================================================================

--- a/plugins/materials/principled.cpp
+++ b/plugins/materials/principled.cpp
@@ -325,29 +325,31 @@ class PrincipledPlugin : public Material {
     // bsdf_util.h:200 fresnel_conductor_polarized + :499
     // fresnel_iridescence_channel<true>.
     // ==================================================================
-    // Host-precompute the per-RGB-channel conductor (n,k) + F82 value g from a
-    // per-material (f0, F82-tint) pair. Called ONCE from the ctor — this is the
-    // per-hit-inversion optimization the plan mandates (plan §0 decision 5;
-    // Cycles re-inverts per shade only because its fresnel structs are per-hit).
+    // Gulbrandsen "Artist Friendly Metallic Fresnel" (JCGT 2014) inversion: an
+    // artist (f0, specular-tint) pair → conductor (n,k) + the F82 value g (used as
+    // the phase selector). Shared by the per-material ctor precompute (RGB leg) and
+    // the per-λ spectral leg (thinFilmConductorSpectral). Exact mirror of
+    // gpu_materials.h::gpu_pr_conductorNK. Cycles bsdf_microfacet.h:365-383; g reuses
+    // the metallic lobe's own F82 evaluation at cosθ=1/7 (bsdf_util.h:186).
+    static void conductorNK(float f0, float tint, float& n, float& k, float& g) {
+        const float r = std::min(f0, 0.999f);
+        g = f82Channel(1.0f / 7.0f, f0, tint);
+        const float sqrtR = std::sqrt(r);
+        // n = mix((1+√r)/(1−√r), (1−r)/(1+r), g); k = safe_sqrt((r(n+1)²−(n−1)²)/(1−r)).
+        const float nLo = (1.0f + sqrtR) / (1.0f - sqrtR);
+        const float nHi = (1.0f - r) / (1.0f + r);
+        n = nLo + (nHi - nLo) * g;
+        const float kNum = r * (n + 1.0f) * (n + 1.0f) - (n - 1.0f) * (n - 1.0f);
+        k = std::sqrt(std::max(0.0f, kNum / (1.0f - r)));
+    }
+    // Host-precompute the per-RGB-channel conductor (n,k,g) from the per-material
+    // (base_color, specular-tint) pair. Called ONCE from the ctor — the per-hit
+    // inversion optimization for the RGB leg (Cycles re-inverts per shade only
+    // because its fresnel structs are per-hit).
     void precomputeConductorNK() {
-        for (int c = 0; c < 3; ++c) {
-            const float f0 = (&baseColor_.x)[c];
-            const float tint = (&specularTint_.x)[c];
-            const float r = std::min(f0, 0.999f);
-            // g = fresnel_f82(1/7, f0, b) with b = f82tint_B(f0, tint) — exactly the
-            // metallic lobe's own F82 evaluation at cosθ=1/7 (bsdf_util.h:186).
-            const float g = f82Channel(1.0f / 7.0f, f0, tint);
-            const float sqrtR = std::sqrt(r);
-            // n = mix((1+√r)/(1−√r), (1−r)/(1+r), g); k = safe_sqrt((r(n+1)²−(n−1)²)/(1−r)).
-            const float nLo = (1.0f + sqrtR) / (1.0f - sqrtR);
-            const float nHi = (1.0f - r) / (1.0f + r);
-            const float n = nLo + (nHi - nLo) * g;
-            const float kNum = r * (n + 1.0f) * (n + 1.0f) - (n - 1.0f) * (n - 1.0f);
-            const float k = std::sqrt(std::max(0.0f, kNum / (1.0f - r)));
-            filmMetalN_[c] = n;
-            filmMetalK_[c] = k;
-            filmMetalG_[c] = g;
-        }
+        for (int c = 0; c < 3; ++c)
+            conductorNK((&baseColor_.x)[c], (&specularTint_.x)[c],
+                        filmMetalN_[c], filmMetalK_[c], filmMetalG_[c]);
     }
     // Per-RGB-channel conductor iridescence F at half-vector cosine `cosI`, using
     // the precomputed (n,k,g) + the Rec.709-baked CIE sensitivity LUT — Cycles
@@ -365,19 +367,36 @@ class PrincipledPlugin : public Material {
         }
         return out;
     }
-    // Spectral leg. Cycles has no spectral n,k for the F82 conductor, so the plan
-    // (§0 decision 5) evaluates the RGB-channel conductor iridescence and upsamples
-    // the resulting reflectance to spectral — APPROXIMATED-equal-to-Cycles, and the
-    // sanctioned "upsample a reflectance colour" JH usage (memory
-    // spectral-upsample-nonlinearity-scaled-bsdf; same trick as the film-free
-    // transmission spectral fallback below). Documented RGB↔spectral hue difference
-    // by construction (pkg128 §B; recorded, not gated).
+    // Spectral leg — PER-λ NATIVE (pkg182). Upsample the artist f0 (base_color) and
+    // specular-tint at EACH sampled wavelength, invert the conductor (n,k) per-λ via
+    // the Gulbrandsen model (conductorNK), and run the analytic Belcour-Barla Airy
+    // summation per-λ with the exact single-λ sensitivity phasor exp(i·2π·m·OPD/λ)
+    // (sensitivitySpectral) — the SAME per-λ discipline as the dielectric spectral
+    // leg (thinFilmFresnelSpectral) and the pkg163 rule. This supersedes PR-2's
+    // "upsample an RGB conductor reflectance" approximation with the exact per-λ
+    // evaluation (no Jakob-Hanika round-trip), matching what Cycles does internally
+    // and the dielectric leg's discipline. Exact under spectral/colored illumination;
+    // in Astroray's 4-sample hero pipeline the white-light saturation gain is small
+    // (~10% peak) — see tests/test_pkg182_conductor_spectral_native.py for the data.
+    // The per-hit per-λ inversion is cheap and runs only on the metallic film path.
+    // compFss (f0) stays film-free. Cycles reference: bsdf_util.h:499
+    // fresnel_iridescence_channel<true> over :200 fresnel_conductor_polarized, with
+    // (n,k) from the F82 inversion (bsdf_microfacet.h:365-383).
     astroray::SampledSpectrum thinFilmConductorSpectral(
             float cosI, const astroray::SampledWavelengths& lam) const {
-        Vec3 rgb = thinFilmConductorRGB(cosI);
-        float maxc = std::max({rgb.x, rgb.y, rgb.z, 1.0f});
-        Vec3 tint = rgb * (1.0f / maxc);
-        return upsample(tint, lam) * maxc;
+        namespace tf = astroray::thinfilm;
+        astroray::SampledSpectrum f0 = upsample(baseColor_, lam);
+        astroray::SampledSpectrum tint = upsample(specularTint_, lam);
+        astroray::SampledSpectrum out(0.0f);
+        for (int i = 0; i < astroray::kSpectrumSamples; ++i) {
+            float n, k, g;
+            conductorNK(f0[i], tint[i], n, k, g);
+            const float lambda = lam.lambda(i);
+            auto S = [lambda](float argOPD) { return tf::sensitivitySpectral(argOPD, lambda); };
+            out[i] = tf::fresnelIridescenceChannel<true>(
+                1.0f, thinFilmThickness_, thinFilmIor_, n, k, g, cosI, nullptr, S);
+        }
+        return out;
     }
 
     // ==================================================================

--- a/tests/test_pkg182_conductor_spectral_native.py
+++ b/tests/test_pkg182_conductor_spectral_native.py
@@ -1,0 +1,122 @@
+"""pkg182 follow-up — CONDUCTOR (metallic) thin-film SPECTRAL leg is per-λ native.
+
+PR-2/PR-3 shipped the conductor thin-film spectral leg as a Jakob-Hanika upsample
+of the per-RGB-channel iridescence result (Cycles has no spectral n,k for the F82
+conductor, so it was documented APPROXIMATED-equal-to-Cycles). This change makes
+the leg per-λ native: at each sampled wavelength it upsamples base_color +
+specular_tint, inverts the conductor (n,k) via Gulbrandsen, and runs the analytic
+Belcour-Barla Airy summation with the exact single-λ sensitivity phasor — the same
+discipline the dielectric spectral leg already uses. See
+principled.cpp::thinFilmConductorSpectral / gpu_pr_thinFilmConductorSpectral.
+
+Astroray's `path_tracer` is spectral-first (the legacy RGB integrator was deleted,
+spectral-core.md), so a plain `r.render()` on a metallic Principled sphere runs
+exactly this per-λ leg.
+
+MEASURED FINDING (this branch, RTX 5070 Ti):
+  In Astroray's 4-wavelength hero pipeline the per-λ native leg and the prior
+  RGB-upsample leg are near-identical — white-environment hue-sweep saturation
+  moved mean 0.0488 -> 0.0499, max 0.1842 -> 0.2045 (i.e. removing the JH round-
+  trip recovers ~10% of peak chroma), and the per-λ spectral-reshape signal under
+  a saturated colored light is ~0.01. The Airy reflectance is smooth enough to be
+  JH-reconstructible at 4 samples, so there is NO dramatic muting to undo here; the
+  change's value is exactness (no JH round-trip), consistency with the dielectric
+  leg, and being the correct foundation for higher spectral sample counts / spectral
+  light sources — at zero <false>/<true> STACK cost. The vs-Blender-5.2 per-channel
+  pixel-match is the acceptance gate and remains LEAD-DEFERRED (needs the oracle).
+
+Gates here (CPU). thickness-0 bit-equality, furnace no-gain and chromatic-change on
+this same spectral path are already gated by test_thin_film_pr2; GPU/CPU spectral
+parity by test_pkg178_thinfilm_gpu_cpu_parity. This file guards the two properties
+that must survive on the per-λ leg: it stays chromatic (iridescence not washed out)
+and its hue trajectory still sweeps with thickness.
+"""
+import numpy as np
+import pytest
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+
+try:
+    import astroray
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray not built")
+
+_W = 96
+_SEED = 7
+
+# plan §4 conductor hue-trajectory grid (same as conductor_hue_sweep.py).
+_THICKNESSES = [100.0, 200.0, 400.0, 800.0, 1500.0, 3000.0]
+_FILM_IORS = [1.2, 1.5, 1.8]
+_BASE_COLOR = (0.9, 0.9, 0.9)  # neutral metal so iridescence is the dominant chroma
+
+# Washout guard, NOT an improvement claim. Measured on this branch: mean cell
+# saturation 0.0499, max 0.2045 over the grid. These floors sit comfortably below
+# that so a future change that flattens the per-λ leg (loses the iridescence) fails.
+_MEAN_SAT_FLOOR = 0.035
+_MAX_SAT_FLOOR = 0.15
+
+
+def _render(thickness_nm, film_ior, *, res=_W, spp=128):
+    r = astroray.Renderer()
+    r.set_use_gpu(False)  # CPU leg; GPU/CPU parity is a separate gate
+    r.set_background_color([1.0, 1.0, 1.0])
+    params = {
+        "ior": 1.5, "roughness": 0.08, "metallic": 1.0, "transmission_weight": 0.0,
+        "thin_film_thickness": thickness_nm, "thin_film_ior": film_ior,
+    }
+    mid = r.create_material("principled", list(_BASE_COLOR), params)
+    r.add_sphere([0.0, 0.0, 0.0], 1.0, mid)
+    r.set_integrator("path_tracer")
+    r.setup_camera([0, 0, 4], [0, 0, 0], [0, 1, 0], 40.0, 1.0, 0.0, 4.0, res, res)
+    r.set_seed(_SEED)
+    # render(spp, depth, denoiser, apply_gamma) — LINEAR.
+    return np.asarray(r.render(spp, 16, None, False), dtype=np.float32).reshape(res, res, 3)
+
+
+def _roi_mean_rgb(img):
+    h, w, _ = img.shape
+    roi = img[int(h * 0.25):int(h * 0.75), int(w * 0.25):int(w * 0.75)]
+    return roi.reshape(-1, 3).mean(axis=0)
+
+
+def _saturation(mean_rgb):
+    mx = float(mean_rgb.max())
+    mn = float(mean_rgb.min())
+    return (1.0 - mn / mx) if mx > 0 else 0.0
+
+
+# ---------------------------------------------------------------------------
+# the per-λ leg stays chromatic across the sweep (iridescence not washed out)
+# ---------------------------------------------------------------------------
+def test_conductor_spectral_stays_chromatic():
+    sats = []
+    for d in _THICKNESSES:
+        for fior in _FILM_IORS:
+            sats.append(_saturation(_roi_mean_rgb(_render(d, fior))))
+    sats = np.asarray(sats)
+    mean_sat, max_sat = float(sats.mean()), float(sats.max())
+    print(f"\n[pkg182 conductor per-λ] mean_sat={mean_sat:.4f} max_sat={max_sat:.4f} "
+          f"(RGB-upsample baseline: mean 0.0488, max 0.1842)")
+    assert mean_sat >= _MEAN_SAT_FLOOR, (
+        f"per-λ conductor mean saturation {mean_sat:.4f} < floor {_MEAN_SAT_FLOOR} "
+        "— the thin-film iridescence has washed out to gray (leg broken)")
+    assert max_sat >= _MAX_SAT_FLOOR, (
+        f"per-λ conductor max saturation {max_sat:.4f} < floor {_MAX_SAT_FLOOR} "
+        "— the strongest iridescent cell lost its chroma (leg broken)")
+
+
+# ---------------------------------------------------------------------------
+# hue trajectory still present across thickness (iridescence not washed out)
+# ---------------------------------------------------------------------------
+def test_conductor_spectral_hue_moves_with_thickness():
+    # A fixed film IOR, sweep thickness; the ROI-mean channel signature must move.
+    fior = 1.8
+    means = [_roi_mean_rgb(_render(d, fior)) for d in _THICKNESSES]
+    sigs = np.asarray([[m[0] / (m[1] + 1e-6), m[2] / (m[1] + 1e-6)] for m in means])
+    spread = float(np.abs(sigs - sigs.mean(axis=0)).max())
+    assert spread > 0.05, (
+        f"conductor thin-film hue does not move with thickness (max Δsig={spread:.3f})")


### PR DESCRIPTION
## What

Make the Principled **metallic (F82 conductor) thin-film SPECTRAL leg per-λ native** on both CPU and GPU, superseding the PR-2/PR-3 "upsample an RGB conductor reflectance" approximation.

- CPU [`thinFilmConductorSpectral`](plugins/materials/principled.cpp): upsample `base_color`+`specular_tint` per sampled λ, invert (n,k) per-λ via a new shared `conductorNK` helper (Gulbrandsen), run the analytic Belcour-Barla Airy with `sensitivitySpectral`. `precomputeConductorNK` refactored to call the same helper (no behavior change).
- GPU [`gpu_pr_thinFilmConductorSpectral`](include/astroray/gpu_materials.h): same, reusing the existing per-hit `gpu_pr_conductorNK`.
- New `tests/test_pkg182_conductor_spectral_native.py`.

Citations: Belcour & Barla 2017; Gulbrandsen JCGT 2014; Cycles `bsdf_util.h:499` `fresnel_iridescence_channel<true>` + `:200` `fresnel_conductor_polarized`.

## Gates (RTX 5070 Ti, fresh build)

| Gate | Result |
|---|---|
| cuobjdump `<false>` STACK | **3608 / REG 254 — unchanged** |
| cuobjdump `<true>` STACK | **6592 / REG 254 — unchanged** (only CONSTANT[2] +40 B) |
| thickness-0 bit-equality | PASS (CPU + GPU ×3) |
| CPU/GPU spectral parity | 12/12 (metallic within 0.7%) |
| furnace no-gain | PASS |
| non-principled perf | `<false>` shade kernel resource-usage byte-identical |

17/17 gate tests pass (`test_thin_film_pr2` + `test_pkg182_conductor_spectral_native` + `test_pkg178_thinfilm_gpu_cpu_parity`).

The per-hit per-λ Gulbrandsen inversion lands **only** inside the `<true>` HasPrincipled instantiation, exactly as `gpu_types.h`'s data-isolation note prescribes — so the non-principled `<false>` kernel is untouched.

## ⚠️ Measured finding — read before merging

The premise that the RGB-upsample makes metal thin-film *visibly muted* **does not hold in Astroray's 4-sample hero-wavelength pipeline.** Clean before/after on the white-environment conductor hue-sweep:

- saturation: **mean 0.0488 → 0.0499, max 0.1842 → 0.2045 (~10% peak)**
- per-λ spectral-reshape signal under a saturated colored light: **~0.01**

At 4 λ the Airy reflectance is smooth enough to be Jakob-Hanika-reconstructible, so per-λ ≈ RGB-upsample under a flat illuminant (they diverge only under spectral/colored light or many more samples). The RGB-upsample's only error was JH round-trip desaturation — which is what this ~10% recovers.

**This is a correctness/consistency win, not the visible saturation jump the ticket implied:** exact per-λ evaluation (no JH round-trip), consistent with the already-per-λ dielectric leg, correct under spectral/colored illumination — at zero STACK cost. The true "matches Cycles saturation" verdict needs the Blender 5.2 spectral oracle (lead-deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
