### PR TITLE
build(pkg183): stale-object ABI-mixed-binary guard in all three build wrappers

### DIFF
--- a/.astroray_plan/packages/pkg183-incremental-build-staleness-guard.md
+++ b/.astroray_plan/packages/pkg183-incremental-build-staleness-guard.md
@@ -2,8 +2,9 @@
 
 **Pillar:** 5 (build infrastructure / verification integrity)
 **Track:** A
-**Status:** proposed (filed 2026-08-12 after the hygiene run burned ~3 hours
-on phantom crashes caused by this)
+**Status:** in-review (PR pending, 2026-08-12 — items 1–3 implemented:
+header-hash stamp + force-clean-on-mismatch and a <5 s host-only ABI canary
+wired into all three build wrappers; item 4 evaluated-only, see Lessons)
 **Estimated effort:** S–M
 **Depends on:** `scripts/build/build_cuda.bat`, `scripts/build/build_cuda_worktree.bat`,
 repo-root `build_cuda_worktree.bat`.
@@ -51,3 +52,67 @@ arch-89 pin applied to both build wrappers (both reverted), and a session-start
    `build-cuda-worktree-debug-config` memory).
 4. Consider moving build trees off OneDrive (e.g. `%LOCALAPPDATA%\astroray-build`)
    so mtimes are trustworthy — evaluate against the existing sccache setup.
+
+## Implementation notes (items 1–3, 2026-08-12)
+
+- New helper `scripts/build/build_guard.py` (registered in `scripts/README.md`)
+  owns three subcommands so the `.bat` files avoid batch-language gymnastics:
+  - `check`  — SHA-256 over the layout-critical headers (`include/astroray/*.h`
+    + `include/raytracer.h`), compared to `build_cuda/.astroray_build_stamp`;
+    prints `WIPE` or `OK`. `WIPE` when the header hash changed **or** a
+    configured tree (`CMakeCache.txt` present) has no stamp (predates the guard,
+    so it may already be ABI-mixed → force-clean once). A never-configured tree
+    prints `OK` (nothing to wipe).
+  - `write`  — records `{header_hash, sha}` into the stamp after a successful build.
+  - `canary` — reuses `tests/runtime_setup.py` to put the CUDA/OIDN `_deps`
+    DLL dirs on the loader path, then runs the exact spec repro
+    (`Renderer().get_material_backend_capabilities(create_material('lambertian',…))`).
+    Exit 6 on a Python-level failure; a hard access-violation kills the process
+    with its own non-zero code, which the wrappers also treat as a canary trip.
+- Wipe mechanism is `cmake --build <dir> --config Release --target clean`
+  (generator-agnostic; removes all objects unconditionally, not mtime-based),
+  chosen over `rmdir` so the configure-less root wrapper stays valid.
+- Canary failure is a **distinct** exit path (code 6, loud banner) so it is
+  never confused with a compile/link failure (code 5). Missing `python` on
+  PATH downgrades the guard to a warning rather than failing the build.
+
+## Lessons
+
+### Item 4 (move build trees off OneDrive) — evaluate-only assessment
+
+**Recommendation: do NOT move the build tree yet; the pkg183 stamp+canary
+already neutralises the failure mode this item targets. Revisit only if the
+force-clean-on-mismatch proves too costly in practice.**
+
+Interaction with the existing sccache / `%LOCALAPPDATA%` cache setup:
+- Today `SCCACHE_DIR` and `FETCHCONTENT_BASE_DIR` already live under
+  `%LOCALAPPDATA%\astroray-cache` (off OneDrive); only the `build_cuda/` object
+  tree and the source checkout remain on OneDrive. So the compiler *cache* is
+  already immune to OneDrive mtime churn — it is the object tree's mtimes that
+  Ninja trusts and OneDrive mangles.
+- Moving `build_cuda/` to `%LOCALAPPDATA%\astroray-build\<tree-id>` would make
+  Ninja's incremental staleness detection trustworthy again, which is the real
+  root cause. `SCCACHE_BASEDIR=%CD%` (the *source* root) is unaffected — sccache
+  hashes sources by path relative to the source tree, not the build dir, so
+  cross-tree cache hits (host-C/C++ ~98%) are preserved.
+
+Expected win: eliminates the underlying ABI-mixed-binary risk (not just guards
+against it), and would let us drop the conservative full-object force-clean —
+recovering true incremental builds across layout-changing commits. Marginal
+build-time win on top of that is small (objects already write to local disk via
+OneDrive's local cache; the pain is correctness, not throughput).
+
+Migration risk (why it is deferred, not done here):
+- Every consumer that assumes `build_cuda/` lives *inside* the checkout must be
+  updated in lockstep: `tests/runtime_setup.py` build-dir discovery, the
+  `.pyd`-mtime canonical-path checks in the rebuild/verify skills, the Blender
+  addon staging (`build_blender_addon_cuda/`), CI paths, and the
+  `astroray.__file__` stale-`.pyd` guards. Missing one silently reintroduces a
+  shadow-`.pyd` class of bug ([[stale_pyd_locations]]).
+- Per-worktree build dirs need a stable, collision-free mapping from worktree
+  path → build dir (branch names alone collide across re-created worktrees).
+- The generator-mismatch and `--config Release` guards already in the wrappers
+  assume a per-tree `build_cuda/`; relocating changes their invariants.
+
+This is a genuine follow-up package (S–M), not a rider on pkg183. Filing it
+separately keeps the low-risk stamp+canary landable now.

--- a/.astroray_plan/packages/pkg183-incremental-build-staleness-guard.md
+++ b/.astroray_plan/packages/pkg183-incremental-build-staleness-guard.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 5 (build infrastructure / verification integrity)
 **Track:** A
-**Status:** in-review (PR pending, 2026-08-12 — items 1–3 implemented:
+**Status:** in-review (PR #592, 2026-08-12 — items 1–3 implemented:
 header-hash stamp + force-clean-on-mismatch and a <5 s host-only ABI canary
 wired into all three build wrappers; item 4 evaluated-only, see Lessons)
 **Estimated effort:** S–M

--- a/.astroray_plan/packages/pkg183-incremental-build-staleness-guard.md
+++ b/.astroray_plan/packages/pkg183-incremental-build-staleness-guard.md
@@ -3,8 +3,9 @@
 **Pillar:** 5 (build infrastructure / verification integrity)
 **Track:** A
 **Status:** in-review (PR #592, 2026-08-12 — items 1–3 implemented:
-header-hash stamp + force-clean-on-mismatch and a <5 s host-only ABI canary
-wired into all three build wrappers; item 4 evaluated-only, see Lessons)
+header-hash stamp + force-clean-on-mismatch, a <5 s host-only ABI canary, AND
+a cuobjdump ground-truth CUDA-arch gate (PR #590 scope-add) wired into all
+three build wrappers; item 4 evaluated-only, see Lessons)
 **Estimated effort:** S–M
 **Depends on:** `scripts/build/build_cuda.bat`, `scripts/build/build_cuda_worktree.bat`,
 repo-root `build_cuda_worktree.bat`.
@@ -32,6 +33,30 @@ fabricate a coherent-looking git-bisect result.
 Consequences observed before diagnosis: two bogus regression specs filed, an
 arch-89 pin applied to both build wrappers (both reverted), and a session-start
 "stale .pyd" state on main that may have had the same origin.
+
+### Second incident — stale CUDA arch in the cache (PR #590 verification, 2026-08-12)
+
+The PR #590 hardware verifier found `CMAKE_CUDA_ARCHITECTURES:STRING=52` (stale
+Maxwell virtual-PTX) cached in **every** `build_cuda/CMakeCache.txt` inspected —
+the main checkout's and every worktree's. Because the root `build_cuda_worktree.bat`
+only builds and never reconfigures, the value persists indefinitely. Consequence
+already realised: a `cuobjdump` register/stack gate was measured as
+`<false,false> STACK 2640` against a stale-arch build when the true sm_120 SASS
+number is 3608→3632 — the reading was taken on irrelevant `compute_52` PTX
+(JIT'd at runtime), not the sm_120 SASS that actually runs. This directly
+invalidates resource-gate readings, i.e. the exact "verification integrity"
+pillar this package owns.
+
+Subtlety established while implementing pkg183: the cache line is an
+**unreliable** signal. On a Ninja tree configured with `ASTRORAY_CUDA_ARCHS=native`,
+CMakeLists' non-cache `set(CMAKE_CUDA_ARCHITECTURES ...)` (CMakeLists.txt:57)
+*shadows* the cache — the cache reads `52` yet the built `.pyd` embeds `sm_120`
+(confirmed via `cuobjdump --list-elf … → sm_120.cubin`). The stale `52` is only
+*live* where `ASTRORAY_CUDA_ARCHS` is unset (the VS-generator worktrees). So the
+guard's ground truth must be the **built artifact** (`cuobjdump --list-elf` on
+`astroray*.pyd`), not the cache line — that never false-positives on a harmless
+shadow and catches every live variant (stale cache, shadowing surprises, wrong
+`-D`).
 
 ## Work
 
@@ -69,12 +94,30 @@ arch-89 pin applied to both build wrappers (both reverted), and a session-start
     (`Renderer().get_material_backend_capabilities(create_material('lambertian',…))`).
     Exit 6 on a Python-level failure; a hard access-violation kills the process
     with its own non-zero code, which the wrappers also treat as a canary trip.
+  - `arch-verify` — **CUDA-arch gate (PR #590 scope-add):** `cuobjdump --list-elf`
+    on the built `astroray*.pyd`; the embedded cubin arch is the ground truth
+    (the CMakeCache line is not — it can be a harmless shadow). Expected arch
+    auto-detects via `nvidia-smi --query-gpu=compute_cap` (fallback: fail only
+    when the ONLY embedded arch is pre-Volta legacy). Exit 7 + loud banner on
+    mismatch; missing `cuobjdump`/`nvidia-smi` downgrades to a warning so it can
+    never cause a false build failure.
+  - `arch-check` — advisory-only pre-build read of the cache arch line; prints a
+    heads-up on a legacy-looking value but NEVER gates (deferring to arch-verify).
 - Wipe mechanism is `cmake --build <dir> --config Release --target clean`
   (generator-agnostic; removes all objects unconditionally, not mtime-based),
   chosen over `rmdir` so the configure-less root wrapper stays valid.
 - Canary failure is a **distinct** exit path (code 6, loud banner) so it is
-  never confused with a compile/link failure (code 5). Missing `python` on
-  PATH downgrades the guard to a warning rather than failing the build.
+  never confused with a compile/link failure (code 5); the CUDA-arch gate uses
+  code 7. Missing `python` on PATH downgrades the guard to a warning rather than
+  failing the build.
+- **Not fixed here (deliberate):** the underlying CMakeLists non-cache
+  `set(CMAKE_CUDA_ARCHITECTURES …)` at line 57 (which leaves the cache reading
+  `52` while the compile is correct) and `configure_and_build.bat` not passing
+  `ASTRORAY_CUDA_ARCHS` (which lets VS-generator worktrees compile a *live*
+  stale 52). Both are outside pkg183's wrapper-only authorized surface. The
+  artifact gate makes the symptom loud and un-missable regardless; a follow-up
+  package should FORCE the cache from `ASTRORAY_CUDA_ARCHS` at the CMakeLists
+  level so the arch is correct at the source, not just gated post-build.
 
 ## Lessons
 

--- a/build_cuda_worktree.bat
+++ b/build_cuda_worktree.bat
@@ -18,6 +18,9 @@ REM   5 = cmake build failed
 REM   6 = pkg183 ABI canary failed (freshly built .pyd crashes on a host-only
 REM       lambertian capability query = stale-object / ABI-mixed binary; distinct
 REM       from a compile/link failure, which uses code 5)
+REM   7 = pkg183 CUDA arch gate failed (cuobjdump: built .pyd embeds the wrong
+REM       GPU arch = stale/shadowed CMAKE_CUDA_ARCHITECTURES; resource/perf gate
+REM       numbers measured here would be invalid; PR #590 incident)
 
 setlocal enabledelayedexpansion
 
@@ -160,6 +163,9 @@ if %ERRORLEVEL% neq 0 (
         echo [pkg183] layout-critical headers changed since last build -- force-cleaning objects
         cmake --build build_cuda --config Release --target clean
     )
+    REM Advisory-only heads-up on a legacy-looking cached CUDA arch; the post-build
+    REM cuobjdump gate is authoritative (the cache line can be a harmless shadow).
+    python "%CD%\scripts\build\build_guard.py" arch-check --build-dir "%CD%\build_cuda"
 )
 
 echo Running: cmake --build build_cuda --config Release --target astroray
@@ -185,6 +191,18 @@ if %ERRORLEVEL% neq 0 (
     echo [pkg183] WARNING: python not on PATH; skipping build stamp + ABI canary
 ) else (
     python "%CD%\scripts\build\build_guard.py" write --repo-root "%CD%" --build-dir "%CD%\build_cuda" --sha %ACTUAL_SHA%
+    echo [pkg183] verifying built CUDA arch ^(cuobjdump ground truth^)...
+    python "%CD%\scripts\build\build_guard.py" arch-verify --pyd-dir "%CD%\build_cuda"
+    if !ERRORLEVEL! neq 0 (
+        echo ====================================================================
+        echo ERROR [pkg183]: CUDA ARCH GATE FAILED -- the built .pyd targets the
+        echo wrong GPU arch ^(stale/shadowed CMAKE_CUDA_ARCHITECTURES^). Resource
+        echo and perf gate numbers measured on this binary would be INVALID.
+        echo Reconfigure with -DCMAKE_CUDA_ARCHITECTURES=native and rebuild
+        echo before verifying. See pkg183 spec incident ^(PR #590^).
+        echo ====================================================================
+        exit /b 7
+    )
     echo [pkg183] running host-only ABI canary ^(no GPU^)...
     python "%CD%\scripts\build\build_guard.py" canary --repo-root "%CD%" --build-dir "%CD%\build_cuda"
     if !ERRORLEVEL! neq 0 (

--- a/build_cuda_worktree.bat
+++ b/build_cuda_worktree.bat
@@ -15,6 +15,9 @@ REM   2 = MSVC bootstrap failed (cl.exe not on PATH after vcvars)
 REM   3 = nvcc not found
 REM   4 = worktree HEAD mismatch (contamination guard)
 REM   5 = cmake build failed
+REM   6 = pkg183 ABI canary failed (freshly built .pyd crashes on a host-only
+REM       lambertian capability query = stale-object / ABI-mixed binary; distinct
+REM       from a compile/link failure, which uses code 5)
 
 setlocal enabledelayedexpansion
 
@@ -139,6 +142,26 @@ REM Debug and dies with /RTC1 + /O2 -> D8016 on every .cu file. Same fix as
 REM scripts/build/build_cuda_worktree.bat; see memory
 REM build-cuda-worktree-debug-config.
 echo [Phase 3] CUDA build...
+
+REM --- pkg183 incremental-build staleness guard ------------------------------
+REM This OneDrive tree defeats mtime-based staleness detection, so crossing a
+REM layout-changing commit boundary can leave objects compiled against an old
+REM struct layout to be linked with fresh ones (ABI-mixed binary -> host-side
+REM access violations). Compare a hash of the layout-critical headers against
+REM the last build's stamp; on mismatch force a full object clean (correctness
+REM over speed) instead of trusting mtimes.
+where python >nul 2>&1
+if %ERRORLEVEL% neq 0 (
+    echo [pkg183] WARNING: python not on PATH; skipping staleness guard
+) else (
+    set "GUARD_DECISION=OK"
+    for /f "usebackq delims=" %%g in (`python "%CD%\scripts\build\build_guard.py" check --repo-root "%CD%" --build-dir "%CD%\build_cuda"`) do set "GUARD_DECISION=%%g"
+    if "!GUARD_DECISION!"=="WIPE" (
+        echo [pkg183] layout-critical headers changed since last build -- force-cleaning objects
+        cmake --build build_cuda --config Release --target clean
+    )
+)
+
 echo Running: cmake --build build_cuda --config Release --target astroray
 cmake --build build_cuda --config Release --target astroray
 if %ERRORLEVEL% neq 0 (
@@ -154,6 +177,25 @@ cmake --build build_cuda --config Release --target astroray_test_helpers
 if %ERRORLEVEL% neq 0 (
     echo ERROR: astroray_test_helpers build failed with code %ERRORLEVEL%
     exit /b 5
+)
+
+REM --- pkg183 build stamp + host-only ABI canary -----------------------------
+where python >nul 2>&1
+if %ERRORLEVEL% neq 0 (
+    echo [pkg183] WARNING: python not on PATH; skipping build stamp + ABI canary
+) else (
+    python "%CD%\scripts\build\build_guard.py" write --repo-root "%CD%" --build-dir "%CD%\build_cuda" --sha %ACTUAL_SHA%
+    echo [pkg183] running host-only ABI canary ^(no GPU^)...
+    python "%CD%\scripts\build\build_guard.py" canary --repo-root "%CD%" --build-dir "%CD%\build_cuda"
+    if !ERRORLEVEL! neq 0 (
+        echo ====================================================================
+        echo ERROR [pkg183]: ABI CANARY FAILED -- this is NOT a compile/link error.
+        echo The freshly built astroray.pyd crashed on a host-only lambertian
+        echo capability query -- the stale-object / ABI-mixed-binary signature.
+        echo The binary is NOT trustworthy. Remedy: rmdir /s /q build_cuda then rebuild.
+        echo ====================================================================
+        exit /b 6
+    )
 )
 
 echo.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,6 +13,7 @@ new reusable script, register it here in the same commit.
 | Build engine `.pyd` (dev, Ninja + sccache) | `scripts/build/build_cuda.bat` |
 | Build engine in an agent worktree (Ninja) | `scripts/build/build_cuda_worktree.bat` |
 | Build engine in an agent worktree (VS generator; what `hardware-verifier` / `package-implementer` / `tests/test_hw_verifier_buildenv.py` invoke) | repo-root `build_cuda_worktree.bat` |
+| Incremental-build staleness guard (header-hash stamp + <5 s host-only ABI canary) invoked by all three build wrappers | `scripts/build/build_guard.py` (pkg183) |
 | Build/package/install the Blender addon | `scripts/build/build_blender_addon.py` (default backend: `cuda`) |
 | One-command Blender dev loop (build → install → smoke) | `scripts/dev_addon.ps1` |
 | Run the test suite against a build dir | `scripts/dev/run_tests.py` (default: `build_cuda/`) |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,7 +13,7 @@ new reusable script, register it here in the same commit.
 | Build engine `.pyd` (dev, Ninja + sccache) | `scripts/build/build_cuda.bat` |
 | Build engine in an agent worktree (Ninja) | `scripts/build/build_cuda_worktree.bat` |
 | Build engine in an agent worktree (VS generator; what `hardware-verifier` / `package-implementer` / `tests/test_hw_verifier_buildenv.py` invoke) | repo-root `build_cuda_worktree.bat` |
-| Incremental-build staleness guard (header-hash stamp + <5 s host-only ABI canary) invoked by all three build wrappers | `scripts/build/build_guard.py` (pkg183) |
+| Build-integrity guard (header-hash stamp, <5 s host-only ABI canary, cuobjdump CUDA-arch gate) invoked by all three build wrappers | `scripts/build/build_guard.py` (pkg183) |
 | Build/package/install the Blender addon | `scripts/build/build_blender_addon.py` (default backend: `cuda`) |
 | One-command Blender dev loop (build → install → smoke) | `scripts/dev_addon.ps1` |
 | Run the test suite against a build dir | `scripts/dev/run_tests.py` (default: `build_cuda/`) |

--- a/scripts/build/build_cuda.bat
+++ b/scripts/build/build_cuda.bat
@@ -29,6 +29,9 @@ set CCLAUNCH=
 where sccache >nul 2>&1 && set CCLAUNCH=sccache
 if "%CCLAUNCH%"=="" echo [build_cuda] WARNING: sccache not on PATH; building without compiler cache
 
+REM pkg183: repo root captured BEFORE cd build_cuda for the staleness guard.
+set "REPO_ROOT=%CD%"
+
 mkdir build_cuda 2>nul
 cd build_cuda
 
@@ -59,6 +62,25 @@ cmake .. ^
 
 if errorlevel 1 (echo CMake configure failed & exit /b 1)
 
+REM --- pkg183 incremental-build staleness guard ------------------------------
+REM On this OneDrive tree Ninja's mtime-based staleness detection is unreliable,
+REM so crossing a layout-changing commit boundary can leave objects compiled
+REM against an old struct layout to be linked with fresh ones (ABI-mixed binary
+REM -> host-side access violations). Compare a hash of the layout-critical
+REM headers against the last build's stamp; on mismatch force a full object
+REM clean (correctness over speed) instead of trusting mtimes.
+where python >nul 2>&1 || goto :pkg183_guard_skip
+set GUARD_DECISION=OK
+for /f "usebackq delims=" %%g in (`python "%REPO_ROOT%\scripts\build\build_guard.py" check --repo-root "%REPO_ROOT%" --build-dir "%CD%"`) do set GUARD_DECISION=%%g
+if "%GUARD_DECISION%"=="WIPE" (
+    echo [build_cuda] pkg183: layout-critical headers changed since last build -- force-cleaning objects
+    cmake --build . --config Release --target clean
+)
+goto :pkg183_guard_done
+:pkg183_guard_skip
+echo [build_cuda] WARNING: python not on PATH; skipping pkg183 staleness guard
+:pkg183_guard_done
+
 cmake --build . --config Release --target astroray
 if errorlevel 1 (echo Build failed & exit /b 1)
 
@@ -67,3 +89,20 @@ REM without it the pkg92 RNG/PractRand tests fail with a spurious
 REM ModuleNotFoundError (same fix as build_cuda_worktree.bat).
 cmake --build . --config Release --target astroray_test_helpers
 if errorlevel 1 (echo astroray_test_helpers build failed & exit /b 1)
+
+REM --- pkg183 build stamp + host-only ABI canary -----------------------------
+where python >nul 2>&1 || goto :pkg183_post_skip
+for /f %%i in ('git -C "%REPO_ROOT%" rev-parse HEAD') do set HEAD_SHA=%%i
+python "%REPO_ROOT%\scripts\build\build_guard.py" write --repo-root "%REPO_ROOT%" --build-dir "%CD%" --sha %HEAD_SHA%
+echo [build_cuda] pkg183: running host-only ABI canary (no GPU)...
+python "%REPO_ROOT%\scripts\build\build_guard.py" canary --repo-root "%REPO_ROOT%" --build-dir "%CD%"
+if errorlevel 1 (
+    echo ====================================================================
+    echo ERROR [pkg183]: ABI CANARY FAILED -- this is NOT a compile/link error.
+    echo The freshly built astroray.pyd crashed on a host-only lambertian
+    echo capability query -- the stale-object / ABI-mixed-binary signature.
+    echo The binary is NOT trustworthy. Remedy: rmdir /s /q build_cuda ^&^& rebuild.
+    echo ====================================================================
+    exit /b 6
+)
+:pkg183_post_skip

--- a/scripts/build/build_cuda.bat
+++ b/scripts/build/build_cuda.bat
@@ -76,6 +76,9 @@ if "%GUARD_DECISION%"=="WIPE" (
     echo [build_cuda] pkg183: layout-critical headers changed since last build -- force-cleaning objects
     cmake --build . --config Release --target clean
 )
+REM Advisory-only heads-up on a legacy-looking cached CUDA arch (the post-build
+REM cuobjdump gate below is authoritative; the cache line can be a harmless shadow).
+python "%REPO_ROOT%\scripts\build\build_guard.py" arch-check --build-dir "%CD%"
 goto :pkg183_guard_done
 :pkg183_guard_skip
 echo [build_cuda] WARNING: python not on PATH; skipping pkg183 staleness guard
@@ -94,6 +97,17 @@ REM --- pkg183 build stamp + host-only ABI canary -----------------------------
 where python >nul 2>&1 || goto :pkg183_post_skip
 for /f %%i in ('git -C "%REPO_ROOT%" rev-parse HEAD') do set HEAD_SHA=%%i
 python "%REPO_ROOT%\scripts\build\build_guard.py" write --repo-root "%REPO_ROOT%" --build-dir "%CD%" --sha %HEAD_SHA%
+echo [build_cuda] pkg183: verifying built CUDA arch (cuobjdump ground truth)...
+python "%REPO_ROOT%\scripts\build\build_guard.py" arch-verify --pyd-dir "%CD%"
+if errorlevel 1 (
+    echo ====================================================================
+    echo ERROR [pkg183]: CUDA ARCH GATE FAILED -- the built .pyd targets the
+    echo wrong GPU arch ^(stale/shadowed CMAKE_CUDA_ARCHITECTURES^). Resource/perf
+    echo gate numbers measured on this binary would be INVALID. Reconfigure with
+    echo -DCMAKE_CUDA_ARCHITECTURES=native and rebuild before verifying.
+    echo ====================================================================
+    exit /b 7
+)
 echo [build_cuda] pkg183: running host-only ABI canary (no GPU)...
 python "%REPO_ROOT%\scripts\build\build_guard.py" canary --repo-root "%REPO_ROOT%" --build-dir "%CD%"
 if errorlevel 1 (

--- a/scripts/build/build_cuda_worktree.bat
+++ b/scripts/build/build_cuda_worktree.bat
@@ -78,6 +78,9 @@ set CCLAUNCH=
 where sccache >nul 2>&1 && set CCLAUNCH=sccache
 if "%CCLAUNCH%"=="" echo [build_cuda_worktree] WARNING: sccache not on PATH; building without compiler cache
 
+REM pkg183: repo root captured BEFORE cd build_cuda for the staleness guard.
+set "REPO_ROOT=%CD%"
+
 REM Create build directory
 mkdir build_cuda 2>nul
 cd build_cuda
@@ -116,6 +119,25 @@ if errorlevel 1 (
     exit /b 1
 )
 
+REM --- pkg183 incremental-build staleness guard ------------------------------
+REM Ninja's mtime-based staleness detection is unreliable on this OneDrive tree,
+REM so crossing a layout-changing commit boundary can leave objects compiled
+REM against an old struct layout to be linked with fresh ones (ABI-mixed binary
+REM -> host-side access violations). Compare a hash of the layout-critical
+REM headers against the last build's stamp; on mismatch force a full object
+REM clean (correctness over speed) instead of trusting mtimes.
+where python >nul 2>&1 || goto :pkg183_guard_skip
+set GUARD_DECISION=OK
+for /f "usebackq delims=" %%g in (`python "%REPO_ROOT%\scripts\build\build_guard.py" check --repo-root "%REPO_ROOT%" --build-dir "%CD%"`) do set GUARD_DECISION=%%g
+if "%GUARD_DECISION%"=="WIPE" (
+    echo [build_cuda_worktree] pkg183: layout-critical headers changed since last build -- force-cleaning objects
+    cmake --build . --config Release --target clean
+)
+goto :pkg183_guard_done
+:pkg183_guard_skip
+echo [build_cuda_worktree] WARNING: python not on PATH; skipping pkg183 staleness guard
+:pkg183_guard_done
+
 REM Build
 REM --config Release is REQUIRED and must not be dropped. It is a no-op for the
 REM single-config NMake generator configured above, but if this build_cuda/ tree
@@ -138,6 +160,22 @@ if errorlevel 1 (
     echo ERROR: astroray_test_helpers build failed
     exit /b 1
 )
+
+REM --- pkg183 build stamp + host-only ABI canary -----------------------------
+where python >nul 2>&1 || goto :pkg183_post_skip
+python "%REPO_ROOT%\scripts\build\build_guard.py" write --repo-root "%REPO_ROOT%" --build-dir "%CD%" --sha %ACTUAL_SHA%
+echo [build_cuda_worktree] pkg183: running host-only ABI canary (no GPU)...
+python "%REPO_ROOT%\scripts\build\build_guard.py" canary --repo-root "%REPO_ROOT%" --build-dir "%CD%"
+if errorlevel 1 (
+    echo ====================================================================
+    echo ERROR [pkg183]: ABI CANARY FAILED -- this is NOT a compile/link error.
+    echo The freshly built astroray.pyd crashed on a host-only lambertian
+    echo capability query -- the stale-object / ABI-mixed-binary signature.
+    echo The binary is NOT trustworthy. Remedy: rmdir /s /q build_cuda ^&^& rebuild.
+    echo ====================================================================
+    exit /b 6
+)
+:pkg183_post_skip
 
 echo [build_cuda_worktree] Build succeeded
 exit /b 0

--- a/scripts/build/build_cuda_worktree.bat
+++ b/scripts/build/build_cuda_worktree.bat
@@ -133,6 +133,9 @@ if "%GUARD_DECISION%"=="WIPE" (
     echo [build_cuda_worktree] pkg183: layout-critical headers changed since last build -- force-cleaning objects
     cmake --build . --config Release --target clean
 )
+REM Advisory-only heads-up on a legacy-looking cached CUDA arch (the post-build
+REM cuobjdump gate below is authoritative; the cache line can be a harmless shadow).
+python "%REPO_ROOT%\scripts\build\build_guard.py" arch-check --build-dir "%CD%"
 goto :pkg183_guard_done
 :pkg183_guard_skip
 echo [build_cuda_worktree] WARNING: python not on PATH; skipping pkg183 staleness guard
@@ -164,6 +167,17 @@ if errorlevel 1 (
 REM --- pkg183 build stamp + host-only ABI canary -----------------------------
 where python >nul 2>&1 || goto :pkg183_post_skip
 python "%REPO_ROOT%\scripts\build\build_guard.py" write --repo-root "%REPO_ROOT%" --build-dir "%CD%" --sha %ACTUAL_SHA%
+echo [build_cuda_worktree] pkg183: verifying built CUDA arch (cuobjdump ground truth)...
+python "%REPO_ROOT%\scripts\build\build_guard.py" arch-verify --pyd-dir "%CD%"
+if errorlevel 1 (
+    echo ====================================================================
+    echo ERROR [pkg183]: CUDA ARCH GATE FAILED -- the built .pyd targets the
+    echo wrong GPU arch ^(stale/shadowed CMAKE_CUDA_ARCHITECTURES^). Resource/perf
+    echo gate numbers measured on this binary would be INVALID. Reconfigure with
+    echo -DCMAKE_CUDA_ARCHITECTURES=native and rebuild before verifying.
+    echo ====================================================================
+    exit /b 7
+)
 echo [build_cuda_worktree] pkg183: running host-only ABI canary (no GPU)...
 python "%REPO_ROOT%\scripts\build\build_guard.py" canary --repo-root "%REPO_ROOT%" --build-dir "%CD%"
 if errorlevel 1 (

--- a/scripts/build/build_guard.py
+++ b/scripts/build/build_guard.py
@@ -33,6 +33,28 @@ Subcommands:
       Exits 0 on success, 6 if the call raises a Python exception. A hard
       C-level crash (access violation) kills this process with its own non-zero
       code, which the calling wrapper likewise treats as a canary failure.
+
+  arch-verify --pyd-dir D [--expect sm_120]
+      GROUND-TRUTH CUDA arch gate (PR #590 incident, 2026-08-12): run
+      `cuobjdump --list-elf` on the built astroray*.pyd and fail (exit 7) if the
+      embedded cubin arch does not match the expected native arch. This is
+      authoritative where the CMakeCache `CMAKE_CUDA_ARCHITECTURES` line is NOT:
+      on a Ninja tree the cache can read `52` yet the .pyd embeds `sm_120`
+      (CMakeLists' non-cache set() shadows the cache when ASTRORAY_CUDA_ARCHS is
+      defined), while in VS-generator worktrees where ASTRORAY_CUDA_ARCHS is
+      unset the stale 52 is LIVE — that produced cuobjdump register/stack
+      readings (2640) taken on irrelevant compute_52 PTX instead of the true
+      sm_120 SASS (3608). Expected arch auto-detects via
+      `nvidia-smi --query-gpu=compute_cap`; if that is unavailable it falls back
+      to a legacy-sentinel rule (fail when the ONLY embedded arch is pre-Volta,
+      e.g. sm_52). Missing cuobjdump downgrades to a warning (never a false
+      build failure).
+
+  arch-check --build-dir D
+      Fast, advisory-only pre-build read of the CMakeCache
+      `CMAKE_CUDA_ARCHITECTURES` line. Prints a heads-up when it looks legacy;
+      NEVER gates (the cache line is unreliable — see arch-verify). The
+      post-build arch-verify is the gate.
 """
 import argparse
 import hashlib
@@ -124,6 +146,128 @@ def _cmd_canary(repo_root: Path, build_dir: str | None) -> int:
     return 0
 
 
+ARCH_EXIT = 7
+
+
+def _find_astroray_pyd(pyd_dir: Path) -> Path | None:
+    """Locate the built astroray module .pyd (not astroray_test_helpers).
+
+    Searches the given dir and its Release/ subdir (VS multi-config layout).
+    """
+    import os
+    for base in (pyd_dir, pyd_dir / "Release"):
+        if not base.is_dir():
+            continue
+        for name in sorted(os.listdir(base)):
+            low = name.lower()
+            if low.startswith("astroray") and low.endswith(".pyd") and "test_helpers" not in low:
+                return base / name
+    return None
+
+
+def _detect_native_arch() -> str | None:
+    """Local GPU compute capability as an sm_ token, e.g. '12.0' -> 'sm_120'."""
+    import subprocess
+    try:
+        out = subprocess.run(
+            ["nvidia-smi", "--query-gpu=compute_cap", "--format=csv,noheader"],
+            capture_output=True, text=True, timeout=15, check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if out.returncode != 0:
+        return None
+    first = (out.stdout or "").strip().splitlines()
+    if not first:
+        return None
+    cc = first[0].strip()  # "12.0"
+    if not cc or "." not in cc:
+        return None
+    major, minor = cc.split(".", 1)
+    return f"sm_{major}{minor}"
+
+
+def _cuobjdump_arches(pyd: Path) -> tuple[set[str], bool]:
+    """Return (embedded sm_ arches, cuobjdump_available)."""
+    import re
+    import subprocess
+    try:
+        out = subprocess.run(
+            ["cuobjdump", "--list-elf", str(pyd)],
+            capture_output=True, text=True, timeout=60, check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return set(), False
+    arches = set(re.findall(r"sm_(\d+)", out.stdout or ""))
+    return {f"sm_{a}" for a in arches}, True
+
+
+def _cmd_arch_verify(pyd_dir: Path, expect: str | None) -> int:
+    pyd = _find_astroray_pyd(pyd_dir)
+    if pyd is None:
+        print(f"[pkg183] arch-verify WARNING: no astroray*.pyd found under {pyd_dir}; skipping")
+        return 0
+
+    arches, available = _cuobjdump_arches(pyd)
+    if not available:
+        print("[pkg183] arch-verify WARNING: cuobjdump not on PATH; skipping arch gate")
+        return 0
+    if not arches:
+        print(f"[pkg183] arch-verify WARNING: no SASS cubin embedded in {pyd.name} "
+              "(PTX-only build?); cannot confirm native arch")
+        return 0
+
+    expected = expect or _detect_native_arch()
+    embedded = ",".join(sorted(arches))
+
+    if expected is None:
+        # Could not determine the intended arch. Still catch the exact incident
+        # signature: a build whose ONLY embedded arch is legacy (pre-Volta).
+        legacy_only = all(int(a[3:]) < 70 for a in arches)
+        if legacy_only:
+            print(f"[pkg183] arch-verify FAIL: {pyd.name} embeds only legacy arch(es) "
+                  f"[{embedded}] (pre-Volta); expected the native GPU arch. "
+                  "This is the stale-CMAKE_CUDA_ARCHITECTURES=52 signature.")
+            return ARCH_EXIT
+        print(f"[pkg183] arch-verify: could not detect native arch (nvidia-smi); "
+              f"embedded=[{embedded}], no legacy-only -> accepting")
+        return 0
+
+    if expected in arches:
+        print(f"[pkg183] arch-verify OK: {pyd.name} embeds {expected} (embedded=[{embedded}])")
+        return 0
+
+    print("====================================================================")
+    print(f"[pkg183] arch-verify FAIL: {pyd.name} embeds [{embedded}] but the local "
+          f"GPU needs {expected}.")
+    print("The built binary targets the WRONG CUDA arch (stale/shadowed")
+    print("CMAKE_CUDA_ARCHITECTURES). Any cuobjdump register/stack or perf gate")
+    print("numbers measured on this .pyd are INVALID (they would reflect JIT'd")
+    print(f"PTX, not native {expected} SASS). Reconfigure with")
+    print("-DCMAKE_CUDA_ARCHITECTURES=native and rebuild before verifying.")
+    print("====================================================================")
+    return ARCH_EXIT
+
+
+def _cmd_arch_check(build_dir: Path) -> int:
+    cache = build_dir / "CMakeCache.txt"
+    if not cache.exists():
+        return 0
+    value = ""
+    for line in cache.read_text(encoding="utf-8", errors="ignore").splitlines():
+        if line.startswith(("CMAKE_CUDA_ARCHITECTURES:", "CMAKE_CUDA_ARCHITECTURES=")):
+            value = line.split("=", 1)[1].strip() if "=" in line else ""
+            break
+    tokens = [t for t in value.replace(";", " ").split() if t]
+    legacy_only = bool(tokens) and all(t.isdigit() and int(t) < 70 for t in tokens)
+    if legacy_only:
+        print(f"[pkg183] arch-check ADVISORY: CMakeCache CMAKE_CUDA_ARCHITECTURES={value} "
+              "looks legacy. This may be a harmless shadowed cache line (Ninja + "
+              "ASTRORAY_CUDA_ARCHS=native) or a live stale arch; the post-build "
+              "arch-verify gate is authoritative.")
+    return 0
+
+
 def main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(description="pkg183 incremental-build staleness guard")
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -141,10 +285,21 @@ def main(argv: list[str]) -> int:
     p_canary.add_argument("--repo-root", required=True)
     p_canary.add_argument("--build-dir", default=None)
 
+    p_archv = sub.add_parser("arch-verify")
+    p_archv.add_argument("--pyd-dir", required=True)
+    p_archv.add_argument("--expect", default=None)
+
+    p_archc = sub.add_parser("arch-check")
+    p_archc.add_argument("--build-dir", required=True)
+
     args = parser.parse_args(argv)
 
     if args.cmd == "canary":
         return _cmd_canary(Path(args.repo_root).resolve(), args.build_dir)
+    if args.cmd == "arch-verify":
+        return _cmd_arch_verify(Path(args.pyd_dir).resolve(), args.expect)
+    if args.cmd == "arch-check":
+        return _cmd_arch_check(Path(args.build_dir).resolve())
 
     repo_root = Path(args.repo_root).resolve()
     build_dir = Path(args.build_dir).resolve()

--- a/scripts/build/build_guard.py
+++ b/scripts/build/build_guard.py
@@ -1,0 +1,160 @@
+"""pkg183 - incremental-build staleness guard.
+
+Guards against ABI-mixed binaries: stale object files compiled against an older
+struct layout getting linked with fresh objects. On the OneDrive tree, Ninja's
+mtime-based staleness detection is unreliable (OneDrive mangles mtimes), so a
+layout-changing commit boundary crossed via branch-switching can silently
+produce a binary that access-violates on host-only code (the incident that
+motivated this: get_material_backend_capabilities on a lambertian crashed on
+every contaminated binary). See pkg183 spec and the
+`incremental-build-signature-staleness` memory.
+
+Strategy: hash the layout-critical headers (include/astroray/*.h,
+include/raytracer.h) and record that hash + the HEAD SHA in a stamp file next
+to the build tree. On the next build, if the header hash changed, the wrapper
+force-cleans object files (correctness over speed) instead of trusting mtimes.
+
+Subcommands:
+  check --repo-root R --build-dir B
+      Emit WIPE (stale objects present that must be force-cleaned) or OK.
+      Never exits non-zero for a normal decision; a non-zero exit means the
+      guard itself could not run and the caller should warn but continue.
+
+  write --repo-root R --build-dir B --sha S
+      Record the current header hash + SHA into <build-dir>/.astroray_build_stamp.
+      Call this AFTER a successful configure/build.
+
+  canary --repo-root R [--build-dir D]
+      Host-only (<5 s, no GPU) ABI smoke check: import the freshly built
+      astroray and run the exact 3-line repro that access-violated on every
+      ABI-mixed binary during the 2026-08-11 incident. Reuses
+      tests/runtime_setup.py to put the CUDA/OIDN dependency DLL dirs on the
+      loader path (the .pyd links _deps DLLs that are not otherwise on PATH).
+      Exits 0 on success, 6 if the call raises a Python exception. A hard
+      C-level crash (access violation) kills this process with its own non-zero
+      code, which the calling wrapper likewise treats as a canary failure.
+"""
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+STAMP_NAME = ".astroray_build_stamp"
+
+
+def _layout_headers(repo_root: Path) -> list[Path]:
+    """Layout-critical headers whose struct changes must invalidate objects.
+
+    Exactly the set named in the pkg183 spec: every .h under include/astroray/
+    plus include/raytracer.h. Sorted for a deterministic hash.
+    """
+    headers = sorted((repo_root / "include" / "astroray").glob("*.h"))
+    rt = repo_root / "include" / "raytracer.h"
+    if rt.exists():
+        headers.append(rt)
+    return headers
+
+
+def _header_hash(repo_root: Path) -> str:
+    h = hashlib.sha256()
+    for path in _layout_headers(repo_root):
+        rel = path.relative_to(repo_root).as_posix()
+        h.update(rel.encode("utf-8"))
+        h.update(b"\0")
+        h.update(path.read_bytes())
+        h.update(b"\0")
+    return h.hexdigest()
+
+
+def _cmd_check(repo_root: Path, build_dir: Path) -> int:
+    current = _header_hash(repo_root)
+    stamp = build_dir / STAMP_NAME
+    cache = build_dir / "CMakeCache.txt"
+
+    # A tree that was never configured has no objects to be stale -> nothing to
+    # wipe. Let the wrapper configure + build fresh.
+    if not cache.exists():
+        print("OK")
+        return 0
+
+    if not stamp.exists():
+        # Configured build with no stamp = predates this guard; it may already
+        # be ABI-mixed. Force-clean once so the first guarded build is trusted.
+        print("WIPE")
+        return 0
+
+    try:
+        recorded = json.loads(stamp.read_text(encoding="utf-8")).get("header_hash", "")
+    except (ValueError, OSError):
+        print("WIPE")
+        return 0
+
+    print("WIPE" if recorded != current else "OK")
+    return 0
+
+
+def _cmd_write(repo_root: Path, build_dir: Path, sha: str) -> int:
+    build_dir.mkdir(parents=True, exist_ok=True)
+    payload = {"header_hash": _header_hash(repo_root), "sha": sha}
+    (build_dir / STAMP_NAME).write_text(json.dumps(payload) + "\n", encoding="utf-8")
+    print(f"[pkg183] build stamp written: sha={sha[:12]} header_hash={payload['header_hash'][:12]}")
+    return 0
+
+
+CANARY_EXIT = 6
+
+
+def _cmd_canary(repo_root: Path, build_dir: str | None) -> int:
+    import os
+    if build_dir:
+        os.environ["ASTRORAY_BUILD_DIR"] = str(Path(build_dir).resolve())
+    sys.path.insert(0, str(repo_root / "tests"))
+    try:
+        import runtime_setup
+        runtime_setup.configure_test_imports()
+        import astroray
+        r = astroray.Renderer()
+        m = r.create_material("lambertian", [0.5, 0.5, 0.5], {})
+        caps = r.get_material_backend_capabilities(m)
+    except Exception as exc:  # noqa: BLE001 - any failure here is a canary trip
+        print(f"[pkg183] canary EXCEPTION: {type(exc).__name__}: {exc}")
+        return CANARY_EXIT
+    print(f"[pkg183] canary caps: {caps}")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="pkg183 incremental-build staleness guard")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_check = sub.add_parser("check")
+    p_check.add_argument("--repo-root", required=True)
+    p_check.add_argument("--build-dir", required=True)
+
+    p_write = sub.add_parser("write")
+    p_write.add_argument("--repo-root", required=True)
+    p_write.add_argument("--build-dir", required=True)
+    p_write.add_argument("--sha", required=True)
+
+    p_canary = sub.add_parser("canary")
+    p_canary.add_argument("--repo-root", required=True)
+    p_canary.add_argument("--build-dir", default=None)
+
+    args = parser.parse_args(argv)
+
+    if args.cmd == "canary":
+        return _cmd_canary(Path(args.repo_root).resolve(), args.build_dir)
+
+    repo_root = Path(args.repo_root).resolve()
+    build_dir = Path(args.build_dir).resolve()
+
+    if args.cmd == "check":
+        return _cmd_check(repo_root, build_dir)
+    if args.cmd == "write":
+        return _cmd_write(repo_root, build_dir, args.sha)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/test_hw_verifier_buildenv.py
+++ b/tests/test_hw_verifier_buildenv.py
@@ -201,12 +201,16 @@ def test_step0_hygiene_preserved():
     # The hardware-verifier.md Step 2 (smoke-check) is unchanged in the spec.
     # The wrapper builds into the worktree's own build_cuda/, and Step 2
     # verifies the freshly built .pyd is the one imported.
-    # This test confirms the wrapper does not delete the worktree .pyd before
-    # it can rebuild it (the exact #318 --target clean failure).
+    # This test confirms the wrapper does not UNCONDITIONALLY delete the
+    # worktree .pyd before it can rebuild it (the exact #318 --target clean
+    # failure).
     #
-    # The .bat file does NOT run cmake --target clean before the build.
-    # It only runs: cmake --build build_cuda --target astroray
-    # So the .pyd is preserved until the rebuild completes.
+    # pkg183 update: the wrapper now runs `cmake --build ... --target clean`
+    # ONLY when the layout-critical-header stamp mismatches (an ABI-mixed-binary
+    # risk), immediately followed by a full rebuild in the same invocation. On
+    # the common unchanged-tree path the stamp matches and NO clean runs, so the
+    # #318 unconditional-clean regression is not reintroduced. When a clean does
+    # run it is deliberate: a stale .pyd that would be ABI-mixed must not survive.
     assert True  # Contract verified by .bat logic
 
 


### PR DESCRIPTION
## Summary

Guards against the incremental-build staleness class documented in the pkg183 spec (the 2026-08-11 hygiene-run incident: ~3h burned on phantom host-side access violations + a fabricated git-bisect result, all caused by stale objects compiled against a pre-#574 struct layout being linked with fresh objects — an ABI-mixed binary).

Two mechanisms, mirrored into **all three** build wrappers in their own idiom:

1. **Header-hash stamp + force-clean-on-mismatch.** A new helper `scripts/build/build_guard.py check` SHA-256-hashes the layout-critical headers (`include/astroray/*.h` + `include/raytracer.h`) and compares to `build_cuda/.astroray_build_stamp`. On mismatch (or a configured tree with no stamp → predates the guard, may already be ABI-mixed) the wrapper runs `cmake --build … --target clean` (generator-agnostic, removes all objects unconditionally — not mtime-based). On match the incremental path is **untouched**.
2. **<5 s host-only ABI canary.** After every build the wrapper runs the exact spec repro (`Renderer().get_material_backend_capabilities(create_material('lambertian',…))`) via `build_guard.py canary`. A crash exits with a **distinct code 6 + loud banner**, never confused with a compile/link failure (code 5). Reuses `tests/runtime_setup.py` for the CUDA/OIDN `_deps` DLL dirs.

Item 4 (move build trees off OneDrive) is **evaluate-only** — assessment written into the spec Lessons section; recommendation is to defer to a separate package (deferred because every `build_cuda/`-inside-checkout consumer would need lockstep updates).

## Authorized surface

Spec Work items 1–3 target the three build wrappers. Files changed:
- `scripts/build/build_guard.py` **(new)** — the helper the spec's implementation notes call for ("prefer a python helper over batch gymnastics").
- `build_cuda_worktree.bat`, `scripts/build/build_cuda.bat`, `scripts/build/build_cuda_worktree.bat` — the three wrappers named in the spec's Depends-on.
- `scripts/README.md` — registers the new helper (no-duplicate-scripts rule).
- `tests/test_hw_verifier_buildenv.py` — updated the now-stale comment in `test_step0_hygiene_preserved` (the root wrapper now *conditionally* runs `--target clean`); no assertion changed. `test_gpu_serialization_preserved` (root wrapper must be "lock"-free) still passes — my added text avoids that substring.
- `.astroray_plan/packages/pkg183-…md` — status flip + implementation notes + item-4 Lessons.

Nothing outside the spec's scope.

## Evidence

### (a) Run twice on an unchanged tree — second run stays incremental, canary passes

Run 1 (fresh worktree; no prior stamp → guard force-cleans a freshly-configured, not-yet-built tree = harmless no-op, then full build):
```
[build_cuda] pkg183: layout-critical headers changed since last build -- force-cleaning objects
[1/2] Cleaning all built files...
Cleaning... 0 files.
...
[pkg183] build stamp written: sha=084be7b40653 header_hash=2479f4205015
[build_cuda] pkg183: running host-only ABI canary (no GPU)...
[pkg183] canary caps: {'cpu': True, 'spectral': True, 'gpu': True, ...}
```
Run 2 (unchanged tree): **no** force-clean line (stamp matched → guard OK path, pure no-op), canary passes:
```
[pkg183] build stamp written: sha=084be7b40653 header_hash=2479f4205015
[build_cuda] pkg183: running host-only ABI canary (no GPU)...
[pkg183] canary caps: {'cpu': True, 'spectral': True, 'gpu': True, ...}
```
(The residual Ninja object recompiles on run 2 are OneDrive-mtime churn — the underlying disease this package guards *around* — and are sccache-served. The guard's OK path touches no objects, so it adds no rebuild-time regression.)

### (b) Header-hash mismatch triggers the wipe path

To isolate the guard from a source change, I tampered the stored stamp `header_hash` (unchanged source → only a force-clean can cause a rebuild), then reran the wrapper:
```
check decision: WIPE
[build_cuda] pkg183: layout-critical headers changed since last build -- force-cleaning objects
[1/2] Cleaning all built files...
Cleaning... 116 files.      <-- 116 stale objects actually removed
...
[pkg183] build stamp written: sha=084be7b40653 header_hash=2479f4205015   <-- stamp self-heals to correct hash
[pkg183] canary caps: {'cpu': True, 'spectral': True, 'gpu': True, ...}
```

### (c) Canary catches a broken .pyd

Shadowed the freshly built `astroray.pyd` with a corrupt file (real `_deps` DLLs still resolvable, so only the binary is bad):
```
[pkg183] canary EXCEPTION: ImportError: DLL load failed while importing astroray: %1 is not a valid Win32 application.
CANARY_EXIT_ON_BROKEN=6
# restored:
[pkg183] canary caps: {'cpu': True, 'spectral': True, ...}
CANARY_EXIT_ON_GOOD=0
```

### Last 5 lines of a build log (run 2, incremental, exit 0)
```
[24/27] Linking CXX static library astroray_core_impl.lib
[25/27] Building CXX object CMakeFiles\astroray_test_helpers.dir\module\test_helpers_module.cpp.obj
[26/27] Linking CXX shared module astroray_test_helpers.cp313-win_amd64.pyd
[build_cuda] pkg183: running host-only ABI canary (no GPU)...
[pkg183] canary caps: {'cpu': True, 'spectral': True, 'gpu': True, 'gpu_spectral': True, 'gpu_approximate': False, 'closure_graph': True, 'closure_count': 1, 'gpu_type': 'closure_graph', 'notes': 'spectral closure-graph GPU lowering'}
```

### Tests
`pytest tests/test_hw_verifier_buildenv.py -v` → **13 passed** (incl. `test_gpu_serialization_preserved`, `test_step0_hygiene_preserved`). Differential lint gate: 0 new findings (ruff/markdownlint/codespell/git-diff-check). No GPU render suites run (nothing here needs them; other agents hold the GPU).

## Acceptance criteria
- [x] Item 1: header-hash stamp + force-clean-on-mismatch in all three wrappers
- [x] Item 2: <5 s host-only ABI canary in all three wrappers (distinct failure exit code)
- [x] Item 3: force-clean wired into both `build_cuda_worktree.bat` copies + the dev wrapper
- [x] Item 4: evaluated-only (spec Lessons section)
- [x] `.bat` files are CRLF (`git ls-files --eol` → `w/crlf attr/text eol=crlf`)
- [x] helper registered in `scripts/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Scope addition (PR #590 finding): cuobjdump CUDA-arch gate

The PR #590 hardware verifier found `CMAKE_CUDA_ARCHITECTURES:STRING=52` (stale Maxwell PTX) cached in **every** `build_cuda/CMakeCache.txt`. The root wrapper only builds, never reconfigures, so it persisted — a `cuobjdump` register/stack gate read `<false,false> STACK 2640` on `compute_52` PTX instead of the true sm_120 SASS (3608). That invalidates resource-gate readings — the exact "verification integrity" pillar this package owns.

**Key finding established while implementing:** the cache line is an **unreliable** signal. On a Ninja tree with `ASTRORAY_CUDA_ARCHS=native`, CMakeLists' non-cache `set(CMAKE_CUDA_ARCHITECTURES …)` (line 57) *shadows* the cache — the cache reads `52` yet the `.pyd` embeds `sm_120`. So the guard's ground truth is the **built artifact** (`cuobjdump --list-elf`), not the cache line. This never false-positives on a harmless shadow and catches every live variant.

- `build_guard.py arch-verify` (post-build **gate**): `cuobjdump --list-elf` the `astroray*.pyd`; fail (**exit 7**, loud banner) if the embedded cubin arch ≠ the local native arch (auto-detected via `nvidia-smi --query-gpu=compute_cap`; legacy-only fallback when nvidia-smi is absent). Missing `cuobjdump`/`nvidia-smi` → warning, never a false build failure.
- `build_guard.py arch-check` (post-configure **advisory**): heads-up on a legacy-looking cache line; never gates.
- Wired into all three wrappers. Distinct exit code 7 (vs 6 canary, 5 build).

### Evidence — never false-positives on a shadowed cache (the realistic Ninja case)

Forced the cache back to `52` (the common shadowed state) and ran the Ninja wrapper. Advisory fires, but the artifact gate reads the `.pyd` and PASSES because the compile is actually native:
```
[pkg183] arch-check ADVISORY: CMakeCache CMAKE_CUDA_ARCHITECTURES=52 looks legacy. ... the post-build arch-verify gate is authoritative.
[build_cuda] pkg183: verifying built CUDA arch (cuobjdump ground truth)...
[pkg183] arch-verify OK: astroray.cp313-win_amd64.pyd embeds sm_120 (embedded=[sm_120])
[pkg183] canary caps: {'cpu': True, 'spectral': True, 'gpu': True, ...}
```
(Cache line still reads `52`; artifact is `sm_120` — the gate is not fooled.)

### Evidence — the gate FAILS loudly on a wrong arch (exit 7)

Ran the exact wrapper if-block with a forced wrong `--expect sm_52`:
```
[pkg183] arch-verify FAIL: astroray.cp313-win_amd64.pyd embeds [sm_120] but the local GPU needs sm_52. ...
ERROR [pkg183]: CUDA ARCH GATE FAILED -- the built .pyd targets the wrong GPU arch ...
ARCHFAIL_EXIT=7          # "SHOULD NOT REACH HERE" never printed
```

### Batch bug caught by an actual run

The first wrapper run with the arch block errored with `. was unexpected at this time.` and silently skipped the canary: unescaped `(...)` inside the Ninja `if errorlevel 1 (...)` block closed the block early at parse time. Fixed (`^(` / `^)`), re-ran clean (advisory → arch-verify OK → canary, exit 0). This is why empirical wrapper runs, not inspection, are the acceptance evidence.

### Not fixed here (deliberate, out of scope)

The **root cause** is CMakeLists line 57 using a non-cache `set()` (leaves the cache untruthful) and `configure_and_build.bat` not passing `ASTRORAY_CUDA_ARCHS` (lets VS-generator worktrees compile a *live* stale 52). Both are outside pkg183's wrapper-only authorized surface. The artifact gate makes the symptom loud regardless; the spec Lessons flags a follow-up package to FORCE the cache from `ASTRORAY_CUDA_ARCHS` at the source. **`CMakeLists.txt` and `configure_and_build.bat` were NOT touched.**

### Updated authorized surface

Adds `arch-verify`/`arch-check` to `scripts/build/build_guard.py` and one gate + one advisory call to each of the three wrappers. No new files. Still nothing outside the spec's three-wrapper + helper surface. Lint: 0 new findings. `pytest tests/test_hw_verifier_buildenv.py` → 13 passed.
