### PR TITLE
docs: round closeout 2026-08-12 -> 2026-08-13

### DIFF
--- a/.astroray_plan/docs/NEXT_STAGE_REPORT.md
+++ b/.astroray_plan/docs/NEXT_STAGE_REPORT.md
@@ -1,12 +1,13 @@
 # Astroray Next Stage Report
 
-**Date:** 2026-08-10 (rewritten at round closeout — Principled-BSDF completion
-run, 2026-08-08 → 2026-08-10, 17 PRs merged #566–#582).
+**Date:** 2026-08-13 (rewritten at round closeout — GPU capability restoration
++ Principled spectral correctness run, 2026-08-12 → 2026-08-13, 15 PRs merged
+#585–#599).
 **Prepared by:** the architect (round closeout).
 **Scope:** the round closed with no open PRs. Full detail:
-`.astroray_plan/docs/STATUS.md` (round-closeout section "2026-08-08 →
-2026-08-10"), `.astroray_plan/docs/ROADMAP.md` ("Current sequencing" +
-matching round-closeout entry).
+`.astroray_plan/docs/STATUS.md` (round-closeout section "2026-08-12 →
+2026-08-13"), `.astroray_plan/docs/ROADMAP.md` (matching round-closeout
+entry; "Current sequencing" unchanged — no new owner directive this round).
 
 > Strategic gate: **RELEASED 2026-05-10** by pkg56 Phase C. Strategy in
 > [`ROADMAP.md`](ROADMAP.md), full status in [`STATUS.md`](STATUS.md).
@@ -15,99 +16,134 @@ matching round-closeout entry).
 
 ## 1. Current state (one screen)
 
-- **The Integration Milestone's originally-scoped package set is DONE:**
-  pkg175 (one-command dev loop, PR #547), pkg176 (Blender native steering
-  wheel, Stages 0–4, PRs #555/#556/#561/#568), pkg177 (DCC-architecture
-  decision, ratified, PR #546), pkg119 Phases B/C (differential harness +
-  graceful degradation, PRs #550/#564).
-- **The milestone's owner-requested extension is also DONE:** pkg178
-  (native Cycles Principled BSDF, Stages 0–5, PRs #566–#581) — a faithful
-  `"principled"` material plugin (core lobes, coat/sheen/anisotropy/
-  approx-SSS/emission/alpha, thin film + thin wall per Belcour-Barla
-  2017), CPU+GPU byte-mirrored, routed from the Blender addon. Two
-  correctness prerequisites/side-findings this surfaced were fixed the
-  same run: **pkg181** (dedicated-light BSDF visibility — the systemic
-  ~12–20% Astroray-vs-Cycles dim + dark lamp reflections, PR #569) and
-  **pkg182** (`ggxReflect` eval-D/pdf-D consistency — low-roughness
-  Principled metallic/specular near-black, PR #582). **pkg179**
-  (dielectric dead-sample "3× rate") was CLOSED by diagnosis — a
-  measurement mislabel, owner ratified no-fix.
-- **The settlement round's remaining item closed too:** pkg172 effect (A)
-  — the pbrt-v4 guarded-pdf form removes the universal 0.628%/bounce
-  `f/(pdf+1e-3)` energy loss CPU+GPU (PRs #551/#553/#576). Effect (B)
-  stays pkg173's separate scope.
-- **Per the owner's 2026-08-03 directive's own sequencing** — (a)
-  settlement, (b) Integration Milestone, (c) *"only then Pillar 4
-  unpause"* — **both (a) and (b) are now complete.** (c) is next in the
-  directive's own order, but Pillar 4 has an explicit standing PAUSED
-  marker in ROADMAP.md pending an owner go-ahead; this report surfaces it
-  as the top candidate, not as an executed decision — **do not unpause
-  unilaterally, confirm with the owner first.**
-- **Two packages that were explicitly de-prioritized "below the
-  Integration Milestone"** (pkg173 bounce-1 geometry-sampling parity,
-  pkg153 wavefront_diff remainder) **re-enter the open pool now that the
-  milestone is closed**, per their own spec text — still genuinely
-  low-priority sub-percent tail, not urgent.
-- **Open, not blocking, carried forward:** thin-film-vs-Cycles saturation
-  parity verification (pkg178 follow-up: metal iridescence is an
-  RGB-upsample approximation, less saturated than Cycles' per-λ); one
-  coordinated pkg119-B/pkg129 harness band re-pin (reflecting pkg181 +
-  Smith-G + pkg172(A) + thin-film + pkg182 together, all landed since the
-  bands were last set); the durable `GLoweredMaterial`
-  by-value-`GMaterial`-copy fix (recurring data-leak class hit and
-  locally patched by both pkg178 Stage 3 and PR #579; prototyped in
-  worktree `.claude/worktrees/sad-maxwell-ff99d1`, uncommitted, needs
-  re-apply on settled main).
+- **The Integration Milestone stays fully closed** (unchanged this round —
+  see ROADMAP.md "Current sequencing"). This round's work sits downstream of
+  it: GPU capability restoration (first GPU image textures, a viewport
+  progressive-refinement correctness fix) and Principled BSDF spectral
+  correctness follow-ups (per-λ conductor thin-film, dispersion, transmission
+  colour/scalar separation), plus a build-integrity guard.
+- **Landed this round:** pkg183 (build-integrity guard, PR #592), pkg185
+  (GPU glass-caustic gate closed by a test-scene fix, PR #589), pkg186
+  (first GPU image-texture support, PR #590), a pkg182 follow-up (per-λ
+  conductor thin-film, PR #586), pkg187 (Principled BSDF dispersion,
+  CPU-complete + GPU-wired, PR #593), pkg184 (`template<bool HasPhotons>`
+  kernel isolation, PR #597), pkg191 (GPU viewport progressive refinement,
+  PR #598), pkg188 (Principled transmission colour/scalar separation, PR
+  #599). pkg175 flipped to `done` as a drift-gate fix (PR #547 had already
+  merged 2026-08-07; its spec status had gone stale).
+- **HEADLINE ENGINE FINDING (pkg195 design session, PR #596):**
+  `multiwavelength_path_tracer` has **no light sampling** — every lamp-lit
+  NIR/UV render is black end-to-end (measured mean 0.00034 vs sky, all
+  profiles, even under a 5000K blackbody sun). The Spectral Profile node is
+  a visible-band no-op by design; the IR/UV Response node is destructive
+  (replaces the wired BSDF with grey, changing the *visible* render too).
+  Sodium/mercury-vapor and CIE F2/F3 lamp SPDs already ship in
+  `data/spectral_profiles/profiles.bin` and the engine-side
+  `EmissionSpectrum::MeasuredSPD` parser exists — the addon just never sends
+  anything but `blackbody`/`rgb`. Full inventory:
+  `.astroray_plan/docs/spectral-node-system-design-2026-08.md`. **pkg195
+  Phase 1 spec is filed (Stage A = the light-sampling fix, CPU-only, does
+  NOT touch the wavefront GPU kernels) but not yet implemented — this is
+  the single highest-signal correctness item in the open pool.**
+- **A fleet-wide false-reading class was caught and fixed mid-round:** every
+  local `build_cuda/` tree carried a stale cached
+  `CMAKE_CUDA_ARCHITECTURES=52` CMakeCache entry (shadowed at configure time
+  by CMakeLists' non-cache `set()`, so the actually-compiled kernels were
+  correct sm_120 SASS all along, but `cuobjdump` reads against the cache-line
+  arch produced phantom resource-gate numbers — worktree STACK 2640 vs the
+  true sm_120 `<false>` baseline of STACK 3608). **pkg183** now ships an
+  automatic artifact-ground-truth gate (`cuobjdump --list-elf`, exit 7)
+  against this class going forward, but the root cause itself (CMakeLists,
+  `configure_and_build.bat`, `build_blender_addon.py`'s hardcoded
+  arch/Debug revert) is still open, queued as a separate infra PR.
+- **Open, not blocking, carried forward:** pkg189 (GPU wavefront dispersion
+  enablement — unblocks pkg187's GPU-visible leg and the pre-existing pkg64
+  dielectric xfail, both share the same hero-λ-refraction no-op), pkg190
+  (GPU procedural textures, needs a pkg119-B re-baseline first), pkg192/
+  pkg193 (viewport-addon diagnosis-first specs from owner hands-on
+  feedback: interactivity 3–5fps vs Cycles ~30fps, camera-view overlay
+  misalignment), pkg194 (Principled tinted-layer spectral carry + thin-wall
+  per-λ — priority raised by pkg188's QUANTIFIED ~72% band-error finding on
+  coloured-tint-over-dark-base materials), the durable `GLoweredMaterial`
+  by-value-`GMaterial`-copy fix (still prototyped, uncommitted, in worktree
+  `.claude/worktrees/sad-maxwell-ff99d1`), pkg180 (systemic-dim diagnosis,
+  still open dispatchable).
+- **Still standing, unresolved:** the Pillar 4 unpause decision (pkg45/46/
+  48/49/50/51 + pkg107, GR/astro science layer) — no new owner directive
+  this round; ROADMAP.md's PAUSED marker is unchanged. Surfaced again below
+  as the top strategic (not code) item.
 - **Environment:** RTX 5070 Ti workstation; Blender 5.1/5.2 installed
-  locally (real-host checks mandatory for addon-facing PRs).
+  locally (real-host checks mandatory for addon-facing PRs). Every code PR
+  this round was dual-gated (CI + independent RTX hardware verification);
+  three hardware verifiers were serialized through the GPU lock overnight.
 
 ---
 
 ## 2. Deployable set (prioritized)
 
-Grep `^Status:`/`**Status:**` in each spec before dispatch (memory
+Grep `^\*\*Status:\*\*` in each spec before dispatch (memory
 `orchestrator-next-stage-report-stale`) — this report can go stale.
 
-**Top candidate — needs an explicit owner decision, not a silent
-dispatch:**
+**Top candidate — needs an explicit owner decision, not a silent dispatch:**
 
 1. **Pillar 4 unpause** (pkg45/46/48/49/50/51 + pkg107, GR/astro science
-   layer). This is the directive's own next step now that (a)+(b) are
-   complete, but ROADMAP.md's PAUSED marker has stood since 2026-06-08 and
-   the directive didn't say "auto-unpause on milestone completion" in so
-   many words — **surface this to the owner and get an explicit
-   go/no-go before dispatching any pkg45-tier work.**
+   layer). Unchanged since the last report — ROADMAP.md's PAUSED marker has
+   stood since 2026-06-08; still no explicit go-ahead. **Surface this to
+   the owner before dispatching any pkg45-tier work.**
 
-**Hygiene / closeout debt (small, unblocks clean baselines for everything
-after it):**
+**Correctness-tier, highest signal in the open pool:**
 
-2. **Coordinated pkg119-B/pkg129 harness band re-pin** — five landed
-   packages (pkg181, pkg172(A) Smith-G-adjacent changes, thin-film,
-   pkg182) have moved rendered energy/hue since these bands were last set;
-   re-baseline once, with per-pin justification (pkg166 precedent),
-   architect sign-off on the batch.
-3. **pkg165** — verify-and-close. A focused confirm on pkg158's exact
-   Step-0 scene at r ∈ {0.0, 0.3, 0.6, 0.9} closes the paperwork; every
-   existing reading is already in-band. Trivial, non-urgent.
-4. **Durable `GLoweredMaterial` by-value-copy fix** — re-apply the
+2. **pkg195 Stage A** — give `MultiwavelengthPathTracer::pathTrace` spectral
+   NEE over dedicated lights. Fixes a real, currently-shipping defect
+   (every lamp-lit NIR/UV render is black); CPU-only, explicitly scoped to
+   NOT touch the wavefront GPU kernels (REG:254 stays untouched). Do not
+   scope-creep into Phases 2–4 (recorded in the design doc §5) — Stage A
+   alone is the dispatchable unit.
+3. **pkg189** — GPU wavefront dispersion enablement. Closes the pre-existing
+   hero-λ-refraction no-op that both pkg187's Principled dispersion and the
+   long-standing pkg64 dielectric xfail are blocked on; lights up two
+   features at once.
+4. **pkg194** — Principled tinted-layer spectral carry + thin-wall per-λ.
+   Priority raised by pkg188's quantified ~72% band-error finding on
+   coloured-tint-over-dark-base materials (0% for the common white-tint
+   case, so this is a real-but-narrow defect, not a universal one).
+
+**Hygiene / addon-facing (owner explicitly gave feedback on these):**
+
+5. **pkg192** — viewport navigation interactivity (3–5fps vs Cycles' ~30fps)
+   — diagnosis-first spec.
+6. **pkg193** — camera-view overlay misalignment — diagnosis-first spec.
+7. **pkg190** — GPU procedural textures (pkg186 slice 2) — **blocked on a
+   pkg119-B re-baseline first**, do not dispatch before that re-baseline
+   lands.
+8. **Infra: CUDA-arch root-cause PR** — force `CMAKE_CUDA_ARCHITECTURES`
+   from `ASTRORAY_CUDA_ARCHS` at the CMakeLists cache level (not a
+   non-cache `set()`), and pass `ASTRORAY_CUDA_ARCHS` through
+   `configure_and_build.bat` + fix `build_blender_addon.py`'s hardcoded
+   arch/Debug revert. Closes the false-reading class pkg183 currently only
+   detects after the fact.
+9. **Durable `GLoweredMaterial` by-value-copy fix** — re-apply the
    prototyped PR-2-based fix from worktree
-   `.claude/worktrees/sad-maxwell-ff99d1` on settled main. No dedicated
-   spec filed yet; file one if this is picked up (the recurring-leak
-   pattern across pkg178 Stage 3 and PR #579 is evidence enough for a
-   CLAUDE.md §6-citable structural fix, not another ad-hoc patch).
+   `.claude/worktrees/sad-maxwell-ff99d1` on settled main. File a dedicated
+   spec if picked up (recurring-leak pattern across pkg178 Stage 3 and PR
+   #579 is evidence enough for a CLAUDE.md §6-citable structural fix).
 
-**Re-entered pool (was below the milestone, now open again — still
-genuinely low priority):**
+**Re-entered / long-tail pool (still genuinely low priority):**
 
-5. **pkg173** — bounce-1 geometry-sampling parity (pkg172 effect (B));
-   holds pkg156's 0.998 SSIM restoration clause.
-6. **pkg153** — wavefront_diff remainder, gate-failure-reviewer disposition
-   in flight.
-7. **pkg155 Phase 2** — shade-stage register recovery (221 regs/thread →
-   ≤128 target); opportunistic GPU-lock gap-filler, not compile-only.
-8. **pkg128** — thin-film residual charter (standalone Glass/Metallic node
-   cells + spectral showcase), now unblocked: pkg178 Stage 4 already built
-   and shipped the shared Belcour-Barla utility this package rides.
+10. **pkg180** — systemic Astroray-vs-Cycles dim, diagnosis-first, still
+    open dispatchable.
+11. **pkg173** — bounce-1 geometry-sampling parity (pkg172 effect (B));
+    holds pkg156's 0.998 SSIM restoration clause.
+12. **pkg153** — wavefront_diff remainder, gate-failure-reviewer disposition
+    in flight.
+13. **pkg155 Phase 2** — shade-stage register recovery (221 regs/thread →
+    ≤128 target); opportunistic GPU-lock gap-filler, not compile-only.
+14. **pkg128** — thin-film residual charter (standalone Glass/Metallic node
+    cells + spectral showcase), rides the shared Belcour-Barla utility
+    pkg178/pkg182 already built.
+15. **pkg165** — verify-and-close. A focused confirm on pkg158's exact
+    Step-0 scene at r ∈ {0.0, 0.3, 0.6, 0.9} closes the paperwork; every
+    existing reading is already in-band. Trivial, non-urgent.
 
 **Not this phase:** anything not explicitly named above; Pillar 4 stays
 PAUSED until the owner go-ahead in item 1 above.
@@ -116,28 +152,33 @@ PAUSED until the owner go-ahead in item 1 above.
 
 ## 3. Drop-in prompt for the next session
 
-**First: get the owner's read on Pillar 4 unpause** (item 1) — this is a
+**First: get the owner's read on Pillar 4 unpause** (item 1) — a
 milestone-scale sequencing decision, not a code dispatch. While that's
-pending, the hygiene/closeout items (2–4) are safe autonomous work: they
-close paperwork and re-baseline bands that landed code has already moved,
-without opening new scope. If the owner confirms Pillar 4, pkg45 is the
-first pickup per the original Pillar-4 spec queue (pkg45–pkg51 + pkg107).
-If the owner wants more polish before that, pkg173/pkg153/pkg155-Phase-2/
-pkg128 (items 5–8) are the next-best backlog, in roughly that priority
-order (correctness-tail > perf > material-completeness).
+pending, **pkg195 Stage A (item 2) is the standout autonomous pickup** — it
+fixes a real, currently-shipping engine defect (lamp-lit NIR/UV renders are
+black), is CPU-only, and does not touch the register-saturated wavefront GPU
+kernels. After that: pkg189 (item 3, unblocks two features at once), then
+pkg194 (item 4, quantified real defect). The addon-feedback items (5–6) and
+pkg190 (7, gated on its own prerequisite) are next-best; the infra
+root-cause PR (8) and the `GLoweredMaterial` fix (9) are hygiene debt that
+unblocks clean baselines going forward. Items 10–15 are the long-tail pool,
+in roughly that priority order.
 
 Rules that stay live from this round: **energy gates render LINEAR with an
 upper bound** (pkg166); **state the `.pyd` mtime next to every probe A/B
-number**; **mirror the CONDITION, not just the term, in every CPU→GPU
-port**; **CPU/GPU material work is byte-mirrored in the same PR, never
-split across sessions** (the pkg160→pkg163→pkg178 discipline); **any new
-lobe/closure that touches the shade path must be measured against the
-`template<bool HasPrincipled>` isolation boundary** — a naive addition can
-reopen the +52% non-principled regression pkg178's D4 fix closed; **eval
-and pdf must use the SAME functional form for the same NDF** (the pkg182
-class of bug — check this explicitly whenever a new lobe's `eval`/`sample`
-pair is written). Cite per CLAUDE.md §6 (`/cite-algorithm`) for any new
-algorithm.
+number**; **verify `cuobjdump` resource-gate readings against the TRUE
+compiled arch, not the CMakeCache line** — the cache can be shadowed at
+configure time by a non-cache `set()`, giving phantom Maxwell-PTX readings
+that look like real register/stack deltas (this round's pkg183/pkg187
+incident; pkg183's `arch-verify` gate now catches it automatically);
+**mirror the CONDITION, not just the term, in every CPU→GPU port**;
+**CPU/GPU material work is byte-mirrored in the same PR, never split across
+sessions**; **any new lobe/closure that touches the shade path must be
+measured against the `template<bool HasPrincipled>` isolation boundary**
+(and now the `template<bool HasPhotons>` boundary pkg184 added — a naive
+addition can reopen either regression class); **eval and pdf must use the
+SAME functional form for the same NDF** (the pkg182 class of bug). Cite per
+CLAUDE.md §6 (`/cite-algorithm`) for any new algorithm.
 
 ---
 
@@ -147,8 +188,8 @@ algorithm.
   (pr-reviewer doc-only rule). Source PRs need the independent-review
   SIGN-OFF/BLOCK gate (pkg98) before push.
 - **`src/gpu/wavefront/stage_advance.cu` is a serialization point** for any
-  GPU-lane package (pkg155 Phase 2, a Pillar-4 GPU package, etc.) — check
-  for other in-flight touches before dispatching.
+  GPU-lane package (pkg155 Phase 2, pkg189, a Pillar-4 GPU package, etc.) —
+  check for other in-flight touches before dispatching.
 - **CI is blind to GPU correctness** — never declare a round clean on CI
   green alone; run the full RTX hardware sweep at closeout (memory:
   `ci_has_no_gpu_runtime_blindspot`).
@@ -156,13 +197,16 @@ algorithm.
   linear with floor+ceiling (memory:
   `gamma-furnace-cannot-detect-energy-gain`).
 - **Addon-facing PRs need a real-Blender leg** — `dev_addon.ps1 -Smoke`
-  (pkg175) is the standing mechanism; gate on the printed sentinel, not
-  the exit code.
+  (pkg175, now done) is the standing mechanism; gate on the printed
+  sentinel, not the exit code.
 - **The GPU wavefront is NOT run-to-run bit-exact** (~1.19e-07–2e-7 atomic
   floor) — gate at the 1e-5 Monte-Carlo convention, not exact equality.
 - **Watch the shadow-`.pyd` trap** — verify `astroray.__file__` resolves to
   the canonical build output and check `.pyd` mtime vs HEAD (memory:
   `stale_pyd_locations`).
+- **Watch the stale-CMakeCache CUDA-arch trap** — the cache line can lie;
+  trust `cuobjdump --list-elf` on the linked `.pyd`, which pkg183's
+  `arch-verify` gate now does automatically in all three build wrappers.
 - **Grep `^Status:` (or `**Status:**`) in the spec before dispatching** —
   this report's §2 prose can go stale vs the spec header (memory:
   `orchestrator-next-stage-report-stale`).
@@ -170,7 +214,7 @@ algorithm.
 - **Cost routing (2026-08):** bounded grunt work (docs flips, lint fixes,
   report assembly, pre-review critique, well-specified gated
   implementation) routes to the `delegate` skill's open-weight tiers,
-  evidence-verified, never trusted; Claude stays on architect/specs,
+  evidence-verified, never trusted. Claude stays on architect/specs,
   cycles-parity, ABI reachability, gate-failure root-cause, merge
   decisions, and visual inspection.
 

--- a/.astroray_plan/docs/ROADMAP.md
+++ b/.astroray_plan/docs/ROADMAP.md
@@ -258,6 +258,48 @@ fix:
   to pkg55 Phase B per the spec's escape clause; smaller H2/H5
   follow-ups split out as **pkg83** + **pkg84**.
 
+**Round closeout (2026-08-12 → 2026-08-13): 15 PRs (#585–#599), no open PRs at closeout — GPU capability restoration (first GPU texture support, viewport progressive-refinement fix) + Principled spectral correctness (per-λ conductor thin-film, dispersion, transmission colour/scalar separation) + a build-integrity guard.**
+**pkg183 DONE** (PR #592) — stale-object ABI-mixed-binary guard in all three
+build wrappers, plus a cuobjdump ground-truth CUDA-arch gate (exit 6/7) that
+catches the fleet-wide stale `CMAKE_CUDA_ARCHITECTURES=52` CMakeCache
+incident this round also surfaced (worktree STACK 2640 readings were
+Maxwell-PTX artifacts; true sm_120 `<false>` baseline is STACK 3608). Root
+cause (CMakeLists non-cache `set()`, `configure_and_build.bat`,
+`build_blender_addon.py` hardcoded arch/Debug revert) queued as a separate
+infra follow-up PR. **pkg185 CLOSED** (PR #589) — the GPU glass-caustic
+parity gate failure root-caused to an un-Ω-scaled test-scene sun light, not
+GPU transport (SSIM 0.0101→0.9606 after the test fix); GPU transport
+confirmed healthy. **pkg186 DONE** (PR #590) — first GPU image-texture
+support (baked buffer + nearest fetch) + backend-aware `__gpu_features__`
+so the addon Diagnostics panel stops overclaiming GPU capability. **pkg182
+follow-up DONE** (PR #586) — per-λ-native Principled conductor thin-film
+supersedes the RGB-upsample approximation (17/17 gates HW-verified); the
+saturation-jump premise didn't hold at 4 samples, but this closes a real
+JH-round-trip correctness gap. **pkg187 DONE** (PR #593) — Principled BSDF
+dispersion, CPU-complete (OpenPBR/Cycles-WIP Cauchy fit, cited; prism
+chromatic spread 4.267→5.345px), GPU wired but gated on the pre-existing
+pkg189 no-op filed the same day. **pkg184 DONE** (PR #597) —
+`template<bool HasPhotons>` isolation of the photon-caustic k-NN gather,
+non-photon shade kernel −2.3% wall time. **pkg191 DONE** (PR #598) — GPU
+viewport progressive refinement: the GPU dispatch ignored the
+`renderSeed==0` fresh-random contract, making every viewport chunk render
+identical noise; one-spot fix, MSE-to-256spp 7.0e-4→1.3e-5. **pkg188
+DONE** (PR #599) — Principled film-off transmission colour/scalar
+separation CPU+GPU retires the Stage-3b upsample hack; QUANTIFIED a ~72%
+band-error residual on coloured-tint-over-dark-base materials, raising the
+priority of the new **pkg194** descope. **pkg175 drift-gate fix**: flipped
+to done (PR #547, 2026-08-07 — its spec had stayed "in review" past its
+own merge). **HEADLINE ENGINE FINDING** from the pkg195 spectral-node
+design session (PR #596): `multiwavelength_path_tracer` has NO light
+sampling — every lamp-lit NIR/UV render is black end-to-end; Phase 1 spec
+filed, not yet implemented. **Specs filed, open:** pkg189 (GPU dispersion
+enablement, next up), pkg190 (GPU procedural textures), pkg192/pkg193
+(viewport-addon diagnosis-first, from owner hands-on feedback), pkg194,
+pkg195. **Owner decisions:** wavefront perf ceiling stays at 1.5s
+(ratified); overnight autonomous run authorized. Full detail:
+`.astroray_plan/docs/STATUS.md` round-closeout section "2026-08-12 →
+2026-08-13". Pillar 4 stays PAUSED.
+
 **Round closeout (2026-08-08 → 2026-08-10): 17 PRs (#566–#582) — Principled-BSDF completion run, no open PRs at closeout.**
 **pkg178 native Cycles Principled BSDF is now fully COMPLETE** (Stages
 0–5, PRs #566–#581): a faithful `"principled"` material plugin (core

--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -1,5 +1,101 @@
 # Astroray Status
 
+**2026-08-12 → 2026-08-13 (day run + overnight, 15 PRs merged #585–#599, no
+open PRs at closeout): GPU capability-restoration wave (first GPU texture
+support, viewport progressive-refinement fix) + two Principled spectral
+correctness fixes + a build-integrity guard — plus a HEADLINE engine finding
+that every lamp-lit NIR/UV render is black end-to-end.**
+- **pkg183 DONE** (PR #592, 2026-08-12) — stale-object ABI-mixed-binary guard
+  (header-hash stamp + force-clean-on-mismatch, <5s host-only ABI canary) in
+  all three build wrappers, plus a cuobjdump ground-truth CUDA-arch gate
+  (exit codes 6/7) that catches the fleet-wide stale
+  `CMAKE_CUDA_ARCHITECTURES=52` CMakeCache class of incident: worktree
+  resource-gate readings of STACK 2640 were Maxwell-PTX artifacts, the true
+  sm_120 `<false>` baseline is STACK 3608. The root-cause trio (CMakeLists
+  non-cache `set()`, `configure_and_build.bat`, `build_blender_addon.py`
+  hardcoded arch/Debug revert) is deliberately out of scope — queued as an
+  infra follow-up PR.
+- **pkg185 CLOSED** (PR #589, 2026-08-12) — the GPU glass-caustic parity gate
+  failure root-caused to the TEST SCENE, not GPU transport: the sun light
+  was un-Ω-scaled, driving irradiance to ~19100 and collapsing SSIM to
+  0.0101 on 3 legitimate specular fireflies; fixed the test, SSIM
+  0.0101→0.9606, GPU peak 1007→0.41. GPU transport confirmed healthy.
+- **pkg186 DONE** (PR #590, 2026-08-12) — first GPU image-texture support:
+  baked-buffer + nearest fetch, `__constant__ c_wfTexBinding`, after a
+  verifier-caught +24B kernel-signature regression was fixed back to exact
+  kernel identity (REG:254/STACK:3608/CONSTANT:1700). Backend-aware
+  `__gpu_features__` dict — the addon Diagnostics panel no longer claims GPU
+  textures/volumes/adaptive/GR it doesn't have.
+- **pkg182 follow-up DONE** (PR #586, 2026-08-11) — per-λ-native Principled
+  conductor thin-film supersedes the RGB-upsample approximation; 17/17 gates
+  HW-verified. Measured finding: saturation barely moved (mean
+  0.0488→0.0499, max 0.1842→0.2045) — the premise that RGB-upsample
+  visibly mutes metal iridescence doesn't hold in the 4-sample
+  hero-wavelength pipeline; this is a correctness/consistency win (no JH
+  round-trip loss, correct under spectral/colored light), not the
+  saturation jump the ticket implied.
+- **pkg187 DONE** (PR #593, 2026-08-12) — Principled BSDF dispersion,
+  CPU-complete (OpenPBR/Cycles-WIP Cauchy fit from IOR+Abbe, cited): prism
+  chromatic spread 4.267→5.345px, zero-dispersion bit-identical, `<false>`
+  shade kernel byte-identical at TRUE sm_120
+  (REG:254/STACK:3608/CONSTANT:1700). GPU leg wired but gated on the
+  pre-existing pkg189 no-op (hero-λ refraction never varies IOR on GPU —
+  the dielectric reference shares the same gap). Two premise corrections:
+  no shipped Blender exposes a Dispersion socket (unmerged upstream WIP
+  #162041 — the addon got a forward-compatible probe); `test_gpu_prism_
+  rainbow_parity`'s XPASS was vacuous, xfail retained.
+- **pkg184 DONE** (PR #597, 2026-08-12) — `template<bool HasPhotons>`
+  isolation of the photon-caustic k-NN gather (8 kernel instantiations):
+  every HasPhotons=false variant strictly below baseline (STACK
+  −128..−256B), HasPhotons=true variants byte-identical; non-photon
+  glass-sphere shade kernel −2.3% wall vs +0.1% byte-identical control.
+- **pkg191 DONE** (PR #598, 2026-08-12) — GPU viewport progressive
+  refinement: root cause was the GPU dispatch ignoring the
+  `renderSeed==0` → fresh-random contract, so every viewport chunk
+  rendered IDENTICAL noise. One-spot fix in `blender_module.cpp`;
+  MSE-to-256spp 7.0e-4→1.3e-5 across iterations, HW-verified.
+- **pkg188 DONE** (PR #599, 2026-08-12) — Principled film-off transmission
+  colour/scalar separation, CPU+GPU (retires the "Stage-3b upsample hack")
+  + a weight-path clamp guard. Finding C descoped to new spec pkg194.
+  QUANTIFIED residual: `upsample(a·b)` vs `upsample(a)·upsample(b)` up to
+  ~72% band error on coloured-tint-over-dark-base (0% for the common
+  white-tint case) — this raises pkg194's priority.
+- **pkg175 flipped to done** (PR #547, 2026-08-07 — drift-gate fix, its spec
+  had stayed "in review" past its own merge): one-command Blender dev loop,
+  150s full rebuild / 5.8s `-SkipBuild`, on-hardware smoke `RESULT PASS`.
+- **HEADLINE ENGINE FINDING (pkg195 design session, PR #596, 2026-08-12):**
+  `multiwavelength_path_tracer` has NO light sampling — every lamp-lit
+  NIR/UV render is black end-to-end. The profile-selector node is a
+  visible-band no-op; the IR/UV response node is destructive.
+  Sodium/mercury lamp SPDs are already engine-ready but not exposed. A
+  drawn-spectrum node is filed as a genuine differentiator (no other
+  renderer has one). pkg195 Phase 1 spec filed, not yet implemented.
+- **Specs filed, not yet implemented:** pkg189 (GPU wavefront dispersion
+  enablement — the hero-λ refraction no-op both pkg187 and the pre-existing
+  dielectric xfail are blocked on; PR #591, next up), pkg190 (GPU
+  procedural textures, pkg186 slice 2, needs a pkg119-B re-baseline first;
+  PR #594), pkg192/pkg193 (viewport-addon diagnosis-first specs from owner
+  hands-on feedback, PR #595 — pkg192 viewport interactivity 3-5fps vs
+  Cycles ~30fps, pkg193 camera-view overlay misalignment; pkg191, filed in
+  the same PR, landed same round — see above), pkg195 (spectral node
+  system, above).
+- **Infra, not tied to a package:** `.gitattributes` forces CRLF checkout
+  for `.bat`/`.cmd` (PR #585, prevents the class of silent cmd.exe
+  mis-parse this repo has hit before); comprehensive repo hygiene sweep
+  (PR #587, pre-session — dead code/scripts/tests/docs removal, tcnn
+  opt-in, guardrails; filed pkg183/184/185).
+- **Owner decisions (2026-08-12):** wavefront perf ceiling STAYS at 1.5s
+  (ratified, improve opportunistically); overnight autonomous run
+  authorized; owner hands-on addon feedback drove pkg191-193 + the
+  spectral-node design (pkg195).
+- **Round verification discipline:** every code PR dual-gated (CI +
+  independent RTX hardware verification); three verifiers serialized via
+  the GPU lock overnight.
+- **Open follow-ups carried forward:** pkg189 (next up), pkg190, pkg192,
+  pkg193, pkg194 (priority raised by the 72% finding above), pkg195, the
+  infra arch root-cause PR, the `GLoweredMaterial` by-value prototype
+  re-apply (worktree `sad-maxwell`), pkg180 diagnosis.
+
 **2026-08-11 (post-Principled-block parity verification + harness band re-pin —
 CLOSES the last two owed pkg178 items):** thin-film saturation parity vs Blender
 5.2 Cycles is VERIFIED and the coordinated pkg119-B/pkg129 band re-pin is DONE;
@@ -402,6 +498,166 @@ pkg151/pkg147 open, HELD by pr-merger for owner approval on CMakeLists
 touches. Full round closeout pending.
 
 **Last updated:** 2026-07-20 (Overnight autonomous run on the travel laptop — RTX 3000 Ada sm_89, CUDA 13.2, no OptiX SDK. **pkg55 Phase C Sessions C3+C4 landed** (PR #486 non-visible-band + naive-MW wavefront; PR #490 TLAS/instancing + deformation-motion in the wavefront) and **C5 is open-verified** (PR #494 photon caustics, 2/2 gates + 40-test regression green on RTX, not yet merged) — Phase C is now 5 of 7 sessions done/verified. **pkg89 GAP-1 landed** (PR #489 — dedicated lights uploaded to GPU, Blender-lamp scenes stop rendering DARK on GPU: AREA 0.998 / POINT 0.997 parity) with **GAP-2 energy audit** escalated to pkg122. **pkg121 Phase A** chi² sampler harness (PR #485 — Mitsuba BSD-3 port; Lambertian anchor passes p=0.23; Disney spec-lobe failures xfail'd → pkg123). **pkg119-A** Blender parity coverage matrix (PR #487 — v4 AST-scanned: 131 SUPPORTED / 23 APPROXIMATED / 370 DROPPED-SILENT / 20 stale sockets of 524). 15 new specs filed (pkg123-137) covering correctness/sampling + eight platform techniques + material candidates. Direct-to-main: root-shadow-pyd trap killed (94ae956), permissions allowlist (1efe9bc), pkg115-harness CUDA-13 fix (3778f37), other-engines research sweep (7a4c970).).
+
+## Round closeout 2026-08-12 → 2026-08-13 — GPU capability restoration (textures, viewport progressive refinement) + Principled spectral correctness (conductor thin-film, dispersion, transmission separation) + build-integrity guard; HEADLINE FINDING: NIR/UV lamp-lit renders are black end-to-end
+
+**15 PRs merged (#585–#599), no open PRs at closeout.** See the top-of-file
+summary for the full headline; this section is the archival record.
+
+### pkg183 — stale-object ABI-mixed-binary build-integrity guard (PR #592, 2026-08-12)
+
+Header-hash stamp + force-clean-on-mismatch, a <5s host-only ABI canary, and
+a cuobjdump ground-truth CUDA-arch gate wired into all three build wrappers
+(exit codes 6/7). The arch gate is the direct guard against the fleet-wide
+stale `CMAKE_CUDA_ARCHITECTURES=52` CMakeCache incident this same round
+surfaced (see cross-cutting note below). Item 4 (move build trees off
+OneDrive) evaluated-only, deferred to a separate package.
+
+### pkg185 — GPU glass-caustic parity gate CLOSED by test-scene fix (PR #589, 2026-08-12)
+
+The gate's SSIM 0.0101 failure was diagnosed to the reference sun light
+being un-Ω-scaled, driving test-scene irradiance to ~19100 and collapsing
+SSIM on 3 legitimate specular fireflies. Corrected the test scene, not the
+engine: SSIM 0.0101→0.9606, GPU peak 1007→0.41. GPU transport confirmed
+healthy throughout.
+
+### pkg186 — GPU image-texture sampling, first GPU texture support (PR #590, 2026-08-12)
+
+Baked buffer + nearest fetch, `__constant__ c_wfTexBinding`. A verifier
+caught a +24B kernel-signature regression mid-review, fixed back to exact
+kernel identity (REG:254/STACK:3608/CONSTANT:1700). Backend-aware
+`__gpu_features__` dict added so the addon Diagnostics panel stops
+overclaiming GPU textures/volumes/adaptive/GR support it doesn't have.
+
+### pkg182 follow-up — per-λ-native Principled conductor thin-film (PR #586, 2026-08-11)
+
+Supersedes the RGB-upsample conductor-thin-film approximation with a
+per-λ-native Airy evaluation on both CPU and GPU (Belcour-Barla + Gulbrandsen
+NK inversion, cited). 17/17 gates HW-verified, `<false>`/`<true>` STACK
+unchanged. Measured finding: saturation barely moved (mean 0.0488→0.0499,
+max 0.1842→0.2045) — the premise that RGB-upsample visibly mutes metal
+iridescence does not hold in the 4-sample hero-wavelength pipeline; this
+lands as a correctness/consistency win (no JH round-trip loss, correct
+under spectral/colored illumination), not the saturation jump the ticket
+implied.
+
+### pkg187 — Principled BSDF dispersion, CPU-complete + GPU-wired (PR #593, 2026-08-12)
+
+OpenPBR/Cycles-WIP two-term Cauchy fit `n(λ)=A+B/λ²` from d-line IOR +
+Abbe number (cited). CPU chromatic prism spread 4.267→5.345px,
+zero-dispersion bit-identical, `<false>` shade kernel byte-identical to
+main at TRUE sm_120. GPU leg wired into the existing hero-collapse
+dispersion infra but gated on the pre-existing pkg189 no-op — filed as a
+follow-up spec the same day. Two premise corrections surfaced during
+implementation: no shipped Blender exposes a Dispersion socket (unmerged
+upstream WIP #162041; addon ships a forward-compatible probe instead), and
+`test_gpu_prism_rainbow_parity`'s XPASS under `--runxfail` was vacuous (no
+real GPU render ran) — xfail retained, not un-xfailed.
+
+### pkg184 — `template<bool HasPhotons>` shade-kernel isolation (PR #597, 2026-08-12)
+
+Isolates the photon-caustic k-NN gather into 8 kernel instantiations:
+every HasPhotons=false variant strictly below the pre-change baseline
+(STACK −128 to −256B across `<F,F>/<F,T>/<T,F>/<T,T>`), HasPhotons=true
+variants byte-identical. Non-photon glass-sphere shade kernel measured
+−2.3% wall time vs a +0.1% byte-identical control — a real perf win, not
+noise.
+
+### pkg191 — GPU viewport progressive refinement (PR #598, 2026-08-12)
+
+Root cause: the GPU dispatch path ignored the engine's `renderSeed==0` →
+fresh-random-per-call contract (memory `seed-zero-is-random-sentinel`), so
+every viewport refinement chunk rendered with IDENTICAL noise instead of
+accumulating new samples. One-spot fix in `blender_module.cpp`;
+MSE-to-256spp-reference improved 7.0e-4→1.3e-5 across refinement
+iterations, HW-verified.
+
+### pkg188 — Principled film-off transmission colour/scalar separation (PR #599, 2026-08-12)
+
+Retires the "Stage-3b upsample hack" CPU+GPU: transmission colour and
+transmission scalar are now upsampled and applied separately instead of as
+a pre-multiplied product, plus a weight-path clamp guard. Findings A+B
+landed; Finding C descoped to new spec **pkg194** with a QUANTIFIED
+residual — `upsample(a·b)` vs `upsample(a)·upsample(b)` diverges up to
+~72% band error on a coloured-tint-over-dark-base material (0% for the
+common white-tint case) — raising pkg194's priority.
+
+### pkg175 — drift-gate fix: flipped to done (PR #547, 2026-08-07)
+
+Spec status had stayed "in review (PR pending)" past its own 2026-08-07
+merge. One-command Blender dev loop (build → package → install → launch →
+headless smoke-render); 150s full rebuild / 5.8s `-SkipBuild`, on-hardware
+smoke `RESULT PASS` (already recorded verified in ROADMAP.md's Integration
+Milestone section).
+
+### Cross-cutting: fleet-wide stale CUDA-arch CMakeCache incident
+
+Every local `build_cuda/` tree carried a cached
+`CMAKE_CUDA_ARCHITECTURES=52` (stale Maxwell PTX) alongside the intended
+`ASTRORAY_CUDA_ARCHS=native`/`120`; CMakeLists' non-cache `set()` shadows it
+at configure time so the actually-compiled kernels were correct sm_120 SASS
+all along, but `cuobjdump` reads against the cache-line arch produced
+phantom resource-gate numbers (worktree STACK 2640 vs the true sm_120
+`<false>` baseline of STACK 3608) — this false reading was caught and
+corrected mid-round on both pkg183's and pkg187's measurements. **pkg183**
+now ships an automatic artifact-ground-truth gate against this class going
+forward. The root cause itself (CMakeLists non-cache `set()`,
+`configure_and_build.bat` not passing `ASTRORAY_CUDA_ARCHS`, and
+`build_blender_addon.py`'s hardcoded arch/Debug revert) is intentionally
+out of pkg183's wrapper-only scope — queued as a separate infra follow-up
+PR.
+
+### Specs filed this round, not yet implemented
+
+**pkg189** (PR #591, 2026-08-12) — GPU wavefront dispersion enablement: the
+hero-λ refraction path is a pre-existing no-op end-to-end for both the
+dielectric reference and pkg187's Principled dispersion; discovered during
+pkg187. **Next up.**
+**pkg190** (PR #594, 2026-08-12) — GPU procedural-texture support (pkg186
+slice 2), requires a pkg119-B re-baseline first.
+**pkg192/pkg193** (PR #595, 2026-08-12) — viewport-addon diagnosis-first
+specs from owner hands-on feedback: pkg192 viewport navigation
+interactivity (3–5 fps vs Cycles ~30 fps), pkg193 camera-view overlay
+misalignment. (pkg191, filed in the same PR, landed this round — see
+above.)
+**pkg194** (filed via PR #599 as the pkg188 Finding-C descope) — Principled
+tinted-layer spectral carry + thin-wall per-λ; priority raised by the 72%
+band-error finding.
+**pkg195** (PR #596, 2026-08-12) — spectral node-system design doc + Phase 1
+spec, from an owner-directed Fable design session. **HEADLINE ENGINE
+FINDING:** `multiwavelength_path_tracer` has NO light sampling — every
+lamp-lit NIR/UV render is black. The profile-selector node is a
+visible-band no-op; the IR/UV response node is destructive. Sodium/mercury
+lamp SPDs are already engine-ready, just not exposed. A drawn-spectrum node
+is identified as a genuine differentiator (no other renderer has one).
+
+### Infra, not tied to a package
+
+`.gitattributes` forces CRLF checkout for `.bat`/`.cmd` (PR #585) —
+prevents the silent cmd.exe mis-parse class this repo has hit before
+(memory `bat-files-need-crlf`). Comprehensive repo hygiene sweep (PR #587,
+pre-session, 2026-08-11) — dead code/scripts/tests/docs removal, tcnn
+opt-in, guardrails; filed pkg183/184/185 (all landed this round, above).
+
+### Owner decisions and process notes (2026-08-12)
+
+Wavefront perf ceiling STAYS at 1.5s (ratified, improve opportunistically
+— no revert dispatch). Overnight autonomous run authorized. Owner
+hands-on addon feedback drove pkg191-193 and the spectral-node design
+(pkg195). Every code PR this round was dual-gated (CI + independent RTX
+hardware verification); three hardware verifiers were serialized through
+the GPU lock overnight.
+
+### Open follow-ups (not closed, tracked forward, do not re-derive)
+
+pkg189 (GPU dispersion enablement — next up), pkg190 (GPU procedural
+textures), pkg192 (viewport interactivity), pkg193 (camera overlay
+alignment), pkg194 (tinted-layer spectral carry — priority raised),
+pkg195 (spectral node system Phase 1), the infra CUDA-arch root-cause PR
+(CMakeLists/`configure_and_build.bat`/`build_blender_addon.py`), the
+durable `GLoweredMaterial` by-value-copy fix (still prototyped,
+uncommitted, in worktree `.claude/worktrees/sad-maxwell-ff99d1`), and
+pkg180 (systemic-dim diagnosis, still open).
 
 ## Round closeout 2026-08-08 → 2026-08-10 — Principled-BSDF completion run: pkg178 COMPLETE (Stages 0-5, native Cycles Principled incl. thin film/thin wall), pkg172(A) closed, pkg176 COMPLETE (Stages 0-4, Blender native steering wheel), pkg182 filed+fixed, pkg181 done, pkg179 closed by diagnosis
 

--- a/.astroray_plan/packages/pkg175-blender-dev-loop-one-command.md
+++ b/.astroray_plan/packages/pkg175-blender-dev-loop-one-command.md
@@ -2,7 +2,10 @@
 
 **Pillar:** Integration Milestone (Blender/DCC integration — see ROADMAP "Integration Milestone")
 **Track:** A (tooling + real-host verification; smoke render needs the local RTX + Blender 5.1)
-**Status:** in review (PR pending, 2026-08-07 — script + guards + smoke landed; guard unit tests green (14/14), lint clean. On-hardware smoke `RESULT PASS`, `-Launch`, and loop timing pending parent RTX/Blender verification)
+**Status:** done (PR #547, 2026-08-07 — one-command dev loop (build → package →
+install → launch → headless smoke-render); 150s full rebuild / 5.8s
+`-SkipBuild`; guard unit tests green (14/14), lint clean, on-hardware smoke
+`RESULT PASS`)
 **Estimated effort:** S–M (scripting + hardening of existing pieces, not new machinery)
 **Depends on:** nothing hard. Builds on: `build_blender_addon.py` + `ADDON_FILES` (packaging allow-list — memory `addon-packaging-file-list`), `scripts/verify_pkg88b_blender.py` / `verify_pkg114_*_blender.py` / `verify_pkg115_textures_blender.py` (the existing headless real-host patterns), the `-DASTRORAY_DISABLE_OPENMP=ON` addon-build constraint (memory `mingw_openmp_blender_deadlock`), the stale-`.pyd` discipline (memory `stale_pyd_locations`).
 

--- a/.astroray_plan/packages/pkg182-ggxreflect-eval-d-pdf-d-consistency.md
+++ b/.astroray_plan/packages/pkg182-ggxreflect-eval-d-pdf-d-consistency.md
@@ -7,7 +7,12 @@ r=0.02/0.05/0.10 0.067→**0.604** (matches the `metal` reference), r=0.30
 0.567→0.603; dielectric-specular r=0.02/0.05/0.10 0.025→**0.231**, r=0.30
 0.217→0.230. Register-neutral: `<false>` STACK 3608 B / `<true>` STACK
 6592 B unchanged. 14 new/extended tests + 73-test regression green, RTX
-5070 Ti hardware-verified.)
+5070 Ti hardware-verified. Follow-up PR #586, 2026-08-12 — per-λ-native
+Principled conductor thin-film supersedes the RGB-upsample approximation,
+17/17 gates HW-verified; saturation mean 0.0488→0.0499, max
+0.1842→0.2045 — a correctness/consistency win, not the visible saturation
+jump the ticket implied, per memory
+`per-lambda-conductor-thinfilm-equals-rgb-upsample`.)
 **Estimated effort:** S (eval-only fix, sampler/pdf untouched)
 **Depends on:** `disney.cpp` / `gpu_materials.h` GGX reflect evaluators
 (metallic + specular + anisotropic lobes); discovered as a blocker for

--- a/.astroray_plan/packages/pkg183-incremental-build-staleness-guard.md
+++ b/.astroray_plan/packages/pkg183-incremental-build-staleness-guard.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 5 (build infrastructure / verification integrity)
 **Track:** A
-**Status:** in-review (PR #592, 2026-08-12 — items 1–3 implemented:
+**Status:** done (PR #592, 2026-08-12 — items 1–3 implemented:
 header-hash stamp + force-clean-on-mismatch, a <5 s host-only ABI canary, AND
 a cuobjdump ground-truth CUDA-arch gate (PR #590 scope-add) wired into all
 three build wrappers; item 4 evaluated-only, see Lessons)

--- a/.astroray_plan/packages/pkg187-principled-dispersion.md
+++ b/.astroray_plan/packages/pkg187-principled-dispersion.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 3/5 (spectral light transport / Blender parity)
 **Track:** A
-**Status:** CPU-complete + GPU-wired (PR #593, 2026-08-12 — CPU chromatic prism
+**Status:** done — CPU-complete + GPU-wired (PR #593, 2026-08-12 — CPU chromatic prism
 red/blue spread 4.27→5.35px; zero-dispersion byte-identical; addon forward-probe
 unit-tested; `<false>` shade kernel **REG:254/STACK:3608 byte-identical to main**
 at TRUE sm_120 — see the register-gate note below. GPU-visible wavefront


### PR DESCRIPTION
## Summary

Doc-only round closeout for the 15-PR day+overnight session #585-#599 (2026-08-12 -> 2026-08-13). No source/test changes.

- Flips landed-spec `Status:` lines to `done`: pkg183 (build-integrity guard, PR #592), pkg187 (Principled BSDF dispersion, PR #593; kept its accurate "CPU-complete + GPU-wired" detail after the `done` keyword). pkg184/185/186/188/191 were already flipped to `done` by their own landing PRs — verified, untouched.
- Appends a landed follow-up note to pkg182's Status line (PR #586, per-lambda-native conductor thin-film supersedes the RGB-upsample approximation).
- Drift-gate fix: pkg175's spec had stayed `in review (PR pending)` past its own PR #547 merge (2026-08-07) — flipped to `done`, headline numbers pulled from ROADMAP.md's already-recorded parent-verification record (150s full rebuild / 5.8s `-SkipBuild`, on-hardware smoke `RESULT PASS`).
- New top-of-file STATUS.md entry + archival "Round closeout 2026-08-12 -> 2026-08-13" section: pkg183/184/185/186/187/188/191 landed, the pkg182 follow-up, the fleet-wide stale-CUDA-arch CMakeCache incident (and pkg183's new artifact-ground-truth gate against it), specs filed (pkg189/190/192/193/194/195), and the pkg195 HEADLINE finding that `multiwavelength_path_tracer` has no light sampling (every lamp-lit NIR/UV render is black end-to-end).
- ROADMAP.md: new round-closeout entry above the prior 2026-08-08->2026-08-10 one; "Current sequencing" left untouched (no new owner directive this round).
- NEXT_STAGE_REPORT.md rewritten for the next round: pkg195 Stage A (fix the light-sampling defect, CPU-only) is now the top correctness-tier pickup, ahead of pkg189 (GPU dispersion enablement, unblocks pkg187's GPU leg + the pkg64 dielectric xfail) and pkg194 (priority raised by pkg188's quantified ~72% band-error finding); Pillar 4 unpause stays the top strategic (not code) item, unresolved this round.

Every changed line traces to a landed PR from `git log`/`gh pr list --state closed` evidence gathered this session; no code, tests, or CMakeLists touched.

## Test plan
- [x] `git status --porcelain` shows only `.astroray_plan/` files touched
- [x] Diff reviewed line-by-line against the PR list/bodies before commit
- CI (docs-only path, no GPU dispatch needed)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>