### PR TITLE
perf(pkg184): template<bool HasPhotons> isolation of photon-caustic KNN gather

### DIFF
--- a/.astroray_plan/packages/pkg184-stage-advance-hasphotons-isolation.md
+++ b/.astroray_plan/packages/pkg184-stage-advance-hasphotons-isolation.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 5 (GPU performance)
 **Track:** A (register-pressure work; requires cuobjdump + perf gates)
-**Status:** proposed (filed during the 2026-08-11 hygiene run's runtime audit)
+**Status:** done (PR #PENDING, 2026-08-12 — every HasPhotons=false shade variant strictly below baseline: STACK −256/−256/−128/−128 B across `<F,F>/<F,T>/<T,F>/<T,T>`; all HasPhotons=true variants byte-identical to baseline; REG:254 unchanged; non-photon glass-sphere shade kernel −2.76% wall vs +0.50% byte-identical control; base = current main e6b9f24 incl. pkg187 dispersion)
 **Estimated effort:** M
 **Depends on:** pkg157 `template<bool Deferred>` and pkg178 Stage-3b
 `template<bool HasPrincipled>` — this is the third application of the same

--- a/.astroray_plan/packages/pkg184-stage-advance-hasphotons-isolation.md
+++ b/.astroray_plan/packages/pkg184-stage-advance-hasphotons-isolation.md
@@ -43,3 +43,54 @@ Note: instantiation count doubles (2→4 kernel variants per templated axis
 product). If compile time or cubin size becomes a concern, gate the
 `HasPhotons=true` variants behind the same launch-side selection the
 Principled split uses.
+
+---
+
+## Hardware verification 2026-08-12 (PR #597, independent verifier pass)
+
+**Hardware:** RTX 5070 Ti (sm_120 / Blackwell), Windows 11 Enterprise
+10.0.26200, NVIDIA driver 610.47 (CUDA UMD 13.3), CUDA Toolkit 12.8.61
+(nvcc), OptiX SDK 9.1.0 (as configured; not exercised by this GPU-wavefront
+gate). Build: MSVC 19.44.35207 (VS2022 BuildTools), VS-generator
+`build_cuda` (root wrapper, `-DASTRORAY_CUDA_ARCHS=120
+-DCMAKE_CUDA_ARCHITECTURES=120`).
+
+**Arch discipline:** the PR worktree (`e14efed58...`) and an independent
+merge-base baseline (`e6b9f24`, checked out fresh into a dedicated baseline
+worktree) were both rebuilt from scratch via `build_cuda_worktree.bat`.
+pkg183's post-link `cuobjdump --list-elf` gate confirmed `sm_120` (not a
+stale/shadowed arch) on both `.pyd`s before any number below was trusted.
+
+**Contamination guard:** worktree HEAD verified against the PR's
+`headRefOid` (`e14efed580114341052fd798058d6ff15706153e`) before building.
+**Anomaly (not caused by this session):** an untracked, pre-existing stray
+file `stage_advance.cu` (containing pkg184's diff content) was found sitting
+at the **main repo root** (`Astroray/stage_advance.cu`, mtime predating this
+session). It is not referenced by `CMakeLists.txt` (which points at the real
+`src/gpu/wavefront/stage_advance.cu`) so it did not contaminate any build in
+this session, but it is worktree-contamination residue from some other
+agent/process and should be cleaned up by whoever owns that checkout.
+
+### Gate table (measured vs claimed)
+
+| # | Gate | Claimed | Measured | Verdict |
+|---|------|---------|----------|---------|
+| 1 | cuobjdump post-link resource matrix, all 8 `stageShadeBucketedKernel<HasPrincipled,HasTexture,HasPhotons>` instantiations (native sm_120, `cuobjdump --dump-resource-usage`) vs an independently-rebuilt merge-base (`e6b9f24`) baseline | `<F,F,false>` 3608→3352 (−256); `<F,F,true>` 3608→3608 (byte-identical); `<F,T,false>` 3608→3352 (−256); `<F,T,true>` 3608→3608; `<T,F,false>` 6616→6488 (−128); `<T,F,true>` 6616→6616; `<T,T,false>` 6616→6488 (−128); `<T,T,true>` 6616→6616; REG:254 everywhere | Independently-rebuilt baseline (fresh worktree at `e6b9f24`): `<F,F>`=STACK 3608, `<F,T>`=3608, `<T,F>`=6616 (CONSTANT[2]:368), `<T,T>`=6616 (CONSTANT[2]:368) — matches the claimed baseline table exactly. PR tree measured: `<F,F,false>`=3352, `<F,F,true>`=3608, `<F,T,false>`=3352, `<F,T,true>`=3608, `<T,F,false>`=6488, `<T,F,true>`=6616, `<T,T,false>`=6488, `<T,T,true>`=6616. **All 8 deltas match the claimed table exactly**; REG:254 on every one of the 8 instantiations. | **PASS** |
+| 2 | Perf A/B, glass-sphere caustic scene, wavefront route, 256 spp, min-of-7 with GPU burn-in, `wavefront_stage_shade_bucketed_n7` `sum_ms` (`ASTRORAY_PROFILE`) | Photons OFF: 93.623 ms → 91.039 ms (−2.76%). Photons ON (noise-floor control): 1045.40 ms → 1050.62 ms (+0.50%) | Photons OFF: baseline median 93.107 ms (min 92.985 ms, n=7) → pkg184 median 90.933 ms (min 90.863 ms, n=7) = **−2.34%** (median) / **−2.28%** (min-of-min). Photons ON: baseline median 985.579 ms (min 980.329 ms) → pkg184 median 986.539 ms (min 981.131 ms) = **+0.10%** (median) / **+0.08%** (min-of-min). Both directions confirmed: non-photon variant faster, photon-ON variant flat within noise (smaller than the PR's own reported control band). Launch count 572/render on both sides, both builds — matches the PR's methodology description. | **PASS** |
+| 3 | Photon-caustic parity — `tests/test_gpu_caustic_parity.py` + `tests/test_pkg55_c5_photon_wavefront.py`, plus mandatory visual inspection | "2 passed, 1 xpassed (pre-existing prism xfail, unrelated)" | `2 passed, 1 xpassed in 2.39s` — exact match. `test_gpu_glass_sphere_caustic_parity`: caustic-ROI energy GPU=45.0501 CPU=41.1944 ratio=1.094x, SSIM=0.9606, GPU peak luminance=0.406. Visual: `pkg113_gpu_glass_sphere.png` / `pkg113_cpu_glass_sphere.png` both show a coherent, focused warm-toned caustic blob at the expected floor location with sparse MC noise pixels around it — no fireflies, no magenta/black NaN patches, no banding, no mode regression (still monochrome-warm, not spectral/rainbow). The HasPhotons=true gather path is visibly still firing correctly. `test_gpu_prism_rainbow_parity` XPASS (documented out-of-scope xfail; render is scattered noise as expected, unrelated to this PR). `test_wavefront_photons_off_identity` PASSED. | **PASS** |
+| 4 | Broad regression slice (implementer claims 49 pass: photon emission/store, pkg157 firefly, pkg159 crypto, pkg178 principled+thinfilm parity, pkg186 texture parity, pkg187 dispersion) | "49 passed" | Ran a superset covering every named area plus additional pkg178 sub-suites (alpha, aniso, GPU/CPU parity, furnace, stage5 native routing, thin-film parity) and pkg186's features guard: **85 passed, 0 failed** (15.42s) — includes `test_gpu_photon_emission.py` (3), `test_gpu_photon_store.py` (4), `test_pkg157_wavefront_firefly_clamp_port.py` (7), `test_pkg159_wavefront_cryptomatte.py` (4), `test_pkg178_alpha.py` (11), `test_pkg178_aniso.py` (9), `test_pkg178_principled_gpu_cpu_parity.py`, `test_pkg178_principled_gpu_furnace.py`, `test_pkg178_stage5_native_routing.py`, `test_pkg178_thinfilm_gpu_cpu_parity.py` (all GPU/CPU ratio bands 0.95–1.05, all within), `test_pkg186_gpu_features_guard.py` (7), `test_pkg186_gpu_texture_parity.py` (2), `test_pkg187_addon_dispersion_probe.py` (3), `test_pkg187_principled_dispersion.py` (4), `test_pkg187_principled_dispersion_gpu_parity.py` (2). Zero failures. | **PASS (exceeds claim)** |
+
+**Overall verdict: mergeable on HW evidence.** All 4 gates PASS, independently
+re-measured (not just re-run against the PR's self-reported numbers) — the
+cuobjdump matrix was cross-checked against a from-scratch baseline rebuild at
+the exact claimed merge-base `e6b9f24`, and the perf A/B used a genuinely
+separate baseline `.pyd` rather than trusting the PR body's own numbers. No
+gate was relaxed; nothing needed escalation. The Blender-addon layer was not
+touched by this change (`launchStageShadeBucketed` signature unchanged) and
+was out of scope for this verification.
+
+**Anomaly log:** the stray root-level `stage_advance.cu` noted above under
+"Contamination guard" — advisory only, did not affect this session's build
+correctness (confirmed via `CMakeLists.txt` source-list grep), but should be
+triaged/deleted by its owner to avoid a future false-positive diff or stale
+include.

--- a/.astroray_plan/packages/pkg184-stage-advance-hasphotons-isolation.md
+++ b/.astroray_plan/packages/pkg184-stage-advance-hasphotons-isolation.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 5 (GPU performance)
 **Track:** A (register-pressure work; requires cuobjdump + perf gates)
-**Status:** done (PR #PENDING, 2026-08-12 — every HasPhotons=false shade variant strictly below baseline: STACK −256/−256/−128/−128 B across `<F,F>/<F,T>/<T,F>/<T,T>`; all HasPhotons=true variants byte-identical to baseline; REG:254 unchanged; non-photon glass-sphere shade kernel −2.76% wall vs +0.50% byte-identical control; base = current main e6b9f24 incl. pkg187 dispersion)
+**Status:** done (PR #597, 2026-08-12 — every HasPhotons=false shade variant strictly below baseline: STACK −256/−256/−128/−128 B across `<F,F>/<F,T>/<T,F>/<T,T>`; all HasPhotons=true variants byte-identical to baseline; REG:254 unchanged; non-photon glass-sphere shade kernel −2.76% wall vs +0.50% byte-identical control; base = current main e6b9f24 incl. pkg187 dispersion)
 **Estimated effort:** M
 **Depends on:** pkg157 `template<bool Deferred>` and pkg178 Stage-3b
 `template<bool HasPrincipled>` — this is the third application of the same

--- a/src/gpu/wavefront/stage_advance.cu
+++ b/src/gpu/wavefront/stage_advance.cu
@@ -378,7 +378,14 @@ __device__ int intersectPathSlot(
 // its pre-pkg186 REG/STACK footprint (the three signature params cost +24 B stack).
 __constant__ GWavefrontTextureBinding c_wfTexBinding;
 
-template<bool Deferred, bool HasPrincipled, bool HasTexture = false>
+// pkg184 — HasPhotons isolates the bounce-0 photon-map caustic KNN gather
+// (photonGridGatherKnn, 50-neighbour live set) behind `if constexpr`. The gather
+// only ever fires at bounce 0 in scenes that carry a photon grid, yet ptxas had to
+// allocate its registers/stack in EVERY instantiation of the REG:254-pinned shade
+// kernel. Threading HasPhotons lets the fleet's non-photon <*,*,false> kernels
+// compile with ZERO gather codegen; the launcher picks <true> off hasPhotonGrid.
+// See .astroray_plan/packages/pkg184-stage-advance-hasphotons-isolation.md.
+template<bool Deferred, bool HasPrincipled, bool HasTexture = false, bool HasPhotons = false>
 __device__ bool shadePathSlot(
     int idx,
     GPUWavefrontState& state,
@@ -697,20 +704,27 @@ __device__ bool shadePathSlot(
     // (color SoA) and converts to XYZ at the regen stage. To match MW behavior, we store
     // photon XYZ contrib in separate photon_xyz_* SoA fields and add it to accum_xyz
     // during regen (after spectral color→XYZ conversion), preserving the XYZ+XYZ math.
-    if (bounce == 0 && hasPhotonGrid && !useLuminanceOutput && photonGrid.numPhotons > 0) {
-        // rec is already the primary hit from intersectPathSlot; check non-emissive.
-        if (mat.emissionIntensity <= 0.0f) {
-            int found = 0;
-            GVec3 E = astroray::photon::gpu::photonGridGatherKnn(
-                photonGrid, rec.point, 50, 1.1f, found);
-            if (found > 0) {
-                GVec3 alb = mat.baseColor;
-                GVec3 photonContrib = GVec3(alb.x * E.x, alb.y * E.y, alb.z * E.z)
-                                      * photonScale;
-                // Store in photon_xyz SoA; will be added to accum_xyz during regen.
-                state.photon_xyz_x[idx] = photonContrib.x;
-                state.photon_xyz_y[idx] = photonContrib.y;
-                state.photon_xyz_z[idx] = photonContrib.z;
+    // pkg184: gated at COMPILE time on HasPhotons so ptxas allocates the 50-neighbour
+    // gather's live set only in the <*,*,true> instantiations. The runtime guard is
+    // preserved unchanged inside — a HasPhotons=true kernel is byte-identical to the
+    // pre-pkg184 kernel; a HasPhotons=false kernel (launched when hasPhotonGrid is
+    // false) never gathered anyway, so this is behaviour-preserving.
+    if constexpr (HasPhotons) {
+        if (bounce == 0 && hasPhotonGrid && !useLuminanceOutput && photonGrid.numPhotons > 0) {
+            // rec is already the primary hit from intersectPathSlot; check non-emissive.
+            if (mat.emissionIntensity <= 0.0f) {
+                int found = 0;
+                GVec3 E = astroray::photon::gpu::photonGridGatherKnn(
+                    photonGrid, rec.point, 50, 1.1f, found);
+                if (found > 0) {
+                    GVec3 alb = mat.baseColor;
+                    GVec3 photonContrib = GVec3(alb.x * E.x, alb.y * E.y, alb.z * E.z)
+                                          * photonScale;
+                    // Store in photon_xyz SoA; will be added to accum_xyz during regen.
+                    state.photon_xyz_x[idx] = photonContrib.x;
+                    state.photon_xyz_y[idx] = photonContrib.y;
+                    state.photon_xyz_z[idx] = photonContrib.z;
+                }
             }
         }
     }
@@ -1046,7 +1060,7 @@ __global__ void stageIntersectQueuedKernel(
     shade_queues[matType * capacity + slot] = idx;
 }
 
-template<bool HasPrincipled, bool HasTexture>  // pkg178 Stage-3b D4; pkg186 texture
+template<bool HasPrincipled, bool HasTexture, bool HasPhotons>  // pkg178 D4; pkg186 texture; pkg184 photons
 __global__ void stageShadeBucketedKernel(
     GPUWavefrontState state,
     GPUWavefrontHitBuffers hitBufs,
@@ -1082,7 +1096,7 @@ __global__ void stageShadeBucketedKernel(
     // pkg186: texture data comes from the __constant__ c_wfTexBinding symbol, NOT
     // kernel params — keeps the untextured <false,false> signature at its
     // pre-pkg186 footprint (see c_wfTexBinding note above).
-    bool alive = shadePathSlot<true, HasPrincipled, HasTexture>(idx, state, hitBufs, tlas, instances, blas,
+    bool alive = shadePathSlot<true, HasPrincipled, HasTexture, HasPhotons>(idx, state, hitBufs, tlas, instances, blas,
                                bvhNodes, prims, tris, spheres, motionVerts,
                                materials, lights, numLights,
                                totalLightPower, dedLights, numDed,
@@ -1245,22 +1259,42 @@ void launchStageShadeBucketed(
                 clampDirect, clampIndirect, \
                 photonGrid, hasPhotonGrid, photonScale, \
                 d_cryptoObjectRanks, d_cryptoMaterialRanks, cryptoDepth
+        // pkg184: hasPhotonGrid selects the <*,*,true> instantiation, which is the
+        // ONLY one carrying the photonGridGatherKnn codegen. The fleet's non-photon
+        // scenes launch <*,*,false>, whose ptxas footprint drops back below the
+        // pre-pkg184 kernel (acceptance = cuobjdump on the <false,false,false>
+        // symbol, native sm_120). All 8 are referenced so they land in the cubin.
+        const bool hasPhotons = hasPhotonGrid;
         const void* kptr =
             hasPrincipled
-                ? (hasTexture ? (const void*)stageShadeBucketedKernel<true, true>
-                              : (const void*)stageShadeBucketedKernel<true, false>)
-                : (hasTexture ? (const void*)stageShadeBucketedKernel<false, true>
-                              : (const void*)stageShadeBucketedKernel<false, false>);
+                ? (hasTexture
+                    ? (hasPhotons ? (const void*)stageShadeBucketedKernel<true, true, true>
+                                  : (const void*)stageShadeBucketedKernel<true, true, false>)
+                    : (hasPhotons ? (const void*)stageShadeBucketedKernel<true, false, true>
+                                  : (const void*)stageShadeBucketedKernel<true, false, false>))
+                : (hasTexture
+                    ? (hasPhotons ? (const void*)stageShadeBucketedKernel<false, true, true>
+                                  : (const void*)stageShadeBucketedKernel<false, true, false>)
+                    : (hasPhotons ? (const void*)stageShadeBucketedKernel<false, false, true>
+                                  : (const void*)stageShadeBucketedKernel<false, false, false>));
         astroray::gpu_profile::ScopedTimer _t(
             "wavefront_stage_shade_bucketed_n7", kptr, blocks, threads);
-        if (hasPrincipled && hasTexture)
-            stageShadeBucketedKernel<true, true><<<blocks, threads>>>(ASTRORAY_PKG186_SHADE_ARGS);
+        if (hasPrincipled && hasTexture && hasPhotons)
+            stageShadeBucketedKernel<true, true, true><<<blocks, threads>>>(ASTRORAY_PKG186_SHADE_ARGS);
+        else if (hasPrincipled && hasTexture)
+            stageShadeBucketedKernel<true, true, false><<<blocks, threads>>>(ASTRORAY_PKG186_SHADE_ARGS);
+        else if (hasPrincipled && hasPhotons)
+            stageShadeBucketedKernel<true, false, true><<<blocks, threads>>>(ASTRORAY_PKG186_SHADE_ARGS);
         else if (hasPrincipled)
-            stageShadeBucketedKernel<true, false><<<blocks, threads>>>(ASTRORAY_PKG186_SHADE_ARGS);
+            stageShadeBucketedKernel<true, false, false><<<blocks, threads>>>(ASTRORAY_PKG186_SHADE_ARGS);
+        else if (hasTexture && hasPhotons)
+            stageShadeBucketedKernel<false, true, true><<<blocks, threads>>>(ASTRORAY_PKG186_SHADE_ARGS);
         else if (hasTexture)
-            stageShadeBucketedKernel<false, true><<<blocks, threads>>>(ASTRORAY_PKG186_SHADE_ARGS);
+            stageShadeBucketedKernel<false, true, false><<<blocks, threads>>>(ASTRORAY_PKG186_SHADE_ARGS);
+        else if (hasPhotons)
+            stageShadeBucketedKernel<false, false, true><<<blocks, threads>>>(ASTRORAY_PKG186_SHADE_ARGS);
         else
-            stageShadeBucketedKernel<false, false><<<blocks, threads>>>(ASTRORAY_PKG186_SHADE_ARGS);
+            stageShadeBucketedKernel<false, false, false><<<blocks, threads>>>(ASTRORAY_PKG186_SHADE_ARGS);
         #undef ASTRORAY_PKG186_SHADE_ARGS
         cudaError_t err = cudaGetLastError();
         if (err != cudaSuccess) {


### PR DESCRIPTION
## Summary
Third application of the `if constexpr` isolation lever in `stage_advance.cu`
(after pkg157 `Deferred`, pkg178 `HasPrincipled`). Threads a `HasPhotons` axis
through `shadePathSlot` / `stageShadeBucketedKernel` (now
`<HasPrincipled, HasTexture, HasPhotons>`, 8 instantiations) and wraps the
bounce-0 `photonGridGatherKnn` 50-neighbour caustic gather in
`if constexpr (HasPhotons)`. The launcher selects the `<*,*,true>` instantiation
off the runtime `hasPhotonGrid` flag via the existing kptr ternary + shared
`ASTRORAY_PKG186_SHADE_ARGS` macro; the fleet's non-photon scenes launch
`<*,*,false>` with zero gather codegen. Follows the pkg186 pattern exactly â€” no
new kernel signature params (texture bindings stay in `__constant__ c_wfTexBinding`).

## cuobjdump resource matrix (native sm_120, post-link .pyd, all 8 instantiations)
Base = current main **e6b9f24** (includes pkg187 Principled dispersion, which the
shade kernel's `gpu_materials.h` include pulls in). REG:254-capped in every
variant â†’ occupancy identical (1 block/SM) across the board; STACK is the spill volume.

| `<P,T,Ph>` | pre-pkg184 baseline `<P,T>` | pkg184 | Î” STACK |
|---|---|---|---|
| `<F,F,false>` | 3608 | **3352** | **âˆ’256** |
| `<F,F,true>`  | 3608 | 3608 | 0 (byte-identical) |
| `<F,T,false>` | 3608 | **3352** | **âˆ’256** |
| `<F,T,true>`  | 3608 | 3608 | 0 (byte-identical) |
| `<T,F,false>` | 6616 (C2:368) | **6488** | **âˆ’128** |
| `<T,F,true>`  | 6616 (C2:368) | 6616 | 0 (byte-identical) |
| `<T,T,false>` | 6616 (C2:368) | **6488** | **âˆ’128** |
| `<T,T,true>`  | 6616 (C2:368) | 6616 | 0 (byte-identical) |

- **Every** HasPhotons=false variant is strictly below baseline (âˆ’256/âˆ’256/âˆ’128/âˆ’128 B).
- **Every** HasPhotons=true variant is byte-identical to baseline â€” turning the
  axis on reproduces the exact pre-pkg184 kernel, confirming clean isolation.
- REG:254 unchanged everywhere â†’ no occupancy change.

Note: an earlier measurement against the *pre-pkg187* base (ab9b106) showed
`<T,T,false>` regressing +256 B (register-saturated ptxas non-monotonicity). After
rebasing onto current main (pkg187 dispersion codegen), that regression is gone and
the variant now improves âˆ’128 B. Numbers above are the current-main truth.

## Perf A/B (glass-sphere caustic scene, wavefront route, 256 spp, min-of-7 with burn-in, RTX 5070 Ti)
Metric = `wavefront_stage_shade_bucketed_n7` total GPU time (`sum_ms`, deterministic
572 launches per render), via `ASTRORAY_PROFILE`.

| scene | baseline (e6b9f24) | pkg184 | Î” |
|---|---|---|---|
| **photons OFF** (launches `<F,F,false>`, âˆ’256 B) | 93.623 ms | **91.039 ms** | **âˆ’2.76 %** |
| photons ON (launches `<F,F,true>`, byte-identical) | 1045.40 ms | 1050.62 ms | +0.50 % |

The photons-ON pair is the noise-floor control (byte-identical kernel â†’ +0.50 %).
The âˆ’2.76 % non-photon win exceeds that floor and reproduced across two independent
build/measure cycles (âˆ’2.3 % pre-rebase, âˆ’2.76 % post-rebase). Photon-ON shade time
is ~11Ã— higher, confirming the gather is the expensive live set worth isolating.

## Compile-time delta
Isolated device recompile of `stage_advance.cu` (delete obj + rebuild target).
Characterized on the pre-pkg187 base ab9b106 (clean 4-vs-8, both trees available):
4 shade instantiations **57.5 s** -> 8 instantiations **98.8 s** (**+41.3 s / +72%**
on this single TU). On current main (e6b9f24; pkg187 dispersion makes the principled
kernels heavier) the pkg184 8-instantiation TU compiles in **138.3 s**; the
current-main 4-instantiation baseline tree was not retained so the exact current
delta is not recomputed, but the ~+70% doubling character holds. This is the heaviest
TU so it sits on the build critical path, yet the full guarded build completes
normally. The spec's launch-side-gating mitigation (trim HasPhotons=true x
Principled/Texture combos that rarely co-occur with caustics) remains available if the
team later wants to claw this back; not warranted now.

## Gates
- `tests/test_pkg55_c5_photon_wavefront.py` + `tests/test_gpu_caustic_parity.py`: **2 passed, 1 xpassed** (pre-existing prism xfail, unrelated).
- Broader wavefront/photon/principled/texture/dispersion sweep (photon emission/store, pkg157 firefly, pkg159 crypto, pkg178 principled+thinfilm parity, pkg186 texture parity, pkg187 dispersion): **49 passed**.
- Advisory lint: **0 new findings**.

## Algorithm sourcing
No new algorithm â€” pure register-pressure isolation of the existing pkg55-C5/pkg113
photon gather (Jensen 1996 photon map; already cited in `stage_advance.cu` and
`gpu_photon_store.h`). No physics/sampling change.

## Authorized surface
- **Spec intended:** `src/gpu/wavefront/stage_advance.cu` (the sole file named in the spec's Work section).
- **Actually changed:** `src/gpu/wavefront/stage_advance.cu` + spec Status flip. Nothing outside the spec's scope. Kernel launcher signature (`launchStageShadeBucketed`) unchanged â€” `hasPhotonGrid` was already a parameter â€” so no ABI/call-site changes and no header edits.

## Build log (last 5 lines, pkg184 @ 1abf35d, native sm_120)
```
[pkg183] verifying built CUDA arch (cuobjdump ground truth)...
[pkg183] arch-verify OK: astroray.cp313-win_amd64.pyd embeds sm_120 (embedded=[sm_120])
[pkg183] running host-only ABI canary (no GPU)...
[pkg183] canary caps: {'cpu': True, 'spectral': True, 'gpu': True, 'gpu_spectral': True, 'gpu_approximate': False, 'closure_graph': True, 'closure_count': 1, 'gpu_type': 'closure_graph', 'notes': 'spectral closure-graph GPU lowering'}
Build succeeded
```

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)
