### PR TITLE
docs(pkg191/192/193): viewport-addon diagnosis-first specs from owner feedback

### DIFF
--- a/.astroray_plan/packages/pkg191-viewport-gpu-progressive-refinement.md
+++ b/.astroray_plan/packages/pkg191-viewport-gpu-progressive-refinement.md
@@ -1,0 +1,163 @@
+# pkg191 — Viewport progressive refinement broken on GPU
+
+**Pillar:** 5 / integration-first
+**Track:** A
+**Status:** open (filed 2026-08-12 from owner hands-on addon feedback —
+memory [[owner-addon-feedback-2026-08-12]], finding #1)
+**Estimated effort:** M
+**Depends on:** none hard; touches the pkg56/pkg83/pkg84/pkg114 viewport
+session machinery (`view_update` / `view_draw` / `render_viewport_frame`).
+
+---
+
+## Symptom (owner, first-hand)
+
+Rendering the viewport with the **GPU backend**, the image "stays static at the
+noisy 1-sample state" — it does not visibly refine as samples accumulate. The
+**CPU viewport progressively refines** and is the comparison control. So this is
+a GPU-path-specific regression in the progressive loop, not a global sampler bug.
+
+---
+
+## MANDATORY FIRST STEP — reproduce on a freshly built CURRENT addon
+
+The owner's installed addon "might have been sliiiightly dated." **Do not debug
+the reported symptom until you have reproduced it on a from-current-`main` build.**
+Concretely, before any code change:
+
+1. Build the addon `.pyd` OpenMP-OFF against current `main`
+   (`build_blender_addon_cuda`; see [[pkg119b-harness-runbook]] and
+   [[mingw_openmp_blender_deadlock]]), verify `.pyd` mtime ≥ `git log -1 HEAD`,
+   and confirm `astroray.__file__` loads the canonical build output
+   (not a shadow `.pyd`; [[stale_pyd_locations]]).
+2. Stage the addon from that build (`build_blender_addon.py`; the ADDON_FILES
+   allow-list, [[addon-packaging-file-list]]) into Blender 5.1
+   ([[blender-5-1-installed-locally]]).
+3. Reproduce headlessly if at all possible (see "Headless repro" below) and,
+   if not, in the real viewport. **Record whether the current build still
+   exhibits the bug.** If it is already fixed on `main`, the deliverable becomes
+   a regression test that pins the fix + an owner-visual note; STOP and report
+   that, do not manufacture a fix.
+
+---
+
+## Where the loop lives (verified line refs, current `main` fb9538d)
+
+The viewport progressive accumulator is Python-side, in
+`blender_addon/exporter.py`:
+
+- `Exporter.render_viewport_frame` (`exporter.py:504-603`) is the per-frame
+  worker. It:
+  - short-circuits when `self._viewport_current_spp >= self._viewport_target_spp`
+    (`exporter.py:521-522`);
+  - renders **one chunk** of `viewport_chunk_samples(settings, current_spp)`
+    samples (`exporter.py:560`) via `renderer.render(samples, depth, None,
+    False, …, skip_upload)` (`exporter.py:565-573`);
+  - **accumulates in Python** as a running mean of chunks
+    (`exporter.py:585-597`): `accum = (accum*old_spp + chunk*samples)/new_spp`,
+    then `_viewport_current_spp = new_spp`;
+  - pushes the texture + status (`exporter.py:599-602`) and returns `True`.
+- The **redraw pump** is the only thing that turns one chunk into progressive
+  refinement: both `view_update` (`exporter.py:671-672`) and `view_draw`
+  (`exporter.py:733-734`) call `request_viewport_redraw_fn()` — i.e.
+  `RenderEngine.tag_redraw()` (`__init__.py:1244-1248`) — **iff**
+  `_viewport_current_spp < _viewport_target_spp`. Each `tag_redraw` should
+  schedule another `view_draw`, which renders the next chunk (with
+  `needs_progress` true at `exporter.py:705`) and re-accumulates.
+- Chunk/target sizing: `_viewport_target_samples` = `preview_samples`
+  (`__init__.py:1214-1216`); `_viewport_chunk_samples` = `min(viewport_chunk_spp,
+  remaining)`, default chunk 1 (`__init__.py:1218-1223`).
+
+So on paper the design already refines chunk-by-chunk driven by `tag_redraw`.
+The bug is that on GPU the pump stalls at the first chunk.
+
+---
+
+## Diagnosis-first — reproduce → localize → fix
+
+### Reproduce
+- Headless repro (preferred, scriptable): drive `Exporter.view_draw` in a loop
+  with a stub/real `context` whose camera hash is held **constant** (no camera
+  motion), GPU backend forced, and assert `_viewport_current_spp` climbs
+  `1 → chunk → 2·chunk → … → preview_samples` across successive calls. Do the
+  same with the CPU backend as the control. The failing GPU case should plateau
+  at the first chunk. Reuse the pkg119-B harness plumbing for a real-Blender
+  headless driver if the stub can't exercise the GPU `render()`.
+- If it only reproduces in the live viewport, capture the `update_stats`
+  "Viewport N/M spp" string (`__init__.py:1250-1257`) over ~2 s of no input on
+  GPU vs CPU.
+
+### Localize — the ranked hypotheses (instrument, do not guess)
+Add temporary per-call logging of `(_viewport_current_spp, target,
+camera_changed, needs_progress, settings_changed, samples, pixels is None,
+return value)` in `view_draw` / `render_viewport_frame`, GPU vs CPU:
+
+1. **`tag_redraw` doesn't re-arm `view_draw` on GPU.** If a long GPU
+   `render()` holds the draw and the redraw request posted during the draw is
+   coalesced/dropped, the loop never re-fires. Compare how many `view_draw`
+   calls arrive after input stops on GPU vs CPU. (This is the most likely
+   cause given "stuck at frame 1".)
+2. **GPU `render()` returns `None` or a fresh 1-sample buffer on chunk ≥ 2.**
+   `render_viewport_frame` returns early on `pixels is None`
+   (`exporter.py:574-575`) *without* advancing `_viewport_current_spp` — so the
+   status would show "1/M" forever and every redraw re-renders chunk 1. Check
+   the GPU return on the 2nd call specifically (a first-call prewarm/upload path
+   differs, `exporter.py:492-499`).
+3. **`camera_changed` / `settings_changed` false-positive on GPU** resets the
+   accumulator every frame (`render_viewport_frame:516-518`,
+   `_reset_viewport_accumulation`). If the camera hash is nondeterministic frame
+   to frame (float jitter in `_camera_state_hash`, `__init__.py:1259-1293`),
+   `render_key` flips, `_viewport_accum_key` mismatches, spp resets to the chunk
+   size each frame → looks static at "noisy 1-sample". Verify the hash is
+   byte-stable across identical-camera GPU frames.
+4. **`skip_upload=False` on every GPU chunk re-clears device accumulation.**
+   `view_draw` calls `render_viewport_frame` with the default `skip_upload=False`
+   (`exporter.py:725-729`), so each GPU chunk re-uploads geometry. If the GPU
+   `renderer.render(..., skip_upload=False)` path internally `clear()`s or
+   re-seeds identically (same seed → identical noise, [[seed-zero-is-random-sentinel]]),
+   the "accumulation" averages identical frames and never denoises. Verify the
+   GPU render actually advances its RNG stream per chunk (distinct noise per
+   call), else the Python running-mean is averaging duplicates.
+
+Pin the ONE actual cause with evidence before touching code. Record the ruled-out
+hypotheses in Lessons.
+
+### Fix
+Scope the fix to the localized cause. Likely shapes (do not implement
+speculatively — implement the one the evidence selects):
+- (H1) ensure a progress redraw is re-armed after the GPU draw completes (e.g.
+  a timer-based `tag_redraw`, matching how Cycles pumps progressive viewport
+  passes) so the chunk loop advances.
+- (H2/H4) make the GPU chunk render advance the sample stream (distinct seed per
+  chunk) and return a valid buffer on chunk ≥ 2; treat `pixels is None` as a
+  logged error, not a silent stall.
+- (H3) stabilise the camera/render-key hash so identical GPU frames don't reset
+  the accumulator.
+
+---
+
+## Acceptance criteria
+
+- [ ] **Reproduced (or shown already-fixed) on a freshly built current-`main`
+      addon `.pyd`** BEFORE any code change; the dated-addon caveat is
+      discharged in writing.
+- [ ] A **headless / scriptable** assertion that `_viewport_current_spp` climbs
+      monotonically to `preview_samples` across successive `view_draw` calls
+      with a fixed camera on the **GPU** backend (CPU as passing control),
+      gated as a test.
+- [ ] The single root cause is identified with instrumented evidence; ruled-out
+      hypotheses recorded in Lessons.
+- [ ] The GPU viewport **visibly refines** (noise drops as spp climbs) — an
+      **owner-visual note** with a before/after capture (metrics can pass on
+      garbage; [[general-photon-loop-needs-solid-glass]] — a human must confirm
+      the noise actually decreases, not just that spp counts up).
+- [ ] No regression to the CPU viewport progressive loop (same test passes CPU).
+
+## Hard non-goals
+
+- **No interactivity / fps work** — that is pkg192. This package is purely
+  "does the still viewport refine on GPU". Keep camera-motion perf out of scope.
+- **No new denoiser wiring.** OIDN viewport toggle stays as-is
+  (`exporter.py:547-552`); refinement here means MC noise dropping with spp.
+- **No sampler/RNG rewrite** beyond what the localized cause requires; if the
+  cause is the redraw pump (H1), do not touch the engine.

--- a/.astroray_plan/packages/pkg192-viewport-navigation-interactivity.md
+++ b/.astroray_plan/packages/pkg192-viewport-navigation-interactivity.md
@@ -1,0 +1,147 @@
+# pkg192 — Viewport navigation interactivity (3-5 fps vs Cycles ~30 fps)
+
+**Pillar:** 5 / integration-first
+**Track:** A
+**Status:** open (filed 2026-08-12 from owner hands-on addon feedback —
+memory [[owner-addon-feedback-2026-08-12]], finding #2)
+**Estimated effort:** M-L (diagnosis + cheapest high-leverage fixes only)
+
+**Depends on:** the pkg56/pkg83/pkg114 viewport session machinery. Best filed
+AFTER pkg191 lands (a stalled progressive loop confounds any fps measurement —
+you need the accumulator advancing correctly before profiling frame cost).
+
+---
+
+## Symptom + owner framing (record verbatim in Lessons)
+
+While orbiting the camera in the rendered viewport, Astroray runs at **~3-5 fps
+vs Cycles' ~30 fps**. **The owner explicitly does NOT expect full Cycles-parity
+interactivity in one package** — this is a tracked long-term gap. The goal of
+this package is a **meaningful fps improvement** from the cheapest high-leverage
+fixes, backed by a per-frame profile that says where the time actually goes.
+
+---
+
+## MANDATORY FIRST STEP — reproduce + PROFILE on a freshly built current addon
+
+Dated-addon caveat ([[owner-addon-feedback-2026-08-12]]): the owner's build
+"might have been sliiiightly dated." Before proposing any fix:
+
+1. Build addon `.pyd` OpenMP-OFF against current `main`, verify mtime/`__file__`
+   ([[stale_pyd_locations]], [[pkg119b-harness-runbook]],
+   [[mingw_openmp_blender_deadlock]]), stage into Blender 5.1
+   ([[blender-5-1-installed-locally]], [[addon-packaging-file-list]]).
+2. **Measure the current fps** while orbiting on this build (GPU backend, a
+   representative scene). This package is diagnosis-first: the profile is the
+   deliverable's foundation, not an afterthought.
+
+There is already a per-stage perf recorder wired through the viewport:
+`viewport_perf_record_fn("materials"|"geometry"|"lights"|"environment"|"render",
+t0)` (`exporter.py:472-486, 664`) and `viewport_perf_frame_complete_fn`
+(`exporter.py:649, 665`). **Use it** — grep `blender_addon/` for
+`viewport_perf_record` / `_viewport_perf` to find the sink and dump per-frame
+breakdowns; do not add a parallel profiler ([[integration-first-directive-2026-08]],
+scripts/README no-duplicate rule).
+
+---
+
+## Where camera-motion cost is paid (verified line refs, current `main`)
+
+Camera-only moves (orbit/pan/zoom) do **not** fire a depsgraph update, so
+Blender routes them to `view_draw`, not `view_update` (documented at
+`exporter.py:613-614`, `__init__.py:1261-1263`). Per orbit frame,
+`view_draw` (`exporter.py:678-753`):
+
+1. detects `camera_changed` via `_camera_state_hash` (`exporter.py:700-704`,
+   hash at `__init__.py:1259-1293`);
+2. if changed, calls `render_viewport_frame(... reset_accumulation=
+   camera_substantive_changed or settings_changed ...)` — **note it passes NO
+   `skip_upload` argument, so it defaults to `False`** (`exporter.py:725-729`);
+3. `render_viewport_frame` re-runs `setup_viewport_camera` +
+   `renderer.render(samples, depth, …, skip_upload=False)` at the **full
+   region resolution** `region.width × region.height` (`exporter.py:512-573`).
+
+### The two prime suspects (confirm with the profiler before fixing)
+
+**Suspect A — full geometry re-upload every orbit frame.**
+`skip_upload=False` (`exporter.py:725`) means each camera-only frame pays a full
+scene push to the device even though geometry is unchanged. Contrast: the
+pkg114-inc3d path deliberately sets `skip_upload=True` for transform-only refits
+(`exporter.py:441-444, 656-657`, and the F12 `skip_upload=True` note at
+`__init__.py:3923`). A pure camera move changes **only** the camera — geometry,
+BVH/BLAS, materials, lights are all identical — so it should render from current
+device state with `skip_upload=True`. If the profiler shows the "render" bucket
+dominated by upload (or a `geometry` bucket firing on orbit), **making camera-only
+`view_draw` frames pass `skip_upload=True` is the single cheapest high-leverage
+fix.** Verify the C++ `render(..., skip_upload=True)` path is safe when only the
+camera changed (camera is set separately via `setup_viewport_camera`, so it
+should be).
+
+**Suspect B — no reduced-resolution navigation mode.**
+Every orbit frame renders at full `region.width × region.height`
+(`exporter.py:512-513`). Cycles renders navigation at reduced resolution first
+(progressive-resolution / "start_resolution") and refines to full res once the
+camera settles. Astroray has **no** low-res nav path. Adding one — render at
+`width/N × height/N` while `camera_changed` has been true within the last few
+frames, snap to full res on settle — is the standard Cycles-reference lever.
+Cite `intern/cycles/blender/session.cpp` / `BlenderSession::reset` +
+`start_resolution` (Apache-2.0) as the reference (already cited in
+`_camera_substantive_state_hash`, `__init__.py:1300-1304`).
+
+---
+
+## Diagnosis-first — reproduce → localize → fix
+
+1. **Profile** (mandatory first step above): per-frame breakdown of the
+   `materials/geometry/lights/environment/render` buckets while orbiting, GPU
+   backend. Establish which bucket dominates. Expected finding: `render` (with
+   an embedded full upload) and/or full-res cost dominate; `geometry` should
+   ideally be zero on camera-only frames — if it is NOT, that itself is a bug
+   (a camera move is re-syncing the scene).
+2. **Localize** the dominant cost to Suspect A (upload), Suspect B (resolution),
+   or something the profile reveals (e.g. per-frame material re-convert, BVH
+   rebuild, texture re-upload). Grep how a camera move could reach
+   `sync_viewport_scene`/`apply_depsgraph_updates` (`exporter.py:461-502,
+   605-676`) — it should NOT on a pure camera move; if it does, that is the bug.
+3. **Fix — cheapest high-leverage only:**
+   - (A) route camera-only `view_draw` frames through `skip_upload=True` so no
+     geometry re-upload is paid on orbit; guard so the FIRST frame after a real
+     scene edit still uploads.
+   - (B) add a reduced-resolution navigation render while the camera is moving,
+     snapping to full resolution when it settles (reuse the existing
+     `camera_changed` signal + a settle timer/redraw).
+   - Implement whichever the profile justifies; if both are cheap and additive,
+     do both. Do NOT attempt sample reprojection / TAA / motion-vector reuse —
+     out of scope, explicitly deferred to a future package.
+
+---
+
+## Acceptance criteria
+
+- [ ] **Reproduced + profiled on a freshly built current-`main` addon** BEFORE
+      any fix; the dated-addon caveat discharged in writing.
+- [ ] A recorded **per-frame profile** (using the existing
+      `viewport_perf_record` plumbing) attributing orbit-frame cost to specific
+      buckets, GPU backend, before and after the fix.
+- [ ] **Measured, meaningful fps improvement** while orbiting on a representative
+      scene (report the before/after numbers; note the RTX clock-drift caveat —
+      min-of-N, [[gpu-perf-ab-clock-drift]]). Full Cycles parity is explicitly
+      NOT required.
+- [ ] Camera-only frames provably avoid full geometry re-upload (Suspect A) —
+      instrumented evidence the `geometry`/upload cost is gone on orbit — OR a
+      documented reason that was not the dominant cost.
+- [ ] No correctness regression: after the camera settles, the viewport still
+      converges to the same full-resolution image (the reduced-res nav path, if
+      added, must snap back to full res). Owner-visual note confirming orbit
+      feels smoother and the settled image is unchanged.
+
+## Hard non-goals
+
+- **No full Cycles-parity interactivity target.** Owner-framed: meaningful
+  improvement, not 30 fps.
+- **No sample reprojection / temporal reuse / TAA / motion vectors.** Deferred.
+- **No engine-side wavefront register work** ([[wavefront-shade-kernels-register-saturated]]) —
+  this is an addon-loop/upload-avoidance + resolution-scaling package, not a
+  kernel-perf package.
+- **No changes to the still-frame progressive loop** owned by pkg191; land pkg191
+  first so fps profiling isn't confounded by a stalled accumulator.

--- a/.astroray_plan/packages/pkg193-camera-view-overlay-alignment.md
+++ b/.astroray_plan/packages/pkg193-camera-view-overlay-alignment.md
@@ -1,0 +1,163 @@
+# pkg193 — Camera-view overlay vs preview-render misalignment
+
+**Pillar:** 5 / integration-first
+**Track:** A
+**Status:** open (filed 2026-08-12 from owner hands-on addon feedback —
+memory [[owner-addon-feedback-2026-08-12]], finding #4)
+**Estimated effort:** M
+
+**Depends on:** none hard; isolated to the viewport camera translation
+(`_setup_viewport_camera` / `_apply_camera`). Independent of pkg191/pkg192.
+
+---
+
+## Symptom (owner, first-hand)
+
+In **camera view** (numpad 0), Blender's GUI overlays — the selected-object
+outline / wireframe — "don't exactly line up with the preview render. Close but
+not exact." A small, consistent projection offset between where Blender draws the
+overlay and where Astroray renders the geometry. This also undermines
+**final-render compositing trust** (an F12 render that is a few px off from the
+viewport framing composites wrong).
+
+---
+
+## MANDATORY FIRST STEP — reproduce on a freshly built current addon
+
+Dated-addon caveat ([[owner-addon-feedback-2026-08-12]]). Before any change:
+build addon `.pyd` against current `main`, verify mtime/`__file__`
+([[stale_pyd_locations]]), stage into Blender 5.1
+([[blender-5-1-installed-locally]], [[addon-packaging-file-list]]), and confirm
+the misalignment still reproduces. A prior "BUG-08" pass (see below) already
+touched this exact code; verify what its state is on current `main` before
+attributing a new bug.
+
+---
+
+## Where the camera translation lives (verified line refs, current `main`)
+
+`blender_addon/__init__.py`:
+
+- `_setup_viewport_camera` (`__init__.py:1589-1655`) is the viewport camera
+  builder. Two branches:
+  - **CAMERA view** (`__init__.py:1605-1613`): applies `view_camera_zoom` via
+    `_camera_view_zoom_scale` (`__init__.py:1578-1587`) and passes
+    `view_camera_offset` as `viewport_shift` into `_apply_camera`.
+  - **PERSP/ORTHO** (`__init__.py:1615-1655`): derives vfov from
+    `rv3d.window_matrix[1][1]`.
+- `_apply_camera` (`__init__.py:1877-1935+`) builds lookFrom/lookAt/vup from
+  `matrix_world` and, when `rv3d` is present, sets
+  **`vfov = 2·atan(1/window_matrix[1][1])`** (`__init__.py:1916-1920`) — a
+  **symmetric-frustum** extraction. It then passes a scalar `vfov`, `aspect`,
+  and an image-plane `shift` to the C++ `renderer.setup_camera(...)`
+  (final call analogous to `__init__.py:1654`).
+- `_compute_vfov_degrees` (`__init__.py:1848-1875`) is the datablock fallback
+  (sensor_fit HORIZONTAL/VERTICAL/AUTO → vfov), used for F12/rv3d-absent.
+
+### The prime hypothesis — asymmetric frustum / principal point dropped
+
+Blender's camera-view `window_matrix` is generally an **off-center (asymmetric)
+frustum**. The principal point shifts away from image center due to:
+- camera `shift_x` / `shift_y` (lens shift),
+- `view_camera_offset` (CAMERA-view pan) and `view_camera_zoom`,
+- the **sensor-fit letterboxing**: when the render aspect ≠ the viewport region
+  aspect, Blender fits the camera frame inside the region (the passepartout),
+  which offsets/rescales the projected frame.
+
+The GUI overlay is drawn with Blender's **exact** `window_matrix` (off-center
+terms `window_matrix[2][0]`, `window_matrix[2][1]` and the top/bottom/left/right
+asymmetry included). But `_apply_camera` reads **only `[1][1]`** and reduces the
+projection to a **symmetric vfov + a single shift scalar** (`__init__.py:1916-1920`).
+Any asymmetry Blender has that isn't captured by that one shift term becomes a
+**constant pixel offset** — exactly the "close but not exact" the owner sees.
+The most likely concrete culprit is the **film-fit / region-vs-render aspect**
+mismatch (sensor_fit AUTO + a viewport region whose aspect differs from the
+render output aspect), followed by lens-shift double-counting between
+`viewport_shift` and any datablock `shift_x/shift_y`.
+
+Secondary: the C++ `setup_camera` may only accept a symmetric vfov+aspect(+shift)
+and be **structurally unable** to represent an arbitrary asymmetric frustum. If
+so, the fix is to extract the full frustum extents (l/r/t/b) from
+`window_matrix` and either (a) extend `setup_camera` to take asymmetric extents,
+or (b) compute the exact symmetric-vfov-plus-shift that reproduces Blender's
+frame for the common (aspect-mismatch, lens-shift) cases. Decide by measurement.
+
+---
+
+## Diagnosis-first — reproduce → MEASURE → localize → fix
+
+### Reproduce with a quantitative measurement (not eyeballing)
+Build a **wireframe-aligned test scene**: a single axis-aligned cube (or a quad
+with known-UV corners) centered in camera view, on a plain background. Render the
+Astroray preview to an image and, in the same Blender state, capture the camera
+overlay / project the cube's world-space corners through Blender's
+`window_matrix @ view_matrix` to expected pixel coords. **Measure the pixel
+offset** (and any scale/aspect error) between the projected corners and the
+rendered cube edges. This must be a repeatable number, headlessly if possible
+(`bpy_extras.object_utils.world_to_camera_view` or an explicit
+`window_matrix @ view_matrix` projection gives the reference pixel coords without
+a GUI). Record offset in px at several conditions:
+- render aspect == region aspect vs render aspect != region aspect (isolates
+  film-fit);
+- `shift_x/shift_y` = 0 vs nonzero (isolates lens shift);
+- `view_camera_zoom`/`offset` = 0 vs nonzero (isolates viewport zoom/pan);
+- sensor_fit AUTO vs HORIZONTAL vs VERTICAL.
+
+The condition(s) where the offset appears pin the cause.
+
+### Localize
+Attribute the measured offset to one of: (i) aspect/film-fit fit-inside-region
+scaling, (ii) principal-point / asymmetric-frustum terms dropped by the
+`[1][1]`-only vfov extraction, (iii) lens-shift double-count or sign error
+between `viewport_shift` and datablock `shift`, (iv) a half-pixel / pixel-center
+convention mismatch between the C++ film sampling and Blender's. Cite the Cycles
+reference for the correct fit math: `intern/cycles/blender/camera.cpp`
+`blender_camera_sync` / `blender_camera_border` / the `sensor_fit` +
+`view_camera_zoom`/`offset` handling (Apache-2.0) — this is the canonical
+"how Blender maps camera → film window" and the addon should match it
+([[cycles-parity]] discipline; do not invent the fit math, borrow it,
+per the cite-algorithm rule).
+
+### Fix
+Correct the localized term so projected overlay corners and rendered edges agree
+to sub-pixel (or ≤1 px) on the test scene, for all four condition axes above.
+Prefer reproducing Blender's exact frustum (full l/r/t/b extents from
+`window_matrix`) over patching a single shift scalar, IF the C++ camera can
+accept it; otherwise document precisely which asymmetry cases are covered and
+which remain approximated, and why.
+
+---
+
+## Acceptance criteria
+
+- [ ] **Reproduced on a freshly built current-`main` addon** with a
+      **quantitative pixel-offset measurement** (not eyeballing) BEFORE any fix;
+      dated-addon caveat discharged in writing.
+- [ ] The offset is attributed to a specific cause (film-fit / principal-point /
+      lens-shift / pixel-center convention) with the per-condition measurement
+      table recorded in Lessons.
+- [ ] After the fix, a **wireframe-aligned cube's** projected corners
+      (Blender `window_matrix @ view_matrix`) and the Astroray-rendered edges
+      agree within **≤1 px** across the four condition axes (aspect-match/mismatch,
+      lens-shift on/off, viewport zoom/pan on/off, sensor_fit AUTO/H/V), gated by
+      a headless test.
+- [ ] The camera-view overlay visually lines up with the preview render —
+      **owner-visual note** with a before/after capture.
+- [ ] **F12 final render** framing is verified consistent with the corrected
+      viewport framing (the compositing-trust angle) — same cube, F12 vs
+      viewport, corners agree.
+
+## Hard non-goals
+
+- **No orthographic-camera projection rewrite.** `_compute_vfov_degrees` returns
+  a placeholder 40° for non-PERSP (`__init__.py:1856-1860`); ORTHO alignment is
+  a separate, pre-existing gap — note it, do not fix it here unless the test
+  scene is PERSP-only and ORTHO is out of the measured conditions.
+- **No DoF / bokeh alignment work** — aperture is orthogonal to the framing
+  offset.
+- **No viewport-perf or progressive-loop changes** (pkg191/pkg192 own those);
+  this package changes only the camera projection/translation math.
+- **No unilateral C++ `setup_camera` ABI change** without an ABI-reachability
+  check ([[cpp-abi-guard]], addon target reachable) — if asymmetric extents
+  require a signature change, sweep all call sites (F12 `render`, tests, the
+  PERSP branch) in the same change.


### PR DESCRIPTION
Three Track-A, diagnosis-first specs filed from direct owner feedback after hands-on Blender addon use (2026-08-12; memory note owner-addon-feedback-2026-08-12).

## Specs
- **pkg191** — Viewport GPU progressive refinement stuck at the noisy 1-sample state (CPU viewport refines; GPU-path-specific). Ranked hypotheses: tag_redraw not re-arming view_draw on GPU / chunk-2 render returns None / camera-hash false-positive resetting the accumulator / duplicate-seed chunks averaging identical noise.
- **pkg192** — Viewport orbit interactivity ~3-5 fps vs Cycles ~30 fps. Diagnosis-first with the existing `viewport_perf_record` plumbing; prime suspects are full geometry re-upload every orbit frame (`view_draw` passes default `skip_upload=False`) and the absence of a reduced-resolution navigation mode. Owner framing recorded: meaningful improvement, NOT full Cycles parity, in one package.
- **pkg193** — Camera-view GUI overlay vs preview-render pixel misalignment. Prime hypothesis: `_apply_camera` reduces Blender's asymmetric camera-view `window_matrix` to a symmetric vfov + single shift (reads only `[1][1]`), dropping principal-point / film-fit asymmetry. Requires a quantitative pixel-offset measurement on a wireframe-aligned cube; also gates F12 compositing trust.

## Shared discipline
Every spec makes **"reproduce on a freshly built current addon"** the mandatory first step — the owner's installed build may have been dated, so no bug is attributed until reproduced on current `main`. Each cites verified addon line refs (`blender_addon/exporter.py`, `blender_addon/__init__.py`) and is scoped reproduce -> localize -> fix. No STATUS.md changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)