### PR TITLE
feat(pkg189): GPU wavefront hero-λ dispersion enablement

### DIFF
--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -44,7 +44,7 @@ that every lamp-lit NIR/UV render is black end-to-end.**
   no shipped Blender exposes a Dispersion socket (unmerged upstream WIP
   #162041 — the addon got a forward-compatible probe); `test_gpu_prism_
   rainbow_parity`'s XPASS was vacuous, xfail retained.
-- **pkg189 DONE** (PR #TBD, 2026-08-13) — GPU wavefront hero-λ dispersion
+- **pkg189 DONE** (PR #603, 2026-08-13) — GPU wavefront hero-λ dispersion
   enablement. Root cause: the wavefront shade kernel never persisted the
   sampler's `terminateSecondary()` hero-collapse back to the per-path SoA, so
   the mutated λ-pdfs evaporated each bounce and `spectrumToXYZ` kept summing all

--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -44,6 +44,18 @@ that every lamp-lit NIR/UV render is black end-to-end.**
   no shipped Blender exposes a Dispersion socket (unmerged upstream WIP
   #162041 — the addon got a forward-compatible probe); `test_gpu_prism_
   rainbow_parity`'s XPASS was vacuous, xfail retained.
+- **pkg189 DONE** (PR #TBD, 2026-08-13) — GPU wavefront hero-λ dispersion
+  enablement. Root cause: the wavefront shade kernel never persisted the
+  sampler's `terminateSecondary()` hero-collapse back to the per-path SoA, so
+  the mutated λ-pdfs evaporated each bounce and `spectrumToXYZ` kept summing all
+  4 wavelengths (achromatic). Fix: SoA write-back gated by a compile-time
+  `HasDispersion` 4th axis (zero REG/STACK — `<*,*,*,0>`≡`<*,*,*,1>`, fleet
+  `<0,0,0,0>` REG:254/STACK:3352). GPU dispersion now LIVE for BOTH families:
+  dielectric BK7 disp/flat **0.5508**, Principled **0.5507** (were ~1.00 no-op),
+  CPU/GPU per-channel parity within 4%, visually-confirmed spectral rainbow on a
+  glass sphere. `test_pkg64_gpu_cpu_parity` un-xfailed → real mean-ratio gate;
+  pkg187 GPU no-op gate flipped to assert live dispersion. Flat-prism *photon*
+  caustic still noise (2-face-GPU-photon follow-up — orthogonal, out of scope).
 - **pkg184 DONE** (PR #597, 2026-08-12) — `template<bool HasPhotons>`
   isolation of the photon-caustic k-NN gather (8 kernel instantiations):
   every HasPhotons=false variant strictly below baseline (STACK

--- a/.astroray_plan/packages/pkg189-gpu-wavefront-dispersion-enablement.md
+++ b/.astroray_plan/packages/pkg189-gpu-wavefront-dispersion-enablement.md
@@ -216,3 +216,136 @@ REFRACTION path (verified by a real spectral rainbow on a glass sphere in
 2-face flat-prism (or closure-graph Principled) caster is the pre-existing follow-up
 (`general-photon-loop-needs-solid-glass`); per the Non-goals this PR does not touch
 the photon path. Recorded for a follow-up spec, not addressed here.
+the photon path. Recorded for a follow-up spec, not addressed here.
+
+---
+
+## Hardware verification 2026-08-13
+
+Independent verifier run for PR #603, on the main RTX box (not the laptop —
+`current-machine-rtx5070ti`). Worktree HEAD `79010edab191ca952649ac1b03b0cbb2911367bc`
+confirmed == PR #603 head SHA (no contamination).
+
+**Hardware/software:** NVIDIA GeForce RTX 5070 Ti, driver 610.47 (WDDM), CUDA UMD
+13.3, CUDA Toolkit v12.8 (nvcc), OptiX 9.1.0, OIDN 2.4.1, MSVC 19.44.35207 (VS 2022
+BuildTools 17.14), Windows 11 Enterprise 10.0.26200. Build: `build_cuda_worktree.bat`
+→ VS-generator `build_cuda`, `-DASTRORAY_CUDA_ARCHS=native`, exit 0; sm_120 confirmed
+via `cuobjdump --list-elf` on the post-link `.pyd`; pkg183 ABI canary PASS.
+
+**Baseline rebuild note:** the main-repo checkout's `build_cuda/` was stale-configured
+with the Ninja generator (leftover from an unrelated session) rather than the
+VS-generator pipeline this PR's numbers were measured on. Deleted and reconfigured via
+`cmake --preset windows-cuda-vs -DASTRORAY_CUDA_ARCHS=native` before the baseline build
+— otherwise the "identical pipeline" baseline claim would not have held. Baseline =
+merge-base `34ef214f902111bf7116956bc1f2ebd2d58edef1` (main was already sitting on it).
+
+### Gate 1 — register matrix (cuobjdump, native sm_120, post-link `.pyd`)
+
+Independently rebuilt baseline (`34ef214`, VS-generator, native) reproduced the PR's
+claimed BEFORE numbers exactly for all 8 `<P,T,Ph>` base specializations:
+
+| spec | BEFORE (measured, baseline rebuild) | PR claim | AFTER D=0 (measured) | AFTER D=1 (measured) | PR claim AFTER |
+|---|---|---|---|---|---|
+| `<0,0,0,·>` | REG:254 STACK:3352 | 3352 | REG:254 STACK:3352 | REG:254 STACK:3352 | 3352/3352 |
+| `<0,0,1,·>` | REG:254 STACK:3608 | 3608 | REG:254 STACK:3608 | REG:254 STACK:3608 | 3608/3608 |
+| `<0,1,0,·>` | REG:254 STACK:3352 | 3352 | REG:254 STACK:3352 | REG:254 STACK:3352 | 3352/3352 |
+| `<0,1,1,·>` | REG:254 STACK:3608 | 3608 | REG:254 STACK:3608 | REG:254 STACK:3608 | 3608/3608 |
+| `<1,0,0,·>` (principled) | REG:254 STACK:6488 | 6488 | REG:254 STACK:6528 | REG:254 STACK:6528 | 6528/6528 |
+| `<1,0,1,·>` | REG:254 STACK:6616 | 6616 | REG:254 STACK:6656 | REG:254 STACK:6656 | 6656/6656 |
+| `<1,1,0,·>` | REG:254 STACK:6488 | 6488 | REG:254 STACK:6528 | REG:254 STACK:6528 | 6528/6528 |
+| `<1,1,1,·>` | REG:254 STACK:6616 | 6616 | REG:254 STACK:6656 | REG:254 STACK:6656 | 6656/6656 |
+
+All 16 pkg189 instantiations present in the post-link `.pyd`. Fleet (non-principled)
+kernels byte-identical before/after; `D=0`≡`D=1` for all 8 base specs; principled
+specs +40 B STACK, REG:254 unchanged. **PASS — matches claims exactly.**
+
+### Gate 2 — control flip
+
+`test_gpu_dielectric_dispersion_control_flips`: flat=0.2133 bk7=0.1175 disp/flat=**0.5508**.
+`test_gpu_principled_dispersion_control_flips`: flat=0.2042 disp=0.1125 disp/flat=**0.5507**.
+`test_gpu_dispersion_wired_mirrors_dielectric_reference`: principled=0.5514, dielectric=0.5502.
+**PASS — matches claims exactly (were ~1.00 no-op pre-fix).**
+
+### Gate 3 — CPU/GPU per-channel parity
+
+Dielectric BK7: GPU/CPU = [1.0381, 0.9817, 0.9724] (claimed [1.038, 0.982, 0.972]).
+Principled: GPU/CPU = [1.0376, 0.9831, 0.9786] (claimed [1.038, 0.983, 0.979]).
+**PASS — matches claims exactly.**
+
+### Gate 4 — test dispositions
+
+- `test_pkg64_gpu_cpu_parity`: real gate (no xfail marker), PASSED. Mean-ratio
+  [0.8416, 0.8723, 0.8846], ROI 0.789× (claimed [0.842, 0.872, 0.885], 0.789×). Match.
+- `test_pkg187_..._gpu_parity::test_gpu_dispersion_wired_mirrors_dielectric_reference`:
+  PASSED on the live-dispersion assertion (0.5514/0.5502).
+- `test_gpu_prism_rainbow_parity`: XFAIL under normal run; re-ran standalone with
+  `--runxfail` and it **genuinely fails** (hue spread 0.365 ≥0.12 but bright coverage
+  0.009% < 0.005 floor) — confirmed NOT a vacuous XPASS. Also ran the full 22-test
+  family under `--runxfail`: 21 passed, exactly this 1 genuine failure, no other
+  hidden xfails.
+
+**PASS — all three dispositions verified as claimed.**
+
+### Gate 5 — regression sweep
+
+Targeted dispersion+caustic family (10 files, 22 collected): **21 passed, 1 xfailed**
+(the honest rainbow-caustic xfail above), 0 failures — includes glass-sphere photon
+caustic (ROI 1.094×, SSIM 0.9606), CPU/GPU prism, Sellmeier IOR datasheet (rel-err
+≤1.42e-5), dielectric glass furnace CPU+GPU, zero-dispersion bit-identical check.
+Broader wavefront/principled slice (8 files, 44 collected, own choosing): **42 passed,
+2 skipped** (pre-existing skips: `test_wavefront_intersect_parity` env-gated,
+`test_testu01_smallcrush` external-tool-gated — unrelated to this PR), 0 failures.
+
+**PASS — no regressions found.**
+
+### Gate 6 — visual inspection (read every PNG)
+
+- `pkg189_gpu_rainbow_flat.png` (dielectric ior=1.5) / `pkg189_gpu_rainbow_principled_flat.png`:
+  pure black/white/gray silhouette, **zero color** — achromatic control confirmed.
+- `pkg189_gpu_rainbow_bk7.png`: visible blue fringe on the upper rim and orange fringe
+  on the lower rim of the refracted disc — real, structured chromatic fringing (not
+  noise).
+- `pkg189_gpu_rainbow_principled.png`: a genuine **spectral ring** around the top of
+  the refracted disc — blue at the top transitioning through green/yellow to
+  orange/red at the bottom edge. Matches the claimed "full ROYGBIV rainbow ring."
+- `pkg113_gpu_prism_rainbow.png` (the honestly-xfailing flat-prism photon caustic):
+  confirmed **sparse salt-and-pepper noise** — isolated colored dots with no coherent
+  band structure. This visually corroborates the xfail is honest, not a masked
+  regression.
+- `pkg113_gpu_glass_sphere.png` / `pkg113_cpu_glass_sphere.png`: both show a clean,
+  focused warm-toned caustic glow on a dark floor (not noise); GPU/CPU differ only in
+  minor speckle consistent with independent MC streams, not structural artifacts.
+- `pkg64_gpu_p3_parity_gpu.png` / `_cpu.png` (from the newly-real `test_pkg64_gpu_cpu_parity`):
+  small thumbnails, both show a consistent small point-light + faint ground reflection,
+  no NaN pixels (no magenta/black spikes), no banding.
+- `pkg187_principled_flat.png` / `_dispersive.png`, `pkg29_flat_prism.png` /
+  `pkg29_bk7_prism.png`: no fireflies, no NaN pixels, no mode regressions observed.
+
+**PASS — no visual regressions; the rainbow structure is real, not a metrics-passing
+noise artifact.**
+
+### Gate 7 — perf spot-check
+
+cuobjdump independently confirmed the non-principled fleet kernel SASS is
+byte-identical before/after (Gate 1), which is a stronger guarantee than wall-clock
+timing. As a spot-check, ran a min-of-N (6 runs, first 2 discarded as GPU warm-up)
+non-dispersive scene A/B on both builds:
+
+- pkg189 build: all_times = [0.3769, 0.1219, 0.1230, 0.1229, 0.1223, 0.1224]s,
+  min_of_warm = **0.1223s**
+- baseline build: all_times = [0.3460, 0.1217, 0.1227, 0.1232, 0.1230, 0.1230]s,
+  min_of_warm = **0.1227s**
+
+pkg189 is ~0.3% faster than baseline — within noise floor
+(`gpu-perf-ab-clock-drift`), consistent with bit-identical SASS. **PASS — no
+regression.**
+
+### Overall verdict
+
+**All 7 gates PASS.** Numbers measured independently match the PR's claims exactly
+(register matrix, control flip, CPU/GPU parity, test dispositions, regression sweep).
+Visual inspection confirms the rainbow structure is real spectral dispersion, not a
+metrics-passing noise artifact, and confirms the honest-xfail rainbow-photon-caustic
+render is genuinely sparse noise. Perf spot-check confirms no regression, corroborated
+by byte-identical SASS. **Mergeable on HW evidence** (merge decision itself belongs to
+the architect/owner, not this verifier session).

--- a/.astroray_plan/packages/pkg189-gpu-wavefront-dispersion-enablement.md
+++ b/.astroray_plan/packages/pkg189-gpu-wavefront-dispersion-enablement.md
@@ -2,7 +2,19 @@
 
 **Pillar:** 3/5 (spectral light transport / CPU-GPU parity)
 **Track:** A
-**Status:** open (found 2026-08-12 during pkg187 Principled-dispersion
+**Status:** done (PR #TBD, 2026-08-13 — GPU wavefront hero-λ dispersion now LIVE
+for both material families: GPU dielectric BK7 disp/flat **0.5508** and Principled
+disp/flat **0.5507** (were ~1.00 no-op), matching the CPU reference ~0.55; CPU/GPU
+per-channel mean-ratio within 4% (dielectric [1.038, 0.982, 0.972], Principled
+[1.038, 0.983, 0.979]); **visually-confirmed spectral rainbow** on a closed glass
+sphere (full ROYGBIV ring for Principled). Register gate: the `HasDispersion` 4th
+axis adds **zero** REG/STACK — fleet kernel `<0,0,0,0>` REG:254 STACK:3352, and
+`<*,*,*,0>`≡`<*,*,*,1>` byte-identical across all 8 base specializations
+(cuobjdump, native sm_120). Work item 3 finding: the flat-prism dispersive
+*photon* caustic is unchanged (still sparse noise) — a separate 2-face-GPU-photon
+follow-up, orthogonal to this wavefront fix.)
+
+**Status (original):** open (found 2026-08-12 during pkg187 Principled-dispersion
 implementation; the implementer empirically established that GPU wavefront
 hero-wavelength dispersion is a **no-op for ALL materials** — a pre-existing
 frozen gap, not a pkg187 defect).
@@ -147,3 +159,60 @@ LOOKING at the render**, not just numbers.
 - **No spill on the flat-IOR fast path** — the dispersive branch must be a
   compile-time specialization; non-dispersive REG:254 kernels stay pinned and
   bit-unchanged.
+
+---
+
+## Implementation notes (PR #TBD, 2026-08-13)
+
+**Root cause (one bug, both material families).** The GPU wavefront `shadePathSlot`
+reconstructs `lambdas` as a **stack local** from the per-path SoA each bounce. The
+dispersive sampler (`gpu_material_sample_spectral`) already computed the hero IOR
+against `wl.lambda[0]` and called `wl.terminateSecondary()` on a refraction event
+(zeroing the secondary pdfs) — but the shade kernel's SoA write-back never persisted
+the mutated `lambda[]`/`pdf[]`. So the collapse evaporated the instant the bounce
+returned: the next bounce re-read the un-collapsed pdfs and `stageRegenKernel`'s
+`spectrumToXYZ` (which skips `pdf==0`) still summed all four wavelengths — every
+dispersive path deposited a broadband spectrum at a hero-bent location, washing out
+to flat-IOR glass. The CPU wavefront mirror (`advance_one_bounce`) never had this bug
+because its `ps.lambdas` is a member of the persistent `PathState`. Confirmed for BOTH
+the Sellmeier dielectric (`GMAT_DIELECTRIC`, `gpu_dielectric_sample_spectral`) and the
+Cauchy Principled glass (`GMAT_CLOSURE_GRAPH`, `gpu_principled_sample`).
+
+**Fix.** `shadePathSlot` now writes the (collapsed) `lambdas.lambda[]`/`pdf[]` back to
+SoA after the BSDF sample, gated by a new compile-time `HasDispersion` (4th) template
+axis; selected off a host-side `SceneUploadResult.hasDispersive` flag (any uploaded
+material `isDispersive`). A **4th axis** (not hung off `HasPrincipled`) is required
+because the dielectric-dispersive path runs with `HasPrincipled=false` — a plain
+Sellmeier dielectric returns an empty closure graph and uploads as `GMAT_DIELECTRIC`,
+never setting the principled flag.
+
+**Register gate (cuobjdump, native sm_120, post-link `.pyd`).** The write-back is 8
+stores of already-live values; it adds **zero** REG/STACK even when compiled in:
+`<*,*,*,0>` ≡ `<*,*,*,1>` byte-identical for all 8 base specializations. Fleet kernel
+`stageShadeBucketedKernel<false,false,false,false>` = REG:254 STACK:3352 (matches the
+documented pre-pkg189 `<F,F,F>` baseline). Non-dispersive scenes launch `<*,*,*,0>`,
+so their output is bit-unchanged and perf cannot regress.
+
+**Work item 2 (test conversions).** `test_pkg64_gpu_cpu_parity`: xfail removed,
+re-pointed to a real per-channel mean-ratio + ROI-energy parity gate on the canonical
+wavefront path (no SMS-GPU surface touched; the caustic-caster flags are harmless
+public-API settings on the wavefront route). `test_gpu_prism_rainbow_parity`: hardened
+with a bright-coverage floor so it is a **genuine** render-level check that honestly
+XFAILS on the flat-prism photon noise (~0.009% bright coverage) instead of vacuously
+XPASSing — see Work item 3. New `test_pkg189_gpu_wavefront_dispersion.py` is the
+primary oracle (control-flip + CPU/GPU parity + visual rainbow). The pre-existing
+`test_pkg187_...gpu_parity::test_gpu_dispersion_wired_mirrors_dielectric_reference`
+asserted the no-op (`0.95 ≤ disp/flat ≤ 1.05`); it was flipped to assert the now-live
+behavior (its own docstring predicted "enabling it lights up BOTH... through this same
+wiring").
+
+**Work item 3 (photon-caustic evaluation — measured).** The flat-prism dispersive
+**photon** caustic is a forward-transport phenomenon on the pkg113 photon pre-pass,
+which is dielectric-oriented and uses only the general BVH loop; a flat 2-quad caster
+scatters into sparse chromatic noise (measured: ~0.009% bright coverage, no caustic
+band). pkg189's wavefront fix is **orthogonal** — it enables the camera/closed-solid
+REFRACTION path (verified by a real spectral rainbow on a glass sphere in
+`test_pkg189`), not the forward photon caustic. Extending the photon pre-pass to a
+2-face flat-prism (or closure-graph Principled) caster is the pre-existing follow-up
+(`general-photon-loop-needs-solid-glass`); per the Non-goals this PR does not touch
+the photon path. Recorded for a follow-up spec, not addressed here.

--- a/.astroray_plan/packages/pkg189-gpu-wavefront-dispersion-enablement.md
+++ b/.astroray_plan/packages/pkg189-gpu-wavefront-dispersion-enablement.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 3/5 (spectral light transport / CPU-GPU parity)
 **Track:** A
-**Status:** done (PR #TBD, 2026-08-13 — GPU wavefront hero-λ dispersion now LIVE
+**Status:** done (PR #603, 2026-08-13 — GPU wavefront hero-λ dispersion now LIVE
 for both material families: GPU dielectric BK7 disp/flat **0.5508** and Principled
 disp/flat **0.5507** (were ~1.00 no-op), matching the CPU reference ~0.55; CPU/GPU
 per-channel mean-ratio within 4% (dielectric [1.038, 0.982, 0.972], Principled
@@ -162,7 +162,7 @@ LOOKING at the render**, not just numbers.
 
 ---
 
-## Implementation notes (PR #TBD, 2026-08-13)
+## Implementation notes (PR #603, 2026-08-13)
 
 **Root cause (one bug, both material families).** The GPU wavefront `shadePathSlot`
 reconstructs `lambdas` as a **stack local** from the per-path SoA each bounce. The

--- a/include/astroray/gpu_scene_upload.h
+++ b/include/astroray/gpu_scene_upload.h
@@ -32,6 +32,14 @@ struct SceneUploadResult {
     std::vector<int>           materialTextureId;
     bool                       hasTexture = false;
 
+    // pkg189 — true when ANY uploaded material is dispersive (Sellmeier dielectric
+    // → GMAT_DIELECTRIC, or Cauchy Principled glass → GMAT_CLOSURE_GRAPH; both set
+    // GMaterial::isDispersive in scene_upload.cu). Selects the
+    // stageShadeBucketedKernel<*,*,*,true> instantiation carrying the hero-λ
+    // collapse SoA write-back; false keeps the fleet on the byte-identical
+    // <*,*,*,false> kernel.
+    bool                       hasDispersive = false;
+
     std::vector<GLight>     lights;
     // pkg89-GPU / GAP 1 — dedicated lights (Blender POINT/SPOT/SUN/AREA lamps
     // routed through astroray::Light). Their cumulativePower continues the

--- a/include/astroray/gpu_wavefront_state.h
+++ b/include/astroray/gpu_wavefront_state.h
@@ -359,7 +359,12 @@ void launchStageShadeBucketed(
     // is published to constant memory once per frame via
     // setWavefrontTextureBinding (below) — NOT passed here — so this signature
     // (shared by the untextured fleet kernel) keeps its pre-pkg186 REG/STACK.
-    bool hasTexture);
+    bool hasTexture,
+    // pkg189: hasDispersion=true selects stageShadeBucketedKernel<*,*,*,true>,
+    // the only instantiations carrying the hero-λ collapse SoA write-back for
+    // dispersive refraction; false selects <*,*,*,false>, byte-identical to the
+    // pre-pkg189 kernels. Host-side flag (any uploaded material isDispersive).
+    bool hasDispersion);
 
 // pkg186 — publish the frame's image-texture arrays into the shade kernel's
 // __constant__ binding. Call ONCE per frame before launchStageShadeBucketed (only

--- a/src/gpu/scene_upload.cu
+++ b/src/gpu/scene_upload.cu
@@ -693,6 +693,12 @@ SceneUploadResult buildSceneArrays(const Renderer& cpu, const Camera* cam) {
         if (g.type == GMAT_CLOSURE_GRAPH && g.closureCount >= 1 &&
             g.closures[0].type == GCLOSURE_PRINCIPLED)
             r.hasPrincipled = true;
+        // pkg189: flag scenes carrying ANY dispersive material so the wavefront
+        // launcher selects the <*,*,*,true> shade kernel (hero-λ collapse
+        // write-back). Set for both the Sellmeier dielectric (GMAT_DIELECTRIC)
+        // and the Cauchy Principled glass (GMAT_CLOSURE_GRAPH) paths above.
+        if (g.isDispersive)
+            r.hasDispersive = true;
         // pkg186 — bake an image-texture base color (TexturedLambertian holding
         // an ImageTexture) into the flat device texel buffer and record its id in
         // the per-material parallel array. Keeps materialTextureId[] index-aligned

--- a/src/gpu/wavefront/gpu_wavefront_snapshot.cu
+++ b/src/gpu/wavefront/gpu_wavefront_snapshot.cu
@@ -1574,7 +1574,8 @@ std::vector<float> cuda_wavefront_render(
                                      d_cryptoObj, d_cryptoMat,     // pkg159
                                      cryptoOn ? cryptoDepth : 0,
                                      res.hasPrincipled,  // pkg178 Stage-3b D4
-                                     res.hasTexture);     // pkg186 (data via c_wfTexBinding)
+                                     res.hasTexture,      // pkg186 (data via c_wfTexBinding)
+                                     res.hasDispersive);  // pkg189 hero-λ collapse write-back
             launchStageShadow(state, hitBufs, d_neeF, d_neeI,
                               d_shadowQueue, d_shadowCount, total_paths,
                               d_tlas, d_instances, d_blas,  // pkg55-C4

--- a/src/gpu/wavefront/stage_advance.cu
+++ b/src/gpu/wavefront/stage_advance.cu
@@ -385,7 +385,26 @@ __constant__ GWavefrontTextureBinding c_wfTexBinding;
 // kernel. Threading HasPhotons lets the fleet's non-photon <*,*,false> kernels
 // compile with ZERO gather codegen; the launcher picks <true> off hasPhotonGrid.
 // See .astroray_plan/packages/pkg184-stage-advance-hasphotons-isolation.md.
-template<bool Deferred, bool HasPrincipled, bool HasTexture = false, bool HasPhotons = false>
+// pkg189 — HasDispersion isolates the hero-λ collapse write-back for dispersive
+// refraction (dielectric Sellmeier + Principled Cauchy glass) behind
+// `if constexpr`. The dispersive sampler (gpu_material_sample_spectral) calls
+// wl.terminateSecondary() on a refraction event, which zeroes the secondary
+// wavelengths' pdfs on the LOCAL `lambdas` reconstructed from SoA at the top of
+// this function. Without persisting that mutated `lambdas` back to the per-path
+// SoA, the collapse evaporates the moment this bounce returns: the next bounce
+// re-reads the un-collapsed pdfs, and stageRegenKernel's spectrumToXYZ still sums
+// all 4 wavelengths — so every dispersive path deposits a broadband spectrum at a
+// hero-bent location and the chromatic separation washes out to flat-IOR glass
+// (the pkg187 no-op: GPU BK7 0.2139 ≈ flat 0.2131). The CPU wavefront mirror
+// (src/cpu/wavefront/path_kernel.cpp::advance_one_bounce) does not need this: its
+// ps.lambdas is a member of the persistent PathState, so the collapse persists
+// for free. Threading HasDispersion lets the fleet's non-dispersive
+// <*,*,*,false> kernels compile with ZERO extra live state (the REG:254-pinned
+// shade kernel stays byte-identical); the launcher picks <true> off the
+// host-side hasDispersive scene flag. See
+// .astroray_plan/packages/pkg189-gpu-wavefront-dispersion-enablement.md.
+template<bool Deferred, bool HasPrincipled, bool HasTexture = false, bool HasPhotons = false,
+         bool HasDispersion = false>
 __device__ bool shadePathSlot(
     int idx,
     GPUWavefrontState& state,
@@ -887,6 +906,28 @@ __device__ bool shadePathSlot(
     state.was_specular[idx] = wasSpecular ? 1 : 0;
     state.rng_dimension[idx] = rng.dimension();
 
+    // pkg189 — persist the hero-λ collapse. gpu_material_sample_spectral above
+    // called wl.terminateSecondary() on a dispersive refraction event (setting
+    // lambda[i]=lambda[0], pdf[i]=0 for the secondaries). Write the mutated
+    // lambdas back to SoA so the collapse survives into the next bounce AND into
+    // stageRegenKernel's spectrumToXYZ accumulation (which skips pdf==0 samples).
+    // For a non-refracting dispersive hit lambdas is unchanged, so this writes
+    // back identical values (bit-neutral). Compiled out entirely on the
+    // <*,*,*,false> fleet kernels via if constexpr, keeping their footprint and
+    // output bit-identical (register gate). Placed only on the surviving/max-depth
+    // path: the RR-kill and pdf<=0 early returns above cannot follow a collapse
+    // (RR runs before sampling; a dispersive refraction always yields pdf=1).
+    if constexpr (HasDispersion) {
+        state.lambda_0[idx] = lambdas.lambda[0];
+        state.lambda_1[idx] = lambdas.lambda[1];
+        state.lambda_2[idx] = lambdas.lambda[2];
+        state.lambda_3[idx] = lambdas.lambda[3];
+        state.lambda_pdf_0[idx] = lambdas.pdf[0];
+        state.lambda_pdf_1[idx] = lambdas.pdf[1];
+        state.lambda_pdf_2[idx] = lambdas.pdf[2];
+        state.lambda_pdf_3[idx] = lambdas.pdf[3];
+    }
+
     int next_bounce = bounce + 1;
     state.bounce[idx] = next_bounce;
     if (next_bounce >= max_depth) {
@@ -1060,7 +1101,7 @@ __global__ void stageIntersectQueuedKernel(
     shade_queues[matType * capacity + slot] = idx;
 }
 
-template<bool HasPrincipled, bool HasTexture, bool HasPhotons>  // pkg178 D4; pkg186 texture; pkg184 photons
+template<bool HasPrincipled, bool HasTexture, bool HasPhotons, bool HasDispersion>  // pkg178 D4; pkg186 texture; pkg184 photons; pkg189 dispersion
 __global__ void stageShadeBucketedKernel(
     GPUWavefrontState state,
     GPUWavefrontHitBuffers hitBufs,
@@ -1096,7 +1137,7 @@ __global__ void stageShadeBucketedKernel(
     // pkg186: texture data comes from the __constant__ c_wfTexBinding symbol, NOT
     // kernel params — keeps the untextured <false,false> signature at its
     // pre-pkg186 footprint (see c_wfTexBinding note above).
-    bool alive = shadePathSlot<true, HasPrincipled, HasTexture, HasPhotons>(idx, state, hitBufs, tlas, instances, blas,
+    bool alive = shadePathSlot<true, HasPrincipled, HasTexture, HasPhotons, HasDispersion>(idx, state, hitBufs, tlas, instances, blas,
                                bvhNodes, prims, tris, spheres, motionVerts,
                                materials, lights, numLights,
                                totalLightPower, dedLights, numDed,
@@ -1222,7 +1263,11 @@ void launchStageShadeBucketed(
     // NOT passed here — the driver publishes it to c_wfTexBinding (constant
     // memory) once per frame via setWavefrontTextureBinding, so this signature
     // (shared by the untextured fleet kernel) stays at its pre-pkg186 footprint.
-    bool              hasTexture)
+    bool              hasTexture,
+    // pkg189: selects the <*,*,*,true> instantiation carrying the hero-λ collapse
+    // write-back. Host-side flag (any uploaded material isDispersive); the
+    // non-dispersive fleet passes false and stays register/stack-identical.
+    bool              hasDispersion)
 {
     if (capacity <= 0) return;
     // One launch covers all buckets: grid = NUM_TYPES * capacity threads;
@@ -1264,37 +1309,61 @@ void launchStageShadeBucketed(
         // scenes launch <*,*,false>, whose ptxas footprint drops back below the
         // pre-pkg184 kernel (acceptance = cuobjdump on the <false,false,false>
         // symbol, native sm_120). All 8 are referenced so they land in the cubin.
+        // pkg189: hasDispersion adds a 4th orthogonal axis. It selects the ONLY
+        // instantiations carrying the hero-λ collapse SoA write-back; the fleet's
+        // non-dispersive scenes launch <*,*,*,false>, byte-identical to the
+        // pre-pkg189 <*,*,*> kernels (acceptance = cuobjdump on the
+        // <false,false,false,false> symbol vs a same-pipeline main baseline). The
+        // 4-bit selector picks one of the 16 instantiations; all 16 are referenced
+        // so they land in the cubin for the register report.
         const bool hasPhotons = hasPhotonGrid;
-        const void* kptr =
-            hasPrincipled
-                ? (hasTexture
-                    ? (hasPhotons ? (const void*)stageShadeBucketedKernel<true, true, true>
-                                  : (const void*)stageShadeBucketedKernel<true, true, false>)
-                    : (hasPhotons ? (const void*)stageShadeBucketedKernel<true, false, true>
-                                  : (const void*)stageShadeBucketedKernel<true, false, false>))
-                : (hasTexture
-                    ? (hasPhotons ? (const void*)stageShadeBucketedKernel<false, true, true>
-                                  : (const void*)stageShadeBucketedKernel<false, true, false>)
-                    : (hasPhotons ? (const void*)stageShadeBucketedKernel<false, false, true>
-                                  : (const void*)stageShadeBucketedKernel<false, false, false>));
+        const int sel = (hasPrincipled ? 8 : 0) | (hasTexture ? 4 : 0)
+                      | (hasPhotons ? 2 : 0) | (hasDispersion ? 1 : 0);
+        #define ASTRORAY_PKG189_KPTR(P,T,Ph,D) \
+                (const void*)stageShadeBucketedKernel<P,T,Ph,D>
+        const void* kptr = nullptr;
+        switch (sel) {
+            case  0: kptr = ASTRORAY_PKG189_KPTR(false,false,false,false); break;
+            case  1: kptr = ASTRORAY_PKG189_KPTR(false,false,false,true ); break;
+            case  2: kptr = ASTRORAY_PKG189_KPTR(false,false,true ,false); break;
+            case  3: kptr = ASTRORAY_PKG189_KPTR(false,false,true ,true ); break;
+            case  4: kptr = ASTRORAY_PKG189_KPTR(false,true ,false,false); break;
+            case  5: kptr = ASTRORAY_PKG189_KPTR(false,true ,false,true ); break;
+            case  6: kptr = ASTRORAY_PKG189_KPTR(false,true ,true ,false); break;
+            case  7: kptr = ASTRORAY_PKG189_KPTR(false,true ,true ,true ); break;
+            case  8: kptr = ASTRORAY_PKG189_KPTR(true ,false,false,false); break;
+            case  9: kptr = ASTRORAY_PKG189_KPTR(true ,false,false,true ); break;
+            case 10: kptr = ASTRORAY_PKG189_KPTR(true ,false,true ,false); break;
+            case 11: kptr = ASTRORAY_PKG189_KPTR(true ,false,true ,true ); break;
+            case 12: kptr = ASTRORAY_PKG189_KPTR(true ,true ,false,false); break;
+            case 13: kptr = ASTRORAY_PKG189_KPTR(true ,true ,false,true ); break;
+            case 14: kptr = ASTRORAY_PKG189_KPTR(true ,true ,true ,false); break;
+            case 15: kptr = ASTRORAY_PKG189_KPTR(true ,true ,true ,true ); break;
+        }
+        #undef ASTRORAY_PKG189_KPTR
         astroray::gpu_profile::ScopedTimer _t(
             "wavefront_stage_shade_bucketed_n7", kptr, blocks, threads);
-        if (hasPrincipled && hasTexture && hasPhotons)
-            stageShadeBucketedKernel<true, true, true><<<blocks, threads>>>(ASTRORAY_PKG186_SHADE_ARGS);
-        else if (hasPrincipled && hasTexture)
-            stageShadeBucketedKernel<true, true, false><<<blocks, threads>>>(ASTRORAY_PKG186_SHADE_ARGS);
-        else if (hasPrincipled && hasPhotons)
-            stageShadeBucketedKernel<true, false, true><<<blocks, threads>>>(ASTRORAY_PKG186_SHADE_ARGS);
-        else if (hasPrincipled)
-            stageShadeBucketedKernel<true, false, false><<<blocks, threads>>>(ASTRORAY_PKG186_SHADE_ARGS);
-        else if (hasTexture && hasPhotons)
-            stageShadeBucketedKernel<false, true, true><<<blocks, threads>>>(ASTRORAY_PKG186_SHADE_ARGS);
-        else if (hasTexture)
-            stageShadeBucketedKernel<false, true, false><<<blocks, threads>>>(ASTRORAY_PKG186_SHADE_ARGS);
-        else if (hasPhotons)
-            stageShadeBucketedKernel<false, false, true><<<blocks, threads>>>(ASTRORAY_PKG186_SHADE_ARGS);
-        else
-            stageShadeBucketedKernel<false, false, false><<<blocks, threads>>>(ASTRORAY_PKG186_SHADE_ARGS);
+        #define ASTRORAY_PKG189_LAUNCH(P,T,Ph,D) \
+                stageShadeBucketedKernel<P,T,Ph,D><<<blocks, threads>>>(ASTRORAY_PKG186_SHADE_ARGS)
+        switch (sel) {
+            case  0: ASTRORAY_PKG189_LAUNCH(false,false,false,false); break;
+            case  1: ASTRORAY_PKG189_LAUNCH(false,false,false,true ); break;
+            case  2: ASTRORAY_PKG189_LAUNCH(false,false,true ,false); break;
+            case  3: ASTRORAY_PKG189_LAUNCH(false,false,true ,true ); break;
+            case  4: ASTRORAY_PKG189_LAUNCH(false,true ,false,false); break;
+            case  5: ASTRORAY_PKG189_LAUNCH(false,true ,false,true ); break;
+            case  6: ASTRORAY_PKG189_LAUNCH(false,true ,true ,false); break;
+            case  7: ASTRORAY_PKG189_LAUNCH(false,true ,true ,true ); break;
+            case  8: ASTRORAY_PKG189_LAUNCH(true ,false,false,false); break;
+            case  9: ASTRORAY_PKG189_LAUNCH(true ,false,false,true ); break;
+            case 10: ASTRORAY_PKG189_LAUNCH(true ,false,true ,false); break;
+            case 11: ASTRORAY_PKG189_LAUNCH(true ,false,true ,true ); break;
+            case 12: ASTRORAY_PKG189_LAUNCH(true ,true ,false,false); break;
+            case 13: ASTRORAY_PKG189_LAUNCH(true ,true ,false,true ); break;
+            case 14: ASTRORAY_PKG189_LAUNCH(true ,true ,true ,false); break;
+            case 15: ASTRORAY_PKG189_LAUNCH(true ,true ,true ,true ); break;
+        }
+        #undef ASTRORAY_PKG189_LAUNCH
         #undef ASTRORAY_PKG186_SHADE_ARGS
         cudaError_t err = cudaGetLastError();
         if (err != cudaSuccess) {

--- a/tests/test_gpu_caustic_parity.py
+++ b/tests/test_gpu_caustic_parity.py
@@ -306,12 +306,19 @@ def test_gpu_glass_sphere_caustic_parity(test_results_dir):
 # Flip to a real gate once the flat-prism 2-face GPU port lands (follow-up).
 # ---------------------------------------------------------------------------
 @pytest.mark.xfail(
-    reason="Flat-prism dispersive caustic on GPU needs the explicit 2-face port "
-           "(Phase 2 decided the 2-face path stays CPU; the GPU general BVH loop "
-           "scatters a flat 2-quad caster into chromatic noise — gpu_photon_emit.h "
-           "header + memory general-photon-loop-needs-solid-glass). The glass-sphere "
-           "gate above is the in-scope GPU caustic acceptance; the prism is a "
-           "documented follow-up.",
+    reason="Flat-prism dispersive CAUSTIC on GPU needs the explicit 2-face photon "
+           "port (Phase 2 decided the 2-face path stays CPU; the GPU general BVH "
+           "loop scatters a flat 2-quad caster into sparse chromatic noise — "
+           "gpu_photon_emit.h + memory general-photon-loop-needs-solid-glass). "
+           "pkg189 (2026-08-13) ENABLED GPU wavefront hero-λ dispersion, but that is "
+           "the camera/closed-solid REFRACTION path (verified by a real spectral "
+           "rainbow in test_pkg189_gpu_wavefront_dispersion — sphere caster); it does "
+           "NOT drive this flat-prism forward-CAUSTIC, a photon-pre-pass phenomenon "
+           "that remains the documented 2-face-GPU-photon follow-up. The prior XPASS "
+           "was vacuous — hue-spread passes on sparse salt-and-pepper noise; the "
+           "bright-coverage floor below now makes this a GENUINE render-level check "
+           "that honestly xfails on the noise (measured: ~0.009% bright coverage, no "
+           "caustic band) until the 2-face port lands.",
     strict=False,
 )
 def test_gpu_prism_rainbow_parity(test_results_dir):
@@ -338,17 +345,26 @@ def test_gpu_prism_rainbow_parity(test_results_dir):
         img = img.reshape(mod.HEIGHT, mod.WIDTH, 3)
     _save_image(img, os.path.join(test_results_dir, "pkg113_gpu_prism_rainbow.png"))
 
-    # A real rainbow has a wide spread of hues. The flat-prism GPU general loop
-    # does not produce this (it scatters); this assert is EXPECTED to fail (xfail)
-    # until the 2-face GPU port lands.
+    # A real rainbow caustic is (1) a wide spread of hues AND (2) a spatially
+    # COHERENT bright band on the floor. The flat-prism GPU general loop scatters
+    # into sparse noise: hue-spread alone passes on that noise (the old vacuous
+    # XPASS; memory general-photon-loop-needs-solid-glass), so we ALSO require a
+    # bright-coverage floor that only a real caustic band clears. Measured on the
+    # current noise: ~0.009% bright coverage — this assert honestly XFAILS until
+    # the 2-face GPU photon-emission port lands.
+    lum = _luminance(img)
+    bright_coverage = float((lum > 0.05).mean())
     rgb = img.reshape(-1, 3)
-    bright = rgb[_luminance(img).reshape(-1) > 0.05]
+    bright = rgb[lum.reshape(-1) > 0.05]
     hue_spread = 0.0
     if bright.shape[0] > 16:
         import colorsys
         hues = np.array([colorsys.rgb_to_hsv(*p)[0] for p in bright[:4000]])
         hue_spread = float(hues.std())
-    assert hue_spread >= 0.12, (
-        f"prism hue spread {hue_spread:.3f} — flat prism on the GPU general loop "
-        f"does not produce a structured rainbow (expected; see xfail reason)."
+    assert hue_spread >= 0.12 and bright_coverage >= 0.005, (
+        f"prism hue spread {hue_spread:.3f}, bright coverage {bright_coverage*100:.3f}% "
+        f"— flat prism on the GPU general photon loop does not produce a structured, "
+        f"spatially-coherent rainbow caustic (sparse noise; expected xfail — the "
+        f"2-face GPU photon port is the follow-up. pkg189's wavefront rainbow is "
+        f"verified separately in test_pkg189_gpu_wavefront_dispersion)."
     )

--- a/tests/test_pkg187_principled_dispersion_gpu_parity.py
+++ b/tests/test_pkg187_principled_dispersion_gpu_parity.py
@@ -1,5 +1,13 @@
 """pkg187 — dispersive Principled on the GPU wavefront leg: wired + faithful mirror.
 
+UPDATED 2026-08-13 by pkg189: the "GPU dispersion is a frozen no-op" premise below
+is HISTORICAL. pkg189 enabled the GPU wavefront hero-λ collapse (persisting it to
+SoA), so dispersion is now LIVE for BOTH dielectric and Principled — exactly as the
+"enabling it lights up BOTH" note predicted. test_gpu_dispersion_wired_mirrors_
+dielectric_reference below has been flipped to assert the live behavior; the CPU
+companion is unchanged. The no-op measurements in the table below are the pre-pkg189
+state, kept for the record.
+
 WHY THIS GATE IS "MIRROR THE DIELECTRIC", NOT "GPU==CPU"
 --------------------------------------------------------
 The production GPU path is the wavefront (megakernels were deleted;
@@ -93,34 +101,42 @@ _P_DISP = {**_P_FLAT, **DISP}
 
 
 def test_gpu_dispersion_wired_mirrors_dielectric_reference():
-    # --- GPU wavefront leg: dispersion is a pre-existing no-op for BOTH the
-    #     dielectric reference and the pkg187 Principled wiring (no NEW divergence).
+    # --- UPDATED by pkg189 (GPU wavefront hero-λ dispersion enablement). ---
+    # This gate ORIGINALLY (pkg187) asserted GPU dispersion was a NO-OP
+    # (0.95 <= disp/flat <= 1.05) for BOTH the dielectric reference and the
+    # Principled wiring, because the GPU wavefront hero-collapse never persisted
+    # to SoA (the pkg187 docstring above predicted: "enabling it lights up BOTH
+    # dielectric and Principled through this same wiring"). pkg189 landed that
+    # enablement, so the no-op assertion is now FALSE: dispersion measurably dims
+    # the mean (the hero collapse drops the broadband wash), tracking the CPU
+    # reference. The gate is flipped to assert dispersion is LIVE and that
+    # Principled still MIRRORS the dielectric reference (the original intent).
     gp_flat = _means(_render(True, "principled", _P_FLAT))
     gp_disp = _means(_render(True, "principled", _P_DISP))
     gd_flat = _means(_render(True, "dielectric", {"ior": 1.5}))
     gd_disp = _means(_render(True, "dielectric", {"sellmeier_preset": "bk7"}))
 
-    p_ratio = gp_disp / np.maximum(gp_flat, 1e-8)   # Principled disp/flat on GPU
-    d_ratio = gd_disp / np.maximum(gd_flat, 1e-8)    # dielectric reference disp/flat on GPU
+    p_ratio = float(gp_disp.mean() / max(gp_flat.mean(), 1e-8))   # Principled disp/flat on GPU
+    d_ratio = float(gd_disp.mean() / max(gd_flat.mean(), 1e-8))   # dielectric reference disp/flat on GPU
 
-    print("\n[pkg187 GPU wiring gate]")
-    print(f"  GPU principled disp/flat = {np.round(p_ratio,4)}")
-    print(f"  GPU dielectric disp/flat = {np.round(d_ratio,4)}")
+    print("\n[pkg189 GPU wiring gate — dispersion now LIVE]")
+    print(f"  GPU principled disp/flat = {p_ratio:.4f}")
+    print(f"  GPU dielectric disp/flat = {d_ratio:.4f}")
 
-    for c, ch in enumerate("RGB"):
-        # Principled introduces no NEW dispersion divergence on the GPU leg
-        # (matches the frozen dielectric behavior: dispersion is a wavefront no-op).
-        assert 0.95 <= p_ratio[c] <= 1.05, (
-            f"pkg187 GPU: Principled dispersion unexpectedly changed the wavefront "
-            f"render (ch {ch} disp/flat={p_ratio[c]:.4f}); the GPU wavefront leg is "
-            f"the frozen no-op path -- a change here means the wiring diverged from "
-            f"the dielectric reference.")
-        # The dielectric reference exhibits the SAME frozen no-op -> the gate is
-        # pre-existing infra, not pkg187.
-        assert 0.95 <= d_ratio[c] <= 1.05, (
-            f"pkg187 GPU: dielectric reference dispersion is NOT a no-op (ch {ch} "
-            f"disp/flat={d_ratio[c]:.4f}) -- the wavefront dispersion infra changed "
-            f"upstream; re-evaluate pkg187's GPU gate against the new behavior.")
+    # Dispersion is LIVE on the GPU wavefront leg (was a no-op ~1.0 pre-pkg189).
+    assert p_ratio < 0.90, (
+        f"pkg189 GPU: Principled dispersion is still a no-op (disp/flat={p_ratio:.4f} "
+        f">= 0.90) — the hero-λ collapse write-back is not reaching the Principled "
+        f"(<true,...,true>) shade instantiation.")
+    assert d_ratio < 0.90, (
+        f"pkg189 GPU: dielectric dispersion is still a no-op (disp/flat={d_ratio:.4f} "
+        f">= 0.90) — the hero-λ collapse write-back is not reaching the dielectric "
+        f"(<false,...,true>) shade instantiation.")
+    # Principled tracks the dielectric reference's dispersion magnitude (original
+    # "mirrors dielectric" intent): both dim by a similar factor.
+    assert abs(p_ratio - d_ratio) < 0.15, (
+        f"pkg189 GPU: Principled dispersion magnitude ({p_ratio:.4f}) diverges from "
+        f"the dielectric reference ({d_ratio:.4f}) by > 0.15.")
 
 
 def test_cpu_dispersion_is_real_and_mirrors_dielectric():

--- a/tests/test_pkg189_gpu_wavefront_dispersion.py
+++ b/tests/test_pkg189_gpu_wavefront_dispersion.py
@@ -1,0 +1,276 @@
+"""pkg189 — GPU wavefront hero-λ dispersion enablement (acceptance oracle).
+
+Before pkg189 the GPU wavefront hero-wavelength dispersion was a NO-OP for every
+material (pkg187 measured GPU dielectric BK7 0.2139 ≈ flat 0.2131, GPU Principled
+disp 0.2041 == flat 0.2041). Root cause: gpu_material_sample_spectral collapses
+to the hero wavelength via wl.terminateSecondary() (zeroing secondary pdfs) on a
+dispersive refraction, but the wavefront shade kernel reconstructed `lambdas` as a
+stack local and never wrote the mutated pdfs back to the per-path SoA — so the
+collapse evaporated and stageRegenKernel's spectrumToXYZ still summed all four
+wavelengths (broadband → achromatic). pkg189 persists the collapse to SoA behind a
+compile-time HasDispersion axis (flat-IOR fleet kernels bit-unchanged).
+
+This is the acceptance oracle for that fix:
+  * CONTROL FLIP — GPU dispersive disp/flat mean-ratio must now DIFFER from the
+    ~1.0 no-op, for BOTH dielectric (Sellmeier) and Principled (Cauchy) glass.
+    Expected magnitude tracks the CPU reference (disp dims the mean to ~0.55×).
+  * CPU/GPU PARITY — per-channel mean-ratio (NOT SSIM: independent MC streams,
+    memory ssim-wrong-gate-for-independent-rng).
+  * VISUAL RAINBOW — a dispersive glass sphere refracting a colored backdrop is
+    rendered to PNG for the mandatory human/parent visual check (the metrics pass
+    on garbage; memory general-photon-loop-needs-solid-glass). The sphere is a
+    CLOSED solid with outward normals (the documented "good" caster case).
+
+GPU-gated: skips when CUDA is absent (CI has no GPU); /verify runs on RTX.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+import pytest
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+sys.path.insert(0, os.path.dirname(__file__))
+
+try:
+    import astroray
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray not built")
+
+if AVAILABLE and not astroray.__features__.get("cuda", False):
+    pytest.skip(
+        "CUDA feature not in this build — pkg189 GPU wavefront dispersion needs the "
+        "RTX box; /verify runs this there.",
+        allow_module_level=True,
+    )
+
+WIDTH = HEIGHT = 48
+SAMPLES = 256
+MAX_DEPTH = 8
+SEED = 189189
+
+DISP = {"dispersion_scale": 1.0, "dispersion_abbe": 20.0}
+_P_FLAT = {"transmission_weight": 1.0, "ior": 1.5, "roughness": 0.02, "metallic": 0.0}
+_P_DISP = {**_P_FLAT, **DISP}
+
+
+def _make_scene(use_gpu: bool, kind: str, params: dict, width: int, height: int):
+    """Glass sphere refracting a red/blue/green colored backdrop — the pkg187
+    acceptance scene (glass sphere is a CLOSED solid with outward normals)."""
+    r = astroray.Renderer()
+    r.set_background_color([0.30, 0.45, 0.65])
+    red = r.create_material("lambertian", [1.0, 0.05, 0.03], {})
+    green = r.create_material("lambertian", [0.05, 1.0, 0.08], {})
+    blue = r.create_material("lambertian", [0.03, 0.08, 1.0], {})
+    r.add_triangle([-3, -3, -2.5], [0, -3, -2.5], [0, 3, -2.5], red)
+    r.add_triangle([-3, -3, -2.5], [0, 3, -2.5], [-3, 3, -2.5], red)
+    r.add_triangle([0, -3, -2.5], [3, -3, -2.5], [3, 3, -2.5], blue)
+    r.add_triangle([0, -3, -2.5], [3, 3, -2.5], [0, 3, -2.5], blue)
+    r.add_triangle([-3, -3, -2.6], [3, -3, -2.6], [0, -1.2, -2.6], green)
+    mat = r.create_material(kind, [1.0, 1.0, 1.0], params)
+    r.add_sphere([0.0, 0.0, 0.0], 0.9, mat)
+    r.setup_camera([0.0, 0.0, 2.0], [0.0, 0.0, 0.0], [0.0, 1.0, 0.0],
+                   55.0, width / height, 0.0, 2.0, width, height)
+    r.set_integrator("path_tracer")
+    r.set_integrator_param("max_depth", MAX_DEPTH)
+    if use_gpu:
+        r.set_use_gpu(True)
+        r.set_wavelength_range(380.0, 780.0)   # engage the spectral wavefront leg
+        r.set_output_mode("srgb")
+    r.set_seed(SEED)
+    return r
+
+
+def _render(use_gpu: bool, kind: str, params: dict,
+            width: int = WIDTH, height: int = HEIGHT, samples: int = SAMPLES) -> np.ndarray:
+    r = _make_scene(use_gpu, kind, params, width, height)
+    img = np.asarray(r.render(samples, MAX_DEPTH, None, False), dtype=np.float64)
+    if img.ndim == 1:
+        img = img.reshape(height, width, 3)
+    return img
+
+
+def _means(img):
+    return np.array([float(img[..., c].mean()) for c in range(3)])
+
+
+def _gpu_available() -> bool:
+    return astroray.Renderer().gpu_available
+
+
+# ---------------------------------------------------------------------------
+# CONTROL FLIP — dispersion is now LIVE on the GPU wavefront leg (was a no-op).
+# ---------------------------------------------------------------------------
+
+def test_gpu_dielectric_dispersion_control_flips():
+    """GPU dielectric BK7 disp/flat must DIFFER from the ~1.0 no-op (pkg187:
+    0.2139/0.2131 ≈ 1.003). After pkg189 the hero collapse persists → dispersion
+    dims the mean toward the CPU reference (~0.55×)."""
+    if not _gpu_available():
+        pytest.skip("CUDA GPU not available on this machine")
+    flat = _means(_render(True, "dielectric", {"ior": 1.5})).mean()
+    disp = _means(_render(True, "dielectric", {"sellmeier_preset": "bk7"})).mean()
+    ratio = disp / max(flat, 1e-8)
+    print(f"\n[pkg189 GPU dielectric control] flat={flat:.4f} bk7={disp:.4f} "
+          f"disp/flat={ratio:.4f}")
+    assert ratio < 0.90, (
+        f"pkg189 GPU dielectric dispersion is STILL a no-op (bk7/flat={ratio:.4f} "
+        f">= 0.90). The hero-λ collapse is not persisting — check the HasDispersion "
+        f"write-back in shadePathSlot and hasDispersive scene flag.")
+
+
+def test_gpu_principled_dispersion_control_flips():
+    """GPU Principled (Cauchy) disp/flat must DIFFER from the ~1.0 no-op (pkg187:
+    0.2041/0.2041 == 1.000). After pkg189 dispersion is live for Principled too."""
+    if not _gpu_available():
+        pytest.skip("CUDA GPU not available on this machine")
+    flat = _means(_render(True, "principled", _P_FLAT)).mean()
+    disp = _means(_render(True, "principled", _P_DISP)).mean()
+    ratio = disp / max(flat, 1e-8)
+    print(f"\n[pkg189 GPU principled control] flat={flat:.4f} disp={disp:.4f} "
+          f"disp/flat={ratio:.4f}")
+    assert ratio < 0.90, (
+        f"pkg189 GPU Principled dispersion is STILL a no-op (disp/flat={ratio:.4f} "
+        f">= 0.90). Principled glass lowers to GMAT_CLOSURE_GRAPH; check the "
+        f"HasDispersion write-back reaches the <true,...,true> instantiation.")
+
+
+# ---------------------------------------------------------------------------
+# CPU/GPU PARITY — per-channel mean-ratio (NOT SSIM; independent MC streams).
+# ---------------------------------------------------------------------------
+
+def _parity(kind: str, disp_params: dict, label: str):
+    gpu = _means(_render(True, kind, disp_params))
+    cpu = _means(_render(False, kind, disp_params))
+    ratio = gpu / np.maximum(cpu, 1e-6)
+    print(f"\n[pkg189 CPU/GPU parity {label}] GPU={np.round(gpu,4)} "
+          f"CPU={np.round(cpu,4)} GPU/CPU={np.round(ratio,4)}")
+    # Per-channel mean-ratio band. Independent MC streams + the hero-collapse's
+    # single-wavelength-per-path variance make an exact match unreachable; a
+    # generous band still catches "GPU dispersion diverges from CPU" (e.g. a
+    # missing collapse → GPU stays bright while CPU dims).
+    for c, ch in enumerate("RGB"):
+        assert 0.75 <= ratio[c] <= 1.30, (
+            f"pkg189 {label} CPU/GPU dispersive parity FAILED ch {ch}: "
+            f"GPU/CPU mean-ratio {ratio[c]:.4f} outside [0.75, 1.30] "
+            f"(GPU {gpu[c]:.4f}, CPU {cpu[c]:.4f}).")
+
+
+def test_gpu_cpu_dielectric_dispersive_parity():
+    if not _gpu_available():
+        pytest.skip("CUDA GPU not available on this machine")
+    _parity("dielectric", {"sellmeier_preset": "bk7"}, "dielectric-bk7")
+
+
+def test_gpu_cpu_principled_dispersive_parity():
+    if not _gpu_available():
+        pytest.skip("CUDA GPU not available on this machine")
+    _parity("principled", _P_DISP, "principled")
+
+
+# ---------------------------------------------------------------------------
+# VISUAL RAINBOW — a dispersive glass sphere refracts a WHITE backdrop split by
+# a sharp dark bar. White light spread by dispersion produces a spectral fringe
+# (rainbow) at the refracted high-contrast edges. The flat-IOR control is
+# perfectly ACHROMATIC (grayscale), so ANY chromatic content in the dispersive
+# render is the dispersion — a clean, correctly-signed metric AND a dramatic
+# visual. PNGs saved for the mandatory human/parent visual check.
+# ---------------------------------------------------------------------------
+
+def _make_rainbow_scene(kind: str, params: dict, w: int, h: int):
+    r = astroray.Renderer()
+    r.set_background_color([0.0, 0.0, 0.0])
+    white = r.create_material("light", [1, 1, 1], {"intensity": 2.0})
+    r.add_triangle([-6, -6, -3], [6, -6, -3], [6, 6, -3], white)
+    r.add_triangle([-6, -6, -3], [6, 6, -3], [-6, 6, -3], white)
+    dark = r.create_material("lambertian", [0.0, 0.0, 0.0], {})
+    r.add_triangle([-6, 0.0, -2.7], [6, 0.0, -2.7], [6, 0.6, -2.7], dark)
+    r.add_triangle([-6, 0.0, -2.7], [6, 0.6, -2.7], [-6, 0.6, -2.7], dark)
+    mat = r.create_material(kind, [1, 1, 1], params)
+    r.add_sphere([0, 0, 0], 0.9, mat)
+    r.setup_camera([0, 0, 2.0], [0, 0, 0], [0, 1, 0], 55.0, w / h, 0.0, 2.0, w, h)
+    r.set_integrator("path_tracer")
+    r.set_integrator_param("max_depth", MAX_DEPTH)
+    r.set_use_gpu(True)
+    r.set_wavelength_range(380.0, 780.0)
+    r.set_output_mode("srgb")
+    r.set_seed(SEED)
+    img = np.asarray(r.render(512, MAX_DEPTH, None, False), dtype=np.float32)
+    if img.ndim == 1:
+        img = img.reshape(h, w, 3)
+    return img
+
+
+def _saturation(img):
+    """Mean HSV-style saturation (max-min)/max over lit sphere pixels — 0 for a
+    grayscale (achromatic) render, >0 when wavelengths separate into color."""
+    lum = 0.2126 * img[..., 0] + 0.7152 * img[..., 1] + 0.0722 * img[..., 2]
+    m = lum > 0.02
+    if m.sum() < 16:
+        return 0.0
+    mx = img.max(axis=-1)
+    mn = img.min(axis=-1)
+    sat = (mx - mn) / np.maximum(mx, 1e-6)
+    return float(sat[m].mean())
+
+
+def test_gpu_dielectric_rainbow_visual(test_results_dir):
+    if not _gpu_available():
+        pytest.skip("CUDA GPU not available on this machine")
+    from base_helpers import save_image
+
+    w = h = 200
+    flat_img = _make_rainbow_scene("dielectric", {"ior": 1.5}, w, h)
+    bk7_img = _make_rainbow_scene("dielectric", {"sellmeier_preset": "bk7"}, w, h)
+
+    flat_png = os.path.join(test_results_dir, "pkg189_gpu_rainbow_flat.png")
+    bk7_png = os.path.join(test_results_dir, "pkg189_gpu_rainbow_bk7.png")
+    save_image(flat_img, flat_png)
+    save_image(bk7_img, bk7_png)
+
+    s_flat = _saturation(flat_img)
+    s_bk7 = _saturation(bk7_img)
+    print(f"\n[pkg189 GPU dielectric rainbow] saturation flat={s_flat:.4f} "
+          f"bk7={s_bk7:.4f}\n  FLAT PNG: {flat_png}\n  BK7  PNG: {bk7_png}\n"
+          f"  PARENT: open both PNGs — the flat control is pure grayscale; the BK7 "
+          f"render shows a colored spectral fringe (rainbow) at the refracted edges.")
+    # The flat control is achromatic (grayscale); the dispersive render must carry
+    # clear chromatic content. Absolute floor + a wide margin over the control.
+    assert s_bk7 > 0.05 and s_bk7 > s_flat * 3.0, (
+        f"pkg189 GPU dielectric: dispersive render lacks chromatic content "
+        f"(bk7 sat {s_bk7:.4f} vs flat {s_flat:.4f}). No spectral fringe / rainbow.")
+
+
+def test_gpu_principled_rainbow_visual(test_results_dir):
+    if not _gpu_available():
+        pytest.skip("CUDA GPU not available on this machine")
+    from base_helpers import save_image
+
+    w = h = 200
+    flat_img = _make_rainbow_scene(
+        "principled", {"transmission_weight": 1.0, "ior": 1.5, "roughness": 0.0}, w, h)
+    disp_img = _make_rainbow_scene(
+        "principled", {"transmission_weight": 1.0, "ior": 1.5, "roughness": 0.0,
+                       "dispersion_scale": 3.0, "dispersion_abbe": 15.0}, w, h)
+
+    flat_png = os.path.join(test_results_dir, "pkg189_gpu_rainbow_principled_flat.png")
+    disp_png = os.path.join(test_results_dir, "pkg189_gpu_rainbow_principled.png")
+    save_image(flat_img, flat_png)
+    save_image(disp_img, disp_png)
+
+    s_flat = _saturation(flat_img)
+    s_disp = _saturation(disp_img)
+    print(f"\n[pkg189 GPU principled rainbow] saturation flat={s_flat:.4f} "
+          f"disp={s_disp:.4f}\n  FLAT PNG: {flat_png}\n  DISP PNG: {disp_png}\n"
+          f"  PARENT: open both PNGs — the flat control is grayscale; the dispersive "
+          f"Principled render shows a full spectral rainbow ring at the refracted edge.")
+    assert s_disp > 0.05 and s_disp > s_flat * 3.0, (
+        f"pkg189 GPU principled: dispersive render lacks chromatic content "
+        f"(disp sat {s_disp:.4f} vs flat {s_flat:.4f}). No rainbow.")

--- a/tests/test_pkg64_gpu_cpu_parity.py
+++ b/tests/test_pkg64_gpu_cpu_parity.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import os
 import sys
-from pathlib import Path
 
 import numpy as np
 import pytest
@@ -53,8 +52,6 @@ HEIGHT = 64
 # not pure noise. 512 is a modest robustness bump without quadrupling runtime.
 SAMPLES = 512
 MAX_DEPTH = 10
-
-BASELINES_DIR = Path(__file__).parent / "baselines" / "pkg64-gpu-phase3"
 
 
 def _make_prism_scene(use_gpu: bool):
@@ -131,82 +128,25 @@ def _receiver_energy(pixels: np.ndarray) -> float:
     return float(np.sum(lum[receiver]))
 
 
-def _ssim(img1: np.ndarray, img2: np.ndarray) -> float:
-    """Structural similarity index (SSIM) between two images.
+def test_pkg64_gpu_cpu_parity(test_results_dir):
+    """GPU (wavefront) vs CPU dispersive-BK7 prism parity on the CANONICAL path.
 
-    Simplified windowed SSIM for 3-channel images. Mirrors the pkg54b NIR-band
-    parity gate pattern (tests/test_pkg54b_phase2_gpu_parity.py). We don't need
-    skimage.metrics.structural_similarity here because the per-channel mean +
-    variance + covariance pattern is sufficient at the 0.97 threshold.
+    pkg189 re-point (was xfail 2026-06-08, "SMS-GPU frozen"). The megakernels are
+    deleted; GPU `path_tracer` routes through the wavefront integrator, whose
+    hero-λ dispersion pkg189 enabled. This is now a REAL gate: the dispersive BK7
+    sphere caster refracts CHROMATICALLY on both CPU and GPU, so their per-channel
+    means agree. No SMS-GPU surface is touched — the caustic-caster / refractive-
+    caustics flags in _make_prism_scene are harmless public-API settings on the
+    wavefront path (the frozen SMS-GPU code is not on this route).
 
-    Returns mean SSIM over RGB channels.
-    """
-    from math import sqrt
-
-    # Constants from Wang 2004 SSIM paper (DOI 10.1109/TIP.2003.819861).
-    C1 = (0.01 * 1.0) ** 2  # (K1 * L)^2, L=1.0 for normalized images
-    C2 = (0.03 * 1.0) ** 2  # (K2 * L)^2
-
-    ssim_channels = []
-    for ch in range(3):
-        x = img1[..., ch].astype(np.float64)
-        y = img2[..., ch].astype(np.float64)
-
-        mu_x = np.mean(x)
-        mu_y = np.mean(y)
-        sigma_x = np.std(x)
-        sigma_y = np.std(y)
-        sigma_xy = np.mean((x - mu_x) * (y - mu_y))
-
-        numerator = (2 * mu_x * mu_y + C1) * (2 * sigma_xy + C2)
-        denominator = (mu_x**2 + mu_y**2 + C1) * (sigma_x**2 + sigma_y**2 + C2)
-        ssim_ch = numerator / denominator
-        ssim_channels.append(ssim_ch)
-
-    return float(np.mean(ssim_channels))
-
-
-@pytest.mark.xfail(
-    reason="SMS-GPU SSIM parity FROZEN AS LEGACY (owner decision 2026-06-08). The "
-           "Wave-5 glass fix (PR #404) legitimately improved GPU output past the frozen "
-           "parity baseline, so SSIM drifted to ~0.835 < 0.85. SMS-GPU is no longer the "
-           "canonical caustic path — pkg113 forward photon-map is — so this structural "
-           "gate is retired rather than recalibrated. The ROI energy-ratio gate (the "
-           "robust primary check) still asserts. Evidence: pkg64-gpu-hw-sweep-2026-05-31.md.",
-    strict=False,
-)
-def test_pkg64_gpu_cpu_parity_ssim(test_results_dir):
-    """GPU vs CPU SMS parity on the prism scene (pkg64-gpu Session 2).
-
-    LEGACY/xfail since 2026-06-08 — see the xfail marker above. SMS-GPU is frozen;
-    the SSIM gate drifted because the glass fix improved GPU output. Kept for the
-    record + the ROI energy-ratio check; pkg113 photon-map supersedes SMS-GPU.
-
-    Re-spec from the Session 1 deferral: the original SSIM >= 0.97 gate is
-    unreachable for two independent MC streams at this spp — measured CPU-vs-CPU
-    SSIM (same engine, different seed) is only ~0.53 at 256 spp, BELOW the 0.97
-    threshold, so no implementation can clear it (memory
-    `ssim-wrong-gate-for-independent-rng`). Two changes make the gate honest:
-
-      1. Match the integrator: GPU now uses "path_tracer" (NEE) like the CPU side
-         (see _make_prism_scene). The Session 1 test compared GPU
-         "multiwavelength_path_tracer" (NEE OFF, dark floor) against CPU
-         "path_tracer" (NEE ON, lit floor) — an integrator mismatch, not a
-         dispersion gap. Matching lifts SSIM from ~0.49 to ~0.93.
-      2. ROI luminance-parity is the primary robust gate (per the memory above);
-         SSIM is kept as a secondary structural check at a noise-floor-aware
-         threshold (0.85; measured ~0.92-0.93 with the dispersion fix).
-
-    The residual SSIM gap to 0.97 is the documented "Option B (hero-wavelength)
-    stalls at 0.93-0.95" case the spec owner pre-accepted (2026-05-24); a future
-    Option-A (per-wavelength split) session can push higher if needed.
+    Gate = per-channel mean-ratio (NOT SSIM: independent MC streams make SSIM
+    unreachable — CPU-vs-CPU is ~0.53 at this spp; memory
+    ssim-wrong-gate-for-independent-rng) + the caustic-ROI energy ratio. The PNGs
+    are written for the mandatory parent visual check.
     """
     probe = astroray.Renderer()
     if not probe.gpu_available:
         pytest.skip("CUDA GPU not available on this machine")
-
-    baseline_gpu_path = BASELINES_DIR / "parity-gpu.npy"
-    baseline_cpu_path = BASELINES_DIR / "parity-cpu.npy"
 
     # Multi-seed averaging (same seeds for GPU and CPU to compare apples-to-apples).
     test_seeds = (145, 211, 333)
@@ -228,56 +168,38 @@ def test_pkg64_gpu_cpu_parity_ssim(test_results_dir):
     e_cpu = _receiver_energy(cpu_avg)
     energy_ratio = e_gpu / max(e_cpu, 1e-6)
 
-    ssim_val = _ssim(gpu_avg, cpu_avg)
+    gpu_means = np.array([float(gpu_avg[..., c].mean()) for c in range(3)])
+    cpu_means = np.array([float(cpu_avg[..., c].mean()) for c in range(3)])
+    chan_ratio = gpu_means / np.maximum(cpu_means, 1e-6)
 
     print(
-        f"\n[pkg64-gpu Phase 3 GPU/CPU parity] "
-        f"SSIM={ssim_val:.4f}, "
-        f"receiver energy GPU={e_gpu:.4f} CPU={e_cpu:.4f} ratio={energy_ratio:.3f}x"
+        f"\n[pkg64 GPU/CPU wavefront-dispersion parity] "
+        f"receiver energy GPU={e_gpu:.4f} CPU={e_cpu:.4f} ratio={energy_ratio:.3f}x | "
+        f"per-channel mean-ratio GPU/CPU={np.round(chan_ratio, 4)}"
     )
-
-    if not baseline_gpu_path.exists() or not baseline_cpu_path.exists():
-        # First run: capture baselines and skip.
-        baseline_gpu_path.parent.mkdir(parents=True, exist_ok=True)
-        np.save(baseline_gpu_path, gpu_avg)
-        np.save(baseline_cpu_path, cpu_avg)
-        pytest.skip(
-            f"pkg64-gpu Phase 3 GPU/CPU parity baselines not present. "
-            f"Captured GPU baseline at {baseline_gpu_path}, "
-            f"CPU baseline at {baseline_cpu_path}. "
-            f"Measured SSIM {ssim_val:.4f}, energy ratio {energy_ratio:.3f}x. "
-            f"Re-run this test to assert the gates (SSIM >= 0.85 + ROI energy parity)."
-        )
-
-    baseline_gpu = np.load(baseline_gpu_path)
-    baseline_cpu = np.load(baseline_cpu_path)
-    baseline_ssim = _ssim(baseline_gpu, baseline_cpu)
 
     # Primary robust gate (memory ssim-wrong-gate-for-independent-rng): the caustic
-    # ROI luminance must agree GPU vs CPU within a generous band. This catches the
-    # integrator/lighting-divergence class of bug (e.g. the Session 1 NEE mismatch
-    # that put GPU ~16x off) without being fooled by per-pixel MC noise.
+    # ROI luminance must agree GPU vs CPU within a generous band. Catches the
+    # integrator/lighting-divergence class of bug without being fooled by MC noise.
     assert 0.5 <= energy_ratio <= 2.0, (
-        f"pkg64-gpu GPU/CPU parity ROI energy gate FAILED: "
+        f"pkg64 GPU/CPU parity ROI energy gate FAILED: "
         f"GPU/CPU receiver-energy ratio {energy_ratio:.3f}x outside [0.5, 2.0]. "
         f"A gross deviation indicates GPU and CPU are not rendering the same "
-        f"transport (e.g. NEE/integrator mismatch), not a dispersion gap."
+        f"transport, not a dispersion gap."
     )
 
-    # Secondary structural gate: SSIM >= 0.85. The original 0.97 was unreachable for
-    # independent MC streams (CPU-vs-CPU SSIM is ~0.53 at this spp). With matched
-    # integrators the dispersion fix reaches ~0.92-0.93; 0.85 leaves margin while
-    # still distinguishing a correct chromatic caustic (~0.93) from the broken
-    # Session 1 hero-only/mismatch baseline (~0.49-0.52).
-    assert ssim_val >= 0.85, (
-        f"pkg64-gpu GPU/CPU parity SSIM gate FAILED: "
-        f"measured {ssim_val:.4f} < gate 0.85. GPU diverges from CPU structurally "
-        f"(baseline SSIM was {baseline_ssim:.4f}). If baselines were captured "
-        f"incorrectly, delete {baseline_gpu_path} and {baseline_cpu_path}, then re-run."
-    )
+    # Dispersion-aware structural gate: per-channel mean-ratio. A missing hero-λ
+    # collapse on GPU would leave the BK7 sphere brighter/less chromatic than CPU
+    # (the pkg189 no-op signature), pushing a channel outside the band.
+    for c, ch in enumerate("RGB"):
+        assert 0.75 <= chan_ratio[c] <= 1.30, (
+            f"pkg64 GPU/CPU dispersive parity FAILED ch {ch}: mean-ratio "
+            f"{chan_ratio[c]:.4f} outside [0.75, 1.30] "
+            f"(GPU {gpu_means[c]:.4f}, CPU {cpu_means[c]:.4f})."
+        )
 
     print(
-        f"[pkg64-gpu Phase 3 GPU/CPU parity] PASS: "
-        f"SSIM {ssim_val:.4f} >= 0.85, ROI energy ratio {energy_ratio:.3f}x in [0.5,2.0] "
-        f"(baseline SSIM {baseline_ssim:.4f})"
+        f"[pkg64 GPU/CPU wavefront-dispersion parity] PASS: "
+        f"per-channel mean-ratio {np.round(chan_ratio, 4)} in [0.75,1.30], "
+        f"ROI energy ratio {energy_ratio:.3f}x in [0.5,2.0]"
     )


### PR DESCRIPTION
## Summary

GPU wavefront hero-λ dispersion was a **no-op for every material** (pkg187 finding). **Root cause:** `shadePathSlot` reconstructs `lambdas` as a stack local from the per-path SoA each bounce; the dispersive sampler (`gpu_material_sample_spectral`) already collapses to the hero wavelength via `wl.terminateSecondary()` (zeroing secondary pdfs) on a refraction event — but the shade kernel never persisted the mutated `lambda[]`/`pdf[]` back to SoA, so the collapse evaporated each bounce and `stageRegenKernel`'s `spectrumToXYZ` kept summing all four wavelengths (broadband → achromatic). The CPU wavefront mirror (`advance_one_bounce`) never had this bug because `ps.lambdas` is a member of the persistent `PathState`. One fix covers **both** dielectric (`GMAT_DIELECTRIC` + Sellmeier) and Principled (`GMAT_CLOSURE_GRAPH` + Cauchy).

**Fix:** persist the collapsed `lambda[]`/`pdf[]` to SoA after the BSDF sample, gated by a new compile-time `HasDispersion` (4th) template axis, selected off a host-side `SceneUploadResult.hasDispersive` flag. A **4th axis** (not hung off `HasPrincipled`) is required because the dielectric-dispersive path runs with `HasPrincipled=false` (a plain Sellmeier dielectric returns an empty closure graph → uploads as `GMAT_DIELECTRIC`, never setting the principled flag).

## Authorized surface

Spec Specification touches the wavefront integrator (`stageAdvance`/`stageShadeBucketed`) + photon-caustic evaluation. Files changed vs. that intent:

| File | In spec? | Note |
|---|---|---|
| `src/gpu/wavefront/stage_advance.cu` | yes | `HasDispersion` axis + SoA write-back + 16-way launcher dispatch |
| `include/astroray/gpu_wavefront_state.h` | yes | launcher decl `+hasDispersion` |
| `src/gpu/scene_upload.cu` + `include/astroray/gpu_scene_upload.h` | yes (upload side is "already correct" but the host-side scene flag is new) | set/carry `hasDispersive` (a host bool; no device-layout change, no re-do of the pkg64/pkg187 upload) |
| `src/gpu/wavefront/gpu_wavefront_snapshot.cu` | yes | production launch call passes `res.hasDispersive` |
| `tests/test_pkg189_*` (new), `test_pkg64_*`, `test_pkg187_*gpu_parity`, `test_gpu_caustic_parity` | yes (Work item 2) | see Test dispositions |
| `.astroray_plan/…/pkg189….md`, `STATUS.md` | docs | status flip + notes |

No SMS-GPU surface touched. No photon-pre-pass code changed.

## Register gate — cuobjdump before/after (post-link `.pyd`, native `sm_120`)

Baseline built on the **identical pipeline** (git-stash the branch → rebuild → cuobjdump), so the only delta is this PR's diff. `<P,T,Ph,D>` = `<HasPrincipled,HasTexture,HasPhotons,HasDispersion>`.

| specialization | BEFORE (pre-pkg189, `<P,T,Ph>`) | AFTER `D=0` | AFTER `D=1` |
|---|---|---|---|
| `<0,0,0,·>` (fleet) | REG:254 STACK:**3352** | REG:254 STACK:**3352** | REG:254 STACK:**3352** |
| `<0,0,1,·>` | REG:254 STACK:3608 | REG:254 STACK:3608 | REG:254 STACK:3608 |
| `<0,1,0,·>` | REG:254 STACK:3352 | REG:254 STACK:3352 | REG:254 STACK:3352 |
| `<0,1,1,·>` | REG:254 STACK:3608 | REG:254 STACK:3608 | REG:254 STACK:3608 |
| `<1,0,0,·>` (principled) | REG:254 STACK:6488 | REG:254 STACK:**6528** | REG:254 STACK:6528 |
| `<1,0,1,·>` | REG:254 STACK:6616 | REG:254 STACK:6656 | REG:254 STACK:6656 |
| `<1,1,0,·>` | REG:254 STACK:6488 | REG:254 STACK:6528 | REG:254 STACK:6528 |
| `<1,1,1,·>` | REG:254 STACK:6616 | REG:254 STACK:6656 | REG:254 STACK:6656 |

- **Fleet (non-principled) kernels: byte-identical** before/after (3352 / 3608). The REG:254-saturated fast path is untouched.
- `D=0` ≡ `D=1` for **all 8** base specializations → the `if constexpr(HasDispersion)` write-back adds **zero** REG/STACK even when compiled in (it's 8 stores of already-live values).
- **Principled** specializations: **+40 B STACK** (6488→6528, 6616→6656), **REG:254 unchanged** → no occupancy change; a template-arity effect (the `D=0` body is if-constexpr'd out), 0.6% of a 6.5 KB stack, on the principled-only path.

## Perf A/B (non-dispersive)

Non-dispersive scenes launch `hasDispersive=false` → `<*,*,*,0>`. The non-principled fleet kernel is **byte-identical** (cuobjdump above), so those renders are **bit-identical** and perf cannot regress — a stronger guarantee than a noisy wall-time A/B. Non-dispersive *principled* scenes carry the +40 B STACK (REG/occupancy unchanged); negligible. Regression sweep below confirms no behavior change.

## Control flip (dispersion now LIVE) + CPU/GPU parity

Measured 256 spp, spectral srgb, glass sphere refracting a colored backdrop (the pkg187 scene):

| material | GPU flat | GPU disp | disp/flat | CPU/GPU per-channel mean-ratio |
|---|---|---|---|---|
| dielectric BK7 | 0.2133 | 0.1175 | **0.5508** (was ~1.003 no-op) | [1.038, 0.982, 0.972] |
| Principled (Cauchy) | 0.2042 | 0.1125 | **0.5507** (was 1.000 no-op) | [1.038, 0.983, 0.979] |

Both track the CPU reference (~0.55). CPU/GPU per-channel mean-ratio within 4% (NOT SSIM — independent MC streams).

## Rainbow — visually confirmed (I read the renders)

High-contrast probe (dispersive glass sphere refracting a white backdrop split by a dark bar):
- **Flat control (ior=1.5):** pure grayscale — no color at all.
- **BK7 (Sellmeier):** orange/blue chromatic fringing arcs around the refracted disc.
- **Principled (dispersion_scale=3, Abbe=15):** a **full ROYGBIV spectral rainbow ring** (blue→green→yellow→orange→red).

The achromatic flat control proves the color is the dispersion, not an artifact. `test_pkg189_gpu_wavefront_dispersion` saves these PNGs and gates saturation (flat 0.036 → BK7 0.147; principled flat 0.035 → disp **0.218**).

## Test dispositions (Work item 2 + frozen-path)

- **`test_pkg64_gpu_cpu_parity`** — xfail **removed**, re-pointed to a real per-channel mean-ratio + ROI-energy parity gate on the **canonical wavefront path** (no SMS-GPU surface touched; the caustic-caster flags are harmless public-API settings on the wavefront route). Passes: mean-ratio [0.842, 0.872, 0.885], ROI 0.789×.
- **`test_pkg187_…gpu_parity::test_gpu_dispersion_wired_mirrors_dielectric_reference`** — was asserting the **no-op** (`0.95 ≤ disp/flat ≤ 1.05`); **flipped** to assert live dispersion (its own docstring predicted "enabling it lights up BOTH… through this same wiring"). Passes: principled 0.5514, dielectric 0.5502.
- **`test_gpu_prism_rainbow_parity`** — the flat-prism dispersive **photon** caustic (a forward-transport phenomenon on the pkg113 pre-pass), **orthogonal** to this wavefront fix and out of scope (Non-goal: no photon-path work). Work item 3 measured it: still sparse noise (~0.009% bright coverage, no caustic band). Hardened with a bright-coverage floor so it is a **genuine** render-level check that honestly **XFAILS** on the noise instead of vacuously XPASSing; reason updated to point at the 2-face-GPU-photon follow-up and at `test_pkg189` for the real wavefront rainbow. Not un-frozen, not un-xfailed.

## Regression sweep (Work item 4)

`16 passed, 1 xfailed` across the dispersion + caustic family: glass-sphere photon caustic (ROI 1.094×, unchanged), CPU prism rainbow, CPU/GPU spectral prism, non-dispersive GPU material parity (lambertian/metal/dielectric/disney), GPU Sellmeier IOR datasheet, pkg187 CPU dispersion (incl. zero-dispersion bit-identical), dielectric glass furnace (CPU+GPU). The 1 xfail is the honest flat-prism-photon marker above.

## Acceptance criteria

- [x] Dielectric BK7 prism chromatic distinct from flat-IOR (0.5508 vs ~1.0 no-op) + visually-confirmed rainbow.
- [x] Principled glass chromatic (0.5507) + visually-confirmed rainbow (full spectral ring).
- [x] CPU/GPU chromatic parity via per-channel mean-ratio (within 4%), both prisms.
- [x] `test_pkg64_gpu_cpu_parity` a real gate (xfail removed) on the canonical path; `test_gpu_prism_rainbow_parity` asserts real pixels (bright-coverage floor, honest XFAIL) — no more vacuous XPASS.
- [x] Zero-dispersion / flat-IOR output bit-unchanged; no perf regression (cuobjdump: fleet kernel byte-identical, `D=0`≡`D=1`).

## Build log (last 5 lines)

```
[pkg183] canary caps: {'cpu': True, 'spectral': True, 'gpu': True, 'gpu_spectral': True, 'gpu_approximate': False, 'closure_graph': True, 'closure_count': 1, 'gpu_type': 'closure_graph', 'notes': 'spectral closure-graph GPU lowering'}

========================================
Build succeeded
========================================
```

Build: `build_cuda_worktree.bat` (VS-generator `build_cuda`, `-DASTRORAY_CUDA_ARCHS=native`), exit 0, pkg183 arch gate (`sm_120.cubin` confirmed via `cuobjdump --list-elf`) + ABI canary PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
