### PR TITLE
feat(pkg196): reduced-resolution viewport navigation — 8.36→18.52 fps (2.2x)

### DIFF
--- a/.astroray_plan/packages/pkg196-viewport-reduced-res-navigation.md
+++ b/.astroray_plan/packages/pkg196-viewport-reduced-res-navigation.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 5 / integration-first
 **Track:** A
-**Status:** open (filed 2026-08-13 from the pkg192 profile — PR #605)
+**Status:** done (PR #609, 2026-08-13 — divisor N=2; orbit fps 8.36→18.52 p50 / 8.54→18.99 min, 2.2x; 100k tris 1280×720 1spp GPU, same harness as pkg192)
 **Estimated effort:** M
 **Depends on:** pkg192 (PR #605 — camera-only `skip_upload=True`; its profile is the
 evidence base), pkg191 (progressive still-frame loop — MUST NOT be disturbed).

--- a/benchmarks/viewport_parity/run.py
+++ b/benchmarks/viewport_parity/run.py
@@ -314,7 +314,8 @@ def _drive_pan_zoom_orbit(eng, renderer_proxy: CountingRenderer,
                           chunk_spp: int, max_depth: int,
                           use_oidn_pass: bool,
                           path: str = "camera_only",
-                          camera_skip_upload: bool = False):
+                          camera_skip_upload: bool = False,
+                          nav_res_divisor: int = 1):
     """Drive the camera path. Returns dict of measurements for one config.
 
     ``path`` chooses which Blender scenario to emulate:
@@ -360,10 +361,20 @@ def _drive_pan_zoom_orbit(eng, renderer_proxy: CountingRenderer,
         else:
             dispatch_ms.append(0.0)
 
+        # pkg196: reduced-resolution navigation. On a camera_only (moving) frame
+        # the addon renders at region/N and upscales for display (Cycles
+        # start_resolution; blender_addon/exporter.py view_draw). We model the
+        # render-side cost by shrinking the camera + render dims by nav_res_divisor
+        # on camera_only frames. nav_res_divisor==1 reproduces the pkg192 baseline.
+        rw, rh = width, height
+        if path == "camera_only" and nav_res_divisor > 1:
+            rw = max(1, width // nav_res_divisor)
+            rh = max(1, height // nav_res_divisor)
+
         # 2) camera setup — matches _setup_viewport_camera's renderer call.
         real.setup_camera(
             look_from, look_at, [0, 1, 0],
-            float(vfov), width / max(1, height), 0.0, 10.0, width, height,
+            float(vfov), rw / max(1, rh), 0.0, 10.0, rw, rh,
         )
 
         # 3) optional OIDN pass registration (H3 toggle).
@@ -503,6 +514,7 @@ def run(args) -> dict:
                         use_oidn_pass=use_oidn,
                         path=path,
                         camera_skip_upload=args.camera_skip_upload,
+                        nav_res_divisor=args.nav_res_divisor,
                     )
                     result["config"] = {
                         "tris_target": tris,
@@ -517,6 +529,7 @@ def run(args) -> dict:
                         "n_frames": args.frames,
                         "path": path,
                         "camera_skip_upload": args.camera_skip_upload,
+                        "nav_res_divisor": args.nav_res_divisor,
                     }
                     out["configs"].append(result)
 
@@ -575,6 +588,13 @@ def main(argv=None) -> int:
                    help="pkg192: render camera_only frames with skip_upload=True "
                         "(the shipped addon behavior — skips the per-frame CPU BVH "
                         "rebuild on pure camera moves). Off = pre-pkg192 baseline.")
+    p.add_argument("--nav-res-divisor", dest="nav_res_divisor", type=int,
+                   default=1,
+                   help="pkg196: render camera_only (moving) frames at region/N "
+                        "resolution and upscale on display (the reduced-resolution "
+                        "navigation mode). 1 = full res (pkg192 baseline); 2 or 4 = "
+                        "the shipped nav divisor. Camera settles snap back to full "
+                        "res (not modeled here — this measures the moving-frame arm).")
     p.add_argument("--no-h3", action="store_true",
                    help="Skip the OIDN A/B (H3).")
     p.add_argument("--with-transform-edit", action="store_true",

--- a/blender_addon/exporter.py
+++ b/blender_addon/exporter.py
@@ -26,6 +26,24 @@ import numpy as np
 from enum import IntFlag
 
 
+# pkg196: reduced-resolution viewport navigation.
+# Cycles reference: intern/cycles/blender/session.cpp
+# BlenderSession::reset + `start_resolution` (Apache-2.0). Cycles renders
+# navigation frames at a reduced `start_resolution` and progressively resolves
+# to full resolution once the view settles. We mirror that: while the camera is
+# actively moving, render at region.width/N x region.height/N and upscale on
+# display (draw_texture_2d bilinear), then snap back to full res on settle and
+# hand off to the pkg191 progressive still-frame loop. Accumulation is reset on
+# every resolution switch so mixed-resolution buffers are never blended.
+VIEWPORT_NAV_RES_DIVISOR = 2   # render W/2 x H/2 while the camera is moving.
+VIEWPORT_NAV_SETTLE_S = 0.25   # snap back to full res after this quiet window.
+
+
+def _nav_clock():
+    """Monotonic clock for the nav-settle debounce (patchable in tests)."""
+    return time.perf_counter()
+
+
 class Change(IntFlag):
     """Bitflags for scene-change classification. ORed together to represent
     a set of domains that need re-upload."""
@@ -282,6 +300,12 @@ class Exporter:
         self._viewport_skip_upload_next = False  # pkg114 inc 3d: next render is a
         # TLAS-only refit → render(skip_upload=True); set by apply_depsgraph_updates,
         # consumed by view_update.
+        # pkg196: reduced-resolution navigation state. _viewport_render_divisor is
+        # the resolution divisor of the LAST rendered frame (1 = full res);
+        # _viewport_nav_last_change_time is the _nav_clock() timestamp of the most
+        # recent camera move, used for the settle debounce in view_draw.
+        self._viewport_render_divisor = 1
+        self._viewport_nav_last_change_time = 0.0
 
         # Per-domain caches
         self._camera_cache = CameraCache(bpy_module)
@@ -502,20 +526,29 @@ class Exporter:
         self._viewport_full_synced = True
 
     def render_viewport_frame(self, renderer, context, settings, region,
-                             reset_accumulation, engine_methods, skip_upload=False):
+                             reset_accumulation, engine_methods, skip_upload=False,
+                             res_divisor=1):
         """Set up camera, run render, update cached GPU texture.
 
         skip_upload (pkg114 inc 3d): render from the CURRENT device state without a
         full geometry re-upload — used after a TLAS-only instance-transform refit
         (update_instance_transform + upload_instance_transforms), so a transform-only
-        edit of instanced objects pays only the cheap instance/TLAS re-push."""
-        width = max(1, region.width)
-        height = max(1, region.height)
+        edit of instanced objects pays only the cheap instance/TLAS re-push.
+
+        res_divisor (pkg196): render at region.width/N x region.height/N while the
+        camera is moving (N>1), upscaled on display. A change of divisor is a
+        resolution switch and resets accumulation so reduced- and full-resolution
+        buffers are never blended (Cycles start_resolution semantics)."""
+        res_divisor = max(1, int(res_divisor))
+        width = max(1, region.width // res_divisor)
+        height = max(1, region.height // res_divisor)
         render_key = engine_methods['viewport_render_key'](context, settings, region)
 
-        if reset_accumulation or render_key != self._viewport_accum_key:
+        if (reset_accumulation or render_key != self._viewport_accum_key
+                or res_divisor != self._viewport_render_divisor):
             self._reset_viewport_accumulation()
             self._viewport_accum_key = render_key
+        self._viewport_render_divisor = res_divisor
 
         self._viewport_target_spp = engine_methods['viewport_target_samples'](settings)
         if self._viewport_current_spp >= self._viewport_target_spp:
@@ -713,7 +746,27 @@ class Exporter:
                 and new_substantive_hash != self._viewport_camera_substantive_hash
             )
 
-            if camera_changed or needs_progress or settings_changed or self._viewport_texture is None:
+            # pkg196: reduced-resolution navigation decision. While the camera is
+            # actively moving (changed this frame) OR still inside the settle
+            # window after the last move, render at a reduced divisor and upscale;
+            # once the view has been quiet for VIEWPORT_NAV_SETTLE_S, snap back to
+            # full res (divisor 1) and hand off to the pkg191 progressive loop.
+            # Cycles start_resolution analogue (session.cpp BlenderSession::reset).
+            now = _nav_clock()
+            if camera_changed:
+                self._viewport_nav_last_change_time = now
+            within_settle = (
+                (now - self._viewport_nav_last_change_time) < VIEWPORT_NAV_SETTLE_S)
+            navigating = self._viewport_full_synced and (
+                camera_changed
+                or (within_settle and self._viewport_render_divisor > 1))
+            desired_divisor = VIEWPORT_NAV_RES_DIVISOR if navigating else 1
+            resolution_switch = (desired_divisor != self._viewport_render_divisor)
+
+            render_needed = (camera_changed or needs_progress or settings_changed
+                             or self._viewport_texture is None or resolution_switch)
+
+            if render_needed:
                 renderer = self._get_viewport_renderer()
                 # If user opened rendered-shading without ever firing view_update,
                 # renderer has no scene. Fall back to full sync.
@@ -751,12 +804,19 @@ class Exporter:
                     and camera_changed
                 )
 
+                # pkg196: the fresh-sync fallback frame builds the BVH and seeds
+                # the still-frame loop — it (and any pre-sync frame) always renders
+                # full res. Only a fully-synced camera-motion frame reduces res.
+                frame_divisor = desired_divisor if not did_fresh_sync else 1
+
                 t0 = time.perf_counter()
                 self.render_viewport_frame(
                     renderer, context, settings, region,
-                    reset_accumulation=(camera_substantive_changed or settings_changed),
+                    reset_accumulation=(camera_substantive_changed or settings_changed
+                                        or resolution_switch),
                     engine_methods=engine_methods,
                     skip_upload=camera_only_frame,
+                    res_divisor=frame_divisor,
                 )
                 # pkg192: record orbit/pan/zoom frames through the existing
                 # pkg56-A ring buffer. view_draw previously left camera-motion
@@ -769,8 +829,13 @@ class Exporter:
                 self._viewport_camera_hash = new_hash
                 self._viewport_camera_substantive_hash = new_substantive_hash
 
-                if self._viewport_current_spp < self._viewport_target_spp:
-                    request_viewport_redraw_fn()
+            # pkg196: keep pumping redraws while the view is settling at reduced
+            # res (so it always resolves to full res even if the reduced chunk hit
+            # the sample target), or while the pkg191 progressive loop is refining
+            # at full res. Without the settle pump the view could stick at low res.
+            settling = within_settle and self._viewport_render_divisor > 1
+            if settling or self._viewport_current_spp < self._viewport_target_spp:
+                request_viewport_redraw_fn()
 
             if self._viewport_texture is None:
                 return

--- a/tests/test_pkg196_nav_resolution.py
+++ b/tests/test_pkg196_nav_resolution.py
@@ -1,0 +1,327 @@
+"""pkg196 — reduced-resolution viewport navigation state machine.
+
+While the camera is actively moving, view_draw renders at region/N resolution
+(upscaled on display); once the view has been quiet for VIEWPORT_NAV_SETTLE_S it
+snaps back to full resolution and hands off to the pkg191 progressive loop.
+Accumulation resets on every resolution switch (never blend mixed-res buffers).
+
+Cycles reference: intern/cycles/blender/session.cpp BlenderSession::reset +
+start_resolution (Apache-2.0).
+
+These drive the REAL addon engine through a mock RenderEngine (recording
+renderer, stubbed bpy) with an injectable nav clock, so the settle debounce is
+exercised deterministically without wall-clock sleeps.
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# Loader + stubs (same shape as test_blender_viewport_session.py)
+# ---------------------------------------------------------------------------
+
+def _load_blender_addon(monkeypatch, renderer_cls):
+    bpy_module = types.ModuleType("bpy")
+    bpy_types_module = types.ModuleType("bpy.types")
+    bpy_props_module = types.ModuleType("bpy.props")
+
+    class _Base:
+        pass
+
+    class _RenderEngineBase:
+        def __init__(self):
+            self.tag_redraw_calls = 0
+        def report(self, *_a, **_k): return None
+        def update_progress(self, *_a, **_k): return None
+        def update_stats(self, *_a, **_k): return None
+        def test_break(self): return False
+        def bind_display_space_shader(self, *_a, **_k): return None
+        def unbind_display_space_shader(self, *_a, **_k): return None
+        def tag_redraw(self): self.tag_redraw_calls += 1
+
+    bpy_types_module.Panel = _Base
+    bpy_types_module.Operator = _Base
+    bpy_types_module.AddonPreferences = _Base
+    bpy_types_module.PropertyGroup = _Base
+    bpy_types_module.RenderEngine = _RenderEngineBase
+    bpy_module.types = bpy_types_module
+
+    for name in ("BoolProperty", "IntProperty", "FloatProperty", "StringProperty",
+                 "PointerProperty", "FloatVectorProperty", "EnumProperty"):
+        setattr(bpy_props_module, name, lambda **_kwargs: None)
+    bpy_module.props = bpy_props_module
+    bpy_module.path = types.SimpleNamespace(abspath=lambda p: p)
+
+    shader_blending_module = types.ModuleType("shader_blending")
+    shader_blending_module.blend_shader_specs = {}
+    shader_blending_module.add_shader_specs = {}
+
+    mathutils_module = types.ModuleType("mathutils")
+    mathutils_module.Vector = lambda values: values
+
+    astroray_module = types.ModuleType("astroray")
+    astroray_module.__version__ = "test"
+    astroray_module.__features__ = {"cuda": False, "spectral": True}
+    astroray_module.__file__ = "/fake/astroray.pyd"
+    astroray_module.Renderer = renderer_cls
+    astroray_module.integrator_registry_names = lambda: ["path_tracer"]
+    astroray_module.material_registry_names = lambda: ["lambertian"]
+    astroray_module.pass_registry_names = lambda: []
+
+    monkeypatch.setitem(sys.modules, "bpy", bpy_module)
+    monkeypatch.setitem(sys.modules, "bpy.types", bpy_types_module)
+    monkeypatch.setitem(sys.modules, "bpy.props", bpy_props_module)
+    monkeypatch.setitem(sys.modules, "shader_blending", shader_blending_module)
+    monkeypatch.setitem(sys.modules, "mathutils", mathutils_module)
+    monkeypatch.setitem(sys.modules, "astroray", astroray_module)
+
+    module_path = Path(__file__).parent.parent / "blender_addon" / "__init__.py"
+    spec = importlib.util.spec_from_file_location("astroray_blender_addon_pkg196", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Matrix4:
+    def __init__(self, rows):
+        self.rows = [list(r) for r in rows]
+
+    def __getitem__(self, i):
+        return self.rows[i]
+
+    def inverted(self):
+        return _Matrix4([[1.0 if i == j else 0.0 for j in range(4)] for i in range(4)])
+
+
+IDENTITY = _Matrix4([[1.0, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])
+SHIFTED = _Matrix4([[1.0, 0, 0, 1.0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])
+SHIFTED2 = _Matrix4([[1.0, 0, 0, 2.0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])
+
+
+def _make_settings():
+    return types.SimpleNamespace(
+        use_adaptive_sampling=False,
+        clamp_direct=0.0, clamp_indirect=0.0, filter_glossy=0.0,
+        use_reflective_caustics=True, use_refractive_caustics=True,
+        light_sampler='power', device_mode='cpu',
+        preview_samples=1, max_bounces=4,
+        diffuse_bounces=2, glossy_bounces=2, transmission_bounces=2,
+        volume_bounces=0, transparent_bounces=2,
+        wavelength_preset='visible', wavelength_min=380.0, wavelength_max=780.0,
+        colourmap='grayscale', integrator_type='path_tracer',
+        viewport_display_pass='combined', viewport_oidn=False,
+    )
+
+
+def _make_context(view_matrix, region_w=320, region_h=240):
+    rv3d = types.SimpleNamespace(
+        view_matrix=view_matrix, view_perspective='PERSP',
+        view_camera_zoom=0.0, view_camera_offset=(0.0, 0.0))
+    region = types.SimpleNamespace(width=region_w, height=region_h)
+    space = types.SimpleNamespace(lens=50.0)
+    scene = types.SimpleNamespace(camera=None, custom_raytracer=_make_settings())
+    return types.SimpleNamespace(region=region, region_data=rv3d,
+                                 space_data=space, scene=scene)
+
+
+class _RecordingRenderer:
+    def __init__(self):
+        self.render_calls = 0
+
+    def set_adaptive_sampling(self, *_): pass
+    def set_clamp_direct(self, *_): pass
+    def set_clamp_indirect(self, *_): pass
+    def set_filter_glossy(self, *_): pass
+    def set_use_reflective_caustics(self, *_): pass
+    def set_use_refractive_caustics(self, *_): pass
+    def set_light_sampler(self, *_): pass
+    def set_wavelength_range(self, *_): pass
+    def set_output_mode(self, *_): pass
+    def set_integrator(self, *_): pass
+    def set_use_gpu(self, *_): pass
+    def clear(self): pass
+    def clear_passes(self): pass
+    def add_pass(self, *_): pass
+    @property
+    def gpu_available(self): return False
+    def setup_camera(self, *args, **_kw): pass
+
+    def render(self, *_a, **_k):
+        self.render_calls += 1
+        return np.full((2, 2, 3), float(self.render_calls), dtype=np.float32)
+
+
+def _wire(monkeypatch, renderer_cls=_RecordingRenderer):
+    """Load addon, build engine, stub scene sync + camera + display path.
+    Returns (addon, engine, clock, dims) where clock is a mutable [t] list
+    driving the nav-settle debounce and dims records rendered (w, h)."""
+    addon = _load_blender_addon(monkeypatch, renderer_cls)
+    engine = addon.CustomRaytracerRenderEngine()
+
+    monkeypatch.setattr(engine, 'convert_materials', lambda dg, r: {})
+    monkeypatch.setattr(engine, 'convert_objects', lambda dg, r, mm: None)
+    monkeypatch.setattr(engine, 'convert_lights', lambda dg, r: None)
+    monkeypatch.setattr(engine, 'setup_world', lambda scene, r: None)
+    monkeypatch.setattr(engine, 'bind_display_space_shader', lambda s: None)
+    monkeypatch.setattr(engine, 'unbind_display_space_shader', lambda: None)
+
+    dims = []
+
+    def _rec_camera(renderer, ctx, w, h):
+        dims.append((w, h))
+        renderer.setup_camera()
+    monkeypatch.setattr(engine, '_setup_viewport_camera', _rec_camera)
+    monkeypatch.setattr(engine, '_update_viewport_texture',
+                        lambda pixels, w, h: setattr(engine, '_viewport_texture', object()))
+
+    clock = [1000.0]
+    monkeypatch.setattr(addon.exporter_module, '_nav_clock', lambda: clock[0])
+    return addon, engine, clock, dims
+
+
+def _draw(engine, ctx):
+    depsgraph = types.SimpleNamespace(scene=ctx.scene)
+    try:
+        engine.view_draw(ctx, depsgraph)
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_moving_camera_renders_reduced_resolution(monkeypatch):
+    """A camera-motion view_draw frame renders at region/N resolution."""
+    addon, engine, clock, dims = _wire(monkeypatch)
+    exporter = engine._get_exporter()
+
+    ctx = _make_context(IDENTITY)
+    engine.view_update(ctx, types.SimpleNamespace(scene=ctx.scene))
+    assert dims[-1] == (320, 240), "initial full sync must render full res"
+    assert exporter._viewport_render_divisor == 1
+
+    clock[0] += 0.01
+    _draw(engine, _make_context(SHIFTED))
+    n = addon.exporter_module.VIEWPORT_NAV_RES_DIVISOR
+    assert dims[-1] == (320 // n, 240 // n), "camera move must render reduced res"
+    assert exporter._viewport_render_divisor == n
+
+
+def test_settle_snaps_back_to_full_resolution(monkeypatch):
+    """After the settle window elapses with no camera change, view_draw snaps
+    back to full resolution and resets accumulation (no mixed-res blend)."""
+    addon, engine, clock, dims = _wire(monkeypatch)
+    exporter = engine._get_exporter()
+    settle = addon.exporter_module.VIEWPORT_NAV_SETTLE_S
+
+    ctx = _make_context(IDENTITY)
+    engine.view_update(ctx, types.SimpleNamespace(scene=ctx.scene))
+
+    # Move -> reduced res.
+    clock[0] += 0.01
+    _draw(engine, _make_context(SHIFTED))
+    assert exporter._viewport_render_divisor > 1
+    renders_after_move = engine._viewport_renderer.render_calls
+
+    # Still within settle, camera stable -> NO re-render, stays reduced.
+    clock[0] += settle / 2.0
+    _draw(engine, _make_context(SHIFTED))
+    assert engine._viewport_renderer.render_calls == renders_after_move, (
+        "within the settle window a stable camera must not re-render")
+    assert exporter._viewport_render_divisor > 1
+
+    # Past the settle window -> snap to full res, reset accumulation.
+    clock[0] += settle * 2.0
+    _draw(engine, _make_context(SHIFTED))
+    assert dims[-1] == (320, 240), "settle must snap back to full resolution"
+    assert exporter._viewport_render_divisor == 1
+    assert exporter._viewport_current_spp == 1, (
+        "resolution switch must reset accumulation to a fresh full-res chunk")
+
+
+def test_no_stuck_low_res_after_settle(monkeypatch):
+    """Once settled at full res, further stable frames stay full res and the
+    still-frame path (pkg191) is not forced back to reduced res."""
+    addon, engine, clock, _dims = _wire(monkeypatch)
+    exporter = engine._get_exporter()
+    settle = addon.exporter_module.VIEWPORT_NAV_SETTLE_S
+
+    ctx = _make_context(IDENTITY)
+    engine.view_update(ctx, types.SimpleNamespace(scene=ctx.scene))
+
+    clock[0] += 0.01
+    _draw(engine, _make_context(SHIFTED))          # reduced
+    clock[0] += settle * 2.0
+    _draw(engine, _make_context(SHIFTED))          # snap full
+    assert exporter._viewport_render_divisor == 1
+
+    # Several more quiet frames well past the window: must stay full res.
+    for _ in range(3):
+        clock[0] += settle * 2.0
+        _draw(engine, _make_context(SHIFTED))
+        assert exporter._viewport_render_divisor == 1, "stuck / re-reduced after settle"
+
+
+def test_continuous_motion_stays_reduced(monkeypatch):
+    """Every frame of a continuous orbit (new camera each frame) renders reduced."""
+    addon, engine, clock, dims = _wire(monkeypatch)
+    n = addon.exporter_module.VIEWPORT_NAV_RES_DIVISOR
+
+    ctx = _make_context(IDENTITY)
+    engine.view_update(ctx, types.SimpleNamespace(scene=ctx.scene))
+
+    for mat in (SHIFTED, SHIFTED2, IDENTITY, SHIFTED):
+        clock[0] += 0.016
+        _draw(engine, _make_context(mat))
+        assert dims[-1] == (320 // n, 240 // n)
+
+
+def test_reduced_frame_still_skips_geometry_upload(monkeypatch):
+    """The reduced-res nav frame must keep the pkg192 skip_upload=True fast path
+    (no per-frame BVH rebuild) — reduced res layers on top, not instead."""
+    class _SkipSpy(_RecordingRenderer):
+        def __init__(self):
+            super().__init__()
+            self.skip_flags = []
+        def render(self, *_a, **_k):
+            self.skip_flags.append(bool(_a[9]) if len(_a) > 9 else False)
+            return super().render(*_a, **_k)
+
+    _addon, engine, clock, _dims = _wire(monkeypatch, renderer_cls=_SkipSpy)
+    ctx = _make_context(IDENTITY)
+    engine.view_update(ctx, types.SimpleNamespace(scene=ctx.scene))
+    r = engine._viewport_renderer
+    assert r.skip_flags == [False], "initial sync must upload (build BVH)"
+
+    clock[0] += 0.01
+    _draw(engine, _make_context(SHIFTED))
+    assert r.skip_flags[-1] is True, "reduced nav frame must skip_upload=True"
+
+
+def test_settled_full_res_render_path_is_unchanged(monkeypatch):
+    """Byte-equivalence guard: at a settled camera the render dimensions equal
+    the region dimensions exactly (divisor 1) — the full-res convergence path is
+    identical to pre-pkg196, so the settled image is unchanged."""
+    addon, engine, clock, dims = _wire(monkeypatch)
+    exporter = engine._get_exporter()
+    settle = addon.exporter_module.VIEWPORT_NAV_SETTLE_S
+
+    ctx = _make_context(IDENTITY)
+    engine.view_update(ctx, types.SimpleNamespace(scene=ctx.scene))
+    # A still camera from the very first frame (no motion) renders full res.
+    assert dims[-1] == (320, 240)
+    assert exporter._viewport_render_divisor == 1
+
+    # Orbit then settle; the settled frame's dims must be exactly the region.
+    clock[0] += 0.01
+    _draw(engine, _make_context(SHIFTED))
+    clock[0] += settle * 2.0
+    _draw(engine, _make_context(SHIFTED))
+    assert dims[-1] == (ctx.region.width, ctx.region.height)


### PR DESCRIPTION
## pkg196 — Reduced-resolution viewport navigation

Layers a Cycles-style reduced-resolution navigation mode onto the pkg192
camera-only viewport path. While the camera is actively moving, `view_draw`
renders at `region/N × region/N` and upscales for display (bilinear via
`draw_texture_2d`); once the view has been quiet for a settle window, it snaps
back to full resolution and hands off to the pkg191 progressive still-frame
loop. Accumulation is reset on every resolution switch so reduced- and full-res
buffers are never blended.

**Divisor: N=2** (chosen by measurement — see below). Half-resolution matches
Cycles' navigation default and keeps the moving preview legible (2× upscale is
minimally noticeable), whereas N=4 buys ~10 more fps at a visibly blocky 4×
upscale during motion.

### Algorithm citation (CLAUDE.md §6)
Cycles `intern/cycles/blender/session.cpp` `BlenderSession::reset` +
`start_resolution` (Apache-2.0) — cited in `exporter.py`.

### Measured orbit fps (min-of-N, burn-in; RTX 5070 Ti, `benchmarks/viewport_parity`)
Scene identical to the pkg192 profile: **100k tris, 1280×720, 1 spp, GPU,
`--camera-skip-upload`**. Two runs × 59 steady frames each (frame 0 dropped as
warm-up); camera-setup + render boundary (same measurement as pkg192's 8.44 fps).

| nav divisor | min frame ms | p50 frame ms | fps (min) | fps (p50) | speedup (p50) |
|-------------|-------------|-------------|-----------|-----------|---------------|
| 1 (baseline)| 117.07      | 119.58      | 8.54      | 8.36      | 1.00×         |
| **2 (ship)**| 52.65       | 54.01       | **18.99** | **18.52** | **2.22×**     |
| 4           | 32.64       | 36.17       | 30.63     | 27.65     | 3.31×         |

Baseline reproduces pkg192's ~8.44 fps (8.36 p50 / 8.54 min). Divisor 2 hits the
spec's ~20 fps projection (18.5 p50 / 19.0 min fps).

### Acceptance criteria
- [x] Measured orbit fps before/after on the pkg192 harness/scene (min-of-N,
      burn-in): **8.36 → 18.52 fps p50 (2.2×)**, meaningful gain over 8.44 baseline.
- [x] Settled image byte-equivalent to pre-change: at a settled camera the
      render path is `res_divisor=1` — dimensions equal the region exactly and
      the render call is identical to pre-pkg196 (guarded by
      `test_settled_full_res_render_path_is_unchanged`). No stuck low-res frames
      after settle (`test_no_stuck_low_res_after_settle`, settle-window redraw pump).
- [x] pkg191 still-frame progressive loop untouched: the divisor=1 path is
      byte-identical; progressive accumulation verified by the pre-existing
      `test_view_draw_progresses_until_preview_sample_target` (passing).
- [x] Nav-resolution state machine covered by an addon test (mock RenderEngine,
      injectable settle clock): `tests/test_pkg196_nav_resolution.py` (6 tests).

### Hard non-goals (respected)
No TAA/reprojection/motion vectors. No engine/kernel changes. The ~27 ms
unconditional upload floor is untouched. No F12 changes.

### Authorized surface
Spec Specification touches: addon viewport (`blender_addon/exporter.py`
view_draw + `render_viewport_frame`) and the pkg192 harness
(`benchmarks/viewport_parity/run.py`), plus a new addon test. Files actually
changed:
- `blender_addon/exporter.py` — nav-resolution state machine + `res_divisor`.
- `benchmarks/viewport_parity/run.py` — `--nav-res-divisor` arm (extends, not forks).
- `tests/test_pkg196_nav_resolution.py` — new state-machine test (mock RenderEngine).

No files outside the spec's Specification/Non-goals. **No `.cu/.cpp/.h/CMakeLists`
changed** — this is addon-Python only; the engine `.pyd` used for the fps
measurement was rebuilt at HEAD (`b577bb8`, sm_120 verified, ABI canary green)
solely to run the GPU harness, not because this PR changes engine code.

### Tests
`tests/test_pkg196_nav_resolution.py` (6) + adjacent viewport suites
(`test_blender_viewport_session.py`, `test_pkg114_exporter_transform_dispatch.py`,
`test_pkg116_exporter_caches.py`, `test_blender_viewport_passes.py`,
`test_addon_viewport_camera_vfov.py`, `test_addon_dof_aperture.py`) — all pass,
no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
