### PR TITLE
feat(pkg198): Stage 1 — CPU light-path pass classification (premise-corrected spec)

### DIFF
--- a/.astroray_plan/docs/pkg198-lightpath-pass-classification-research.md
+++ b/.astroray_plan/docs/pkg198-lightpath-pass-classification-research.md
@@ -1,0 +1,58 @@
+# pkg198 Stage 1 — CPU light-path pass classification: algorithm sourcing
+
+**Cite-algorithm (CLAUDE.md §6).** The tagging conventions are NOT invented — they mirror
+Cycles' render-pass (light-path-expression) model, which is what Blender users expect from
+`Diffuse Direct/Indirect`, `Glossy …`, `Transmission …`, `Emission`, `Environment`.
+
+## Sources (Apache-2.0, Blender/Cycles `main`)
+- `intern/cycles/kernel/film/light_passes.h`
+  - `film_write_direct_light`, `film_write_indirect_light`,
+    `film_write_emission_or_background_pass`, `film_write_background`.
+- `intern/cycles/kernel/integrator/shade_surface.h`
+  - `integrate_surface_bsdf_bssrdf_bounce` (weight lock), `integrate_surface_direct_light`.
+
+## The Cycles model (verified 2026-08-14 by fetching the two files above)
+1. **Category (diffuse / glossy / transmission) is locked at the FIRST surface bounce**
+   (`INTEGRATOR_STATE(state, path, bounce) == 0`): Cycles stores `pass_diffuse_weight` and
+   `pass_glossy_weight` from the BSDF eval; transmission weight is the residual
+   `1 - diffuse - glossy`. These weights persist unchanged through all later (indirect)
+   bounces — the category of the *camera-visible* surface labels ALL light that reaches it.
+2. **Direct vs indirect is by bounce count**: light gathered at the first surface = DIRECT;
+   light gathered after further bounces = INDIRECT, apportioned by the SAME first-hit weights.
+3. **Emission / environment**: `film_write_emission_or_background_pass` — when the contribution
+   is *directly visible* (`!(path_flag & PATH_RAY_ANY_PASS)`, i.e. before any non-specular pass
+   bounce) surface emission → `PASS_EMISSION` and background → the environment pass. After a
+   pass bounce, emission/background is folded into the diffuse/glossy/transmission INDIRECT
+   passes by the stored weights.
+
+## Adaptation to Astroray's granularity (documented approximation)
+Astroray's `evalSpectral` returns a single combined spectrum (no per-closure diffuse/glossy
+split), and `BSDFSampleSpectral` carries no lobe label. So the continuous
+`pass_diffuse_weight`/`pass_glossy_weight` split is not available. We use the coarser but
+faithful **single path-label** form of the same model (the label variant Cycles itself falls
+back to when closure weights are unavailable):
+
+- One category `firstCat ∈ {DIFFUSE, GLOSSY, TRANSMISSION}` is locked at the first BSDF sample.
+- **Category of a sample** (`sampleCat`): TRANSMISSION if the sampled `wi` crossed the surface
+  (sign of `dot(wo,N)` ≠ sign of `dot(wi,N)`, geometric sign test — no distance/sentinel
+  consumed, per [[occlusion-sentinel-as-distance-class-of-bug]]); else GLOSSY if the sample is
+  a delta reflection (mirror) or `material->isGlossy()`; else DIFFUSE. This gives: lambertian→
+  diffuse, metal/mirror→glossy, dielectric/thin_glass refraction→transmission & Fresnel
+  reflection→glossy, principled-glass→transmission, other principled→glossy (Stage-1 fold:
+  a mixed Principled surface's diffuse energy is counted glossy — acceptable, documented).
+- **Direct regime = `firstCat == -1`** (no BSDF interaction yet): NEE → `<cat>_DIRECT`
+  (cat = reflect category of the vertex material); directly-seen surface emission →
+  `PASS_EMISSION`; background miss → `PASS_ENVIRONMENT`.
+- **Indirect regime = after `firstCat` locked**: every contribution (NEE, lamp hit, emissive
+  hit, SMS caustic, background miss) → `<firstCat>_INDIRECT`.
+
+## Sum-to-beauty invariant (gate 1)
+Every `color += X` in `pathTraceSpectral` is paired with exactly one `passes[p] += X` (total
+partition), so `Σ passes == beauty` per sample, per wavelength bundle, EXACTLY in spectral
+space. Passes are stored as XYZ (same convention as `SampleResult.color`) and converted to
+linear sRGB in the render loop alongside beauty (`xyzToLinearSRGB` is a linear matrix, so the
+sum invariant survives conversion and averaging). The only sub-percent slack is the per-channel
+`max(·,0)` gamut clamp applied per-pass vs. per-beauty, negligible for in-gamut scenes.
+
+Opt-in photon-mapped caustic (added in `sampleFull` after `pathTraceSpectral`) is routed to
+`PASS_DIFFUSE_INDIRECT` so the invariant also holds when photon mapping is enabled.

--- a/.astroray_plan/packages/pkg198-gpu-wavefront-light-path-aov-passes.md
+++ b/.astroray_plan/packages/pkg198-gpu-wavefront-light-path-aov-passes.md
@@ -10,6 +10,66 @@ much headroom the shade kernel has before this heavier accumulation is even atte
 
 ---
 
+## IMPLEMENTER FINDING — 2026-08-14 — BLOCKED PENDING OWNER DECISION (status left `open`)
+
+Before running the register probe I verified the spec's load-bearing premise on current `main`
+(HEAD 4643de3), and it does not hold: **there is no CPU light-path-pass reference to mirror or
+parity-test against.** The light-path passes (`PASS_DIFFUSE_DIRECT` … `PASS_ENVIRONMENT`) are
+plumbed end-to-end but are **never populated on CPU either** — they are dead plumbing, not a
+"CPU works / GPU is black" gap.
+
+Evidence (grep-verified, whole repo, code files only):
+- The render loop at `include/raytracer.h:3228,3241` accumulates `sPass = ir.passes` into
+  `passColor` → `cam.renderPassBuffers[...][idx]` (`:3327`). That is the *only* consumer.
+- `SampleResult.passes` (`include/raytracer.h:1731`) is zero-initialised and **no integrator or
+  BSDF ever writes to it.** The one and only reference to `.passes` in the entire codebase
+  outside the struct definition is the read at `:3228`. `git grep "passes\["` / `"\.passes"`
+  across all `*.cpp/*.cu/*.h` returns zero write sites.
+- The default integrator `spectral_path_tracer.cpp::sampleFull` (`:162-247`) fills
+  `color/albedo/normal/depth/bounceCount` but leaves `r.passes` at zero.
+- `Renderer::pathTraceSpectral` (`:2476`) takes **no pass-output parameter** and carries no
+  first-bounce-lobe / direct-indirect / emission-environment classification.
+- The two existing tests that touch these passes (`test_blender_viewport_passes.py`,
+  `test_python_bindings.py`) use fully **mocked** renderers returning constant buffers; they
+  exercise the addon plumbing, not any real classification.
+
+Consequence for pkg198 as written:
+- Spec §"Why this exists" claim that these passes are "filled per-sample by the CPU render loop
+  … while working on CPU" is factually wrong — CPU returns black too.
+- Acceptance criterion 2 ("Enabled passes match the CPU render within a tight per-channel
+  band … beauty must equal the sum of the lit passes") is unsatisfiable: the CPU reference is
+  all zeros, so there is nothing to parity-match and no CPU sum-to-beauty invariant to hold.
+- The IMPLEMENTATION-NOTES instruction to "mirror the CONDITIONS exactly (which bounce/event
+  classifies as diffuse-direct vs indirect)" has no CPU conditions to mirror.
+
+The register probe (spec's mandated first step) is therefore **not the gating blocker**: even a
+perfectly clean `<false,false,false,false>` probe would not let pkg198 satisfy its own
+acceptance criteria, because the whole design is defined relative to a CPU implementation that
+does not exist. Building the GPU accumulation + a from-scratch CPU classifier + a native sm_120
+build (hours, GPU lock) before confirming scope would violate "no invented accumulation scheme"
+and "do not silently widen scope."
+
+Recommended re-scoping options for the owner (not chosen unilaterally):
+- **(A) Split off a CPU prerequisite package** that implements the light-path classification in
+  `pathTraceSpectral` (first-bounce lobe category + direct/indirect split + emission/environment
+  tagging, citing Cycles `kernel/film/light_passes.h` + `integrator/shade_surface.h`,
+  Apache-2.0), landing a real CPU reference. pkg198 then becomes the GPU mirror as originally
+  framed, with the register probe as its gate. This is the honest ordering.
+- **(B) Redefine pkg198's parity gate** to self-consistency (beauty == sum of the GPU passes,
+  and per-pass sanity on a scene with isolated lobes) with **no** CPU cross-check, and treat the
+  CPU passes as a separately-tracked gap. Ships a GPU-only feature but forfeits the CPU↔GPU
+  parity that is half the spec's stated Pillar-3 value.
+- **(C) Park pkg198** until the CPU half exists (dependency inversion — this package assumed a
+  prerequisite that was never built).
+
+Secondary note: the spec's own baseline `STACK` figure is internally inconsistent — `254 / 3608
+/ 1700` in §"hard part"/§probe vs the dispatch's `254 / 3352 / 1700`. Whichever is correct must
+be re-confirmed via `cuobjdump` on the FINAL linked `.pyd` before any probe number is trusted.
+
+No worktree build was run, no GPU lock was taken, no PR opened.
+
+---
+
 ## Why this exists (verified line refs, current `main`)
 
 Astroray has a full Cycles-style render-pass registry — `PASS_DIFFUSE_DIRECT`,

--- a/.astroray_plan/packages/pkg198-gpu-wavefront-light-path-aov-passes.md
+++ b/.astroray_plan/packages/pkg198-gpu-wavefront-light-path-aov-passes.md
@@ -1,152 +1,107 @@
-# pkg198 — GPU wavefront light-path-expression render passes (diffuse/glossy/transmission direct+indirect, emission, environment)
+# pkg198 — Light-path-expression render passes (diffuse/glossy/transmission direct+indirect, emission, environment)
 
 **Pillar:** 5 / integration-first (also 3 — CPU↔GPU parity)
 **Track:** A
-**Status:** open (filed 2026-08-13 — GPU-parity vetted set; **probe-first, may park**)
-**Estimated effort:** L (register-hostile — the up-front probe decides whether it ships at all)
-**Depends on:** pkg197 (first-hit guide AOVs — land it first; its register probe tells us how
-much headroom the shade kernel has before this heavier accumulation is even attempted);
+**Status:** Stage 1 (CPU classification) — done (PR #TBD, 2026-08-14 — sum-to-beauty rel_L1
+0.0000, per-channel ratio 1.000/1.000/1.000; isolated-lobe leak <1e-2). Stage 2 (GPU wavefront
+mirror + register probe) — **open, probe-first, may-park**.
+**Estimated effort:** Stage 1 = M (landed). Stage 2 = L (register-hostile — the up-front probe
+decides whether it ships at all).
+**Depends on:** Stage 2 depends on Stage 1 (this PR — the CPU reference to mirror) and pkg197
+(first-hit guide AOVs — its intersect-stage capture + `__constant__` binding is the template);
 [[wavefront-shade-kernels-register-saturated]]; [[closure-graph-lobe-count-spills-fused-kernel]].
 
 ---
 
-## IMPLEMENTER FINDING — 2026-08-14 — BLOCKED PENDING OWNER DECISION (status left `open`)
+## Why this exists (premise CORRECTED 2026-08-14 — implementer finding)
 
-Before running the register probe I verified the spec's load-bearing premise on current `main`
-(HEAD 4643de3), and it does not hold: **there is no CPU light-path-pass reference to mirror or
-parity-test against.** The light-path passes (`PASS_DIFFUSE_DIRECT` … `PASS_ENVIRONMENT`) are
-plumbed end-to-end but are **never populated on CPU either** — they are dead plumbing, not a
-"CPU works / GPU is black" gap.
+The package was filed as "the GPU half of a CPU↔GPU light-path-AOV parity gap: passes work on
+CPU, are black on GPU." **That premise was false.** Verified on `main` (grep, whole repo, code
+files only):
 
-Evidence (grep-verified, whole repo, code files only):
-- The render loop at `include/raytracer.h:3228,3241` accumulates `sPass = ir.passes` into
-  `passColor` → `cam.renderPassBuffers[...][idx]` (`:3327`). That is the *only* consumer.
-- `SampleResult.passes` (`include/raytracer.h:1731`) is zero-initialised and **no integrator or
-  BSDF ever writes to it.** The one and only reference to `.passes` in the entire codebase
-  outside the struct definition is the read at `:3228`. `git grep "passes\["` / `"\.passes"`
-  across all `*.cpp/*.cu/*.h` returns zero write sites.
-- The default integrator `spectral_path_tracer.cpp::sampleFull` (`:162-247`) fills
-  `color/albedo/normal/depth/bounceCount` but leaves `r.passes` at zero.
-- `Renderer::pathTraceSpectral` (`:2476`) takes **no pass-output parameter** and carries no
+- `SampleResult.passes` (`include/raytracer.h:1731`) was zero-initialised and **no integrator or
+  BSDF ever wrote to it** — the single reference outside the struct definition was the read at
+  `include/raytracer.h:3228` (`sPass = ir.passes`), accumulated into `cam.renderPassBuffers`.
+- The default integrator `spectral_path_tracer.cpp::sampleFull` filled color/albedo/normal/depth
+  but left `r.passes` zero; `pathTraceSpectral` took no pass-output parameter and had no
   first-bounce-lobe / direct-indirect / emission-environment classification.
-- The two existing tests that touch these passes (`test_blender_viewport_passes.py`,
-  `test_python_bindings.py`) use fully **mocked** renderers returning constant buffers; they
-  exercise the addon plumbing, not any real classification.
+- The two tests touching these passes used **mocked** renderers returning constant buffers.
 
-Consequence for pkg198 as written:
-- Spec §"Why this exists" claim that these passes are "filled per-sample by the CPU render loop
-  … while working on CPU" is factually wrong — CPU returns black too.
-- Acceptance criterion 2 ("Enabled passes match the CPU render within a tight per-channel
-  band … beauty must equal the sum of the lit passes") is unsatisfiable: the CPU reference is
-  all zeros, so there is nothing to parity-match and no CPU sum-to-beauty invariant to hold.
-- The IMPLEMENTATION-NOTES instruction to "mirror the CONDITIONS exactly (which bounce/event
-  classifies as diffuse-direct vs indirect)" has no CPU conditions to mirror.
-
-The register probe (spec's mandated first step) is therefore **not the gating blocker**: even a
-perfectly clean `<false,false,false,false>` probe would not let pkg198 satisfy its own
-acceptance criteria, because the whole design is defined relative to a CPU implementation that
-does not exist. Building the GPU accumulation + a from-scratch CPU classifier + a native sm_120
-build (hours, GPU lock) before confirming scope would violate "no invented accumulation scheme"
-and "do not silently widen scope."
-
-Recommended re-scoping options for the owner (not chosen unilaterally):
-- **(A) Split off a CPU prerequisite package** that implements the light-path classification in
-  `pathTraceSpectral` (first-bounce lobe category + direct/indirect split + emission/environment
-  tagging, citing Cycles `kernel/film/light_passes.h` + `integrator/shade_surface.h`,
-  Apache-2.0), landing a real CPU reference. pkg198 then becomes the GPU mirror as originally
-  framed, with the register probe as its gate. This is the honest ordering.
-- **(B) Redefine pkg198's parity gate** to self-consistency (beauty == sum of the GPU passes,
-  and per-pass sanity on a scene with isolated lobes) with **no** CPU cross-check, and treat the
-  CPU passes as a separately-tracked gap. Ships a GPU-only feature but forfeits the CPU↔GPU
-  parity that is half the spec's stated Pillar-3 value.
-- **(C) Park pkg198** until the CPU half exists (dependency inversion — this package assumed a
-  prerequisite that was never built).
-
-Secondary note: the spec's own baseline `STACK` figure is internally inconsistent — `254 / 3608
-/ 1700` in §"hard part"/§probe vs the dispatch's `254 / 3352 / 1700`. Whichever is correct must
-be re-confirmed via `cuobjdump` on the FINAL linked `.pyd` before any probe number is trusted.
-
-No worktree build was run, no GPU lock was taken, no PR opened.
+So `PASS_DIFFUSE_DIRECT … PASS_ENVIRONMENT` were plumbed end-to-end (registry, Python bindings
+`module/blender_module.cpp:2241-2257`, addon viewport selector) but returned **black on BOTH
+backends**. This was a whole-feature gap, not a GPU-parity gap — which makes it more valuable to
+fix, not less. Coordinator decision (2026-08-14): **Option A**, staged like pkg199 — build the
+CPU classification first (Stage 1), then mirror it on the GPU wavefront (Stage 2).
 
 ---
 
-## Why this exists (verified line refs, current `main`)
+## Stage 1 — CPU light-path pass classification  ✅ DONE (this PR)
 
-Astroray has a full Cycles-style render-pass registry — `PASS_DIFFUSE_DIRECT`,
-`PASS_DIFFUSE_INDIRECT`, `PASS_GLOSSY_*`, `PASS_TRANSMISSION_*`, `PASS_VOLUME_*`,
-`PASS_EMISSION`, `PASS_ENVIRONMENT`, `PASS_AO`, `PASS_SHADOW` — exposed to Python
-(`module/blender_module.cpp:2202-2218`) and filled per-sample by the **CPU** render loop
-(`include/raytracer.h:3121-3213`, `passColor[...]` accumulation → `cam.renderPassBuffers`).
+Implement the classification in the default spectral path tracer so the existing plumbing lights
+up: first-bounce lobe category (diffuse/glossy/transmission), direct vs indirect split, and
+emission/environment tagging — **citing Cycles** `kernel/film/light_passes.h` +
+`integrator/shade_surface.h` (Apache-2.0). Research notes:
+`.astroray_plan/docs/pkg198-lightpath-pass-classification-research.md`.
 
-The **GPU wavefront path fills none of them.** `cuda_wavefront_render`
-(`module/blender_module.cpp:1836-1846`) returns only the beauty RGB; no `.cu` file writes
-`renderPassBuffers` (grep-verified). So every compositor workflow that relies on light-path
-AOVs — per-pass denoise, relight, per-lobe colour grade, emission/environment isolation —
-silently returns black on the (default) GPU backend, while working on CPU. This is the
-second half of the "GPU AOV/render-pass" parity gap (pkg197 owns the cheap first-hit-guide
-half).
+Design (adapted to Astroray's granularity — single combined `evalSpectral`, no per-closure
+split, so the coarser single-path-label variant of the Cycles model is used):
+- `pathTraceSpectral` gained an optional `outPasses` accumulator; every `color += X` is paired
+  with exactly one `passes[p] += X` (total partition → Σpasses == beauty EXACTLY in spectral
+  space). Passes carry XYZ (same convention as `SampleResult.color`) and are converted to linear
+  sRGB in the render loop with the same matrix as beauty, so the invariant holds in linear sRGB.
+- Category locked at the first BSDF interaction (Cycles locks pass weights at bounce 0):
+  TRANSMISSION if the sampled `wi` crossed the surface (geometric sign test — no distance/
+  sentinel, per [[occlusion-sentinel-as-distance-class-of-bug]]); else GLOSSY for a delta/mirror
+  reflection or glossy material; else DIFFUSE. Direct = light gathered before that lock; indirect
+  = after. Directly-visible emission → `PASS_EMISSION`; directly-visible background →
+  `PASS_ENVIRONMENT`; both fold into `<firstCat>_INDIRECT` after a bounce.
 
-## The hard part — this is register-hostile, and may not be worth it
+Stage 1 acceptance — all met:
+- [x] Σ(light-path passes) == beauty (LINEAR) on an all-lobe scene: per-channel ratio
+      `[1.000, 1.00000001, 1.00000001]`, pixelwise rel_L1 `0.0000`.
+- [x] Isolated-lobe sanity: pure-diffuse → glossy/transmission < diffuse·1e-2 (measured 0.0);
+      metal → diffuse < glossy·1e-2 (measured 0.0); glass → transmission carries the refraction.
+- [x] Emission and environment passes populate for directly-visible emitters/background.
+- [x] Real-binding tests (`tests/test_pkg198_lightpath_passes.py`) replace reliance on the mocks
+      (mocks kept); the two pre-existing `xfail`-gated pass tests in `test_python_bindings.py`
+      un-xfailed and passing.
 
-Unlike pkg197's one-shot first-hit guides, light-path passes require **per-path, per-lobe
-accumulators carried through every bounce**: each contribution must be tagged
-diffuse/glossy/transmission × direct/indirect and splatted to the right pass, with the
-direct/indirect split tracked across the path and the first-bounce lobe category remembered.
-That is on the order of 8-10 extra `Vec3` (or spectral) accumulators of **live per-path
-state** in the exact kernel that is already pinned at **REG 254 / STACK 3608 / CONSTANT[0]
-1700** (`stageShadeBucketedKernel<…>`, `src/gpu/wavefront/stage_advance.cu:1105`). Adding
-per-hit live state is precisely the class of change that spilled the fused shade kernel +52%
-before ([[closure-graph-lobe-count-spills-fused-kernel]], [[wavefront-shade-kernels-register-saturated]]).
+## Stage 2 — GPU wavefront mirror + register probe  (OPEN, probe-first, may-park)
 
-**This package is therefore probe-first and explicitly may-park** (the pkg194 discipline).
+Mirror the Stage-1 classification on the GPU wavefront so the passes agree CPU↔GPU on the
+default backend. This is the register-hostile half.
 
-## MANDATORY FIRST STEP — decide feasibility before building
+### MANDATORY FIRST STEP — decide feasibility before building
+1. Design the GPU pass-accumulation layout against the Stage-1 CPU reference + Cycles film model.
+   Per-path pass accumulators are per-hit live state in the shade kernel that is already
+   REG-254-saturated. Study whether some passes can be captured OFF the shade kernel (pkg197's
+   intersect-stage capture; emission/environment may be accumulatable outside shade).
+2. Register-probe the minimal version — carry pass accumulators as SoA global-memory scatter
+   (per-pixel pass buffers written incrementally per bounce), so the shade kernel holds pointers,
+   not ~10 accumulators. Isolate behind a compile-time `HasLightPassAOVs` axis (pkg184/pkg189
+   if-constexpr) so the pass-less fleet specialization is byte-identical by construction.
+3. **HARD gate:** `stageShadeBucketedKernel<…,false>` (pass-less) stays at the verified fleet
+   baseline **REG 254 / STACK 3352 / CONSTANT[0] 1700** — confirm on the FINAL linked `.pyd` via
+   `cuobjdump` (sm_120 confirmed via `--list-elf` first; never `ptxas -v`). NB: **3352 is
+   correct**; the earlier `3608` figure in this spec was the stale pre-pkg184/4-axis number —
+   pkg190's HW verification re-confirmed 3352 independently.
+4. If even the global-scatter form spills the pass-less specialization or regresses non-AOV perf,
+   **STOP and park with the cuobjdump evidence** — a clean park is a valid outcome (pkg194
+   discipline). The value (a compositor power-user feature) does not justify a fleet-wide
+   regression on every GPU render.
 
-1. **Design the pass-accumulation layout** citing Cycles' film pass model
-   (`intern/cycles/kernel/film/`, `integrator/shade_surface.h`, Apache-2.0 — how it tags
-   `PASS_DIFFUSE_DIRECT` etc. and carries the light-path flags). Do NOT invent an
-   accumulation scheme (CLAUDE.md §6 / [[cite-algorithm]]).
-2. **Register probe the minimal version** — carry the pass accumulators as SoA global-memory
-   scatter (per-pixel pass buffers written incrementally per bounce) rather than live
-   registers, so the shade kernel holds pointers, not 10 accumulators. Build native-sm_120,
-   read `stageShadeBucketedKernel<false,false,false,false>` STACK/REG/CONSTANT via `cuobjdump`.
-   HARD gate: the pass-less fleet specialization stays **3608 / 254 / 1700** (isolate behind a
-   compile-time `HasAOVPasses` axis — the pkg184/pkg189 if-constexpr pattern — so scenes that
-   don't request passes pay nothing).
-3. **If even the global-scatter form spills the pass-less specialization or regresses
-   non-AOV perf, STOP and report.** The value (a compositor power-user feature) does not
-   justify a fleet-wide regression on every render. Acceptable outcomes: (a) ships isolated
-   behind the compile-time axis with zero pass-less regression; (b) parks with the cuobjdump
-   evidence and a recommendation.
+### Stage 2 scope (only if the probe clears)
+- Fill the same passes on the wavefront, matching Stage-1 CPU semantics; copy-back alongside the
+  beauty/guide plumbing established by pkg197 (one path, do not fork).
+- Parity gate: CPU vs GPU per-pass per-channel mean-ratio (not SSIM) on the Stage-1 scenes; GPU
+  beauty must still equal the sum of the GPU passes (energy closure).
+- Non-AOV GPU renders show no perf regression (min-of-N, burn-in — [[gpu-perf-ab-clock-drift]]).
+- Headless Blender 5.1: passes populate on the GPU backend and round-trip through the compositor.
+- **RTX 5070 Ti hardware gate** ([[ci_has_no_gpu_runtime_blindspot]]), bound to HEAD.
 
-## Scope (only if the probe clears)
-
-- Fill `PASS_DIFFUSE_DIRECT/INDIRECT`, `PASS_GLOSSY_DIRECT/INDIRECT`,
-  `PASS_TRANSMISSION_DIRECT/INDIRECT`, `PASS_EMISSION`, `PASS_ENVIRONMENT` on the wavefront,
-  matching CPU semantics (`include/raytracer.h:3121-3161`) so CPU↔GPU passes agree.
-- `PASS_AO` / `PASS_SHADOW` are secondary; include only if free within the same accumulation
-  pass. `PASS_VOLUME_*` is out of scope until GPU volumes exist (**pkg199**).
-- Copy-back the pass buffers alongside the beauty/guide plumbing established by pkg197 — one
-  path, do not fork.
-
-## Acceptance criteria
-
-- [ ] Probe reported FIRST: `stageShadeBucketedKernel<false,false,false,false>` stays
-      **3608 / 254 / 1700** with passes isolated behind a compile-time axis (cuobjdump
-      evidence), OR a documented park.
-- [ ] Enabled passes match the CPU render within a tight per-channel band on a scene with
-      distinct diffuse/glossy/transmission/emission/environment content (CPU↔GPU pass parity
-      test); the beauty must still equal the sum of the lit passes (energy closure check).
-- [ ] Non-AOV GPU renders show **no perf regression** (min-of-N, burn-in —
-      [[gpu-perf-ab-clock-drift]]) vs the pkg197 baseline.
-- [ ] Headless Blender 5.1: the light-path passes populate on the GPU backend and round-trip
-      through the compositor / EXR.
-- [ ] **RTX 5070 Ti hardware gate** ([[ci_has_no_gpu_runtime_blindspot]]), bound to HEAD.
-
-## Hard non-goals
-
+## Hard non-goals (both stages)
 - **No lobe-array shrink or shared live-state widening** to buy register room (pkg178/pkg184).
-- **No volume passes** until pkg199 lands GPU volumes.
-- **No cryptomatte rework** (already GPU-wired, pkg159) and **no first-hit guide AOVs**
-  (pkg197) — this package is the light-path split only.
-- **Do not force it to ship.** A clean park with evidence is a valid, expected outcome.
+- **No volume passes** until pkg199 lands GPU volumes (`PASS_VOLUME_*` left untouched).
+- **No cryptomatte rework** (pkg159) and **no first-hit guide AOVs** (pkg197) — light-path split
+  only.
+- **Do not force Stage 2 to ship.** A clean park with evidence is a valid, expected outcome.

--- a/.astroray_plan/packages/pkg198-gpu-wavefront-light-path-aov-passes.md
+++ b/.astroray_plan/packages/pkg198-gpu-wavefront-light-path-aov-passes.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 5 / integration-first (also 3 — CPU↔GPU parity)
 **Track:** A
-**Status:** Stage 1 (CPU classification) — done (PR #TBD, 2026-08-14 — sum-to-beauty rel_L1
+**Status:** Stage 1 (CPU classification) — done (PR #614, 2026-08-14 — sum-to-beauty rel_L1
 0.0000, per-channel ratio 1.000/1.000/1.000; isolated-lobe leak <1e-2). Stage 2 (GPU wavefront
 mirror + register probe) — **open, probe-first, may-park**.
 **Estimated effort:** Stage 1 = M (landed). Stage 2 = L (register-hostile — the up-front probe

--- a/include/raytracer.h
+++ b/include/raytracer.h
@@ -2482,12 +2482,30 @@ public:
             const SMSHook& smsHook = SMSHook(),
             float* cryptoObjectRanks = nullptr,    // pkg87b: per-pixel crypto object ranks
             float* cryptoMaterialRanks = nullptr,  // pkg87b: per-pixel crypto material ranks
-            int cryptoDepth = 6) {                  // pkg87b: number of (id, weight) pairs
+            int cryptoDepth = 6,                    // pkg87b: number of (id, weight) pairs
+            // pkg198 Stage 1: optional per-pass spectral accumulators (light-path
+            // AOVs). When non-null, every radiance contribution added to `color`
+            // is ALSO splatted to exactly one pass (total partition → Σpasses ==
+            // beauty). Classification mirrors Cycles kernel/film/light_passes.h +
+            // integrator/shade_surface.h (Apache-2.0); see
+            // .astroray_plan/docs/pkg198-lightpath-pass-classification-research.md.
+            std::array<astroray::SampledSpectrum, PASS_COUNT>* outPasses = nullptr) {
         const int rrDepth = 3;
         astroray::SampledSpectrum color(0.0f);
         astroray::SampledSpectrum throughput(1.0f);
         Ray ray = r;
         bool wasSpecular = true;
+        // pkg198 Stage 1: light-path pass category, locked at the first BSDF
+        // interaction (Cycles locks pass_diffuse/glossy_weight at bounce 0).
+        // -1 = not yet set (DIRECT regime); 0=diffuse, 1=glossy, 2=transmission.
+        // DIRECT-pass index = cat*3, INDIRECT-pass index = cat*3+1 (see the
+        // RenderPassIndex enum layout). Emission/environment seen before the
+        // first bounce go to PASS_EMISSION / PASS_ENVIRONMENT; after a bounce
+        // they fold into <firstCat>_INDIRECT.
+        int firstCat = -1;
+        auto addPass = [&](int passIdx, const astroray::SampledSpectrum& contrib) {
+            if (outPasses) (*outPasses)[passIdx] += contrib;
+        };
         // pkg120: BSDF pdf that generated the CURRENT continuation ray (the
         // previous bounce's sample). Parked next to wasSpecular so the
         // two-sided MIS emissive-hit term can weight this leg by the power
@@ -2524,13 +2542,21 @@ public:
                             hasWorldVolume
                                 ? lh.emission * worldTransmittanceSpectral(lh.t, lambdas)
                                 : lh.emission;
+                        // pkg198: a lamp hit by a continuation ray is indirect light
+                        // (bounce > 0), folded into the first-bounce category's INDIRECT
+                        // pass (Cycles film_write_indirect_light).
+                        int lampPass = (firstCat < 0 ? 0 : firstCat) * 3 + 1;
                         if (wasSpecular) {
-                            color += clampContribSpectral(throughput * lampEmission, lambdas, bounce);
+                            astroray::SampledSpectrum c =
+                                clampContribSpectral(throughput * lampEmission, lambdas, bounce);
+                            color += c; addPass(lampPass, c);
                         } else {
                             float lp = lights.pdfValue(ray.origin, ray.direction);
                             float bp = bsdfPdfPrev;
                             float wB = (bp * bp) / (bp * bp + lp * lp + 1e-8f);
-                            color += clampContribSpectral(throughput * lampEmission * wB, lambdas, bounce);
+                            astroray::SampledSpectrum c =
+                                clampContribSpectral(throughput * lampEmission * wB, lambdas, bounce);
+                            color += c; addPass(lampPass, c);
                         }
                     }
                     break;  // path terminates on the lamp
@@ -2552,7 +2578,13 @@ public:
                         Vec3 bg = (Vec3(1) * (1 - t) + Vec3(0.5f, 0.7f, 1.0f) * t) * 0.2f;
                         envSpec = astroray::RGBIlluminantSpectrum({bg.x, bg.y, bg.z}).sample(lambdas);
                     }
-                    color += clampContribSpectral(throughput * envSpec, lambdas, bounce);
+                    // pkg198: directly-visible background → PASS_ENVIRONMENT; background
+                    // reached after a bounce → <firstCat>_INDIRECT (Cycles
+                    // film_write_emission_or_background_pass / film_write_background).
+                    int envPass = (firstCat < 0) ? PASS_ENVIRONMENT : (firstCat * 3 + 1);
+                    astroray::SampledSpectrum c =
+                        clampContribSpectral(throughput * envSpec, lambdas, bounce);
+                    color += c; addPass(envPass, c);
                 }
                 break;
             }
@@ -2577,7 +2609,12 @@ public:
                         grEmission[i] = finiteClamped(grResult.emission[i], 0.0f, 20.0f);
                     }
                     if (!grEmission.isZero()) {
-                        color += clampContribSpectral(throughput * grEmission, lambdas, bounce);
+                        // pkg198: GR/black-hole emission — treat like surface emission
+                        // (PASS_EMISSION when directly visible, else indirect).
+                        int grPass = (firstCat < 0) ? PASS_EMISSION : (firstCat * 3 + 1);
+                        astroray::SampledSpectrum c =
+                            clampContribSpectral(throughput * grEmission, lambdas, bounce);
+                        color += c; addPass(grPass, c);
                     }
                 }
                 if (grResult.captured) {
@@ -2607,10 +2644,16 @@ public:
             astroray::SampledSpectrum Le_spec =
                 rec.material->emittedSpectral(rec, lambdas);
             if (!Le_spec.isZero()) {
+                // pkg198: directly-visible surface emission → PASS_EMISSION; emission
+                // reached after a non-specular bounce → <firstCat>_INDIRECT (Cycles
+                // film_write_emission_or_background_pass).
+                int emitPass = (firstCat < 0) ? PASS_EMISSION : (firstCat * 3 + 1);
                 if (bounce == 0 || wasSpecular) {
                     // Camera / post-specular ray: no NEE leg competes for this
                     // direction, so the whole emission is taken (w_B = 1).
-                    color += clampContribSpectral(throughput * Le_spec, lambdas, bounce);
+                    astroray::SampledSpectrum c =
+                        clampContribSpectral(throughput * Le_spec, lambdas, bounce);
+                    color += c; addPass(emitPass, c);
                 } else {
                     // pkg120: two-sided MIS. A BSDF-sampled continuation ray hit
                     // an emitter at a diffuse bounce. Add the BSDF-sampled leg
@@ -2631,7 +2674,9 @@ public:
                     // Same power-heuristic form as the NEE leg above and the GPU
                     // gpu_mw_powerHeuristic, so w_L + w_B ≈ 1 per direction.
                     float wB = (bp * bp) / (bp * bp + lp * lp + 1e-8f);
-                    color += clampContribSpectral(throughput * Le_spec * wB, lambdas, bounce);
+                    astroray::SampledSpectrum c =
+                        clampContribSpectral(throughput * Le_spec * wB, lambdas, bounce);
+                    color += c; addPass(emitPass, c);
                 }
                 break;
             }
@@ -2681,7 +2726,17 @@ public:
                         if (hasWorldVolume && worldVolumeDensity > 0.0f) {
                             neeContrib *= worldTransmittanceSpectral(ls.distance, lambdas);
                         }
-                        color += clampContribSpectral(neeContrib, lambdas, bounce);
+                        // pkg198: NEE at the first (camera-visible) surface is DIRECT
+                        // light, tagged by that surface's reflect lobe (diffuse/glossy);
+                        // NEE at a deeper vertex is INDIRECT, tagged by firstCat. NEE
+                        // only fires on non-delta lobes, so a shadow connection is always
+                        // a reflection-side event → diffuse or glossy (never transmission).
+                        int neePass = (firstCat < 0)
+                            ? (rec.material->isGlossy() ? 1 : 0) * 3 + 0
+                            : firstCat * 3 + 1;
+                        astroray::SampledSpectrum c =
+                            clampContribSpectral(neeContrib, lambdas, bounce);
+                        color += c; addPass(neePass, c);
                     }
                 }
             }
@@ -2698,7 +2753,14 @@ public:
                 astroray::SampledSpectrum smsContribution =
                     smsHook(rec, wo, throughput, lambdas, gen);
                 if (!smsContribution.isZero()) {
-                    color += clampContribSpectral(throughput * smsContribution, lambdas, bounce);
+                    // pkg198: SMS caustic gathered at this receiver vertex — same
+                    // direct/indirect tagging as NEE (light arriving at the surface).
+                    int smsPass = (firstCat < 0)
+                        ? (rec.material->isGlossy() ? 1 : 0) * 3 + 0
+                        : firstCat * 3 + 1;
+                    astroray::SampledSpectrum c =
+                        clampContribSpectral(throughput * smsContribution, lambdas, bounce);
+                    color += c; addPass(smsPass, c);
                 }
             }
 
@@ -2716,6 +2778,20 @@ public:
             // pkg120: carry this bounce's BSDF pdf so the next iteration's
             // emissive-hit two-sided MIS can weight the BSDF leg (see above).
             bsdfPdfPrev = bss.pdf;
+
+            // pkg198 Stage 1: lock the light-path category at the FIRST BSDF
+            // interaction (Cycles locks pass_diffuse/glossy_weight at bounce 0).
+            // TRANSMISSION if the sampled continuation crossed the surface (a
+            // geometric sign test on rec.normal — no distance/sentinel consumed);
+            // else GLOSSY for a delta/mirror reflection or a glossy material; else
+            // DIFFUSE. All indirect light through this vertex inherits firstCat.
+            if (firstCat < 0) {
+                float sWo = wo.dot(rec.normal);
+                float sWi = bss.wi.dot(rec.normal);
+                bool transmitted = (sWo * sWi) < 0.0f;
+                firstCat = transmitted ? 2
+                         : ((bss.isDelta || rec.material->isGlossy()) ? 1 : 0);
+            }
 
             // pkg87b: Cryptomatte per-shade-point accumulation.
             // Weight = average(throughput · bsdf_eval), per Cycles film_write_cryptomatte_slots (Apache-2.0).
@@ -3278,6 +3354,17 @@ inline void Renderer::render(Camera& cam, int maxSamples, int maxDepth,
                         passColor[PASS_VOLUME_INDIRECT] *= filmExposure;
                         passColor[PASS_EMISSION] *= filmExposure;
                         passColor[PASS_ENVIRONMENT] *= filmExposure;
+                        // pkg198 Stage 1: the light-path passes carry XYZ radiance (same
+                        // convention as beauty pre-conversion). Convert them to linear
+                        // sRGB with the SAME matrix as beauty (below) so the sum-to-beauty
+                        // invariant Σpasses == beauty holds in linear sRGB. Volume passes
+                        // are left untouched (pkg199 territory); COLOR/AO/SHADOW stay zero.
+                        for (int passIndex : {PASS_DIFFUSE_DIRECT, PASS_DIFFUSE_INDIRECT,
+                                              PASS_GLOSSY_DIRECT, PASS_GLOSSY_INDIRECT,
+                                              PASS_TRANSMISSION_DIRECT, PASS_TRANSMISSION_INDIRECT,
+                                              PASS_EMISSION, PASS_ENVIRONMENT}) {
+                            passColor[passIndex] = xyzToLinearSRGB(passColor[passIndex]);
+                        }
                         color = xyzToLinearSRGB(color);
                         if (applyGamma) {
                             color.x = std::pow(finiteClamped(color.x, 0.0f, 1.0f), 1.0f / 2.2f);

--- a/plugins/integrators/spectral_path_tracer.cpp
+++ b/plugins/integrators/spectral_path_tracer.cpp
@@ -6,6 +6,7 @@
 #include "astroray/manifold/mesh_attempt.h"    // pkg111: gatherTriangleCasters
 #include "astroray/manifold/mesh_caustic.h"    // pkg111: rayTriHit
 
+#include <array>      // pkg198: std::array<SampledSpectrum, PASS_COUNT> pass buffers
 #include <algorithm>  // pkg111: std::sort, std::min, std::max
 #include <cstdio>     // pkg113 CAUSTIC_DBG
 #include <cstdlib>    // pkg113 CAUSTIC_DBG (getenv)
@@ -218,11 +219,23 @@ public:
             cryptoDepth = camera_->cryptomatteDepth;
         }
 
+        // pkg198 Stage 1: per-pass spectral accumulators for the light-path AOVs.
+        // pathTraceSpectral splats every radiance contribution to exactly one pass
+        // (total partition), so Σpasses == rad exactly in spectral space.
+        std::array<astroray::SampledSpectrum, PASS_COUNT> passSpectra;
+        passSpectra.fill(astroray::SampledSpectrum(0.0f));
         astroray::SampledSpectrum rad =
             renderer_->pathTraceSpectral(ray, maxDepth_, lambdas, gen,
                                           &bounces, &weight, smsHook,
-                                          cryptoObjRanks, cryptoMatRanks, cryptoDepth);
+                                          cryptoObjRanks, cryptoMatRanks, cryptoDepth,
+                                          &passSpectra);
         astroray::XYZ xyz = rad.toXYZ(lambdas);
+        // Project each pass to XYZ (same convention as r.color); the render loop
+        // converts to linear sRGB alongside beauty so the sum invariant survives.
+        for (int p = 0; p < PASS_COUNT; ++p) {
+            astroray::XYZ pxyz = passSpectra[p].toXYZ(lambdas);
+            r.passes[p] = Vec3(pxyz.X, pxyz.Y, pxyz.Z);
+        }
 
         // pkg111: Add photon-mapped caustic at the first diffuse hit (when ready).
         if (photonMapReady_ && bvh) {
@@ -234,9 +247,15 @@ public:
                     rec.point, photonGatherK_, photonGatherRadius_);
                 const Vec3 alb = rec.material->getAlbedo();
                 // Lambertian receiver: L = (albedo/π) · E. The causticScale folds 1/π.
-                xyz.X += alb.x * E.X * photonCausticScale_;
-                xyz.Y += alb.y * E.Y * photonCausticScale_;
-                xyz.Z += alb.z * E.Z * photonCausticScale_;
+                Vec3 causticXYZ(alb.x * E.X * photonCausticScale_,
+                                alb.y * E.Y * photonCausticScale_,
+                                alb.z * E.Z * photonCausticScale_);
+                xyz.X += causticXYZ.x;
+                xyz.Y += causticXYZ.y;
+                xyz.Z += causticXYZ.z;
+                // pkg198: keep Σpasses == beauty when photon caustics are on — the
+                // gather lands on a diffuse receiver → diffuse-indirect pass.
+                r.passes[PASS_DIFFUSE_INDIRECT] += causticXYZ;
             }
         }
 

--- a/tests/test_pkg198_lightpath_passes.py
+++ b/tests/test_pkg198_lightpath_passes.py
@@ -1,0 +1,208 @@
+"""pkg198 Stage 1 — CPU light-path render-pass classification.
+
+Real-binding tests (not the mocked-renderer viewport tests in
+test_blender_viewport_passes.py). These render actual scenes on the CPU default
+`path_tracer` integrator and read `get_render_pass_buffer(...)`, which pkg198
+now populates for the first time (previously dead plumbing — SampleResult.passes
+had zero write sites repo-wide).
+
+Gates (coordinator dispatch):
+  1. sum-to-beauty invariant, LINEAR, on a scene exercising all lobes.
+  2. isolated-lobe sanity (pure-diffuse -> glossy/transmission ~zero, etc.).
+  3. per-pass PNGs written for visual inspection.
+
+Classification mirrors Cycles kernel/film/light_passes.h + shade_surface.h
+(Apache-2.0); see .astroray_plan/docs/pkg198-lightpath-pass-classification-research.md.
+"""
+import os
+
+import numpy as np
+import pytest
+
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+
+from base_helpers import save_image  # noqa: E402
+
+try:
+    import astroray
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray module not available")
+
+LIGHT_PATH_PASSES = [
+    "diffuse_direct", "diffuse_indirect",
+    "glossy_direct", "glossy_indirect",
+    "transmission_direct", "transmission_indirect",
+    "emission", "environment",
+]
+
+
+def _camera(r, w=48, h=48):
+    r.setup_camera(
+        look_from=[0, 0, 6], look_at=[0, 0, 0], vup=[0, 1, 0],
+        vfov=45, aspect_ratio=1.0, aperture=0.0, focus_dist=6.0,
+        width=w, height=h,
+    )
+
+
+def _sum_passes(r):
+    total = None
+    for name in LIGHT_PATH_PASSES:
+        buf = np.array(r.get_render_pass_buffer(name), dtype=np.float64)
+        total = buf if total is None else total + buf
+    return total
+
+
+def test_all_light_path_passes_readable(test_results_dir):
+    """Every light-path pass buffer reads back with the right shape and finite values."""
+    r = astroray.Renderer()
+    _camera(r)
+    r.set_background_color([0.05, 0.07, 0.12])
+    diffuse = r.create_material("lambertian", [0.7, 0.2, 0.2], {})
+    r.add_sphere([0, 0, 0], 1.4, diffuse)
+    r.add_point_light([3, 4, 3], {'mode': 'rgb', 'color': [1.0, 1.0, 1.0]}, 40.0)
+    r.render(samples_per_pixel=16, max_depth=4, apply_gamma=False)
+    for name in LIGHT_PATH_PASSES:
+        buf = np.array(r.get_render_pass_buffer(name), dtype=np.float32)
+        assert buf.shape == (48, 48, 3), f"{name} wrong shape {buf.shape}"
+        assert np.all(np.isfinite(buf)), f"{name} has non-finite values"
+
+
+def test_sum_to_beauty_linear(test_results_dir):
+    """Gate 1: Σ(light-path passes) == beauty, per-channel, in LINEAR space.
+
+    Passes and beauty are built from the same per-sample radiance contributions
+    (total partition), so the sum is near-exact; the only slack is the per-channel
+    gamut clamp applied per-pass vs per-beauty."""
+    r = astroray.Renderer()
+    _camera(r)
+    r.set_background_color([0.10, 0.12, 0.18])
+    # All lobes: diffuse + glossy (metal) + transmission (glass) + emission,
+    # plus a directly-visible non-black background (environment).
+    diffuse = r.create_material("lambertian", [0.6, 0.6, 0.6], {})
+    metal = r.create_material("metal", [0.9, 0.9, 0.9], {"roughness": 0.15})
+    glass = r.create_material("dielectric", [1.0, 1.0, 1.0], {"ior": 1.5})
+    emit = r.create_material("light", [1.0, 0.9, 0.7], {"intensity": 6.0})
+    r.add_sphere([0, -1001.2, 0], 1000.0, diffuse)   # floor
+    r.add_sphere([-1.4, -0.3, 0.2], 0.9, metal)
+    r.add_sphere([1.4, -0.3, 0.4], 0.9, glass)
+    r.add_sphere([0.0, 1.5, -0.5], 0.5, emit)
+    r.add_point_light([3, 4, 3], {'mode': 'rgb', 'color': [1.0, 1.0, 1.0]}, 60.0)
+
+    beauty = np.array(
+        r.render(samples_per_pixel=96, max_depth=6, apply_gamma=False),
+        dtype=np.float64,
+    )
+    passes_sum = _sum_passes(r)
+
+    # Per-channel mean-ratio (the classic invariant gate; NOT SSIM).
+    beauty_mean = beauty.reshape(-1, 3).mean(axis=0)
+    passes_mean = passes_sum.reshape(-1, 3).mean(axis=0)
+    ratio = passes_mean / np.maximum(beauty_mean, 1e-6)
+    # Also a pixelwise relative L1 to catch localized partition leaks.
+    denom = np.maximum(np.abs(beauty).sum(), 1e-6)
+    rel_l1 = np.abs(passes_sum - beauty).sum() / denom
+
+    save_image(beauty.astype(np.float32), os.path.join(test_results_dir, "pkg198_beauty.png"))
+    save_image(passes_sum.astype(np.float32), os.path.join(test_results_dir, "pkg198_passes_sum.png"))
+
+    print(f"[pkg198] sum-to-beauty per-channel ratio = {ratio}, rel_L1 = {rel_l1:.4f}")
+    assert np.allclose(ratio, 1.0, atol=0.03), f"per-channel ratio off: {ratio}"
+    assert rel_l1 < 0.03, f"pixelwise relative L1 too high: {rel_l1:.4f}"
+
+
+def _pass_mean(r, name):
+    return float(np.array(r.get_render_pass_buffer(name), dtype=np.float64).mean())
+
+
+def test_isolated_diffuse(test_results_dir):
+    """Gate 2a: a pure-diffuse lit scene -> diffuse passes carry energy,
+    glossy and transmission passes are ~zero."""
+    r = astroray.Renderer()
+    _camera(r)
+    r.set_background_color([0.0, 0.0, 0.0])
+    diffuse = r.create_material("lambertian", [0.7, 0.7, 0.7], {})
+    r.add_sphere([0, -1001.2, 0], 1000.0, diffuse)
+    r.add_sphere([0, 0, 0], 1.2, diffuse)
+    r.add_point_light([3, 4, 3], {'mode': 'rgb', 'color': [1.0, 1.0, 1.0]}, 60.0)
+    r.render(samples_per_pixel=48, max_depth=5, apply_gamma=False)
+    for name in LIGHT_PATH_PASSES:
+        save_image(
+            np.array(r.get_render_pass_buffer(name), dtype=np.float32),
+            os.path.join(test_results_dir, f"pkg198_diffuse_{name}.png"),
+        )
+    d_direct = _pass_mean(r, "diffuse_direct")
+    d_indirect = _pass_mean(r, "diffuse_indirect")
+    glossy = _pass_mean(r, "glossy_direct") + _pass_mean(r, "glossy_indirect")
+    trans = _pass_mean(r, "transmission_direct") + _pass_mean(r, "transmission_indirect")
+    print(f"[pkg198] diffuse-scene: d_direct={d_direct:.4f} d_indirect={d_indirect:.4f} "
+          f"glossy={glossy:.6f} trans={trans:.6f}")
+    assert d_direct > 1e-3, "diffuse_direct should carry the point-light NEE"
+    assert d_indirect > 1e-4, "diffuse_indirect should carry inter-reflection"
+    assert glossy < d_direct * 1e-2, f"glossy leaked in a pure-diffuse scene: {glossy}"
+    assert trans < d_direct * 1e-2, f"transmission leaked in a pure-diffuse scene: {trans}"
+
+
+def test_isolated_glossy(test_results_dir):
+    """Gate 2b: a metal sphere on a black background -> glossy passes carry the
+    reflected light, diffuse/transmission ~zero on the metal."""
+    r = astroray.Renderer()
+    _camera(r)
+    r.set_background_color([0.15, 0.15, 0.15])  # something for the mirror to reflect
+    metal = r.create_material("metal", [0.95, 0.95, 0.95], {"roughness": 0.1})
+    r.add_sphere([0, 0, 0], 1.4, metal)
+    r.add_point_light([3, 4, 3], {'mode': 'rgb', 'color': [1.0, 1.0, 1.0]}, 60.0)
+    r.render(samples_per_pixel=48, max_depth=5, apply_gamma=False)
+    glossy = _pass_mean(r, "glossy_direct") + _pass_mean(r, "glossy_indirect")
+    diffuse = _pass_mean(r, "diffuse_direct") + _pass_mean(r, "diffuse_indirect")
+    print(f"[pkg198] glossy-scene: glossy={glossy:.4f} diffuse={diffuse:.6f}")
+    assert glossy > 1e-3, "glossy passes should carry the metal reflection"
+    # Only the metal sphere and background are present; diffuse must stay ~zero.
+    assert diffuse < glossy * 1e-2, f"diffuse leaked in a metal scene: {diffuse}"
+
+
+def test_isolated_transmission(test_results_dir):
+    """Gate 2c: a glass sphere -> transmission passes carry the refracted light."""
+    r = astroray.Renderer()
+    _camera(r)
+    r.set_background_color([0.2, 0.25, 0.3])
+    glass = r.create_material("dielectric", [1.0, 1.0, 1.0], {"ior": 1.5})
+    diffuse = r.create_material("lambertian", [0.6, 0.6, 0.6], {})
+    r.add_sphere([0, -1001.2, 0], 1000.0, diffuse)
+    r.add_sphere([0, 0, 0], 1.2, glass)
+    r.add_point_light([3, 4, 3], {'mode': 'rgb', 'color': [1.0, 1.0, 1.0]}, 60.0)
+    r.render(samples_per_pixel=64, max_depth=8, apply_gamma=False)
+    trans = _pass_mean(r, "transmission_direct") + _pass_mean(r, "transmission_indirect")
+    print(f"[pkg198] transmission-scene: trans={trans:.4f}")
+    assert trans > 1e-3, "transmission passes should carry the refracted light through glass"
+
+
+def test_emission_pass(test_results_dir):
+    """A directly-visible emissive surface populates PASS_EMISSION."""
+    r = astroray.Renderer()
+    _camera(r)
+    r.set_background_color([0.0, 0.0, 0.0])
+    emit = r.create_material("light", [1.0, 0.85, 0.6], {"intensity": 5.0})
+    r.add_sphere([0, 0, 0], 1.3, emit)
+    r.render(samples_per_pixel=16, max_depth=3, apply_gamma=False)
+    emission = _pass_mean(r, "emission")
+    print(f"[pkg198] emission-scene: emission={emission:.4f}")
+    assert emission > 1e-3, "emission pass empty for a directly-visible emitter"
+
+
+def test_environment_pass(test_results_dir):
+    """A directly-visible non-black background populates PASS_ENVIRONMENT."""
+    r = astroray.Renderer()
+    _camera(r)
+    r.set_background_color([0.3, 0.4, 0.5])
+    diffuse = r.create_material("lambertian", [0.7, 0.7, 0.7], {})
+    r.add_sphere([0, 0, 0], 0.8, diffuse)  # small, leaves background visible
+    r.add_point_light([3, 4, 3], {'mode': 'rgb', 'color': [1.0, 1.0, 1.0]}, 40.0)
+    r.render(samples_per_pixel=16, max_depth=3, apply_gamma=False)
+    environment = _pass_mean(r, "environment")
+    print(f"[pkg198] environment-scene: environment={environment:.4f}")
+    assert environment > 1e-3, "environment pass empty for a directly-visible background"

--- a/tests/test_pkg198_lightpath_passes.py
+++ b/tests/test_pkg198_lightpath_passes.py
@@ -18,12 +18,11 @@ import os
 
 import numpy as np
 import pytest
-
 from runtime_setup import configure_test_imports
 
 configure_test_imports()
 
-from base_helpers import save_image  # noqa: E402
+from base_helpers import save_image
 
 try:
     import astroray

--- a/tests/test_python_bindings.py
+++ b/tests/test_python_bindings.py
@@ -1313,7 +1313,6 @@ def test_render_pass_buffers_exist_and_are_finite():
         assert np.isfinite(buf).all(), f"{key} contains non-finite values"
 
 
-@pytest.mark.xfail(reason="render passes not ported to the spectral path_tracer — deferred", strict=False)
 def test_emission_pass_isolated_from_diffuse_direct():
     r = create_renderer()
     r.set_seed(77)
@@ -1330,7 +1329,6 @@ def test_emission_pass_isolated_from_diffuse_direct():
         "Diffuse direct should be much darker than emission in emissive-only scene"
 
 
-@pytest.mark.xfail(reason="render passes not ported to the spectral path_tracer — deferred", strict=False)
 def test_component_passes_sum_approximately_matches_beauty():
     r = create_renderer()
     r.set_seed(123)

--- a/tests/test_python_bindings.py
+++ b/tests/test_python_bindings.py
@@ -1442,7 +1442,6 @@ def test_linear_output_preserves_hdr_values():
     assert float(np.max(gamma[:, :, 0])) <= 1.0 + 1e-6, "Gamma output should remain display-range encoded"
 
 
-@pytest.mark.xfail(reason="render passes not ported to the spectral path_tracer — deferred", strict=False)
 def test_emission_pass_preserves_hdr_values():
     """Render pass buffers should stay in linear HDR space for multilayer EXR export."""
     r = create_renderer()


### PR DESCRIPTION
## pkg198 Stage 1 — CPU light-path pass classification (premise-corrected)

Option A from the coordinator's re-scope, staged like pkg199. **Stage 1 (CPU classification) — this PR. Stage 2 (GPU wavefront mirror + register probe) — spec-only, still open/may-park.**

### Premise correction (the reason this became more valuable, not less)
The package was filed as "GPU half of a CPU↔GPU parity gap: passes work on CPU, black on GPU." **That was false.** `SampleResult.passes` had **zero write sites repo-wide** — the light-path passes (`PASS_DIFFUSE_DIRECT … PASS_ENVIRONMENT`) were plumbed end-to-end (registry, `blender_module.cpp:2241-2257`, addon viewport selector) but returned **black on BOTH backends**. A whole-feature gap, not a parity gap. This PR implements the CPU classification so the plumbing lights up for the first time; Stage 2 will mirror it on the GPU wavefront.

### Algorithm (CLAUDE.md §6 — cited, not invented)
Classification mirrors **Cycles `kernel/film/light_passes.h` + `integrator/shade_surface.h` (Apache-2.0)**: category locked at the first BSDF interaction (Cycles locks `pass_diffuse/glossy_weight` at bounce 0), direct vs indirect by whether light was gathered before/after that lock, emission/environment tagged for directly-visible emitters/background. Astroray's single combined `evalSpectral` (no per-closure split) means the coarser single-path-label variant of the model is used — documented in `.astroray_plan/docs/pkg198-lightpath-pass-classification-research.md`. Category from the sampled continuation: transmission if `wi` crossed the surface (geometric sign test, no distance/sentinel), else glossy for delta/mirror or glossy material, else diffuse.

`pathTraceSpectral` gained an optional `outPasses` accumulator; **every `color += X` is paired with exactly one `passes[p] += X` (total partition)**, so Σpasses == beauty exactly. Passes carry XYZ (like `SampleResult.color`) and are converted to linear sRGB in the render loop with the same matrix as beauty.

### Measured gates (CPU, `tests/test_pkg198_lightpath_passes.py`, 7/7 pass)
- **Sum-to-beauty (LINEAR)** on an all-lobe scene (diffuse floor + metal + glass + emitter + non-black bg): per-channel ratio **[1.000, 1.00000001, 1.00000001]**, pixelwise **rel_L1 = 0.0000**. Beauty and Σpasses PNGs are pixel-identical.
- **Isolated-lobe sanity**: pure-diffuse → glossy=0.0, transmission=0.0 (both < diffuse·1e-2); metal → diffuse=0.0 (< glossy·1e-2); glass → transmission carries the refraction (0.0344).
- **Emission** pass mean 0.8744 for a directly-visible emitter; **environment** 0.3692 for directly-visible background; emission preserves linear HDR (max ~18 for intensity-20 light).
- **Un-xfailed** 3 pre-existing pass tests in `test_python_bindings.py` whose xfail reason ("render passes not ported to the spectral path_tracer — deferred") this PR closes; verified passing without `--runxfail`. Cryptomatte/transparent-alpha/bounce-limit/filter_glossy/caustics/gamma/beauty-HDR xfails are separate deferred features, left untouched.

### Regression
- `test_python_bindings.py`: 95 passed (0 regressions; the 9 that "fail" under `--runxfail` are pre-existing xfails for unrelated deferred features).
- Furnace/energy/reflection surface (`test_material_properties`, `test_disney_reflection_not_black`, `test_dielectric_glass_furnace`, `test_disney_opaque_furnace`, `test_pkg122_light_energy_calibration`): 35 passed. Beauty is byte-identical (the change only refactors `color += clampContribSpectral(X)` into `c=…; color+=c;` and adds pass splatting — no RNG calls, no beauty math changed).

### Build (last 5 lines — clean sm_120, exit 0)
```
[pkg183] arch-verify OK: astroray.cp313-win_amd64.pyd embeds sm_120 (embedded=[sm_120])
[pkg183] running host-only ABI canary (no GPU)...
[pkg183] canary caps: {'cpu': True, 'spectral': True, 'gpu': True, 'gpu_spectral': True, 'closure_graph': True, ...}
========================================
Build succeeded
========================================
```
Note: the correct worktree arch knob is `-DASTRORAY_CUDA_ARCHS=native` (not `CMAKE_CUDA_ARCHITECTURES`, which `CMakeLists.txt:95` FORCE-overwrites) — worth remembering for future worktree builds.

### Authorized surface
Spec Stage-1 scope = CPU light-path classification in the default spectral path tracer, wired into the existing `SampleResult.passes` / `get_render_pass_buffer` plumbing (no binding changes). Files changed:
- `include/raytracer.h` — pass accumulation in `pathTraceSpectral` + render-loop XYZ→linear-sRGB pass conversion. **(in scope)**
- `plugins/integrators/spectral_path_tracer.cpp` — request `outPasses`, project to XYZ. **(in scope)**
- `tests/test_pkg198_lightpath_passes.py` — new real-binding tests. **(in scope)**
- `tests/test_python_bindings.py` — un-xfail 3 now-passing pass tests. **(in scope — un-xfail discipline)**
- `.astroray_plan/docs/pkg198-lightpath-pass-classification-research.md` — research notes. **(required by §6)**
- `.astroray_plan/packages/pkg198-…md` — spec premise correction + Stage 1/2 split + STACK baseline fix (254/3352/1700). **(directed by coordinator)**

No `.cu` touched; GPU render path unchanged. Do not merge — pr-reviewer handles that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
