### PR TITLE
feat(pkg190): GPU procedural texture support — 3D-voxel bake-at-upload (checker/brick/wave/magic)

### DIFF
--- a/.astroray_plan/packages/pkg190-gpu-procedural-texture-support.md
+++ b/.astroray_plan/packages/pkg190-gpu-procedural-texture-support.md
@@ -2,10 +2,14 @@
 
 **Pillar:** 5 / integration-first
 **Track:** A
-**Status:** open (filed 2026-08-12 as the pkg186 deferred follow-up; pkg186
-PR #590 shipped the IMAGE-texture slice and explicitly deferred procedural
-nodes + the pkg119-B procedural reclassification — see pkg186 Lessons
-"Deferred to follow-up").
+**Status:** done (PR #TBD, 2026-08-14 — 3D-voxel bake-at-upload GPU procedural
+eval; pkg119-B TRANSLATION-BUG 4→0: TEX_CHECKER 0.8425→0.9512, TEX_BRICK
+0.8980→0.9158, TEX_MAGIC 0.8358→0.9639, TEX_WAVE 0.8935→0.9575, all at 64³;
+register identity gate byte-identical across all 16 shade specializations;
+textured_plane CPU/GPU mean-ratio 1.000/1.000/1.000).
+Filed 2026-08-12 as the pkg186 deferred follow-up; pkg186 PR #590 shipped the
+IMAGE-texture slice and explicitly deferred procedural nodes + the pkg119-B
+procedural reclassification — see pkg186 Lessons "Deferred to follow-up".
 **Estimated effort:** L
 **Depends on:** pkg186 (PR #590 — image-texture slice; establishes the
 `__constant__ c_wfTexBinding` binding, the `<HasPrincipled,HasTexture>`

--- a/.astroray_plan/packages/pkg190-gpu-procedural-texture-support.md
+++ b/.astroray_plan/packages/pkg190-gpu-procedural-texture-support.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 5 / integration-first
 **Track:** A
-**Status:** done (PR #TBD, 2026-08-14 — 3D-voxel bake-at-upload GPU procedural
+**Status:** done (PR #612, 2026-08-14 — 3D-voxel bake-at-upload GPU procedural
 eval; pkg119-B TRANSLATION-BUG 4→0: TEX_CHECKER 0.8425→0.9512, TEX_BRICK
 0.8980→0.9158, TEX_MAGIC 0.8358→0.9639, TEX_WAVE 0.8935→0.9575, all at 64³;
 register identity gate byte-identical across all 16 shade specializations;

--- a/include/advanced_features.h
+++ b/include/advanced_features.h
@@ -173,6 +173,14 @@ public:
         hasGenBBox_ = true;
     }
     CoordMode getCoordMode() const { return coordMode; }
+    // pkg190 — read-only bbox accessors so the GPU scene-upload (scene_upload.cu)
+    // can bake a Generated/Object-coord procedural into a 3D voxel buffer and
+    // hand the GPU sampler the same (genMin, genSize) frame this class uses to
+    // build the normalized Generated coordinate (see the CoordMode::Generated
+    // branch above: g = clamp((objectPoint - genMin_) / genSize_, 0, 1)).
+    bool hasGeneratedBBox() const { return hasGenBBox_; }
+    Vec3 getGeneratedMin()  const { return genMin_; }
+    Vec3 getGeneratedSize() const { return genSize_; }
     // pkg59 follow-up: apply Mapping(Location, Rotation.z, Scale) at sample
     // time. 4-arg overload kept for backward compat (rotation defaults to 0).
     void setUVTransform(float sx, float sy, float ox, float oy) {

--- a/include/astroray/gpu_types.h
+++ b/include/astroray/gpu_types.h
@@ -592,6 +592,16 @@ struct GImageTexture {
     int offset;   // start index into the flat texel buffer
     int width;
     int height;
+    // pkg190 — procedural-texture slice. depth == 1 → a 2D image (or a 2D-UV
+    // procedural bake), sampled by (u,v) via gpu_sampleImageTexture (the pkg186
+    // path, unchanged). depth > 1 → a 3D voxel bake of a Generated/Object-coord
+    // procedural, sampled by the normalized Generated coordinate via
+    // gpu_sampleProcedural3D. genMin/genSize carry the SAME object-space bbox the
+    // CPU Texture uses (Texture::getGeneratedMin/Size) so the GPU rebuilds the
+    // identical g = clamp((objectPoint - genMin)/genSize, 0, 1).
+    int   depth   = 1;
+    GVec3 genMin  = GVec3(0.f, 0.f, 0.f);
+    GVec3 genSize = GVec3(1.f, 1.f, 1.f);
 };
 
 // pkg186 — wavefront image-texture binding. Published ONCE per frame into a
@@ -658,6 +668,29 @@ HD inline GVec3 gpu_sampleImageTexture(const GImageTexture& tex,
     if (i > tex.width  - 1) i = tex.width  - 1;
     if (j > tex.height - 1) j = tex.height - 1;
     return texels[tex.offset + j * tex.width + i];
+}
+
+// pkg190 — nearest-neighbour 3D voxel fetch for a baked Generated/Object-coord
+// procedural. `g` is the normalized Generated coordinate in [0,1]^3, built by
+// the caller EXACTLY as the CPU does (g = clamp((objectPoint - genMin)/genSize,
+// 0, 1); include/advanced_features.h CoordMode::Generated). The bake stores cell
+// CENTERS (value at (idx+0.5)/res), so a floor(g*res) fetch returns the cell
+// containing g — the point-sampled twin of the CPU's continuous evaluation.
+// Filtering is parity-coupled: the CPU procedural is point-sampled per shade, so
+// the GPU point-samples the same grid. Do NOT add GPU-only trilinear filtering
+// unless the CPU sampler gains it in lockstep (pkg186 Decision 2; pkg190).
+HD inline GVec3 gpu_sampleProcedural3D(const GImageTexture& tex,
+                                       const GVec3* texels, GVec3 g) {
+    float gx = g.x < 0.f ? 0.f : (g.x > 1.f ? 1.f : g.x);
+    float gy = g.y < 0.f ? 0.f : (g.y > 1.f ? 1.f : g.y);
+    float gz = g.z < 0.f ? 0.f : (g.z > 1.f ? 1.f : g.z);
+    int i = (int)(gx * (float)tex.width);
+    int j = (int)(gy * (float)tex.height);
+    int k = (int)(gz * (float)tex.depth);
+    if (i > tex.width  - 1) i = tex.width  - 1;
+    if (j > tex.height - 1) j = tex.height - 1;
+    if (k > tex.depth  - 1) k = tex.depth  - 1;
+    return texels[tex.offset + (k * tex.height + j) * tex.width + i];
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/run_parity.py
+++ b/scripts/run_parity.py
@@ -39,6 +39,10 @@ CSV_COLUMNS = [
     "time_ms",
     "peak_mem_mb",
     "ssim_to_cycles",
+    # pkg190 — per-channel astroray CPU-vs-GPU mean-ratio ("r,g,b"). The standing
+    # oracle for the textured_plane procedural scene (never SSIM: independent RNG
+    # streams — [[ssim-wrong-gate-for-independent-rng]]).
+    "mean_ratio_cpu_gpu",
     "skip_reason",
 ]
 ENGINES = ("cycles-cpu", "cycles-cuda", "astroray-cpu", "astroray-gpu")
@@ -93,6 +97,14 @@ class Scene:
 def _load_scenes() -> dict[str, Scene]:
     scenes = {
         "cornell": Scene("cornell", samples=64, width=512, height=512, astroray_scene_id=1),
+        # pkg190 — standing procedural-texture parity scene: a UV-mapped checker
+        # quad + diffuse floor + one area (emissive-quad) light, built natively
+        # from a Python scene-spec so both the astroray CPU and GPU legs render it.
+        # Oracle is the per-channel CPU/GPU mean-ratio (Cycles legs are skipped;
+        # the procedural bake's parity target is CPU==GPU, not a hand-matched
+        # Cycles checker).
+        "textured_plane": Scene("textured_plane", samples=64, width=256,
+                                height=256, astroray_scene_id=2),
     }
     if MANIFEST.exists():
         with MANIFEST.open("rb") as fh:
@@ -284,6 +296,52 @@ bpy.ops.render.render(write_still=True)
 """
 
 
+def _astroray_textured_plane_script(scene: Scene, output: Path, device: str) -> str:
+    """pkg190 — UV-mapped procedural checker quad + diffuse floor + one area
+    (emissive-quad) light, built natively so the astroray CPU and GPU legs render
+    the identical scene. The checker is a UV-coord-mode procedural, so it drives
+    the pkg190 2D UV bake (the pkg186 image path). Oracle is CPU/GPU mean-ratio."""
+    return f"""
+import os
+os.environ.setdefault('OPENCV_IO_ENABLE_OPENEXR', '1')
+import imageio.v3 as iio
+import numpy as np
+import astroray
+
+r = astroray.Renderer()
+if {device == 'gpu'!r}:
+    r.set_use_gpu(True)
+r.set_seed(1)
+r.set_background_color([0.25, 0.25, 0.25])
+
+# Low-frequency UV checker (procedural, UV coord mode -> pkg190 2D bake).
+r.create_procedural_texture("chk", "checker",
+    [0.9, 0.15, 0.15, 0.15, 0.15, 0.9, 6.0], "UV")
+checker = r.create_material("lambertian", [0.8, 0.8, 0.8], {{"texture": "chk"}})
+floor_mat = r.create_material("lambertian", [0.6, 0.6, 0.6], {{}})
+light_mat = r.create_material("light", [1.0, 0.95, 0.9], {{"intensity": 8.0}})
+
+# Checker quad (UV [0,1]^2) standing at z=0, facing +Z toward the camera.
+n = [0, 0, 1]
+A, B, C, D = [-1.5, -1.5, 0], [1.5, -1.5, 0], [1.5, 1.5, 0], [-1.5, 1.5, 0]
+r.add_triangle_layers(A, B, C, checker, {{"UVMap": [[0, 0], [1, 0], [1, 1]]}}, n, n, n)
+r.add_triangle_layers(A, C, D, checker, {{"UVMap": [[0, 0], [1, 1], [0, 1]]}}, n, n, n)
+
+# Diffuse floor below.
+r.add_triangle([-4, -1.6, -2], [4, -1.6, -2], [4, -1.6, 2], floor_mat)
+r.add_triangle([-4, -1.6, -2], [4, -1.6, 2], [-4, -1.6, 2], floor_mat)
+
+# One area light (emissive quad), above-front, facing down toward the checker.
+r.add_triangle([-1, 2.5, 1.5], [1, 2.5, 1.5], [1, 2.5, 0.5], light_mat)
+r.add_triangle([-1, 2.5, 1.5], [1, 2.5, 0.5], [-1, 2.5, 0.5], light_mat)
+
+r.setup_camera([0, 0, 4.5], [0, 0, 0], [0, 1, 0], 40.0,
+               {scene.width / scene.height!r}, 0.01, 4.5, {scene.width}, {scene.height})
+pixels = np.asarray(r.render({scene.samples}, 8, None, False), dtype=np.float32)
+iio.imwrite({str(output)!r}, pixels)
+"""
+
+
 def _astroray_blend_script(scene: Scene, output: Path, device: str) -> str:
     """Render template for `.blend` scenes via pkg76's importer.
 
@@ -325,6 +383,8 @@ def _astroray_script(scene: Scene, output: Path, device: str) -> str:
         from the .blend file. The pkg71 manifest's ``reference_spp`` /
         resolution drive the render call.
     """
+    if scene.scene_id == "textured_plane":
+        return _astroray_textured_plane_script(scene, output, device)
     if scene.scene_id != "cornell":
         if scene.blend_path is None:
             raise ValueError(f"scene {scene.scene_id!r} has no .blend path")
@@ -449,6 +509,35 @@ def _ssim(output: Path, reference: Path) -> str:
         return ""
 
 
+def _mean_ratio(output: Path, reference: Path) -> str:
+    """pkg190 — per-channel mean-ratio (output/reference), as "r,g,b". The
+    procedural CPU/GPU parity oracle: robust to independent-RNG MC noise (which
+    windowed SSIM is not — [[ssim-wrong-gate-for-independent-rng]])."""
+    if not output.exists() or not reference.exists():
+        return ""
+    try:
+        import os
+        os.environ.setdefault('OPENCV_IO_ENABLE_OPENEXR', '1')
+        import imageio.v3 as iio  # type: ignore
+        import numpy as np  # type: ignore
+
+        a = iio.imread(output).astype("float64")[..., :3]
+        b = iio.imread(reference).astype("float64")[..., :3]
+        if a.shape != b.shape:
+            return ""
+        am = a.reshape(-1, 3).mean(axis=0)
+        bm = b.reshape(-1, 3).mean(axis=0)
+        parts = [f"{(am[c] / bm[c]) if bm[c] > 1e-9 else float('nan'):.4f}"
+                 for c in range(3)]
+        return ",".join(parts)
+    except Exception:
+        return ""
+
+
+def _astroray_cpu_ref(scene: Scene) -> Path:
+    return REFS / f"{scene.scene_id}-astroray-cpu-{scene.samples}.exr"
+
+
 def _run_tuple(
     scene: Scene,
     engine: str,
@@ -457,6 +546,12 @@ def _run_tuple(
     runs: int,
     timeout: int,
 ) -> dict[str, str]:
+    # pkg190 — textured_plane's oracle is astroray CPU-vs-GPU mean-ratio; it has
+    # no hand-matched Cycles scene, so the Cycles legs are intentionally skipped.
+    if scene.scene_id == "textured_plane" and engine.startswith("cycles"):
+        return _row(scene, engine,
+                    skip_reason="textured_plane oracle is CPU/GPU mean-ratio "
+                                "(no Cycles leg)")
     RESULTS.mkdir(parents=True, exist_ok=True)
     suffix = ".exr"
     with tempfile.TemporaryDirectory(prefix=f"{scene.scene_id}-{engine}-", dir=RESULTS) as tmp:
@@ -489,12 +584,22 @@ def _run_tuple(
             ssim = "1.000000"
         else:
             ssim = _ssim(final_output, ref)
+        # pkg190 — CPU/GPU mean-ratio oracle: astroray-cpu stores a reference,
+        # astroray-gpu ratios against it (the loop runs cpu before gpu).
+        mean_ratio = ""
+        if engine == "astroray-cpu":
+            cpu_ref = _astroray_cpu_ref(scene)
+            cpu_ref.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(final_output, cpu_ref)
+        elif engine == "astroray-gpu":
+            mean_ratio = _mean_ratio(final_output, _astroray_cpu_ref(scene))
         return _row(
             scene,
             engine,
             time_ms=f"{statistics.median(times):.3f}",
             peak_mem_mb=f"{max(mem, default=0.0):.1f}" if any(mem) else "",
             ssim_to_cycles=ssim,
+            mean_ratio_cpu_gpu=mean_ratio,
         )
 
 
@@ -505,6 +610,7 @@ def _row(
     time_ms: str = "",
     peak_mem_mb: str = "",
     ssim_to_cycles: str = "",
+    mean_ratio_cpu_gpu: str = "",
     skip_reason: str = "",
 ) -> dict[str, str]:
     skip_reason = " ".join(skip_reason.splitlines())
@@ -515,6 +621,7 @@ def _row(
         "time_ms": time_ms,
         "peak_mem_mb": peak_mem_mb,
         "ssim_to_cycles": ssim_to_cycles,
+        "mean_ratio_cpu_gpu": mean_ratio_cpu_gpu,
         "skip_reason": skip_reason,
     }
 
@@ -574,8 +681,20 @@ def main(argv: list[str] | None = None) -> int:
         gate = 0.95 if row["scene"] == "cornell" else 0.85
         if float(row["ssim_to_cycles"]) < gate:
             failed.append(f"{row['scene']}/{row['engine']}={row['ssim_to_cycles']} (<{gate})")
+    # pkg190 — textured_plane CPU/GPU per-channel mean-ratio gate (never SSIM;
+    # band mirrors the pkg119-B / pkg186 CPU-vs-GPU parity-band tolerance).
+    for row in rows:
+        if row["scene"] != "textured_plane" or row["engine"] != "astroray-gpu":
+            continue
+        if row["skip_reason"] or not row["mean_ratio_cpu_gpu"]:
+            failed.append("textured_plane/astroray-gpu missing CPU/GPU mean-ratio")
+            continue
+        ratios = [float(x) for x in row["mean_ratio_cpu_gpu"].split(",")]
+        if any(not (0.85 <= rc <= 1.18) for rc in ratios):
+            failed.append(
+                f"textured_plane CPU/GPU mean-ratio {ratios} out of band [0.85,1.18]")
     if failed:
-        print("SSIM gate failed: " + ", ".join(failed), file=sys.stderr)
+        print("Parity gate failed: " + ", ".join(failed), file=sys.stderr)
         return 1
     return 0
 

--- a/scripts/run_parity.py
+++ b/scripts/run_parity.py
@@ -444,9 +444,9 @@ def _render_once(
         return _run_command([blender, "--background", "--python", str(script)], ROOT, timeout)
 
     # Astroray engines.
-    if scene.scene_id == "cornell" or scene.blend_path is not None:
-        # Cornell uses the in-script Python scene; .blend scenes go through
-        # pkg76's importer (`tools.blend_import.import_blend`).
+    if scene.scene_id in ("cornell", "textured_plane") or scene.blend_path is not None:
+        # Cornell and pkg190's textured_plane use in-script Python scene-specs;
+        # .blend scenes go through pkg76's importer (`tools.blend_import.import_blend`).
         if scene.blend_path is not None and not scene.blend_path.exists():
             return 0.0, 0.0, "scene_blend_not_found"
         device = "gpu" if engine == "astroray-gpu" else "cpu"
@@ -509,6 +509,26 @@ def _ssim(output: Path, reference: Path) -> str:
         return ""
 
 
+def _read_exr_float(path: Path):
+    """Read a linear float EXR as an (H,W,3) float64 RGB array. Uses OpenCV
+    (IMREAD_UNCHANGED) — imageio 2.37's default EXR plugin silently returns
+    uint8 with a zeroed channel for these files, which nan-poisons a mean-ratio;
+    cv2 returns the true float32 data (verified). cv2 reads BGR, so reverse to
+    RGB. Returns None on failure."""
+    import os
+    os.environ.setdefault('OPENCV_IO_ENABLE_OPENEXR', '1')
+    import numpy as np  # type: ignore
+    import cv2  # type: ignore
+
+    img = cv2.imread(str(path), cv2.IMREAD_UNCHANGED)
+    if img is None:
+        return None
+    img = np.asarray(img, dtype="float64")
+    if img.ndim != 3 or img.shape[2] < 3:
+        return None
+    return img[..., 2::-1]  # BGR(A) -> RGB
+
+
 def _mean_ratio(output: Path, reference: Path) -> str:
     """pkg190 — per-channel mean-ratio (output/reference), as "r,g,b". The
     procedural CPU/GPU parity oracle: robust to independent-RNG MC noise (which
@@ -516,14 +536,9 @@ def _mean_ratio(output: Path, reference: Path) -> str:
     if not output.exists() or not reference.exists():
         return ""
     try:
-        import os
-        os.environ.setdefault('OPENCV_IO_ENABLE_OPENEXR', '1')
-        import imageio.v3 as iio  # type: ignore
-        import numpy as np  # type: ignore
-
-        a = iio.imread(output).astype("float64")[..., :3]
-        b = iio.imread(reference).astype("float64")[..., :3]
-        if a.shape != b.shape:
+        a = _read_exr_float(output)
+        b = _read_exr_float(reference)
+        if a is None or b is None or a.shape != b.shape:
             return ""
         am = a.reshape(-1, 3).mean(axis=0)
         bm = b.reshape(-1, 3).mean(axis=0)

--- a/src/gpu/scene_upload.cu
+++ b/src/gpu/scene_upload.cu
@@ -703,11 +703,13 @@ SceneUploadResult buildSceneArrays(const Renderer& cpu, const Camera* cam) {
         // an ImageTexture) into the flat device texel buffer and record its id in
         // the per-material parallel array. Keeps materialTextureId[] index-aligned
         // with materials[] (a -1 sentinel for every non-image material preserves
-        // the untextured flat-albedo fast path). Procedural textures are a
-        // follow-up slice — they are not TexturedLambertian/ImageTexture here.
+        // the untextured flat-albedo fast path). pkg190 extends this to bake
+        // PROCEDURAL textures (also TexturedLambertian, non-ImageTexture) into the
+        // same buffer — 3D voxel for Generated/Object coords, 2D for UV.
         int texId = -1;
         if (auto* tl = dynamic_cast<TexturedLambertian*>(m.get())) {
-            if (auto img = std::dynamic_pointer_cast<ImageTexture>(tl->getTexture())) {
+            std::shared_ptr<Texture> tex = tl->getTexture();
+            if (auto img = std::dynamic_pointer_cast<ImageTexture>(tex)) {
                 if (!img->getData().empty()) {
                     auto tit = texIdx.find(img.get());
                     if (tit != texIdx.end()) {
@@ -727,7 +729,95 @@ SceneUploadResult buildSceneArrays(const Renderer& cpu, const Camera* cam) {
                     }
                     r.hasTexture = true;
                 }
+            } else if (tex) {
+                // pkg190 — bake a PROCEDURAL base-colour texture (checker / brick /
+                // wave / magic / …) into the flat device texel buffer, then reuse
+                // the pkg186 fetch machinery. Two domains, matching how the CPU
+                // Texture evaluates the node (include/advanced_features.h
+                // Texture::textureCoordinates):
+                //   * Generated / Object coord mode → the node is a 3D field over
+                //     the object's normalized bbox → bake a res^3 VOXEL grid in
+                //     [0,1]^3 (the same space the CPU passes as `p`), sampled on the
+                //     GPU by the Generated coordinate (gpu_sampleProcedural3D).
+                //   * UV coord mode → the node is a 2D field of (u,v) → bake a res^2
+                //     grid sampled by the pkg186 2D UV path (depth == 1).
+                // The bake calls the material's OWN CPU evaluator, so parity is
+                // exact-by-construction modulo grid resolution (no procedural math
+                // is re-derived on the device — cite-algorithm safe).
+                Texture* key = tex.get();
+                auto tit = texIdx.find(key);
+                if (tit != texIdx.end()) {
+                    texId = tit->second;
+                    r.hasTexture = true;
+                } else {
+                    const bool uvMode =
+                        tex->getCoordMode() == Texture::CoordMode::UV;
+                    // pkg190 default bake resolution; escalate a specific high-
+                    // frequency node only if its parity/SSIM gate demands it.
+                    int res = 64;
+                    GImageTexture desc;
+                    desc.offset = (int)r.textureTexels.size();
+                    desc.width  = res;
+                    desc.height = res;
+                    if (uvMode) {
+                        desc.depth = 1;  // 2D UV field → pkg186 image path verbatim
+                        r.textureTexels.reserve(r.textureTexels.size() +
+                                                (size_t)res * res);
+                        // Bake row j at v = 1 - (j+0.5)/res so the GPU 2D fetch
+                        // (which v-flips, mirroring CPU ImageTexture::value) round-
+                        // trips to value(u, v) exactly.
+                        for (int j = 0; j < res; ++j) {
+                            float v = 1.0f - (j + 0.5f) / res;
+                            for (int i = 0; i < res; ++i) {
+                                float u = (i + 0.5f) / res;
+                                Vec3 c = tex->value(Vec2(u, v), Vec3(u, v, 0.0f));
+                                r.textureTexels.push_back(GVec3(c.x, c.y, c.z));
+                            }
+                        }
+                    } else {
+                        // Generated / Object 3D voxel bake. genMin/genSize come from
+                        // the CPU texture's baked object bbox so the GPU rebuilds
+                        // the identical normalized coordinate.
+                        desc.depth = res;
+                        Vec3 gmin  = tex->hasGeneratedBBox() ? tex->getGeneratedMin()
+                                                             : Vec3(0.f, 0.f, 0.f);
+                        Vec3 gsize = tex->hasGeneratedBBox() ? tex->getGeneratedSize()
+                                                             : Vec3(1.f, 1.f, 1.f);
+                        desc.genMin  = GVec3(gmin.x,  gmin.y,  gmin.z);
+                        desc.genSize = GVec3(gsize.x, gsize.y, gsize.z);
+                        r.textureTexels.reserve(r.textureTexels.size() +
+                                                (size_t)res * res * res);
+                        // Bake cell CENTERS over the normalized [0,1]^3 domain the
+                        // CPU passes as `p` (= g) in CoordMode::Generated. Storage
+                        // is k-major: idx = (k*res + j)*res + i.
+                        for (int k = 0; k < res; ++k) {
+                            float pz = (k + 0.5f) / res;
+                            for (int j = 0; j < res; ++j) {
+                                float py = (j + 0.5f) / res;
+                                for (int i = 0; i < res; ++i) {
+                                    float px = (i + 0.5f) / res;
+                                    Vec3 c = tex->value(Vec2(px, py),
+                                                        Vec3(px, py, pz));
+                                    r.textureTexels.push_back(GVec3(c.x, c.y, c.z));
+                                }
+                            }
+                        }
+                    }
+                    texId = (int)r.textures.size();
+                    texIdx[key] = texId;
+                    r.textures.push_back(desc);
+                    r.hasTexture = true;
+                }
             }
+            // pkg190 fold-guard exactness (advisory #1, PR #590): a textured
+            // lambertian's flat baseColor is only a fallback. Neutralize it so the
+            // shade-path albedo swap (throughput *= texUp / upsample(baseColor))
+            // divides by a FIXED neutral reference (upsample(1,1,1)) independent of
+            // the material's own base chroma — an exact, unbiased swap even for a
+            // saturated base. Net reflectance stays texUp, so the pkg186 image path
+            // (previously dividing by a near-gray base) is unchanged.
+            if (texId >= 0)
+                r.materials[id].baseColor = GVec3(1.f, 1.f, 1.f);
         }
         r.materialTextureId.push_back(texId);
         return id;

--- a/src/gpu/wavefront/stage_advance.cu
+++ b/src/gpu/wavefront/stage_advance.cu
@@ -657,31 +657,65 @@ __device__ bool shadePathSlot(
     if constexpr (HasTexture) {
         const int* matTexId = c_wfTexBinding.matTexId;
         int texId = matTexId[rec.materialId];
-        if (texId >= 0 && rec.primId >= 0 &&
-            prims[rec.primId].type == GPRIM_TRIANGLE) {
-            const GTriangle& ttri = tris[prims[rec.primId].index];
-            if (ttri.hasUV) {
-                GVec3 e1 = ttri.v1 - ttri.v0, e2 = ttri.v2 - ttri.v0;
-                GVec3 ep = rec.point - ttri.v0;
-                float d00 = e1.dot(e1), d01 = e1.dot(e2), d11 = e2.dot(e2);
-                float d20 = ep.dot(e1), d21 = ep.dot(e2);
-                float denom = d00 * d11 - d01 * d01;
-                if (fabsf(denom) > 1e-20f) {
-                    float b1 = (d11 * d20 - d01 * d21) / denom;
-                    float b2 = (d00 * d21 - d01 * d20) / denom;
-                    float b0 = 1.0f - b1 - b2;
-                    float uu = b0 * ttri.uv0.x + b1 * ttri.uv1.x + b2 * ttri.uv2.x;
-                    float vv = b0 * ttri.uv0.y + b1 * ttri.uv1.y + b2 * ttri.uv2.y;
-                    GVec3 texColor = gpu_sampleImageTexture(
-                        c_wfTexBinding.textures[texId], c_wfTexBinding.texelBuf, uu, vv);
-                    GSampledSpectrum texUp =
-                        gpu_rgbToSampledSpectrum(texColor, lambdas, mat.spectralMode);
-                    GSampledSpectrum baseUp =
-                        gpu_rgbToSampledSpectrum(mat.baseColor, lambdas, mat.spectralMode);
-                    for (int s = 0; s < G_SPECTRUM_SAMPLES; ++s) {
-                        float d = baseUp[s];
-                        throughput.v[s] *= (d > 1e-8f ? texUp[s] / d : 0.0f);
+        if (texId >= 0) {
+            const GImageTexture& tdesc = c_wfTexBinding.textures[texId];
+            GVec3 texColor;
+            bool  haveTex = false;
+            if (tdesc.depth > 1) {
+                // pkg190 — 3D voxel procedural (Generated/Object coord). Rebuild
+                // the SAME normalized coordinate the CPU used
+                // (include/advanced_features.h CoordMode::Generated):
+                //   g = clamp((objectPoint - genMin)/genSize, 0, 1).
+                // The addon bakes world transforms into vertices, so world ==
+                // object space for these (non-instanced) meshes and rec.point IS
+                // objectPoint. Needs no triangle UVs (works for any hit prim);
+                // instanced-mesh object-local Generated coords are the same cut
+                // pkg178/pkg186 took for instanced anisotropy/texture.
+                GVec3 g;
+                g.x = tdesc.genSize.x > 1e-6f
+                    ? (rec.point.x - tdesc.genMin.x) / tdesc.genSize.x : 0.0f;
+                g.y = tdesc.genSize.y > 1e-6f
+                    ? (rec.point.y - tdesc.genMin.y) / tdesc.genSize.y : 0.0f;
+                g.z = tdesc.genSize.z > 1e-6f
+                    ? (rec.point.z - tdesc.genMin.z) / tdesc.genSize.z : 0.0f;
+                texColor = gpu_sampleProcedural3D(tdesc, c_wfTexBinding.texelBuf, g);
+                haveTex = true;
+            } else if (rec.primId >= 0 &&
+                       prims[rec.primId].type == GPRIM_TRIANGLE) {
+                const GTriangle& ttri = tris[prims[rec.primId].index];
+                if (ttri.hasUV) {
+                    GVec3 e1 = ttri.v1 - ttri.v0, e2 = ttri.v2 - ttri.v0;
+                    GVec3 ep = rec.point - ttri.v0;
+                    float d00 = e1.dot(e1), d01 = e1.dot(e2), d11 = e2.dot(e2);
+                    float d20 = ep.dot(e1), d21 = ep.dot(e2);
+                    float denom = d00 * d11 - d01 * d01;
+                    if (fabsf(denom) > 1e-20f) {
+                        float b1 = (d11 * d20 - d01 * d21) / denom;
+                        float b2 = (d00 * d21 - d01 * d20) / denom;
+                        float b0 = 1.0f - b1 - b2;
+                        float uu = b0*ttri.uv0.x + b1*ttri.uv1.x + b2*ttri.uv2.x;
+                        float vv = b0*ttri.uv0.y + b1*ttri.uv1.y + b2*ttri.uv2.y;
+                        texColor = gpu_sampleImageTexture(
+                            tdesc, c_wfTexBinding.texelBuf, uu, vv);
+                        haveTex = true;
                     }
+                }
+            }
+            if (haveTex) {
+                GSampledSpectrum texUp =
+                    gpu_rgbToSampledSpectrum(texColor, lambdas, mat.spectralMode);
+                // pkg190 fold-guard (advisory #1, PR #590): mat.baseColor is
+                // upload-neutralized to (1,1,1) for EVERY textured material
+                // (scene_upload.cu), so baseUp is a FIXED neutral reference with no
+                // near-zero band. The albedo swap throughput *= texUp/baseUp is an
+                // exact, chroma-independent substitution (net reflectance = texUp,
+                // since the downstream diffuse fold re-multiplies by this same
+                // baseUp). Clamp the denominator instead of the old hard-zero
+                // branch (which would nuke a band for a saturated base).
+                GSampledSpectrum baseUp =
+                    gpu_rgbToSampledSpectrum(mat.baseColor, lambdas, mat.spectralMode);
+                for (int s = 0; s < G_SPECTRUM_SAMPLES; ++s) {
+                    throughput.v[s] *= texUp[s] / fmaxf(baseUp[s], 1e-4f);
                 }
             }
         }

--- a/tests/test_pkg190_gpu_procedural_texture.py
+++ b/tests/test_pkg190_gpu_procedural_texture.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python
+"""pkg190 — GPU procedural-texture rendering: not-flat + CPU/GPU parity.
+
+pkg186 added GPU sampling for IMAGE textures but collapsed every PROCEDURAL
+texture node (checker / brick / wave / magic / …) to the material's flat
+`getAlbedo()` on the GPU wavefront path. pkg190 bakes the CPU procedural
+evaluator into a device buffer at scene-upload time and samples it on the GPU:
+  * Generated/Object coord mode → a res^3 VOXEL bake in [0,1]^3, sampled by the
+    normalized Generated coordinate (gpu_sampleProcedural3D). This mirrors how
+    the pkg119-B parity scenes drive procedurals (no TexCoord node → Blender
+    default Generated) — the (a)-set the re-baseline convicted.
+  * UV coord mode → a res^2 bake reusing the pkg186 2D UV image path.
+
+Acceptance gates (mirror test_pkg186_gpu_texture_parity):
+  * test_gpu_procedural_is_not_flat — a GPU render of a Generated-coord checker
+    must differ substantially from the same geometry rendered as flat albedo
+    (proves the procedural is evaluated on the device, not dropped). Metrics on
+    garbage pass, so we also assert real spatial colour contrast.
+  * test_cpu_gpu_procedural_parity — per-channel MEAN-RATIO of CPU vs GPU within
+    band (NOT SSIM: independent RNG streams — [[ssim-wrong-gate-for-independent-rng]]).
+  * test_saturated_base_is_neutralised — the fold-guard (advisory #1, PR #590):
+    a textured material's render is independent of its flat base-colour chroma
+    (base is upload-neutralised so the albedo swap is an exact, unbiased texUp).
+
+GPU-gated: skips when no CUDA device (CI has none); this is an RTX-box leg.
+"""
+
+import astroray
+import numpy as np
+import pytest
+from base_helpers import create_renderer, render_image, setup_camera
+
+
+def _has_cuda_gpu(renderer):
+    return bool(astroray.__features__.get("cuda", False)) and \
+        bool(getattr(renderer, "gpu_available", False))
+
+
+# Generated-coord bbox for a quad spanning x,y in [-1,1]; z padded so the checker
+# samples a fixed z-slice (a flat quad only intersects one plane of the 3D field).
+_BBOX_MIN = [-1.0, -1.0, -1.0]
+_BBOX_SIZE = [2.0, 2.0, 2.0]
+
+# Checker cell colours: two saturated, contrasting colours so a flat-albedo drop
+# is unmistakable and there is strong spatial variation to gate on.
+_C1 = (0.9, 0.1, 0.1)   # red
+_C2 = (0.1, 0.1, 0.9)   # blue
+_CHECK_SCALE = 4.0      # cells across the normalized [0,1] bbox
+
+
+def _add_checker_material(renderer, c1, c2, scale, base_color, name):
+    # params: [c1.r,g,b, c2.r,g,b, scale] (module/blender_module.cpp checker path)
+    renderer.create_procedural_texture(
+        name, "checker",
+        [c1[0], c1[1], c1[2], c2[0], c2[1], c2[2], scale], "GENERATED")
+    renderer.set_texture_generated_bbox(name, _BBOX_MIN, _BBOX_SIZE)
+    return renderer.create_material("lambertian", list(base_color),
+                                    {"texture": name})
+
+
+def _build_scene(renderer, *, textured=True, base_color=(0.8, 0.8, 0.8),
+                 c1=_C1, c2=_C2):
+    renderer.set_background_color([0.8, 0.8, 0.8])
+    if textured:
+        mat = _add_checker_material(renderer, c1, c2, _CHECK_SCALE, base_color,
+                                    "pkg190_checker")
+    else:
+        mat = renderer.create_material("lambertian", list(base_color), {})
+
+    # UV-mapped quad at z=0 facing the camera. UVs unused by the 3D Generated
+    # path but kept so the geometry matches the pkg186 quad exactly.
+    A, B = [-1, -1, 0], [1, -1, 0]
+    C, D = [1, 1, 0], [-1, 1, 0]
+    n = [0, 0, 1]
+    renderer.add_triangle_layers(A, B, C, mat, {"UVMap": [[0, 0], [1, 0], [1, 1]]},
+                                 n, n, n)
+    renderer.add_triangle_layers(A, C, D, mat, {"UVMap": [[0, 0], [1, 1], [0, 1]]},
+                                 n, n, n)
+    setup_camera(renderer, look_from=[0, 0, 3], look_at=[0, 0, 0], vup=[0, 1, 0],
+                 vfov=45, width=64, height=64)
+
+
+def _render(*, textured=True, use_gpu=True, base_color=(0.8, 0.8, 0.8),
+            c1=_C1, c2=_C2, samples=96, seed=1):
+    r = create_renderer()
+    if use_gpu:
+        if not _has_cuda_gpu(r):
+            pytest.skip("No CUDA GPU available — pkg190 procedural gate runs on the RTX box.")
+        r.set_use_gpu(True)
+    # Pin the RNG so same-engine A/B renders (base-neutralisation) differ ONLY in
+    # the variable under test, not MC noise (seed 0 is the random sentinel —
+    # [[seed-zero-is-random-sentinel]]).
+    r.set_seed(seed)
+    _build_scene(r, textured=textured, base_color=base_color, c1=c1, c2=c2)
+    return render_image(r, samples=samples, max_depth=3, apply_gamma=False)
+
+
+def _channel_means(img):
+    return np.array([float(img[..., c].mean()) for c in range(3)])
+
+
+def test_gpu_procedural_is_not_flat():
+    """GPU checker render must differ from a flat render AND carry real spatial
+    colour contrast (metrics pass on garbage — [[general-photon-loop-needs-solid-glass]])."""
+    tex = _render(textured=True, use_gpu=True)
+    flat = _render(textured=False, use_gpu=True)
+    mean_abs_diff = float(np.abs(tex - flat).mean())
+    assert mean_abs_diff > 0.05, (
+        f"GPU procedural render too close to flat albedo (mean|diff|="
+        f"{mean_abs_diff:.4f}); the checker was likely dropped on GPU."
+    )
+    # Red/blue checker → red channel must vary spatially (red cells vs blue cells).
+    red = tex[..., 0]
+    assert red.max() - red.min() > 0.1, (
+        "GPU procedural render shows no red-channel spatial contrast — checker not applied."
+    )
+
+
+def test_cpu_gpu_procedural_parity():
+    """Per-channel mean-ratio of CPU vs GPU checker render within band."""
+    gpu = _render(textured=True, use_gpu=True)
+    cpu = _render(textured=True, use_gpu=False)
+    gm = _channel_means(gpu)
+    cm = _channel_means(cpu)
+    assert cm.mean() > 0.02, f"CPU reference too dark to gate: {cm}"
+    assert gm.mean() > 0.02, f"GPU render too dark to gate: {gm}"
+    ratio = gm / np.maximum(cm, 1e-6)
+    for c, rc in enumerate(ratio):
+        assert 0.80 <= rc <= 1.25, (
+            f"channel {c} CPU/GPU mean-ratio {rc:.3f} out of band "
+            f"[0.80,1.25]; cpu={cm}, gpu={gm}"
+        )
+
+
+def test_saturated_base_is_neutralised():
+    """Fold-guard exactness: the textured render is INDEPENDENT of the material's
+    flat base-colour chroma (base is upload-neutralised to (1,1,1), so the albedo
+    swap divides by a fixed neutral reference — an exact, unbiased texUp). A
+    saturated red base and a neutral base must render the same checker."""
+    sat = _render(textured=True, use_gpu=True, base_color=(1.0, 0.0, 0.0))
+    neu = _render(textured=True, use_gpu=True, base_color=(1.0, 1.0, 1.0))
+    # Same RNG path/seed and identical geometry → the only difference would be a
+    # base-chroma leak. Allow a hair of float noise.
+    mean_abs_diff = float(np.abs(sat - neu).mean())
+    assert mean_abs_diff < 0.01, (
+        f"Textured render depends on base-colour chroma (mean|diff|="
+        f"{mean_abs_diff:.4f}); the fold-guard is not neutralising the base."
+    )
+
+
+def _luminance_render(textured):
+    """A direct GPU wavefront render with use_luminance_output=True (the
+    non-visible / luminance-only band). render() first to build the BVH (no
+    standalone build_acceleration binding), then the luminance-band render."""
+    r = create_renderer()
+    if not _has_cuda_gpu(r):
+        pytest.skip("No CUDA GPU available — pkg190 luminance-band leg runs on the RTX box.")
+    r.set_use_gpu(True)
+    r.set_seed(1)
+    _build_scene(r, textured=textured)
+    render_image(r, samples=1, max_depth=2, apply_gamma=False)
+    return np.asarray(
+        astroray.cuda_wavefront_render(r, 96, 3, 1, 380.0, 780.0, True, True),
+        dtype=np.float32)
+
+
+def test_rgb_texture_luminance_band_covered():
+    """Advisory #2 (PR #590): the RGB-texture × use_luminance_output (non-visible
+    / luminance-only band) combination was untested. use_luminance_output is a
+    SPECIALIST non-visible-band mode (luminance-avg RR + Rayleigh sky), so RGB
+    textures are only meaningful in the visible band — the production wavefront
+    render path runs use_luminance_output=False (see cuda_wavefront_render
+    default and gpu_wavefront_snapshot.cu). This leg asserts the combination is
+    DEFINED (finite, no NaN/inf) and that the texture is still APPLIED under the
+    luminance band (textured != flat) — i.e. the per-λ fold is not silently
+    dropped or undefined; it is not, however, a visible-band parity claim."""
+    tex = _luminance_render(textured=True)
+    flat = _luminance_render(textured=False)
+    assert np.all(np.isfinite(tex)), "luminance-band textured render has non-finite pixels"
+    assert np.all(np.isfinite(flat)), "luminance-band flat render has non-finite pixels"
+    # The RGB texture must still influence the luminance-band result (red/blue
+    # checker cells carry different luminance than the flat 0.8 base).
+    mean_abs_diff = float(np.abs(tex - flat).mean())
+    assert mean_abs_diff > 1e-4, (
+        f"luminance-band render ignores the RGB texture (mean|tex-flat|="
+        f"{mean_abs_diff:.2e}); the fold was dropped under use_luminance_output."
+    )


### PR DESCRIPTION
## Summary

Closes the pkg119-B flat-albedo drop for **procedural** texture nodes on the GPU wavefront path. Builds on pkg186's image-texture machinery: bakes the CPU procedural evaluator into device buffers at scene upload and samples them on the GPU. Chosen strategy (coordinator-approved): **Option A — 3D-voxel bake-at-upload**, because the (a)-set nodes are all Generated-coordinate 3D fields (a 2D UV bake cannot represent them), it reuses the already-cited CPU evaluators (no device math to re-derive), and the fetch stays off the register-saturated shade kernel.

## MANDATED re-baseline first — the premise trap

The historical "5 residual TRANSLATION-BUGs" story was **stale/false**. Fresh pkg119-B re-baseline (OpenMP-OFF `build_blender_addon_cuda`, Blender 5.2, res64/spp16, SPP-escalation on) on current main:
- `BSDF_TRANSPARENT` (0.9639) and `world:World` (0.9752) now **PASS** — confirming the runbook's SSIM-false-positive disproof.
- The real TRANSLATION-BUG set was **4 nodes, all procedural textures**.

Classification (verified by **direct render inspection**, not assumed — Astroray-GPU legs were byte-identical across all 7 procedural nodes at mean|Δ|≈0.001 while Cycles legs differed 0.03–0.04, the flat-drop signature):
- **(a) genuine flat-albedo drops → this package's payoff:** TEX_CHECKER, TEX_BRICK, TEX_MAGIC, TEX_WAVE.
- **(b) noise false-positive:** BSDF_GLASS, TEX_VORONOI (NOISE-LIMITED).
- **(c) intentional-divergence:** 7 APPROXIMATED (refraction/sheen/translucent/3 volumes/wavelength).

## Reclassification result (primary acceptance)

pkg119-B TRANSLATION-BUG **4 → 0** ("Follow-up candidates: _none_"); summary 25 → **30 pass**. All four at **64³** (MAGIC did not need 128³):

| node | before | after |
|---|---|---|
| TEX_CHECKER | 0.8425 TRANSLATION-BUG | **0.9512 PASS** |
| TEX_BRICK | 0.8980 TRANSLATION-BUG | **0.9158 PASS** |
| TEX_MAGIC | 0.8358 TRANSLATION-BUG | **0.9639 PASS** |
| TEX_WAVE | 0.8935 TRANSLATION-BUG | **0.9575 PASS** |

Visual confirmation (contact sheet `test_results/pkg190_evidence/pkg190_procedural_contact_sheet.png`, [Cycles \| Astroray-GPU]): all four patterns now render on GPU, no longer flat.

## Register-identity gate (HARD) — PASS

Native sm_120 post-link `cuobjdump --dump-resource-usage`: **all 16** `stageShadeBucketedKernel` specializations byte-identical before/after (diff empty). The all-false fleet kernel `<0,0,0,0>` = **REG:254 STACK:3352 CONSTANT[0]:1700** (note: the spec's cited 3608 is the HasPhotons `<0,0,1,0>` variant on the current 4-axis template `<HasPrincipled,HasTexture,HasPhotons,HasDispersion>`). Only the `HasTexture` branch changed; the non-textured fleet is unchanged by construction (3D fetch + fold live inside `if constexpr(HasTexture)`).

## Other acceptance items

- **Fold-guard (advisory #1):** textured `baseColor` is upload-neutralized to (1,1,1) so the albedo swap divides by a fixed neutral reference — exact & chroma-independent (hard-zero branch replaced by clamped denominator). Proven by `test_saturated_base_is_neutralised` (saturated-red base == neutral base, bit-identical with pinned seed). Net reflectance = texUp unchanged, so pkg186 image parity is preserved (52 texture tests green).
- **Advisory #2 (RGB-texture × use_luminance_output):** covered by a real parity leg (`test_rgb_texture_luminance_band_covered`) — finite + texture still applied under the non-visible luminance band.
- **`textured_plane` parity scene** added to `scripts/run_parity.py` with a CPU/GPU per-channel **mean-ratio** oracle (never SSIM). Measured via the documented command `python scripts/run_parity.py --scene textured_plane` (exit 0): CPU/GPU mean-ratio **1.0000 / 0.9996 / 0.9998**. NOTE: the original submission's number came from a direct-Renderer-API inline check, not this command; hw-612 caught two run_parity wiring defects (missing `_render_once` guard + an imageio-EXR-read bug that nan-poisoned the ratio), both fixed in commit b2b42eb (see the PR comment for verbatim output).
- **Filtering constraint recorded:** nearest-sampling in lockstep with the point-sampled CPU evaluator (bake stores cell centers); no unilateral GPU filtering.

## Tests

- `tests/test_pkg190_gpu_procedural_texture.py`: 4 passed (not-flat, CPU/GPU mean-ratio, base-neutralization exactness, luminance-band coverage).
- Regression: pkg186 texture parity, spectral textures, texture plugins, pkg115 procedural, principled texture, uv plumbing (**52 passed**); GPU features guard + pkg64/pkg178 CPU-GPU parity (**14 passed**).

## Authorized surface

Spec Specification/Work touched: `src/gpu/scene_upload.cu`, `src/gpu/wavefront/stage_advance.cu`, `include/astroray/gpu_types.h`, `scripts/run_parity.py`, new test. Also touched (justified): `include/advanced_features.h` — read-only `Texture` bbox getters (`hasGeneratedBBox`/`getGeneratedMin`/`getGeneratedSize`) required so the host bake reads the same (genMin,genSize) frame the CPU uses; additive, no signature changes. All within spec scope; no out-of-spec drift.

## Build evidence (last lines, exit 0)

```
[36/39] Linking CUDA static library CMakeFiles\astroray_cuda.dir\cmake_device_link.obj
[37/39] Linking CUDA static library astroray_cuda.lib
[38/39] Linking CXX shared module astroray.cp313-win_amd64.pyd
Done.
```
Built with `-DASTRORAY_CUDA_ARCHS=native` (sm_120 confirmed via `cuobjdump --list-elf`).

Note: the advisory lint gate reports ~134 `git-diff-check/whitespace` findings; these are an environmental `git diff --check` false-positive in this repo (the already-merged pkg199 commit shows the same 41 findings and merged clean). Changed lines are byte-verified clean (xxd + cat -A).

Algorithm sourcing: no new device algorithms — the bake reuses the material's own CPU procedural evaluators (checker cites Cycles `svm/checker.h`, etc.), so parity is exact-by-construction modulo grid resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

