### PR TITLE
feat(pkg192): viewport navigation interactivity — skip per-frame BVH rebuild on camera-only (orbit/pan/zoom) frames

### DIFF
--- a/.astroray_plan/packages/pkg192-viewport-navigation-interactivity.md
+++ b/.astroray_plan/packages/pkg192-viewport-navigation-interactivity.md
@@ -2,7 +2,12 @@
 
 **Pillar:** 5 / integration-first
 **Track:** A
-**Status:** open (filed 2026-08-12 from owner hands-on addon feedback —
+**Status:** in review (PR #605, 2026-08-13 — Suspect A only: camera-only
+orbit/pan/zoom frames render with skip_upload=True, skipping the ~48ms per-frame
+CPU BVH rebuild; GPU 100k-tri 1280x720 min-of-N: render 103.98->54.68ms,
+frame 167.54->118.45ms, 5.97->8.44 fps. Suspect B reduced-res nav + the residual
+~27ms wavefront buildSceneArrays/upload floor deferred to a follow-up — see PR)
+(filed 2026-08-12 from owner hands-on addon feedback —
 memory [[owner-addon-feedback-2026-08-12]], finding #2)
 **Estimated effort:** M-L (diagnosis + cheapest high-leverage fixes only)
 

--- a/benchmarks/viewport_parity/run.py
+++ b/benchmarks/viewport_parity/run.py
@@ -313,7 +313,8 @@ def _drive_pan_zoom_orbit(eng, renderer_proxy: CountingRenderer,
                           width: int, height: int, n_frames: int,
                           chunk_spp: int, max_depth: int,
                           use_oidn_pass: bool,
-                          path: str = "camera_only"):
+                          path: str = "camera_only",
+                          camera_skip_upload: bool = False):
     """Drive the camera path. Returns dict of measurements for one config.
 
     ``path`` chooses which Blender scenario to emulate:
@@ -380,8 +381,17 @@ def _drive_pan_zoom_orbit(eng, renderer_proxy: CountingRenderer,
                 pass
 
         # 4) render — chunk_spp samples, depth from settings.
+        # pkg192: mirror the shipped addon. A camera-only orbit/pan/zoom frame
+        # renders from the current device state with skip_upload=True (geometry,
+        # BVH, materials, lights, env unchanged) so the per-frame CPU BVH rebuild
+        # is skipped — the profile's dominant orbit-frame cost. Frame 0 uploads
+        # (BVH build) via _build_renderer's upload_scene(); the camera_only path
+        # is a static scene so every subsequent frame is safely skip_upload=True.
+        # transform_edit keeps skip_upload=False (geometry may change per tick).
+        skip_upload = camera_skip_upload and path == "camera_only"
         t0 = time.perf_counter()
-        real.render(chunk_spp, max_depth)
+        real.render(chunk_spp, max_depth, None, False,
+                    -1, -1, -1, -1, -1, skip_upload)
         render_ms.append((time.perf_counter() - t0) * 1000.0)
         astroray.record_viewport_stage("render", render_ms[-1])
 
@@ -492,6 +502,7 @@ def run(args) -> dict:
                         max_depth=args.max_depth,
                         use_oidn_pass=use_oidn,
                         path=path,
+                        camera_skip_upload=args.camera_skip_upload,
                     )
                     result["config"] = {
                         "tris_target": tris,
@@ -505,6 +516,7 @@ def run(args) -> dict:
                         "max_depth": args.max_depth,
                         "n_frames": args.frames,
                         "path": path,
+                        "camera_skip_upload": args.camera_skip_upload,
                     }
                     out["configs"].append(result)
 
@@ -558,6 +570,11 @@ def main(argv=None) -> int:
                    help="integrator name (pkg55-B': 'wavefront_path_tracer' "
                         "routes GPU renders through the wavefront pipeline)")
     p.add_argument("--gpu-only", action="store_true")
+    p.add_argument("--camera-skip-upload", dest="camera_skip_upload",
+                   action="store_true",
+                   help="pkg192: render camera_only frames with skip_upload=True "
+                        "(the shipped addon behavior — skips the per-frame CPU BVH "
+                        "rebuild on pure camera moves). Off = pre-pkg192 baseline.")
     p.add_argument("--no-h3", action="store_true",
                    help="Skip the OIDN A/B (H3).")
     p.add_argument("--with-transform-edit", action="store_true",

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -1656,6 +1656,7 @@ class CustomRaytracerRenderEngine(RenderEngine):
             context, depsgraph, RAYTRACER_AVAILABLE,
             _configure_backend_for_context,
             _viewport_perf_record,
+            _viewport_perf_frame_complete,
             _effective_integrator_name,
             self._camera_state_hash,
             self._camera_substantive_state_hash,

--- a/blender_addon/exporter.py
+++ b/blender_addon/exporter.py
@@ -677,6 +677,7 @@ class Exporter:
 
     def view_draw(self, context, depsgraph, raytracer_available,
                  configure_backend_fn, viewport_perf_record_fn,
+                 viewport_perf_frame_complete_fn,
                  effective_integrator_name_fn, camera_state_hash_fn,
                  camera_substantive_state_hash_fn,  request_viewport_redraw_fn,
                  engine_methods):
@@ -716,17 +717,55 @@ class Exporter:
                 renderer = self._get_viewport_renderer()
                 # If user opened rendered-shading without ever firing view_update,
                 # renderer has no scene. Fall back to full sync.
-                if self._viewport_texture is None:
+                did_fresh_sync = self._viewport_texture is None
+                if did_fresh_sync:
                     self.sync_viewport_scene(renderer, depsgraph, settings,
                                             configure_backend_fn,
                                             viewport_perf_record_fn,
                                             effective_integrator_name_fn)
 
+                # pkg192: pure camera moves (orbit / pan / zoom) change ONLY the
+                # camera — geometry, BVH, materials, lights and environment are
+                # all identical to the last synced frame. Render from the current
+                # device state with skip_upload=True so we skip the per-frame CPU
+                # BVH rebuild (renderer.buildAcceleration), which the profile
+                # showed dominated orbit-frame cost (~48 ms of a ~100 ms render on
+                # a 100k-tri scene; benchmarks/viewport_parity). The camera is
+                # published separately by setup_viewport_camera, so a camera-only
+                # skip_upload render stays correct (verified: identical image at a
+                # fixed camera, image updates as the camera moves).
+                # view_draw NEVER re-syncs the scene (only view_update does), so
+                # on a camera move the geometry/BVH is guaranteed identical to
+                # the last sync. Guard: the fresh-sync fallback frame (and any
+                # frame before the scene was ever fully synced) still uploads so
+                # the BVH is built for the current geometry. Progressive
+                # still-frame refine frames (camera unchanged, pkg191's loop) are
+                # deliberately left on the upload path — this fix is scoped to
+                # camera-motion interactivity only.
+                # NOTE: settings_changed is NOT a valid exclusion here — the
+                # render key hashes the camera state, so it flips on every camera
+                # move; gating on camera_changed is what isolates orbit/pan/zoom.
+                camera_only_frame = (
+                    not did_fresh_sync
+                    and self._viewport_full_synced
+                    and camera_changed
+                )
+
+                t0 = time.perf_counter()
                 self.render_viewport_frame(
                     renderer, context, settings, region,
                     reset_accumulation=(camera_substantive_changed or settings_changed),
-                    engine_methods=engine_methods
+                    engine_methods=engine_methods,
+                    skip_upload=camera_only_frame,
                 )
+                # pkg192: record orbit/pan/zoom frames through the existing
+                # pkg56-A ring buffer. view_draw previously left camera-motion
+                # frames unprofiled (only view_update recorded), so the per-stage
+                # overlay / viewport_perf_stats never saw the interactive path
+                # that the owner's fps complaint is about.
+                viewport_perf_record_fn("render", t0)
+                viewport_perf_frame_complete_fn()
+
                 self._viewport_camera_hash = new_hash
                 self._viewport_camera_substantive_hash = new_substantive_hash
 

--- a/tests/test_blender_viewport_session.py
+++ b/tests/test_blender_viewport_session.py
@@ -362,6 +362,62 @@ def test_view_draw_re_renders_when_camera_changes(monkeypatch):
     )
 
 
+class _SkipUploadRecordingRenderer(_RecordingRenderer):
+    """Also captures the skip_upload flag (10th positional render arg) so
+    pkg192 can assert camera-only frames avoid the per-frame geometry
+    re-upload / BVH rebuild."""
+    def __init__(self):
+        super().__init__()
+        self.skip_upload_flags = []
+
+    def render(self, *_a, **_k):
+        # render_viewport_frame passes skip_upload as the 10th positional arg.
+        skip = _a[9] if len(_a) > 9 else _k.get("skip_upload", False)
+        self.skip_upload_flags.append(bool(skip))
+        return super().render(*_a, **_k)
+
+
+def test_view_draw_camera_only_frame_skips_geometry_upload(monkeypatch):
+    """pkg192: a pure camera move (orbit/pan/zoom) must re-render with
+    skip_upload=True so the per-frame CPU BVH rebuild is avoided, while the
+    initial full sync still uploads (skip_upload=False) to build the BVH."""
+    _SkipUploadRecordingRenderer.construction_count = 0
+    addon = _load_blender_addon(monkeypatch,
+                                renderer_cls=_SkipUploadRecordingRenderer)
+    engine = addon.CustomRaytracerRenderEngine()
+    _patch_out_gpu_calls(addon, monkeypatch, engine)
+
+    monkeypatch.setattr(engine, 'convert_materials', lambda dg, r: {})
+    monkeypatch.setattr(engine, 'convert_objects', lambda dg, r, mm: None)
+    monkeypatch.setattr(engine, 'convert_lights', lambda dg, r: None)
+    monkeypatch.setattr(engine, 'setup_world', lambda scene, r: None)
+    monkeypatch.setattr(engine, '_setup_viewport_camera',
+                        lambda r, ctx, w, h: r.setup_camera())
+    monkeypatch.setattr(engine, 'bind_display_space_shader', lambda s: None)
+    monkeypatch.setattr(engine, 'unbind_display_space_shader', lambda: None)
+
+    # Initial sync via view_update — must upload (build the BVH).
+    ctx_a = _make_context(IDENTITY)
+    depsgraph_a = types.SimpleNamespace(scene=ctx_a.scene)
+    engine.view_update(ctx_a, depsgraph_a)
+    r = engine._viewport_renderer
+    assert r.skip_upload_flags == [False], (
+        "the initial view_update sync must render with skip_upload=False "
+        "so the geometry/BVH is uploaded")
+
+    # User orbits/pans — view_matrix changes. This camera-only frame must
+    # render from device state with skip_upload=True.
+    ctx_b = _make_context(SHIFTED)
+    depsgraph_b = types.SimpleNamespace(scene=ctx_b.scene)
+    try:
+        engine.view_draw(ctx_b, depsgraph_b)
+    except Exception:
+        pass
+    assert r.skip_upload_flags[-1] is True, (
+        "a camera-only view_draw frame must render with skip_upload=True "
+        "(no per-frame geometry re-upload on orbit/pan/zoom)")
+
+
 def test_view_draw_re_renders_on_camera_view_zoom_change(monkeypatch):
     """The user reported 'zooming in or out doesnt change how the image is
     rendered' — the view_draw camera-zoom hash must catch this."""


### PR DESCRIPTION
## Summary

Diagnosis-first per the spec. Profiled the orbit hot path with the existing
`benchmarks/viewport_parity` harness (pkg56-A `viewport_perf` ring buffer, GPU
backend, no new profiler), localized the dominant cost, and applied the single
cheapest high-leverage fix the spec predicted (**Suspect A**).

## Profile (GPU RTX 5070 Ti, sm_120, 100k-tri scene, path_tracer, 1 spp, min-of-N)

Per-orbit-frame `render()` cost decomposes cleanly (the CPU BVH rebuild +
`buildSceneArrays`/upload are resolution-independent; the kernel scales with
pixels, so full-res minus tiny-res isolates it):

| component | cost | how measured |
|---|---|---|
| CPU BVH rebuild (`renderer.buildAcceleration`) | **~48 ms** | `render(skip_upload=False)` − `render(skip_upload=True)`, both res |
| `buildSceneArrays` + H2D upload | ~27 ms | tiny-res (64×64) `render(skip_upload=True)` |
| kernel (path tracing) | ~25 ms | full-res − tiny-res |
| **full-res `render()` total** | **~100–140 ms** → ~5 fps | harness `camera_only` |

- The addon dispatcher fires **0** uploads on camera-only frames
  (`h1_upload_geometry_calls_per_frame_max = 0`) — the re-upload/rebuild is
  entirely *inside* `render()`, invisible to the addon's upload counters. This
  is why the cost was mis-attributed.
- **Key finding vs the spec's mental model:** the ~48 ms BVH rebuild is the
  dominant, resolution-independent cost, and it *is* removed by the spec's
  proposed `skip_upload=True` (the binding gates `buildAcceleration` on
  `!skipUpload`, `blender_module.cpp:1726`). The wavefront's `buildSceneArrays`
  + `wfUpload` (~27 ms) run unconditionally regardless of the flag
  (`gpu_wavefront_snapshot.cu:1328`, "unconditional-upload policy… depsgraph-
  selective upload remains the shared follow-up") — that residual floor is
  **not** addressed here (see Deferred).

## Fix

Route camera-only `view_draw` frames (orbit/pan/zoom) through
`render(skip_upload=True)`. `view_draw` never re-syncs scene state, so on a
camera move geometry/BVH/materials/lights/env are provably identical to the
last sync; the camera is published separately by `setup_viewport_camera`.
Guarded so the fresh-sync fallback (and any pre-sync frame) still uploads to
build the BVH. Progressive still-frame refine frames (pkg191's loop, camera
unchanged) are deliberately left on the upload path — scoped to camera-motion.

Also wired the existing pkg56-A perf ring buffer into `view_draw` (it recorded
only `view_update` before, so the interactive orbit path was unprofiled), and
added a `--camera-skip-upload` before/after switch to the harness.

## Measured result (GPU, 100k tris, 1280×720, 40 frames, min-of-N steady state)

| | render mean | frame mean | fps (frame mean) |
|---|---|---|---|
| **before** (skip_upload=False) | 103.98 ms | 167.54 ms | **5.97** |
| **after** (skip_upload=True) | 54.68 ms | 118.45 ms | **8.44** |

render **−47% (~1.9×)**, frame fps **+41%**. Delta ≫ the ~5% RTX boost-clock
drift confound ([[gpu-perf-ab-clock-drift]]; min-of-N + warmup). Full Cycles
parity was explicitly not the target.

**Correctness:** at a fixed camera, `skip=False` and `skip=True` give identical
means (0.5979 = 0.5979; diff is pure 16-spp noise); moving the camera with
`skip=True` changes the image (|Δ|=0.153 ≫ noise); no black/stale frames.

## Build evidence (shipped change is pure-Python; GPU build was for profiling)

Fresh sm_120 build in the worktree (`build_cuda_worktree.bat`), last 5 log lines:
```
[pkg183] verifying built CUDA arch (cuobjdump ground truth)...
[pkg183] arch-verify OK: astroray.cp313-win_amd64.pyd embeds sm_120 (embedded=[sm_120])
[pkg183] running host-only ABI canary (no GPU)...
[pkg183] canary caps: {'cpu': True, 'spectral': True, 'gpu': True, ...}
Build succeeded
```
`.pyd` mtime 2026-08-13 20:52:35; `cuobjdump --list-elf` → `sm_120`.

## Tests

`pytest tests/test_blender_viewport_session.py tests/test_viewport_parity_harness.py
tests/test_viewport_perf_stats.py tests/test_blender_viewport_passes.py
tests/test_pkg116_exporter_caches.py tests/test_pkg114_exporter_transform_dispatch.py
tests/test_blender_progressive_accumulation.py tests/test_blender_backend_policy.py`
→ **75 passed** (+ new `test_view_draw_camera_only_frame_skips_geometry_upload`
guard: initial sync renders `skip_upload=False`, camera-only frame renders
`skip_upload=True`). No pre-existing behavioral assertion was flipped.

## Acceptance criteria

- [x] Reproduced + profiled on a freshly built current-`main` addon BEFORE the fix; dated-addon caveat discharged (rebuilt sm_120 at HEAD 5d4ac27).
- [x] Recorded per-frame profile via the existing `viewport_perf` plumbing, GPU backend, before/after.
- [x] Measured, meaningful fps improvement (5.97 → 8.44 fps, +41%; render ~1.9×), min-of-N, clock-drift caveat noted.
- [x] Camera-only frames provably avoid the per-frame geometry re-upload/BVH rebuild — instrumented (guard test asserts `skip_upload=True`; profile shows the ~48 ms is gone).
- [x] No correctness regression: fixed-camera image identical; the fix touches no reduced-res path so the settled full-res image is unchanged.

## Authorized surface

Spec targets `view_draw`'s `skip_upload` (Suspect A) + the existing profiler
plumbing. Changed:
- `blender_addon/exporter.py` — `view_draw` `skip_upload` guard + orbit-frame perf recording (in scope: Suspect A + profiler)
- `blender_addon/__init__.py` — thread `_viewport_perf_frame_complete` into the `view_draw` call so orbit frames are recorded (in scope: enables the profile deliverable)
- `benchmarks/viewport_parity/run.py` — `--camera-skip-upload` before/after switch (in scope: reuses the canonical harness, no new script per §5b)
- `tests/test_blender_viewport_session.py` — guard test (acceptance evidence)

No `.cu/.cpp/.h/CMakeLists` changed. Nothing outside the spec's Specification.

## Deferred (Suspect B — reduced-resolution navigation)

The profile justifies it as additive: the ~25 ms kernel + ~63 ms/frame pixel
readback/accumulation floor at full res is resolution-scaling and untouched by
this fix (projection: A+B → ~20 fps). It is a non-trivial addon state machine
(nav-resolution + settle redraw) that must not disturb pkg191's still-frame
accumulation, so it is **not** folded in here (spec: "reduced-res nav path, if
added"). Recommend a follow-up package. The residual ~27 ms wavefront
`buildSceneArrays`/upload floor (the repo's known "depsgraph-selective upload"
follow-up) is likewise deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
