### PR TITLE
feat(pkg188): Principled transmission colour/scalar-separation + weight-path clamp guard

### DIFF
--- a/.astroray_plan/packages/pkg188-principled-residual-spectral-consistency.md
+++ b/.astroray_plan/packages/pkg188-principled-residual-spectral-consistency.md
@@ -2,8 +2,10 @@
 
 **Pillar:** 3/5 (spectral consistency / CPU-GPU parity)
 **Track:** A
-**Status:** in-progress (Findings A+B implemented on branch `pkg188`, PR pending —
-2026-08-12; Finding C descoped to pkg194). Numbers pasted into Lessons on build.
+**Status:** done (PR #599, 2026-08-12 — Findings A+B landed: transmission
+colour/scalar separation + weight-path clamp guard, CPU+GPU; `<false>` kernel held at
+3608/254/1700; CPU/GPU parity ≤1.02, glass furnace 0.955 no-gain; residual up to ~72%
+band error on coloured-tint-over-dark-base → pkg194. Finding C descoped to pkg194.)
 **Estimated effort:** M
 **Depends on:** PR #586 (must land first); pkg168 (RGB→spectral upsampling
 parity — the fix template); pkg167 / [[rough-glass-residual-is-multiscatter]]

--- a/.astroray_plan/packages/pkg188-principled-residual-spectral-consistency.md
+++ b/.astroray_plan/packages/pkg188-principled-residual-spectral-consistency.md
@@ -184,3 +184,51 @@ a phantom ~313-line diff. Repaired by restoring HEAD and re-applying the hunks v
 byte-level Python replacement with CRLF-matched new lines, leaving the scattered
 LF-only lines untouched. Final diff: real hunks only (`git diff --ignore-cr-at-eol`
 == `git diff`). `principled.cpp` is uniform LF and was unaffected.
+
+---
+
+## Hardware verification 2026-08-13 (PR #599, independent verifier pass)
+
+**Hardware:** RTX 5070 Ti (sm_120 / Blackwell, compute_cap 12.0), Windows 11
+Enterprise 10.0.26200, NVIDIA driver 610.47 (KMD 610.47, CUDA UMD 13.3),
+CUDA Toolkit v12.8 (nvcc). Build: MSVC 14.44.35207 (VS2022 BuildTools),
+VS-generator `build_cuda` (root wrapper). CMakeCache confirms
+`ASTRORAY_CUDA_ARCHS=120` / `CMAKE_CUDA_ARCHITECTURES=120`.
+
+**Contamination guard:** worktree HEAD `8a05599a4a2bb01d37673887c2862efd480ebf47`
+verified against PR #599's `headRefOid` before building — match.
+
+**Build note:** the first `cmd /c build_cuda_worktree.bat ...` invocation from
+Bash hit the known false-green pattern (banner-only output, exit 0, nothing
+built); rebuilt successfully via PowerShell. pkg183 guard on the real build:
+header-hash stamp `sha=8a05599a4a2b`, `cuobjdump --list-elf` arch-verify OK
+(embeds `sm_120` only), host-only ABI canary caps
+`{'cpu': True, 'spectral': True, 'gpu': True, 'gpu_spectral': True,
+'gpu_approximate': False, 'closure_graph': True, 'closure_count': 1}`.
+**Anomaly investigated and dismissed:** the freshly-built `.pyd`'s mtime was
+~11 min *older* than HEAD's commit timestamp — the OneDrive-mtime pattern
+([[incremental-build-signature-staleness]]). Discharged by re-running the
+canary + arch-verify a second time after GPU-lock reacquisition (both still
+pass) and confirming `astroray.__file__` resolves to
+`build_cuda\Release\astroray.cp313-win_amd64.pyd` under this worktree, not a
+shadow copy.
+
+### Gate table (measured vs claimed)
+
+| # | Gate | Claimed | Measured | Verdict |
+|---|------|---------|----------|---------|
+| 1 | Register gate: `cuobjdump -res-usage` post-link on the final `.pyd`, all 4 `stageShadeBucketedKernel<HasPrincipled,HasTexture>` instantiations | `<F,F>`/`<F,T>` = REG254/STACK3608/CONST[0]1700; `<T,F>`/`<T,T>` = STACK6616, +CONST[2]344 | `<Lb0,Lb0>` = `REG:254 STACK:3608 CONSTANT[0]:1700`; `<Lb0,Lb1>` = `REG:254 STACK:3608 CONSTANT[0]:1700`; `<Lb1,Lb0>` = `REG:254 STACK:6616 CONSTANT[2]:344 CONSTANT[0]:1700`; `<Lb1,Lb1>` = `REG:254 STACK:6616 CONSTANT[2]:344 CONSTANT[0]:1700` — **exact match on all 4** | **PASS** |
+| 2 | `tests/test_pkg188_transmission_colour_upsample_parity.py`, CPU/GPU parity ≤1.02 on tinted glass + coat-over-tinted-glass | 3/3 pass, parity ≤1.02 | 3/3 **PASSED**. `glass_tint_r0.15`: R/G/B mean ratios 1.0013/1.0023/1.0035. `glass_tint_r0.40`: 1.0070/1.0113/1.0168 (max observed ratio, median-B, = **1.0197**). `coat_over_tinted_glass`: 1.0067/1.0009/1.0048. All within the test's [0.95,1.05] band and within the claimed ≤1.02 bound. | **PASS** |
+| 3 | GPU glass furnace, LINEAR (`apply_gamma=False`), ~0.955, no energy gain (upper-bound assert present) | ~0.955 | `test_pkg178_principled_gpu_furnace.py`: 4/4 **PASSED**. glass(r=0.1) mean=0.9867 ratio=0.9919; glass(r=0.4) mean=0.9499 ratio=**0.9549** (matches "~0.955" claim). `_assert_band` enforces both `mat <= ref*ceil` (ceil=1.05, energy-GAIN guard) and `mat >= ref*floor` — confirmed present and passing, not floor-only. | **PASS** |
+| 4 | Regression slice (implementer claims 179 green + 35 chi²; representative subset: pkg178 parity, glass caustic family, thin-film gates) | green | Ran 13 files (`test_pkg178_principled_gpu_cpu_parity`, `test_pkg178_thinfilm_gpu_cpu_parity`, `test_glass_sphere_caustic`, `test_gpu_caustic_parity`, `test_prism_caustic_rainbow`, `test_sms_caustic_spectral`, `test_sms_caustic_validation`, `test_thin_film_pr1`, `test_thin_film_pr2`, `test_thin_film_ab_harness`, `test_principled_bsdf`, `test_dielectric_glass_furnace`, `test_disney_rough_glass_furnace`): **65 passed, 1 xpassed in 23.21s**. The 1 xpass is `test_gpu_prism_rainbow_parity` (pkg189/dispersion territory, untouched by this PR's diff — pre-existing xfail-passes-anyway, not a pkg188 regression). Zero failures. | **PASS** |
+| 5 | Visual: CPU vs GPU tinted-glass sphere render, colour/hue match | no hue shift | Rendered `glass_tint_r0.15` and `coat_over_tinted_glass` (256×256, 256spp, seed 188188, `apply_gamma=True`, same scene as the parity test) both legs. `glass_tint_r0.15`: mean cpu=0.4242 gpu=0.4243 — visually identical warm terracotta hue. `coat_over_tinted_glass`: mean cpu=0.3046 gpu=0.3053 — visually identical dark blue-teal hue. No fireflies, no banding, no magenta/black NaN pixels (explicit `isnan`/`isinf` check on raw float buffers: 0/0 both legs, both scenes). No mode regression. PNGs at `test_results/pkg188_visual_*_{cpu,gpu}.png` (gitignored, not committed — reproducible via the parity-test scene setup). | **PASS** |
+| 6 | Line-ending: `gpu_materials.h` diff is real hunks (~23/8), not a rewrite | ~23/8 | `git diff main...HEAD --stat -- include/astroray/gpu_materials.h`: `1 file changed, 23 insertions(+), 8 deletions(-)` — exact match, phantom-diff repair held. | **PASS** |
+
+**Overall verdict: mergeable on HW evidence.** All 6 gates PASS with
+independently re-measured numbers (register gate via a fresh `cuobjdump
+-res-usage` pass, parity/furnace/regression via fresh pytest runs, visual via
+an independently-written render matching the parity test's scene). No gate
+was relaxed; nothing needed escalation to `gate-failure-reviewer`. pkg194
+follow-up (Finding C: thin-wall per-λ R'/T' + tinted-layer colour×colour
+spectral-carry) remains open as documented in this spec's prior Lessons
+section — out of scope for this verification pass.

--- a/.astroray_plan/packages/pkg188-principled-residual-spectral-consistency.md
+++ b/.astroray_plan/packages/pkg188-principled-residual-spectral-consistency.md
@@ -2,8 +2,8 @@
 
 **Pillar:** 3/5 (spectral consistency / CPU-GPU parity)
 **Track:** A
-**Status:** open (found 2026-08-12 during the post-pkg178/pkg182 spectral-
-integration audit; **enhancement tier — start after PR #586 lands**)
+**Status:** in-progress (Findings A+B implemented on branch `pkg188`, PR pending —
+2026-08-12; Finding C descoped to pkg194). Numbers pasted into Lessons on build.
 **Estimated effort:** M
 **Depends on:** PR #586 (must land first); pkg168 (RGB→spectral upsampling
 parity — the fix template); pkg167 / [[rough-glass-residual-is-multiscatter]]
@@ -109,3 +109,76 @@ regression; the fix was `template<bool HasPrincipled>` if-constexpr isolation,
   this package is transmission + lobe-assembly + delta-event `fSpectral` only.
 - **No start before PR #586 lands** — this is explicitly enhancement-tier and
   sequenced behind it to avoid conflicting edits in `principled.cpp`.
+
+---
+
+## Lessons (2026-08-12, implementation)
+
+**Finding A was real, not already-fixed.** The film-off transmission spectral eval
+already had a `max(rgb, 1.0f)` "maxc guard", so at first glance it looked handled.
+But the `1.0f` FLOOR is a *clamp/energy-gain* guard, not a magnitude normalizer: for
+a sub-unit BSDF value (`rgb < 1`, the common case) `maxc == 1` and the code upsampled
+`colour · achromatic_scalar` directly — the exact JH magnitude-nonlinearity
+([[spectral-upsample-nonlinearity-scaled-bsdf]]). The fix separates the chromatic
+reflectance colour from the achromatic geometry/Fresnel scalar (incl. the glass
+eta², which now lives entirely in `scalar` and never touches the upsample argument):
+`upsample(colour)·scalar`, with the `max(colour,1)` clamp-guard retained only for a
+(never-reached here) colour>1 case. Done via an optional `(colour,scalar)` out-param
+on `transmissionEvalRGB`/`gpu_pr_transmissionEval` so the RGB pipeline is byte-
+unchanged (nullptr default). CPU + GPU twin.
+
+**Finding B's clamp guard is a defensive no-op — proven, not assumed.** Traced every
+weight-carrying lobe in `assembleLobes`: the running `weight` is seeded at 1 and only
+ever multiplied by factors ≤1 (baseColor, tints, layering directional albedos,
+metallic/transmission/coat scalars), so `L.weight ≤ 1` always and `wMax == 1`. The
+added `max(...,1)` guard on the `wSpec` upsample never bites today; it locks the
+invariant against any future >1 weight and satisfies the acceptance criterion.
+
+**The deep Finding B (colour×colour product in `assembleLobes`) was NOT fixed and is
+descoped to pkg194.** The magnitude class is handled (Finding A + the guard); the
+residual is a *colour×colour* nonlinearity — `upsample(a·b) ≠ upsample(a)·upsample(b)`
+— that only appears when TWO layering factors are both chromatic (a coloured coat
+Beer / sheen / specular tint stacked over a coloured base). Fixing it correctly
+requires carrying per-lobe *spectral* state through the per-shade device
+`assembleLobes`, i.e. adding per-hit spectral live state — precisely the class
+[[closure-graph-lobe-count-spills-fused-kernel]] warns spilled the fused shade kernel
+(+52% non-Principled regression). That is register-hostile and forbidden by this
+package's hard `<false>`=3608/254/1700 constraint, so it is deferred with an
+empirical register-probe-first plan in pkg194.
+
+**Quantified residual (CPU JH upsample, 380–780nm/5nm, `_cpu_rgb_upsample_batch`):**
+band-integrated relative error of `upsample(a·b)` (current) vs
+`upsample(a)·upsample(b)` (spectrally-correct per-layer product) for representative
+tinted-layer stacks:
+
+| stack (tint a / base b)            | band relErr | max per-λ relErr |
+|------------------------------------|-------------|------------------|
+| sheen [1,.7,.8] / dark [.1,.1,.12] | **72.5%**   | 387%             |
+| saturated coat [.3,.7,1] / mid [.6,.5,.4] | **34.9%** | 94%           |
+| deep coat [.2,.4,.9] / bright [.85,.8,.75] | 20.1%   | 72%             |
+| specular [.9,.55,.25] / neutral [.7,.7,.7] | 5.4%    | 19%             |
+
+**This is SURPRISINGLY LARGE and raises the pkg194 follow-up's priority** (flagged
+per the dispatch's >5% rule). Interpretation: the two forms are the RGB-product
+approximation of layering (`upsample(a·b)`, what the code does — integrates to the
+RGB product `a·b` under white light) vs the spectrally-correct per-layer reflectance
+product (`upsample(a)·upsample(b)`). They diverge most for SATURATED tints over
+DARK/MID bases, where the JH sigmoid is most nonlinear. The **common case is
+unaffected**: a WHITE tint gives `upsample([1,1,1]·b) == upsample(b)` (0% error), so
+only materials with a genuinely COLOURED coat/sheen/specular tint stacked over a
+coloured base are hit. The magnitude class (achromatic scalar × colour) that Finding
+A/B fixed is orthogonal and fully resolved; this residual is the colour×colour class,
+which needs the register-gated spectral-carry restructure (pkg194 Item 1).
+
+**Finding C descoped to pkg194** (thin-wall per-λ R'/T' + the tinted-layer
+spectral-carry above). One Finding-C sub-item was found ALREADY CORRECT and must not
+be re-audited: GPU delta Principled events DO fill `fSpectral`, via the generic
+eta²-clamp guard at `gpu_materials.h:3268-3273` (mirrors the CPU delta branch). The
+spec's worry that they "never fill fSpectral" was stale.
+
+**Line-ending hazard (as warned):** `gpu_materials.h` has MIXED endings in HEAD
+(2992 CRLF + 313 LF lines). The Edit tool rewrote the whole file to uniform CRLF →
+a phantom ~313-line diff. Repaired by restoring HEAD and re-applying the hunks via
+byte-level Python replacement with CRLF-matched new lines, leaving the scattered
+LF-only lines untouched. Final diff: real hunks only (`git diff --ignore-cr-at-eol`
+== `git diff`). `principled.cpp` is uniform LF and was unaffected.

--- a/.astroray_plan/packages/pkg194-principled-tinted-layer-spectral-carry-and-thinwall-perlambda.md
+++ b/.astroray_plan/packages/pkg194-principled-tinted-layer-spectral-carry-and-thinwall-perlambda.md
@@ -1,0 +1,107 @@
+# pkg194 — Principled tinted-layer spectral-carry + thin-wall per-λ R'/T' (pkg188 Finding C follow-up)
+
+**Pillar:** 3/5 (spectral consistency / CPU-GPU parity)
+**Track:** A
+**Status:** open (filed 2026-08-12 as the pkg188 Finding-C descope; enhancement tier)
+**Estimated effort:** L (register-gate probe up front — may be blocked)
+**Depends on:** pkg188 (Findings A+B landed — transmission colour/scalar separation +
+weight-path clamp guard); pkg168 (RGB→spectral upsample parity template);
+[[closure-graph-lobe-count-spills-fused-kernel]] (the register-spill hazard this
+package must probe before committing to the restructure).
+
+> **Concurrency note:** several agents were filing specs when this was created; if
+> the number `pkg194` collides with another spec, renumber to the next free slot.
+
+---
+
+## Why this exists
+
+pkg188 fixed the two *cheap, correct-in-the-common-case* residual spectral gaps in
+the native Principled BSDF (Finding A: film-off transmission upsampled the RGB
+product; Finding B: missing weight-path clamp guard). It **explicitly descoped**
+two items that require either a register-hostile restructure or genuinely new
+per-λ work. This package carries them.
+
+### Item 1 — tinted-layer `assembleLobes` spectral-carry (the deep Finding B)
+
+`assembleLobes` (`plugins/materials/principled.cpp`) bakes chromatic, view-dependent
+attenuation (coat Beer tint, sheen tint, specular-tint layering albedos) × the
+lobe reflectance colour into a single RGB `L.weight`, which is then upsampled once
+in `evalLobeSpectral` (`wSpec = upsample(L.weight/wMax)·wMax` after pkg188). When two
+of those factors are BOTH chromatic (e.g. a coloured coat Beer tint over a coloured
+base), this is `upsample(a·b) ≠ upsample(a)·upsample(b)` — a colour×colour JH
+nonlinearity that magnitude-normalization does **not** remove (it only fixes the
+achromatic-scalar/magnitude class, which pkg188 handled).
+
+**pkg188 measured this residual** (CPU JH upsample, 380–780nm/5nm grid,
+`_cpu_rgb_upsample_batch`, MODE_ALBEDO): band-integrated relative error of
+`upsample(a·b)` vs `upsample(a)·upsample(b)` for representative tinted-layer stacks
+was **up to ~72%** (coloured sheen over dark base), ~35% (saturated coat over mid
+base), ~20% (deep coat over bright base), ~5% (specular tint over neutral base). This
+is **surprisingly large** — larger than the sub-5% pkg188 expected — which is why
+this follow-up is filed with elevated priority rather than as a nicety. It is only
+reachable on materials with a *coloured* coat/sheen/specular tint stacked over a
+*coloured* base; the common case (white tints) is exactly 0% (`upsample([1,1,1]·b) ==
+upsample(b)`). See the pkg188 PR/Lessons table.
+
+**The fix is register-hostile.** Correctly upsampling each colour separately and
+multiplying in the spectral domain means carrying per-lobe *spectral* state through
+`assembleLobes` (which runs per-shade on device, re-assembled because it is
+view-dependent). Adding per-hit spectral live state is exactly the class of change
+[[closure-graph-lobe-count-spills-fused-kernel]] warns spilled the fused shade
+kernel (+52% non-Principled regression). pkg188's live-state analysis: the running
+`weight` is `Vec3`; a spectral carry would widen it to `kSpectrumSamples` floats per
+tracked factor.
+
+**Required approach (do this FIRST, before any implementation):**
+1. Empirically probe the register cost. Prototype the spectral-carry inside the
+   `if constexpr (HasPrincipled)` branch ONLY, build native-sm_120, and read the
+   post-link `<false>` AND `<true>` `stageShadeBucketed` specialization
+   STACK/REG/CONSTANT via `cuobjdump` (NOT `ptxas -v` —
+   [[wavefront-shade-kernels-register-saturated]]). The HARD gate: `<false>` must
+   stay at **STACK 3608 / REG 254 / CONSTANT[0] 1700**; `<true>` must not regress
+   non-Principled perf (min-of-N, burn-in per [[gpu-perf-ab-clock-drift]]).
+2. If the probe spills either specialization, **STOP and report** — the value
+   (a sub-X% band error on an uncommon coloured-coat-over-coloured-base material)
+   almost certainly does not justify a shared-kernel regression. Prefer a CPU-only
+   fix (CPU has no register gate) with the GPU twin left on the pkg188 behaviour and
+   the divergence documented, OR park the item.
+
+### Item 2 — thin-wall R'/T' per-λ native
+
+Thin-wall (`thin_wall=true`) glass computes the analytic R'/T' split per-RGB-channel
+(`thinGlassFresnelRGB`, `principled.cpp`) with a film-on RGB sensitivity path, not
+per-λ native. Bring it to per-λ native (the pkg163/pkg182 discipline) so the
+thin-glass reflect/transmit lobes evaluate Fresnel per wavelength. Mirror on the GPU
+twin (`gpu_materials.h` `gpu_pr_*` thin-glass functions) inside `HasPrincipled`.
+
+---
+
+## NOT in scope / already correct — do not re-audit
+
+- **GPU delta Principled `fSpectral`** — pkg188 verified this is ALREADY correct:
+  delta (smooth-glass) Principled events fill `fSpectral` via the generic
+  eta²-clamp guard at `gpu_materials.h:3268-3273` (factor >1 magnitude, upsample the
+  normalized tint), mirroring `PrincipledPlugin::sampleSpectral`'s delta branch. The
+  pkg188 spec's Finding-C worry that they "never fill fSpectral" was stale. Do NOT
+  reopen this.
+- Transmission film-off colour/scalar separation and the weight-path clamp guard —
+  landed in pkg188 (Findings A+B).
+
+## Acceptance criteria
+
+- [ ] Item 1: register-gate probe run and reported FIRST; restructure implemented
+      only if `<false>` stays 3608/254/1700 and `<true>` shows no non-Principled
+      regression — otherwise a documented CPU-only fix or an explicit park, with the
+      cuobjdump evidence in the PR.
+- [ ] Item 1: on a coloured-coat-over-coloured-base scene, the tinted-layer band
+      error is measurably reduced vs the pkg188 baseline (report the before/after
+      numbers from the same `_cpu_rgb_upsample_batch` harness).
+- [ ] Item 2: thin-wall R'/T' evaluated per-λ on CPU + GPU twin; parity test locks
+      CPU↔GPU; furnace energy conserves (linear, bounded above).
+
+## Hard non-goals
+
+- **No lobe-array shrink** to buy register room (pkg188/pkg178 rule — if-constexpr
+  isolation, never shrink shared state).
+- **No reopening** the GPU delta `fSpectral` path (already correct).

--- a/include/astroray/gpu_materials.h
+++ b/include/astroray/gpu_materials.h
@@ -2088,8 +2088,13 @@ __device__ inline float gpu_pr_thinGlassTransmitPdf(const GPrincipledLobe& L, co
 }
 
 // --- Transmission rough glass (principled.cpp:406-488) ---------------------
+// pkg188 Finding A (GPU twin of principled.cpp transmissionEvalRGB): film-OFF
+// branches optionally split into chromatic reflectance COLOUR + achromatic SCALAR so
+// the spectral caller upsamples the colour at natural magnitude and applies the
+// scalar (incl. glass eta²) post-upsample. RGB callers pass nullptr → unchanged.
 __device__ inline GVec3 gpu_pr_transmissionEval(const GPrincipledClosure& c, const GPrincipledLobe& L,
-                                                const GHitRecord& rec, const GVec3& wo, const GVec3& wi) {
+                                                const GHitRecord& rec, const GVec3& wo, const GVec3& wi,
+                                                GVec3* outColour = nullptr, float* outScalar = nullptr) {
     if (L.isDelta) return GVec3(0.f);  // delta handled in sampling
     float cosO = rec.normal.dot(wo), cosI = rec.normal.dot(wi);
     bool entering = rec.frontFace;
@@ -2116,6 +2121,7 @@ __device__ inline GVec3 gpu_pr_transmissionEval(const GPrincipledClosure& c, con
         }
         float F = gpu_pr_fresnelDielectric(HdotO, 1.f, L.ior);
         float fr = D * G * F / (4.f * cosO * cosI + 1e-8f) * cosI;
+        if (outColour) { *outColour = L.weight * c.specularTint; *outScalar = fr; }
         return L.weight * c.specularTint * fr;
     }
     if (cosO * cosI >= 0.f) return GVec3(0.f);
@@ -2147,6 +2153,7 @@ __device__ inline GVec3 gpu_pr_transmissionEval(const GPrincipledClosure& c, con
     ft /= (etap * etap);
     float scale = ft * fabsf(cosI) * gpu_ggxGlassCompensationFactor(L.roughness, etap, fabsf(cosO));
     GVec3 res = L.weight * gpu_pr_sqrtColor(c.color) * scale;
+    if (outColour) { *outColour = L.weight * gpu_pr_sqrtColor(c.color); *outScalar = scale; }
     return gvec3_max(res, GVec3(0.f));
 }
 __device__ inline float gpu_pr_transmissionPdf(const GPrincipledLobe& L, const GHitRecord& rec,
@@ -2189,7 +2196,9 @@ __device__ inline GSampledSpectrum gpu_pr_transmissionEvalSpectral(
     float etap = entering ? L.ior : (1.f / L.ior);
     float filmIor = entering ? c.thinFilmIor : c.thinFilmIor / L.ior;
     float F0real = gpu_pr_F0_from_ior(etap);
-    GSampledSpectrum wSpec = gpu_rgbToSampledSpectrum(L.weight, wl, GSPEC_RGB_ALBEDO);
+    // pkg188 Finding B: weight-path clamp-guard (see gpu_pr_evalLobeSpectral; no-op ≤1).
+    float wMax = fmaxf(fmaxf(fmaxf(L.weight.x, L.weight.y), L.weight.z), 1.f);
+    GSampledSpectrum wSpec = gpu_rgbToSampledSpectrum(L.weight * (1.f / wMax), wl, GSPEC_RGB_ALBEDO) * wMax;
     GSampledSpectrum tintSpec = gpu_rgbToSampledSpectrum(c.specularTint, wl, GSPEC_RGB_ALBEDO);
     if (cosO > 0.f && cosI > 0.f) {  // reflection sub-lobe
         GVec3 wm = (wo + wi).normalized();
@@ -2362,7 +2371,10 @@ __device__ inline GSampledSpectrum gpu_pr_evalLobeSpectral(const GPrincipledClos
                                                            const GHitRecord& rec, const GVec3& wo, const GVec3& wi,
                                                            const GSampledWavelengths& wl) {
     float nl = rec.normal.dot(wi), nv = rec.normal.dot(wo);
-    GSampledSpectrum wSpec = gpu_rgbToSampledSpectrum(L.weight, wl, GSPEC_RGB_ALBEDO);
+    // pkg188 Finding B: weight-path clamp-guard (twin of principled.cpp
+    // evalLobeSpectral). Defensive no-op at weight ≤ 1 (wMax==1).
+    float wMax = fmaxf(fmaxf(fmaxf(L.weight.x, L.weight.y), L.weight.z), 1.f);
+    GSampledSpectrum wSpec = gpu_rgbToSampledSpectrum(L.weight * (1.f / wMax), wl, GSPEC_RGB_ALBEDO) * wMax;
     switch (L.kind) {
         case GPR_SUBSURFACE:  // approximate SSS = Lambert (D2=a)
         case GPR_DIFFUSE: {
@@ -2425,12 +2437,15 @@ __device__ inline GSampledSpectrum gpu_pr_evalLobeSpectral(const GPrincipledClos
             // pkg178 Stage 4 PR-3: with the film ON, evaluate F per-λ natively
             // (pkg163 discipline); OFF path is the exact Stage-3b upsample hack.
             if (gpu_pr_filmActive(c)) return gpu_pr_transmissionEvalSpectral(c, L, rec, wo, wi, wl);
-            // Colour upsampled; achromatic geometry/Fresnel scalar per-λ (principled.cpp:664-672).
-            GVec3 rgb = gpu_pr_transmissionEval(c, L, rec, wo, wi);
+            // pkg188 Finding A (twin of principled.cpp Transmission case): upsample the
+            // reflectance COLOUR at natural magnitude, apply the achromatic scalar
+            // (incl. eta²) post-upsample — not the RGB product.
+            GVec3 colour(0.f);
+            float scalar = 0.f;
+            GVec3 rgb = gpu_pr_transmissionEval(c, L, rec, wo, wi, &colour, &scalar);
             if (rgb.x <= 0.f && rgb.y <= 0.f && rgb.z <= 0.f) return GSampledSpectrum(0.f);
-            float maxc = fmaxf(fmaxf(fmaxf(rgb.x, rgb.y), rgb.z), 1.f);
-            GVec3 tint = rgb * (1.f / maxc);
-            return gpu_rgbToSampledSpectrum(tint, wl, GSPEC_RGB_ALBEDO) * maxc;
+            float maxc = fmaxf(fmaxf(fmaxf(colour.x, colour.y), colour.z), 1.f);
+            return gpu_rgbToSampledSpectrum(colour * (1.f / maxc), wl, GSPEC_RGB_ALBEDO) * (maxc * scalar);
         }
         case GPR_THINGLASS_REFLECT: {  // GGX reflection, constant F=R' (in weight)
             if (nl <= 0.f || nv <= 0.f) return GSampledSpectrum(0.f);

--- a/plugins/materials/principled.cpp
+++ b/plugins/materials/principled.cpp
@@ -1115,8 +1115,17 @@ class PrincipledPlugin : public Material {
     // Transmission rough glass (Walter 2007 / pbrt-v4, disney.cpp) — reflection
     // tinted by specular_tint (Stage-1 white default), transmission by
     // sqrt(base_color) (Cycles generalized_schlick transmission_tint).
+    // pkg188 Finding A: the film-OFF branches optionally split their result into the
+    // chromatic reflectance COLOUR and the achromatic geometric/Fresnel SCALAR (RGB
+    // value = colour·scalar). The spectral caller upsamples the colour at its natural
+    // magnitude and applies the scalar post-upsample, instead of upsampling the
+    // product (Jakob-Hanika is magnitude-nonlinear — the glass eta² and the D·G·F
+    // geometry were being baked into the upsample argument, exactly the
+    // [[spectral-upsample-nonlinearity-scaled-bsdf]] / pkg168 bug class). RGB pipeline
+    // callers pass nullptr and get the unchanged product.
     Vec3 transmissionEvalRGB(const Lobe& L, const HitRecord& rec, const Vec3& wo,
-                             const Vec3& wi) const {
+                             const Vec3& wi, Vec3* outColour = nullptr,
+                             float* outScalar = nullptr) const {
         if (L.isDelta) return Vec3(0);  // delta handled in sampling
         float cosO = rec.normal.dot(wo), cosI = rec.normal.dot(wi);
         bool entering = rec.frontFace;
@@ -1145,6 +1154,7 @@ class PrincipledPlugin : public Material {
             }
             float F = fresnelDielectric(HdotO, 1.0f, L.ior);
             float fr = D * G * F / (4.0f * cosO * cosI + 1e-8f) * cosI;  // brdf·cosI
+            if (outColour) { *outColour = L.weight * specularTint_; *outScalar = fr; }
             return L.weight * specularTint_ * fr;
         }
         if (cosO * cosI >= 0.0f) return Vec3(0);
@@ -1177,6 +1187,7 @@ class PrincipledPlugin : public Material {
         ft /= (etap * etap);
         float scale = ft * std::abs(cosI) * ggxGlassComp(etap, std::abs(cosO));
         Vec3 res = L.weight * sqrtColor(baseColor_) * scale;
+        if (outColour) { *outColour = L.weight * sqrtColor(baseColor_); *outScalar = scale; }
         return Vec3::max(res, Vec3(0.0f));
     }
 
@@ -1194,7 +1205,9 @@ class PrincipledPlugin : public Material {
         float etap = entering ? L.ior : (1.0f / L.ior);
         float filmIor = entering ? thinFilmIor_ : thinFilmIor_ / L.ior;
         float F0real = F0_from_ior(etap);
-        astroray::SampledSpectrum wSpec = upsample(L.weight, lam);
+        // pkg188 Finding B: weight-path clamp-guard (see evalLobeSpectral; no-op at ≤1).
+        float wMax = std::max({L.weight.x, L.weight.y, L.weight.z, 1.0f});
+        astroray::SampledSpectrum wSpec = upsample(L.weight * (1.0f / wMax), lam) * wMax;
         astroray::SampledSpectrum tintSpec = upsample(specularTint_, lam);
         if (cosO > 0.0f && cosI > 0.0f) {  // reflection sub-lobe
             Vec3 wm = (wo + wi).normalized();
@@ -1657,7 +1670,16 @@ public:
                                                const Vec3& wo, const Vec3& wi,
                                                const astroray::SampledWavelengths& lam) const {
         float nl = rec.normal.dot(wi), nv = rec.normal.dot(wo);
-        astroray::SampledSpectrum wSpec = upsample(L.weight, lam);
+        // pkg188 Finding B: weight-path clamp-guard. upsample() clamps its argument to
+        // [0,1], so a weight component >1 would silently lose energy to the JH ALBEDO
+        // LUT (the [[rough-glass-residual-is-multiscatter]] clamp class). Factor the >1
+        // magnitude out and re-apply post-upsample. In practice the running layering
+        // weight is seeded at 1 and only multiplied by factors ≤1 (baseColor, tints,
+        // layering albedos, metallic/transmission scalars — all ≤1), so wMax==1 and
+        // this is a defensive no-op today; it locks the invariant against any future
+        // >1 weight.
+        float wMax = std::max({L.weight.x, L.weight.y, L.weight.z, 1.0f});
+        astroray::SampledSpectrum wSpec = upsample(L.weight * (1.0f / wMax), lam) * wMax;
         switch (L.kind) {
             case LobeKind::Subsurface:  // approximate SSS = Lambert (D2=a)
             case LobeKind::Diffuse: {
@@ -1722,13 +1744,21 @@ public:
                 // pkg178 Stage 4 PR-1: with the film ON, evaluate F per-λ natively
                 // (pkg163 discipline); OFF path is the exact Stage-3b upsample hack.
                 if (filmActive()) return transmissionEvalSpectral(L, rec, wo, wi, lam);
-                // Colour upsampled; achromatic geometry/Fresnel scalar per-λ (native).
-                Vec3 rgb = transmissionEvalRGB(L, rec, wo, wi);
+                // pkg188 Finding A: upsample the reflectance COLOUR at its natural
+                // magnitude and apply the achromatic geometry/Fresnel scalar (incl. the
+                // glass eta² in `scalar`) AFTER the upsample. Previously the whole RGB
+                // product was upsampled with a max(...,1) floor, so for the sub-unit
+                // BSDF value the floor was 1 and the achromatic scalar was baked into
+                // the upsample argument — the JH magnitude-nonlinearity bug. The maxc
+                // clamp-guard here only bites if the colour itself exceeds 1 (it never
+                // does: colour = weight·tint ≤ 1); the eta² lives in `scalar`.
+                Vec3 colour(0.0f);
+                float scalar = 0.0f;
+                Vec3 rgb = transmissionEvalRGB(L, rec, wo, wi, &colour, &scalar);
                 if (rgb.x <= 0.0f && rgb.y <= 0.0f && rgb.z <= 0.0f)
                     return astroray::SampledSpectrum(0.0f);
-                float maxc = std::max({rgb.x, rgb.y, rgb.z, 1.0f});
-                Vec3 tint = rgb * (1.0f / maxc);
-                return upsample(tint, lam) * maxc;
+                float maxc = std::max({colour.x, colour.y, colour.z, 1.0f});
+                return upsample(colour * (1.0f / maxc), lam) * (maxc * scalar);
             }
             case LobeKind::ThinGlassReflect: {  // GGX reflection, constant F=R' (in weight)
                 if (nl <= 0.0f || nv <= 0.0f) return astroray::SampledSpectrum(0.0f);

--- a/tests/test_pkg188_transmission_colour_upsample_parity.py
+++ b/tests/test_pkg188_transmission_colour_upsample_parity.py
@@ -1,0 +1,136 @@
+"""pkg188 — Principled transmission colour/scalar-separation CPU<->GPU parity.
+
+Finding A rewrote the film-OFF transmission spectral eval so the chromatic
+reflectance COLOUR is upsampled at its natural magnitude and the achromatic
+geometry/Fresnel scalar (incl. the glass eta^2) is applied AFTER the upsample,
+instead of upsampling the whole RGB product with a max(...,1) floor (which, for a
+sub-unit BSDF value, upsampled colour*scalar directly — the Jakob-Hanika
+magnitude-nonlinearity bug pkg168/pkg167 already fixed elsewhere). Finding B added
+the weight-path clamp-guard on the same eval.
+
+Both the CPU eval (principled.cpp) and its device twin (gpu_materials.h) got the
+identical rewrite. The risk this file guards is that the two legs drift out of
+lockstep — a monolithic-BSDF twin divergence, exactly the pkg141/160/163/168/170
+bug class. `path_tracer` is spectral-first, so a plain render() exercises the
+spectral eval directly.
+
+The materials use a SATURATED transmission tint (red-orange glass), which is where
+the JH magnitude-nonlinearity has the largest effect, plus a coat-over-tinted-base
+layered case that drives a chromatic running `weight` through the guarded path.
+
+CUDA-gated: the building/verifying LEAD runs this on the RTX box and pastes the
+per-channel ratios into the PR (commands in the footer).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+
+try:
+    import astroray
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray not built")
+
+if AVAILABLE and not astroray.__features__.get("cuda", False):
+    pytest.skip(
+        "CUDA feature not in this build -- pkg188 transmission parity needs the "
+        "RTX box (LEAD runs this).",
+        allow_module_level=True,
+    )
+
+WIDTH = HEIGHT = 48
+SAMPLES = 256
+MAX_DEPTH = 6
+SEED = 188188
+
+# Saturated red-orange glass tint: sqrt(base_color) tints the transmission lobe,
+# so a strongly chromatic base is the maximal Finding-A signal.
+GLASS_TINT = [0.85, 0.22, 0.10]
+BACKGROUND = [0.40, 0.45, 0.55]
+
+RATIO_LOW = 0.95
+RATIO_HIGH = 1.05
+
+CASES = [
+    ("glass_tint_r0.15",
+     GLASS_TINT, {"metallic": 0.0, "transmission_weight": 1.0, "ior": 1.5, "roughness": 0.15}),
+    ("glass_tint_r0.40",
+     GLASS_TINT, {"metallic": 0.0, "transmission_weight": 1.0, "ior": 1.5, "roughness": 0.40}),
+    # Coat over a tinted transmissive base: the coat Beer tint makes the running
+    # layering `weight` chromatic before it reaches the transmission lobe, so this
+    # row exercises the Finding-B weight-path guard together with Finding A.
+    ("coat_over_tinted_glass",
+     GLASS_TINT, {"metallic": 0.0, "transmission_weight": 0.8, "ior": 1.5, "roughness": 0.25,
+                  "coat_weight": 1.0, "coat_roughness": 0.1, "coat_tint": [0.3, 0.7, 1.0]}),
+]
+
+
+def _make_scene(use_gpu: bool, color, params: dict):
+    r = astroray.Renderer()
+    r.set_background_color(BACKGROUND)
+    mat = r.create_material("principled", color, params)
+    r.add_sphere([0.0, 0.0, 0.0], 0.9, mat)
+    # Full-frame coverage (pkg160/pkg178 framing): every primary ray hits the sphere.
+    r.setup_camera([0.0, 0.0, 1.35], [0.0, 0.0, 0.0], [0.0, 1.0, 0.0],
+                   60.0, WIDTH / HEIGHT, 0.0, 1.35, WIDTH, HEIGHT)
+    r.set_integrator("path_tracer")
+    r.set_integrator_param("max_depth", MAX_DEPTH)
+    if use_gpu:
+        r.set_use_gpu(True)
+    return r
+
+
+def _render(use_gpu: bool, color, params: dict) -> np.ndarray:
+    r = _make_scene(use_gpu=use_gpu, color=color, params=params)
+    r.set_seed(SEED)
+    # 4th positional arg is applyGamma -- False keeps both legs linear.
+    return np.asarray(r.render(SAMPLES, MAX_DEPTH, None, False), dtype=np.float64)
+
+
+@pytest.mark.parametrize("label,color,params", CASES, ids=[c[0] for c in CASES])
+def test_pkg188_transmission_gpu_cpu_parity(label, color, params):
+    gpu = _render(use_gpu=True, color=color, params=params)
+    cpu = _render(use_gpu=False, color=color, params=params)
+
+    assert gpu.shape == (HEIGHT, WIDTH, 3)
+    assert cpu.shape == (HEIGHT, WIDTH, 3)
+    assert np.all(np.isfinite(gpu)), "GPU render produced NaN/Inf"
+    assert np.all(np.isfinite(cpu)), "CPU render produced NaN/Inf"
+
+    rows = []
+    for c, ch in enumerate("RGB"):
+        cpu_mean, gpu_mean = float(cpu[..., c].mean()), float(gpu[..., c].mean())
+        cpu_med, gpu_med = float(np.median(cpu[..., c])), float(np.median(gpu[..., c]))
+        mr = gpu_mean / cpu_mean if cpu_mean > 1e-8 else float("nan")
+        medr = gpu_med / cpu_med if cpu_med > 1e-8 else float("nan")
+        rows.append((ch, cpu_mean, gpu_mean, mr, cpu_med, gpu_med, medr))
+
+    print(f"\n[pkg188 transmission GPU/CPU parity] case={label} "
+          f"band=[{RATIO_LOW}, {RATIO_HIGH}]")
+    for ch, cm, gm, mr, cmed, gmed, medr in rows:
+        print(f"  {ch}: mean cpu={cm:.5f} gpu={gm:.5f} ratio={mr:.4f} | "
+              f"median cpu={cmed:.5f} gpu={gmed:.5f} ratio={medr:.4f}")
+
+    for ch, cm, gm, mr, cmed, gmed, medr in rows:
+        assert RATIO_LOW <= mr <= RATIO_HIGH, (
+            f"pkg188 transmission GPU/CPU MEAN parity FAILED case={label} "
+            f"channel {ch}: ratio {mr:.4f} outside [{RATIO_LOW}, {RATIO_HIGH}] "
+            f"(cpu={cm:.5f}, gpu={gm:.5f})")
+        assert RATIO_LOW <= medr <= RATIO_HIGH, (
+            f"pkg188 transmission GPU/CPU MEDIAN parity FAILED case={label} "
+            f"channel {ch}: ratio {medr:.4f} outside [{RATIO_LOW}, {RATIO_HIGH}] "
+            f"(cpu={cmed:.5f}, gpu={gmed:.5f})")
+
+
+# ===========================================================================
+# LEAD RUN COMMANDS (after build_cuda_worktree.bat, on the RTX box):
+#   pytest tests/test_pkg188_transmission_colour_upsample_parity.py -v -s
+# The -s flag surfaces the per-channel measured ratios to paste into the PR.
+# ===========================================================================


### PR DESCRIPTION
## Summary

pkg188 closes two of the three residual spectral-consistency gaps in the native
Principled BSDF, both of the RGB-then-upsample-the-product class that pkg168/pkg167
already proved wrong. Finding C is descoped to a filed follow-up (pkg194).

**Finding A — film-off transmission upsampled the product.** The spectral eval
computed `rgb = transmissionEvalRGB(...)` (the full BSDF product `colour · achromatic_scalar`)
then upsampled it with a `max(rgb, 1.0f)` floor. For a sub-unit BSDF value the floor
is `1`, so it upsampled `colour · scalar` **directly** — the achromatic geometry/Fresnel
scalar (and the glass eta²) baked into the Jakob-Hanika argument, which is
magnitude-nonlinear ([[spectral-upsample-nonlinearity-scaled-bsdf]]). Fix: separate
the chromatic reflectance colour from the achromatic scalar and upsample the colour
at its natural magnitude, applying the scalar **post**-upsample — `upsample(colour)·scalar`.
The eta² now lives entirely in `scalar` and never touches the upsample argument.
Implemented via an optional `(colour, scalar)` out-param on
`transmissionEvalRGB` / `gpu_pr_transmissionEval` so the RGB pipeline is byte-unchanged
(nullptr default). CPU (`principled.cpp`) + GPU twin (`gpu_materials.h`).

**Finding B — weight-path clamp guard.** Added the `max(...,1)` factor-out guard on the
`wSpec = upsample(L.weight)` upsample (`evalLobeSpectral` + `transmissionEvalSpectral`,
CPU + GPU). Traced every weight-carrying lobe: the running `weight` is seeded at 1 and
only multiplied by factors ≤1, so `L.weight ≤ 1` always and the guard is a **defensive
no-op today** — it locks the invariant against any future >1 weight. The deep Finding B
(colour×colour product in `assembleLobes`) needs a register-hostile spectral-carry and
is descoped to pkg194 — see the residual section below.

**Finding C — descoped to pkg194.** Thin-wall per-λ R'/T' + the tinted-layer
spectral-carry. One Finding-C sub-item was found **already correct** and must not be
re-audited: GPU delta Principled events DO fill `fSpectral`, via the generic eta²-clamp
guard at `gpu_materials.h:3268-3273` (mirrors the CPU delta branch). The spec's worry
that they "never fill fSpectral" was stale.

## Authorized surface

Spec Specification targeted `principled.cpp` (film-off transmission + assembleLobes weight
path) and its GPU twin `gpu_materials.h`. Files actually changed:

| File | In spec scope? | Why |
|------|----------------|-----|
| `plugins/materials/principled.cpp` | yes | Findings A + B (CPU) |
| `include/astroray/gpu_materials.h` | yes | Findings A + B (GPU twin) |
| `tests/test_pkg188_transmission_colour_upsample_parity.py` | new | Finding A/B parity lock |
| `.astroray_plan/packages/pkg188-*.md` | yes | status flip + Lessons |
| `.astroray_plan/packages/pkg194-*.md` | new | Finding C descope follow-up |

Nothing outside the spec's Specification/Non-goals. No lobe-array shrink; no
reflection/metal spectral work reopened.

## Register gate (cuobjdump post-link, native sm_120) — PASS

All per-λ additions land inside the `if constexpr (HasPrincipled)` branch, so the
`<false>` shade-kernel specialization is provably untouched. Confirmed on the final
linked `.pyd`:

| `stageShadeBucketedKernel` | REG | STACK | CONSTANT[0] |
|---|---|---|---|
| `<false,false>` (Lb0,Lb0) | 254 | **3608** | **1700** |
| `<false,true>`  (Lb0,Lb1) | 254 | **3608** | **1700** |
| `<true,false>`  (Lb1,Lb0) | 254 | 6616 | 1700 (+CONSTANT[2]:344) |
| `<true,true>`   (Lb1,Lb1) | 254 | 6616 | 1700 (+CONSTANT[2]:344) |

`<false>` = REG 254 / STACK 3608 / CONSTANT[0] 1700 — **exactly the pinned baseline**,
before == after. The `<true>` (HasPrincipled) kernels carry my changes at STACK 6616,
unchanged.

## Furnace energy — linear (`apply_gamma=False`), floor AND ceiling

`pytest tests/test_pkg178_principled_gpu_furnace.py -v -s` (GPU, vs white Lambertian, band [floor, 1.05]):

| case | mean | ref | ratio |
|------|------|-----|-------|
| diffuse/Lambert | 0.9902 | 0.9947 | 0.9955 |
| EON diffuse | 0.9900 | 0.9947 | 0.9952 |
| metallic r0.3 | 0.9772 | 0.9947 | 0.9824 |
| metallic r0.6 | 0.9730 | 0.9947 | 0.9781 |
| glass r0.1 | 0.9867 | 0.9947 | 0.9919 |
| glass r0.4 | 0.9499 | 0.9947 | 0.9549 |

No energy gain (all ≤ 1.05), no loss below the floor. CPU furnace
(`test_principled_bsdf.py`) also green.

## CPU/GPU per-channel parity — PASS

`pytest tests/test_pkg188_transmission_colour_upsample_parity.py -v -s` (band [0.95, 1.05], mean + median ratios):

| case | R | G | B |
|------|---|---|---|
| glass_tint_r0.15 | 1.0013 / 1.0021 | 1.0023 / 1.0026 | 1.0035 / 1.0027 |
| glass_tint_r0.40 | 1.0070 / 1.0100 | 1.0113 / 1.0045 | 1.0168 / 1.0197 |
| coat_over_tinted_glass | 1.0067 / 1.0080 | 1.0009 / 1.0050 | 1.0048 / 1.0090 |

Saturated red-orange transmission tint (maximal Finding-A signal) + a coat-over-tinted-glass
case (chromatic running weight through the guarded path). CPU and GPU twins in lockstep.

## Residual (Finding B deep case) — SURPRISINGLY LARGE, raises pkg194 priority

The magnitude class (achromatic scalar × colour) is fully fixed by A/B. The **colour×colour**
class remains in `assembleLobes` for tinted-layer stacks. Measured with the CPU JH upsample
the renderer uses (`_cpu_rgb_upsample_batch`, MODE_ALBEDO, 380–780nm/5nm), band-integrated
relerr of `upsample(a·b)` (current) vs `upsample(a)·upsample(b)` (spectrally-correct
per-layer product):

| tint a / base b | band relErr | max per-λ |
|---|---|---|
| sheen [1,.7,.8] / dark [.1,.1,.12] | **72.5%** | 387% |
| saturated coat [.3,.7,1] / mid [.6,.5,.4] | **34.9%** | 94% |
| deep coat [.2,.4,.9] / bright [.85,.8,.75] | 20.1% | 72% |
| specular [.9,.55,.25] / neutral [.7,.7,.7] | 5.4% | 19% |

This is **much larger than the sub-5% pkg188 expected** (flagged per the dispatch's >5%
rule) and is why pkg194 is filed with elevated priority. It only bites materials with a
genuinely COLOURED coat/sheen/specular tint over a COLOURED base; the common white-tint case
is exactly 0% (`upsample([1,1,1]·b) == upsample(b)`). The correct fix carries per-lobe
*spectral* state through the per-shade device `assembleLobes` — per-hit spectral live state,
exactly the class [[closure-graph-lobe-count-spills-fused-kernel]] warns spilled the fused
kernel — so it is register-gated and deferred to pkg194 with an empirical-probe-first plan.

## Regression sweep (all green)

- `test_pkg178_principled_gpu_cpu_parity` (transmission parity), `test_pkg187_*` (dispersion),
  `test_thin_wall_pr4`, `test_thin_film_pr1/pr2`, `test_rough_glass`, `test_pkg182_conductor_spectral_native` — 48 passed.
- `test_spectral_materials`, `test_spectral_gpu_materials`, `test_pkg168_*` (upsampling parity),
  `test_disney_rough_glass_furnace`, `test_dielectric_glass_furnace`, `test_optical_glass_materials`,
  `test_pkg108_*` (Disney/dielectric glass — unaffected, confirmed) — 96 passed.
- `test_chi2_principled` (sampler unchanged by this eval-only change) — 35 passed, 1 known xfail.

## Build log (last 5 lines)

```
[pkg183] arch-verify OK: astroray.cp313-win_amd64.pyd embeds sm_120 (embedded=[sm_120])
[pkg183] running host-only ABI canary (no GPU)...
[pkg183] canary caps: {'cpu': True, 'spectral': True, 'gpu': True, 'gpu_spectral': True, ...}
========================================
Build succeeded
========================================
```
(EXITCODE=0; arch gate + ABI canary passed.)

## Algorithm citation (CLAUDE.md §6)

No new algorithm. The fix reuses the established pkg168 shape ("upsample the reflectance
colour, never albedo·cosθ/π") and the pkg118/pkg152 delta eta²-clamp maxc-factor pattern,
both cited inline.

## Acceptance criteria

- [x] Finding A: transmission lobe upsamples colour not product; CPU + GPU twin both updated; parity test locks it.
- [x] Finding B: weight-path maxc guard added (traced no-op); furnace conserves (linear, bounded above).
- [x] Finding C: descoped with filed follow-up (pkg194) recorded in Lessons.
- [x] `<false>` STACK/REG unchanged (3608/254/1700) shown via cuobjdump; no non-Principled regression.
- [x] CPU/GPU per-channel mean-ratio parity within band on transmission + layering scenes.

## Notes

- **Lint (advisory, non-blocking):** 23 `git-diff-check/whitespace` findings on added lines of
  `gpu_materials.h` are the CRLF `\r` flagged as trailing whitespace — these `.h` files are
  CRLF-convention in-repo (2992/3305 HEAD lines) and my added lines match that convention;
  no real trailing whitespace (verified byte-level). Diff is clean hunks only
  (`git diff` == `git diff --ignore-cr-at-eol`, 23/8).
- **pkg194 numbering:** several agents were filing specs concurrently; origin/main reached
  pkg193 at push time so I used pkg194. If it collides, renumber to the next free slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
