### PR TITLE
docs: post-closeout addendum -- pkg189, pkg195 Stage A+B, CUDA-arch infra root cause (#601-603)

### DIFF
--- a/.astroray_plan/docs/NEXT_STAGE_REPORT.md
+++ b/.astroray_plan/docs/NEXT_STAGE_REPORT.md
@@ -1,13 +1,15 @@
 # Astroray Next Stage Report
 
-**Date:** 2026-08-13 (rewritten at round closeout — GPU capability restoration
-+ Principled spectral correctness run, 2026-08-12 → 2026-08-13, 15 PRs merged
-#585–#599).
-**Prepared by:** the architect (round closeout).
-**Scope:** the round closed with no open PRs. Full detail:
-`.astroray_plan/docs/STATUS.md` (round-closeout section "2026-08-12 →
-2026-08-13"), `.astroray_plan/docs/ROADMAP.md` (matching round-closeout
-entry; "Current sequencing" unchanged — no new owner directive this round).
+**Date:** 2026-08-13 (refreshed for a post-closeout addendum — 3 more PRs
+merged overnight on top of the 2026-08-12 → 2026-08-13 round closeout,
+#601–#603: CUDA-arch infra root cause, GPU wavefront dispersion, pkg195
+Stage A+B).
+**Prepared by:** the architect (post-closeout addendum).
+**Scope:** no open PRs at time of writing. Full detail:
+`.astroray_plan/docs/STATUS.md` (top addendum entry "2026-08-13
+(post-closeout addendum...)", plus the round-closeout section below it),
+`.astroray_plan/docs/ROADMAP.md` ("Current sequencing" unchanged — no new
+owner directive this round).
 
 > Strategic gate: **RELEASED 2026-05-10** by pkg56 Phase C. Strategy in
 > [`ROADMAP.md`](ROADMAP.md), full status in [`STATUS.md`](STATUS.md).
@@ -22,52 +24,54 @@ entry; "Current sequencing" unchanged — no new owner directive this round).
   progressive-refinement correctness fix) and Principled BSDF spectral
   correctness follow-ups (per-λ conductor thin-film, dispersion, transmission
   colour/scalar separation), plus a build-integrity guard.
-- **Landed this round:** pkg183 (build-integrity guard, PR #592), pkg185
-  (GPU glass-caustic gate closed by a test-scene fix, PR #589), pkg186
-  (first GPU image-texture support, PR #590), a pkg182 follow-up (per-λ
-  conductor thin-film, PR #586), pkg187 (Principled BSDF dispersion,
-  CPU-complete + GPU-wired, PR #593), pkg184 (`template<bool HasPhotons>`
-  kernel isolation, PR #597), pkg191 (GPU viewport progressive refinement,
-  PR #598), pkg188 (Principled transmission colour/scalar separation, PR
-  #599). pkg175 flipped to `done` as a drift-gate fix (PR #547 had already
-  merged 2026-08-07; its spec status had gone stale).
-- **HEADLINE ENGINE FINDING (pkg195 design session, PR #596):**
-  `multiwavelength_path_tracer` has **no light sampling** — every lamp-lit
-  NIR/UV render is black end-to-end (measured mean 0.00034 vs sky, all
-  profiles, even under a 5000K blackbody sun). The Spectral Profile node is
-  a visible-band no-op by design; the IR/UV Response node is destructive
-  (replaces the wired BSDF with grey, changing the *visible* render too).
-  Sodium/mercury-vapor and CIE F2/F3 lamp SPDs already ship in
-  `data/spectral_profiles/profiles.bin` and the engine-side
-  `EmissionSpectrum::MeasuredSPD` parser exists — the addon just never sends
-  anything but `blackbody`/`rgb`. Full inventory:
-  `.astroray_plan/docs/spectral-node-system-design-2026-08.md`. **pkg195
-  Phase 1 spec is filed (Stage A = the light-sampling fix, CPU-only, does
-  NOT touch the wavefront GPU kernels) but not yet implemented — this is
-  the single highest-signal correctness item in the open pool.**
-- **A fleet-wide false-reading class was caught and fixed mid-round:** every
-  local `build_cuda/` tree carried a stale cached
-  `CMAKE_CUDA_ARCHITECTURES=52` CMakeCache entry (shadowed at configure time
-  by CMakeLists' non-cache `set()`, so the actually-compiled kernels were
-  correct sm_120 SASS all along, but `cuobjdump` reads against the cache-line
-  arch produced phantom resource-gate numbers — worktree STACK 2640 vs the
-  true sm_120 `<false>` baseline of STACK 3608). **pkg183** now ships an
-  automatic artifact-ground-truth gate (`cuobjdump --list-elf`, exit 7)
-  against this class going forward, but the root cause itself (CMakeLists,
-  `configure_and_build.bat`, `build_blender_addon.py`'s hardcoded
-  arch/Debug revert) is still open, queued as a separate infra PR.
-- **Open, not blocking, carried forward:** pkg189 (GPU wavefront dispersion
-  enablement — unblocks pkg187's GPU-visible leg and the pre-existing pkg64
-  dielectric xfail, both share the same hero-λ-refraction no-op), pkg190
-  (GPU procedural textures, needs a pkg119-B re-baseline first), pkg192/
-  pkg193 (viewport-addon diagnosis-first specs from owner hands-on
-  feedback: interactivity 3–5fps vs Cycles ~30fps, camera-view overlay
-  misalignment), pkg194 (Principled tinted-layer spectral carry + thin-wall
-  per-λ — priority raised by pkg188's QUANTIFIED ~72% band-error finding on
-  coloured-tint-over-dark-base materials), the durable `GLoweredMaterial`
-  by-value-`GMaterial`-copy fix (still prototyped, uncommitted, in worktree
-  `.claude/worktrees/sad-maxwell-ff99d1`), pkg180 (systemic-dim diagnosis,
-  still open dispatchable).
+- **Landed the closeout round (2026-08-12 → 2026-08-13, #585–#599):** pkg183
+  (build-integrity guard, PR #592), pkg185 (GPU glass-caustic gate closed by
+  a test-scene fix, PR #589), pkg186 (first GPU image-texture support, PR
+  #590), a pkg182 follow-up (per-λ conductor thin-film, PR #586), pkg187
+  (Principled BSDF dispersion, CPU-complete + GPU-wired, PR #593), pkg184
+  (`template<bool HasPhotons>` kernel isolation, PR #597), pkg191 (GPU
+  viewport progressive refinement, PR #598), pkg188 (Principled transmission
+  colour/scalar separation, PR #599). pkg175 flipped to `done` as a
+  drift-gate fix (PR #547 had already merged 2026-08-07; its spec status had
+  gone stale).
+- **Landed the overnight addendum (#601–#603, on top of the closeout
+  above):** the CUDA-arch infra root-cause PR (#601 — closes all three
+  causes behind the stale-arch incident: truthful CMakeLists `CACHE FORCE`,
+  VS-generator `native` resolution via `nvidia-smi`, `build_blender_addon.py`
+  arch default/reconfigure fix), **pkg189** (#603 — GPU wavefront hero-λ
+  dispersion now LIVE for both dielectric and Principled, closing the
+  pkg187 GPU-visible gap and the pre-existing pkg64 dielectric xfail), and
+  **pkg195 Stage A+B** (#602 — see the HEADLINE FINDING below, now FIXED for
+  the CPU MW tracer). Owner-facing wins: lamp-lit NIR/UV renders now work
+  (mean 0.0003→0.0709), sodium lamps render amber from the Blender light
+  panel, GPU prisms render real ROYGBIV rainbows.
+- **HEADLINE ENGINE FINDING (pkg195 design session, PR #596) — now FIXED for
+  CPU (PR #602, Stage A+B):** `multiwavelength_path_tracer` had **no light
+  sampling** — every lamp-lit NIR/UV render was black end-to-end (measured
+  mean 0.00034 vs sky, all profiles, even under a 5000K blackbody sun). Fix:
+  dedicated-light NEE ported from the template integrator + spectral lamp
+  presets in the addon (`spectrum_mode` enum). A latent
+  degenerate-power-CDF NaN in `PowerLightSampler` (narrow-line SPDs, e.g.
+  sodium, silently dropped the lamp) was fixed along the way. **Stage C**
+  (`register_spectral_profile` binding, Drawn/Preset/Blackbody spectrum
+  nodes, in-band Replace mode, IR/UV de-fang, Sellmeier B/C) remains OPEN,
+  independently landable — see item 2 below.
+- **Flat-prism GPU-photon dispersion follow-up (from #603):** pkg189 fixed
+  the wavefront *shade-path* dispersion no-op, but the flat-prism dispersive
+  *photon-caustic* render is still sparse noise (a separate, orthogonal
+  2-face-GPU-photon gap). `test_gpu_prism_rainbow_parity` was converted from
+  a vacuous XPASS to an honest, owned XFAIL. Not yet filed as its own spec —
+  candidate for a dedicated pkg number if picked up.
+- **Open, not blocking, carried forward:** pkg190 (GPU procedural textures,
+  needs a pkg119-B re-baseline first), pkg192/pkg193 (viewport-addon
+  diagnosis-first specs from owner hands-on feedback: interactivity 3–5fps
+  vs Cycles ~30fps, camera-view overlay misalignment — pkg192's pkg191
+  soft-dependency is now satisfied), pkg194 (Principled tinted-layer
+  spectral carry + thin-wall per-λ — priority raised by pkg188's QUANTIFIED
+  ~72% band-error finding on coloured-tint-over-dark-base materials), the
+  durable `GLoweredMaterial` by-value-`GMaterial`-copy fix (still
+  prototyped, uncommitted, in worktree `.claude/worktrees/sad-maxwell-
+  ff99d1`), pkg180 (systemic-dim diagnosis, still open dispatchable).
 - **Still standing, unresolved:** the Pillar 4 unpause decision (pkg45/46/
   48/49/50/51 + pkg107, GR/astro science layer) — no new owner directive
   this round; ROADMAP.md's PAUSED marker is unchanged. Surfaced again below
@@ -91,38 +95,36 @@ Grep `^\*\*Status:\*\*` in each spec before dispatch (memory
    stood since 2026-06-08; still no explicit go-ahead. **Surface this to
    the owner before dispatching any pkg45-tier work.**
 
-**Correctness-tier, highest signal in the open pool:**
+**Correctness-tier, highest signal in the open pool** (pkg189 and pkg195
+Stage A both landed overnight, #603/#602 — re-ranked accordingly):
 
-2. **pkg195 Stage A** — give `MultiwavelengthPathTracer::pathTrace` spectral
-   NEE over dedicated lights. Fixes a real, currently-shipping defect
-   (every lamp-lit NIR/UV render is black); CPU-only, explicitly scoped to
-   NOT touch the wavefront GPU kernels (REG:254 stays untouched). Do not
-   scope-creep into Phases 2–4 (recorded in the design doc §5) — Stage A
-   alone is the dispatchable unit.
-3. **pkg189** — GPU wavefront dispersion enablement. Closes the pre-existing
-   hero-λ-refraction no-op that both pkg187's Principled dispersion and the
-   long-standing pkg64 dielectric xfail are blocked on; lights up two
-   features at once.
-4. **pkg194** — Principled tinted-layer spectral carry + thin-wall per-λ.
+2. **pkg194** — Principled tinted-layer spectral carry + thin-wall per-λ.
    Priority raised by pkg188's quantified ~72% band-error finding on
    coloured-tint-over-dark-base materials (0% for the common white-tint
-   case, so this is a real-but-narrow defect, not a universal one).
+   case, so this is a real-but-narrow defect, not a universal one). Now the
+   top correctness item in the open pool.
+3. **pkg190** — GPU procedural textures (pkg186 slice 2) + the pkg119-B
+   re-baseline it needs first. No longer blocked by anything else in
+   flight; the re-baseline is part of this item's own dispatchable unit.
+4. **pkg192** — viewport navigation interactivity (3–5fps vs Cycles'
+   ~30fps) — diagnosis-first spec. Its pkg191 soft-dependency (GPU
+   progressive-refinement correctness) is now satisfied (PR #598, landed).
+5. **pkg193** — camera-view overlay misalignment — diagnosis-first spec.
+6. **pkg195 Stage C** — spectral node system remainder:
+   `register_spectral_profile` binding + Drawn/Preset/Blackbody spectrum
+   nodes + in-band Replace mode + IR/UV de-fang + Sellmeier B/C.
+   Independently landable now that Stages A+B are done (#602); not urgent
+   (the correctness-critical light-sampling gap Stage A closed was the
+   headline item, not Stage C's authoring niceties).
 
-**Hygiene / addon-facing (owner explicitly gave feedback on these):**
+**Hygiene / follow-up (not yet filed as a dedicated spec):**
 
-5. **pkg192** — viewport navigation interactivity (3–5fps vs Cycles' ~30fps)
-   — diagnosis-first spec.
-6. **pkg193** — camera-view overlay misalignment — diagnosis-first spec.
-7. **pkg190** — GPU procedural textures (pkg186 slice 2) — **blocked on a
-   pkg119-B re-baseline first**, do not dispatch before that re-baseline
-   lands.
-8. **Infra: CUDA-arch root-cause PR** — force `CMAKE_CUDA_ARCHITECTURES`
-   from `ASTRORAY_CUDA_ARCHS` at the CMakeLists cache level (not a
-   non-cache `set()`), and pass `ASTRORAY_CUDA_ARCHS` through
-   `configure_and_build.bat` + fix `build_blender_addon.py`'s hardcoded
-   arch/Debug revert. Closes the false-reading class pkg183 currently only
-   detects after the fact.
-9. **Durable `GLoweredMaterial` by-value-copy fix** — re-apply the
+7. **Flat-prism GPU-photon dispersion** — pkg189 (#603) fixed the wavefront
+   shade-path hero-λ collapse, but the flat-prism dispersive *photon*
+   caustic is still sparse noise (orthogonal 2-face-GPU-photon gap;
+   `test_gpu_prism_rainbow_parity` is now an honest, owned XFAIL rather than
+   a vacuous XPASS). File a dedicated spec before dispatching.
+8. **Durable `GLoweredMaterial` by-value-copy fix** — re-apply the
    prototyped PR-2-based fix from worktree
    `.claude/worktrees/sad-maxwell-ff99d1` on settled main. File a dedicated
    spec if picked up (recurring-leak pattern across pkg178 Stage 3 and PR
@@ -130,18 +132,18 @@ Grep `^\*\*Status:\*\*` in each spec before dispatch (memory
 
 **Re-entered / long-tail pool (still genuinely low priority):**
 
-10. **pkg180** — systemic Astroray-vs-Cycles dim, diagnosis-first, still
+9. **pkg180** — systemic Astroray-vs-Cycles dim, diagnosis-first, still
     open dispatchable.
-11. **pkg173** — bounce-1 geometry-sampling parity (pkg172 effect (B));
+10. **pkg173** — bounce-1 geometry-sampling parity (pkg172 effect (B));
     holds pkg156's 0.998 SSIM restoration clause.
-12. **pkg153** — wavefront_diff remainder, gate-failure-reviewer disposition
+11. **pkg153** — wavefront_diff remainder, gate-failure-reviewer disposition
     in flight.
-13. **pkg155 Phase 2** — shade-stage register recovery (221 regs/thread →
+12. **pkg155 Phase 2** — shade-stage register recovery (221 regs/thread →
     ≤128 target); opportunistic GPU-lock gap-filler, not compile-only.
-14. **pkg128** — thin-film residual charter (standalone Glass/Metallic node
+13. **pkg128** — thin-film residual charter (standalone Glass/Metallic node
     cells + spectral showcase), rides the shared Belcour-Barla utility
     pkg178/pkg182 already built.
-15. **pkg165** — verify-and-close. A focused confirm on pkg158's exact
+14. **pkg165** — verify-and-close. A focused confirm on pkg158's exact
     Step-0 scene at r ∈ {0.0, 0.3, 0.6, 0.9} closes the paperwork; every
     existing reading is already in-band. Trivial, non-urgent.
 
@@ -154,15 +156,16 @@ PAUSED until the owner go-ahead in item 1 above.
 
 **First: get the owner's read on Pillar 4 unpause** (item 1) — a
 milestone-scale sequencing decision, not a code dispatch. While that's
-pending, **pkg195 Stage A (item 2) is the standout autonomous pickup** — it
-fixes a real, currently-shipping engine defect (lamp-lit NIR/UV renders are
-black), is CPU-only, and does not touch the register-saturated wavefront GPU
-kernels. After that: pkg189 (item 3, unblocks two features at once), then
-pkg194 (item 4, quantified real defect). The addon-feedback items (5–6) and
-pkg190 (7, gated on its own prerequisite) are next-best; the infra
-root-cause PR (8) and the `GLoweredMaterial` fix (9) are hygiene debt that
-unblocks clean baselines going forward. Items 10–15 are the long-tail pool,
-in roughly that priority order.
+pending, **pkg194 (item 2) is the standout autonomous pickup** — the
+quantified ~72% band-error finding from pkg188 makes it the highest-signal
+real defect left in the open pool now that pkg189 and pkg195 Stage A have
+landed. After that: pkg190 (item 3, procedural textures + its own
+re-baseline), then pkg192/pkg193 (items 4–5, owner hands-on addon feedback;
+pkg192's pkg191 soft-dependency is now satisfied), then pkg195 Stage C
+(item 6, independently landable authoring niceties, not correctness-urgent).
+The flat-prism GPU-photon dispersion follow-up (item 7) and the
+`GLoweredMaterial` fix (item 8) need a spec filed before dispatch. Items
+9–14 are the long-tail pool, in roughly that priority order.
 
 Rules that stay live from this round: **energy gates render LINEAR with an
 upper bound** (pkg166); **state the `.pyd` mtime next to every probe A/B
@@ -188,7 +191,7 @@ CLAUDE.md §6 (`/cite-algorithm`) for any new algorithm.
   (pr-reviewer doc-only rule). Source PRs need the independent-review
   SIGN-OFF/BLOCK gate (pkg98) before push.
 - **`src/gpu/wavefront/stage_advance.cu` is a serialization point** for any
-  GPU-lane package (pkg155 Phase 2, pkg189, a Pillar-4 GPU package, etc.) —
+  GPU-lane package (pkg155 Phase 2, pkg190, a Pillar-4 GPU package, etc.) —
   check for other in-flight touches before dispatching.
 - **CI is blind to GPU correctness** — never declare a round clean on CI
   green alone; run the full RTX hardware sweep at closeout (memory:

--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -1,5 +1,50 @@
 # Astroray Status
 
+**2026-08-13 (post-closeout addendum — 3 more PRs merged overnight, #601–
+#603, on top of the round closeout below): CUDA-arch infra root cause
+closed, GPU wavefront dispersion goes live, and the HEADLINE lamp-lighting
+finding from the closeout below gets fixed for the CPU MW tracer.
+Owner-facing wins: lamp-lit NIR/UV renders now work (mean 0.0003→0.0709),
+sodium lamps render amber from the Blender light panel, and GPU prisms
+render real ROYGBIV rainbows.**
+- **Infra arch root-cause DONE** (PR #601) — closes the three root causes
+  behind the 2026-08-12 stale-CUDA-arch incident that pkg183 (below) had
+  deliberately left as a follow-up: CMakeLists now sets
+  `CMAKE_CUDA_ARCHITECTURES` as `CACHE ... FORCE` (was a non-cache `set()`
+  silently shadowing the cache), the VS-generator configure entry point
+  (`configure_and_build.bat`) resolves `native` to a real arch via
+  `nvidia-smi` (was compiling sm_52 under the VS generator even though the
+  cache said sm_120), and `build_blender_addon.py` now injects an explicit
+  arch default and re-asserts it on every reconfigure. `cuobjdump
+  --list-elf` ground-truth confirms sm_120 on all three build outputs
+  (VS-gen, Ninja, addon) post-fix.
+- **pkg189 DONE** (PR #603) — GPU wavefront hero-λ dispersion is now LIVE
+  for both material families (see the full entry below); closes the
+  pkg187 GPU-visible gap and the pre-existing pkg64 dielectric xfail. The
+  flat-prism GPU-photon dispersion caustic (still noise) is filed forward
+  as an orthogonal follow-up — its test went from a vacuous XPASS to an
+  honest, owned XFAIL.
+- **pkg195 Stage A+B DONE** (PR #602) — fixes the HEADLINE ENGINE FINDING
+  below for the CPU MW tracer: dedicated-light NEE (spectral, two-sided
+  MIS, gated on `enable_nee` mirroring the template integrator) +
+  spectral lamp presets in the addon (`spectrum_mode` enum — native /
+  preset / custom_profile — sodium_vapor etc. via `measured_spd`). NIR
+  snow-sphere mean 0.0003→0.0709 (>0.05 gate), sodium lamp linear RGB
+  (0.673, 0.127, 0.000) reads amber, headless Blender 5.1 confirms amber
+  sodium vs neutral cie_f2 from the actual light panel UI. Fixed a latent
+  bug along the way: a narrow-line SPD (sodium's ~589 nm spike) drove
+  `PowerLightSampler`'s power-CDF to a degenerate 0/0 NaN selection pdf,
+  silently dropping the lamp — now falls back to uniform selection (PBRT
+  UniformLightSampler pattern). **Verification arc:** the first HW pass
+  FAILED — unconditional NEE changed the CPU MW oracle under 3
+  CPU-vs-GPU parity gates (SSIM 0.995→0.30) — fixed by mirroring the
+  `enable_nee` condition and pinning `enable_nee=0` on the oracle legs
+  (documented Phase-3 contract: GPU MW-leg light sampling is future
+  work); all 10 parity gates recovered to historical values, independently
+  confirmed. Stage C (`register_spectral_profile` binding, Drawn/Preset/
+  Blackbody spectrum nodes, in-band Replace mode, IR/UV de-fang, Sellmeier
+  B/C) remains OPEN, independently landable.
+
 **2026-08-12 → 2026-08-13 (day run + overnight, 15 PRs merged #585–#599, no
 open PRs at closeout): GPU capability-restoration wave (first GPU texture
 support, viewport progressive-refinement fix) + two Principled spectral
@@ -82,15 +127,17 @@ that every lamp-lit NIR/UV render is black end-to-end.**
   Sodium/mercury lamp SPDs are already engine-ready but not exposed. A
   drawn-spectrum node is filed as a genuine differentiator (no other
   renderer has one). pkg195 Phase 1 spec filed, not yet implemented.
-- **Specs filed, not yet implemented:** pkg189 (GPU wavefront dispersion
-  enablement — the hero-λ refraction no-op both pkg187 and the pre-existing
-  dielectric xfail are blocked on; PR #591, next up), pkg190 (GPU
+- **Specs filed, not yet implemented:** pkg190 (GPU
   procedural textures, pkg186 slice 2, needs a pkg119-B re-baseline first;
   PR #594), pkg192/pkg193 (viewport-addon diagnosis-first specs from owner
   hands-on feedback, PR #595 — pkg192 viewport interactivity 3-5fps vs
   Cycles ~30fps, pkg193 camera-view overlay misalignment; pkg191, filed in
-  the same PR, landed same round — see above), pkg195 (spectral node
-  system, above).
+  the same PR, landed same round — see above), pkg195 Stage C (spectral
+  node system remainder — register_spectral_profile binding +
+  Drawn/Preset/Blackbody nodes + in-band Replace mode + IR/UV de-fang +
+  Sellmeier B/C; Stages A+B DONE, see the 2026-08-13 addendum above).
+  pkg189 (used to be listed here) is DONE — see the 2026-08-13 addendum
+  above.
 - **Infra, not tied to a package:** `.gitattributes` forces CRLF checkout
   for `.bat`/`.cmd` (PR #585, prevents the class of silent cmd.exe
   mis-parse this repo has hit before); comprehensive repo hygiene sweep
@@ -103,10 +150,12 @@ that every lamp-lit NIR/UV render is black end-to-end.**
 - **Round verification discipline:** every code PR dual-gated (CI +
   independent RTX hardware verification); three verifiers serialized via
   the GPU lock overnight.
-- **Open follow-ups carried forward:** pkg189 (next up), pkg190, pkg192,
-  pkg193, pkg194 (priority raised by the 72% finding above), pkg195, the
-  infra arch root-cause PR, the `GLoweredMaterial` by-value prototype
-  re-apply (worktree `sad-maxwell`), pkg180 diagnosis.
+- **Open follow-ups carried forward:** pkg190, pkg192, pkg193, pkg194
+  (priority raised by the 72% finding above), pkg195 Stage C, the
+  flat-prism GPU-photon dispersion follow-up (pkg189's #603 honest-xfail),
+  the `GLoweredMaterial` by-value prototype re-apply (worktree
+  `sad-maxwell`), pkg180 diagnosis. pkg189 and the infra arch root-cause PR
+  are DONE — see the 2026-08-13 addendum above.
 
 **2026-08-11 (post-Principled-block parity verification + harness band re-pin —
 CLOSES the last two owed pkg178 items):** thin-film saturation parity vs Blender


### PR DESCRIPTION
## Summary
- Records the three PRs merged overnight on top of the 2026-08-13 round closeout: the CUDA-arch infra root-cause fix (#601), GPU wavefront hero-lambda dispersion enablement (pkg189, #603), and MW-tracer dedicated-light NEE + spectral lamp presets (pkg195 Stage A+B, #602).
- Owner-facing wins recorded: lamp-lit NIR/UV renders now work (mean 0.0003 -> 0.0709), sodium lamps render amber from the Blender light panel, GPU prisms render real ROYGBIV rainbows.
- pkg189 and pkg195 spec `Status:` lines were already correctly flipped within their own merge commits (#603, #602) -- verified, no fix needed.
- Reconciled the "specs filed, not yet implemented" / "open follow-ups" lists in the existing 2026-08-13 STATUS.md closeout section so they no longer contradict the new addendum (pkg189 and the infra-arch item moved from open to done; pkg195 narrowed to Stage C only).
- Re-ranked NEXT_STAGE_REPORT.md's next-round queue: pkg194 (priority raised by the 72% tinted-layer band-error finding) now leads, followed by pkg190, pkg192 (pkg191 soft-dependency now satisfied), pkg193, and pkg195 Stage C. Noted the flat-prism GPU-photon dispersion follow-up from #603's honest-xfail as an unfiled hygiene item.

Doc-only change; no source, tests, or CMake touched.

## Test plan
- [x] `git diff` reviewed -- only `.astroray_plan/docs/STATUS.md` and `.astroray_plan/docs/NEXT_STAGE_REPORT.md` changed
- [x] Every added line traced to PR #601, #602, or #603
- [x] Confirmed pkg189/pkg195 spec `Status:` lines on main already reflect their landed PRs
- N/A build/hardware verification (doc-only)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>