### PR TITLE
build: make CUDA arch handling truthful + native-propagating (stale-arch root causes)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,46 @@ if(ASTRORAY_ENABLE_CUDA)
             if(NOT DEFINED ASTRORAY_CUDA_ARCHS)
                 set(ASTRORAY_CUDA_ARCHS "75;86;89")
             endif()
-            set(CMAKE_CUDA_ARCHITECTURES "${ASTRORAY_CUDA_ARCHS}")
+            # Resolve the "native" keyword to a concrete numeric arch OURSELVES.
+            # CMake's CMAKE_CUDA_ARCHITECTURES=native (3.24+) does NOT propagate
+            # under the Visual Studio generator — it leaves the generated
+            # .vcxproj <CodeGeneration> EMPTY and nvcc silently defaults to
+            # sm_52 (the 2026-08-12 stale-arch incident; produced bogus
+            # compute_52 cuobjdump resource readings). Detecting the numeric
+            # arch via nvidia-smi works identically under Ninja and VS.
+            if(ASTRORAY_CUDA_ARCHS STREQUAL "native")
+                set(_astroray_native_arch "")
+                find_program(_ASTRORAY_NVIDIA_SMI nvidia-smi)
+                if(_ASTRORAY_NVIDIA_SMI)
+                    execute_process(
+                        COMMAND "${_ASTRORAY_NVIDIA_SMI}" --query-gpu=compute_cap --format=csv,noheader
+                        OUTPUT_VARIABLE _astroray_smi_out
+                        OUTPUT_STRIP_TRAILING_WHITESPACE
+                        RESULT_VARIABLE _astroray_smi_rc)
+                    if(_astroray_smi_rc EQUAL 0)
+                        string(REGEX MATCH "[0-9]+\\.[0-9]+" _astroray_cc "${_astroray_smi_out}")
+                        if(_astroray_cc)
+                            string(REPLACE "." "" _astroray_native_arch "${_astroray_cc}")
+                        endif()
+                    endif()
+                endif()
+                if(_astroray_native_arch)
+                    set(ASTRORAY_CUDA_ARCHS "${_astroray_native_arch}")
+                    message(STATUS "ASTRORAY_CUDA_ARCHS=native resolved to sm_${_astroray_native_arch} via nvidia-smi")
+                else()
+                    # nvidia-smi unavailable: fall back to CMake's own native
+                    # keyword (works under Ninja/Makefiles on CMake >= 3.24;
+                    # may still not propagate under VS, hence the arch-verify gate).
+                    message(WARNING "ASTRORAY_CUDA_ARCHS=native: nvidia-smi detection failed; "
+                                    "leaving CMAKE_CUDA_ARCHITECTURES=native for CMake to resolve")
+                endif()
+            endif()
+            # Set as a FORCED cache entry so CMakeCache.txt reflects the EFFECTIVE
+            # value. The previous non-cache set() shadowed the cache: the cache
+            # read a stale 52 while the build targeted sm_120, confusing every
+            # human/agent that inspected CMakeCache (defect #1 of the incident).
+            set(CMAKE_CUDA_ARCHITECTURES "${ASTRORAY_CUDA_ARCHS}" CACHE STRING
+                "CUDA architectures to target (resolved from ASTRORAY_CUDA_ARCHS)" FORCE)
             set(ASTRORAY_CUDA_FOUND TRUE)
             message(STATUS "CUDA found: ${CMAKE_CUDA_COMPILER}")
         else()

--- a/configure_and_build.bat
+++ b/configure_and_build.bat
@@ -5,7 +5,12 @@ set "WORKTREE_DIR=%~dp0"
 cd /d "%WORKTREE_DIR%"
 
 echo Configuring CMake with VS 2022 generator...
-cmake -B build_cuda -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DASTRORAY_USE_CUDA=ON
+REM ASTRORAY_ENABLE_CUDA (not ASTRORAY_USE_CUDA, which is not a real option) enables the
+REM GPU backend; ASTRORAY_CUDA_ARCHS=native pins the local GPU arch. Under the VS
+REM generator the arch MUST be resolved to a numeric value (CMakeLists does this via
+REM nvidia-smi) -- passing the bare "native" keyword leaves .vcxproj CodeGeneration
+REM empty and nvcc defaults to sm_52 (the 2026-08-12 stale-arch incident).
+cmake -B build_cuda -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DASTRORAY_ENABLE_CUDA=ON -DASTRORAY_CUDA_ARCHS=native
 if %ERRORLEVEL% neq 0 (
     echo CMake configuration failed
     exit /b 1

--- a/scripts/build/build_blender_addon.py
+++ b/scripts/build/build_blender_addon.py
@@ -501,12 +501,25 @@ def _ensure_git_longpaths():
         print("    git config --global core.longpaths true")
 
 
-def configure_and_build(python_exe: Path, clean: bool, jobs: int, backend: str = "tcnn", build_id: str | None = None):
+def configure_and_build(python_exe: Path, clean: bool, jobs: int, backend: str = "tcnn",
+                        build_id: str | None = None, cuda_archs: str = "native"):
     global BUILD_DIR
     if backend in ("cuda", "tcnn"):
         _ensure_git_longpaths()
     nvcc = _require_nvcc(backend)
     BUILD_DIR, extra_flags = _backend_config(backend)
+
+    # Pin the CUDA arch for any GPU backend (cuda/tcnn, and auto when it resolves
+    # to cuda — detected via the ENABLE_CUDA=ON flag _backend_config emitted).
+    # Without this the configure fell through to CMakeLists' broad-compat default
+    # (75;86;89), so on an sm_120 (Blackwell) GPU the addon ran JIT'd PTX; and a
+    # reconfigure of an existing cache silently reverted a hand-set native arch
+    # (the PR #593 stale-arch incident). Re-asserting it on EVERY configure keeps
+    # the arch pinned across reconfigures. "native" is resolved to the local
+    # numeric arch inside CMakeLists (works under Ninja + VS). Configurable via
+    # --cuda-archs for CI / distributable multi-arch builds.
+    if "-DASTRORAY_ENABLE_CUDA=ON" in extra_flags:
+        extra_flags = [f"-DASTRORAY_CUDA_ARCHS={cuda_archs}", *extra_flags]
 
     # pkg94: compute build-ID once and inject into C++ compile
     if build_id is None:
@@ -952,6 +965,10 @@ def main():
     ap.add_argument("--backend", choices=["auto", "cpu", "cuda", "tcnn"], default="cuda",
                     help="Build backend: cuda (default, CUDA GPU), tcnn (CUDA+NRC, experimental), "
                          "cpu (CPU-only), auto (probe nvcc, use cuda if found)")
+    ap.add_argument("--cuda-archs", default="native",
+                    help="CUDA arch(s) for GPU backends (default: native - the local GPU's "
+                         "compute cap, resolved numerically in CMakeLists). Pass a CMake arch "
+                         "list e.g. '75;86;89;120' for a distributable multi-arch build.")
     ap.add_argument("--clean", action="store_true", help="Wipe the build dir before configuring")
     ap.add_argument("--configure-only", action="store_true",
                     help="Run cmake configure but skip the build")
@@ -981,7 +998,8 @@ def main():
     # 3. Configure + build (unless configure-only)
     # pkg94: thread build_id through configure→build→stage so the same ID is
     # compiled into C++ and written to the manifest
-    build_id = configure_and_build(python_exe, clean=args.clean, jobs=args.jobs, backend=args.backend)
+    build_id = configure_and_build(python_exe, clean=args.clean, jobs=args.jobs,
+                                   backend=args.backend, cuda_archs=args.cuda_archs)
     if args.configure_only:
         print("configure-only: skipping stage/zip")
         return


### PR DESCRIPTION
Fixes the three confirmed root causes behind the 2026-08-12 fleet-wide stale-CUDA-arch incident (pkg183 spec incident section; memory `worktree-cmake-cuda-arch-stale-cache`). Build-toolchain only; no engine/kernel code changed.

## Authorized surface
Spec scope: the three defects + configure-entry-point pass-through consistency.

| File | Touched | Why |
|------|---------|-----|
| `CMakeLists.txt` | yes | Defects #1 (truthful cache) + #2 (native propagation) |
| `configure_and_build.bat` | yes | VS-gen configure entry point missing the arch pass-through (+ bogus option-name fix) |
| `scripts/build/build_blender_addon.py` | yes | Defect #3 (arch default + reconfigure re-assert) |

Other configure entry points checked and already correct (already pass `-DASTRORAY_CUDA_ARCHS=native`): `scripts/build/build_cuda.bat`, `scripts/build/build_cuda_worktree.bat`. Root `build_cuda_worktree.bat` is build-only (no configure) — untouched, so the `test_gpu_serialization_preserved` "lock"-substring rule is unaffected.

## Defect #1 — cache now truthful
Old non-cache `set(CMAKE_CUDA_ARCHITECTURES ...)` shadowed the cache: CMakeCache read `52` while the build targeted sm_120. Now set as `CACHE STRING ... FORCE`.

| tree | `CMAKE_CUDA_ARCHITECTURES` in CMakeCache.txt (after) |
|------|------|
| VS-generator (`configure_and_build.bat`) | `CMAKE_CUDA_ARCHITECTURES:STRING=120` |
| Ninja (`scripts/build/build_cuda_worktree.bat`) | `CMAKE_CUDA_ARCHITECTURES:STRING=120` |
| Blender addon (`build_blender_addon_cuda`) | `CMAKE_CUDA_ARCHITECTURES:STRING=120` |

Before this PR every inspected `build_cuda/CMakeCache.txt` read `52` (incident).

## Defect #2 — `native` now propagates under the VS generator
Isolated A/B on a minimal standalone CUDA project (VS 17 2022 generator), stock vs fixed native-handling:

| | cache line | `<CodeGeneration>` | `--generate-code` in AdditionalOptions | effective arch |
|--|--|--|--|--|
| **BEFORE** (bare `native`) | `...=52` | empty | **none emitted** | sm_52 (default) |
| **AFTER** (resolve→numeric) | `...=120` | empty | `arch=compute_120,code=[compute_120,sm_120]` | **sm_120** |

(The empty `<CodeGeneration>` is normal CMake behaviour — the arch is expressed via `--generate-code` in `<AdditionalOptions>`, which is present only after the fix.)

**Ground-truth `cuobjdump --list-elf` on the real built `.pyd`, both generators:**
```
VS-gen    build_cuda/Release/astroray.cp313-win_amd64.pyd -> sm_120
Ninja     build_cuda/astroray.cp313-win_amd64.pyd         -> sm_120
addon     build_blender_addon_cuda/astroray.cp313-...pyd  -> sm_120
```
Configure emits: `-- ASTRORAY_CUDA_ARCHS=native resolved to sm_120 via nvidia-smi` under both generators.

## Defect #3 — addon build no longer defaults / reverts to a pre-sm_120 arch
`build_blender_addon.py` now injects `-DASTRORAY_CUDA_ARCHS=<--cuda-archs, default native>` for every GPU backend, re-asserted on every configure. Previously it passed no arch at all → fell through to the CMakeLists broad-compat default (75;86;89), and a reconfigure could silently revert a hand-set native arch (PR #593). Addon `.pyd` now embeds sm_120 (above). `configure_and_build.bat` gets the same pass-through and its bogus `-DASTRORAY_USE_CUDA` (not a real option) corrected to `-DASTRORAY_ENABLE_CUDA`.

## pkg183 guard intact (acceptance harness)
Both touched wrappers run end-to-end, `arch-verify OK` + canary pass:
```
[pkg183] arch-verify OK: astroray.cp313-win_amd64.pyd embeds sm_120 (embedded=[sm_120])
[pkg183] canary caps: {'cpu': True, ..., 'gpu': True, ...}
```

## Build log tails (`.cu` recompiled via CMakeLists change)
VS-generator (`configure_and_build.bat`):
```
  astroray_test_helpers.vcxproj -> ...\build_cuda\Release\astroray_test_helpers.cp313-win_amd64.pyd
Build succeeded
```
Ninja (`scripts/build/build_cuda_worktree.bat`) last lines:
```
[pkg183] arch-verify OK: astroray.cp313-win_amd64.pyd embeds sm_120 (embedded=[sm_120])
[pkg183] running host-only ABI canary (no GPU)...
[pkg183] canary caps: {'cpu': True, ..., 'gpu': True, ...}
[build_cuda_worktree] Build succeeded
```
Addon (`build_blender_addon.py --backend cuda`) last lines:
```
Addon package: ...\dist\astroray-4.0.0-cuda.zip
Done.
```

## Tests / lint
- `tests/test_hw_verifier_buildenv.py`: 13 passed (incl. `test_gpu_serialization_preserved` "lock"-rule).
- Behavioral sweep: no test asserts the old arch/cache behaviour; `scripts/dev/test_blender_addon.py` calls `configure_and_build(...)` with keyword args — the new `cuda_archs` param has a default, no break.
- Lint gate: 20 `git-diff-check` "trailing whitespace" findings on the added `build_blender_addon.py` lines are **false positives** — that file is anomalously CRLF-stored in origin/main, and git flags CR-at-EOL on added lines. Verified zero real trailing space/tab and zero lone CR; edits preserve the file's existing CRLF (autocrlf=false, diff stays minimal). Converting the file to LF would be a ~1000-line unrelated churn.

## Acceptance checklist
- [x] Defect #1: cache truthful (120 on all three trees)
- [x] Defect #2: native → sm_120 under BOTH VS and Ninja (cuobjdump ground truth + A/B)
- [x] Defect #3: addon arch default native + reconfigure re-assert; addon `.pyd` sm_120
- [x] configure_and_build.bat pass-through added; other entry points already correct
- [x] pkg183 guard intact + arch-verify OK on both touched wrappers
- [x] .bat edits CRLF-preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)
