### PR TITLE
feat(pkg195): Stage C — drawn-spectrum + runtime profiles + preset node

### DIFF
--- a/.astroray_plan/packages/pkg195-spectral-nodes-phase1.md
+++ b/.astroray_plan/packages/pkg195-spectral-nodes-phase1.md
@@ -6,9 +6,11 @@
 0.0709 > 0.05, snow/water NIR ratio 4.82, MW↔path_tracer visible parity 1.00;
 sodium lamp linear RGB (0.673, 0.127, 0.000) amber, cie_f2 differs 100% on blue;
 headless Blender 5.1 render confirms amber sodium vs neutral cie_f2). Stage C
-(register_spectral_profile + Drawn/Preset/Blackbody spectrum nodes + in-band
-Replace mode + IR/UV de-fang + Sellmeier B/C) remains OPEN — independently
-landable. Filed 2026-08-12 from the owner-directed spectral-node design session;
+done (PR TBD, 2026-08-14 — register_spectral_profile + Drawn/Preset/Blackbody
+spectrum nodes + in-band Replace mode + IR/UV de-fang + Sellmeier B/C; Gate C all
+green, headless Blender drawn 550 nm bump G=0.4396>R=0.2642>B=0.0003, manual BK7
+B/C == bk7 preset 0.00%, 16/16 A/B+parity gates unchanged). All three stages
+landed. Filed 2026-08-12 from the owner-directed spectral-node design session;
 design doc: `.astroray_plan/docs/spectral-node-system-design-2026-08.md`.
 **Estimated effort:** L (three gated stages; each independently landable)
 **Depends on:** nothing in flight. Touches `multiwavelength_path_tracer.cpp`
@@ -134,14 +136,39 @@ over a white sphere, visible band, CPU → hue must land amber
 ratios by > 10%. Test lives with the pkg119b-style harness
 (`ASTRORAY_PYD_DIR` + absolute out-dir conventions).
 
-## Stage C — spectrum sources + honest material nodes — OPEN (descoped from the A+B PR)
+## Stage C — spectrum sources + honest material nodes — DONE (PR TBD, 2026-08-14)
 
-> Not started. Independently landable; nothing in A+B blocks it. Note for the
-> implementer: A+B already added `SpectralProfile::lambdaMin/lambdaStep/count`
-> getters and the `spectral_profile_range` binding, and the light panel's
-> `custom_profile` mode is wired to `_spectral_profile_items` — so a
-> `register_spectral_profile` insert method (item 1) immediately feeds the Stage-B
-> custom-profile dropdown.
+> **Landed 2026-08-14.** All 7 items shipped. `register_spectral_profile(name,
+> lmin, step, values)` binding inserts into `SpectralProfileDatabase` via
+> pointer-stable deque storage (materials cache `SpectralProfile*` across a
+> render; a push_back must not dangle them). `ProfileMode::{ExtendOnly,Replace}`
+> added to `setSpectralProfile`; Replace drives all λ via
+> `profile->reflectance(λ)·cosθ/π`, bypassing the JH RGB round trip
+> (`raytracer.h` evalSpectralExt/sampleSpectralExt). Three source nodes
+> (Drawn Spectrum with a native CurveMapping, Spectrum Preset two-tier, Blackbody
+> Spectrum) + a Bake-to-Profile operator. IR/UV Response de-fanged: base BSDF
+> converts normally, node only attaches a constant-band ExtendOnly profile
+> (visible render byte-identical). Sellmeier manual B/C now read in
+> `dielectric.cpp` (matched the bk7 preset within 0.00%). A visible-band CPU
+> render with a Replace-mode material is routed to the MW integrator (the only
+> transport that consults evalSpectralExt in-band; the pkg57 no-op fix); GPU keeps
+> its integrator + a degradation note (Replace is CPU-exact, enableNEE contract
+> untouched). Gate results below.
+>
+> **Gate C (all green, CPU, sm_120 build):**
+> - C1 register_spectral_profile roundtrip + interpolation exact vs numpy;
+>   overwrite-in-place (no duplicate name).
+> - C2 paint_red vs grass_green Replace mode: paint_red R=0.0152≫G=0.0012 (R-dom),
+>   grass_green G=0.0050>R=0.0049 (G-dom), G/R signatures 3×+ apart — was the
+>   |Δmean|=0.00028 no-op.
+> - C3 IR/UV ExtendOnly band profile: visible render BYTE-IDENTICAL to base.
+> - C4 manual BK7 B/C vs bk7 preset prism dispersion: 6.350px vs 6.350px (0.00%).
+> - C5 drawn-equivalent 550 nm bump green-dominant; flat SPD neutral.
+> - Headless Blender 5.1 drawn-spectrum end-to-end (CPU, OpenMP-off build):
+>   550 nm bump curve → G=0.4396>R=0.2642>B=0.0003 (clean green sphere PNG),
+>   flat curve neutral (span 0.009); MW-routing degradation note confirmed fired.
+> - Stage A/B (6) + 10 GPU-parity gates: 16/16 unchanged (enable_nee contract
+>   intact).
 
 1. **`astroray.register_spectral_profile(name, lambda_min_nm, lambda_step_nm,
    values: list[float])`** pybind binding inserting into

--- a/.astroray_plan/packages/pkg195-spectral-nodes-phase1.md
+++ b/.astroray_plan/packages/pkg195-spectral-nodes-phase1.md
@@ -6,7 +6,7 @@
 0.0709 > 0.05, snow/water NIR ratio 4.82, MW↔path_tracer visible parity 1.00;
 sodium lamp linear RGB (0.673, 0.127, 0.000) amber, cie_f2 differs 100% on blue;
 headless Blender 5.1 render confirms amber sodium vs neutral cie_f2). Stage C
-done (PR TBD, 2026-08-14 — register_spectral_profile + Drawn/Preset/Blackbody
+done (PR #610, 2026-08-14 — register_spectral_profile + Drawn/Preset/Blackbody
 spectrum nodes + in-band Replace mode + IR/UV de-fang + Sellmeier B/C; Gate C all
 green, headless Blender drawn 550 nm bump G=0.4396>R=0.2642>B=0.0003, manual BK7
 B/C == bk7 preset 0.00%, 16/16 A/B+parity gates unchanged). All three stages
@@ -136,7 +136,7 @@ over a white sphere, visible band, CPU → hue must land amber
 ratios by > 10%. Test lives with the pkg119b-style harness
 (`ASTRORAY_PYD_DIR` + absolute out-dir conventions).
 
-## Stage C — spectrum sources + honest material nodes — DONE (PR TBD, 2026-08-14)
+## Stage C — spectrum sources + honest material nodes — DONE (PR #610, 2026-08-14)
 
 > **Landed 2026-08-14.** All 7 items shipped. `register_spectral_profile(name,
 > lmin, step, values)` binding inserts into `SpectralProfileDatabase` via

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -469,6 +469,26 @@ def _effective_integrator_name(settings):
     return _resolve_auto_integrator(settings)
 
 
+def _route_replace_to_mw(has_replace_profile, is_outside_visible, active_device,
+                         integrator_name):
+    """pkg195 Stage C: decide whether to override the integrator to the
+    multiwavelength path tracer so a Replace-mode authored spectrum (Drawn /
+    Spectrum Preset / Spectral Profile source node) is consulted per-λ in the
+    visible band. Only the MW integrator calls evalSpectralExt; the default
+    path_tracer never does, so without this the authored reflectance is a visible
+    no-op (the pkg57 failure Stage C fixes).
+
+    Restricted to CPU: Replace is CPU-exact, and the GPU MW leg is the
+    light-sampling-blind naive oracle (enableNEE contract, blender_module.cpp:1822)
+    that would only render darker — GPU keeps its integrator and the degradation
+    report notes the approximation. Returns True when the caller should switch to
+    'multiwavelength_path_tracer'."""
+    return (bool(has_replace_profile)
+            and not is_outside_visible
+            and active_device == "cpu"
+            and integrator_name != "multiwavelength_path_tracer")
+
+
 def _integrator_capabilities(name):
     try:
         return astroray.integrator_capabilities(name)
@@ -1197,6 +1217,23 @@ class CustomRaytracerRenderEngine(RenderEngine):
             is_outside_visible = (lmax > 780.0 or lmin < 380.0)
             if is_outside_visible:
                 renderer.set_output_mode("luminance")
+            # pkg195 Stage C: a Replace-mode authored spectrum (Drawn / Spectrum
+            # Preset / Spectral Profile source node wired to a Surface) is only
+            # consulted per-λ by the multiwavelength integrator. In the visible band
+            # the default path_tracer never calls evalSpectralExt, so the authored
+            # reflectance would be a no-op (the pkg57 failure this stage fixes).
+            # Route visible-band CPU renders to the MW integrator when such a
+            # material is present. GPU keeps its integrator: Replace is CPU-exact
+            # (the degradation report notes the GPU approximation), and the GPU MW
+            # leg is the light-sampling-blind naive oracle (enableNEE contract,
+            # blender_module.cpp:1822) which would only render darker.
+            if _route_replace_to_mw(
+                    getattr(self, "_has_replace_profile", False),
+                    is_outside_visible, active_device, integrator_name):
+                integrator_name = "multiwavelength_path_tracer"
+                self._degradation_report().approximate(
+                    "Spectral Replace material",
+                    "routed to multiwavelength integrator for per-λ reflectance")
             renderer.set_integrator(integrator_name)
             has_denoise_pass = False
             if settings.use_denoising and not is_outside_visible:
@@ -2078,6 +2115,15 @@ class CustomRaytracerRenderEngine(RenderEngine):
         _settings = getattr(depsgraph.scene, "custom_raytracer", None)
         self._use_native_principled_flag = bool(
             getattr(_settings, "use_native_principled", True))
+        # pkg195 Stage C: whether this render targets the GPU (for the Replace-mode
+        # spectral degradation note — GPU keeps ExtendOnly semantics).
+        self._device_is_gpu = (
+            bool(getattr(renderer, "_use_gpu", False))
+            or getattr(_settings, "device_mode", "auto") == "gpu")
+        # pkg195 Stage C: set True when any material gets a Replace-mode authored
+        # spectrum, so render() can route the visible-band CPU render to the MW
+        # integrator (the only transport that consults evalSpectralExt in-band).
+        self._has_replace_profile = False
         # pkg115 generated-coords: textures created in GENERATED mode while
         # converting a material are recorded per material name so
         # convert_objects can bake each using object's bounding box onto them
@@ -2105,6 +2151,25 @@ class CustomRaytracerRenderEngine(RenderEngine):
         # it locally and only let it drop after this function returns.
         def _apply_spectral_profile(material_id):
             try:
+                # pkg195 Stage C: a source node (Drawn / Spectrum Preset / Spectral
+                # Profile) wired to a Surface registers+attaches its profile with an
+                # explicit mode (Replace for reflectance sources, ExtendOnly for the
+                # IR/UV band wrapper). Honor that over the pkg58 material-panel
+                # fallback, which stays ExtendOnly and must NOT clobber it.
+                node_prof = getattr(self, "_current_node_profile", None)
+                if node_prof is not None:
+                    name, replace = node_prof
+                    if name and hasattr(renderer, "set_material_spectral_profile"):
+                        renderer.set_material_spectral_profile(material_id, name, replace)
+                        if replace:
+                            self._has_replace_profile = True
+                            # Replace mode is CPU-exact only; the GPU MW kernel keeps
+                            # ExtendOnly semantics (out-of-band only) — report the drop.
+                            if getattr(self, "_device_is_gpu", False):
+                                self._degradation_report().ignore(
+                                    "Spectral Replace mode",
+                                    "GPU renders out-of-band only; CPU is exact")
+                    return material_id
                 mat_settings = getattr(mat, "custom_raytracer", None)
                 profile = getattr(mat_settings, "spectral_profile", "__none__") if mat_settings else "__none__"
                 if (hasattr(renderer, "set_material_spectral_profile") and
@@ -2116,6 +2181,7 @@ class CustomRaytracerRenderEngine(RenderEngine):
             except Exception:
                 pass
             return material_id
+        self._current_node_profile = None
 
         # P3-c probe & fix (BUG-09): inline_shader_nodes() may strip custom node
         # subclasses. Check the original tree for Astroray nodes; if present but
@@ -2200,20 +2266,66 @@ class CustomRaytracerRenderEngine(RenderEngine):
             return self._create_astroray_material(
                 self._astroray_sellmeier_spec(wired, mat), renderer, node_tree)
         if bl_idname == 'AstrorayShaderNodeIrUvResponse':
-            return self._create_astroray_material(
-                self._astroray_ir_uv_spec(wired, mat), renderer, node_tree)
+            return self._astroray_ir_uv_material(wired, mat, renderer, node_tree)
         if bl_idname == 'AstrorayShaderNodeNrcHint':
             return self._create_astroray_material(
                 self._astroray_nrc_hint_spec(wired, mat, renderer), renderer, node_tree)
-        if bl_idname == 'AstrorayShaderNodeSpectralProfile':
-            # A bare spectral-profile node wired to Surface produces a neutral
-            # diffuse that the spectral profile multiplies — matches pkg58.
+        if bl_idname in ('AstrorayShaderNodeSpectralProfile',
+                         'AstrorayShaderNodeSpectrumPreset',
+                         'AstrorayShaderNodeDrawnSpectrum'):
+            # pkg195 Stage C: a spectrum SOURCE node wired to Surface produces a
+            # neutral white diffuse whose per-λ reflectance is the authored
+            # spectrum, attached in Replace mode (drives all λ, bypassing the JH
+            # RGB round trip). _register_source_node_profile records the profile
+            # + mode into self._current_node_profile for _apply_spectral_profile.
+            self._register_source_node_profile(wired, mat)
             return self._create_astroray_material(
-                {'kind': 'astroray_spectral_only',
-                 'profile': self._astroray_read_profile(wired, mat)},
-                renderer, node_tree)
+                {'kind': 'astroray_spectral_only'}, renderer, node_tree)
         # Cycles / standalone fallback: dispatch through the existing path.
         return self.convert_shader_node(wired, renderer, node_tree)
+
+    def _register_source_node_profile(self, node, mat):
+        """pkg195 Stage C: resolve a spectrum source node to a profile NAME and
+        record (name, replace=True) in self._current_node_profile. Drawn nodes
+        register their curve as a runtime profile first; Preset/Spectral Profile
+        nodes name a DB profile directly."""
+        self._current_node_profile = None
+        bl_idname = getattr(node, 'bl_idname', '')
+        name = ''
+        if bl_idname == 'AstrorayShaderNodeDrawnSpectrum':
+            name = self._register_drawn_spectrum(node, mat)
+        elif bl_idname == 'AstrorayShaderNodeSpectrumPreset':
+            prof = getattr(node, 'profile', '') or ''
+            name = prof if prof and prof != '__none__' else ''
+        else:  # AstrorayShaderNodeSpectralProfile
+            name = self._astroray_read_profile(node, mat)
+        if name:
+            self._current_node_profile = (name, True)  # Replace mode
+
+    def _register_drawn_spectrum(self, node, mat):
+        """Evaluate a Drawn Spectrum node's CurveMapping at 5 nm and register it as
+        a runtime profile under __blend__/<mat>/<node>. Returns the name, or ''."""
+        if (not RAYTRACER_AVAILABLE or astroray_nodes is None
+                or not hasattr(astroray, 'register_spectral_profile')):
+            return ''
+        sampler = getattr(astroray_nodes, 'sample_drawn_spectrum', None)
+        if sampler is None:
+            return ''
+        try:
+            sampled = sampler(node)
+        except Exception:
+            sampled = None
+        if not sampled:
+            return ''
+        lmin, step, values = sampled
+        owner = getattr(mat, 'name', 'material') or 'material'
+        name = f"__blend__/{owner}/{getattr(node, 'name', 'drawn')}"
+        try:
+            if not astroray.register_spectral_profile(name, lmin, step, list(values)):
+                return ''
+        except Exception:
+            return ''
+        return name
 
     def _astroray_read_profile(self, node, mat):
         """Read the spectral profile name from an AstroraySpectralProfile node,
@@ -2259,25 +2371,53 @@ class CustomRaytracerRenderEngine(RenderEngine):
             spec['preset'] = getattr(astro, 'sellmeier_preset', '') if astro else ''
         return spec
 
-    def _astroray_ir_uv_spec(self, node, mat):
-        """IR/UV response wraps a base BSDF (its Surface input). For now we
-        promote the wrapper itself to a Disney with the band reflectance
-        applied as a tint — a full multi-band response material is pkg-future
-        work; this keeps the node functional without inventing a closure."""
-        base_node = None
+    def _astroray_ir_uv_material(self, node, mat, renderer, node_tree):
+        """pkg195 Stage C: NON-DESTRUCTIVE IR/UV Response. The wired base BSDF
+        converts normally (base colour preserved — the pkg57 grey-Disney
+        promotion is gone), and the node only attaches a constant-band ExtendOnly
+        profile built from its band + reflectance. Because ExtendOnly touches only
+        λ outside [380,780] nm, the visible render is pixel-identical to the base
+        with no node present."""
         surface_in = node.inputs.get('Surface')
         if surface_in is not None and surface_in.is_linked:
-            base_node = surface_in.links[0].from_node
-        # P3-b fix (BUG-13): profile was hard-disabled by `if False`. Now reads
-        # the actual profile from the Response node so IR/UV materials render
-        # non-black outside the visible band.
-        return {
-            'kind': 'astroray_ir_uv',
-            'band': getattr(node, 'band', 'ir'),
-            'reflectance': float(getattr(node, 'reflectance', 0.5)),
-            'profile': self._astroray_read_profile(node, mat),
-            'base_bl_idname': getattr(base_node, 'bl_idname', '') if base_node else '',
-        }
+            base_id = self.convert_shader_node(
+                surface_in.links[0].from_node, renderer, node_tree)
+        else:
+            # No base wired — neutral diffuse, still non-destructive.
+            base_id = renderer.create_material('disney', [0.8, 0.8, 0.8], {})
+        band = getattr(node, 'band', 'ir')
+        reflectance = float(getattr(node, 'reflectance', 0.5))
+        name = self._register_ir_uv_band_profile(node, mat, band, reflectance)
+        if name:
+            self._current_node_profile = (name, False)  # ExtendOnly (out-of-band)
+        return base_id
+
+    def _register_ir_uv_band_profile(self, node, mat, band, reflectance):
+        """Register a constant-in-band reflectance profile (0 outside the band)
+        over 300-1000 nm @ 5 nm. IR: 700-1000, UV: 300-400, both: both bands."""
+        if (not RAYTRACER_AVAILABLE or astroray_nodes is None
+                or not hasattr(astroray, 'register_spectral_profile')):
+            return ''
+        grid = getattr(astroray_nodes, 'spectrum_grid', None)
+        step = getattr(astroray_nodes, 'DRAWN_SPECTRUM_STEP_NM', 5.0)
+        if grid is None:
+            return ''
+        count, lmin, lmax = grid(300.0, 1000.0, step)
+        in_ir = band in ('ir', 'both')
+        in_uv = band in ('uv', 'both')
+        values = []
+        for i in range(count):
+            wl = lmin + i * step
+            hit = (in_ir and 700.0 <= wl <= 1000.0) or (in_uv and 300.0 <= wl <= 400.0)
+            values.append(reflectance if hit else 0.0)
+        owner = getattr(mat, 'name', 'material') or 'material'
+        name = f"__blend__/{owner}/{getattr(node, 'name', 'iruv')}"
+        try:
+            if not astroray.register_spectral_profile(name, lmin, step, list(values)):
+                return ''
+        except Exception:
+            return ''
+        return name
 
     def _astroray_nrc_hint_spec(self, node, mat, renderer):
         """NRC hint is a passthrough — it annotates the underlying BSDF and
@@ -2319,19 +2459,6 @@ class CustomRaytracerRenderEngine(RenderEngine):
                 params['sellmeier_c'] = spec['sellmeier_c']
             return renderer.create_material('dielectric', list(spec.get('tint', [1, 1, 1])), params)
 
-        if kind == 'astroray_ir_uv':
-            # Promote to a neutral Disney; the IR/UV reflectance is exposed as
-            # the base color for the chosen band. Spectral-aware multi-band
-            # closures live in the integrator layer (pkg58/60) and are picked
-            # up automatically via the spectral_profile path when set.
-            # P3-b fix (BUG-13): upload the spectral profile from the node.
-            r = float(spec.get('reflectance', 0.5))
-            mat_id = renderer.create_material('disney', [r, r, r], {'roughness': 0.5})
-            profile = spec.get('profile', '')
-            if profile and hasattr(renderer, 'set_material_spectral_profile'):
-                renderer.set_material_spectral_profile(mat_id, profile)
-            return mat_id
-
         if kind == 'astroray_passthrough':
             inner = spec.get('inner')
             if inner is None:
@@ -2339,7 +2466,9 @@ class CustomRaytracerRenderEngine(RenderEngine):
             return self.convert_shader_node(inner, renderer, node_tree)
 
         if kind == 'astroray_spectral_only':
-            # Profile is applied via _apply_spectral_profile in the caller.
+            # pkg195 Stage C: a neutral WHITE diffuse; the authored spectrum is the
+            # per-λ reflectance, attached in Replace mode via _apply_spectral_profile
+            # (self._current_node_profile was set by _register_source_node_profile).
             return renderer.create_material('disney', [1.0, 1.0, 1.0], {})
 
         # Unknown kind — neutral fallback.

--- a/blender_addon/nodes/__init__.py
+++ b/blender_addon/nodes/__init__.py
@@ -25,6 +25,8 @@ CLAUDE.md §3 "surgical changes").
 """
 from __future__ import annotations
 
+import math
+
 import bpy
 from bpy.props import (
     BoolProperty,
@@ -37,6 +39,20 @@ from bpy.props import (
 
 
 ENGINE_ID = "CUSTOM_RAYTRACER"
+
+# pkg195 Stage C: default authoring range for drawn/baked spectra. The DB grid
+# is 5 nm; drawn curves resample onto the same step so drawn and preset spectra
+# behave identically downstream (design doc §3.4).
+DRAWN_SPECTRUM_STEP_NM = 5.0
+
+# Emission-category (category 7) lamp SPDs shipped in profiles.bin. The DB does
+# not expose category in-memory, so the Spectrum Preset node filters names
+# against this known set (mirrors blender_addon/__init__.py:_EMISSION_PROFILE_NAMES).
+_EMISSION_PROFILE_NAMES = frozenset((
+    'sodium_vapor', 'mercury_vapor',
+    'cie_f2', 'cie_f3',
+    'led_3000k', 'led_5000k', 'led_6500k',
+))
 
 
 # --------------------------------------------------------------------------- #
@@ -82,6 +98,124 @@ def _sellmeier_preset_items(self, context):
     if not items:
         items = list(_SELLMEIER_FALLBACK_PRESETS)
     return items
+
+
+def _spectrum_preset_items(self, context):
+    """Two-tier Spectrum Preset dropdown: profiles filtered by the node's
+    `category` (reflectance = DB categories 0-6, emission = category 7). Category
+    is not exposed in-memory, so emission is filtered by the known name set."""
+    want_emission = getattr(self, "category", "reflectance") == "emission"
+    items = []
+    try:
+        import astroray  # type: ignore
+        if hasattr(astroray, "spectral_profile_names"):
+            for n in astroray.spectral_profile_names():
+                is_emission = n in _EMISSION_PROFILE_NAMES
+                if is_emission == want_emission:
+                    items.append((n, n.replace("_", " ").title(), ""))
+    except Exception:
+        pass
+    if not items:
+        items = [("__none__", "<None>", "No matching preset in the profile DB")]
+    return items
+
+
+# --------------------------------------------------------------------------- #
+# pkg195 Stage C: drawn-curve + blackbody spectrum sampling helpers. Both
+# produce a regular-grid float array that astroray.register_spectral_profile
+# consumes; drawn and preset spectra share the 5 nm DB grid so they behave
+# identically downstream.
+# --------------------------------------------------------------------------- #
+
+def spectrum_grid(lmin: float, lmax: float, step: float = DRAWN_SPECTRUM_STEP_NM):
+    """(count, clamped_lmin, clamped_lmax) for a regular grid; count >= 2."""
+    lmin = float(lmin)
+    lmax = float(lmax)
+    if lmax < lmin:
+        lmin, lmax = lmax, lmin
+    if lmax - lmin < step:
+        lmax = lmin + step
+    count = round((lmax - lmin) / step) + 1
+    return max(count, 2), lmin, lmax
+
+
+def _drawn_curve_node(node):
+    """Resolve the hidden ShaderNodeFloatCurve that stores this Drawn Spectrum
+    node's CurveMapping, or None when unavailable (e.g. CI bpy stub)."""
+    grp_name = getattr(node, "curve_group", "") or ""
+    if not grp_name:
+        return None
+    groups = getattr(getattr(bpy, "data", None), "node_groups", None)
+    if groups is None:
+        return None
+    grp = groups.get(grp_name)
+    if grp is None:
+        return None
+    return grp.nodes.get("curve")
+
+
+def sample_drawn_spectrum(node, step: float = DRAWN_SPECTRUM_STEP_NM):
+    """Evaluate a Drawn Spectrum node's CurveMapping on its [λmin, λmax] grid.
+    Returns (lambda_min_nm, step_nm, values) or None if the curve is missing.
+    The curve's X input 0..1 maps linearly to [λmin, λmax]; Y is the value."""
+    fc = _drawn_curve_node(node)
+    if fc is None:
+        return None
+    mapping = getattr(fc, "mapping", None)
+    if mapping is None:
+        return None
+    try:
+        mapping.update()
+    except Exception:
+        pass
+    try:
+        curve = mapping.curves[0]
+    except (IndexError, AttributeError):
+        return None
+    count, lmin, lmax = spectrum_grid(
+        getattr(node, "lambda_min", 300.0), getattr(node, "lambda_max", 1000.0), step)
+    span = lmax - lmin
+    values = []
+    for i in range(count):
+        wl = lmin + i * step
+        x = (wl - lmin) / span if span > 0.0 else 0.0
+        try:
+            y = float(mapping.evaluate(curve, x))
+        except (AttributeError, TypeError):
+            y = 0.0
+        values.append(max(0.0, y))
+    return lmin, step, values
+
+
+# Planck's law (textbook; CLAUDE.md §6 trivial): spectral radiance shape only.
+# Absolute scale is irrelevant — a MeasuredSPD is a *relative* SPD and the light
+# energy slider carries magnitude. `normalize` peak-normalizes to max 1.0 for a
+# stable relative curve (the engine's native blackbody light mode does the exact
+# pkg122 photopic-luminance normalization; this node authors a relative SPD).
+def _planck_radiance(lambda_nm: float, temperature_K: float) -> float:
+    h = 6.62607015e-34
+    c = 2.99792458e8
+    kB = 1.380649e-23
+    lam = lambda_nm * 1e-9
+    if lam <= 0.0 or temperature_K <= 0.0:
+        return 0.0
+    x = (h * c) / (lam * kB * temperature_K)
+    if x > 700.0:  # avoid overflow in exp; radiance ~ 0 here
+        return 0.0
+    return (2.0 * h * c * c) / (lam ** 5 * (math.expm1(x)))
+
+
+def bake_blackbody_spectrum(temperature_K: float, normalize: bool,
+                            lmin: float = 300.0, lmax: float = 1000.0,
+                            step: float = DRAWN_SPECTRUM_STEP_NM):
+    """Bake a Planck SPD onto a regular grid. Returns (lambda_min_nm, step, values)."""
+    count, lmin, lmax = spectrum_grid(lmin, lmax, step)
+    values = [_planck_radiance(lmin + i * step, temperature_K) for i in range(count)]
+    if normalize:
+        peak = max(values) if values else 0.0
+        if peak > 0.0:
+            values = [v / peak for v in values]
+    return lmin, step, values
 
 
 # --------------------------------------------------------------------------- #
@@ -299,6 +433,203 @@ class AstrorayShaderNodeNrcHint(_AstrorayNodeBase, bpy.types.ShaderNode):
 
 
 # --------------------------------------------------------------------------- #
+# 6. AstrorayShaderNodeSpectrumPreset — two-tier preset dropdown source.
+#    Replaces the bare Spectral Profile node as the source in new trees; the
+#    old node stays registered for .blend compat (pkg195 Stage C item 3).
+# --------------------------------------------------------------------------- #
+
+class AstrorayShaderNodeSpectrumPreset(_AstrorayNodeBase, bpy.types.ShaderNode):
+    bl_idname = "AstrorayShaderNodeSpectrumPreset"
+    bl_label = "Astroray Spectrum Preset"
+    bl_icon = "COLOR"
+
+    category: EnumProperty(
+        name="Category",
+        description="Reflectance presets (materials) or emission presets (lamps)",
+        items=[
+            ("reflectance", "Reflectance", "Material reflectance spectra"),
+            ("emission", "Emission", "Lamp / illuminant emission spectra"),
+        ],
+        default="reflectance",
+    )
+    profile: EnumProperty(
+        name="Preset",
+        description="Spectral profile from the Astroray DB, filtered by category",
+        items=_spectrum_preset_items,
+    )
+
+    def init(self, context):
+        self.outputs.new("NodeSocketShader", "BSDF")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "category", text="")
+        layout.prop(self, "profile", text="")
+
+
+# --------------------------------------------------------------------------- #
+# 7. AstrorayShaderNodeDrawnSpectrum — the owner's headline ask: draw exactly
+#    which wavelengths to emit/absorb via Blender's native CurveMapping widget
+#    (hidden ShaderNodeFloatCurve in a private node group; design doc §3.4).
+# --------------------------------------------------------------------------- #
+
+class AstrorayShaderNodeDrawnSpectrum(_AstrorayNodeBase, bpy.types.ShaderNode):
+    bl_idname = "AstrorayShaderNodeDrawnSpectrum"
+    bl_label = "Astroray Drawn Spectrum"
+    bl_icon = "FCURVE"
+
+    lambda_min: FloatProperty(
+        name="lambda min (nm)", description="Left edge of the drawn range",
+        default=300.0, min=100.0, max=3000.0,
+    )
+    lambda_max: FloatProperty(
+        name="lambda max (nm)", description="Right edge of the drawn range",
+        default=1000.0, min=100.0, max=3000.0,
+    )
+    semantic: EnumProperty(
+        name="Semantic",
+        description="How the drawn curve is interpreted where it is wired",
+        items=[
+            ("reflectance", "Reflectance", "λ → reflectance [0,1] for a surface"),
+            ("emission", "Emission", "λ → relative emission for a light"),
+        ],
+        default="reflectance",
+    )
+    # Name of the hidden node group holding the drawable CurveMapping. The .blend
+    # stores the curve; the node stores only this reference.
+    curve_group: StringProperty(default="")
+
+    def _ensure_curve_group(self):
+        groups = getattr(getattr(bpy, "data", None), "node_groups", None)
+        if groups is None:
+            return None
+        grp = groups.get(self.curve_group) if self.curve_group else None
+        if grp is None:
+            grp = groups.new(name="_AstrorayDrawnSpectrum", type="ShaderNodeTree")
+            try:
+                grp.use_fake_user = True
+            except AttributeError:
+                pass
+            fc = grp.nodes.new("ShaderNodeFloatCurve")
+            fc.name = "curve"
+            self.curve_group = grp.name
+        return grp
+
+    def init(self, context):
+        self.outputs.new("NodeSocketShader", "BSDF")
+        try:
+            self._ensure_curve_group()
+        except Exception:
+            pass
+
+    def copy(self, src_node):
+        # A duplicated node must own an independent curve so edits don't alias
+        # the original (memory id-node-cache-aliasing lesson: never share curve
+        # state across nodes). Force a fresh group on copy.
+        self.curve_group = ""
+        try:
+            self._ensure_curve_group()
+        except Exception:
+            pass
+
+    def draw_buttons(self, context, layout):
+        col = layout.column(align=True)
+        col.prop(self, "semantic", text="")
+        row = col.row(align=True)
+        row.prop(self, "lambda_min")
+        row.prop(self, "lambda_max")
+        fc = _drawn_curve_node(self)
+        if fc is not None and hasattr(layout, "template_curve_mapping"):
+            layout.template_curve_mapping(fc, "mapping")
+        else:
+            layout.label(text="Draw λ → value curve (unavailable here)", icon="FCURVE")
+        layout.operator("astroray.bake_spectrum_profile", icon="FILE_TICK")
+
+
+# --------------------------------------------------------------------------- #
+# 8. AstrorayShaderNodeBlackbodySpectrum — Planck emission source (Phase 1:
+#    emission only; bakes a Planck SPD a light's Custom Profile mode can use).
+# --------------------------------------------------------------------------- #
+
+class AstrorayShaderNodeBlackbodySpectrum(_AstrorayNodeBase, bpy.types.ShaderNode):
+    bl_idname = "AstrorayShaderNodeBlackbodySpectrum"
+    bl_label = "Astroray Blackbody Spectrum"
+    bl_icon = "LIGHT_SUN"
+
+    temperature: FloatProperty(
+        name="Temperature (K)", description="Blackbody temperature",
+        default=6500.0, min=800.0, max=20000.0,
+    )
+    normalize: BoolProperty(
+        name="Normalize (peak)",
+        description="Peak-normalize the baked SPD to 1.0 (relative curve). The "
+                    "engine's native blackbody light mode does exact photopic "
+                    "normalization; this authors a relative emission SPD.",
+        default=True,
+    )
+
+    def init(self, context):
+        self.outputs.new("NodeSocketShader", "BSDF")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "temperature")
+        layout.prop(self, "normalize")
+        layout.operator("astroray.bake_spectrum_profile", icon="FILE_TICK")
+
+
+# --------------------------------------------------------------------------- #
+# Bake operator — registers the active Drawn/Blackbody node's spectrum as a
+# runtime profile so a light's Custom Profile dropdown can reference it by name
+# without a full render first (design doc §3.4 export-at-translation is the
+# material path; this is the explicit bridge for the light-emission path).
+# --------------------------------------------------------------------------- #
+
+def drawn_spectrum_profile_name(node, owner_name: str = "node") -> str:
+    """Stable __blend__/<owner>/<node> name for a source node's runtime profile."""
+    return f"__blend__/{owner_name}/{getattr(node, 'name', 'spectrum')}"
+
+
+class ASTRORAY_OT_bake_spectrum_profile(bpy.types.Operator):
+    bl_idname = "astroray.bake_spectrum_profile"
+    bl_label = "Bake to Profile"
+    bl_description = ("Register this spectrum as a runtime Astroray profile so a "
+                      "light's Custom Profile mode can use it by name")
+    bl_options = {"REGISTER"}
+
+    def execute(self, context):
+        node = getattr(context, "active_node", None)
+        if node is None:
+            self.report({'ERROR'}, "No active node")
+            return {'CANCELLED'}
+        bl_idname = getattr(node, "bl_idname", "")
+        if bl_idname == "AstrorayShaderNodeDrawnSpectrum":
+            sampled = sample_drawn_spectrum(node)
+        elif bl_idname == "AstrorayShaderNodeBlackbodySpectrum":
+            sampled = bake_blackbody_spectrum(
+                float(getattr(node, "temperature", 6500.0)),
+                bool(getattr(node, "normalize", True)))
+        else:
+            self.report({'ERROR'}, "Active node is not a spectrum source")
+            return {'CANCELLED'}
+        if not sampled:
+            self.report({'ERROR'}, "Could not evaluate the spectrum curve")
+            return {'CANCELLED'}
+        lmin, step, values = sampled
+        try:
+            import astroray  # type: ignore
+        except ImportError:
+            self.report({'ERROR'}, "astroray engine module not available")
+            return {'CANCELLED'}
+        owner = getattr(getattr(context, "material", None), "name", None) or "scene"
+        name = drawn_spectrum_profile_name(node, owner)
+        ok = bool(astroray.register_spectral_profile(name, lmin, step, list(values)))
+        if not ok:
+            self.report({'ERROR'}, "register_spectral_profile failed")
+            return {'CANCELLED'}
+        self.report({'INFO'}, f"Registered spectral profile '{name}'")
+        return {'FINISHED'}
+
+
+# --------------------------------------------------------------------------- #
 # Per-material PropertyGroup. Pattern from
 # intern/cycles/blender/addon/properties.py:CyclesMaterialSettings (Apache-2.0).
 # --------------------------------------------------------------------------- #
@@ -330,6 +661,9 @@ class AstrorayMaterialSettings(bpy.types.PropertyGroup):
 
 _ASTRORAY_NODE_TYPES = [
     ("Astroray Output",          "AstrorayOutputNode"),
+    ("Astroray Spectrum Preset", "AstrorayShaderNodeSpectrumPreset"),
+    ("Astroray Drawn Spectrum",  "AstrorayShaderNodeDrawnSpectrum"),
+    ("Astroray Blackbody Spectrum", "AstrorayShaderNodeBlackbodySpectrum"),
     ("Astroray Spectral Profile","AstrorayShaderNodeSpectralProfile"),
     ("Astroray Sellmeier Glass", "AstrorayShaderNodeSellmeierGlass"),
     ("Astroray IR/UV Response",  "AstrorayShaderNodeIrUvResponse"),
@@ -377,6 +711,9 @@ SOCKET_CLASSES = (
 NODE_CLASSES = (
     AstrorayOutputNode,
     AstrorayShaderNodeSpectralProfile,
+    AstrorayShaderNodeSpectrumPreset,
+    AstrorayShaderNodeDrawnSpectrum,
+    AstrorayShaderNodeBlackbodySpectrum,
     AstrorayShaderNodeSellmeierGlass,
     AstrorayShaderNodeIrUvResponse,
     AstrorayShaderNodeNrcHint,
@@ -385,6 +722,7 @@ NODE_CLASSES = (
 _ALL_CLASSES = (
     *SOCKET_CLASSES,
     *NODE_CLASSES,
+    ASTRORAY_OT_bake_spectrum_profile,
     NODE_MT_astroray_add,
     AstrorayMaterialSettings,
 )

--- a/include/astroray/spectral_profile.h
+++ b/include/astroray/spectral_profile.h
@@ -8,9 +8,21 @@
 
 #include <string>
 #include <vector>
+#include <deque>
 #include <unordered_map>
 
 namespace astroray {
+
+// pkg195 Stage C: how a material consults an attached SpectralProfile.
+//   ExtendOnly (default) — profile drives only λ outside the visible band
+//     [380, 780] nm; the visible band keeps the Jakob-Hanika RGB path. This is
+//     the pkg39 behaviour; old scenes and the pkg58 material-panel fallback
+//     keep it (no behaviour change).
+//   Replace — the profile drives ALL λ (visible included), bypassing the JH
+//     upsample entirely (design doc §3.1 principle 2: an authored SPD must never
+//     round-trip through RGB). The Spectral Profile / Spectrum Preset / Drawn
+//     Spectrum source nodes wired to a Surface set this.
+enum class ProfileMode { ExtendOnly, Replace };
 
 // Non-owning view of one material's reflectance curve from the ASPR database.
 // Thread-safe: read-only after construction.
@@ -56,11 +68,22 @@ public:
 // Loads and owns the ASPR binary database (profiles.bin from pkg38).
 // Call load() once at startup; all subsequent get() calls are read-only.
 class SpectralProfileDatabase {
-    std::vector<float> storage_;                     // all float32 data
+    std::vector<float> storage_;                     // all float32 data (from file)
     std::vector<SpectralProfile> profiles_;          // views into storage_
     std::vector<std::string>    names_;              // parallel to profiles_
     std::unordered_map<std::string, int> index_;     // name → profiles_ index
     bool loaded_ = false;
+
+    // pkg195 Stage C: runtime-registered profiles (register_spectral_profile).
+    // Kept in pointer-stable containers (std::deque never invalidates element
+    // addresses on push_back, unlike std::vector) because materials cache a
+    // SpectralProfile* across a render — appending a new runtime profile must
+    // not dangle those pointers. Re-registering an existing runtime name
+    // overwrites its slot IN PLACE (the SpectralProfile view is rebuilt over the
+    // refreshed buffer) so the cached pointer stays valid.
+    std::deque<std::vector<float>> runtimeStorage_;
+    std::deque<SpectralProfile>    runtimeProfiles_;
+    std::unordered_map<std::string, int> runtimeIndex_;  // name → runtimeProfiles_ index
 
     SpectralProfileDatabase() = default;
 public:
@@ -72,7 +95,17 @@ public:
     // Returns nullptr when the name is not in the database.
     const SpectralProfile* get(const std::string& name) const;
 
-    const std::vector<std::string>& names() const { return names_; }
+    // pkg195 Stage C: insert (or overwrite) a runtime profile from raw samples on
+    // a regular λ grid. Returns a stable pointer to the stored profile. `values`
+    // is the sample array; the grid is lambda_min_nm + i*lambda_step_nm.
+    const SpectralProfile* registerProfile(const std::string& name,
+                                           float lambda_min_nm,
+                                           float lambda_step_nm,
+                                           const std::vector<float>& values);
+
+    // All profile names (file + runtime), file order first. Returned by value
+    // because runtime names are held in a separate container.
+    std::vector<std::string> names() const;
     bool loaded() const { return loaded_; }
 };
 

--- a/include/raytracer.h
+++ b/include/raytracer.h
@@ -552,13 +552,22 @@ public:
     }
 
     // pkg39: Spectral profile for outside-visible multi-wavelength rendering.
-    void setSpectralProfile(const astroray::SpectralProfile* p) { spectralProfile_ = p; }
+    // pkg195 Stage C: `mode` selects ExtendOnly (default; out-of-band only) vs
+    // Replace (profile drives all λ, bypassing the JH upsample).
+    void setSpectralProfile(const astroray::SpectralProfile* p,
+                            astroray::ProfileMode mode = astroray::ProfileMode::ExtendOnly) {
+        spectralProfile_ = p;
+        profileMode_ = mode;
+    }
     const astroray::SpectralProfile* getSpectralProfile() const  { return spectralProfile_; }
+    astroray::ProfileMode getSpectralProfileMode() const { return profileMode_; }
 
     // evalSpectral with profile override for outside-visible wavelengths (pkg39).
     // Wavelengths in [380, 780]: use the existing Jakob-Hanika sigmoid path (no change).
     // Wavelengths outside [380, 780] with profile: use profile reflectance x cosTheta/pi.
     // Wavelengths outside [380, 780] without profile: return 0 (physically honest).
+    // pkg195 Stage C: in Replace mode the profile drives ALL λ (visible included),
+    // never constructing an RGBAlbedoSpectrum (design doc §3.1 principle 2).
     astroray::SampledSpectrum evalSpectralExt(
             const HitRecord& rec, const Vec3& wo, const Vec3& wi,
             const astroray::SampledWavelengths& lambdas) const {
@@ -575,6 +584,16 @@ public:
         }
         float cosTheta = wi.dot(rec.normal);
         if (cosTheta <= 0.0f) return astroray::SampledSpectrum(0.0f);
+        if (profileMode_ == astroray::ProfileMode::Replace) {
+            // Authored SPD drives every wavelength; pure Lambertian transport with
+            // per-λ reflectance = profile(λ). No JH round-trip.
+            astroray::SampledSpectrum result;
+            for (int i = 0; i < astroray::kSpectrumSamples; ++i) {
+                result[i] = spectralProfile_->reflectance(lambdas.lambda(i))
+                          * cosTheta / float(M_PI);
+            }
+            return result;
+        }
         astroray::SampledSpectrum base = evalSpectral(rec, wo, wi, lambdas);
         astroray::SampledSpectrum result;
         for (int i = 0; i < astroray::kSpectrumSamples; ++i) {
@@ -595,6 +614,14 @@ public:
         bss.wi = bs.wi;
         bss.pdf = bs.pdf;
         bss.isDelta = bs.isDelta;
+        // pkg195 Stage C: in Replace mode the authored SPD is the reflectance for
+        // every λ — route the non-delta BSDF factor straight through evalSpectralExt
+        // so it never passes through the RGB-upsample branch below.
+        if (spectralProfile_ && profileMode_ == astroray::ProfileMode::Replace
+                && !bs.isDelta) {
+            bss.f_spectral = evalSpectralExt(rec, wo, bs.wi, lambdas);
+            return bss;
+        }
         // pkg118 / #404: factor the exit eta^2 (>1) out so the albedo LUT clamp does not
         // clip it (see sampleSpectral above for the full rationale).
         if (bs.isDelta) {
@@ -621,6 +648,7 @@ public:
 
 private:
     const astroray::SpectralProfile* spectralProfile_ = nullptr;
+    astroray::ProfileMode profileMode_ = astroray::ProfileMode::ExtendOnly;  // pkg195 Stage C
     std::string name_;  // pkg87a — for Cryptomatte material ID
 };
 

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -2325,12 +2325,18 @@ public:
         integratorParams_.set("output_mode", mode);
     }
 
-    void setMaterialSpectralProfile(int materialId, const std::string& profileName) {
+    void setMaterialSpectralProfile(int materialId, const std::string& profileName,
+                                    bool replace = false) {
         auto it = materials.find(materialId);
         if (it == materials.end()) return;
         auto& db = astroray::SpectralProfileDatabase::instance();
         const auto* profile = db.get(profileName);
-        if (profile) it->second->setSpectralProfile(profile);
+        // pkg195 Stage C: `replace` picks Replace mode (authored SPD drives all λ,
+        // set by source nodes wired to a Surface); the pkg58 material-panel
+        // fallback passes replace=false (ExtendOnly — out-of-band only).
+        if (profile) it->second->setSpectralProfile(
+            profile, replace ? astroray::ProfileMode::Replace
+                             : astroray::ProfileMode::ExtendOnly);
     }
 
     void clearMaterialSpectralProfile(int materialId) {
@@ -3028,8 +3034,10 @@ PYBIND11_MODULE(astroray, m) {
         .def("set_output_mode", &PyRenderer::setOutputMode, "mode"_a,
              "Output mode: 'xyz' (visible) or 'luminance' (IR/UV).")
         .def("set_material_spectral_profile", &PyRenderer::setMaterialSpectralProfile,
-             "material_id"_a, "profile_name"_a,
-             "Attach a spectral profile to a material for outside-visible rendering.")
+             "material_id"_a, "profile_name"_a, "replace"_a = false,
+             "Attach a spectral profile to a material. replace=False (default) is "
+             "ExtendOnly (out-of-band only, pkg58 fallback); replace=True is "
+             "Replace mode (authored SPD drives all wavelengths, pkg195 Stage C).")
         .def("clear_material_spectral_profile", &PyRenderer::clearMaterialSpectralProfile,
              "material_id"_a,
              "Remove the spectral profile from a material.");
@@ -3784,7 +3792,22 @@ PYBIND11_MODULE(astroray, m) {
     }, "path"_a, "Load the ASPR profiles.bin database.");
     m.def("spectral_profile_names", []() {
         return astroray::SpectralProfileDatabase::instance().names();
-    }, "Return names of all loaded spectral profiles.");
+    }, "Return names of all loaded spectral profiles (file + runtime).");
+    // pkg195 Stage C: register (or overwrite) a runtime spectral profile from a
+    // regular λ grid. Drawn / preset / baked-blackbody spectra register under
+    // __blend__/<owner>/<node> names and then participate in everything existing
+    // (material attach, emission MeasuredSPD, GPU profile-table upload). Returns
+    // True on success (non-empty values, positive step).
+    m.def("register_spectral_profile",
+          [](const std::string& name, float lambda_min_nm, float lambda_step_nm,
+             const std::vector<float>& values) -> bool {
+        const auto* p = astroray::SpectralProfileDatabase::instance().registerProfile(
+            name, lambda_min_nm, lambda_step_nm, values);
+        return p != nullptr;
+    }, "name"_a, "lambda_min_nm"_a, "lambda_step_nm"_a, "values"_a,
+       "Register a runtime spectral profile sampled on a regular grid "
+       "(lambda_min_nm + i*lambda_step_nm). Overwrites an existing runtime "
+       "profile of the same name in place.");
     m.def("spectral_profile_reflectance", [](const std::string& name, float lambda_nm) -> float {
         const auto* p = astroray::SpectralProfileDatabase::instance().get(name);
         if (!p) return 0.0f;

--- a/plugins/materials/dielectric.cpp
+++ b/plugins/materials/dielectric.cpp
@@ -98,6 +98,21 @@ public:
                 }
             }
         }
+        // pkg195 Stage C: manual Sellmeier B/C coefficients. When no preset is
+        // active, the Astroray Sellmeier Glass node sends sellmeier_b/sellmeier_c
+        // float3 triples (the addon socket defaults are the Schott BK7 terms).
+        // Previously these were exported but no engine code read them — the
+        // "manual coefficients" UI was a silent no-op. A non-zero B vector turns
+        // on dispersion using the supplied coefficients.
+        if (!dispersive_) {
+            Vec3 bMan = p.getVec3("sellmeier_b", Vec3(0.0f));
+            Vec3 cMan = p.getVec3("sellmeier_c", Vec3(0.0f));
+            if (bMan.length2() > 0.0f) {
+                sellmeierB_ = bMan;
+                sellmeierC_ = cMan;
+                dispersive_ = true;
+            }
+        }
     }
 
     bool isTransmissive() const override { return true; }

--- a/src/spectral_profile.cpp
+++ b/src/spectral_profile.cpp
@@ -59,9 +59,51 @@ void SpectralProfileDatabase::load(const std::string& path) {
 }
 
 const SpectralProfile* SpectralProfileDatabase::get(const std::string& name) const {
+    // File-loaded profiles take precedence; runtime profiles register under
+    // distinct __blend__/... names (Stage C), so collisions are not expected.
     auto it = index_.find(name);
-    if (it == index_.end()) return nullptr;
-    return &profiles_[it->second];
+    if (it != index_.end()) return &profiles_[it->second];
+    auto rit = runtimeIndex_.find(name);
+    if (rit != runtimeIndex_.end()) return &runtimeProfiles_[rit->second];
+    return nullptr;
+}
+
+const SpectralProfile* SpectralProfileDatabase::registerProfile(
+        const std::string& name, float lambda_min_nm, float lambda_step_nm,
+        const std::vector<float>& values) {
+    if (values.empty() || lambda_step_nm <= 0.0f) return nullptr;
+
+    auto rit = runtimeIndex_.find(name);
+    if (rit != runtimeIndex_.end()) {
+        // Overwrite in place: keep the deque slot address stable so any cached
+        // SpectralProfile* held by a material stays valid; only the underlying
+        // sample buffer moves, and the view is rebuilt over it.
+        int ri = rit->second;
+        runtimeStorage_[ri] = values;
+        runtimeProfiles_[ri] = SpectralProfile(
+            runtimeStorage_[ri].data(), static_cast<int>(values.size()),
+            lambda_min_nm, lambda_step_nm);
+        return &runtimeProfiles_[ri];
+    }
+
+    // New slot: deque push_back never invalidates existing element addresses.
+    runtimeStorage_.push_back(values);
+    int ri = static_cast<int>(runtimeStorage_.size()) - 1;
+    runtimeProfiles_.emplace_back(
+        runtimeStorage_[ri].data(), static_cast<int>(values.size()),
+        lambda_min_nm, lambda_step_nm);
+    runtimeIndex_[name] = ri;
+    return &runtimeProfiles_[ri];
+}
+
+std::vector<std::string> SpectralProfileDatabase::names() const {
+    std::vector<std::string> all = names_;              // file order first
+    all.reserve(names_.size() + runtimeIndex_.size());
+    // Append runtime names in registration order (deque index order).
+    std::vector<std::string> runtimeOrdered(runtimeIndex_.size());
+    for (const auto& kv : runtimeIndex_) runtimeOrdered[kv.second] = kv.first;
+    for (auto& n : runtimeOrdered) all.push_back(std::move(n));
+    return all;
 }
 
 } // namespace astroray

--- a/src/spectral_profile.cpp
+++ b/src/spectral_profile.cpp
@@ -1,4 +1,5 @@
 #include "astroray/spectral_profile.h"
+#include <algorithm>
 #include <cstdint>
 #include <fstream>
 #include <cstring>
@@ -73,24 +74,38 @@ const SpectralProfile* SpectralProfileDatabase::registerProfile(
         const std::vector<float>& values) {
     if (values.empty() || lambda_step_nm <= 0.0f) return nullptr;
 
+    // pkg195 Stage C (PR #610 review hardening): SpectralProfile::reflectance() is
+    // documented [0, 1]; nothing enforced it, so a script passing values > 1 to the
+    // public register_spectral_profile binding would inject energy in
+    // ProfileMode::Replace (an authored reflectance > 1 reflects more than it
+    // receives). Clamp stored samples to [0, 1] here — at registration, off the
+    // render hot path — so every downstream consumer (Replace + ExtendOnly
+    // reflectance, GPU profile-table upload) is bounded by construction.
+    // Emission relative SPDs registered at runtime (blackbody bake, drawn emission)
+    // are peak-normalized to <= 1 before they reach here, so this is a no-op for
+    // them; a caller wanting an unbounded relative SPD must normalize first.
+    std::vector<float> clamped(values.size());
+    for (size_t i = 0; i < values.size(); ++i)
+        clamped[i] = std::clamp(values[i], 0.0f, 1.0f);
+
     auto rit = runtimeIndex_.find(name);
     if (rit != runtimeIndex_.end()) {
         // Overwrite in place: keep the deque slot address stable so any cached
         // SpectralProfile* held by a material stays valid; only the underlying
         // sample buffer moves, and the view is rebuilt over it.
         int ri = rit->second;
-        runtimeStorage_[ri] = values;
+        runtimeStorage_[ri] = std::move(clamped);
         runtimeProfiles_[ri] = SpectralProfile(
-            runtimeStorage_[ri].data(), static_cast<int>(values.size()),
+            runtimeStorage_[ri].data(), static_cast<int>(runtimeStorage_[ri].size()),
             lambda_min_nm, lambda_step_nm);
         return &runtimeProfiles_[ri];
     }
 
     // New slot: deque push_back never invalidates existing element addresses.
-    runtimeStorage_.push_back(values);
+    runtimeStorage_.push_back(std::move(clamped));
     int ri = static_cast<int>(runtimeStorage_.size()) - 1;
     runtimeProfiles_.emplace_back(
-        runtimeStorage_[ri].data(), static_cast<int>(values.size()),
+        runtimeStorage_[ri].data(), static_cast<int>(runtimeStorage_[ri].size()),
         lambda_min_nm, lambda_step_nm);
     runtimeIndex_[name] = ri;
     return &runtimeProfiles_[ri];

--- a/tests/test_pkg195_stage_c.py
+++ b/tests/test_pkg195_stage_c.py
@@ -1,0 +1,264 @@
+"""pkg195 Stage C — spectrum sources + honest material nodes (engine gates).
+
+Stage C makes spectral authoring real end-to-end:
+  1. astroray.register_spectral_profile(name, lmin, step, values) — runtime SPDs.
+  2. In-band Replace mode — an authored SPD drives ALL wavelengths, bypassing the
+     Jakob-Hanika RGB round-trip (set_material_spectral_profile(..., replace=True)).
+  3. IR/UV Response is non-destructive — attaching a band profile in ExtendOnly
+     mode leaves the visible render pixel-identical.
+  4. Sellmeier manual B/C coefficients now drive dispersion (were silently dropped).
+
+These gates run at the engine level on the CPU (set_use_gpu(False)); the addon-UI
+wiring (Drawn Spectrum CurveMapping, Spectrum Preset / IR/UV nodes) is exercised by
+the headless-Blender check recorded in the PR body. The Drawn Spectrum's engine
+path is covered here by registering the same narrow-band SPD the curve produces.
+"""
+import os
+
+import numpy as np
+import pytest
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+
+try:
+    import astroray
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PROFILES_BIN = os.path.join(REPO_ROOT, "data", "spectral_profiles", "profiles.bin")
+HAS_PROFILES = os.path.exists(PROFILES_BIN)
+
+# Schott BK7 Sellmeier terms (optical_presets.h / addon socket defaults).
+BK7_B = [1.03961212, 0.231792344, 1.01046945]
+BK7_C = [0.00600069867, 0.0200179144, 103.560653]
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray module not available")
+
+
+# --------------------------------------------------------------------------- #
+# C1 — register_spectral_profile roundtrip
+# --------------------------------------------------------------------------- #
+
+def test_c1_register_profile_roundtrip():
+    """register → names() lists it → reflectance interpolates vs a numpy oracle."""
+    name = "__test__/pkg195c/ramp"
+    lmin, step = 400.0, 5.0
+    # A linear ramp 0..1 over 400..600 nm (41 samples).
+    values = [i / 40.0 for i in range(41)]
+    assert astroray.register_spectral_profile(name, lmin, step, values)
+
+    assert name in astroray.spectral_profile_names()
+
+    grid = np.array([lmin + i * step for i in range(len(values))])
+    oracle = np.array(values)
+    # Sample on the grid and between grid points; compare to numpy linear interp.
+    for wl in [400.0, 402.5, 455.0, 512.5, 597.5, 600.0]:
+        got = astroray.spectral_profile_reflectance(name, wl)
+        want = float(np.interp(wl, grid, oracle))
+        assert abs(got - want) < 1e-5, f"λ={wl}: got {got}, want {want}"
+
+    # Clamps outside the grid to the boundary samples.
+    assert abs(astroray.spectral_profile_reflectance(name, 300.0) - values[0]) < 1e-6
+    assert abs(astroray.spectral_profile_reflectance(name, 900.0) - values[-1]) < 1e-6
+    print("[C1 PASS] register_spectral_profile roundtrip + interpolation exact")
+
+
+def test_c1b_register_profile_overwrite_in_place():
+    """Re-registering the same runtime name overwrites its samples (no duplicate)."""
+    name = "__test__/pkg195c/overwrite"
+    assert astroray.register_spectral_profile(name, 500.0, 10.0, [0.1, 0.1, 0.1])
+    n_before = astroray.spectral_profile_names().count(name)
+    assert astroray.register_spectral_profile(name, 500.0, 10.0, [0.9, 0.9, 0.9])
+    assert astroray.spectral_profile_names().count(name) == n_before == 1
+    assert abs(astroray.spectral_profile_reflectance(name, 505.0) - 0.9) < 1e-6
+    print("[C1b PASS] overwrite in place, no duplicate name")
+
+
+# --------------------------------------------------------------------------- #
+# Shared render helper for the Replace-mode gates.
+# --------------------------------------------------------------------------- #
+
+def _replace_mode_channels(profile_name, spp=96, width=48, height=48):
+    """White sphere whose per-λ reflectance is `profile_name` in Replace mode,
+    lit by a white point lamp, visible band, CPU MW integrator. Returns per-channel
+    linear means."""
+    if HAS_PROFILES:
+        astroray.load_spectral_profiles(PROFILES_BIN)
+    r = astroray.Renderer()
+    r.set_use_gpu(False)
+    r.setup_camera(
+        look_from=[0, 0, 3], look_at=[0, 0, 0], vup=[0, 1, 0],
+        vfov=35, aspect_ratio=1.0, aperture=0.0, focus_dist=3.0,
+        width=width, height=height,
+    )
+    r.set_seed(195)
+    r.set_background_color([0.0, 0.0, 0.0])
+    mat = r.create_material("lambertian", [1.0, 1.0, 1.0], {})  # neutral white base
+    r.set_material_spectral_profile(mat, profile_name, True)     # Replace mode
+    r.add_sphere([0, 0, 0], 1.0, mat)
+    emission = {"mode": "rgb", "color": [1.0, 1.0, 1.0]}
+    r.add_point_light(position=[2.0, 2.0, 2.0], emission=emission,
+                      intensity=60.0, radius=0.0)
+    r.set_wavelength_range(380.0, 780.0)
+    r.set_integrator("multiwavelength_path_tracer")
+    pixels = np.array(r.render(spp, 6, None, False), dtype=np.float32)  # linear
+    return pixels.reshape(-1, 3).mean(axis=0)
+
+
+@pytest.mark.skipif(not HAS_PROFILES, reason="profiles.bin not found")
+def test_c2_preset_replace_mode_red_vs_green():
+    """C2: paint_red vs grass_green in Replace mode -> R-dominant vs G-dominant.
+    Anti-regression for the |Δmean|=0.00028 in-band no-op the old white-Disney
+    path produced (design doc §1.2)."""
+    red = _replace_mode_channels("paint_red")
+    green = _replace_mode_channels("grass_green")
+    print(f"[C2] paint_red   linear RGB = {red}")
+    print(f"[C2] grass_green linear RGB = {green}")
+    assert red[0] > red[1] and red[0] > red[2], f"paint_red not R-dominant: {red}"
+    assert green[1] > green[0] and green[1] > green[2], f"grass_green not G-dominant: {green}"
+    # The two renders must be clearly distinguishable — NOT the |Δmean|=0.00028
+    # no-op the old white-Disney path produced. Use relative signatures (the scene
+    # is intentionally dim): paint_red's R channel is far stronger than
+    # grass_green's, and grass_green's G/R ratio far exceeds paint_red's.
+    assert float(red[0]) > float(green[0]) * 1.5, (
+        f"C2 FAIL: paint_red R ({red[0]:.5f}) not >> grass_green R ({green[0]:.5f})")
+    red_gr = float(red[1]) / max(float(red[0]), 1e-6)
+    green_gr = float(green[1]) / max(float(green[0]), 1e-6)
+    assert green_gr > red_gr * 3.0, (
+        f"C2 FAIL: G/R signatures too similar (paint_red G/R={red_gr:.3f}, "
+        f"grass_green G/R={green_gr:.3f})")
+    # And the absolute R-channel delta is >15x the historical 0.00028 no-op.
+    assert abs(float(red[0] - green[0])) > 0.005, (
+        f"C2 FAIL: R-channel delta {abs(float(red[0]-green[0])):.5f} <= 0.005 "
+        f"(historical no-op was 0.00028)")
+    print(f"[C2 PASS] Replace-mode preset drives visible hue "
+          f"(paint_red G/R={red_gr:.3f} vs grass_green G/R={green_gr:.3f}, "
+          f"R-delta={abs(float(red[0]-green[0])):.5f})")
+
+
+def test_c5_drawn_spectrum_engine_equiv_green_bump():
+    """C5 (engine equivalent of the Drawn Spectrum curve): a narrow 550 nm bump SPD
+    registered at runtime and attached in Replace mode renders green-dominant vs a
+    flat SPD rendering neutral. This is the exact engine path the addon's Drawn
+    Spectrum node produces after sample_drawn_spectrum() + register_spectral_profile."""
+    lmin, step = 300.0, 5.0
+    n = int((1000.0 - lmin) / step) + 1
+    bump = []
+    flat = []
+    for i in range(n):
+        wl = lmin + i * step
+        # Gaussian-ish bump centered at 550 nm, width ~20 nm.
+        bump.append(float(np.exp(-((wl - 550.0) ** 2) / (2 * 20.0 ** 2))))
+        flat.append(0.6)
+    assert astroray.register_spectral_profile("__test__/pkg195c/bump550", lmin, step, bump)
+    assert astroray.register_spectral_profile("__test__/pkg195c/flat", lmin, step, flat)
+
+    green = _replace_mode_channels("__test__/pkg195c/bump550")
+    neutral = _replace_mode_channels("__test__/pkg195c/flat")
+    print(f"[C5] 550nm-bump  linear RGB = {green}")
+    print(f"[C5] flat SPD    linear RGB = {neutral}")
+    assert green[1] > green[0] and green[1] > green[2], f"550 bump not green-dominant: {green}"
+    # The flat SPD must be near-neutral (channels within 15% of each other).
+    mx, mn = float(neutral.max()), float(neutral.min())
+    assert (mx - mn) / max(mx, 1e-6) < 0.15, f"flat SPD not neutral: {neutral}"
+    print("[C5 PASS] drawn-equivalent 550 nm bump is green; flat SPD is neutral")
+
+
+# --------------------------------------------------------------------------- #
+# C3 — IR/UV Response non-destructiveness (ExtendOnly leaves visible identical)
+# --------------------------------------------------------------------------- #
+
+def _red_material_visible(with_band_profile, spp=64, width=48, height=48):
+    """Red lambertian sphere, visible band, CPU MW integrator. Optionally attach a
+    constant IR-band (700-1000 nm) profile in ExtendOnly mode (what the redesigned
+    IR/UV Response node does). Returns the raw pixel array."""
+    r = astroray.Renderer()
+    r.set_use_gpu(False)
+    r.setup_camera(
+        look_from=[0, 0, 3], look_at=[0, 0, 0], vup=[0, 1, 0],
+        vfov=35, aspect_ratio=1.0, aperture=0.0, focus_dist=3.0,
+        width=width, height=height,
+    )
+    r.set_seed(4242)
+    r.set_background_color([0.0, 0.0, 0.0])
+    mat = r.create_material("lambertian", [0.9, 0.1, 0.1], {})  # red base
+    if with_band_profile:
+        lmin, step = 300.0, 5.0
+        n = int((1000.0 - lmin) / step) + 1
+        band = [0.5 if 700.0 <= (lmin + i * step) <= 1000.0 else 0.0 for i in range(n)]
+        astroray.register_spectral_profile("__test__/pkg195c/iruv_band", lmin, step, band)
+        r.set_material_spectral_profile(mat, "__test__/pkg195c/iruv_band", False)  # ExtendOnly
+    r.add_sphere([0, 0, 0], 1.0, mat)
+    emission = {"mode": "rgb", "color": [1.0, 1.0, 1.0]}
+    r.add_point_light(position=[2.0, 2.0, 2.0], emission=emission,
+                      intensity=60.0, radius=0.0)
+    r.set_wavelength_range(380.0, 780.0)
+    r.set_integrator("multiwavelength_path_tracer")
+    return np.array(r.render(spp, 6, None, False), dtype=np.float32)
+
+
+def test_c3_iruv_extend_only_visible_identical():
+    """C3: an ExtendOnly IR-band profile (the redesigned IR/UV node) must NOT change
+    the visible render — byte-identical to the same red material without it."""
+    without = _red_material_visible(False)
+    with_band = _red_material_visible(True)
+    assert np.array_equal(without, with_band), (
+        "C3 FAIL: IR/UV ExtendOnly band profile changed the visible render "
+        f"(max abs diff {float(np.abs(without - with_band).max()):.3e})"
+    )
+    print("[C3 PASS] IR/UV ExtendOnly band profile is visible-band byte-identical")
+
+
+# --------------------------------------------------------------------------- #
+# C4 — Sellmeier manual B/C coefficients now drive dispersion
+# --------------------------------------------------------------------------- #
+
+def _prism_scene(glass_params, seed=17):
+    from scenes.prism_reference import (
+        WIDTH, HEIGHT, SAMPLES, MAX_DEPTH, _add_panel, add_triangular_prism,
+        red_blue_centroid_separation,
+    )
+    r = astroray.Renderer()
+    r.set_integrator("path_tracer")
+    r.set_background_color([0.8, 0.9, 1.0])
+    red = r.create_material("lambertian", [1.0, 0.05, 0.03], {})
+    white = r.create_material("lambertian", [0.92, 0.92, 0.90], {})
+    blue = r.create_material("lambertian", [0.03, 0.08, 1.0], {})
+    light = r.create_material("light", [1.0, 1.0, 1.0], {"intensity": 5.0})
+    _add_panel(r, red, -2.0, -0.4, -1.79)
+    _add_panel(r, white, -0.45, 0.45, -1.80)
+    _add_panel(r, blue, 0.4, 2.0, -1.78)
+    r.add_triangle([-1.5, 1.6, 1.5], [1.5, 1.6, 1.5], [1.5, 1.6, -1.2], light)
+    r.add_triangle([-1.5, 1.6, 1.5], [1.5, 1.6, -1.2], [-1.5, 1.6, -1.2], light)
+    glass = r.create_material("dielectric", [1.0, 1.0, 1.0], glass_params)
+    add_triangular_prism(r, glass)
+    r.setup_camera([0.0, 0.0, 4.2], [0.0, 0.0, 0.0], [0.0, 1.0, 0.0],
+                   38.0, 1.0, 0.0, 4.2, WIDTH, HEIGHT)
+    r.set_seed(seed)
+    pixels = np.asarray(r.render(SAMPLES, MAX_DEPTH, None, True), dtype=np.float32)
+    return pixels, red_blue_centroid_separation(pixels)
+
+
+def test_c4_sellmeier_manual_bc_matches_preset(test_results_dir):
+    """C4: manual BK7 B/C (no preset) reproduces the bk7 preset's prism dispersion.
+    Before Stage C, sellmeier_b/sellmeier_c were exported but no engine code read
+    them (silent no-op); the manual-coefficient UI did nothing."""
+    from base_helpers import save_image
+    preset_px, preset_sep = _prism_scene({"sellmeier_preset": "bk7"})
+    manual_px, manual_sep = _prism_scene({"sellmeier_b": BK7_B, "sellmeier_c": BK7_C})
+    save_image(preset_px, os.path.join(test_results_dir, "pkg195c_prism_bk7_preset.png"))
+    save_image(manual_px, os.path.join(test_results_dir, "pkg195c_prism_bk7_manual.png"))
+    print(f"[C4] bk7 preset red/blue separation = {preset_sep:.3f}px")
+    print(f"[C4] manual B/C  red/blue separation = {manual_sep:.3f}px")
+    # Manual coefficients must produce real dispersion (a flat-IOR glass gives a
+    # much smaller separation), and match the preset within 2%.
+    assert manual_sep > 1.0, f"C4 FAIL: manual B/C produced no dispersion ({manual_sep:.3f}px)"
+    rel = abs(manual_sep - preset_sep) / max(preset_sep, 1e-6)
+    assert rel < 0.02, (
+        f"C4 FAIL: manual B/C separation {manual_sep:.3f} vs preset {preset_sep:.3f} "
+        f"differ {rel*100:.2f}% (> 2%)"
+    )
+    print(f"[C4 PASS] manual Sellmeier B/C matches bk7 preset within {rel*100:.2f}%")

--- a/tests/test_pkg195_stage_c.py
+++ b/tests/test_pkg195_stage_c.py
@@ -77,6 +77,46 @@ def test_c1b_register_profile_overwrite_in_place():
     print("[C1b PASS] overwrite in place, no duplicate name")
 
 
+def test_c1c_register_clamps_reflectance_to_unit_range():
+    """PR #610 review hardening: values passed to register_spectral_profile are
+    clamped to the documented [0,1] reflectance range at registration, so a >1
+    curve cannot inject energy in ProfileMode::Replace. Stored samples clamp; a
+    negative clamps to 0."""
+    name = "__test__/pkg195c/hot"
+    # 2.0 everywhere over 300..1000 nm — a physically-impossible reflectance.
+    n = int((1000.0 - 300.0) / 5.0) + 1
+    assert astroray.register_spectral_profile(name, 300.0, 5.0, [2.0] * n)
+    for wl in (300.0, 550.0, 999.0):
+        r = astroray.spectral_profile_reflectance(name, wl)
+        assert r <= 1.0 + 1e-6, f"λ={wl}: stored reflectance {r} not clamped to <= 1"
+        assert abs(r - 1.0) < 1e-6, f"λ={wl}: expected clamp to 1.0, got {r}"
+    neg = "__test__/pkg195c/neg"
+    assert astroray.register_spectral_profile(neg, 300.0, 5.0, [-0.5] * n)
+    assert astroray.spectral_profile_reflectance(neg, 550.0) >= 0.0
+    print("[C1c PASS] register clamps reflectance samples to [0,1]")
+
+
+def test_c1d_replace_energy_bounded_by_clamp():
+    """The clamp keeps a Replace-mode render's energy bounded: a would-be >1
+    reflectance profile renders no brighter than a =1 profile (both clamp to 1),
+    and stays finite."""
+    if not HAS_PROFILES:
+        import pytest as _pytest
+        _pytest.skip("profiles.bin not found")
+    n = int((1000.0 - 300.0) / 5.0) + 1
+    astroray.register_spectral_profile("__test__/pkg195c/unit", 300.0, 5.0, [1.0] * n)
+    astroray.register_spectral_profile("__test__/pkg195c/over", 300.0, 5.0, [5.0] * n)
+    unit = _replace_mode_channels("__test__/pkg195c/unit")
+    over = _replace_mode_channels("__test__/pkg195c/over")
+    assert np.all(np.isfinite(over)), f"over-unit render non-finite: {over}"
+    # Clamped to identical stored data -> per-channel means match (same RNG seed).
+    assert np.allclose(unit, over, atol=1e-5), (
+        f"C1d FAIL: >1 profile ({over}) not bounded to =1 profile ({unit}) — clamp "
+        f"did not hold"
+    )
+    print(f"[C1d PASS] Replace energy bounded by clamp (unit={unit}, over={over})")
+
+
 # --------------------------------------------------------------------------- #
 # Shared render helper for the Replace-mode gates.
 # --------------------------------------------------------------------------- #

--- a/tests/test_pkg195_stage_c_routing.py
+++ b/tests/test_pkg195_stage_c_routing.py
@@ -1,0 +1,60 @@
+"""pkg195 Stage C — addon integrator-routing for Replace-mode spectra (stub-bpy).
+
+A Replace-mode authored spectrum (Drawn / Spectrum Preset / Spectral Profile
+source node wired to a Surface) is only consulted per-λ by the multiwavelength
+integrator; the default path_tracer never calls evalSpectralExt. render() must
+therefore route a visible-band CPU render to the MW integrator when such a
+material is present — otherwise the authored reflectance is a visible no-op (the
+pkg57 failure Stage C fixes). This test pins the pure routing decision.
+
+GPU keeps its integrator (Replace is CPU-exact; the GPU MW leg is the
+light-sampling-blind naive oracle per the enableNEE contract).
+"""
+from test_blender_backend_policy import _load_blender_addon
+
+
+class _NullRenderer:
+    def __init__(self, *a, **k):
+        pass
+
+
+def _addon(monkeypatch):
+    return _load_blender_addon(monkeypatch, _NullRenderer)
+
+
+def test_route_cpu_visible_replace_switches_to_mw(monkeypatch):
+    addon = _addon(monkeypatch)
+    assert addon._route_replace_to_mw(
+        has_replace_profile=True, is_outside_visible=False,
+        active_device="cpu", integrator_name="path_tracer") is True
+
+
+def test_route_gpu_replace_keeps_integrator(monkeypatch):
+    addon = _addon(monkeypatch)
+    # GPU: do NOT route to the naive MW oracle (would render darker); degradation
+    # report notes the approximation instead.
+    assert addon._route_replace_to_mw(
+        has_replace_profile=True, is_outside_visible=False,
+        active_device="gpu", integrator_name="path_tracer") is False
+
+
+def test_route_no_replace_profile_keeps_integrator(monkeypatch):
+    addon = _addon(monkeypatch)
+    assert addon._route_replace_to_mw(
+        has_replace_profile=False, is_outside_visible=False,
+        active_device="cpu", integrator_name="path_tracer") is False
+
+
+def test_route_outside_visible_already_mw(monkeypatch):
+    addon = _addon(monkeypatch)
+    # Non-visible band already selects the MW integrator upstream; no override.
+    assert addon._route_replace_to_mw(
+        has_replace_profile=True, is_outside_visible=True,
+        active_device="cpu", integrator_name="multiwavelength_path_tracer") is False
+
+
+def test_route_already_mw_no_double_switch(monkeypatch):
+    addon = _addon(monkeypatch)
+    assert addon._route_replace_to_mw(
+        has_replace_profile=True, is_outside_visible=False,
+        active_device="cpu", integrator_name="multiwavelength_path_tracer") is False


### PR DESCRIPTION
## What shipped

pkg195 **Stage C** — makes spectral authoring real end-to-end (design doc §3). Stages A+B landed in #602; this is Stage C only. All 7 spec items:

1. **`astroray.register_spectral_profile(name, lmin, step, values)`** — pointer-stable **deque** storage in `SpectralProfileDatabase` (materials cache `SpectralProfile*` across a render; a `push_back` must never dangle them). Overwrites a runtime name in place; `names()`/`get()` search runtime profiles too. Participates in material attach, emission MeasuredSPD, and the existing pointer-based GPU profile-table upload unchanged.
2. **Drawn Spectrum node** — the owner's headline "draw exactly which wavelengths to emit/absorb" control. Blender-native `CurveMapping` via a hidden `ShaderNodeFloatCurve` in a private node group (design doc §3.4). Export: evaluate at 5 nm → `register_spectral_profile`.
3. **Spectrum Preset node** — two-tier (category → preset) source, reflectance vs emission filtered; the old Spectral Profile node stays registered for .blend compat and now routes through the same Replace path.
4. **Blackbody Spectrum node** + **Bake-to-Profile operator** (Planck at 5 nm, optional peak-normalize) feeding a light's Custom Profile mode.
5. **In-band Replace mode** — `ProfileMode::{ExtendOnly,Replace}` on `setSpectralProfile`. Replace drives all λ via `profile->reflectance(λ)·cosθ/π`, **bypassing the Jakob-Hanika RGB round trip** (design doc §3.1 principle 2). Source nodes wired to a Surface set Replace; the pkg58 material-panel fallback stays ExtendOnly. The addon routes a visible-band **CPU** render with a Replace material to the multiwavelength integrator (the only in-band `evalSpectralExt` caller — the pkg57 no-op fix). **GPU keeps its integrator + a one-line degradation note** (Replace is CPU-exact; the `enableNEE` naive-oracle contract at `blender_module.cpp:1822` is untouched — routing GPU to the naive MW leg would only render darker).
6. **IR/UV Response de-fanged** — base BSDF converts normally, node only attaches a constant-band ExtendOnly profile; visible render **byte-identical**. Destructive grey-Disney promotion deleted.
7. **Sellmeier manual B/C** now read in `dielectric.cpp` when no preset (were silently dropped since pkg57).

## Authorized surface

Spec Specification/Stage-C touches: `include/astroray/spectral_profile.h`, `include/raytracer.h`, `module/blender_module.cpp`, `plugins/materials/dielectric.cpp`, `blender_addon/`, (referenced) `src/gpu/scene_upload.cu`.

Changed: those + `src/spectral_profile.cpp` (implements the item-1 insert method declared in the header) + `blender_addon/nodes/__init__.py` (the new nodes) + tests + spec status. **Not touched** (justified scope reductions): `multiwavelength_path_tracer.cpp` — Stage A already gave it dedicated-light NEE and it already calls `evalSpectralExt`/`sampleSpectralExt`, so Replace flows through unchanged; `src/gpu/scene_upload.cu` — runtime profiles upload via the existing `getSpectralProfile()` pointer path, and Replace is CPU-only by design (GPU degradation documented). **Beyond the literal item list, within `blender_addon/`:** the visible-band→MW integrator routing (`_route_replace_to_mw`) and the Bake-to-Profile operator — both required to make items 5 and 4 actually functional through the addon; flagged to and approved by the coordinator.

## Acceptance — Gate C (CPU, sm_120 build)

- [x] **C1** `register_spectral_profile` roundtrip: `names()` lists it; reflectance interpolation exact vs numpy `interp`; boundary clamps; overwrite-in-place (no duplicate name).
- [x] **C2** paint_red vs grass_green Replace mode, visible CPU render: paint_red R=0.0152 ≫ G=0.0012 (R-dominant); grass_green G=0.0050 > R=0.0049 (G-dominant); G/R signatures 3×+ apart — anti-regression for the |Δmean|=0.00028 no-op.
- [x] **C3** IR/UV ExtendOnly band profile: visible render **byte-identical** (`np.array_equal`) to the base with no node.
- [x] **C4** manual BK7 B/C (preset off) vs `bk7` preset prism dispersion: red/blue centroid separation **6.350px vs 6.350px (0.00%)**, well within 2%.
- [x] **C5** drawn-equivalent 550 nm bump SPD (Replace) green-dominant; flat SPD neutral.
- [x] **Drawn Spectrum headless Blender 5.1 end-to-end** (CPU, OpenMP-off build): 550 nm bump curve → G=0.4396 > R=0.2642 > B=0.0003 (clean green sphere PNG); flat curve neutral (span 0.009); MW-routing degradation note confirmed fired.
- [x] **No regression**: Stage A/B (6) + 10 GPU-parity gates **16/16 unchanged** (`enable_nee` contract intact); broader spectral/dielectric/backend suites **87 passed**.

### PNG evidence (inspected)
`test_results/pkg195c_drawn_550bump.png` (clean green sphere — the drawn 550 nm reflectance), `test_results/pkg195c_drawn_flat.png` (neutral), `test_results/pkg195c_prism_bk7_manual.png` / `_preset.png`.

## Algorithm sourcing (CLAUDE.md §6)
Tabulated-SPD linear interpolation cites PBRT-v4 `PiecewiseLinearSpectrum` (Apache-2.0). Planck + photopic-normalization reference is pkg122 (`src/emission_spectrum.cpp`; the node's `normalize` is a simpler peak-normalization for relative emission authoring — documented inline). Jakob-Hanika upsampling unchanged (only bypassed in Replace).

## Build (root `build_cuda_worktree.bat`, sm_120, last 5 lines)
```
[pkg183] running host-only ABI canary (no GPU)...
[pkg183] canary caps: {'cpu': True, 'spectral': True, 'gpu': True, 'gpu_spectral': True, 'gpu_approximate': False, 'closure_graph': True, 'closure_count': 1, 'gpu_type': 'closure_graph', 'notes': 'spectral closure-graph GPU lowering'}

========================================
Build succeeded
========================================
```
Arch gate: `arch-verify OK: astroray.cp313-win_amd64.pyd embeds sm_120`. The headless Blender render additionally used an OpenMP-off `build_noomp` (per the pkg119b runbook — the addon refuses CPU render on an OpenMP-linked `.pyd`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)