### PR TITLE
fix(pkg185): GPU glass-caustic parity — correct test sun to reference Ω-scaling (SSIM 0.01→0.96)

### DIFF
--- a/.astroray_plan/packages/pkg185-gpu-glass-caustic-parity-failure.md
+++ b/.astroray_plan/packages/pkg185-gpu-glass-caustic-parity-failure.md
@@ -2,9 +2,16 @@
 
 **Pillar:** 3/5 (light transport / GPU parity)
 **Track:** A (RTX hardware root-cause)
-**Status:** open (found 2026-08-12 during the hygiene run's full clean-build
-RTX sweep; pre-existing on `main` — fails identically at 63d94d4 and on the
-hygiene branch)
+**Status:** done (PR #TBD, 2026-08-12 — SSIM 0.0101 → 0.9606, GPU peak 1007 → 0.41;
+root cause: the test scene's sun used raw irradiance `6.0` (radiance S/Ω ≈ 19100)
+instead of the reference scene's Ω-scaled `6.0·Ω` (radiance ≈ 6.0). Harmless
+until pkg181 made dedicated lamps BSDF-visible, at which point the ball-lens
+produced correct-but-high-variance specular sun-disk images (peak ~1007) that
+the CPU reference's independent RNG did not hit at the same pixels, collapsing
+the variance-based SSIM. Fix mirrors the reference scene's Ω-scaling; the
+transport is confirmed in parity — clamp_indirect on both sides independently
+lifts SSIM to 0.97. Found 2026-08-12 during the hygiene run's full clean-build
+RTX sweep; pre-existing on `main` — failed identically at 63d94d4 and 24106ca.)
 **Estimated effort:** M
 **Depends on:** pkg113 GPU photon-caustic pre-pass; `tests/test_gpu_caustic_parity.py`.
 

--- a/.astroray_plan/packages/pkg185-gpu-glass-caustic-parity-failure.md
+++ b/.astroray_plan/packages/pkg185-gpu-glass-caustic-parity-failure.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 3/5 (light transport / GPU parity)
 **Track:** A (RTX hardware root-cause)
-**Status:** done (PR #TBD, 2026-08-12 — SSIM 0.0101 → 0.9606, GPU peak 1007 → 0.41;
+**Status:** done (PR #589, 2026-08-12 — SSIM 0.0101 → 0.9606, GPU peak 1007 → 0.41;
 root cause: the test scene's sun used raw irradiance `6.0` (radiance S/Ω ≈ 19100)
 instead of the reference scene's Ω-scaled `6.0·Ω` (radiance ≈ 6.0). Harmless
 until pkg181 made dedicated lamps BSDF-visible, at which point the ball-lens

--- a/tests/test_gpu_caustic_parity.py
+++ b/tests/test_gpu_caustic_parity.py
@@ -118,8 +118,27 @@ def _build_glass_sphere(use_gpu: bool):
     r.add_sphere([0.0, 0.0, 0.0], 0.6, glass)
     assert r.set_object_caustic_caster(sphere_idx, True)
 
-    r.add_sun_light_dedicated(_norm([0.45, -1.0, 0.0]), 0.01,
-                              {"mode": "rgb", "color": [1.0, 1.0, 1.0]}, 6.0)
+    # pkg185: mirror the reference scene's OMEGA-SCALED sun irradiance
+    # (benchmarks/reference_bank/scenes/glass-sphere-caustic/scene.py:69-74).
+    # `add_sun_light_dedicated`'s last arg is IRRADIANCE S; a distant light's
+    # sun-disk radiance is L = S/Ω. This scene was authored (pkg113, #425) under
+    # the PRE-pkg122 "near-black" scaling where the engine implicitly multiplied
+    # the sun by S·Ω, so a flat `6.0` behaved as radiance ≈ 6.0 (the documented
+    # peak ~0.41 / SSIM ~0.96 passing state). pkg122 corrected that scaling and
+    # the reference scene was updated to `6.0·Ω`; this test scene was not, so its
+    # flat `6.0` silently became radiance ≈ 19100 (S/Ω). That was harmless until
+    # pkg181 made dedicated lamps visible to BSDF rays — the ball-lens then
+    # produces correct-but-high-variance SPECULAR images of the tiny bright sun
+    # disk (peak ~1007), which the CPU reference's independent RNG does not hit at
+    # the same pixels, collapsing the variance-based SSIM to ~0.01. Restoring the
+    # intended dim collimated beam (radiance ≈ 6.0) removes the fireflies and the
+    # GPU/CPU renders agree to SSIM ~0.96 again (peak ~0.41), confirming the
+    # transport itself is in parity. See pkg185 spec.
+    _sun_ang = 0.01
+    _sun_omega = 2.0 * math.pi * (1.0 - math.cos(_sun_ang * 0.5))  # disk solid angle
+    r.add_sun_light_dedicated(_norm([0.45, -1.0, 0.0]), _sun_ang,
+                              {"mode": "rgb", "color": [1.0, 1.0, 1.0]},
+                              6.0 * _sun_omega)
 
     # Floor just past the ball-lens focal plane (paraxial focus is at centre +
     # sunDir*0.9 = (0.37,-0.82,0); floor at y=-1.1 -> caustic at x~0.50). The


### PR DESCRIPTION
## pkg185 — GPU glass-sphere photon-caustic parity failure (SSIM 0.01)

### Symptom
`tests/test_gpu_caustic_parity.py::test_gpu_glass_sphere_caustic_parity` failed
structurally on RTX: **SSIM 0.0101** vs the 0.80 floor, **GPU peak luminance ~1007**,
while the caustic-ROI energy ratio (1.086×) and the 8-bit PNGs looked fine.
Pre-existing on `main` (failed identically at 63d94d4 and 24106ca).

### Root cause (RTX-verified — not a GPU transport bug)
Numeric inspection of the raw float buffers showed the GPU image had exactly **3
firefly pixels** (lum ~1007/986/932) versus everything else ≤ 1.66; the CPU maxed
at 1.61 with no spikes. Those 3 spikes drive the GPU std to 10.2 vs ~0.6, tanking
the variance-based global SSIM. PNG clamping to 8-bit hides them, which is why the
images looked clean.

Isolation (all on the RTX box):
- Fireflies persist with the photon caustic **disabled** → not the gather.
- `clamp_indirect=10` removes them (max → 1.66); `clamp_direct=10` does not →
  they are **indirect (bounce>0)** contributions.
- A kernel-side diagnostic printf showed each spike is a `wasSpecular=1`, `wB=1`
  lamp hit at **bounce 3** — a legitimate all-specular path through the glass ball
  landing on the tiny sun disk (the MIS machinery is correct; it takes the
  specular `wB=1` branch by design).

The real defect is in the **test scene**: it passed the sun IRRADIANCE as a raw
`6.0`, giving a distant-sun radiance `L = S/Ω ≈ 19100`, whereas the reference scene
it claims to mirror (`benchmarks/reference_bank/scenes/glass-sphere-caustic/scene.py:69-74`)
uses `6.0·Ω` so `L ≈ 6.0`. Git history: the flat `6.0` was authored at pkg113
(#425) under the **pre-pkg122 "near-black" scaling** (engine implicitly multiplied
by `S·Ω`), so it then behaved as radiance ≈ 6.0 — the documented passing state
(peak ~0.41, SSIM ~0.96). **pkg122** corrected that scaling (the reference scene
was updated to `6.0·Ω`; the test scene was not), making the flat `6.0` silently
mean radiance ≈ 19100. That stayed harmless — NEE normalizes by the light pdf —
until **pkg181** (#569) made dedicated lamps visible to BSDF rays. The ball-lens
then produces correct-but-high-variance **specular images of the 19100-radiance
sun disk**; at 64 spp the CPU reference's independent RNG doesn't hit the 0.57°
disk at the same pixels, so its peak stays ~1.6 while the GPU spikes to ~1007.

### Fix
Mirror the reference scene's Ω-scaled irradiance (`6.0·Ω`, radiance ≈ 6.0) in the
test scene helper. This restores the intended dim collimated beam, removes the
fireflies, and reproduces the exact numbers the test's own comment documents.
Transport is confirmed already in parity — applying `clamp_indirect` on **both**
renderers independently lifts SSIM to 0.97 with the untouched flat-`6.0` sun.

### Measured before/after (RTX 5070 Ti, seed 17, 64 spp)
| | SSIM | ROI ratio | GPU peak | CPU peak |
|---|---|---|---|---|
| before (flat 6.0) | 0.0101 | 1.086× | 1006.97 | 1.61 |
| **after (6.0·Ω)** | **0.9606** | **1.094×** | **0.406** | 0.39 |
| flat 6.0 + clamp_indirect=10 (both) | 0.9713 | 1.000 | 1.66 | 1.61 |

Visual: new PNGs show a clean **focused caustic** (concentrated orange ellipse) on
the dark floor; GPU and CPU visually consistent, no salt-and-pepper noise.

### Acceptance criteria
- [x] Reproduced on current main; visually inspected GPU + CPU PNGs.
- [x] Checked the pkg157 firefly-clamp path + deposition coords (clamp is disabled
      by default on both sides; deposition correct — root cause is the scene's sun
      radiance, evidence above).
- [x] Root-caused via inspection + kernel diagnostic (no clean-build bisect needed;
      cause is a pre-pkg113 scene-authoring latent, exposed by pkg122→pkg181, per
      the git-history evidence above).
- [x] Re-ran the caustic-family gates (glass_sphere_caustic, caustic_validation,
      photon_map, gpu_photon_emission/store, sms_caustic_validation, pkg64 GPU
      parity, pkg113) + thin-film/principled GPU parity gates + pkg55-c5 (which
      reuses the scene helper) — all pass.

### Authorized surface
- Spec Specification names `tests/test_gpu_caustic_parity.py` (the failing gate).
- Changed: **only** `tests/test_gpu_caustic_parity.py` (sun irradiance in the
  scene helper) + the spec status line. No engine/`.cu`/`.cpp`/`.h` change — a
  kernel diagnostic printf was added transiently and fully reverted (not in the
  diff). Pure-test + docs change; no build artifact ships.

Note: `test_gpu_prism_rainbow_parity` (xfail, `strict=False`) XPASSes; it builds
its own prism scene, is unaffected by this change, and its XPASS does not fail the
suite — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
