### PR TITLE
fix(pkg190): narrow non-UV procedural bake to Generated coord mode (PR #612 follow-up)

### DIFF
--- a/.astroray_plan/packages/pkg190-gpu-procedural-texture-support.md
+++ b/.astroray_plan/packages/pkg190-gpu-procedural-texture-support.md
@@ -490,3 +490,95 @@ previously reported and require no re-verification).
 The single blocking defect (textured_plane CLI routing) is fixed and
 independently re-confirmed on hardware. Combined with the prior session's
 clean results on every other gate, PR #612 is **HW PASS**.
+
+## Hardware verification 2026-08-14 (PR #615)
+
+Independent RTX hardware verification of PR #615 ("fix(pkg190): narrow
+non-UV procedural bake to Generated coord mode", follow-up to PR #612's
+review finding that Object-coord procedurals were incorrectly baked into
+the normalized Generated voxel domain). Code review: SIGN-OFF. CI: 6/6
+green. Verified under `.astroray_plan/.orchestrator.gpu.lock`.
+
+**Hardware/toolchain:**
+- GPU: NVIDIA GeForce RTX 5070 Ti, driver 610.47, 16303 MiB
+- CUDA: nvcc release 12.8, V12.8.61 (arch gate: `cuobjdump` confirms
+  `astroray.cp313-win_amd64.pyd` embeds `sm_120` only — `[pkg183] arch-verify
+  OK: astroray.cp313-win_amd64.pyd embeds sm_120 (embedded=[sm_120])`)
+- OptiX 9.1.0, OIDN 2.4.1
+- Build: fresh worktree `Astroray-hw615` (`git worktree add --detach` at
+  `3b3409b269120151cea7d2df4f59c406cec51a9e`, matches PR #615 head SHA),
+  configured with `configure_and_build.bat`'s cmake invocation (VS 2022
+  generator, `ASTRORAY_CUDA_ARCHS=native`), built via `build_cuda_worktree.bat`.
+  `[pkg183]` ABI canary passed: `{'cpu': True, 'spectral': True, 'gpu': True,
+  'gpu_spectral': True, 'gpu_approximate': False, 'closure_graph': True,
+  'closure_count': 1, 'gpu_type': 'closure_graph', 'notes': 'spectral
+  closure-graph GPU lowering'}`.
+- `.pyd` mtime: 2026-08-14 20:30 (fresh vs HEAD commit time 2026-08-14
+  08:52:24 +1000) — no staleness. `astroray.__file__` resolved to the
+  canonical `build_cuda/Release/astroray.cp313-win_amd64.pyd` in the
+  worktree via `tests/runtime_setup.configure_test_imports()`.
+
+**Smoke-check (pre-test):** `hasattr(r, 'create_procedural_texture')` =
+`True`, `hasattr(r, 'set_texture_generated_bbox')` = `True`,
+`gpu_available` = `True`, `astroray.__features__['cuda']` = `True`. No
+stale-.pyd signature.
+
+**Gate test run — `tests/test_pkg190_gpu_procedural_texture.py`
+(`pytest tests/test_pkg190_gpu_procedural_texture.py -v -s --tb=short`):**
+
+| Test | Result |
+|---|---|
+| test_gpu_procedural_is_not_flat | PASSED |
+| test_cpu_gpu_procedural_parity | PASSED |
+| test_saturated_base_is_neutralised | PASSED |
+| test_rgb_texture_luminance_band_covered | PASSED |
+| test_object_mode_procedural_cpu_evaluates | PASSED |
+| test_object_mode_procedural_gpu_guarded_fallback | PASSED |
+
+`6 passed in 1.29s` — matches PR body's claimed "6/6 passed (4 existing
+gates + 2 new)" exactly.
+
+**Non-regression — documented pkg190 gate, run verbatim
+(`python scripts/run_parity.py --scene textured_plane`):**
+
+```
+scene,engine,samples,time_ms,peak_mem_mb,ssim_to_cycles,mean_ratio_cpu_gpu,skip_reason
+textured_plane,cycles-cpu,64,,,,,textured_plane oracle is CPU/GPU mean-ratio (no Cycles leg)
+textured_plane,cycles-cuda,64,,,,,textured_plane oracle is CPU/GPU mean-ratio (no Cycles leg)
+textured_plane,astroray-cpu,64,1709.099,78.6,,,
+textured_plane,astroray-gpu,64,563.697,259.7,,"1.0000,0.9996,0.9998",
+```
+
+`mean_ratio_cpu_gpu` = **1.0000 / 0.9996 / 0.9998** — byte-identical to the
+pkg190 evidence block above (`1.0000,0.9996,0.9998`, `textured_plane,
+astroray-cpu,64,1381.545,78.4` / `astroray-gpu,64,555.760,260.2`). Timing
+differs (1709.099ms vs 1381.545ms CPU, 563.697ms vs 555.760ms GPU — normal
+run-to-run system-load variance, not a correctness signal); peak_mem_mb and
+the mean-ratio triple are unchanged. Confirms PR #615 does not regress the
+Generated-coord bake path it narrows around.
+
+**Behavior check — Object-coord guarded-fallback A/B (128x128, 96 spp,
+seed=1, `apply_gamma=True`), rendered directly against the built `.pyd`:**
+
+| Render | Mean pixel value (0-255) | Visual |
+|---|---|---|
+| `ab_generated_gpu.png` | 171.70 | Checkerboard, spatial red/blue contrast present (GPU bakes Generated-mode procedural, as before) |
+| `ab_generated_cpu.png` | 163.73 | Checkerboard, vivid red/blue (CPU reference) |
+| `ab_object_gpu.png` | 189.76 | **Flat uniform gray** — no checker pattern |
+| `ab_object_cpu.png` | 165.29 | Checkerboard, vivid red/blue (CPU still evaluates Object-mode procedurals) |
+
+The Object-mode pair is the load-bearing comparison: GPU renders flat gray
+(the guarded getAlbedo() fallback) while CPU still renders the full
+checkerboard (raw-objectPoint evaluation). This matches the PR's claimed
+semantics exactly — Object-mode procedurals are no longer silently
+misbaked into the normalized Generated voxel domain on GPU; they degrade
+to the documented pre-pkg190 flat-albedo fallback, with CPU remaining the
+reference. No fireflies, NaN pixels, banding, or mode regressions observed
+in any of the four renders.
+
+### Verdict: HW PASS
+
+All five verification steps clean: fresh non-stale build (sm_120 arch gate
++ ABI canary), PR test suite 6/6 (matches PR body), pkg190 Generated-path
+parity gate byte-identical to prior evidence, and the Object-mode guarded
+fallback visually confirmed on hardware. PR #615 is **HW PASS**.

--- a/include/astroray/gpu_types.h
+++ b/include/astroray/gpu_types.h
@@ -594,7 +594,7 @@ struct GImageTexture {
     int height;
     // pkg190 — procedural-texture slice. depth == 1 → a 2D image (or a 2D-UV
     // procedural bake), sampled by (u,v) via gpu_sampleImageTexture (the pkg186
-    // path, unchanged). depth > 1 → a 3D voxel bake of a Generated/Object-coord
+    // path, unchanged). depth > 1 → a 3D voxel bake of a Generated-coord
     // procedural, sampled by the normalized Generated coordinate via
     // gpu_sampleProcedural3D. genMin/genSize carry the SAME object-space bbox the
     // CPU Texture uses (Texture::getGeneratedMin/Size) so the GPU rebuilds the
@@ -670,7 +670,7 @@ HD inline GVec3 gpu_sampleImageTexture(const GImageTexture& tex,
     return texels[tex.offset + j * tex.width + i];
 }
 
-// pkg190 — nearest-neighbour 3D voxel fetch for a baked Generated/Object-coord
+// pkg190 — nearest-neighbour 3D voxel fetch for a baked Generated-coord
 // procedural. `g` is the normalized Generated coordinate in [0,1]^3, built by
 // the caller EXACTLY as the CPU does (g = clamp((objectPoint - genMin)/genSize,
 // 0, 1); include/advanced_features.h CoordMode::Generated). The bake stores cell

--- a/src/gpu/scene_upload.cu
+++ b/src/gpu/scene_upload.cu
@@ -705,7 +705,7 @@ SceneUploadResult buildSceneArrays(const Renderer& cpu, const Camera* cam) {
         // with materials[] (a -1 sentinel for every non-image material preserves
         // the untextured flat-albedo fast path). pkg190 extends this to bake
         // PROCEDURAL textures (also TexturedLambertian, non-ImageTexture) into the
-        // same buffer — 3D voxel for Generated/Object coords, 2D for UV.
+        // same buffer — 3D voxel for Generated coords, 2D for UV.
         int texId = -1;
         if (auto* tl = dynamic_cast<TexturedLambertian*>(m.get())) {
             std::shared_ptr<Texture> tex = tl->getTexture();
@@ -735,7 +735,7 @@ SceneUploadResult buildSceneArrays(const Renderer& cpu, const Camera* cam) {
                 // the pkg186 fetch machinery. Two domains, matching how the CPU
                 // Texture evaluates the node (include/advanced_features.h
                 // Texture::textureCoordinates):
-                //   * Generated / Object coord mode → the node is a 3D field over
+                //   * Generated coord mode → the node is a 3D field over
                 //     the object's normalized bbox → bake a res^3 VOXEL grid in
                 //     [0,1]^3 (the same space the CPU passes as `p`), sampled on the
                 //     GPU by the Generated coordinate (gpu_sampleProcedural3D).
@@ -745,13 +745,30 @@ SceneUploadResult buildSceneArrays(const Renderer& cpu, const Camera* cam) {
                 // exact-by-construction modulo grid resolution (no procedural math
                 // is re-derived on the device — cite-algorithm safe).
                 Texture* key = tex.get();
+                // pkg190 follow-up (PR #612 review) — COORD-MODE CONVENTION:
+                // the 3D voxel bake below stores the field over the NORMALIZED
+                // Generated domain ([0,1]^3 over genMin/genSize) and the shade
+                // path rebuilds g = clamp((p - genMin)/genSize, 0, 1) to sample
+                // it. Only CoordMode::Generated evaluates in that space on the
+                // CPU. CoordMode::Object passes the RAW unnormalized
+                // objectPoint (include/advanced_features.h CoordMode::Object),
+                // so an Object bake would diverge CPU<->GPU by construction —
+                // bake Object only if the CPU side gains the identical bbox
+                // normalization in lockstep. Object/Camera/Normal/Reflection/
+                // Window therefore stay UNBAKED: texId stays -1 and the GPU
+                // shades the flat baseColor (the pre-pkg190 degradation; CPU
+                // remains the reference — test_pkg190 test_object_mode_*).
+                const Texture::CoordMode cmode = tex->getCoordMode();
+                const bool uvMode  = cmode == Texture::CoordMode::UV;
+                const bool bakeable =
+                    uvMode || cmode == Texture::CoordMode::Generated;
                 auto tit = texIdx.find(key);
-                if (tit != texIdx.end()) {
+                if (!bakeable) {
+                    // guarded fallback — no bake (see convention above)
+                } else if (tit != texIdx.end()) {
                     texId = tit->second;
                     r.hasTexture = true;
                 } else {
-                    const bool uvMode =
-                        tex->getCoordMode() == Texture::CoordMode::UV;
                     // pkg190 default bake resolution; escalate a specific high-
                     // frequency node only if its parity/SSIM gate demands it.
                     int res = 64;
@@ -775,7 +792,7 @@ SceneUploadResult buildSceneArrays(const Renderer& cpu, const Camera* cam) {
                             }
                         }
                     } else {
-                        // Generated / Object 3D voxel bake. genMin/genSize come from
+                        // Generated 3D voxel bake. genMin/genSize come from
                         // the CPU texture's baked object bbox so the GPU rebuilds
                         // the identical normalized coordinate.
                         desc.depth = res;

--- a/src/gpu/wavefront/stage_advance.cu
+++ b/src/gpu/wavefront/stage_advance.cu
@@ -662,7 +662,9 @@ __device__ bool shadePathSlot(
             GVec3 texColor;
             bool  haveTex = false;
             if (tdesc.depth > 1) {
-                // pkg190 — 3D voxel procedural (Generated/Object coord). Rebuild
+                // pkg190 — 3D voxel procedural (Generated coord; Object-mode
+                // procedurals are never baked — scene_upload.cu convention:
+                // CPU Object passes the raw unnormalized objectPoint). Rebuild
                 // the SAME normalized coordinate the CPU used
                 // (include/advanced_features.h CoordMode::Generated):
                 //   g = clamp((objectPoint - genMin)/genSize, 0, 1).

--- a/tests/test_pkg190_gpu_procedural_texture.py
+++ b/tests/test_pkg190_gpu_procedural_texture.py
@@ -5,11 +5,14 @@ pkg186 added GPU sampling for IMAGE textures but collapsed every PROCEDURAL
 texture node (checker / brick / wave / magic / …) to the material's flat
 `getAlbedo()` on the GPU wavefront path. pkg190 bakes the CPU procedural
 evaluator into a device buffer at scene-upload time and samples it on the GPU:
-  * Generated/Object coord mode → a res^3 VOXEL bake in [0,1]^3, sampled by the
+  * Generated coord mode → a res^3 VOXEL bake in [0,1]^3, sampled by the
     normalized Generated coordinate (gpu_sampleProcedural3D). This mirrors how
     the pkg119-B parity scenes drive procedurals (no TexCoord node → Blender
     default Generated) — the (a)-set the re-baseline convicted.
   * UV coord mode → a res^2 bake reusing the pkg186 2D UV image path.
+  * Any OTHER coord mode (Object/Camera/Normal/Reflection/Window) → UNBAKED
+    (PR #612 follow-up): the GPU shades the flat baseColor; see the
+    Object-mode tests at the bottom of this file.
 
 Acceptance gates (mirror test_pkg186_gpu_texture_parity):
   * test_gpu_procedural_is_not_flat — a GPU render of a Generated-coord checker
@@ -48,22 +51,23 @@ _C2 = (0.1, 0.1, 0.9)   # blue
 _CHECK_SCALE = 4.0      # cells across the normalized [0,1] bbox
 
 
-def _add_checker_material(renderer, c1, c2, scale, base_color, name):
+def _add_checker_material(renderer, c1, c2, scale, base_color, name,
+                          coord_mode="GENERATED"):
     # params: [c1.r,g,b, c2.r,g,b, scale] (module/blender_module.cpp checker path)
     renderer.create_procedural_texture(
         name, "checker",
-        [c1[0], c1[1], c1[2], c2[0], c2[1], c2[2], scale], "GENERATED")
+        [c1[0], c1[1], c1[2], c2[0], c2[1], c2[2], scale], coord_mode)
     renderer.set_texture_generated_bbox(name, _BBOX_MIN, _BBOX_SIZE)
     return renderer.create_material("lambertian", list(base_color),
                                     {"texture": name})
 
 
 def _build_scene(renderer, *, textured=True, base_color=(0.8, 0.8, 0.8),
-                 c1=_C1, c2=_C2):
+                 c1=_C1, c2=_C2, coord_mode="GENERATED"):
     renderer.set_background_color([0.8, 0.8, 0.8])
     if textured:
         mat = _add_checker_material(renderer, c1, c2, _CHECK_SCALE, base_color,
-                                    "pkg190_checker")
+                                    "pkg190_checker", coord_mode)
     else:
         mat = renderer.create_material("lambertian", list(base_color), {})
 
@@ -81,7 +85,7 @@ def _build_scene(renderer, *, textured=True, base_color=(0.8, 0.8, 0.8),
 
 
 def _render(*, textured=True, use_gpu=True, base_color=(0.8, 0.8, 0.8),
-            c1=_C1, c2=_C2, samples=96, seed=1):
+            c1=_C1, c2=_C2, samples=96, seed=1, coord_mode="GENERATED"):
     r = create_renderer()
     if use_gpu:
         if not _has_cuda_gpu(r):
@@ -91,7 +95,8 @@ def _render(*, textured=True, use_gpu=True, base_color=(0.8, 0.8, 0.8),
     # the variable under test, not MC noise (seed 0 is the random sentinel —
     # [[seed-zero-is-random-sentinel]]).
     r.set_seed(seed)
-    _build_scene(r, textured=textured, base_color=base_color, c1=c1, c2=c2)
+    _build_scene(r, textured=textured, base_color=base_color, c1=c1, c2=c2,
+                 coord_mode=coord_mode)
     return render_image(r, samples=samples, max_depth=3, apply_gamma=False)
 
 
@@ -184,4 +189,48 @@ def test_rgb_texture_luminance_band_covered():
     assert mean_abs_diff > 1e-4, (
         f"luminance-band render ignores the RGB texture (mean|tex-flat|="
         f"{mean_abs_diff:.2e}); the fold was dropped under use_luminance_output."
+    )
+
+
+# --- pkg190 follow-up (PR #612 review): Object-coord-mode convention ---------
+# The 3D voxel bake stores the procedural field over the NORMALIZED Generated
+# domain ([0,1]^3 over genMin/genSize). CPU CoordMode::Object passes the RAW
+# unnormalized objectPoint (include/advanced_features.h CoordMode::Object) —
+# no bbox normalization — so an Object-mode bake would diverge CPU<->GPU by
+# construction. Convention pinned in src/gpu/scene_upload.cu: only Generated
+# (3D) and UV (2D) coord modes are baked; Object-mode (and Camera/Normal/
+# Reflection/Window) procedurals stay UNBAKED — the GPU shades the flat
+# baseColor. DOCUMENTED DEGRADATION: Object-mode procedural detail is CPU-only
+# until the CPU path gains the identical bbox normalization in lockstep.
+
+
+def test_object_mode_procedural_cpu_evaluates():
+    """CI-runnable CPU leg: CoordMode::Object procedurals still evaluate on the
+    CPU (raw-objectPoint checker != flat albedo). CPU remains the reference for
+    Object-mode procedurals under the degradation convention above."""
+    cpu_tex = _render(textured=True, use_gpu=False, coord_mode="OBJECT")
+    cpu_flat = _render(textured=False, use_gpu=False)
+    mean_abs_diff = float(np.abs(cpu_tex - cpu_flat).mean())
+    assert mean_abs_diff > 0.05, (
+        f"CPU Object-mode procedural render too close to flat albedo "
+        f"(mean|diff|={mean_abs_diff:.4f}); CPU stopped evaluating Object-mode "
+        f"procedurals — the pinned degradation assumes it is the reference."
+    )
+
+
+def test_object_mode_procedural_gpu_guarded_fallback():
+    """RTX leg: the GPU must NOT bake an Object-mode procedural into the
+    normalized-domain voxel grid (that field is wrong by construction). The
+    guarded fallback is the flat albedo: an unbaked TexturedLambertian uploads
+    getAlbedo() == Vec3(0.5) (advanced_features.h — the documented pre-pkg190
+    flatten), so with the same pinned seed the GPU Object-mode render must
+    match a plain 0.5-gray lambertian render."""
+    tex = _render(textured=True, use_gpu=True, coord_mode="OBJECT")
+    flat = _render(textured=False, use_gpu=True, base_color=(0.5, 0.5, 0.5))
+    mean_abs_diff = float(np.abs(tex - flat).mean())
+    assert mean_abs_diff < 0.01, (
+        f"GPU Object-mode render differs from flat albedo (mean|diff|="
+        f"{mean_abs_diff:.4f}); an Object-mode procedural was baked/sampled on "
+        f"the GPU despite the CPU passing raw unnormalized objectPoint — "
+        f"CPU<->GPU divergence by construction (PR #612 review)."
     )


### PR DESCRIPTION
## Summary

Follow-up from the PR #612 (pkg190) review: the GPU procedural-texture voxel bake in `src/gpu/scene_upload.cu` treated **every** non-UV coord mode as the normalized Generated field (`[0,1]^3` over `genMin`/`genSize`), but the CPU `CoordMode::Object` path (`include/advanced_features.h`) passes the **raw unnormalized** `objectPoint` — so an Object-coord-mode procedural would diverge CPU<->GPU by construction. Latent only because the whole pkg119-B (a)-set is Generated-mode.

- **Bake narrowed**: only `CoordMode::Generated` (3D voxel) and `UV` (2D) are baked. `Object`/`Camera`/`Normal`/`Reflection`/`Window` procedurals stay unbaked — `texId` stays `-1` and the GPU shades the flat `getAlbedo()` fallback (the documented pre-pkg190 degradation; CPU remains the reference). Convention pinned in a comment at the bake site: extend Object only if the CPU side gains the identical bbox normalization in lockstep.
- **Tests** (TDD; RTX leg was red pre-change at mean|diff|=0.219):
  - `test_object_mode_procedural_cpu_evaluates` — CI-runnable: CPU still evaluates Object-mode procedurals.
  - `test_object_mode_procedural_gpu_guarded_fallback` — RTX leg: GPU Object-mode render == 0.5-gray flat lambertian render (pinned seed), i.e. no bogus normalized-domain bake is sampled.
- Stale "Generated/Object" comments corrected in `gpu_types.h` / `stage_advance.cu` (comment-only).

## Register gate

Host-side-only change; verified on sm_120 (`cuobjdump -res-usage`, RTX 5070 Ti build):
- All 16 `stageShadeBucketedKernel` specializations byte-identical vs the pre-change baseline; non-texture `<false,...>` STACK 3352/3608 unchanged.
- Full-file res-usage numbers identical (only nondeterministic anonymous-namespace module-hash name suffixes differ between builds).

## Hardware evidence (RTX 5070 Ti, under `.orchestrator.gpu.lock`)

- `tests/test_pkg190_gpu_procedural_texture.py`: **6/6 passed** (4 existing gates + 2 new).
- Related suites (`pkg186` guard+parity, `pkg115` procedural/noise/voronoi/wave-brick/addon-translation, disney+principled `reflection_not_black`, `material_properties`): **90 passed, 2 pre-existing xfails**.
- Build via `build_cuda_worktree.bat` (arch gate sm_120 + ABI canary green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)