### PR TITLE
docs: pkg186/187/188 — spectral-integration + GPU-parity audit follow-ups

### DIFF
--- a/.astroray_plan/packages/pkg186-gpu-texture-sampling.md
+++ b/.astroray_plan/packages/pkg186-gpu-texture-sampling.md
@@ -1,0 +1,129 @@
+# pkg186 — GPU texture sampling (the GPU path has zero texture support)
+
+**Pillar:** 5 / integration-first
+**Track:** A
+**Status:** open (found 2026-08-12 during the post-pkg178/pkg182 spectral-
+integration + CPU/GPU-parity audit; owner asked "what still lacks GPU parity")
+**Estimated effort:** L (scoped down by the two open decisions below)
+**Depends on:** pkg115 (Blender shader-node texture adoption, CPU); pkg135
+(demand-loaded sparse textures, CPU); pkg119-B (Blender differential parity
+harness — used as the acceptance signal here).
+
+---
+
+## Symptom
+
+The GPU render path has **no texture support at all**. It uploads exactly one
+flat RGB per material:
+
+- `src/gpu/scene_upload.cu` (lines 114, 202, 220, 239, 247) uploads
+  `mat->getAlbedo()` — a single constant `Vec3` — per material. There is no
+  per-texel data, no UV-indexed sampling.
+- `include/astroray/gpu_types.h` has **no texture struct** (it carries the
+  Stage-3b active-UV-layer coordinates at ~line 274, but nothing consumes them
+  as a texture lookup — they are dead weight on the GPU side today).
+- There is **no device-side texture sampling code anywhere** in `src/gpu/**`.
+
+Consequence: any textured Blender material silently renders as **flat albedo**
+on GPU, with **no warning and no addon guard**. The user sees a plausible-but-
+wrong image and has no signal that a texture was dropped.
+
+---
+
+## Likely payoff — the pkg119-B TRANSLATION-BUGs
+
+The 5 residual `TRANSLATION-BUG` entries in the pkg119-B differential-parity
+baseline ([[pkg119b-harness-runbook]], 2026-08-08 baseline 26/12/1) are **all
+procedural texture nodes**. Flat-albedo-on-GPU is the plausible **shared root
+cause**: the CPU reference evaluates the procedural node; the GPU collapses it
+to `getAlbedo()`. This spec therefore requires **re-running pkg119-B as an
+acceptance signal** — if GPU texture support lands correctly, some or all of
+those 5 should reclassify from TRANSLATION-BUG to parity-pass (or at least stop
+being flat-albedo). Record the before/after classification counts.
+
+---
+
+## Required sub-item — backend-aware `__features__` dict
+
+`module/blender_module.cpp` (~line 4491) advertises the capability dict:
+
+```cpp
+m.attr("__features__") = py::dict(
+    "nee"_a=true, "mis"_a=true, "disney_brdf"_a=true, "sah_bvh"_a=true,
+    "adaptive_sampling"_a=true, "volumes"_a=true, "textures"_a=true, "subsurface"_a=true,
+    "gr_black_holes"_a=true,
+    ...
+```
+
+`textures`, `volumes`, `adaptive_sampling`, and `gr_black_holes` are advertised
+`true` **unconditionally**, though on the GPU path all four are CPU-only or
+absent. The addon **Diagnostics panel displays this dict verbatim**, so it tells
+the user "textures: yes" while the active GPU backend silently drops them.
+
+Make the dict **backend-aware**: report per-capability truth for the *active*
+backend (CPU vs CUDA/wavefront). Follow the pattern pkg171 established for the
+CPU-only-integrator guard at `module/blender_module.cpp:1697` — the truth source
+is the capabilities query the addon's `configure_backend` already reads, not a
+hardcoded name. The Diagnostics panel must then show `textures: CPU only` (or
+equivalent) when the GPU backend is selected, until this package closes the gap.
+
+This sub-item is **required** and can land first (it is a small, honest guard
+that stops the silent lie immediately, independent of the larger texture work).
+
+---
+
+## Open decisions (leave these for the implementer, record the choice)
+
+These are genuine forks, not a manufactured menu — decide by scope/payoff:
+
+1. **Image textures vs procedural nodes first.** The pkg119-B residuals are
+   *procedural* nodes, so procedural-first maximizes the parity payoff. But
+   image textures are the more common real-world asset and the simpler upload
+   (a buffer + UV lookup) — a smaller, self-contained first slice. Pick one for
+   this package; the other is a follow-up. State the choice and the reasoning.
+
+2. **CUDA texture objects vs baked buffers.** `cudaTextureObject_t` gives free
+   hardware bilinear + wrap modes but constrains formats/layout; a plain device
+   buffer + manual UV fetch is simpler to wire and easier to make bit-parity
+   with the CPU sampler. Decide per the slice chosen in (1) — procedural nodes
+   have no image to bind and likely want evaluated-in-kernel or a baked buffer;
+   image textures are the natural fit for texture objects.
+
+---
+
+## Work
+
+1. Land the backend-aware `__features__` guard first (required sub-item);
+   verify the Diagnostics panel reflects it in headless Blender.
+2. Add the texture struct to `include/astroray/gpu_types.h` and the device-side
+   sampler in `src/gpu/**` for the slice chosen in decision (1).
+3. Wire the upload in `src/gpu/scene_upload.cu` — the per-material path must
+   carry texture handles/data, not just `getAlbedo()`. Preserve the flat-albedo
+   fast path for untextured materials (no per-texel cost when there is no
+   texture).
+4. Verify CPU/GPU parity on a textured scene (a per-channel mean-ratio gate, not
+   SSIM — independent RNG streams; see [[ssim-wrong-gate-for-independent-rng]]).
+5. **Re-run pkg119-B** ([[pkg119b-harness-runbook]]) and record the
+   TRANSLATION-BUG reclassification for the 5 procedural-texture entries.
+
+## Acceptance criteria
+
+- [ ] `__features__` is backend-aware; Diagnostics panel no longer claims GPU
+      texture support when the GPU backend drops textures.
+- [ ] A textured material renders with its texture (not flat albedo) on the GPU
+      path for the chosen slice, gated by a new test.
+- [ ] CPU/GPU per-channel mean-ratio parity within band on a textured scene.
+- [ ] pkg119-B re-run: before/after TRANSLATION-BUG counts recorded in Lessons;
+      any procedural-texture entry that was flat-albedo is either fixed or
+      explicitly explained as out-of-slice.
+- [ ] Untextured materials show no measurable perf regression (flat-albedo fast
+      path preserved).
+
+## Hard non-goals
+
+- **No attempt to cover both image and procedural textures in one package.**
+  Pick one slice (decision 1); file the other as a follow-up.
+- **No demand-loaded/sparse texture streaming** (that is pkg135's CPU scope; the
+  GPU equivalent is a separate, larger package).
+- **No `volumes`/`gr_black_holes` GPU implementation** — this package only makes
+  the `__features__` dict *honest* about them, it does not implement them.

--- a/.astroray_plan/packages/pkg187-principled-dispersion.md
+++ b/.astroray_plan/packages/pkg187-principled-dispersion.md
@@ -1,0 +1,110 @@
+# pkg187 — Principled BSDF dispersion (achromatic caustics from Principled glass)
+
+**Pillar:** 3/5 (spectral light transport / Blender parity)
+**Track:** A
+**Status:** open (found 2026-08-12 during the post-pkg178/pkg182 spectral-
+integration + CPU/GPU-parity audit; production-relevant since
+`use_native_principled` defaulted **ON** 2026-08-11)
+**Estimated effort:** M
+**Depends on:** pkg178 (native Principled BSDF); pkg31/pkg29 (Sellmeier
+dielectric plugin); pkg64 (GPU Sellmeier / hero-λ upload); SMS/MNEE
+(`include/astroray/mesh_attempt.h`).
+
+---
+
+## Symptom
+
+`PrincipledPlugin` is **not dispersion-aware**, so a Blender Principled glass
+prism produces **silently achromatic caustics** — no rainbow, no chromatic
+split — even when the Blender material sets a nonzero Dispersion.
+
+Concretely:
+
+- `PrincipledPlugin` has **no `iorAt(λ)` override** — it inherits the flat
+  `iorAt` at `include/astroray/raytracer.h:488`, returning the same IOR at every
+  wavelength.
+- **No `isDispersive()` override**, so `src/gpu/scene_upload.cu` never sets the
+  dispersive flag, and the GPU wavelength-aware sampler
+  (`include/astroray/gpu_materials.h:3121`, gated on `GMAT_DIELECTRIC`) is
+  **unreachable** for a Principled material — which lowers to
+  `GMAT_CLOSURE_GRAPH`, not `GMAT_DIELECTRIC` (see
+  [[gpu-dielectric-lowers-to-closure-graph]]).
+- **No `terminateSecondary()` / hero-wavelength collapse on refraction**, so
+  even if the sampler were reached, the chromatic path would not collapse to a
+  hero λ correctly.
+- SMS/MNEE caster gathering (`include/astroray/mesh_attempt.h:45,64`) only
+  requires `isTransmissive()`. A Principled glass prism therefore **enters the
+  chromatic specular-manifold solver** but runs it with **identical IOR at every
+  λ** — the solver does chromatic work and gets an achromatic answer.
+- The Blender addon maps thin-film sockets but has **no Dispersion socket
+  mapping at all** (`grep -rni "dispersion" blender_addon/` returns only the
+  Astroray-native Sellmeier node, never the Principled socket). Blender 4.2+
+  exposes a Dispersion input on Principled BSDF; that value is **dropped
+  silently** on import.
+
+Net: the audit's answer to "is native Principled spectrally consistent?" is
+"no, for refraction" — dispersion is a real Blender socket that this engine
+ignores end to end.
+
+---
+
+## Reference implementation — cite, don't invent
+
+Invoke the `cite-algorithm` skill for the **Abbe-number → dispersion-curve**
+mapping before writing code. Blender's Principled Dispersion input is an Abbe
+number (Vd); the engine's existing dielectric uses Sellmeier coefficients. The
+canonical bridge is the Cauchy or a reduced-Sellmeier fit from (Vd, IOR at
+d-line). Do not hand-roll a wavelength dependence.
+
+- `plugins/materials/dielectric.cpp:110-142` — the existing **Sellmeier**
+  dielectric plugin, including the **pkg64 GPU hero-λ upload** path. This is the
+  in-repo template for `iorAt(λ)`, `isDispersive()`, `terminateSecondary()`, and
+  the scene-upload dispersive flag. Mirror its structure; do not re-derive it.
+- **Cycles' Principled dispersion handling** — how Cycles converts the Abbe
+  number to per-λ IOR for the Principled BSDF transmission lobe. Cite the exact
+  Cycles source (Apache-2.0) in the code and save research notes to
+  `.astroray_plan/docs/` per CLAUDE.md §6.
+
+---
+
+## Work
+
+1. Add `iorAt(λ)`, `isDispersive()`, and `terminateSecondary()` /
+   hero-collapse-on-refraction overrides to `PrincipledPlugin`, driven by the
+   Abbe→dispersion mapping (cited), following `dielectric.cpp:110-142`.
+2. Ensure `src/gpu/scene_upload.cu` uploads the dispersive flag + hero-λ IOR
+   data for a dispersive Principled material. Because Principled lowers to
+   `GMAT_CLOSURE_GRAPH` (not `GMAT_DIELECTRIC`), verify the wavelength-aware
+   refraction path at `gpu_materials.h:3121` is reachable from the closure-graph
+   transmission lobe — if it is gated purely on `GMAT_DIELECTRIC`, that gate
+   must widen or the closure-graph transmission must call the same per-λ IOR.
+3. Add the **Dispersion socket mapping** to the Blender addon Principled import
+   (grep target: the thin-film socket mapping, add Dispersion beside it).
+4. Guard SMS/MNEE (`mesh_attempt.h`): a Principled caster with nonzero
+   dispersion must feed per-λ IOR into the manifold solver; a zero-dispersion
+   Principled must behave exactly as today (no regression).
+
+## Acceptance criteria
+
+- [ ] A Principled glass prism with nonzero Blender Dispersion produces
+      **chromatic** caustics (measurable hue spread), CPU and GPU. Verify
+      **visually** — hue_spread + bright_coverage both pass on noise
+      ([[general-photon-loop-needs-solid-glass]]); LOOK at the render.
+- [ ] Zero-dispersion Principled glass is bit-unchanged from current behavior
+      (regression guard).
+- [ ] CPU/GPU per-λ parity on a dispersive Principled prism (per-channel
+      mean-ratio, not SSIM).
+- [ ] The Blender Dispersion socket round-trips: set it in Blender → engine
+      renders chromatic. Verify headlessly (Blender 5.1 is installed locally;
+      [[blender-5-1-installed-locally]]).
+- [ ] Research notes for the Abbe→dispersion mapping saved under
+      `.astroray_plan/docs/` with the Cycles source cited in-code.
+
+## Hard non-goals
+
+- **No new dispersion model.** Reuse Sellmeier/Cauchy via the cited Abbe mapping;
+  the dielectric plugin already carries the machinery.
+- **No thin-film re-work** — thin-film sockets already map (pkg178); this is only
+  the Dispersion socket + per-λ refraction IOR.
+- **No change to the non-dispersive Principled fast path** beyond adding the
+  overrides; zero-dispersion cost must not move.

--- a/.astroray_plan/packages/pkg188-principled-residual-spectral-consistency.md
+++ b/.astroray_plan/packages/pkg188-principled-residual-spectral-consistency.md
@@ -1,0 +1,111 @@
+# pkg188 — Principled residual spectral-consistency gaps (JH-nonlinearity + clamp class)
+
+**Pillar:** 3/5 (spectral consistency / CPU-GPU parity)
+**Track:** A
+**Status:** open (found 2026-08-12 during the post-pkg178/pkg182 spectral-
+integration audit; **enhancement tier — start after PR #586 lands**)
+**Estimated effort:** M
+**Depends on:** PR #586 (must land first); pkg168 (RGB→spectral upsampling
+parity — the fix template); pkg167 / [[rough-glass-residual-is-multiscatter]]
+(the eta² LUT-clamp bug class).
+
+---
+
+## Symptom
+
+Three residual spots where the native Principled BSDF still does spectral math
+in the RGB-then-upsample-the-product form that pkg168 already proved wrong for
+diffuse. These are **enhancement-tier** — they are not producing a visible
+failure today the way pkg187's dispersion does, but they are the exact
+nonlinearity/clamp classes the project has repeatedly been bitten by, and they
+undermine the "native Principled is spectrally consistent" claim.
+
+### Finding A — film-off transmission still upsamples the product
+
+Film-off transmission is the **only core lobe still evaluated in RGB and then
+upsampled as a product** — self-labelled the "Stage-3b upsample hack":
+- `plugins/materials/principled.cpp:1648-1658`
+- GPU twin `include/astroray/gpu_materials.h:2407-2416`
+
+This is the exact JH-nonlinearity class pkg168 fixed for diffuse
+([[spectral-upsample-nonlinearity-scaled-bsdf]]: JH upsampling is nonlinear in
+magnitude — upsample the reflectance *colour*, never `albedo·cosθ/π` or a
+product). Apply the pkg168 fix shape to the transmission lobe.
+
+### Finding B — assembleLobes multiplies in RGB then upsamples once
+
+`assembleLobes` (`plugins/materials/principled.cpp:658-868`) multiplies base
+colour × sheen tint × coat Beer × layering albedos **in RGB**, then upsamples
+the product a single time. `upsample(a·b) ≠ upsample(a)·upsample(b)` (the same
+nonlinearity as Finding A, at the lobe-assembly level).
+
+Additionally, `upsample()` **clamps to [0,1] with no maxc guard on the weight
+path** — the same clamp class as the pkg167 / rough-glass eta² ALBEDO-LUT-clamp
+bug ([[rough-glass-residual-is-multiscatter]]: the JH ALBEDO LUT clamps rgb>1,
+silently clipping energy). Any weight/product that can exceed 1 before upsample
+loses energy here.
+
+### Finding C — thin-wall R'/T' per-channel + GPU delta events (may be descoped)
+
+Listed for completeness; the implementer may **explicitly descope** this to a
+follow-up if A+B already consume the package budget:
+- Thin-wall R'/T' is per-RGB-channel with a film-on RGB sensitivity LUT (not
+  per-λ native).
+- GPU delta Principled events **never fill `fSpectral`** (generic maxc/upsample
+  guard at `gpu_materials.h:3214`), mirroring the CPU side.
+
+If descoped, file the C follow-up spec at close and note it in Lessons — do not
+leave it as an unrecorded gap.
+
+---
+
+## Hard constraint — do not spill the fused shade kernel
+
+Any change **must keep the `<false>` shade-kernel specialization at STACK 3608 /
+REG 254** ([[closure-graph-lobe-count-spills-fused-kernel]]: adding Principled
+lobes spilled the SHARED shade kernel and caused a +52% non-Principled
+regression; the fix was `template<bool HasPrincipled>` if-constexpr isolation,
+**not** shrinking the lobe array). **All new per-λ work goes inside the
+`HasPrincipled` branch.** Verify with cuobjdump post-link + `ASTRORAY_PROFILE`
+(not `ptxas -v`; [[wavefront-shade-kernels-register-saturated]]) and report the
+`<false>`-specialization STACK/REG before and after.
+
+---
+
+## Work
+
+1. **Finding A:** rewrite the film-off transmission lobe
+   (`principled.cpp:1648-1658` + GPU twin `gpu_materials.h:2407-2416`) to
+   upsample the reflectance colour, not the product, per the pkg168 shape.
+2. **Finding B:** in `assembleLobes` (`principled.cpp:658-868`), move the
+   colour × tint × Beer × layering multiply so upsampling happens on the colours
+   (or restructure so the product is not upsampled once); add a maxc guard on the
+   weight path before `upsample()` so weights >1 are not clipped.
+3. **Finding C:** either implement per-λ thin-wall R'/T' + GPU `fSpectral` fill,
+   or descope with a filed follow-up + Lessons note.
+4. Re-verify CPU/GPU per-channel parity and furnace energy (linear, with an
+   upper bound — [[gamma-furnace-cannot-detect-energy-gain]]) on Principled
+   transmission and layered-Principled scenes.
+
+## Acceptance criteria
+
+- [ ] Finding A: transmission lobe upsamples colour, not product; CPU and GPU
+      twin both updated; a parity test locks it.
+- [ ] Finding B: assembleLobes no longer upsamples an RGB product; weight-path
+      maxc guard added; furnace energy conserves (linear, bounded above).
+- [ ] Finding C: implemented, or descoped with a filed follow-up spec number
+      recorded in Lessons.
+- [ ] `<false>` shade-kernel specialization STACK/REG unchanged (3608/254),
+      shown via cuobjdump before/after; no non-Principled perf regression
+      (min-of-N, burn-in per [[gpu-perf-ab-clock-drift]]).
+- [ ] CPU/GPU per-channel mean-ratio parity within band on the Principled
+      transmission + layering scenes.
+
+## Hard non-goals
+
+- **No lobe-array shrink** to buy register room — the fix is if-constexpr
+  isolation inside `HasPrincipled`, never shrinking shared state.
+- **No re-opening reflection/metal spectral work** (pkg182/pkg163 settled those);
+  this package is transmission + lobe-assembly + delta-event `fSpectral` only.
+- **No start before PR #586 lands** — this is explicitly enhancement-tier and
+  sequenced behind it to avoid conflicting edits in `principled.cpp`.


### PR DESCRIPTION
Doc-only. Files three tightly-scoped package specs from the **2026-08-12
spectral-integration + CPU/GPU-parity audit** (session lead, post-pkg178/pkg182
closeout), prompted by the owner asking (a) whether the native Principled BSDF
is spectrally consistent and (b) what still lacks GPU parity. Native Principled
defaulted ON 2026-08-11, which makes these production-relevant.

## Specs (next free numbers after pkg183/184/185)

- **pkg186 — GPU texture sampling** (Track A, highest priority; integration-first).
  The GPU path has zero texture support: `scene_upload.cu` uploads one flat
  `getAlbedo()` per material, `gpu_types.h` has no texture struct, no device
  sampler exists. Textured Blender materials silently render flat-albedo on GPU
  with no guard. Plausible shared root cause of the 5 pkg119-B procedural
  `TRANSLATION-BUG`s — requires re-running pkg119-B as an acceptance signal.
  Folds in a required sub-item: make the `__features__` dict backend-aware
  (`textures/volumes/adaptive_sampling/gr_black_holes` are advertised `true`
  unconditionally; the Diagnostics panel shows the lie). Two open decisions left
  in-spec: image vs procedural first; CUDA texture objects vs baked buffers.

- **pkg187 — Principled dispersion** (Track A). Principled has no `iorAt(λ)` /
  `isDispersive()` / hero-collapse override, so the GPU wavelength-aware sampler
  is unreachable for `GMAT_CLOSURE_GRAPH`, SMS/MNEE runs the chromatic solver
  with identical IOR per λ (silently achromatic caustics), and the addon has no
  Dispersion socket mapping at all. Cite-algorithm discipline for the
  Abbe→Sellmeier/Cauchy mapping; reference `dielectric.cpp:110-142` + Cycles.

- **pkg188 — Principled residual spectral-consistency gaps** (Track A,
  enhancement-tier, after PR #586). Film-off transmission + `assembleLobes`
  still upsample an RGB product (the pkg168 JH-nonlinearity class); `upsample()`
  clamps to [0,1] with no maxc guard (the pkg167 eta² LUT-clamp class).
  Constraint recorded: must keep the `<false>` shade-kernel specialization at
  STACK 3608 / REG 254 — per-λ work goes inside the `HasPrincipled` branch.

No STATUS.md change (round-close owns it). No code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)