### PR TITLE
feat(pkg187): Principled BSDF dispersion (Cauchy/Abbe) — CPU-complete + GPU-wired

### DIFF
--- a/.astroray_plan/docs/pkg187-principled-dispersion-research.md
+++ b/.astroray_plan/docs/pkg187-principled-dispersion-research.md
@@ -1,0 +1,92 @@
+# pkg187 — Principled BSDF dispersion: algorithm research notes
+
+Per CLAUDE.md §6 / the `cite-algorithm` skill: research done **before** writing
+the Abbe-number → dispersion-curve mapping.
+
+## Problem
+
+Blender's Principled BSDF (WIP) exposes dispersion as an **Abbe number** (Vd)
+plus a **dispersion scale**. The engine needs a per-wavelength IOR `n(λ)` for the
+transmission lobe. Do not hand-roll a wavelength dependence — find the canonical
+formula and a license-compatible reference implementation.
+
+## Canonical source (borrowed)
+
+**Cycles' WIP Principled/Glass dispersion** — Blender PR
+[#162041](https://projects.blender.org/blender/blender/pulls/162041), function
+`bsdf_glass_ior` in `intern/cycles/kernel/closure/bsdf_microfacet.h`
+(Apache-2.0 / compatible). It implements the **OpenPBR Surface specification
+v1.1.1, Eqs. (55) and (56)** — the two-term **Cauchy** empirical dispersion:
+
+```
+n(λ) = A + B / λ²                          (Eq. 55, λ in μm)
+B    = (n_d − 1) · inv_abbe · fac          (Eq. 56)
+A    = n_d − B / λ_d²
+fac  = 1 / (1/λ_F² − 1/λ_C²)
+```
+
+with the Fraunhofer spectral lines (μm): `λ_d = 0.5876`, `λ_C = 0.6563`,
+`λ_F = 0.4861`, and `inv_abbe = dispersion_scale / abbe_number`
+(Cycles `safe_divide`, so `inv_abbe = 0` when the Abbe number is 0 → flat IOR).
+`n_d` is the IOR at the d line (Blender's `IOR` socket).
+
+Cycles source (paraphrased from the PR diff):
+
+```cpp
+// bsdf_glass_ior — Cauchy fit, input ior is the d-line IOR after backface flip.
+constexpr float lambda_d = 0.5876f, lambda_C = 0.6563f, lambda_F = 0.4861f;
+constexpr float fac = 1.0f/(1.0f/(lambda_F*lambda_F) - 1.0f/(lambda_C*lambda_C));
+const float B = (ior - 1.0f) * inv_abbe * fac;   // OpenPBR Eq. 56
+const float A = ior - B / (lambda_d*lambda_d);
+ior = A + B / sqr(wavelength);                    // OpenPBR Eq. 55
+```
+
+The socket→inv_abbe mapping (Cycles OSL / SVM in the same PR):
+
+```
+dispersion_scale = clamp(TransmissionDispersionScale, 0, 1);
+abbe_number      = max(TransmissionDispersionAbbeNumber, 0);   // default 20
+inv_abbe         = safe_divide(dispersion_scale, abbe_number);
+```
+
+Cycles collapses the path to a single sampled wavelength on a dispersive
+interaction (`SR_BSDF_HAS_DISPERSION`, `dispersion_throughput_weight`) — the
+direct analogue of Astroray's `SampledWavelengths::terminateSecondary()`
+hero-wavelength collapse, already used by `DielectricPlugin::sampleSpectral`.
+
+## Why Cauchy, not the engine's Sellmeier
+
+The in-repo dielectric (`plugins/materials/dielectric.cpp`) uses **Sellmeier**
+coefficients (measured glass presets). The Abbe→dispersion bridge here is
+**Cauchy**, matching Cycles exactly — the pkg187 spec explicitly permits
+"Cauchy or a reduced-Sellmeier fit from (Vd, IOR at d-line)". A two-term Cauchy
+fit from `(n_d, Vd)` is the standard and reproduces Cycles bit-for-bit, so the
+`cycles-parity-reviewer` sees the same math. `iorAt`/`isDispersive`/hero-collapse
+**structure** mirrors `dielectric.cpp:110-142`; only the closed form differs
+(Cauchy vs Sellmeier), and it is cited in-code.
+
+## Blender-socket reality (correcting the spec premise)
+
+The pkg187 spec asserted "Blender 4.2+ exposes a Dispersion input on Principled
+BSDF; that value is dropped silently on import." **This is false for every
+installed build.** Headless probe (`bpy`, `ShaderNodeBsdfPrincipled` /
+`ShaderNodeBsdfGlass` / `ShaderNodeBsdfRefraction`):
+
+| Blender | Dispersion socket on Principled / Glass / Refraction |
+|---------|------------------------------------------------------|
+| 4.3.2   | none                                                 |
+| 4.5.0   | none                                                 |
+| 5.1.0   | none                                                 |
+| 5.2.0   | none                                                 |
+
+Dispersion is unmerged upstream WIP (PR #162041). The engine core is still built
+and verified via native dispersion params; the addon gets a forward-compatible
+`put_float` probe (`'Dispersion Scale'` / `'Dispersion Abbe Number'`, single
+`'Dispersion'` alias) that is a no-op today and live the day the PR ships.
+(Coordinator-approved Option A, 2026-08-12.)
+
+## In-code citations
+
+- `plugins/materials/principled.cpp` — `cauchyAB()` cites PR #162041 +
+  OpenPBR v1.1.1 Eqs. 55/56.
+- `include/astroray/gpu_dispersion.cuh` — `gpu_cauchy_ior()` cites the same.

--- a/.astroray_plan/packages/pkg187-principled-dispersion.md
+++ b/.astroray_plan/packages/pkg187-principled-dispersion.md
@@ -2,8 +2,11 @@
 
 **Pillar:** 3/5 (spectral light transport / Blender parity)
 **Track:** A
-**Status:** in progress (pkg187 branch — engine core implemented via Option A;
-CPU/GPU dispersion + forward-compatible addon probe)
+**Status:** CPU-complete + GPU-wired (PR #593, 2026-08-12 — CPU chromatic prism
+red/blue spread 4.27→5.35px; zero-dispersion byte-identical; addon forward-probe
+unit-tested; `<false>` shade kernel REG:254/STACK:2640 unchanged. GPU-visible
+wavefront dispersion deferred to the follow-up spec filed 2026-08-12 — it is a
+pre-existing frozen no-op that the dielectric reference shares.)
 **Estimated effort:** M
 **Depends on:** pkg178 (native Principled BSDF); pkg31/pkg29 (Sellmeier
 dielectric plugin); pkg64 (GPU Sellmeier / hero-λ upload); SMS/MNEE

--- a/.astroray_plan/packages/pkg187-principled-dispersion.md
+++ b/.astroray_plan/packages/pkg187-principled-dispersion.md
@@ -4,10 +4,23 @@
 **Track:** A
 **Status:** CPU-complete + GPU-wired (PR #593, 2026-08-12 — CPU chromatic prism
 red/blue spread 4.27→5.35px; zero-dispersion byte-identical; addon forward-probe
-unit-tested; `<false>` shade kernel REG:254/STACK:2640 unchanged. GPU-visible
-wavefront dispersion deferred to the follow-up spec filed 2026-08-12 — it is a
-pre-existing frozen no-op that the dielectric reference shares.)
+unit-tested; `<false>` shade kernel **REG:254/STACK:3608 byte-identical to main**
+at TRUE sm_120 — see the register-gate note below. GPU-visible wavefront
+dispersion deferred to the follow-up spec filed 2026-08-12 — it is a pre-existing
+frozen no-op that the dielectric reference shares.)
 **Estimated effort:** M
+
+> **Register-gate note (corrected 2026-08-12).** The first measurement read
+> `REG:254/STACK:2640` — that was the **fleet-wide stale-arch artifact**: every
+> `build_cuda` tree carried a cached `CMAKE_CUDA_ARCHITECTURES=52`, so `cuobjdump`
+> read Maxwell PTX, not the sm_120 SASS that runs (pkg183 is shipping an automatic
+> guard). Rebuilt both worktree and a fresh merge-base baseline with
+> `-DASTRORAY_CUDA_ARCHS=120 -DCMAKE_CUDA_ARCHITECTURES=120` (verified
+> `compute_120,sm_120` in the generated project) and re-ran `cuobjdump
+> --dump-resource-usage` on the FINAL LINKED `.pyd`: `stageShadeBucketedKernel<false>`
+> is **REG:254 STACK:3608 CONSTANT[0]:1700 on BOTH** baseline and pkg187 —
+> byte-identical, no register/stack increase (the if-constexpr HasPrincipled
+> isolation holds at the true arch).
 **Depends on:** pkg178 (native Principled BSDF); pkg31/pkg29 (Sellmeier
 dielectric plugin); pkg64 (GPU Sellmeier / hero-λ upload); SMS/MNEE
 (`include/astroray/mesh_attempt.h`).

--- a/.astroray_plan/packages/pkg187-principled-dispersion.md
+++ b/.astroray_plan/packages/pkg187-principled-dispersion.md
@@ -199,3 +199,64 @@ d-line). Do not hand-roll a wavelength dependence.
   the Dispersion socket + per-λ refraction IOR.
 - **No change to the non-dispersive Principled fast path** beyond adding the
   overrides; zero-dispersion cost must not move.
+
+---
+
+## Hardware verification 2026-08-12 (PR #593, independent verifier pass)
+
+**Hardware:** RTX 5070 Ti (sm_120 / Blackwell), Windows 11 Enterprise
+10.0.26200, NVIDIA driver 610.47 (CUDA UMD 13.3), CUDA Toolkit 12.8.61
+(nvcc), OptiX 9.1.0, OIDN 2.4.1. Build: MSVC 19.44.35208 (VS2022 BuildTools),
+VS-generator `build_cuda` (root wrapper) + Ninja for the Blender-addon leg.
+
+**Arch discipline:** both the PR tree and the merge-base baseline were
+rebuilt **from scratch** (`build_cuda/` deleted, reconfigured with
+`-DASTRORAY_CUDA_ARCHS=120 -DCMAKE_CUDA_ARCHITECTURES=120`) after this
+session hit the exact fleet-wide stale-arch failure mode independently: a
+leftover baseline worktree cache read `CMAKE_CUDA_ARCHITECTURES:STRING=52`.
+Post-link `cuobjdump --list-elf` confirmed `sm_120.cubin` (not PTX/Maxwell)
+on every `.pyd` trusted below.
+
+### Gate table (measured vs claimed)
+
+| # | Gate | Claimed | Measured | Verdict |
+|---|------|---------|----------|---------|
+| 1 | Register gate — `stageShadeBucketedKernel<false>` (post-link `.pyd`, `cuobjdump --dump-resource-usage`, true sm_120) | REG:254 STACK:3608 CONSTANT[0]:1700 both sides, byte-identical | PR tree: `REG:254 STACK:3608 CONSTANT[0]:1700`. Baseline (merge-base `7b9cc1b`, independent from-scratch sm_120 rebuild in a separate worktree): `REG:254 STACK:3608 CONSTANT[0]:1700`. **Exact match, zero delta** (not even the allowed CONSTANT[2] delta — that field doesn't appear on `<false>` at all on either side; it only appears on `<true>`, which is out of scope for this gate). | **PASS** |
+| 2 | CPU chromatic dispersion (prism red/blue centroid spread + visual) | 4.267px → 5.345px, max RGB diff ~0.92 | `test_principled_dispersion_is_chromatic`: flat 4.267px, dispersive 5.345px, max abs RGB diff 0.9165 (mean 0.0779). Visual: rendered `pkg187_principled_flat.png` / `pkg187_principled_dispersive.png` (96×96, 32spp) plus a computed diff image — the dispersive render shows a coherent magenta/purple mixing band exactly at the prism silhouette (red bleeding into the blue half and vice versa), matching the pkg29 dielectric reference's established visual signature. This is a structured, localized shift, not scattered noise. | **PASS** |
+| 3 | Zero-dispersion bit-identity (regression guard) | `np.array_equal` | `test_zero_dispersion_is_bit_identical` PASSED (dispersion_scale=0 == no-params == baseline, exact). | **PASS** |
+| 4 | GPU faithful-mirror parity + documented no-op control | Principled disp/flat ≈ dielectric disp/flat (both ≈1.0, no-op); Principled: [0.9986, 1.0026, 0.9998]; dielectric: [0.9997, 1.0136, 1.0025]; CPU disp/flat: principled 0.5541 vs dielectric 0.5518 | `test_gpu_dispersion_wired_mirrors_dielectric_reference`: GPU principled disp/flat = **[0.9986 1.0026 0.9998]**, GPU dielectric disp/flat = **[0.9997 1.0136 1.0025]** — exact match to claim. `test_cpu_dispersion_is_real_and_mirrors_dielectric`: principled disp/flat=**0.5541**, dielectric bk7/flat=**0.5518** — exact match. | **PASS** |
+| 5 | 3 new test files + regression slice | "all pass (68)" | New: `test_pkg187_principled_dispersion.py` 4/4, `test_pkg187_addon_dispersion_probe.py` 3/3, `test_pkg187_principled_dispersion_gpu_parity.py` 2/2 — **9/9**. Regression sweep (pkg178 principled parity, spectral_prism, principled_bsdf, gpu_multiwavelength, gpu_sellmeier_ior, multiwavelength, metal parity pkg123/160/163, reflection_not_black ×2, prism_caustic_rainbow, sms_caustic_spectral, spectral_gpu_materials): **80/80**. Glass-caustic family (caustic_validation, glass_sphere_caustic, gpu_caustic_parity, sms_caustic_validation): **8 passed, 1 xpassed** (see gate 6). Grand total this session: **98 passed, 1 xpassed, 0 failed.** | **PASS** |
+| 6 | `test_gpu_prism_rainbow_parity` stays xfail (not un-xfailed) | retained | Source confirms `@pytest.mark.xfail(strict=False, ...)` still present; run shows `XPASS` (not a hard PASS) in 0.90s. Marker retained as documented. | **PASS** |
+| 7 | (Added mid-run, ABI-review addendum) Blender addon vtable-shift smoke — `getCauchyAB()` is a genuine mid-vtable insertion in `Material` (`raytracer.h`, right after `getSellmeierC()`, before `getTransmission()`), shifting every virtual slot declared after it | register + convert + render a trivial Principled scene without crash/garbage | Built `build_blender_addon_cuda` **from scratch** (`-DASTRORAY_DISABLE_OPENMP=ON`, Ninja, confirmed `sm_120.cubin` via `cuobjdump --list-elf`, no reused objects). Registered in headless Blender 5.1 (`blender_addon.register()` — "Astroray renderer addon registered"), converted a 1-mesh/960-triangle Principled-material sphere scene, rendered via `CUSTOM_RAYTRACER` on GPU (RTX 5070 Ti) in 1.65s. Output: 32×32, **0 NaN pixels**, mean 0.5621, max 1.0 — a plausible lit red sphere (visually confirmed), not a crash or garbage. | **PASS** |
+
+### Build-tooling finding (not a pkg187 gate — flagging for the record)
+
+`scripts/build/build_blender_addon.py`'s `_backend_config()` falls back to a
+**hardcoded CUDA arch list `"75;86;89"`** (no sm_120) whenever
+`ASTRORAY_CUDA_ARCHS` isn't passed on the CLI, and the script exposes no CLI
+flag for it. Worse: re-invoking the script against an **already-correctly-configured**
+`build_blender_addon_cuda` cache (manually set to `Release`/`120`) caused its
+internal reconfigure to silently revert the cache to `CMAKE_BUILD_TYPE=Debug`
++ `CMAKE_CUDA_ARCHITECTURES=52`, which then hard-failed the build
+(`/RTC1`+`/O2` incompatible). Gate 7 above was verified by configuring and
+building the addon module **manually** with explicit
+`-DASTRORAY_CUDA_ARCHS=120 -DCMAKE_CUDA_ARCHITECTURES=120
+-DCMAKE_BUILD_TYPE=Release`, then pointing headless Blender at the resulting
+`.pyd` via `ASTRORAY_PYD_DIR` (the same pattern `benchmarks/blender_parity/render_leg.py`
+already uses) — bypassing the packaging script's buggy reconfigure/zip
+pipeline entirely. The manually-built `.pyd` itself is confirmed sm_120 and
+is what Gate 7 exercised; the packaging/zip/install pipeline itself was
+**not** exercised and should not be assumed fixed by this pass. Recommend a
+follow-up ticket for `build_blender_addon.py` (arch default + cache-revert-on-reconfigure).
+
+### Overall verdict
+
+**All 7 gates PASS on measured hardware evidence.** No visual regressions
+found (chromatic fringe is real and localized, not noise; zero-dispersion
+path untouched; GPU no-op control reads exactly as documented; addon
+vtable-shift smoke is clean). The build-tooling gap above is out-of-scope for
+pkg187 itself (pre-existing script limitation, not something this PR
+introduced or worsened) and does not block merge.
+
+Verifier does not adjudicate the merge decision — this is a numbers report
+for the gate-review/merge process.

--- a/.astroray_plan/packages/pkg187-principled-dispersion.md
+++ b/.astroray_plan/packages/pkg187-principled-dispersion.md
@@ -2,13 +2,25 @@
 
 **Pillar:** 3/5 (spectral light transport / Blender parity)
 **Track:** A
-**Status:** open (found 2026-08-12 during the post-pkg178/pkg182 spectral-
-integration + CPU/GPU-parity audit; production-relevant since
-`use_native_principled` defaulted **ON** 2026-08-11)
+**Status:** in progress (pkg187 branch — engine core implemented via Option A;
+CPU/GPU dispersion + forward-compatible addon probe)
 **Estimated effort:** M
 **Depends on:** pkg178 (native Principled BSDF); pkg31/pkg29 (Sellmeier
 dielectric plugin); pkg64 (GPU Sellmeier / hero-λ upload); SMS/MNEE
 (`include/astroray/mesh_attempt.h`).
+
+> **Correction (2026-08-12, during implementation).** The original spec claimed
+> "Blender 4.2+ exposes a Dispersion input on Principled BSDF; that value is
+> dropped silently on import." **This is false.** A headless `bpy` probe of the
+> installed builds — Blender **4.3.2, 4.5.0, 5.1.0, 5.2.0** — shows **no**
+> Dispersion socket on `ShaderNodeBsdfPrincipled`, `ShaderNodeBsdfGlass`, or
+> `ShaderNodeBsdfRefraction`. Principled dispersion is **unmerged upstream WIP**:
+> Blender PR [#162041](https://projects.blender.org/blender/blender/pulls/162041).
+> Per the coordinator-approved **Option A**, the engine core (Work 1/2/4) ships
+> and is verified via engine-level dispersion params; the addon gets a
+> forward-compatible socket **probe** (no-op today, live when #162041 ships) that
+> is unit-tested against a synthetic node. Work 3 and the Blender-round-trip
+> acceptance criterion are rewritten accordingly below.
 
 ---
 
@@ -38,9 +50,11 @@ Concretely:
   λ** — the solver does chromatic work and gets an achromatic answer.
 - The Blender addon maps thin-film sockets but has **no Dispersion socket
   mapping at all** (`grep -rni "dispersion" blender_addon/` returns only the
-  Astroray-native Sellmeier node, never the Principled socket). Blender 4.2+
-  exposes a Dispersion input on Principled BSDF; that value is **dropped
-  silently** on import.
+  Astroray-native Sellmeier node, never the Principled socket). ~~Blender 4.2+
+  exposes a Dispersion input on Principled BSDF; that value is dropped silently
+  on import.~~ **CORRECTED:** no shipped Blender (4.3–5.2, probed) exposes such a
+  socket — it is unmerged WIP (PR #162041). So nothing is being "dropped"; the
+  addon simply has no forward-compatible probe for the socket the WIP will add.
 
 Net: the audit's answer to "is native Principled spectrally consistent?" is
 "no, for refraction" — dispersion is a real Blender socket that this engine
@@ -64,6 +78,13 @@ d-line). Do not hand-roll a wavelength dependence.
   number to per-λ IOR for the Principled BSDF transmission lobe. Cite the exact
   Cycles source (Apache-2.0) in the code and save research notes to
   `.astroray_plan/docs/` per CLAUDE.md §6.
+  **RESOLVED:** the canonical source is `bsdf_glass_ior` in
+  `intern/cycles/kernel/closure/bsdf_microfacet.h` (Blender PR #162041), which
+  implements the **OpenPBR Surface v1.1.1** two-term **Cauchy** fit
+  `n(λ)=A+B/λ²`, `B=(n_d−1)·(dispersion_scale/Vd)·fac`, `A=n_d−B/λ_d²`, Fraunhofer
+  lines λ_d=0.5876/λ_C=0.6563/λ_F=0.4861 μm. Full notes:
+  `.astroray_plan/docs/pkg187-principled-dispersion-research.md`. Implemented in
+  `principled.cpp::cauchyAB` (CPU) + `gpu_dispersion.cuh::gpu_cauchy_ior` (GPU).
 
 ---
 
@@ -78,27 +99,81 @@ d-line). Do not hand-roll a wavelength dependence.
    refraction path at `gpu_materials.h:3121` is reachable from the closure-graph
    transmission lobe — if it is gated purely on `GMAT_DIELECTRIC`, that gate
    must widen or the closure-graph transmission must call the same per-λ IOR.
-3. Add the **Dispersion socket mapping** to the Blender addon Principled import
-   (grep target: the thin-film socket mapping, add Dispersion beside it).
+3. **(REWRITTEN — Option A.)** No shipped Blender exposes a Dispersion socket
+   (see the correction note above), so add a **forward-compatible probe** beside
+   the thin-film socket mapping: `put_float('dispersion_scale', 'Dispersion
+   Scale', 'Dispersion')` + `put_float('dispersion_abbe', 'Dispersion Abbe
+   Number')`. It is a no-op on every current build (socket absent → nothing
+   written → engine non-dispersive) and round-trips automatically the day PR
+   #162041 ships. Unit-test it against a synthetic node carrying those inputs.
+   Do **not** add a new in-UI Dispersion socket to any Astroray-native node
+   (out of scope).
 4. Guard SMS/MNEE (`mesh_attempt.h`): a Principled caster with nonzero
    dispersion must feed per-λ IOR into the manifold solver; a zero-dispersion
    Principled must behave exactly as today (no regression).
 
 ## Acceptance criteria
 
-- [ ] A Principled glass prism with nonzero Blender Dispersion produces
-      **chromatic** caustics (measurable hue spread), CPU and GPU. Verify
-      **visually** — hue_spread + bright_coverage both pass on noise
-      ([[general-photon-loop-needs-solid-glass]]); LOOK at the render.
-- [ ] Zero-dispersion Principled glass is bit-unchanged from current behavior
-      (regression guard).
-- [ ] CPU/GPU per-λ parity on a dispersive Principled prism (per-channel
-      mean-ratio, not SSIM).
-- [ ] The Blender Dispersion socket round-trips: set it in Blender → engine
-      renders chromatic. Verify headlessly (Blender 5.1 is installed locally;
-      [[blender-5-1-installed-locally]]).
-- [ ] Research notes for the Abbe→dispersion mapping saved under
-      `.astroray_plan/docs/` with the Cycles source cited in-code.
+- [x] A Principled glass prism with nonzero dispersion produces **chromatic**
+      caustics (measurable hue spread) on **CPU** — verified visually (red/blue
+      centroid spread 4.27px → 5.35px, max RGB diff 0.92; LOOKED at the render).
+      **GPU: see the GPU-leg finding below** — GPU wavefront dispersion is a
+      pre-existing frozen no-op (dielectric identical), so the GPU chromatic gate
+      is deferred to the separately-filed follow-up; pkg187 gates the GPU leg on
+      *faithful-mirror-of-the-dielectric-reference* + the register gate instead.
+- [x] Zero-dispersion Principled glass is bit-unchanged from current behavior
+      (regression guard — `np.array_equal` passes).
+- [x] **(REWRITTEN — GPU-leg finding.)** ~~CPU/GPU per-λ parity on a dispersive
+      Principled prism (per-channel mean-ratio, not SSIM).~~ Not achievable: the
+      GPU **wavefront** spectral dispersion (hero-collapse) is a pre-existing,
+      frozen no-op — it does not fire for the dielectric reference either
+      (`test_pkg64_gpu_cpu_parity` xfail since 2026-06-08; pkg64 defers GPU
+      per-wavelength multi-IOR to Session 2). **Measured (256spp, spectral srgb,
+      glass sphere refracting a colored backdrop):**
+
+      | material   | CPU flat | CPU disp | GPU flat | GPU disp |
+      |------------|----------|----------|----------|----------|
+      | Principled | 0.2053   | 0.1138   | 0.2041   | 0.2041   |
+      | dielectric | 0.2144   | 0.1183   | 0.2131   | 0.2139   |
+
+      CPU dispersion is live for BOTH; GPU dispersion is a no-op for BOTH. pkg187
+      wires Principled into the identical infra (scene_upload Cauchy upload +
+      `gpu_material_sample_spectral` hero-IOR + `terminateSecondary`), so the
+      achievable GPU gate is *no new divergence vs the dielectric reference*
+      (`test_pkg187_principled_dispersion_gpu_parity.py`) + the cuobjdump register
+      gate. GPU-visible wavefront dispersion is a **separately-filed follow-up
+      (2026-08-12)**; enabling it lights up dielectric AND Principled through this
+      same wiring.
+- [x] **(REWRITTEN — Option A.)** The forward-compatible addon probe is
+      unit-tested against a synthetic Principled node carrying 'Dispersion Scale'
+      / 'Dispersion Abbe Number' inputs (maps to `dispersion_scale` /
+      `dispersion_abbe`); and the chromatic render is verified via the engine
+      dispersion params. (The literal "set it in Blender's Principled node" path
+      is unreachable until PR #162041 ships — no shipped Blender exposes it.)
+- [x] Research notes for the Abbe→dispersion mapping saved under
+      `.astroray_plan/docs/pkg187-principled-dispersion-research.md` with the
+      Cycles source cited in-code (`principled.cpp::cauchyAB`,
+      `gpu_dispersion.cuh::gpu_cauchy_ior`).
+
+## Lessons / findings
+
+- **Premise correction (Blender socket).** No shipped Blender (4.3.2–5.2.0,
+  headless-probed) exposes a Dispersion socket on Principled/Glass/Refraction —
+  it is unmerged WIP (PR #162041). Verify feature availability against the actual
+  installed DCC before building integration around a socket.
+- **GPU wavefront dispersion is a pre-existing frozen no-op.** The hero-collapse
+  dispersion on the GPU wavefront leg (`stage_advance.cu` →
+  `gpu_material_sample_spectral`) does not produce visible dispersion for the
+  dielectric reference either (BK7 control: GPU flat 0.2131 ≈ bk7 0.2139). The
+  working GPU dispersion is the *photon-caustic* path (pkg113/pkg185), a different
+  mechanism. Enabling GPU wavefront dispersion (and wiring the photon path for
+  closure-graph casters) is a **separately-filed follow-up (2026-08-12)**; pkg187
+  correctly wires Principled into the frozen infra so it lights up for free when
+  that lands.
+- **`--runxfail` XPASS can be vacuous.** `test_gpu_prism_rainbow_parity` "passed"
+  under `--runxfail` in 0.80s with no render output — the assert cleared without a
+  real GPU render. The xfail marker is RETAINED; a real render-level check is
+  needed once GPU dispersion is enabled. Do not report that XPASS as a feature.
 
 ## Hard non-goals
 

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -3201,6 +3201,17 @@ class CustomRaytracerRenderEngine(RenderEngine):
         put_float('thin_film_thickness', 'Thin Film Thickness')
         put_float('thin_film_ior', 'Thin Film IOR')
         put_float('thin_wall', 'Thin Wall')
+        # Dispersion (pkg187) — FORWARD-COMPATIBLE probe. No shipped Blender exposes
+        # a Dispersion socket on Principled BSDF: headless probes of 4.3.2 / 4.5.0 /
+        # 5.1.0 / 5.2.0 all return no such input. It is the unmerged upstream WIP,
+        # Blender PR #162041, which adds two sockets — 'Dispersion Scale' (in [0,1])
+        # and 'Dispersion Abbe Number' (default 20). These put_float calls are a
+        # no-op on every current build (socket absent -> key not written -> engine
+        # stays non-dispersive) and start round-tripping automatically the day that
+        # PR ships. The native material (principled.cpp) reads dispersion_scale +
+        # dispersion_abbe; a one-socket 'Dispersion' build aliases the scale.
+        put_float('dispersion_scale', 'Dispersion Scale', 'Dispersion')
+        put_float('dispersion_abbe', 'Dispersion Abbe Number')
         # Alpha — a REAL value routed to the native transparent lobe; NOT folded
         # into transmission (that conflation is the convicted BSDF_TRANSPARENT
         # bug family the Disney path still carries).

--- a/include/astroray/gpu_dispersion.cuh
+++ b/include/astroray/gpu_dispersion.cuh
@@ -25,3 +25,15 @@ __device__ inline float gpu_sellmeier_ior(const GDispersion& d, float lambda_nm)
              + (d.b3 * l2) / (l2 - d.c3);
     return sqrtf(fmaxf(1.0f, n2));
 }
+
+// pkg187 — Cauchy empirical dispersion n(λ) = A + B/λ² (λ in μm), the model
+// Cycles' WIP Principled dispersion uses (Blender PR #162041,
+// intern/cycles/kernel/closure/bsdf_microfacet.h bsdf_glass_ior; OpenPBR Surface
+// v1.1.1 Eq. 55). For a dispersive Principled material the host packs the fit into
+// GDispersion.b1 = A, b2 = B (see scene_upload.cu closure-graph branch); this is
+// the device twin of PrincipledPlugin::iorAt. NOT called for Sellmeier dielectrics
+// (those use gpu_sellmeier_ior above). Mirrors the CPU cauchyAB evaluation exactly.
+__device__ inline float gpu_cauchy_ior(float A, float B, float lambda_nm) {
+    float lam_um = lambda_nm * 1e-3f; // nm → μm
+    return A + B / (lam_um * lam_um);
+}

--- a/include/astroray/gpu_materials.h
+++ b/include/astroray/gpu_materials.h
@@ -2648,17 +2648,33 @@ __device__ inline GPrincipledDir gpu_pr_chooseAndSampleDir(const GHitRecord& rec
 }
 template <typename TRng>
 __device__ inline GBSDFSample gpu_principled_sample(const GPrincipledClosure& c, GHitRecord& rec,
-                                                    const GVec3& wo, TRng* rng) {
+                                                    const GVec3& wo, TRng* rng,
+                                                    float heroIor = -1.f,
+                                                    bool* refractedOut = nullptr) {
     GBSDFSample s;
     s.wi = rec.normal; s.f = GVec3(0.f); s.fSpectral = GSampledSpectrum(0.f); s.pdf = 0.f; s.isDelta = false;
     GPrincipledLobe lobes[kMaxPrincipledLobes];
     int n = gpu_pr_assembleLobes(c, rec, wo, lobes);
+    // pkg187 -- dispersive Principled: the caller passes the hero-wavelength IOR
+    // (n(lambda0) via gpu_cauchy_ior); the refracting transmission lobe bends with
+    // it. heroIor < 0 (the default, every non-dispersive call at ~line 3013) leaves
+    // the lobe array untouched, so the fast path is byte-identical. Mirrors CPU
+    // PrincipledPlugin::sampleSpectral's transmission-lobe ior override.
+    if (heroIor > 0.f)
+        for (int i = 0; i < n; ++i)
+            if (lobes[i].kind == GPR_TRANSMISSION) lobes[i].ior = heroIor;
     float W = 0.f;
     for (int i = 0; i < n; ++i) W += lobes[i].sel;
     if (W <= 0.f) return s;
     GPrincipledDir ds = gpu_pr_chooseAndSampleDir(rec, wo, rng, lobes, n, W);
     if (!ds.ok) return s;
     s.wi = ds.wi;
+    // pkg187 -- report whether this was a transmission-lobe refraction (wi crossed
+    // to the far hemisphere) so the spectral wrapper can collapse to the hero
+    // wavelength. Same sign test as CPU (reflected iff wi,wo same side of N).
+    if (refractedOut)
+        *refractedOut = (lobes[ds.lobe].kind == GPR_TRANSMISSION) &&
+                        ((s.wi.dot(rec.normal) > 0.f) != (wo.dot(rec.normal) > 0.f));
     if (ds.isDelta) {
         const GPrincipledLobe& L = lobes[ds.lobe];
         float qj = L.sel / W;
@@ -3134,10 +3150,31 @@ __device__ inline GBSDFSample gpu_material_sample_spectral(
     GSampledWavelengths& wl, TRng* rng)
 {
     // pkg64-gpu-sellmeier-upload: dispersive dielectrics need the wavelength-aware
-    // sampler (it calls wl.terminateSecondary() on refraction — hero collapse).
-    GBSDFSample s = (mat.type == GMAT_DIELECTRIC && mat.isDispersive)
-        ? gpu_dielectric_sample_spectral(mat, rec, wo, wl, rng)
-        : gpu_material_sample<HasPrincipled>(mat, rec, wo, rng);
+    // sampler (it calls wl.terminateSecondary() on refraction -- hero collapse).
+    GBSDFSample s;
+    bool handled = false;
+    // pkg187 -- dispersive Principled glass lowers to GMAT_CLOSURE_GRAPH (not
+    // GMAT_DIELECTRIC), so the hero-wavelength refraction + secondary-collapse is
+    // done here rather than through gpu_dielectric_sample_spectral. All state lives
+    // inside this HasPrincipled-only branch, so the shared shade kernel's <false>
+    // instantiation compiles it out entirely (register gate: stageShadeBucketed
+    // <false> stays at STACK/REG baseline). GDispersion.b1/b2 carry the Cauchy
+    // (A,B) fit uploaded by scene_upload.cu's closure-graph branch.
+    if constexpr (HasPrincipled) {
+        if (mat.type == GMAT_CLOSURE_GRAPH && mat.isDispersive &&
+            gpu_closure_graph_is_principled(mat)) {
+            float heroIor = gpu_cauchy_ior(mat.dispersion.b1, mat.dispersion.b2, wl.lambda[0]);
+            bool refracted = false;
+            s = gpu_principled_sample(mat.principled, rec, wo, rng, heroIor, &refracted);
+            if (refracted) wl.terminateSecondary();
+            handled = true;
+        }
+    }
+    if (!handled) {
+        s = (mat.type == GMAT_DIELECTRIC && mat.isDispersive)
+            ? gpu_dielectric_sample_spectral(mat, rec, wo, wl, rng)
+            : gpu_material_sample<HasPrincipled>(mat, rec, wo, rng);
+    }
 
     // Delta lobes (dielectric reflect/refract, smooth-glass disney/closure-graph
     // closures — a plain "dielectric" material lowers to GMAT_CLOSURE_GRAPH) carry a

--- a/include/raytracer.h
+++ b/include/raytracer.h
@@ -492,6 +492,12 @@ public:
     virtual bool isDispersive() const { return false; }
     virtual Vec3 getSellmeierB() const { return Vec3(0.0f); }
     virtual Vec3 getSellmeierC() const { return Vec3(0.0f); }
+    // pkg187 — Principled dispersion carries a Cauchy (A,B) fit rather than
+    // Sellmeier coefficients: n(λ)=A+B/λ² (λ in μm). Returns {A,B,0}. The
+    // closure-graph GPU upload packs these into GDispersion.b1/b2 and the
+    // dispersive-Principled sampler reads them via gpu_cauchy_ior (NOT
+    // gpu_sellmeier_ior). Non-dispersive / non-Principled materials return 0.
+    virtual Vec3 getCauchyAB() const { return Vec3(0.0f); }
     virtual float getTransmission() const { return 0.0f; }
     virtual float getClearcoat() const { return 0.0f; }
     virtual float getClearcoatGloss() const { return 1.0f; }

--- a/plugins/materials/principled.cpp
+++ b/plugins/materials/principled.cpp
@@ -75,6 +75,16 @@ class PrincipledPlugin : public Material {
     Vec3 emissionColor_;
     float emissionStrength_;
     astroray::RGBIlluminantSpectrum emissionSpec_;
+    // pkg187 — Principled dispersion (chromatic refraction). Blender's WIP
+    // Dispersion input (PR #162041) is an (Abbe number, dispersion scale) pair;
+    // the transmission-lobe IOR becomes wavelength-dependent via the OpenPBR
+    // Surface v1.1.1 Cauchy fit. cauchyA_/cauchyB_ are precomputed in the ctor
+    // from ior_ (the d-line IOR) and inv_abbe = dispersion_scale/Abbe. dispersive_
+    // is false (and cauchyB_==0) whenever the material carries no dispersion, so
+    // the zero-dispersion path is byte-identical to pre-pkg187 (Work item: the
+    // non-dispersive Principled fast path is untouched).
+    bool dispersive_;
+    float cauchyA_, cauchyB_;
 
     // Smooth glass below this roughness is treated as a delta transmission event
     // (matches disney.cpp::kDeltaTransmissionRoughness).
@@ -198,6 +208,26 @@ class PrincipledPlugin : public Material {
         float alpha2 = ax * ay;
         float denomA = alpha2 * len2;
         return alpha2 / (float(M_PI) * denomA * denomA + reg);
+    }
+
+    // pkg187 — Abbe/dispersion → Cauchy (A,B) fit for the transmission-lobe IOR.
+    // VERBATIM port of Cycles' WIP Principled dispersion (Blender PR #162041,
+    // intern/cycles/kernel/closure/bsdf_microfacet.h `bsdf_glass_ior`), which
+    // implements the OpenPBR Surface specification v1.1.1 Eqs. (55)/(56):
+    //   n(λ) = A + B/λ²  (λ in μm),   B = (n_d − 1)·(1/V_d)·fac,
+    //   A = n_d − B/λ_d²,  fac = 1/(1/λ_F² − 1/λ_C²).
+    // n_d is the IOR at the Fraunhofer d line; invAbbe = dispersion_scale / V_d
+    // (Cycles' safe_divide → 0 when V_d==0). invAbbe==0 → B=0, A=n_d (flat).
+    // Research notes: .astroray_plan/docs/pkg187-principled-dispersion-research.md.
+    static void cauchyAB(float iorD, float invAbbe, float& A, float& B) {
+        // Fraunhofer spectral lines in μm (Cycles bsdf_glass_ior constants).
+        constexpr float lambda_d = 0.5876f;
+        constexpr float lambda_C = 0.6563f;
+        constexpr float lambda_F = 0.4861f;
+        constexpr float fac = 1.0f / (1.0f / (lambda_F * lambda_F) - 1.0f / (lambda_C * lambda_C));
+        constexpr float invLambdaDSq = 1.0f / (lambda_d * lambda_d);
+        B = (iorD - 1.0f) * invAbbe * fac;
+        A = iorD - B * invLambdaDSq;
     }
 
     // Cycles bsdf_util.h: F0_from_ior.
@@ -1491,11 +1521,24 @@ public:
           emissionStrength_(std::max(0.0f, p.getFloat("emission_strength", 1.0f))),
           emissionSpec_({emissionColor_.x * emissionStrength_,
                          emissionColor_.y * emissionStrength_,
-                         emissionColor_.z * emissionStrength_}) {
+                         emissionColor_.z * emissionStrength_}),
+          dispersive_(false), cauchyA_(ior_), cauchyB_(0.0f) {
         // pkg178 Stage 4 PR-2: host-precompute the metallic-lobe conductor (n,k,g)
         // once (per-material constant; never per hit). No-op for the render unless
         // the film is active on the metallic lobe.
         precomputeConductorNK();
+        // pkg187 — dispersion fit. Cycles' Principled dispersion (PR #162041) is
+        // driven by two sockets: Dispersion Scale ∈ [0,1] and an Abbe number
+        // (default 20). inv_abbe = scale / abbe (safe_divide → 0). A single
+        // "dispersion" alias maps to the scale for forward-compat with a
+        // one-socket build. All default to no dispersion → dispersive_ = false.
+        float dispScale = std::clamp(
+            p.getFloat("dispersion_scale", p.getFloat("dispersion", 0.0f)), 0.0f, 1.0f);
+        float abbe = std::max(0.0f, p.getFloat("dispersion_abbe", 20.0f));
+        float invAbbe = (abbe > 0.0f) ? dispScale / abbe : 0.0f;
+        cauchyAB(ior_, invAbbe, cauchyA_, cauchyB_);
+        // Dispersion only matters on the refracting transmission lobe.
+        dispersive_ = (transmission_ > 1e-4f) && (invAbbe > 0.0f);
     }
 
     Vec3 getAlbedo() const override { return baseColor_; }
@@ -1505,6 +1548,17 @@ public:
     float getIOR() const override { return ior_; }
     float getTransmission() const override { return transmission_; }
     bool isTransmissive() const override { return transmission_ > 1e-4f; }
+    // pkg187 — wavelength-dependent IOR via the OpenPBR Cauchy fit (cauchyAB).
+    // Non-dispersive → the flat d-line IOR, so SMS/MNEE (mesh_attempt.h keys off
+    // iorAt) and every other caller are byte-identical to today. Consumed by the
+    // hero-wavelength refraction collapse below and by scene_upload (GPU).
+    float iorAt(float lambda_nm) const override {
+        if (!dispersive_) return ior_;
+        float lam_um = lambda_nm * 1e-3f;
+        return cauchyA_ + cauchyB_ / (lam_um * lam_um);
+    }
+    bool isDispersive() const override { return dispersive_; }
+    Vec3 getCauchyAB() const override { return Vec3(cauchyA_, cauchyB_, 0.0f); }
     bool isGlossy() const override { return true; }
 
     // pkg178 Stage 3 — emission inside the node (retires the addon promote-to-light
@@ -1802,12 +1856,30 @@ public:
         bss.pdf = 0.0f;
         bss.isDelta = false;
         auto lobes = assembleLobes(rec, wo);
+        // pkg187 — dispersive refraction: the transmission lobe bends at the hero
+        // wavelength's IOR (n(λ₀) via the OpenPBR Cauchy fit). Guarded by
+        // dispersive_, so the non-dispersive path never touches the lobe array and
+        // stays byte-identical. Mirrors DielectricPlugin::sampleSpectral, which
+        // evaluates the Sellmeier IOR at lambdas.lambda(0) before refracting.
+        if (dispersive_) {
+            float heroIor = iorAt(lambdas.lambda(0));
+            for (auto& L : lobes)
+                if (L.kind == LobeKind::Transmission) L.ior = heroIor;
+        }
         float W = 0.0f;
         for (const auto& L : lobes) W += L.sel;
         if (W <= 0.0f) return bss;
         DirSample ds = chooseAndSampleDir(rec, wo, gen, lobes, W);
         if (!ds.ok) return bss;
         bss.wi = ds.wi;
+        // pkg187 — hero-wavelength collapse: each λ refracts differently but only
+        // one direction is traced, so on an actual transmission-lobe refraction
+        // (wi crosses to the far hemisphere) terminate the secondary wavelengths.
+        // Same sign test dielectric.cpp uses (reflected ⇔ wi,wo same side of N).
+        if (dispersive_ && lobes[ds.lobe].kind == LobeKind::Transmission &&
+            (bss.wi.dot(rec.normal) > 0.0f) != (wo.dot(rec.normal) > 0.0f)) {
+            lambdas.terminateSecondary();
+        }
         if (ds.isDelta) {
             const Lobe& L = lobes[ds.lobe];
             float qj = L.sel / W;

--- a/src/gpu/scene_upload.cu
+++ b/src/gpu/scene_upload.cu
@@ -128,6 +128,19 @@ static GMaterial convertMaterial(const std::shared_ptr<Material>& mat) {
         // already-public Material::getGPUTypeName(); does not touch
         // plugins/materials/disney.cpp.
         g.disneyMetalConductor = (mat->getGPUTypeName() == "disney");
+        // pkg187: dispersive Principled glass lowers to GMAT_CLOSURE_GRAPH, so the
+        // dispersion flag/data must ride the closure-graph path too (the dielectric
+        // branch below only fires for GMAT_DIELECTRIC). For the closure-graph path
+        // GDispersion carries the OpenPBR Cauchy fit (b1=A, b2=B) -- NOT Sellmeier
+        // coefficients -- read on device by gpu_cauchy_ior in the dispersive-
+        // Principled spectral sampler. No new GMaterial fields: reuses the existing
+        // isDispersive/dispersion members already copied by-value on every path.
+        if (mat->isDispersive()) {
+            Vec3 ab = mat->getCauchyAB();
+            g.dispersion.b1 = ab.x;  // Cauchy A
+            g.dispersion.b2 = ab.y;  // Cauchy B
+            g.isDispersive = true;
+        }
         g.closureCount = static_cast<uint8_t>(
             std::min(graph.count(), G_MAX_MATERIAL_CLOSURES));
 

--- a/tests/test_pkg187_addon_dispersion_probe.py
+++ b/tests/test_pkg187_addon_dispersion_probe.py
@@ -1,0 +1,145 @@
+"""pkg187 — Blender addon forward-compatible Dispersion socket probe.
+
+No shipped Blender (probed: 4.3.2 / 4.5.0 / 5.1.0 / 5.2.0) exposes a Dispersion
+socket on the Principled BSDF — it is unmerged upstream WIP (Blender PR #162041).
+So the addon cannot map a live socket today. Instead `_principled_native_params`
+carries a FORWARD-COMPATIBLE probe:
+
+    put_float('dispersion_scale', 'Dispersion Scale', 'Dispersion')
+    put_float('dispersion_abbe',  'Dispersion Abbe Number')
+
+This test proves the probe:
+  1. is a NO-OP on a node with no dispersion inputs (today's real Blender) — so
+     the engine stays non-dispersive and nothing regresses;
+  2. maps the two-socket WIP layout ('Dispersion Scale' + 'Dispersion Abbe
+     Number') onto dispersion_scale / dispersion_abbe;
+  3. maps a single-socket 'Dispersion' alias onto dispersion_scale.
+
+Runs OUTSIDE Blender via a mocked `bpy` (the standard addon-unit-test pattern
+from tests/test_addon_dof_aperture.py), with a synthetic node carrying the
+inputs the WIP will add.
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def _load_blender_addon(monkeypatch):
+    bpy_module = types.ModuleType("bpy")
+    bpy_types_module = types.ModuleType("bpy.types")
+    bpy_props_module = types.ModuleType("bpy.props")
+
+    class _Base:
+        pass
+
+    class _RenderEngineBase:
+        def report(self, *_a, **_k): return None
+
+    bpy_types_module.Panel = _Base
+    bpy_types_module.Operator = _Base
+    bpy_types_module.AddonPreferences = _Base
+    bpy_types_module.PropertyGroup = _Base
+    bpy_types_module.RenderEngine = _RenderEngineBase
+    bpy_module.types = bpy_types_module
+
+    for name in ("BoolProperty", "IntProperty", "FloatProperty", "StringProperty",
+                 "PointerProperty", "FloatVectorProperty", "EnumProperty"):
+        setattr(bpy_props_module, name, lambda **_kwargs: None)
+    bpy_module.props = bpy_props_module
+    bpy_module.path = types.SimpleNamespace(abspath=lambda p: p)
+
+    shader_blending_module = types.ModuleType("shader_blending")
+    shader_blending_module.blend_shader_specs = {}
+    shader_blending_module.add_shader_specs = {}
+
+    mathutils_module = types.ModuleType("mathutils")
+    mathutils_module.Vector = lambda values: list(values)
+
+    astroray_module = types.ModuleType("astroray")
+    astroray_module.__version__ = "test"
+    astroray_module.__features__ = {"cuda": False, "spectral": True}
+    astroray_module.__file__ = "/fake/astroray.pyd"
+    astroray_module.integrator_registry_names = lambda: ["path_tracer"]
+    astroray_module.material_registry_names = lambda: ["lambertian", "principled"]
+    astroray_module.pass_registry_names = list
+
+    monkeypatch.setitem(sys.modules, "bpy", bpy_module)
+    monkeypatch.setitem(sys.modules, "bpy.types", bpy_types_module)
+    monkeypatch.setitem(sys.modules, "bpy.props", bpy_props_module)
+    monkeypatch.setitem(sys.modules, "shader_blending", shader_blending_module)
+    monkeypatch.setitem(sys.modules, "mathutils", mathutils_module)
+    monkeypatch.setitem(sys.modules, "astroray", astroray_module)
+
+    module_path = Path(__file__).parent.parent / "blender_addon" / "__init__.py"
+    spec = importlib.util.spec_from_file_location("astroray_blender_addon_pkg187", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class _StubInput:
+    def __init__(self, value):
+        self.is_linked = False
+        self.default_value = float(value)
+        self.type = "VALUE"
+
+
+class _StubNode:
+    """A Principled-like node exposing only the given named inputs."""
+    def __init__(self, sockets):
+        self._inputs = {name: _StubInput(v) for name, v in sockets.items()}
+
+    class _Inputs:
+        def __init__(self, d):
+            self._d = d
+
+        def get(self, name):
+            return self._d.get(name)
+
+    @property
+    def inputs(self):
+        return _StubNode._Inputs(self._inputs)
+
+
+def _engine(monkeypatch):
+    module = _load_blender_addon(monkeypatch)
+    # Skip __init__ (needs a live Blender RenderEngine); the mapping helpers only
+    # use self.get_float_input / self.get_color_input, which are pure.
+    return object.__new__(module.CustomRaytracerRenderEngine)
+
+
+def test_probe_noop_without_dispersion_sockets(monkeypatch):
+    """Today's real Blender: no dispersion socket -> engine stays non-dispersive."""
+    eng = _engine(monkeypatch)
+    node = _StubNode({"Metallic": 0.0, "Roughness": 0.1, "IOR": 1.5})
+    p = eng._principled_native_params(node)
+    assert "dispersion_scale" not in p
+    assert "dispersion_abbe" not in p
+
+
+def test_probe_maps_two_socket_wip_layout(monkeypatch):
+    """PR #162041 two-socket layout round-trips onto the engine param names."""
+    eng = _engine(monkeypatch)
+    node = _StubNode({
+        "IOR": 1.5,
+        "Transmission Weight": 1.0,
+        "Dispersion Scale": 0.7,
+        "Dispersion Abbe Number": 15.0,
+    })
+    p = eng._principled_native_params(node)
+    assert p["dispersion_scale"] == pytest.approx(0.7)
+    assert p["dispersion_abbe"] == pytest.approx(15.0)
+
+
+def test_probe_single_socket_dispersion_alias(monkeypatch):
+    """A one-socket 'Dispersion' build aliases onto dispersion_scale."""
+    eng = _engine(monkeypatch)
+    node = _StubNode({"IOR": 1.5, "Dispersion": 0.5})
+    p = eng._principled_native_params(node)
+    assert p["dispersion_scale"] == pytest.approx(0.5)
+    assert "dispersion_abbe" not in p

--- a/tests/test_pkg187_principled_dispersion.py
+++ b/tests/test_pkg187_principled_dispersion.py
@@ -1,0 +1,148 @@
+"""pkg187 — Principled BSDF dispersion (CPU).
+
+Acceptance coverage (engine-level; the Blender socket is unmerged upstream, see
+the spec correction note + tests/test_pkg187_addon_dispersion_probe.py):
+
+  * A Principled glass prism with nonzero dispersion produces CHROMATIC caustics
+    (measurable red/blue spatial spread beyond the flat prism).
+  * Zero-dispersion Principled glass is BYTE-IDENTICAL to the pre-pkg187 path
+    (regression guard): a render with dispersion_scale=0 == a render with no
+    dispersion params at all, and both == the non-dispersive baseline.
+  * The OpenPBR/Cycles Cauchy fit constants are pinned (blue bends more than red).
+
+Uses the shared pkg29 prism scaffold (closed triangular prism, outward normals)
+but with a native `principled` transmissive glass instead of the dielectric.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+import pytest
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+sys.path.insert(0, os.path.dirname(__file__))
+
+try:
+    import astroray
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+from base_helpers import save_image
+from scenes.prism_reference import (
+    HEIGHT,
+    MAX_DEPTH,
+    SAMPLES,
+    WIDTH,
+    _add_panel,
+    add_triangular_prism,
+    red_blue_centroid_separation,
+)
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray not built")
+
+# Dense-flint-like dispersion: Abbe 20, full scale -> strong, unambiguous spread.
+DISP_PARAMS = {"dispersion_scale": 1.0, "dispersion_abbe": 20.0}
+
+
+def _make_principled_prism_scene(*, glass_extra: dict):
+    r = astroray.Renderer()
+    r.set_integrator("path_tracer")
+    r.set_background_color([0.8, 0.9, 1.0])
+
+    red = r.create_material("lambertian", [1.0, 0.05, 0.03], {})
+    white = r.create_material("lambertian", [0.92, 0.92, 0.90], {})
+    blue = r.create_material("lambertian", [0.03, 0.08, 1.0], {})
+    light = r.create_material("light", [1.0, 1.0, 1.0], {"intensity": 5.0})
+
+    _add_panel(r, red, -2.0, -0.4, -1.79)
+    _add_panel(r, white, -0.45, 0.45, -1.80)
+    _add_panel(r, blue, 0.4, 2.0, -1.78)
+
+    r.add_triangle([-1.5, 1.6, 1.5], [1.5, 1.6, 1.5], [1.5, 1.6, -1.2], light)
+    r.add_triangle([-1.5, 1.6, 1.5], [1.5, 1.6, -1.2], [-1.5, 1.6, -1.2], light)
+
+    # Smooth (delta) transmissive Principled glass; roughness < kDeltaGlassRoughness.
+    params = {"transmission_weight": 1.0, "ior": 1.5, "roughness": 0.02, "metallic": 0.0}
+    params.update(glass_extra)
+    glass = r.create_material("principled", [1.0, 1.0, 1.0], params)
+    add_triangular_prism(r, glass)
+
+    r.setup_camera(
+        [0.0, 0.0, 4.2], [0.0, 0.0, 0.0], [0.0, 1.0, 0.0],
+        38.0, 1.0, 0.0, 4.2, WIDTH, HEIGHT)
+    return r
+
+
+def _render(glass_extra: dict, *, seed: int = 17) -> np.ndarray:
+    r = _make_principled_prism_scene(glass_extra=glass_extra)
+    r.set_seed(seed)
+    return np.asarray(r.render(SAMPLES, MAX_DEPTH, None, True), dtype=np.float32)
+
+
+def test_principled_dispersion_is_chromatic(test_results_dir):
+    flat = _render({})
+    dispersive = _render(DISP_PARAMS)
+
+    save_image(flat, os.path.join(test_results_dir, "pkg187_principled_flat.png"))
+    save_image(dispersive, os.path.join(test_results_dir, "pkg187_principled_dispersive.png"))
+
+    flat_sep = red_blue_centroid_separation(flat)
+    disp_sep = red_blue_centroid_separation(dispersive)
+    diff = np.abs(dispersive - flat)
+
+    print(f"\n  principled flat  red/blue centroid separation: {flat_sep:.3f}px")
+    print(f"  principled disp. red/blue centroid separation: {disp_sep:.3f}px")
+    print(f"  max abs RGB diff: {float(diff.max()):.4f}  mean: {float(diff.mean()):.4f}")
+
+    assert np.isfinite(dispersive).all()
+    assert float(dispersive.mean()) > 0.01
+    # Dispersion must add clear red/blue spatial separation vs the flat prism.
+    assert float(diff.max()) > 0.15
+    assert disp_sep - flat_sep > 1.0
+
+
+def test_zero_dispersion_is_bit_identical(test_results_dir):
+    """Regression guard: dispersion_scale=0 and 'no dispersion params' must both
+    reproduce the non-dispersive baseline BYTE-for-byte (dispersive_ is false, so
+    the added sampleSpectral branches never execute)."""
+    baseline = _render({})
+    scale_zero = _render({"dispersion_scale": 0.0, "dispersion_abbe": 20.0})
+    # A defined abbe with zero scale is still non-dispersive (inv_abbe = 0).
+    abbe_only = _render({"dispersion_abbe": 25.0})
+
+    assert np.array_equal(baseline, scale_zero), (
+        "dispersion_scale=0 perturbed the zero-dispersion render (not bit-identical)")
+    assert np.array_equal(baseline, abbe_only), (
+        "an Abbe number with zero scale perturbed the zero-dispersion render")
+
+
+def test_nonzero_dispersion_actually_changes_the_render():
+    """Sanity companion to the bit-identity guard: the switch is genuinely live."""
+    baseline = _render({})
+    dispersive = _render(DISP_PARAMS)
+    assert not np.array_equal(baseline, dispersive)
+
+
+def test_openpbr_cauchy_constants_pinned():
+    """Pin the ported OpenPBR v1.1.1 / Cycles PR#162041 Cauchy fit: blue (F line)
+    must refract more strongly than red (C line), and the d line reproduces the
+    base IOR. This anchors the constants in principled.cpp::cauchyAB against
+    accidental edits (pure-Python replica of the cited formula)."""
+    lambda_d, lambda_C, lambda_F = 0.5876, 0.6563, 0.4861
+    fac = 1.0 / (1.0 / lambda_F**2 - 1.0 / lambda_C**2)
+    n_d = 1.5
+    inv_abbe = 1.0 / 20.0  # scale 1.0 / Abbe 20
+    B = (n_d - 1.0) * inv_abbe * fac
+    A = n_d - B / lambda_d**2
+
+    def n(lam_um):
+        return A + B / lam_um**2
+
+    assert n(lambda_d) == pytest.approx(n_d, abs=1e-4)   # d line == base IOR
+    assert n(lambda_F) > n(lambda_d) > n(lambda_C)       # blue bends more than red
+    assert (n(lambda_F) - n(lambda_C)) > 0.01            # meaningful spread at Abbe 20

--- a/tests/test_pkg187_principled_dispersion_gpu_parity.py
+++ b/tests/test_pkg187_principled_dispersion_gpu_parity.py
@@ -1,0 +1,152 @@
+"""pkg187 — dispersive Principled on the GPU wavefront leg: wired + faithful mirror.
+
+WHY THIS GATE IS "MIRROR THE DIELECTRIC", NOT "GPU==CPU"
+--------------------------------------------------------
+The production GPU path is the wavefront (megakernels were deleted;
+src/gpu/wavefront/stage_advance.cu -> gpu_material_sample_spectral). On that leg
+the spectral hero-wavelength-collapse dispersion is a PRE-EXISTING, frozen
+feature: the only end-to-end GPU dispersion test (test_pkg64_gpu_cpu_parity) has
+been xfail since 2026-06-08 ("SMS-GPU is frozen"), and pkg64 defers GPU
+per-wavelength multi-IOR refraction to a Session-2 increment. Measured on this
+build (256 spp, spectral srgb, glass sphere refracting a colored backdrop):
+
+    PRINCIPLED  CPU flat=0.2053 disp=0.1138 | GPU flat=0.2041 disp=0.2041
+    DIELECTRIC  CPU flat=0.2144 bk7 =0.1183 | GPU flat=0.2131 bk7 =0.2139
+
+i.e. CPU dispersion is live for BOTH materials, GPU dispersion is a no-op for
+BOTH. pkg187 wires Principled into the SAME infrastructure the dielectric uses
+(scene_upload uploads the Cauchy fit + isDispersive; gpu_material_sample_spectral
+injects the hero-IOR + terminateSecondary). So the correct, ACHIEVABLE GPU gate
+is: pkg187 introduces NO NEW divergence — GPU dispersive Principled tracks the
+GPU dispersive DIELECTRIC reference (both no-op on the wavefront leg today), and
+GPU dispersive Principled tracks GPU flat Principled (the gated no-op). A CPU
+companion proves the wiring is REAL (dispersion measurably changes the render,
+mirroring the dielectric). The full chromatic-caustic visual gate stays CPU-side
+(test_pkg187_principled_dispersion.py).
+
+GPU-visible wavefront dispersion is a separately-filed follow-up (2026-08-12);
+enabling it lights up BOTH dielectric and Principled through this same wiring.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+
+try:
+    import astroray
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray not built")
+
+if AVAILABLE and not astroray.__features__.get("cuda", False):
+    pytest.skip(
+        "CUDA feature not in this build -- pkg187 GPU dispersion wiring gate needs "
+        "the RTX box (LEAD runs this).",
+        allow_module_level=True,
+    )
+
+WIDTH = HEIGHT = 48
+SAMPLES = 256
+MAX_DEPTH = 8
+SEED = 187187
+
+DISP = {"dispersion_scale": 1.0, "dispersion_abbe": 20.0}
+
+
+def _render(use_gpu: bool, kind: str, params: dict) -> np.ndarray:
+    r = astroray.Renderer()
+    r.set_background_color([0.30, 0.45, 0.65])
+    red = r.create_material("lambertian", [1.0, 0.05, 0.03], {})
+    green = r.create_material("lambertian", [0.05, 1.0, 0.08], {})
+    blue = r.create_material("lambertian", [0.03, 0.08, 1.0], {})
+    r.add_triangle([-3, -3, -2.5], [0, -3, -2.5], [0, 3, -2.5], red)
+    r.add_triangle([-3, -3, -2.5], [0, 3, -2.5], [-3, 3, -2.5], red)
+    r.add_triangle([0, -3, -2.5], [3, -3, -2.5], [3, 3, -2.5], blue)
+    r.add_triangle([0, -3, -2.5], [3, 3, -2.5], [0, 3, -2.5], blue)
+    r.add_triangle([-3, -3, -2.6], [3, -3, -2.6], [0, -1.2, -2.6], green)
+    mat = r.create_material(kind, [1.0, 1.0, 1.0], params)
+    r.add_sphere([0.0, 0.0, 0.0], 0.9, mat)
+    r.setup_camera([0.0, 0.0, 2.0], [0.0, 0.0, 0.0], [0.0, 1.0, 0.0],
+                   55.0, WIDTH / HEIGHT, 0.0, 2.0, WIDTH, HEIGHT)
+    r.set_integrator("path_tracer")
+    r.set_integrator_param("max_depth", MAX_DEPTH)
+    if use_gpu:
+        r.set_use_gpu(True)
+        r.set_wavelength_range(380.0, 780.0)   # engage the spectral wavefront leg
+        r.set_output_mode("srgb")
+    r.set_seed(SEED)
+    return np.asarray(r.render(SAMPLES, MAX_DEPTH, None, False), dtype=np.float64)
+
+
+def _means(img):
+    return np.array([float(img[..., c].mean()) for c in range(3)])
+
+
+_P_FLAT = {"transmission_weight": 1.0, "ior": 1.5, "roughness": 0.02, "metallic": 0.0}
+_P_DISP = {**_P_FLAT, **DISP}
+
+
+def test_gpu_dispersion_wired_mirrors_dielectric_reference():
+    # --- GPU wavefront leg: dispersion is a pre-existing no-op for BOTH the
+    #     dielectric reference and the pkg187 Principled wiring (no NEW divergence).
+    gp_flat = _means(_render(True, "principled", _P_FLAT))
+    gp_disp = _means(_render(True, "principled", _P_DISP))
+    gd_flat = _means(_render(True, "dielectric", {"ior": 1.5}))
+    gd_disp = _means(_render(True, "dielectric", {"sellmeier_preset": "bk7"}))
+
+    p_ratio = gp_disp / np.maximum(gp_flat, 1e-8)   # Principled disp/flat on GPU
+    d_ratio = gd_disp / np.maximum(gd_flat, 1e-8)    # dielectric reference disp/flat on GPU
+
+    print("\n[pkg187 GPU wiring gate]")
+    print(f"  GPU principled disp/flat = {np.round(p_ratio,4)}")
+    print(f"  GPU dielectric disp/flat = {np.round(d_ratio,4)}")
+
+    for c, ch in enumerate("RGB"):
+        # Principled introduces no NEW dispersion divergence on the GPU leg
+        # (matches the frozen dielectric behavior: dispersion is a wavefront no-op).
+        assert 0.95 <= p_ratio[c] <= 1.05, (
+            f"pkg187 GPU: Principled dispersion unexpectedly changed the wavefront "
+            f"render (ch {ch} disp/flat={p_ratio[c]:.4f}); the GPU wavefront leg is "
+            f"the frozen no-op path -- a change here means the wiring diverged from "
+            f"the dielectric reference.")
+        # The dielectric reference exhibits the SAME frozen no-op -> the gate is
+        # pre-existing infra, not pkg187.
+        assert 0.95 <= d_ratio[c] <= 1.05, (
+            f"pkg187 GPU: dielectric reference dispersion is NOT a no-op (ch {ch} "
+            f"disp/flat={d_ratio[c]:.4f}) -- the wavefront dispersion infra changed "
+            f"upstream; re-evaluate pkg187's GPU gate against the new behavior.")
+
+
+def test_cpu_dispersion_is_real_and_mirrors_dielectric():
+    # Companion to the GPU no-op gate: on CPU the wiring is LIVE -- Principled
+    # dispersion measurably changes the render, tracking the dielectric reference.
+    cp_flat = _means(_render(False, "principled", _P_FLAT)).mean()
+    cp_disp = _means(_render(False, "principled", _P_DISP)).mean()
+    cd_flat = _means(_render(False, "dielectric", {"ior": 1.5})).mean()
+    cd_disp = _means(_render(False, "dielectric", {"sellmeier_preset": "bk7"})).mean()
+
+    p_eff = cp_disp / cp_flat
+    d_eff = cd_disp / cd_flat
+    print(f"\n[pkg187 CPU wiring-is-real] principled disp/flat={p_eff:.4f} "
+          f"dielectric bk7/flat={d_eff:.4f}")
+
+    # CPU dispersion is live for Principled (dims, exactly as the dielectric does).
+    assert p_eff < 0.9, (
+        f"pkg187 CPU: Principled dispersion had no effect (disp/flat={p_eff:.4f}); "
+        f"the CPU wiring is broken.")
+    # And it tracks the dielectric reference's dispersion magnitude.
+    assert abs(p_eff - d_eff) < 0.1, (
+        f"pkg187 CPU: Principled dispersion magnitude ({p_eff:.4f}) diverges from "
+        f"the dielectric reference ({d_eff:.4f}).")
+
+
+# ===========================================================================
+# LEAD RUN COMMANDS (after build_cuda_worktree.bat, on the RTX box, GPU lock held):
+#   pytest tests/test_pkg187_principled_dispersion_gpu_parity.py -v -s
+# ===========================================================================


### PR DESCRIPTION
## Summary

Makes `PrincipledPlugin` dispersion-aware: the transmission-lobe IOR becomes
wavelength-dependent via the **OpenPBR Surface v1.1.1 / Cycles WIP (PR #162041)
two-term Cauchy fit** `n(λ)=A+B/λ²` from the d-line IOR + Abbe number. A Blender
Principled glass prism with nonzero dispersion now produces **chromatic caustics
on CPU**. Zero-dispersion is byte-identical.

**Algorithm (CLAUDE.md §6, cited in-code):** `bsdf_glass_ior`,
`intern/cycles/kernel/closure/bsdf_microfacet.h` (Blender PR #162041), OpenPBR
Surface v1.1.1 Eqs. (55)/(56). Fraunhofer lines λ_d=0.5876/λ_C=0.6563/λ_F=0.4861 μm,
`inv_abbe = dispersion_scale/Abbe`. Research notes:
`.astroray_plan/docs/pkg187-principled-dispersion-research.md`. Implemented in
`principled.cpp::cauchyAB` (CPU) + `gpu_dispersion.cuh::gpu_cauchy_ior` (GPU).

## Two premise corrections (surfaced during implementation)

1. **No shipped Blender exposes a Dispersion socket** on Principled/Glass/Refraction
   (headless-probed 4.3.2 / 4.5.0 / 5.1.0 / 5.2.0). It is unmerged upstream WIP
   (PR #162041). Per coordinator-approved **Option A**, the addon gets a
   *forward-compatible* `put_float` probe (no-op today, live when #162041 ships),
   unit-tested against a synthetic node; the chromatic gate is verified via engine
   dispersion params.
2. **GPU wavefront dispersion is a pre-existing frozen no-op.** The GPU
   hero-collapse dispersion (`stage_advance.cu` → `gpu_material_sample_spectral`)
   does not produce visible dispersion for the **dielectric reference either**
   (`test_pkg64_gpu_cpu_parity` xfail since 2026-06-08; pkg64 defers GPU
   per-wavelength multi-IOR to Session 2). Per coordinator-approved **Option B**,
   pkg187 correctly **wires** Principled into that same infra and gates the GPU leg
   on *faithful-mirror-of-the-dielectric-reference* + the register gate. GPU-visible
   wavefront dispersion is a **follow-up spec filed 2026-08-12**; it lights up both
   dielectric and Principled through this wiring.

## Measured gates

**CPU chromatic (visual, LOOKED at render):** Principled prism red/blue centroid
spread **4.267px → 5.345px** (+1.078), max RGB diff 0.92.

**Zero-dispersion bit-identity:** `np.array_equal` passes (dispersion_scale=0 and
no-params both == non-dispersive baseline).

**GPU faithful-mirror (256spp, spectral srgb, glass sphere / colored backdrop):**

| material   | CPU flat | CPU disp | GPU flat | GPU disp |
|------------|----------|----------|----------|----------|
| Principled | 0.2053   | 0.1138   | 0.2041   | 0.2041   |
| dielectric | 0.2144   | 0.1183   | 0.2131   | 0.2139   |

GPU test: principled disp/flat = [0.9986, 1.0026, 0.9998] mirrors dielectric
[0.9997, 1.0136, 1.0025] (both no-op → no new divergence). CPU wiring-is-real:
principled disp/flat 0.5541 tracks dielectric 0.5518.

**cuobjdump register gate** (`stageShadeBucketedKernel<false>`, merge-base baseline
7b9cc1b, TRUE **sm_120** — final linked `.pyd`):
- baseline: `REG:254 STACK:3608 CONSTANT[0]:1700`
- pkg187:   `REG:254 STACK:3608 CONSTANT[0]:1700`  → **byte-identical**, no register
  or stack increase. All GPU additions compile out of `<false>` via
  `if constexpr(HasPrincipled)`; **no new GMaterial/GPrincipledClosure fields**.

  > Correction: the first reading was `REG:254/STACK:2640` — the **fleet-wide
  > stale-arch artifact** (every `build_cuda` carried a cached
  > `CMAKE_CUDA_ARCHITECTURES=52`, so `cuobjdump` read Maxwell PTX not the sm_120
  > SASS that runs; pkg183 ships an automatic guard). Re-measured at true sm_120
  > via `-DASTRORAY_CUDA_ARCHS=120 -DCMAKE_CUDA_ARCHITECTURES=120` (verified
  > `compute_120,sm_120` in the generated project) on both trees.

**xfail note:** `test_gpu_prism_rainbow_parity` "passed" under `--runxfail` in 0.80s
with no render output — a **vacuous** XPASS (the assert cleared without a real GPU
render). The xfail is **retained**; a real render-level check is needed once GPU
dispersion is enabled. Not un-xfailed.

**Test evidence (rebased build, RTX 5070 Ti, GPU lock held):**
- `test_pkg187_principled_dispersion.py` — 4/4 (chromatic, bit-identity, Cauchy pin)
- `test_pkg187_addon_dispersion_probe.py` — 3/3
- `test_pkg187_principled_dispersion_gpu_parity.py` — 2/2 (GPU mirror + CPU-real; re-run on the sm_120 build)
- Regressions: pkg178 principled parity, spectral_prism, principled_bsdf,
  spectral_gpu_materials, sellmeier_ior, metal parity, glass caustic, multiwavelength,
  reflection_not_black, prism_caustic_rainbow, sms_caustic_spectral — **all pass (68)**.

**Build (last 5 lines):**
```
  astroray_test_helpers.vcxproj -> ...\build_cuda\Release\astroray_test_helpers.cp313-win_amd64.pyd

========================================
Build succeeded
========================================
```

## Acceptance-criteria checklist
- [x] Chromatic caustics from a dispersive Principled prism — **CPU** (GPU deferred to follow-up; see finding #2)
- [x] Zero-dispersion bit-unchanged (regression guard)
- [x] GPU leg gated on faithful-mirror-of-dielectric + register gate (per-λ GPU/CPU parity not achievable — pre-existing frozen infra, dielectric identical)
- [x] Addon forward-probe unit-tested; chromatic verified via engine params
- [x] Research notes saved; Cycles source cited in-code
- [x] SMS/MNEE (Work 4) feeds per-λ IOR via the existing `iorAt()` hook — no `mesh_attempt.h` change needed

## Authorized surface
Spec Work 1–4 intended: `principled.cpp` (1), `scene_upload.cu` + `gpu_materials.h`
(2), `blender_addon/__init__.py` (3), SMS/MNEE (4). Actually changed: those four,
plus two supporting hooks — `include/raytracer.h` (base `getCauchyAB()` virtual)
and `include/astroray/gpu_dispersion.cuh` (`gpu_cauchy_ior` device twin) — both
direct enablers of Work 1/2, no scope drift. `mesh_attempt.h` **not** touched
(Work 4 satisfied via the existing `iorAt()` hook). Plus 3 new tests, research
notes, and the spec (premise corrections + measured findings).

Do not merge — pr-reviewer handles that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
