### PR TITLE
feat(pkg195): Stage A+B — MW-tracer light sampling + spectral lamp presets

### DIFF
--- a/.astroray_plan/packages/pkg195-spectral-nodes-phase1.md
+++ b/.astroray_plan/packages/pkg195-spectral-nodes-phase1.md
@@ -71,6 +71,18 @@ Add spectral next-event estimation over dedicated lights to
 > leg was silently dropped; `PowerLightSampler` now falls back to uniform light
 > selection for a degenerate CDF (`src/light_sampler.cpp`). Gate results: A1 mean
 > 0.0709, A2 ratio 4.82, A3 per-channel parity 1.00.
+>
+> **NEE is gated on an `enable_nee` integrator param (default 1 = on).** The
+> engine-wide contract `enableNEE = (integrator != "multiwavelength_path_tracer")`
+> (module/blender_module.cpp:1814) makes this integrator the light-sampling-blind
+> NAIVE oracle the GPU wavefront naive route is gated to match (pkg120/pkg156). An
+> unconditional NEE changed that oracle's physics while the GPU comparator did not,
+> collapsing 3 CPU↔GPU parity gates (SSIM 0.30). `enable_nee=0` is byte-identical
+> to the pre-Stage-A integrator; the parity harnesses
+> (`test_gpu_multiwavelength`, `test_pkg55_c3_wavefront_nonvisible`) pin it on the
+> CPU MW oracle legs. **Phase-3 item now explicitly encoded by those gates: the
+> GPU MW/wavefront leg has no dedicated-light sampling — GPU spectral-light NEE
+> parity is deferred to pkg195 Phase 3** (design doc §5, Phase 3).
 
 - Template: the in-header path tracer's dedicated-light NEE
   (`include/raytracer.h:2423` area, and the `astroray::Light` spectral sample

--- a/.astroray_plan/packages/pkg195-spectral-nodes-phase1.md
+++ b/.astroray_plan/packages/pkg195-spectral-nodes-phase1.md
@@ -2,8 +2,14 @@
 
 **Pillar:** 2/3 (spectral rendering / Blender integration)
 **Track:** A
-**Status:** open (filed 2026-08-12 from the owner-directed spectral-node design
-session; design doc: `.astroray_plan/docs/spectral-node-system-design-2026-08.md`)
+**Status:** Stage A + B done (PR #602, 2026-08-13 — MW NIR snow-sphere mean
+0.0709 > 0.05, snow/water NIR ratio 4.82, MW↔path_tracer visible parity 1.00;
+sodium lamp linear RGB (0.673, 0.127, 0.000) amber, cie_f2 differs 100% on blue;
+headless Blender 5.1 render confirms amber sodium vs neutral cie_f2). Stage C
+(register_spectral_profile + Drawn/Preset/Blackbody spectrum nodes + in-band
+Replace mode + IR/UV de-fang + Sellmeier B/C) remains OPEN — independently
+landable. Filed 2026-08-12 from the owner-directed spectral-node design session;
+design doc: `.astroray_plan/docs/spectral-node-system-design-2026-08.md`.
 **Estimated effort:** L (three gated stages; each independently landable)
 **Depends on:** nothing in flight. Touches `multiwavelength_path_tracer.cpp`
 (CPU only), `blender_addon/`, `module/blender_module.cpp`,
@@ -52,10 +58,19 @@ follow-ups recorded in the design doc §5 — do not scope-creep them in.
 
 ---
 
-## Stage A — transport: MW integrator sees lights (prerequisite for everything)
+## Stage A — transport: MW integrator sees lights (prerequisite for everything) — DONE (PR #602)
 
 Add spectral next-event estimation over dedicated lights to
 `MultiwavelengthPathTracer::pathTrace`.
+
+> **Landed 2026-08-13.** Ported the in-header `pathTraceSpectral` dedicated-light
+> NEE + two-sided MIS (raytracer.h:2415-2568) into the MW integrator, using
+> `evalSpectralExt`/`sampleSpectralExt`. Also fixed a latent light-sampler bug the
+> spec's own Gate B exposed: a narrow-line lamp SPD (sodium) makes every light's
+> single-stratum `power()` read 0 → `totalPower==0` → `selPdf=0/0=NaN` → the NEE
+> leg was silently dropped; `PowerLightSampler` now falls back to uniform light
+> selection for a degenerate CDF (`src/light_sampler.cpp`). Gate results: A1 mean
+> 0.0709, A2 ratio 4.82, A3 per-channel parity 1.00.
 
 - Template: the in-header path tracer's dedicated-light NEE
   (`include/raytracer.h:2423` area, and the `astroray::Light` spectral sample
@@ -77,7 +92,16 @@ integrator on a lamp-lit scene within per-channel mean-ratio [0.95, 1.05] of
 the default path tracer (gamma OFF — linear gate, see memory
 gamma-furnace-cannot-detect-energy-gain).
 
-## Stage B — spectral lights in the addon (sodium lamps)
+## Stage B — spectral lights in the addon (sodium lamps) — DONE (PR #602)
+
+> **Landed 2026-08-13.** `light.custom_raytracer` PropertyGroup + spectrum-mode
+> enum + `DATA_PT_custom_raytracer_light` panel (Astroray-engine only, with a
+> per-profile λ-range label via a new `spectral_profile_range` binding).
+> `_build_emission_dict` emits `{'mode':'measured_spd','profile_name':<name>}`
+> (the parser's actual key — the spec's `'profile'` was shorthand), wrapped in a
+> `composite` when the lamp colour is a non-white gel. Headless Blender 5.1 CPU
+> render: sodium amber (display RGB 0.291/0.278/0.0003, R>G>3B) vs neutral cie_f2
+> (0.289/0.287/0.285). Engine-level linear gate: sodium (0.673, 0.127, 0.000).
 
 1. `light.custom_raytracer.spectrum_mode` enum: `native` (default; exactly
    today's blackbody/rgb behaviour) · `preset` (dropdown over emission-category
@@ -98,7 +122,14 @@ over a white sphere, visible band, CPU → hue must land amber
 ratios by > 10%. Test lives with the pkg119b-style harness
 (`ASTRORAY_PYD_DIR` + absolute out-dir conventions).
 
-## Stage C — spectrum sources + honest material nodes
+## Stage C — spectrum sources + honest material nodes — OPEN (descoped from the A+B PR)
+
+> Not started. Independently landable; nothing in A+B blocks it. Note for the
+> implementer: A+B already added `SpectralProfile::lambdaMin/lambdaStep/count`
+> getters and the `spectral_profile_range` binding, and the light panel's
+> `custom_profile` mode is wired to `_spectral_profile_items` — so a
+> `register_spectral_profile` insert method (item 1) immediately feeds the Stage-B
+> custom-profile dropdown.
 
 1. **`astroray.register_spectral_profile(name, lambda_min_nm, lambda_step_nm,
    values: list[float])`** pybind binding inserting into

--- a/.astroray_plan/packages/pkg195-spectral-nodes-phase1.md
+++ b/.astroray_plan/packages/pkg195-spectral-nodes-phase1.md
@@ -230,3 +230,86 @@ ratios by > 10%. Test lives with the pkg119b-style harness
 - GPU spectral-light parity, MW/wavefront GPU NEE, GMaterial Replace mode (Phase 3)
 - Pillar-4 physical units audit, GR emission-model surfacing, log-λ wide-band
   tables (Phase 4)
+
+## Hardware verification 2026-08-13
+
+Independent HW verification of PR #602 (Stage A + B), RTX 5070 Ti, Windows 11
+Enterprise 10.0.26200, NVIDIA driver 610.47, CUDA 12.8 (nvcc V12.8.61), sm_120.
+
+**Round 1 — commit `9018368` (initial Stage A+B): FAIL on Gate 3.**
+- Gate 1 (clean rebuild): PASS — `.pyd` embeds sm_120, ABI canary green,
+  HEAD SHA verified.
+- Gate 2 (`test_pkg195_stage_a_mw_nee.py` + `test_pkg195_stage_b_spectral_lamp.py`,
+  6 tests): PASS, numbers matched claims exactly (A1 mean 0.0709, A2 ratio 4.82,
+  A3 ratio [1,1,1]; B1 sodium (0.6730, 0.1265, 0.0000); B2 max Δ 1.00; B3 gel
+  ~7.0× red suppression).
+- **Gate 3 (deferred GPU parity suites — `test_pkg55_c3_wavefront_nonvisible.py` +
+  `test_gpu_multiwavelength.py`, 10 tests): FAIL, 3/10.**
+  `test_naive_mode_wavefront_cpu_parity` SSIM 0.3001 (gate ≥0.97);
+  `test_visible_band_cpu_gpu_ssim` SSIM 0.3061 (gate ≥0.995);
+  `test_visible_band_no_regression` GPU/CPU mean drift 79.27% (gate <2%).
+  Root cause (confirmed by reading the diff, not the failure alone): Stage A
+  gave `MultiwavelengthPathTracer` unconditional dedicated-light + emissive-hit
+  NEE. Both suites use this exact integrator as their light-sampling-blind
+  "naive" CPU oracle for the GPU wavefront/megakernel comparison
+  (`test_pkg55_c3_wavefront_nonvisible.py:119` literally selects it for
+  `enable_nee=False`). The oracle's physics changed while the GPU comparator
+  did not, so the CPU leg went bright (real NEE on the scene's ceiling-light
+  quad) while the GPU leg stayed dim — a structural collision, not noise.
+  Gates 4-6 (light_sampler.cpp scrutiny, visual PNG inspection, headless-Blender
+  addon smoke) all PASSED independently of this failure. Reported FAIL,
+  did not merge, did not attempt a fix (escalated for an architect decision).
+
+**Fix — commit `c07671e`, spec update `90ee32e`.** Implementer added an
+`enable_nee` integrator param (default on) gating all three NEE/MIS legs in
+`MultiwavelengthPathTracer::pathTrace` (dedicated-light visibility w_B,
+emissive-hit w_B — the exact pkg120/pkg156 bug class — and the NEE sample
+leg), and pinned `enable_nee=0` on the CPU oracle legs in both parity test
+files via `set_integrator_param`. No gate threshold was edited in either test
+file (diff-verified: only `set_integrator_param("enable_nee", 0)` calls added).
+
+**Round 2 — commit `90ee32e` (confirmation pass): PASS, all gates green.**
+- HEAD SHA `90ee32e80d816b9935c415db1528c1c853489e6f` confirmed = PR #602
+  `headRefOid` at time of this check.
+- Gate 1 (clean rebuild): PASS — sm_120 embedded, pkg183 stamp
+  `sha=90ee32e80d81`, ABI canary unchanged/green.
+- Gate 2 (6 pkg195 tests): PASS, identical numbers to Round 1 (unaffected by
+  the fix — these use `enable_nee` default-on).
+- **Gate 3 (10 deferred GPU parity tests): PASS, 10/10, recovered.** Measured
+  independently (not just re-running the assertions — recomputed the exact
+  SSIM/drift values the tests check):
+  - `test_naive_mode_wavefront_cpu_parity`: SSIM = 0.99158 (gate ≥0.97;
+    implementer reported 0.9816 — both comfortably clear the gate; the ~0.01
+    spread across independent runs is consistent with GPU-warp/OpenMP MC
+    sample-stream non-determinism documented elsewhere in this suite, not a
+    correctness concern).
+  - `test_visible_band_cpu_gpu_ssim`: SSIM = 0.995426 (gate ≥0.995; implementer
+    reported 0.9954 — matches to 4 decimal places).
+  - `test_visible_band_no_regression`: CPU mean 0.027330, GPU mean 0.027687,
+    drift = 1.3054% (gate <2%; implementer reported 1.31% — matches).
+  - Remaining 7 of the 10 (NIR/UV band agreement-on-black, visible-band
+    default-unchanged, NIR/UV CPU-GPU SSIM with profiles, no-profile fallback,
+    GPU MW kernel finiteness): all PASS, unchanged from Round 1 (these were
+    never affected — they don't use the naive-oracle integrator in the broken
+    configuration).
+- 16/16 total tests green (`test_pkg55_c3_wavefront_nonvisible.py` +
+  `test_gpu_multiwavelength.py` + both pkg195 Stage A/B files).
+- `enable_nee` diff re-read line-by-line: gating mirrors the in-header
+  template's condition exactly, including the emission two-sided-MIS w_B leg
+  (the pkg156 bug class — this is the leg that would silently re-break GPU
+  naive-mode parity if left unconditional). Parity-test edits pin the oracle
+  without touching any assertion threshold (diff-verified).
+- Gates 4-6 unaffected by the fix commit (`light_sampler.cpp`,
+  `blender_addon/__init__.py`, `module/blender_module.cpp` are untouched
+  between `9018368` and `90ee32e`) — Round 1's PASS results for those stand.
+
+**Visual inspection (unchanged from Round 1, re-confirmed applicable):**
+`test_results/pkg195_gateA_nir_snow.png` (smooth-lit greyscale sphere, visible
+terminator, no fireflies/banding/NaN pixels), `test_results/pkg195_gateB_sodium.png`
+(bright amber sphere, R≫B, clean), `test_results/pkg195_gateB_cie_f2.png`
+(neutral white/grey sphere, clean) — no anomalies in either round.
+
+**Verdict: mergeable on HW evidence.** All 6 verification-workflow gates green
+on the current PR head (`90ee32e`); the Round-1→fix→Round-2 arc is preserved
+here as the record of a real regression the deferred-suite gate was specifically
+designed to catch, and of a fix that did not relax any threshold.

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -5830,7 +5830,16 @@ def register():
         bpy.utils.register_class(cls)
     bpy.types.Scene.custom_raytracer = PointerProperty(type=CustomRaytracerRenderSettings)
     bpy.types.Material.custom_raytracer = PointerProperty(type=CustomRaytracerMaterialSettings)
-    bpy.types.Light.custom_raytracer = PointerProperty(type=CustomRaytracerLightSettings)
+    # pkg195 Stage B: attach spectral-light settings only when bpy.types.Light
+    # exists. CI runs register() under a bpy stub that omits Light (the same class
+    # of stub gap the native shader nodes degrade around above); real Blender
+    # always has it, so the headless-Blender path is unaffected.
+    _light_type = getattr(bpy.types, 'Light', None)
+    if _light_type is not None:
+        _light_type.custom_raytracer = PointerProperty(type=CustomRaytracerLightSettings)
+    else:
+        print("Astroray spectral light settings unavailable: "
+              "module 'bpy.types' has no attribute 'Light'")
     bpy.types.Object.astroray_black_hole = PointerProperty(type=AstrorayBlackHoleProperties)
     bpy.types.Object.astroray_object = PointerProperty(type=AstrorayObjectProperties)
 
@@ -5861,7 +5870,9 @@ def unregister():
 
     del bpy.types.Scene.custom_raytracer
     del bpy.types.Material.custom_raytracer
-    del bpy.types.Light.custom_raytracer
+    _light_type = getattr(bpy.types, 'Light', None)
+    if _light_type is not None and hasattr(_light_type, 'custom_raytracer'):
+        del _light_type.custom_raytracer
     del bpy.types.Object.astroray_black_hole
     del bpy.types.Object.astroray_object
     for cls in reversed(classes):

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -610,6 +610,47 @@ def _spectral_profile_items(self, context):
     items.extend((n, n, '') for n in names)
     return items
 
+# pkg195 Stage B: emission-category (category 7) lamp SPDs shipped in
+# profiles.bin (design doc §1.1). The DB does not expose category in-memory, so
+# the preset dropdown filters the loaded names against this known set (order
+# preserved). Provenance for each is recorded in data/spectral_profiles/sources.md.
+_EMISSION_PROFILE_NAMES = (
+    'sodium_vapor', 'mercury_vapor',
+    'cie_f2', 'cie_f3',
+    'led_3000k', 'led_5000k', 'led_6500k',
+)
+
+
+def _light_emission_preset_items(self, context):
+    if not RAYTRACER_AVAILABLE or not hasattr(astroray, "spectral_profile_names"):
+        return [('sodium_vapor', 'Sodium Vapor', '')]
+    try:
+        available = set(astroray.spectral_profile_names())
+    except Exception:
+        available = set()
+    items = [(n, n.replace('_', ' ').title(), '')
+             for n in _EMISSION_PROFILE_NAMES if n in available]
+    if not items:
+        # DB not loaded / missing emission SPDs: keep the enum non-empty so the
+        # PropertyGroup still registers.
+        items = [('sodium_vapor', 'Sodium Vapor', '')]
+    return items
+
+
+def _profile_range_label(profile_name):
+    """pkg195 Stage B: '300-2500 nm @ 5 nm' style label for a named profile."""
+    if (not RAYTRACER_AVAILABLE or not hasattr(astroray, "spectral_profile_range")
+            or not profile_name or profile_name == "__none__"):
+        return ""
+    try:
+        lmin, lmax, step = astroray.spectral_profile_range(profile_name)
+    except Exception:
+        return ""
+    if lmax <= lmin:
+        return ""
+    return f"{lmin:.0f}-{lmax:.0f} nm @ {step:.0f} nm"
+
+
 def _active_wavelength_band(settings):
     preset = getattr(settings, "wavelength_preset", "visible")
     if preset == "near_ir":
@@ -738,6 +779,54 @@ class CustomRaytracerMaterialSettings(PropertyGroup):
         max=64,
         default=8,
     )
+
+
+class CustomRaytracerLightSettings(PropertyGroup):
+    # pkg195 Stage B: spectral emission mode for dedicated lights. `native`
+    # reproduces exactly today's blackbody/RGB behaviour (light.use_temperature
+    # + light.color). `preset` / `custom_profile` route the emission through a
+    # MeasuredSPD (sodium_vapor etc.), with the light colour kept as a gel tint
+    # via the engine's Composite EmissionSpectrum mode.
+    spectrum_mode: EnumProperty(
+        name="Spectrum",
+        description="How this light's emission spectrum is authored",
+        items=[
+            ('native', 'Native',
+             "Blackbody (from light temperature) or RGB upsample — today's behaviour"),
+            ('preset', 'Lamp Preset',
+             "A measured lamp SPD from the profile database (sodium, mercury, "
+             "fluorescent, LED)"),
+            ('custom_profile', 'Custom Profile',
+             "Any spectral profile by name (e.g. a drawn/imported emission profile)"),
+        ],
+        default='native',
+    )
+    preset_profile: EnumProperty(
+        name="Lamp",
+        description="Measured lamp emission spectrum",
+        items=_light_emission_preset_items,
+    )
+    custom_profile: EnumProperty(
+        name="Profile",
+        description="Spectral profile used as this light's emission SPD",
+        items=_spectral_profile_items,
+        default=0,
+    )
+
+
+def _light_spectrum_profile(light):
+    """pkg195 Stage B: resolved profile name for preset/custom spectrum modes,
+    or '' when the light is in native mode / unresolved."""
+    settings = getattr(light, 'custom_raytracer', None)
+    if settings is None:
+        return ""
+    mode = getattr(settings, 'spectrum_mode', 'native')
+    if mode == 'preset':
+        return getattr(settings, 'preset_profile', "") or ""
+    if mode == 'custom_profile':
+        name = getattr(settings, 'custom_profile', "") or ""
+        return "" if name == "__none__" else name
+    return ""
 
 
 def _preview_helpers():
@@ -4341,6 +4430,24 @@ class CustomRaytracerRenderEngine(RenderEngine):
             # pkg89 Phase B: construct EmissionSpectrum dict from Blender light properties.
             # Q-Owner-1 resolution: default to blackbody (D65 6500K) with color as tint filter.
             # Blender 4.5+ has light.use_temperature toggle; fallback to RGB if not available.
+            #
+            # pkg195 Stage B: preset / custom_profile spectrum modes emit a
+            # MeasuredSPD wrapped in a Composite so the light colour remains a
+            # gel tint (blender_module.cpp parseEmissionSpectrum already handles
+            # both 'measured_spd' and 'composite'). Native mode is unchanged.
+            profile_name = _light_spectrum_profile(light)
+            if profile_name:
+                measured = {'mode': 'measured_spd', 'profile_name': profile_name}
+                tint = list(light.color)
+                # Skip the composite wrapper when the tint is (near-)white so the
+                # SPD reaches the engine unmodulated.
+                if all(abs(c - 1.0) < 1e-4 for c in tint):
+                    return measured
+                return {
+                    'mode': 'composite',
+                    'base': measured,
+                    'filter_rgb': tint,
+                }
             use_temp = getattr(light, 'use_temperature', False)
             if use_temp and hasattr(light, 'temperature'):
                 # Blackbody mode: temperature + color as tint filter.
@@ -5412,8 +5519,53 @@ class OBJECT_PT_astroray_object(Panel):
         layout.prop(ao, "is_caustic_caster")
 
 
+class DATA_PT_custom_raytracer_light(AstrorayPanelBase, Panel):
+    """pkg195 Stage B: spectral emission authoring for the active light."""
+    bl_label = "Astroray Spectrum"
+    bl_space_type = 'PROPERTIES'
+    bl_region_type = 'WINDOW'
+    bl_context = "data"
+
+    @classmethod
+    def poll(cls, context):
+        return (context.scene.render.engine == 'CUSTOM_RAYTRACER'
+                and context.light is not None
+                and hasattr(context.light, 'custom_raytracer'))
+
+    def draw(self, context):
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False
+
+        light = context.light
+        settings = light.custom_raytracer
+        layout.prop(settings, "spectrum_mode")
+
+        mode = settings.spectrum_mode
+        profile_name = ""
+        if mode == 'preset':
+            layout.prop(settings, "preset_profile")
+            profile_name = getattr(settings, "preset_profile", "") or ""
+        elif mode == 'custom_profile':
+            layout.prop(settings, "custom_profile")
+            name = getattr(settings, "custom_profile", "") or ""
+            profile_name = "" if name == "__none__" else name
+
+        if mode != 'native':
+            label = _profile_range_label(profile_name)
+            if label:
+                layout.label(text=label, icon='IPO_LINEAR')
+            layout.label(text="Light colour acts as a gel tint", icon='INFO')
+            # pkg195 Stage B: GPU dedicated lights approximate non-RGB emission
+            # via deviceReference() RGB (emission_spectrum.h:100-108). The
+            # measured SPD is exact only on the CPU integrators; note it so the
+            # artist isn't surprised by a GPU/CPU chroma difference.
+            layout.label(text="GPU: RGB-approximated (CPU is exact)", icon='ERROR')
+
+
 classes = [
     CustomRaytracerRenderSettings, CustomRaytracerMaterialSettings,
+    CustomRaytracerLightSettings,
     AstrorayObjectProperties,
     AstrorayBlackHoleProperties,
     CustomRaytracerRenderEngine,
@@ -5429,6 +5581,7 @@ classes = [
     CustomRaytracerPreferences,
     ASTRORAY_OT_add_black_hole, OBJECT_PT_astroray_black_hole,
     OBJECT_PT_astroray_object,
+    DATA_PT_custom_raytracer_light,
 ]
 
 # ---------------------------------------------------------------------- #
@@ -5677,6 +5830,7 @@ def register():
         bpy.utils.register_class(cls)
     bpy.types.Scene.custom_raytracer = PointerProperty(type=CustomRaytracerRenderSettings)
     bpy.types.Material.custom_raytracer = PointerProperty(type=CustomRaytracerMaterialSettings)
+    bpy.types.Light.custom_raytracer = PointerProperty(type=CustomRaytracerLightSettings)
     bpy.types.Object.astroray_black_hole = PointerProperty(type=AstrorayBlackHoleProperties)
     bpy.types.Object.astroray_object = PointerProperty(type=AstrorayObjectProperties)
 
@@ -5707,6 +5861,7 @@ def unregister():
 
     del bpy.types.Scene.custom_raytracer
     del bpy.types.Material.custom_raytracer
+    del bpy.types.Light.custom_raytracer
     del bpy.types.Object.astroray_black_hole
     del bpy.types.Object.astroray_object
     for cls in reversed(classes):

--- a/include/astroray/spectral_profile.h
+++ b/include/astroray/spectral_profile.h
@@ -44,6 +44,13 @@ public:
     }
 
     bool valid() const noexcept { return data_ != nullptr && n_ > 0; }
+
+    // pkg195 Stage B: grid metadata for the light-panel λ-range label. The DB
+    // ships 300-2500 nm @ 5 nm today, but register_spectral_profile (Stage C)
+    // accepts arbitrary ranges, so read them per-profile rather than assuming.
+    float lambdaMin()  const noexcept { return lmin_; }
+    float lambdaStep() const noexcept { return lstep_; }
+    int   count()      const noexcept { return n_; }
 };
 
 // Loads and owns the ASPR binary database (profiles.bin from pkg38).

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -3744,6 +3744,17 @@ PYBIND11_MODULE(astroray, m) {
         if (!p) return 0.0f;
         return p->reflectance(lambda_nm);
     }, "name"_a, "lambda_nm"_a, "Sample reflectance of a named profile at lambda_nm.");
+    // pkg195 Stage B: (lambda_min_nm, lambda_max_nm, step_nm) for the named
+    // profile, so the addon light panel can label the profile's actual range.
+    // Returns (0, 0, 0) when the name is unknown.
+    m.def("spectral_profile_range", [](const std::string& name) {
+        const auto* p = astroray::SpectralProfileDatabase::instance().get(name);
+        if (!p || !p->valid()) return py::make_tuple(0.0f, 0.0f, 0.0f);
+        float lmin = p->lambdaMin();
+        float step = p->lambdaStep();
+        float lmax = lmin + step * static_cast<float>(p->count() - 1);
+        return py::make_tuple(lmin, lmax, step);
+    }, "name"_a, "Return (lambda_min_nm, lambda_max_nm, step_nm) for a named profile.");
 
     // -----------------------------------------------------------------
     // Pillar 2 spectral core (pkg10). Scaffolding types — not consumed

--- a/plugins/integrators/multiwavelength_path_tracer.cpp
+++ b/plugins/integrators/multiwavelength_path_tracer.cpp
@@ -22,6 +22,16 @@ class MultiwavelengthPathTracer : public Integrator {
     float lambdaMin_;
     float lambdaMax_;
     bool  useLuminanceOutput_;  // true when rendering outside visible
+    // pkg195: gate the dedicated-light NEE + two-sided-MIS legs (Stage A). This
+    // MIRRORS the engine-wide "multiwavelength_path_tracer == naive" contract
+    // (module/blender_module.cpp:1814 sets the GPU wavefront's enableNEE = false
+    // for this integrator) and the pkg156 lesson: the GPU wavefront naive route
+    // is gated to match THIS integrator as the light-sampling-blind oracle, so a
+    // NEE/w_B term firing here in naive mode silently breaks CPU<->GPU parity
+    // (pkg120/pkg156, test_gpu_multiwavelength / test_pkg55_c3). Default ON so the
+    // addon's NIR/UV lamp rendering works (Stage A); parity harnesses that use
+    // this integrator as the naive oracle pin `enable_nee=0`.
+    bool  enableNEE_;
     Renderer* renderer_ = nullptr;
     Camera*   camera_   = nullptr;
 
@@ -49,6 +59,10 @@ public:
             useLuminanceOutput_ = !isInsideVisible(lambdaMin_, lambdaMax_);
         else
             useLuminanceOutput_ = (mode == "luminance");
+        // int route (not getBool): ParamDict::get_ is exact-type-match, and the
+        // set_integrator_param(str,int) binding stores an int — so
+        // set_integrator_param("enable_nee", 0) is only visible via getInt.
+        enableNEE_ = p.getInt("enable_nee", 1) != 0;
     }
 
     void beginFrame(Renderer& scene, Camera& cam) override { renderer_ = &scene; camera_ = &cam; }
@@ -179,7 +193,9 @@ private:
             // camera rays (bounce == 0); a lamp closer than the surface
             // terminates the path and feeds the same two-sided MIS term the
             // emissive path below uses (wB = 1 after a specular bounce).
-            if (bounce > 0 && !lights.getDedicatedLights().empty()) {
+            // Gated on enableNEE_: this is a light-sampling/MIS term and must NOT
+            // fire in naive mode (the GPU-parity oracle contract, pkg156).
+            if (enableNEE_ && bounce > 0 && !lights.getDedicatedLights().empty()) {
                 float surfaceT = didHit ? rec.t : std::numeric_limits<float>::max();
                 astroray::Light::Intersection lh;
                 if (lights.intersectDedicated(ray.origin, ray.direction, 0.001f,
@@ -226,12 +242,17 @@ private:
 
             if (!rec.material) break;
 
-            // Emission (two-sided MIS, mirrors pathTraceSpectral raytracer.h:2496-2527).
+            // Emission. In NEE mode this is the two-sided MIS w_B leg (mirrors
+            // pathTraceSpectral raytracer.h:2496-2527); in naive mode it is the
+            // BYTE-OLD behavior — emission is taken only on a camera / post-
+            // specular ray and DROPPED on a non-specular diffuse hit (no w_B
+            // term). pkg156's exact bug was a w_B term left firing unconditionally
+            // in naive mode, so this else-branch is gated on enableNEE_.
             astroray::SampledSpectrum Le = rec.material->emittedSpectral(rec, lambdas);
             if (!Le.isZero()) {
                 if (bounce == 0 || wasSpecular) {
                     color += throughput * Le;
-                } else {
+                } else if (enableNEE_) {
                     // BSDF-sampled continuation ray hit an emitter at a diffuse
                     // bounce: add the BSDF leg weighted by the power heuristic
                     // against the light-sampling pdf that would have generated it.
@@ -252,7 +273,9 @@ private:
             // Uses evalSpectralExt (profile-aware) for the BSDF factor and
             // ls.emission_spec (EmissionSpectrum::eval at these lambdas) for the
             // light, so blackbody / measured-SPD lamps emit outside 380-780 nm.
-            if (!rec.isDelta && !lights.empty()) {
+            // Gated on enableNEE_ (naive mode has no light sampling — the GPU
+            // parity oracle contract, pkg156).
+            if (enableNEE_ && !rec.isDelta && !lights.empty()) {
                 LightSample ls;
                 lights.sample(ls, rec.point, rec.normal, lambdas, gen);
                 if (ls.pdf > 0) {

--- a/plugins/integrators/multiwavelength_path_tracer.cpp
+++ b/plugins/integrators/multiwavelength_path_tracer.cpp
@@ -146,6 +146,10 @@ private:
         astroray::SampledSpectrum throughput(1.0f);
         Ray ray = r;
         bool wasSpecular = true;
+        // pkg195 Stage A: BSDF pdf that generated the current continuation ray,
+        // used by the two-sided-MIS lamp legs below. Mirrors pathTraceSpectral's
+        // bsdfPdfPrev (raytracer.h:2405).
+        float bsdfPdfPrev = 0.0f;
         std::uniform_real_distribution<float> dist01(0.0f, 1.0f);
         int lastBounce = 0;
         float weightSum = 0.0f;
@@ -154,11 +158,47 @@ private:
         const auto& envMapPtr = renderer_->getEnvironmentMap();
         const auto* envMap  = envMapPtr.get();
         const Vec3  bgColor = renderer_->getBackgroundColor();
+        // pkg195 Stage A: dedicated-light NEE. The MW integrator had no light
+        // sampling of any kind (pre-pkg89), so every Blender lamp (a dedicated
+        // astroray::Light) was invisible and lamp-lit scenes rendered black
+        // outside the visible band. The blocks below port the in-header path
+        // tracer's dedicated-light next-event estimation and two-sided MIS
+        // (pathTraceSpectral, raytracer.h:2415-2568) verbatim in structure,
+        // swapping evalSpectral/sampleSpectral for the profile-aware
+        // evalSpectralExt/sampleSpectralExt so blackbody / measured-SPD lamps
+        // emit correctly outside 380-780 nm. No new estimator (CLAUDE.md §6).
+        const LightList& lights = renderer_->getLights();
 
         for (int bounce = 0; bounce < maxDepth; ++bounce) {
             lastBounce = bounce;
             HitRecord rec;
-            if (!bvh || !bvh->hit(ray, 0.001f, std::numeric_limits<float>::max(), rec)) {
+            bool didHit = bvh && bvh->hit(ray, 0.001f, std::numeric_limits<float>::max(), rec);
+
+            // pkg195 Stage A: dedicated-lamp visibility to BSDF rays (mirrors
+            // pathTraceSpectral raytracer.h:2423-2440). Lamps are invisible to
+            // camera rays (bounce == 0); a lamp closer than the surface
+            // terminates the path and feeds the same two-sided MIS term the
+            // emissive path below uses (wB = 1 after a specular bounce).
+            if (bounce > 0 && !lights.getDedicatedLights().empty()) {
+                float surfaceT = didHit ? rec.t : std::numeric_limits<float>::max();
+                astroray::Light::Intersection lh;
+                if (lights.intersectDedicated(ray.origin, ray.direction, 0.001f,
+                                              surfaceT, lambdas, lh)) {
+                    if (!lh.emission.isZero()) {
+                        if (wasSpecular) {
+                            color += throughput * lh.emission;
+                        } else {
+                            float lp = lights.pdfValue(ray.origin, ray.direction);
+                            float bp = bsdfPdfPrev;
+                            float wB = (bp * bp) / (bp * bp + lp * lp + 1e-8f);
+                            color += throughput * lh.emission * wB;
+                        }
+                    }
+                    break;  // path terminates on the lamp
+                }
+            }
+
+            if (!didHit) {
                 // Environment contribution
                 astroray::SampledSpectrum envSpec(0.0f);
                 Vec3 dir = ray.direction.normalized();
@@ -186,15 +226,56 @@ private:
 
             if (!rec.material) break;
 
-            // Emission
+            // Emission (two-sided MIS, mirrors pathTraceSpectral raytracer.h:2496-2527).
             astroray::SampledSpectrum Le = rec.material->emittedSpectral(rec, lambdas);
             if (!Le.isZero()) {
-                if (bounce == 0 || wasSpecular)
+                if (bounce == 0 || wasSpecular) {
                     color += throughput * Le;
+                } else {
+                    // BSDF-sampled continuation ray hit an emitter at a diffuse
+                    // bounce: add the BSDF leg weighted by the power heuristic
+                    // against the light-sampling pdf that would have generated it.
+                    float lp = lights.empty()
+                        ? 0.0f
+                        : lights.pdfValue(ray.origin, ray.direction);
+                    float bp = bsdfPdfPrev;
+                    float wB = (bp * bp) / (bp * bp + lp * lp + 1e-8f);
+                    color += throughput * Le * wB;
+                }
                 break;
             }
 
             Vec3 wo = -ray.direction.normalized();
+
+            // pkg195 Stage A: dedicated-light NEE with MIS (mirrors
+            // pathTraceSpectral raytracer.h:2537-2568). Skipped on delta lobes.
+            // Uses evalSpectralExt (profile-aware) for the BSDF factor and
+            // ls.emission_spec (EmissionSpectrum::eval at these lambdas) for the
+            // light, so blackbody / measured-SPD lamps emit outside 380-780 nm.
+            if (!rec.isDelta && !lights.empty()) {
+                LightSample ls;
+                lights.sample(ls, rec.point, rec.normal, lambdas, gen);
+                if (ls.pdf > 0) {
+                    Vec3 wi = (ls.position - rec.point).normalized();
+                    HitRecord shadow;
+                    bool hitOccluder = bvh->hit(Ray(rec.point, wi, ray.time), 0.001f,
+                                                ls.distance - 0.001f, shadow);
+                    bool occluded = hitOccluder &&
+                        !(shadow.hitObject && shadow.hitObject->isInfiniteLight());
+                    if (!occluded) {
+                        astroray::SampledSpectrum f_spec =
+                            rec.material->evalSpectralExt(rec, wo, wi, lambdas);
+                        astroray::SampledSpectrum L_spec = ls.emission_spec;
+                        float bsdfPdf = rec.material->pdf(rec, wo, wi);
+                        float a = ls.pdf, b = bsdfPdf;
+                        // pkg140: a delta light sample always gets full MIS weight
+                        // (BSDF sampling can never reproduce it).
+                        float wt = ls.isDelta ? 1.0f : (a * a) / (a * a + b * b + 1e-8f);
+                        color += throughput * f_spec * L_spec *
+                                 (ls.pdf > 1e-8f ? wt / ls.pdf : 0.0f);
+                    }
+                }
+            }
 
             // Russian roulette
             if (bounce > rrDepth) {
@@ -213,6 +294,9 @@ private:
             BSDFSampleSpectral bss = rec.material->sampleSpectralExt(rec, wo, gen, lambdas);
             if (bss.pdf <= 0.0f) break;
             wasSpecular = bss.isDelta;
+            // pkg195 Stage A: carry this bounce's BSDF pdf for the next iteration's
+            // two-sided-MIS lamp/emissive legs (mirrors pathTraceSpectral:2599).
+            bsdfPdfPrev = bss.pdf;
 
             // pkg87b: Cryptomatte accumulation at shade point (before throughput update).
             // Weight = average(throughput · bsdf_eval), per Cycles.

--- a/src/light_sampler.cpp
+++ b/src/light_sampler.cpp
@@ -41,16 +41,30 @@ void PowerLightSampler::sample(LightSample& out, const Vec3& point, const Vec3& 
 
     // Sample light index from unified power CDF.
     std::uniform_real_distribution<float> dist(0, 1);
-    float u = dist(gen) * totalPower;
     size_t idx = 0;
-    for (size_t i = 0; i < powerDist.size(); ++i) {
-        if (u < powerDist[i]) {
-            idx = i;
-            break;
+    float selPdf;
+    if (totalPower > 0.0f) {
+        float u = dist(gen) * totalPower;
+        for (size_t i = 0; i < powerDist.size(); ++i) {
+            if (u < powerDist[i]) {
+                idx = i;
+                break;
+            }
         }
+        selPdf = (idx > 0 ? powerDist[idx] - powerDist[idx - 1] : powerDist[0]) / totalPower;
+    } else {
+        // pkg195: degenerate power CDF (totalPower == 0). This happens when every
+        // light's single-stratification power() luminance estimate misses a narrow
+        // emission line -- e.g. a sodium-vapor lamp whose SPD is a ~589 nm spike, so
+        // the u=0.5 hero wavelengths {380,480,580,680} all read ~0. Without a guard,
+        // selPdf = 0/0 = NaN propagates into out.pdf and the integrator's `pdf > 0`
+        // NEE test silently drops the lamp (renders black). Fall back to uniform
+        // light selection (PBRT UniformLightSampler, Apache-2.0) so the lamp is still
+        // sampled; MIS remains valid because pdfValue() mirrors this same fallback.
+        idx = static_cast<size_t>(dist(gen) * static_cast<float>(totalLights));
+        if (idx >= totalLights) idx = totalLights - 1;
+        selPdf = 1.0f / static_cast<float>(totalLights);
     }
-
-    float selPdf = (idx > 0 ? powerDist[idx] - powerDist[idx - 1] : powerDist[0]) / totalPower;
 
     // Dispatch: first numHittableLights indices are legacy Hittables, rest are dedicated.
     if (idx < numHittableLights) {
@@ -96,18 +110,27 @@ float PowerLightSampler::pdfValue(const Vec3& point, const Vec3& dir) const {
 
     if (lights.empty() && dedicatedLights.empty()) return 0;
 
+    // pkg195: mirror sample()'s uniform fallback for a degenerate power CDF
+    // (totalPower == 0, e.g. a narrow-line lamp). Uniform selPdf = 1/N.
+    const size_t totalLights = lights.size() + dedicatedLights.size();
+    const bool uniformFallback = (totalPower <= 0.0f);
+
     float pdf = 0;
     size_t idx = 0;
 
     // Legacy Hittables.
     for (size_t i = 0; i < lights.size(); ++i, ++idx) {
-        float selPdf = (idx > 0 ? powerDist[idx] - powerDist[idx - 1] : powerDist[0]) / totalPower;
+        float selPdf = uniformFallback
+            ? 1.0f / static_cast<float>(totalLights)
+            : (idx > 0 ? powerDist[idx] - powerDist[idx - 1] : powerDist[0]) / totalPower;
         pdf += selPdf * lights[i]->pdfValue(point, dir);
     }
 
     // Dedicated Lights.
     for (size_t i = 0; i < dedicatedLights.size(); ++i, ++idx) {
-        float selPdf = (idx > 0 ? powerDist[idx] - powerDist[idx - 1] : powerDist[0]) / totalPower;
+        float selPdf = uniformFallback
+            ? 1.0f / static_cast<float>(totalLights)
+            : (idx > 0 ? powerDist[idx] - powerDist[idx - 1] : powerDist[0]) / totalPower;
         pdf += selPdf * dedicatedLights[i]->pdfLi(point, dir);
     }
 

--- a/tests/test_gpu_multiwavelength.py
+++ b/tests/test_gpu_multiwavelength.py
@@ -81,6 +81,14 @@ def _render_pair(lmin, lmax, mode, *,
     cpu.set_wavelength_range(float(lmin), float(lmax))
     cpu.set_output_mode(mode)
     cpu.set_integrator("multiwavelength_path_tracer")
+    # pkg195: this integrator is the GPU parity NAIVE oracle. Stage A gave the CPU
+    # multiwavelength_path_tracer dedicated-light NEE (default on), but the GPU MW
+    # leg still has no light sampling (module/blender_module.cpp:1814 derives
+    # enableNEE=false for this integrator name). Pin the CPU leg naive so parity
+    # compares naive transport on BOTH legs until pkg195 Phase 3 lands GPU
+    # spectral-light NEE. Pinned on both legs (the GPU render path derives naive
+    # from the integrator name, so the param is a no-op there, kept for symmetry).
+    cpu.set_integrator_param("enable_nee", 0)
     cpu_px = np.array(cpu.render(samples_per_pixel=spp, max_depth=depth, apply_gamma=False),
                       dtype=np.float32)
 
@@ -89,6 +97,7 @@ def _render_pair(lmin, lmax, mode, *,
     gpu.set_wavelength_range(float(lmin), float(lmax))
     gpu.set_output_mode(mode)
     gpu.set_integrator("multiwavelength_path_tracer")
+    gpu.set_integrator_param("enable_nee", 0)  # see CPU leg note above
     gpu_px = np.array(gpu.render(samples_per_pixel=spp, max_depth=depth, apply_gamma=False),
                       dtype=np.float32)
 

--- a/tests/test_pkg195_stage_a_mw_nee.py
+++ b/tests/test_pkg195_stage_a_mw_nee.py
@@ -1,0 +1,146 @@
+"""pkg195 Stage A — MultiwavelengthPathTracer dedicated-light NEE.
+
+Before this package the MW integrator had no light sampling of any kind, so every
+Blender lamp (a dedicated astroray::Light) was invisible and lamp-lit scenes
+rendered black outside the visible band (measured mean 0.0003). Stage A ports the
+in-header pathTraceSpectral dedicated-light NEE + two-sided MIS into the MW
+integrator (CPU only; wavefront GPU kernels untouched).
+
+Gates (from the spec):
+  A1: snow sphere + dedicated blackbody sun, band 700-1000 nm -> mean > 0.05.
+  A2: snow vs water_clear NIR mean-ratio > 2.
+  A3: visible-band regression -- MW vs default path_tracer on a lamp-lit scene,
+      per-channel mean-ratio in [0.95, 1.05], LINEAR (apply_gamma=False).
+
+All renders force CPU (set_use_gpu(False)): the NEE fix lives in the CPU
+integrator, and the pkg54 GPU MW megakernel keeps its current behaviour.
+"""
+import os
+
+import numpy as np
+import pytest
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+
+try:
+    import astroray
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PROFILES_BIN = os.path.join(REPO_ROOT, "data", "spectral_profiles", "profiles.bin")
+HAS_PROFILES = os.path.exists(PROFILES_BIN)
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray module not available")
+
+
+def _nir_sphere_render(profile, spp=24, width=48, height=48):
+    """Sphere with `profile` lit by a dedicated blackbody sun, rendered in the
+    700-1000 nm band on the CPU MW integrator. Returns linear luminance pixels.
+
+    The sun is a 3000 K blackbody: its Wien peak (~966 nm) lands inside the
+    700-1000 nm band, so after the pkg122 photopic normalization it still carries
+    real NIR energy (a hot 5778 K sun normalizes almost all of its weight into the
+    visible band, leaving the NIR tail too dim to exercise the gate meaningfully)."""
+    astroray.load_spectral_profiles(PROFILES_BIN)
+    r = astroray.Renderer()
+    r.set_use_gpu(False)
+    r.setup_camera(
+        look_from=[0, 0, 3], look_at=[0, 0, 0], vup=[0, 1, 0],
+        vfov=35, aspect_ratio=1.0, aperture=0.0, focus_dist=3.0,
+        width=width, height=height,
+    )
+    r.set_seed(7)
+    r.set_background_color([0.0, 0.0, 0.0])  # black bg: only the lit sphere shows
+
+    mat = r.create_material("lambertian", [0.5, 0.5, 0.5], {})
+    r.set_material_spectral_profile(mat, profile)
+    r.add_sphere([0, 0, 0], 1.0, mat)
+
+    # Dedicated blackbody sun coming from the camera-facing upper hemisphere so
+    # the visible face of the sphere is lit. A distant light's `direction` is the
+    # direction the light travels (points FROM the light).
+    emission = {"mode": "blackbody", "temperature_K": 3000.0, "tint_rgb": [1, 1, 1]}
+    r.add_sun_light_dedicated(
+        direction=[-0.25, -0.35, -1.0], angular_diameter=0.0093,
+        emission=emission, intensity=25.0,
+    )
+
+    r.set_wavelength_range(700.0, 1000.0)
+    r.set_output_mode("luminance")
+    r.set_integrator("multiwavelength_path_tracer")
+    # apply_gamma=False -> linear energy gate (memory gamma-furnace-cannot-detect-energy-gain).
+    return np.array(r.render(spp, 4, None, False), dtype=np.float32)
+
+
+@pytest.mark.skipif(not HAS_PROFILES, reason="profiles.bin not found")
+def test_a1_nir_snow_sphere_lit_by_dedicated_sun():
+    """A1: snow sphere + dedicated blackbody sun in NIR must be lit (mean > 0.05,
+    was ~0.0003 before the MW-integrator NEE fix)."""
+    pixels = _nir_sphere_render("snow")
+    assert np.all(np.isfinite(pixels)), "NIR render has non-finite pixels"
+    mean = float(pixels.mean())
+    assert mean > 0.05, (
+        f"A1 FAIL: NIR snow sphere mean {mean:.4f} <= 0.05 -- dedicated sun not seen "
+        f"by the MW integrator"
+    )
+    print(f"[A1 PASS] NIR snow-sphere mean luminance = {mean:.4f}")
+
+
+@pytest.mark.skipif(not HAS_PROFILES, reason="profiles.bin not found")
+def test_a2_nir_snow_brighter_than_water():
+    """A2: snow (NIR R~0.76) must be > 2x brighter than water_clear (NIR R~0.03)
+    under the same dedicated sun."""
+    snow = float(_nir_sphere_render("snow").mean())
+    water = float(_nir_sphere_render("water_clear").mean())
+    ratio = snow / max(water, 1e-6)
+    assert ratio > 2.0, (
+        f"A2 FAIL: snow/water NIR mean-ratio {ratio:.2f} <= 2 "
+        f"(snow={snow:.4f}, water={water:.4f})"
+    )
+    print(f"[A2 PASS] snow/water NIR mean-ratio = {ratio:.2f} "
+          f"(snow={snow:.4f}, water={water:.4f})")
+
+
+def _visible_lamp_scene(integrator, spp=96, width=48, height=48):
+    """Lambertian sphere lit by a dedicated point light, visible band, CPU.
+    Returns per-channel linear means for `integrator`."""
+    r = astroray.Renderer()
+    r.set_use_gpu(False)
+    r.setup_camera(
+        look_from=[0, 0, 3], look_at=[0, 0, 0], vup=[0, 1, 0],
+        vfov=40, aspect_ratio=1.0, aperture=0.0, focus_dist=3.0,
+        width=width, height=height,
+    )
+    r.set_seed(20260813)  # fixed, non-zero (seed 0 = random sentinel)
+    r.set_background_color([0.0, 0.0, 0.0])
+
+    mat = r.create_material("lambertian", [0.6, 0.5, 0.4], {})
+    r.add_sphere([0, 0, 0], 1.0, mat)
+    emission = {"mode": "rgb", "color": [1.0, 1.0, 1.0]}
+    r.add_point_light(position=[2.0, 2.0, 2.0], emission=emission,
+                      intensity=40.0, radius=0.0)
+
+    r.set_wavelength_range(380.0, 780.0)
+    r.set_integrator(integrator)
+    pixels = np.array(r.render(spp, 6, None, False), dtype=np.float32)  # linear
+    return pixels.reshape(-1, pixels.shape[-1]).mean(axis=0)
+
+
+def test_a3_visible_band_regression_vs_default_tracer():
+    """A3: on a lamp-lit visible-band scene, the MW integrator must match the
+    default path_tracer per-channel within [0.95, 1.05] (linear)."""
+    ref = _visible_lamp_scene("path_tracer")
+    mw = _visible_lamp_scene("multiwavelength_path_tracer")
+    assert np.all(np.isfinite(ref)) and np.all(np.isfinite(mw))
+    assert np.all(ref > 1e-4), f"reference scene channel(s) too dark: {ref}"
+    ratio = mw / ref
+    print(f"[A3] path_tracer per-channel mean = {ref}")
+    print(f"[A3] MW          per-channel mean = {mw}")
+    print(f"[A3] per-channel ratio = {ratio}")
+    assert np.all((ratio > 0.95) & (ratio < 1.05)), (
+        f"A3 FAIL: MW vs path_tracer per-channel ratio {ratio} outside [0.95, 1.05]"
+    )
+    print("[A3 PASS] MW matches default path_tracer within 5% per channel")

--- a/tests/test_pkg195_stage_b_spectral_lamp.py
+++ b/tests/test_pkg195_stage_b_spectral_lamp.py
@@ -1,0 +1,115 @@
+"""pkg195 Stage B — spectral lamp presets (engine-level gate).
+
+The addon's _build_emission_dict emits, for a light in spectrum_mode='preset'
+(or 'custom_profile'), the dict this test feeds directly to the engine:
+    {'mode': 'measured_spd', 'profile_name': <name>}          # white light colour
+    {'mode': 'composite', 'base': {...measured...},            # tinted (gel) light
+     'filter_rgb': [r, g, b]}
+Both are already parsed by module/blender_module.cpp::parseEmissionSpectrum.
+
+Gate B (from the spec): a point lamp in preset/sodium_vapor over a white sphere,
+visible band CPU -> amber hue (R > G > 3*B in linear mean); switching to cie_f2
+changes per-channel ratios by > 10%.
+
+This test validates the engine + emission-dict physics on the CPU (set_use_gpu
+False). The full addon-UI wiring is exercised by the headless-Blender check in the
+PR body (blender_addon/__init__.py DATA_PT_custom_raytracer_light path).
+
+A companion note: sodium's SPD is a narrow ~589 nm spike whose single-stratum
+power() estimate is zero; pkg195 adds a uniform-selection fallback in
+PowerLightSampler for that degenerate CDF so the lamp is not silently dropped.
+"""
+import os
+
+import numpy as np
+import pytest
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+
+try:
+    import astroray
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PROFILES_BIN = os.path.join(REPO_ROOT, "data", "spectral_profiles", "profiles.bin")
+HAS_PROFILES = os.path.exists(PROFILES_BIN)
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray module not available")
+
+
+def _lamp_scene_channels(emission, spp=64, width=48, height=48):
+    """White sphere lit by a point lamp with the given emission dict, rendered in
+    the visible band on the CPU. Returns per-channel linear means."""
+    astroray.load_spectral_profiles(PROFILES_BIN)
+    r = astroray.Renderer()
+    r.set_use_gpu(False)
+    r.setup_camera(
+        look_from=[0, 0, 3], look_at=[0, 0, 0], vup=[0, 1, 0],
+        vfov=35, aspect_ratio=1.0, aperture=0.0, focus_dist=3.0,
+        width=width, height=height,
+    )
+    r.set_seed(101)
+    r.set_background_color([0.0, 0.0, 0.0])
+    mat = r.create_material("lambertian", [1.0, 1.0, 1.0], {})  # white sphere
+    r.add_sphere([0, 0, 0], 1.0, mat)
+    r.add_point_light(position=[2.0, 2.0, 2.0], emission=emission,
+                      intensity=60.0, radius=0.0)
+    r.set_wavelength_range(380.0, 780.0)
+    r.set_integrator("multiwavelength_path_tracer")
+    pixels = np.array(r.render(spp, 6, None, False), dtype=np.float32)  # linear
+    return pixels.reshape(-1, 3).mean(axis=0)
+
+
+@pytest.mark.skipif(not HAS_PROFILES, reason="profiles.bin not found")
+def test_b1_sodium_lamp_is_amber():
+    """B1: sodium_vapor preset lamp -> amber (R > G > 3*B) linear."""
+    ch = _lamp_scene_channels({"mode": "measured_spd", "profile_name": "sodium_vapor"})
+    R, G, B = float(ch[0]), float(ch[1]), float(ch[2])
+    print(f"[B1] sodium linear RGB = ({R:.4f}, {G:.4f}, {B:.4f})")
+    assert R > G > 3.0 * B, (
+        f"B1 FAIL: sodium lamp not amber -- R={R:.4f} G={G:.4f} B={B:.4f} "
+        f"(need R > G > 3*B)"
+    )
+    print("[B1 PASS] sodium lamp is amber")
+
+
+@pytest.mark.skipif(not HAS_PROFILES, reason="profiles.bin not found")
+def test_b2_cie_f2_differs_from_sodium():
+    """B2: switching sodium_vapor -> cie_f2 changes per-channel ratios by > 10%."""
+    sod = _lamp_scene_channels({"mode": "measured_spd", "profile_name": "sodium_vapor"})
+    f2 = _lamp_scene_channels({"mode": "measured_spd", "profile_name": "cie_f2"})
+    # Compare per-channel where the reference (f2, broadband) is non-negligible.
+    rel = np.abs(sod / np.maximum(f2, 1e-6) - 1.0)
+    print(f"[B2] sodium = {sod}")
+    print(f"[B2] cie_f2 = {f2}")
+    print(f"[B2] per-channel relative change = {rel}")
+    assert rel.max() > 0.10, (
+        f"B2 FAIL: sodium vs cie_f2 per-channel change {rel.max():.3f} <= 0.10"
+    )
+    print(f"[B2 PASS] sodium vs cie_f2 max per-channel change = {rel.max():.2f}")
+
+
+@pytest.mark.skipif(not HAS_PROFILES, reason="profiles.bin not found")
+def test_b3_composite_gel_tint_path():
+    """B3: the composite (non-white gel tint) emission dict -- what
+    _build_emission_dict emits when the lamp colour is not white -- renders and a
+    blue gel measurably suppresses the amber sodium output vs no gel."""
+    plain = _lamp_scene_channels({"mode": "measured_spd", "profile_name": "sodium_vapor"})
+    # Blue gel: filters out the amber; the composite base is the sodium SPD.
+    gelled = _lamp_scene_channels({
+        "mode": "composite",
+        "base": {"mode": "measured_spd", "profile_name": "sodium_vapor"},
+        "filter_rgb": [0.2, 0.2, 1.0],
+    })
+    print(f"[B3] plain sodium = {plain}")
+    print(f"[B3] blue-gel     = {gelled}")
+    assert np.all(np.isfinite(gelled))
+    # The blue gel must attenuate the (amber-dominant) red channel.
+    assert gelled[0] < plain[0] * 0.9, (
+        f"B3 FAIL: blue gel did not suppress sodium's red channel "
+        f"({gelled[0]:.4f} vs {plain[0]:.4f})"
+    )
+    print("[B3 PASS] composite gel tint attenuates as expected")

--- a/tests/test_pkg55_c3_wavefront_nonvisible.py
+++ b/tests/test_pkg55_c3_wavefront_nonvisible.py
@@ -117,6 +117,13 @@ def _render_wavefront_vs_cpu(lmin, lmax, mode, *,
     cpu.set_output_mode(mode)
     # For naive mode, use multiwavelength_path_tracer; else path_tracer
     cpu.set_integrator("multiwavelength_path_tracer" if not enable_nee else "path_tracer")
+    if not enable_nee:
+        # pkg195: Stage A gave multiwavelength_path_tracer dedicated-light NEE
+        # (default on), but here it is the naive oracle for the GPU wavefront leg
+        # rendered with enable_nee=False (no light sampling). Pin it naive so both
+        # legs compare naive transport until pkg195 Phase 3 lands GPU
+        # spectral-light NEE.
+        cpu.set_integrator_param("enable_nee", 0)
     cpu_px = np.array(cpu.render(samples_per_pixel=spp, max_depth=depth, apply_gamma=False),
                       dtype=np.float32)
 


### PR DESCRIPTION
## pkg195 Stage A + B — MW-tracer dedicated-light NEE + spectral lamp presets

Implements **Stage A** and **Stage B** of pkg195 (spec:
`.astroray_plan/packages/pkg195-spectral-nodes-phase1.md`). **Stage C is
descoped** and remains OPEN — it is independently landable (register_spectral_profile
binding + Drawn/Preset/Blackbody spectrum nodes + in-band Replace mode + IR/UV
de-fang + Sellmeier B/C). CPU-only; **the wavefront GPU kernels are untouched**
(register-budget firewall).

### Stage A — MW integrator sees lights (CPU NEE)
`MultiwavelengthPathTracer::pathTrace` had no light sampling of any kind, so every
Blender lamp (a dedicated `astroray::Light`) was invisible and lamp-lit scenes
rendered black outside the visible band. Ported the in-header `pathTraceSpectral`
dedicated-light NEE + two-sided MIS (`include/raytracer.h:2415-2568`) verbatim in
structure, swapping `evalSpectral`/`sampleSpectral` for the profile-aware
`evalSpectralExt`/`sampleSpectralExt`. No new estimator (CLAUDE.md §6 — the MIS is
the existing power-heuristic; cited in the code header).

**Latent bug fixed (spec's own Gate B exposed it):** a narrow-line lamp SPD
(sodium's ~589 nm spike) makes every light's single-stratum `power()` luminance
estimate read 0 → `totalPower==0` → `selPdf = 0/0 = NaN` → the NEE `pdf > 0` test
silently drops the lamp (renders black). `PowerLightSampler::sample`/`pdfValue` now
fall back to uniform light selection for a degenerate power CDF (PBRT
UniformLightSampler, Apache-2.0). Zero blast radius for existing RGB/blackbody
scenes (only triggers when `totalPower<=0`, which never happens for them).

**Gate A (measured, CPU, linear):**
- A1: snow sphere + dedicated 3000 K blackbody sun, band 700-1000 nm → mean **0.0709 > 0.05** (was 0.0003). *(Visual: `test_results/pkg195_gateA_nir_snow.png` shows a genuinely lit sphere with a smooth sun terminator.)*
- A2: snow vs water_clear NIR mean-ratio **4.82 > 2**.
- A3: visible-band MW vs default `path_tracer` per-channel ratio **[1.00, 1.00, 1.00]** ∈ [0.95, 1.05] (apply_gamma=False).

### Stage B — spectral lamp presets in the addon
- `light.custom_raytracer` PropertyGroup + `spectrum_mode` enum (native / preset / custom_profile) + `DATA_PT_custom_raytracer_light` panel (Astroray engine only) with a per-profile λ-range label.
- `_build_emission_dict` emits `{'mode':'measured_spd','profile_name':<name>}` for preset/custom modes (the parser's real key — the spec's `'profile'` was shorthand), wrapped in `composite` when the lamp colour is a non-white gel tint. Reuses the existing `blender_module.cpp::parseEmissionSpectrum` parser.
- New `spectral_profile_range` binding + `SpectralProfile::lambdaMin/lambdaStep/count` getters for the truthful panel label (forward-compatible with Stage C runtime profiles).
- GPU note documented in the panel: dedicated non-RGB lamps fall back to `deviceReference()` RGB on GPU; CPU is exact.

**Gate B (measured):**
- B1 (engine, linear): sodium_vapor preset lamp → RGB **(0.673, 0.127, 0.000)**, R > G > 3·B ✓ amber.
- B2: sodium vs cie_f2 max per-channel change **1.00 > 0.10**.
- B3: composite blue-gel attenuates sodium's red channel 7× (0.673 → 0.096).
- **Headless Blender 5.1 CPU render** (full addon UI wiring, spectrum_mode='preset'): sodium display RGB (0.291, 0.278, 0.0003) R>G>3B ✓ amber; cie_f2 neutral (0.289, 0.287, 0.285). *(Visual: `test_results/pkg195_gateB_sodium.png` = amber sphere, `pkg195_gateB_cie_f2.png` = neutral sphere.)*

### Authorized surface
Spec Specification touches: `multiwavelength_path_tracer.cpp` (Stage A), `blender_addon/` + `module/blender_module.cpp` (Stage B). Actually changed, with justification:
- `plugins/integrators/multiwavelength_path_tracer.cpp` — Stage A NEE. **In spec.**
- `blender_addon/__init__.py` — Stage B UI + emission dict. **In spec.**
- `module/blender_module.cpp` — Stage B `spectral_profile_range` binding (spec said reuse the existing emission parser; this adds only a read-only range query for the panel label). **In spec (Stage B item 3, λ-range label).**
- `include/astroray/spectral_profile.h` — 3 additive const getters for the range binding. **Minimal support for the above.**
- `src/light_sampler.cpp` — **NOT in the spec's file list.** Required: the spec assumed sodium "works today via MeasuredSPD" (design doc §1.3), but the degenerate-power-CDF NaN silently drops narrow-line lamps. Without this fix Gate B renders black. Zero blast radius (guarded on `totalPower<=0`).
- `tests/test_pkg195_stage_a_mw_nee.py`, `tests/test_pkg195_stage_b_spectral_lamp.py` — new gates.

`plugins/materials/dielectric.cpp` (spec Stage C, Sellmeier B/C) is **not touched** — Stage C descoped.

### Build (last 5 lines, root `build_cuda_worktree.bat`, sm_120)
```
[pkg183] canary caps: {'cpu': True, 'spectral': True, 'gpu': True, 'gpu_spectral': True, 'gpu_approximate': False, 'closure_graph': True, 'closure_count': 1, 'gpu_type': 'closure_graph', 'notes': 'spectral closure-graph GPU lowering'}

========================================
Build succeeded
========================================
```
Arch gate: `arch-verify OK: astroray.cp313-win_amd64.pyd embeds sm_120`. ABI canary passed.

### Tests
- New: `test_pkg195_stage_a_mw_nee.py` (3), `test_pkg195_stage_b_spectral_lamp.py` (3) — all pass.
- Regression (CPU): `test_multiwavelength`, `test_pkg125_cpu_path_tracer_band_awareness`, `test_pkg89_phase_b_dedicated_lights`, `test_pkg140`, `test_pkg181`, `test_pkg144`, `test_spectral_*`, `test_pkg89_g8` — **101 passed, 2 skipped, 0 regressions** (`-m "not gpu"`). pkg55-C3's NIR/UV "black" assertion verified still holds on the CPU side (NIR 0.00018, UV 0.00027, both < 1e-3).

### GPU firewall / disclosure
Diff touches **zero** GPU/wavefront/`.cu`/`.cuh` files (verified). GPU-gated suites (`test_pkg55_c3_wavefront_nonvisible`, `test_gpu_multiwavelength`) were deferred to the hardware-verifier closeout because the GPU lock was held by pkg189 during implementation; my changes touch no GPU code, so no GPU regression is expected.

### Acceptance criteria
- [x] Stage A: MW integrator dedicated-light NEE + MIS, CPU only, wavefront untouched
- [x] Gate A1/A2/A3 pass (measured above)
- [x] Stage B: spectrum_mode enum + panel + measured_spd emission dict + GPU note
- [x] Gate B amber + cie_f2 difference (engine + headless Blender)
- [x] No new `blender_addon/*.py` module (edited `__init__.py`, already in ADDON_FILES)
- [x] Build clean (sm_120, ABI canary, arch gate)
- [ ] Stage C — descoped, OPEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update 2026-08-13 — CPU↔GPU MW parity collision + resolution (verifier finding)

Independent verification flagged 3 pre-existing parity gates broken by the first
revision: `test_pkg55_c3_wavefront_nonvisible::test_naive_mode_wavefront_cpu_parity`
(SSIM 0.30 vs 0.97), `test_gpu_multiwavelength::test_visible_band_cpu_gpu_ssim`
(0.306 vs 0.995), `test_visible_band_no_regression` (79% mean drift).

**Root cause:** those suites use the CPU `MultiwavelengthPathTracer` as the NAIVE
oracle for the GPU naive/MW legs (both historically light-sampling-blind). The
engine-wide contract `enableNEE = (integrator != "multiwavelength_path_tracer")`
(`module/blender_module.cpp:1814`) is exactly what gates the GPU wavefront naive
route to match this oracle (pkg120/pkg156). My Stage-A NEE was **unconditional**,
so the CPU oracle's physics changed while the GPU comparator did not — the fix was
right, the unconditionality was the defect (the pkg156 lesson: "mirror the
CONDITION, not just the term").

**Resolution (commit `c07671e`):** the NEE leg, the lamp-intersection leg, and the
two-sided-MIS `w_B` emission term now fire only when `enable_nee` (integrator
param, **default 1 = on** so the addon's NIR/UV lamp rendering works). `enable_nee=0`
is **byte-identical** to the pre-Stage-A integrator (verified: NIR snow mean 0.0709
with NEE on → **exactly 0.0** with NEE off). The parity harnesses pin
`set_integrator_param("enable_nee", 0)` on the CPU MW oracle legs with a comment
stating the contract; **no SSIM/band thresholds were changed.** Feature gates
A1-A3/B1-B3 still pass (they run NEE-on by default). The spec now records GPU
MW-leg light sampling as the Phase-3 item these gates explicitly encode.

**GPU re-run:** the 3 fixed gates + 7 previously-passing GPU parity gates are
pending the RTX sweep — the GPU lock was held by pkg189 verifier (PR #603) at
push time. CPU-side proof that parity will recover: the CPU oracle is now
byte-identical to the pre-Stage-A integrator under `enable_nee=0`, which the GPU
naive route was already matched to. CPU regression sweep: 56 passed, 0 regressions.
