### PR TITLE
feat(pkg201): Stage 1 — addon settings-honour (world_max_bounces PASS, use_light_tree honoured, latent set_light_sampler crash fixed)

### DIFF
--- a/.astroray_plan/docs/pkg201-stage1-results.md
+++ b/.astroray_plan/docs/pkg201-stage1-results.md
@@ -1,0 +1,69 @@
+# pkg201 Stage 1 — addon-side settings-honour: results & delta
+
+**Run:** 2026-08-14, RTX 5070 Ti. Driver: `scripts/verify_pkg200_honour_matrix_run.py`
+(the pkg200 driver, corrected in-place by pkg201 — see below), re-run VERBATIM on
+my addon build via `--addon-dir dist/astroray`.
+**Engine `.pyd`:** `dist/astroray/astroray.cp313-win_amd64.pyd`, mtime
+2026-08-14 19:40:55 (OpenMP-OFF, sm_120 via cuobjdump `--list-elf`; built with
+`dev_addon.ps1 -Smoke`, register + liveness smoke PASS on Blender 5.1 AND 5.2).
+My change is Python-only (addon), so this engine binary == current main.
+**Method:** identical to pkg200 — per-row A/B through the TRUE F12 path
+(`bpy.ops.render.render`, CUSTOM_RAYTRACER, GPU), 32-bit LINEAR EXRs
+(`apply_gamma=False`), per-channel mean/max/variance via cv2 (never SSIM),
+pinned nonzero seeds, `PKG200_LEG PASS` sentinel-gated. Results byte-identical on
+5.1 and 5.2 unless noted.
+
+## Closed rows (before pkg201 -> after pkg201)
+
+| Stage | Row | pkg200 verdict (#616) | pkg201 verdict | Measured (LINEAR, this run) |
+|-------|-----|-----------------------|----------------|-----------------------------|
+| 1 | world_max_bounces | **HONEST-FAIL** (1.0971 = 1.0971) | **PASS** | lum_mean A(0)=0.20931 -> B(12)=1.0969, ratio 5.241 (5.1 ≡ 5.2) |
+| 1 | use_light_tree | **KNOWN-GAP** (inert; no pixel change) | **NEEDS-VISUAL — confirmed honoured** | \|dLum\| mean 0.02809 (5.1) / 0.03713 (5.2); both frames valid lit renders differing only in the NEE sampler noise field (multimodal Read) |
+
+### world_max_bounces (Finding B)
+The addon read `world.light_settings.max_bounces` — the ambient-occlusion
+datablock, which has **no** `max_bounces` member — so `getattr(..., 1024)` always
+won and the control was inert. Fixed to `world.cycles.max_bounces` (the real
+Cycles world light-path prop; the GPU wavefront already gates env contribution on
+`bounce <= worldMaxBounces`, `stage_advance.cu:312`). The pkg200 driver Row
+encoded the bug as its override path (`world.light_settings.max_bounces`), which
+`_apply_overrides` silently skips as a non-existent attr — so the row could never
+flip on a verbatim re-run. Closing Finding B therefore includes repointing that
+Row (and the `check_completeness` alias) to `world.cycles.max_bounces` so the
+matrix tests the corrected attribute.
+
+### use_light_tree (promoted from KNOWN_GAPS)
+The addon read the custom UI tri-state directly and passed it to
+`set_light_sampler`, which **threw** for `'uniform'`/`'light_tree'` (engine
+accepts only `'power'`/`'tree'`, `blender_module.cpp:1531`) — a latent crash only
+masked because the default is `'power'`. pkg201 `resolve_light_sampler` reconciles
+the native `use_light_tree` bool AND translates the UI enum to a valid engine
+token: True->`'tree'`, False->`'power'` (the engine has no uniform sampler, so
+uniform collapses to power — stays APPROXIMATED). A new `use_light_tree` MATRIX
+row + `many_lights` scene were added (KNOWN_GAPS now empty). The scene uses pure
+**Emission-shader** spheres — the addon maps those to the hittable
+`create_material('light',...)` NEE emitter (`__init__.py:3657`); a Principled-BSDF
+emission is not an NEE light and leaves the tree empty (the near-black
+false-negative first hit during bring-up). Toggling the native prop now changes
+the GPU wavefront render measurably; visual confirm: both A(power)/B(tree) are
+valid lit rooms differing only in sampler noise (not garbage).
+
+## Control spot-check (untouched rows — driver edits must be benign)
+
+| Row | pkg201 verdict | Measured | Matches #616? |
+|-----|----------------|----------|---------------|
+| film_exposure | PASS | per-ch mean-ratio 2.000, 2.000, 2.000 | yes (2.000) |
+| max_bounces | PASS | lum_mean 0.034429 -> 0.43035, ratio 12.500 | yes (12.5×) |
+| seed_repeat | PASS | \|dLum\| max ≤ 7.9e-07 (reproducible) | yes |
+
+The in-place driver corrections (world_max_bounces override repoint,
+`light_sampling` promoted to `_PLUMBED_APPROXIMATED`, new `use_light_tree` row,
+`_alias` additions, empty `KNOWN_GAPS`) leave every neighbouring row's verdict
+and numbers unchanged. `check_completeness()`: 26 plumbed props -> 26 rows, OK.
+
+## Not in scope / follow-ups
+- Stage 2 (Findings D/E/F) and Stage 3 (Findings A/C) remain open per the spec.
+- The engine has no dedicated **uniform** light sampler; the UI `uniform` enum
+  value collapses to `'power'` at the engine boundary (a pre-existing condition
+  surfaced, not introduced, by pkg201). If a real uniform sampler is wanted that
+  is a separate engine package.

--- a/.astroray_plan/packages/pkg201-gpu-wavefront-settings-honour.md
+++ b/.astroray_plan/packages/pkg201-gpu-wavefront-settings-honour.md
@@ -2,7 +2,7 @@
 
 **Pillar:** Integration Milestone (Blender/DCC integration — the steering wheel must actually steer)
 **Track:** A (engine/kernel work on the GPU wavefront + a small addon-side exporter fix; gated on real Blender 5.1/5.2 F12 renders on RTX)
-**Status:** open (filed 2026-08-14). Direct follow-up to pkg200 (PR #616): closes the GPU-plumbing gaps that pkg200's honour matrix recorded as HONEST-FAIL.
+**Status:** Stage 1 done (PR pending, 2026-08-14 — `world_max_bounces` HONEST-FAIL→PASS ratio 5.24 on 5.1/5.2; `use_light_tree` KNOWN-GAP→NEEDS-VISUAL-confirmed honoured; also fixed a latent set_light_sampler crash). Stages 2 and 3 open. Direct follow-up to pkg200 (PR #616): closes the GPU-plumbing gaps that pkg200's honour matrix recorded as HONEST-FAIL.
 **Estimated effort:** L, staged by risk (Stage 1 = S addon-only; Stage 2 = M GPU host/splat plumbing; Stage 3 = probe-first, register-hostile, may-park).
 **Depends on:** pkg200 (`.astroray_plan/docs/pkg200-honour-matrix-results.md` — the findings this package closes, referenced by letter; `scripts/verify_pkg200_honour_matrix_run.py` — the verbatim re-run gate). pkg176 (native-settings plumbing; `blender_addon/settings_map.py`, `__init__.py::convert_scene`). pkg55 wavefront (`module/blender_module.cpp` GPU dispatch, `src/gpu/wavefront/gpu_wavefront_snapshot.cu::cuda_wavefront_render`).
 
@@ -34,6 +34,8 @@ Closes **B** and the **use_light_tree** known-gap. Pure Python, in `blender_addo
 2. **use_light_tree:** reconcile the tri-state-vs-bool mismatch in `settings_map.py`/`convert_scene` so toggling the native `scene.cycles.use_light_tree` actually reaches `renderer.set_light_sampler` (native `True` → light-tree sampler, `False` → the uniform/other sampler; preserve the custom tri-state's third state if it still has a distinct meaning, else collapse to the native bool per the pkg176 Stage-1 rule). Decide the mapping explicitly in the PR body — do not silently pick.
 
 **Stage 1 acceptance:** the pkg200 `world_max_bounces` row (currently `1.0971 = 1.0971`) flips to PASS (strictly-monotone energy vs depth) re-running the driver verbatim; the `use_light_tree` known-gap row now shows a pixel change when the native prop toggles. Both are addon-only — no `.pyd` rebuild required beyond a register/liveness smoke.
+
+**Stage 1 DONE (2026-08-14, `.astroray_plan/docs/pkg201-stage1-results.md`).** `world_max_bounces`: HONEST-FAIL→**PASS** (A(0)=0.209 → B(12)=1.097, ratio 5.24, 5.1≡5.2) — Finding B fixed (`world.cycles.max_bounces`); the pkg200 driver's Row override (which encoded the AO-datablock bug) was repointed in-place to the corrected attr. `use_light_tree`: KNOWN-GAP→**NEEDS-VISUAL, confirmed honoured** (|dLum| mean 0.028/0.037; both A/B valid lit frames differing in sampler noise) — promoted from `KNOWN_GAPS` to a real matrix row (`many_lights` Emission-emitter scene). Also fixed a **latent crash** the reconciliation exposed: `set_light_sampler` accepts only `'power'`/`'tree'` but the UI enum shipped `'uniform'`/`'light_tree'`; `resolve_light_sampler` now translates to a valid engine token (uniform→power; engine has no uniform sampler). Two changes beyond the spec's literal Stage-1 text, both justified in the PR: (1) the pkg200 driver correction is required because the Row encoded the very bug Finding B fixes; (2) the enum→token translation is required or the fix crashes on Blender's default scene.
 
 ### Stage 2 — GPU plumbing, LOW register risk (host/splat/pre-pass, not the shade kernel's per-ray live state)
 

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -4769,9 +4769,15 @@ class CustomRaytracerRenderEngine(RenderEngine):
         else:
             renderer.set_world_volume(0.0, [1.0, 1.0, 1.0], 0.0)
 
-        # Apply world bounce limit (Cycles: world.light_settings.max_bounces)
-        world_settings = getattr(world, 'light_settings', None)
-        world_max_bounces = int(getattr(world_settings, 'max_bounces', 1024)) if world_settings else 1024
+        # Apply world bounce limit (Cycles: world.cycles.max_bounces). pkg201
+        # Finding B: the prior read used world.light_settings.max_bounces, but
+        # light_settings is the ambient-occlusion datablock (WorldLighting) and
+        # has NO max_bounces member, so getattr(..., 1024) always won and the
+        # control was inert. The real Cycles world light-path prop is
+        # world.cycles.max_bounces; keep a getattr default for worlds without a
+        # cycles block (non-Cycles scene / test stub) so nothing hard-crashes.
+        world_cycles = getattr(world, 'cycles', None)
+        world_max_bounces = int(getattr(world_cycles, 'max_bounces', 1024)) if world_cycles else 1024
         renderer.set_world_max_bounces(world_max_bounces)
 
         # Try loading HDRI first.

--- a/blender_addon/native_settings.py
+++ b/blender_addon/native_settings.py
@@ -192,6 +192,34 @@ def report_unsupported_native_controls(scene, report=None, emit=True):
     return messages
 
 
+def resolve_light_sampler(cycles, custom_value):
+    """pkg201 Stage 1: reconcile the native Cycles ``use_light_tree`` bool with
+    Astroray's ``uniform`` / ``power`` / ``light_tree`` tri-state.
+
+    Cycles exposes only a ``use_light_tree`` bool (the ``light_sampling`` row in
+    ``settings_map`` is a documented SEMANTIC MISMATCH). Before pkg201 the
+    exporter read the custom tri-state directly, so toggling the native prop
+    changed nothing (pkg200 ``use_light_tree`` known-gap). This makes the native
+    bool authoritative for the tree-vs-non-tree axis while preserving the
+    tri-state's distinct non-tree choice:
+
+      * ``use_light_tree`` True  -> ``light_tree`` (honour the native enable).
+      * ``use_light_tree`` False -> defer to the custom non-tree choice
+        (``uniform`` vs ``power``); a stale custom ``light_tree`` is overridden
+        by the native OFF and falls back to ``power`` (Astroray's non-tree
+        default), so the native bool always wins.
+
+    Returns ``None`` when the scene has no ``use_light_tree`` (non-Cycles scene
+    or a unit-test stub) so the proxy falls through to the custom value
+    unchanged.
+    """
+    if cycles is None or not hasattr(cycles, "use_light_tree"):
+        return None
+    if cycles.use_light_tree:
+        return "light_tree"
+    return custom_value if custom_value in ("uniform", "power") else "power"
+
+
 def resolve_native_settings(scene, report=None):
     """Resolve the DIRECT-mapped settings for ``scene`` and return a
     :class:`ResolvedSettings` view.
@@ -212,4 +240,11 @@ def resolve_native_settings(scene, report=None):
             resolved[custom_attr] = DIRECT_DEFAULTS[custom_attr]
         # else: settings still carries the attr (a pre-retirement object / test
         # stub) -> leave unresolved so the proxy falls through to it unchanged.
+    # pkg201 Stage 1: reconcile the APPROXIMATED light_sampling row (native
+    # use_light_tree bool -> tri-state) so both the F12 (convert_scene) and
+    # viewport (sync_viewport_scene) paths honour the native toggle via the
+    # existing renderer.set_light_sampler(settings.light_sampler) call sites.
+    light_sampler = resolve_light_sampler(cycles, getattr(settings, "light_sampler", "power"))
+    if light_sampler is not None:
+        resolved["light_sampler"] = light_sampler
     return ResolvedSettings(settings, resolved)

--- a/blender_addon/native_settings.py
+++ b/blender_addon/native_settings.py
@@ -193,31 +193,33 @@ def report_unsupported_native_controls(scene, report=None, emit=True):
 
 
 def resolve_light_sampler(cycles, custom_value):
-    """pkg201 Stage 1: reconcile the native Cycles ``use_light_tree`` bool with
-    Astroray's ``uniform`` / ``power`` / ``light_tree`` tri-state.
+    """pkg201 Stage 1: resolve the light-sampler token the ENGINE session should
+    use, reconciling the native Cycles ``use_light_tree`` bool with Astroray's
+    ``uniform`` / ``power`` / ``light_tree`` UI tri-state.
 
-    Cycles exposes only a ``use_light_tree`` bool (the ``light_sampling`` row in
-    ``settings_map`` is a documented SEMANTIC MISMATCH). Before pkg201 the
-    exporter read the custom tri-state directly, so toggling the native prop
-    changed nothing (pkg200 ``use_light_tree`` known-gap). This makes the native
-    bool authoritative for the tree-vs-non-tree axis while preserving the
-    tri-state's distinct non-tree choice:
+    The engine's ``set_light_sampler`` accepts ONLY ``'power'`` and ``'tree'``
+    (``module/blender_module.cpp`` ``setLightSampler``); it has no separate
+    uniform sampler. So this returns one of those two tokens, and BOTH the native
+    bool and the UI enum are translated here:
 
-      * ``use_light_tree`` True  -> ``light_tree`` (honour the native enable).
-      * ``use_light_tree`` False -> defer to the custom non-tree choice
-        (``uniform`` vs ``power``); a stale custom ``light_tree`` is overridden
-        by the native OFF and falls back to ``power`` (Astroray's non-tree
-        default), so the native bool always wins.
+      * If the scene carries the native ``use_light_tree`` bool it is
+        authoritative for the tree-vs-non-tree axis:
+        True  -> ``'tree'`` (honour the native enable),
+        False -> ``'power'`` (the engine's only non-tree sampler; the UI's
+        uniform-vs-power distinction cannot be expressed at the engine boundary,
+        so it collapses to power — status stays ``approximated``).
+      * Otherwise (non-Cycles scene / unit-test stub) translate the UI enum:
+        ``'light_tree'`` -> ``'tree'``, anything else -> ``'power'``.
 
-    Returns ``None`` when the scene has no ``use_light_tree`` (non-Cycles scene
-    or a unit-test stub) so the proxy falls through to the custom value
-    unchanged.
+    Before pkg201 the exporter passed the raw UI enum straight to the engine,
+    which threw for ``'uniform'`` / ``'light_tree'`` (a latent crash only avoided
+    because the default is ``'power'`` and non-default samplers were never
+    F12-rendered); it also never read the native bool (pkg200 known-gap). This
+    fixes both. Always returns a valid engine token, never ``None``.
     """
-    if cycles is None or not hasattr(cycles, "use_light_tree"):
-        return None
-    if cycles.use_light_tree:
-        return "light_tree"
-    return custom_value if custom_value in ("uniform", "power") else "power"
+    if cycles is not None and hasattr(cycles, "use_light_tree"):
+        return "tree" if cycles.use_light_tree else "power"
+    return "tree" if custom_value == "light_tree" else "power"
 
 
 def resolve_native_settings(scene, report=None):
@@ -240,11 +242,12 @@ def resolve_native_settings(scene, report=None):
             resolved[custom_attr] = DIRECT_DEFAULTS[custom_attr]
         # else: settings still carries the attr (a pre-retirement object / test
         # stub) -> leave unresolved so the proxy falls through to it unchanged.
-    # pkg201 Stage 1: reconcile the APPROXIMATED light_sampling row (native
-    # use_light_tree bool -> tri-state) so both the F12 (convert_scene) and
-    # viewport (sync_viewport_scene) paths honour the native toggle via the
-    # existing renderer.set_light_sampler(settings.light_sampler) call sites.
-    light_sampler = resolve_light_sampler(cycles, getattr(settings, "light_sampler", "power"))
-    if light_sampler is not None:
-        resolved["light_sampler"] = light_sampler
+    # pkg201 Stage 1: resolve the APPROXIMATED light_sampling row to the engine
+    # token ('power' | 'tree'), reconciling the native use_light_tree bool AND
+    # translating the UI enum, so both the F12 (convert_scene) and viewport
+    # (sync_viewport_scene) paths honour the native toggle via the existing
+    # renderer.set_light_sampler(settings.light_sampler) call sites (which would
+    # otherwise throw on the UI's 'uniform'/'light_tree' values).
+    resolved["light_sampler"] = resolve_light_sampler(
+        cycles, getattr(settings, "light_sampler", "power"))
     return ResolvedSettings(settings, resolved)

--- a/blender_addon/settings_map.py
+++ b/blender_addon/settings_map.py
@@ -100,10 +100,11 @@ _RENDER_SAMPLING = [
                  "pkg119-A marked DROPPED; addon NOW reads scene.cycles.filter_width natively."),
     MappingEntry("sampling", "light_sampling", "scene.cycles.use_light_tree",
                  "custom_raytracer.light_sampler", "renderer.set_light_sampler", "approximated", "n/a",
-                 "SEMANTIC MISMATCH: Astroray has uniform/power/light_tree tri-state; Cycles exposes only a "
-                 "use_light_tree bool (+light_sampling_threshold). pkg201 Stage 1 reconciles it in "
-                 "native_settings.resolve_light_sampler: native True -> light_tree, native False -> the "
-                 "custom non-tree choice (uniform/power). Stays APPROXIMATED (bool cannot express uniform vs power)."),
+                 "SEMANTIC MISMATCH: Astroray's UI has a uniform/power/light_tree tri-state; Cycles exposes only "
+                 "a use_light_tree bool, and the ENGINE's set_light_sampler accepts only 'power'/'tree' (no uniform "
+                 "sampler). pkg201 Stage 1 reconciles in native_settings.resolve_light_sampler: native True -> "
+                 "'tree', native False -> 'power'. Stays APPROXIMATED (neither Cycles nor the engine can express "
+                 "uniform vs power)."),
 ]
 
 # ---------------------------------------------------------------------------

--- a/blender_addon/settings_map.py
+++ b/blender_addon/settings_map.py
@@ -101,7 +101,9 @@ _RENDER_SAMPLING = [
     MappingEntry("sampling", "light_sampling", "scene.cycles.use_light_tree",
                  "custom_raytracer.light_sampler", "renderer.set_light_sampler", "approximated", "n/a",
                  "SEMANTIC MISMATCH: Astroray has uniform/power/light_tree tri-state; Cycles exposes only a "
-                 "use_light_tree bool (+light_sampling_threshold). Stays custom-only until reconciled (Stage 1 rule)."),
+                 "use_light_tree bool (+light_sampling_threshold). pkg201 Stage 1 reconciles it in "
+                 "native_settings.resolve_light_sampler: native True -> light_tree, native False -> the "
+                 "custom non-tree choice (uniform/power). Stays APPROXIMATED (bool cannot express uniform vs power)."),
 ]
 
 # ---------------------------------------------------------------------------
@@ -144,9 +146,11 @@ _LIGHT_PATHS = [
     MappingEntry("light_paths", "use_fast_gi", "scene.cycles.use_fast_gi", "",
                  "(none)", "dropped", "DROPPED-SILENT",
                  "Fast GI approximation not implemented; no engine target."),
-    MappingEntry("light_paths", "world_max_bounces", "scene.world.light_settings.max_bounces", "",
+    MappingEntry("light_paths", "world_max_bounces", "scene.world.cycles.max_bounces", "",
                  "renderer.set_world_max_bounces", "direct", "n/a",
-                 "Read natively today from world.light_settings.max_bounces."),
+                 "Read natively from world.cycles.max_bounces (pkg201 Finding B; the "
+                 "prior read used world.light_settings.max_bounces, the AO datablock "
+                 "which has no max_bounces member, so the control was inert)."),
 ]
 
 # ---------------------------------------------------------------------------

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -55,4 +55,7 @@ their package closes — the PR + STATUS.md hold the evidence. Exceptions that
 REMAIN because they are reusable harnesses (registered in the table above):
 `scripts/verify_pkg175_smoke_blender.py` (wired into `dev_addon.ps1`) and the
 `scripts/verify_pkg200_honour_matrix*.py` + `pkg200_honour_matrix.py` A/B
-honour driver.
+honour driver. pkg201 extended that driver in place (not a fork): the
+`world_max_bounces` row was repointed to `world.cycles.max_bounces` (Finding B),
+and a `use_light_tree` row + its `many_lights` scene builder were added
+(promoting the former pkg200 known-gap) — no new script.

--- a/scripts/pkg200_honour_matrix.py
+++ b/scripts/pkg200_honour_matrix.py
@@ -52,11 +52,14 @@ import settings_map  # noqa: E402  (path set above)
 # pkg119-B) and are explicitly out of THIS matrix (pkg200 spec, "Scope").
 HONOUR_CATEGORIES = frozenset({"render", "sampling", "light_paths", "film", "denoising"})
 
-# The two APPROXIMATED denoise rows that ARE plumbed today (resolve_denoiser_pass
-# / viewport denoise) — included per the spec's "plus the plumbed approximated
-# denoise rows". Every OTHER approximated row (light_sampling / use_light_tree)
-# is a documented gap, see KNOWN_GAPS.
-_PLUMBED_APPROXIMATED = frozenset({"denoiser", "use_preview_denoising"})
+# APPROXIMATED rows that ARE plumbed today and therefore carry a real honour
+# obligation: the two denoise rows (resolve_denoiser_pass / viewport denoise),
+# plus `light_sampling` (the native scene.cycles.use_light_tree bool), which
+# pkg201 Stage 1 reconciled onto Astroray's uniform/power/light_tree tri-state
+# (native_settings.resolve_light_sampler). It stays status="approximated" — a
+# bool cannot express uniform-vs-power — but it is no longer a silent gap, so it
+# is enumerated into the honour surface and gets its own matrix row.
+_PLUMBED_APPROXIMATED = frozenset({"denoiser", "use_preview_denoising", "light_sampling"})
 
 
 def enumerate_direct_surface() -> list[str]:
@@ -80,15 +83,12 @@ def enumerate_direct_surface() -> list[str]:
 
 # Documented gaps: plumbed-looking but NOT honoured natively today. Recorded as
 # findings, never tested as honoured (spec "Explicitly out of the honour matrix").
-KNOWN_GAPS = {
-    "use_light_tree": (
-        "scene.cycles.use_light_tree is APPROXIMATED and NOT read at F12: "
-        "convert_scene reads the custom light_sampler tri-state "
-        "(settings.light_sampler), never the native use_light_tree bool. "
-        "Toggling the native prop changes nothing. Follow-up: reconcile the "
-        "tri-state vs. bool semantic mismatch (settings_map light_sampling row)."
-    ),
-}
+#
+# pkg201 Stage 1 PROMOTED the former `use_light_tree` gap into a real matrix row
+# (the `use_light_tree` Row below): the native scene.cycles.use_light_tree bool
+# is now reconciled onto the tri-state and reaches renderer.set_light_sampler, so
+# toggling it changes the render. The gap dict is now empty.
+KNOWN_GAPS: dict[str, str] = {}
 
 
 # --------------------------------------------------------------------------- #
@@ -343,21 +343,33 @@ MATRIX: list[Row] = [
         variant_a=(("cycles.transparent_max_bounces", 0),),
         variant_b=(("cycles.transparent_max_bounces", 12),),
         note="stacked alpha-transparent quads; alpha depth 0 vs 12"),
-    Row("world_max_bounces", ("world.light_settings.max_bounces",), "hdri_box", "1",
+    Row("world_max_bounces", ("world.cycles.max_bounces",), "hdri_box", "1",
         p_monotone_energy,
         common=(("cycles.max_bounces", 16), ("cycles.diffuse_bounces", 16)),
-        variant_a=(("world.light_settings.max_bounces", 0),),
-        variant_b=(("world.light_settings.max_bounces", 12),),
-        note="world-lit box; world max bounces 0 vs 12. NOTE: the addon reads a "
-             "NON-EXISTENT attr world.light_settings.max_bounces (WorldLighting has "
-             "no such member; the real Cycles prop is world.cycles.max_bounces), so "
-             "getattr(..., 1024) always wins — override is inert. Expected HONEST-FAIL."),
+        variant_a=(("world.cycles.max_bounces", 0),),
+        variant_b=(("world.cycles.max_bounces", 12),),
+        note="world-lit box; world max bounces 0 vs 12. pkg201 Finding B: the addon "
+             "now reads world.cycles.max_bounces (the real Cycles world light-path "
+             "prop). The pre-pkg201 read used world.light_settings.max_bounces — the "
+             "AO datablock, which has no max_bounces member, so the override was inert "
+             "(pkg200 recorded HONEST-FAIL). This row now exercises the corrected attr."),
     Row("volume_bounces", ("volume_bounces",), "volume_box", "1", p_monotone_energy,
         common=(("cycles.max_bounces", 16),),
         variant_a=(("cycles.volume_bounces", 0),),
         variant_b=(("cycles.volume_bounces", 8),),
         note="KNOWN-PARTIAL candidate: volume transport only partly implemented "
              "(settings_map note). HONEST-FAIL if non-responsive — file, do not fix."),
+    Row("use_light_tree", ("use_light_tree",), "many_lights", "1", p_changes_pixels,
+        kind="visual",
+        variant_a=(("cycles.use_light_tree", False),),
+        variant_b=(("cycles.use_light_tree", True),),
+        note="many small area lights of widely varying power/position. pkg201 Stage 1 "
+             "reconciles native scene.cycles.use_light_tree onto the tri-state (False -> "
+             "non-tree 'power', True -> 'light_tree'); the two samplers pick different "
+             "light subsets per NEE ray, so the noise field differs at a pinned seed. "
+             "Was a pkg200 KNOWN-GAP (inert; no pixel change). p_changes_pixels -> "
+             "NEEDS-VISUAL + a multimodal Read confirms a legitimate sampler change "
+             "(not garbage), mirroring the caustics rows."),
 
     # ---- Stage 2: clamps + filter-glossy firefly clipping ----
     Row("sample_clamp_direct", ("sample_clamp_direct",), "firefly", "2", p_clamp,
@@ -476,9 +488,13 @@ def check_completeness() -> None:
     not match exactly (unassigned prop = a silently-untested control; duplicate =
     ambiguous ownership). Raises AssertionError with the drift."""
     surface = set(enumerate_direct_surface())
-    # world_max_bounces is enumerated by its native_prop "world_max_bounces" in
-    # settings_map but its Blender path is world.light_settings.max_bounces; map.
-    _alias = {"world_max_bounces": "world.light_settings.max_bounces",
+    # Some settings_map native_prop ids differ from the Blender dotted path the
+    # matrix Row exercises; map native_prop -> Row path here. world_max_bounces ->
+    # world.cycles.max_bounces (pkg201 Finding B corrected the read off the AO
+    # datablock). light_sampling is the native_prop for scene.cycles.use_light_tree
+    # (pkg201 promoted it from KNOWN_GAPS to the use_light_tree Row).
+    _alias = {"world_max_bounces": "world.cycles.max_bounces",
+              "light_sampling": "use_light_tree",
               "film_transparent": "render.film_transparent",
               "resolution_x": "render.resolution_x",
               "resolution_y": "render.resolution_y"}

--- a/scripts/pkg200_honour_matrix.py
+++ b/scripts/pkg200_honour_matrix.py
@@ -363,13 +363,19 @@ MATRIX: list[Row] = [
         kind="visual",
         variant_a=(("cycles.use_light_tree", False),),
         variant_b=(("cycles.use_light_tree", True),),
-        note="many small area lights of widely varying power/position. pkg201 Stage 1 "
-             "reconciles native scene.cycles.use_light_tree onto the tri-state (False -> "
-             "non-tree 'power', True -> 'light_tree'); the two samplers pick different "
-             "light subsets per NEE ray, so the noise field differs at a pinned seed. "
-             "Was a pkg200 KNOWN-GAP (inert; no pixel change). p_changes_pixels -> "
-             "NEEDS-VISUAL + a multimodal Read confirms a legitimate sampler change "
-             "(not garbage), mirroring the caustics rows."),
+        note="18 EMISSION-shader spheres in 3 clusters of widely varying power. They "
+             "must be pure Emission-node materials (addon maps those to the hittable "
+             "create_material('light',...) NEE emitter, __init__.py:3657); a Principled "
+             "BSDF with emission takes the 'principled' path and is NOT an NEE light, so "
+             "the scene stays unlit and no tree is built (AREA/POINT lamps are dedicated "
+             "and likewise excluded from the pkg86-B GPU tree). pkg201 Stage 1 makes the "
+             "addon forward native scene.cycles.use_light_tree to the engine token "
+             "('power'/'tree') via resolve_light_sampler — the pre-pkg201 raw-enum "
+             "pass-through threw for 'uniform'/'light_tree'. False('power')/True('tree') "
+             "select different NEE light subsets, so the GPU wavefront render changes "
+             "measurably; p_changes_pixels -> NEEDS-VISUAL + a multimodal Read confirms "
+             "both frames are valid lit renders differing only in the sampler noise "
+             "field (not garbage), mirroring the caustics rows. Was a pkg200 KNOWN-GAP."),
 
     # ---- Stage 2: clamps + filter-glossy firefly clipping ----
     Row("sample_clamp_direct", ("sample_clamp_direct",), "firefly", "2", p_clamp,

--- a/scripts/verify_pkg200_honour_matrix.py
+++ b/scripts/verify_pkg200_honour_matrix.py
@@ -303,31 +303,55 @@ def build_volume_box(scene):
     _camera(scene, location=(0.0, -6.0, 0.0))
 
 
+def _emissive_mat(name, strength):
+    # Pure EMISSION-shader material -> the addon maps it to create_material(
+    # 'light', ...) (a HITTABLE mesh emitter in the LightList, __init__.py:3657),
+    # NOT the 'principled' path a Principled-BSDF emission would take. The GPU
+    # light tree (pkg86-B) is built ONLY over such hittable emitters; AREA/POINT/
+    # SUN lamps are dedicated lights and are excluded, leaving the tree empty and
+    # collapsing both sampler modes to power-CDF. This is what makes the
+    # use_light_tree toggle observable on the GPU wavefront.
+    m = bpy.data.materials.new(name)
+    m.use_nodes = True
+    nt = m.node_tree
+    for n in list(nt.nodes):
+        if n.type == "BSDF_PRINCIPLED":
+            nt.nodes.remove(n)
+    out = nt.nodes.get("Material Output")
+    emit = nt.nodes.new("ShaderNodeEmission")
+    emit.inputs["Color"].default_value = (1.0, 1.0, 1.0, 1.0)
+    emit.inputs["Strength"].default_value = strength
+    nt.links.new(emit.outputs[0], out.inputs["Surface"])
+    return m
+
+
 def build_many_lights(scene):
-    # Many small area lights of widely varying power arranged in a ring above a
-    # diffuse floor + back wall, lighting a diffuse sphere. The light-sampler
-    # choice (use_light_tree False -> 'power' vs True -> 'light_tree') selects a
-    # different light subset per NEE ray, so at a pinned seed the noise field
-    # differs measurably (pkg201 use_light_tree row; p_changes_pixels + visual).
+    # Many small EMISSIVE SPHERES (hittable emitters) of widely varying power,
+    # spatially clustered, lighting a diffuse floor + back wall. The light-tree
+    # sampler weights emitters by spatial importance, the power sampler by raw
+    # power only, so at a pinned seed the two produce a DIFFERENT NEE noise field
+    # on the diffuse surfaces -> use_light_tree False('power')/True('tree') is
+    # observable. Uses emissive MESH (not AREA lamps): the GPU light tree is
+    # built only over hittable emitters (pkg86-B), so lamps would leave it empty
+    # and both modes would collapse to power-CDF (pkg201 use_light_tree row).
     import math
     _black_world(scene)
     floor = _diffuse_mat("floor", (0.72, 0.72, 0.72))
-    _plane(scene, floor, (0.0, 0.0, -1.5), (0.0, 0.0, 0.0), size=14.0)
+    _plane(scene, floor, (0.0, 0.0, -1.5), (0.0, 0.0, 0.0), size=16.0)
     back = _diffuse_mat("back", (0.6, 0.6, 0.65))
-    _plane(scene, back, (0.0, 4.0, 1.5), (1.5708, 0.0, 0.0), size=14.0)
-    bpy.ops.mesh.primitive_uv_sphere_add(radius=1.0, location=(0.0, 0.5, -0.4))
-    obj = bpy.context.object
-    obj.data.materials.append(_diffuse_mat("subj", (0.8, 0.5, 0.2)))
-    bpy.ops.object.shade_smooth()
-    for i in range(16):
-        ld = bpy.data.lights.new(f"L{i}", type='AREA')
-        ld.energy = 15.0 * (i + 1)          # widely varying power -> importance
-        ld.size = 0.15
-        o = bpy.data.objects.new(f"L{i}", ld)
-        ang = i * (2.0 * math.pi / 16.0)
-        o.location = (3.0 * math.cos(ang), 0.8 + 1.4 * math.sin(ang), 2.0)
-        o.rotation_euler = (math.pi, 0.0, 0.0)  # point down
-        scene.collection.objects.link(o)
+    _plane(scene, back, (0.0, 4.0, 1.5), (1.5708, 0.0, 0.0), size=16.0)
+    # 18 emissive spheres in 3 spatial clusters, emission spanning ~30x so the
+    # tree's spatial+power importance diverges from pure power weighting.
+    clusters = ((-2.6, 0.5, 1.4), (2.6, -0.5, 1.0), (0.0, 2.6, 2.2))
+    for i in range(18):
+        cx, cy, cz = clusters[i % 3]
+        jitter = (i * 0.37) % 1.0
+        loc = (cx + 0.6 * math.cos(i), cy + 0.5 * math.sin(i * 1.7), cz + 0.4 * jitter)
+        strength = 2.0 * (1 + (i % 6) ** 2)    # 2 .. ~52 (wide power spread)
+        bpy.ops.mesh.primitive_uv_sphere_add(radius=0.12, location=loc)
+        s = bpy.context.object
+        s.data.materials.append(_emissive_mat(f"emit{i}", strength))
+        bpy.ops.object.shade_smooth()
     _camera(scene, location=(0.0, -6.0, 0.4))
 
 

--- a/scripts/verify_pkg200_honour_matrix.py
+++ b/scripts/verify_pkg200_honour_matrix.py
@@ -303,6 +303,34 @@ def build_volume_box(scene):
     _camera(scene, location=(0.0, -6.0, 0.0))
 
 
+def build_many_lights(scene):
+    # Many small area lights of widely varying power arranged in a ring above a
+    # diffuse floor + back wall, lighting a diffuse sphere. The light-sampler
+    # choice (use_light_tree False -> 'power' vs True -> 'light_tree') selects a
+    # different light subset per NEE ray, so at a pinned seed the noise field
+    # differs measurably (pkg201 use_light_tree row; p_changes_pixels + visual).
+    import math
+    _black_world(scene)
+    floor = _diffuse_mat("floor", (0.72, 0.72, 0.72))
+    _plane(scene, floor, (0.0, 0.0, -1.5), (0.0, 0.0, 0.0), size=14.0)
+    back = _diffuse_mat("back", (0.6, 0.6, 0.65))
+    _plane(scene, back, (0.0, 4.0, 1.5), (1.5708, 0.0, 0.0), size=14.0)
+    bpy.ops.mesh.primitive_uv_sphere_add(radius=1.0, location=(0.0, 0.5, -0.4))
+    obj = bpy.context.object
+    obj.data.materials.append(_diffuse_mat("subj", (0.8, 0.5, 0.2)))
+    bpy.ops.object.shade_smooth()
+    for i in range(16):
+        ld = bpy.data.lights.new(f"L{i}", type='AREA')
+        ld.energy = 15.0 * (i + 1)          # widely varying power -> importance
+        ld.size = 0.15
+        o = bpy.data.objects.new(f"L{i}", ld)
+        ang = i * (2.0 * math.pi / 16.0)
+        o.location = (3.0 * math.cos(ang), 0.8 + 1.4 * math.sin(ang), 2.0)
+        o.rotation_euler = (math.pi, 0.0, 0.0)  # point down
+        scene.collection.objects.link(o)
+    _camera(scene, location=(0.0, -6.0, 0.4))
+
+
 def build_denoiser_scene(scene):
     # A noisy indirect-lit box at very low spp — denoise has plenty of variance
     # to collapse.
@@ -323,6 +351,7 @@ SCENE_BUILDERS = {
     "open_glass": build_open_glass,
     "caustic": build_caustic,
     "volume_box": build_volume_box,
+    "many_lights": build_many_lights,
     "denoiser_scene": build_denoiser_scene,
 }
 

--- a/tests/test_blender_light_sampler_wiring.py
+++ b/tests/test_blender_light_sampler_wiring.py
@@ -151,7 +151,11 @@ def test_light_sampler_wiring_final_render(monkeypatch):
     engine.convert_scene(depsgraph, MockRenderer(), 16, 16)
 
     assert calls, "convert_scene must call set_light_sampler"
-    assert calls[0] == "light_tree", f"Expected 'light_tree', got {calls[0]}"
+    # pkg201: the engine's set_light_sampler accepts only 'power'/'tree', so the
+    # UI 'light_tree' is translated to the engine token 'tree' before the call
+    # (the old direct pass-through would have thrown ValueError on the real
+    # binding). No native use_light_tree here (cycles=None) -> UI enum decides.
+    assert calls[0] == "tree", f"Expected 'tree', got {calls[0]}"
 
 
 def test_light_sampler_wiring_viewport_render(monkeypatch):
@@ -199,7 +203,9 @@ def test_light_sampler_wiring_viewport_render(monkeypatch):
     engine.view_update(context, depsgraph)
 
     assert calls, "view_update must call set_light_sampler"
-    assert calls[0] == "uniform", f"Expected 'uniform', got {calls[0]}"
+    # pkg201: engine has no uniform sampler -> UI 'uniform' translates to 'power'
+    # (cycles=None here, so the UI enum decides).
+    assert calls[0] == "power", f"Expected 'power', got {calls[0]}"
 
 
 def test_light_sampler_default_is_power(monkeypatch):
@@ -215,7 +221,11 @@ def test_light_sampler_default_is_power(monkeypatch):
 
 
 def test_light_sampler_modes_are_valid(monkeypatch):
-    """All three sampler modes (uniform, power, light_tree) must be accepted."""
+    """All three UI sampler modes must reach the engine as a VALID engine token.
+    The engine accepts only 'power'/'tree' (module/blender_module.cpp), so pkg201
+    translates the UI enum: uniform/power -> 'power', light_tree -> 'tree'. The
+    pre-pkg201 direct pass-through would have thrown for uniform/light_tree."""
+    _EXPECTED = {"uniform": "power", "power": "power", "light_tree": "tree"}
     calls = []
 
     class MockRenderer:
@@ -256,5 +266,5 @@ def test_light_sampler_modes_are_valid(monkeypatch):
 
         engine.convert_scene(depsgraph, MockRenderer(), 16, 16)
 
-        assert calls and calls[0] == mode, \
-            f"Mode '{mode}' must be passed to set_light_sampler"
+        assert calls and calls[0] == _EXPECTED[mode], \
+            f"UI mode '{mode}' must reach the engine as '{_EXPECTED[mode]}', got {calls[0] if calls else None}"

--- a/tests/test_pkg176_stage1_native_settings.py
+++ b/tests/test_pkg176_stage1_native_settings.py
@@ -194,16 +194,23 @@ def test_report_none_is_silent(capsys):
 # --------------------------------------------------------------------------- #
 
 def test_approximated_and_dropped_stay_custom():
-    """light_sampler (approximated), use_adaptive_sampling (dropped) and
-    denoiser_backend (approximated) must fall through to the custom prop even
-    though native counterparts (use_light_tree / use_adaptive_sampling /
-    denoiser) exist on scene.cycles."""
+    """use_adaptive_sampling (dropped) and denoiser_backend (approximated) must
+    fall through to the custom prop even though native counterparts
+    (use_adaptive_sampling / denoiser) exist on scene.cycles.
+
+    light_sampler is APPROXIMATED and was custom-only through pkg176 (this test
+    originally asserted ``resolved.light_sampler == 'power'``, i.e. the native
+    use_light_tree bool was NOT read). pkg201 Stage 1 reconciles that gap: the
+    native ``use_light_tree`` bool now drives the tree-vs-non-tree axis of the
+    tri-state (native True -> 'light_tree'). With ``_native_cycles()`` carrying
+    use_light_tree=True the resolver now overrides the custom 'power'."""
     resolved = ns.resolve_native_settings(_scene(_native_cycles()))
-    assert resolved.light_sampler == 'power'          # not native use_light_tree
+    assert resolved.light_sampler == 'light_tree'      # pkg201: native use_light_tree=True wins
     assert resolved.use_adaptive_sampling is False     # not native True
     assert resolved.denoiser_backend == 'auto'         # not native 'OPTIX'
 
-    # and none of these names are in the resolver's alias set
+    # light_sampler is reconciled OUTSIDE the DIRECT alias loop, so it (and the
+    # genuinely custom-only names) must still be absent from the alias set.
     aliased_custom = {c for _, c in ns.DIRECT_ALIASES}
     for name in ("light_sampler", "use_adaptive_sampling", "denoiser_backend", "adaptive_threshold"):
         assert name not in aliased_custom

--- a/tests/test_pkg176_stage1_native_settings.py
+++ b/tests/test_pkg176_stage1_native_settings.py
@@ -201,11 +201,12 @@ def test_approximated_and_dropped_stay_custom():
     light_sampler is APPROXIMATED and was custom-only through pkg176 (this test
     originally asserted ``resolved.light_sampler == 'power'``, i.e. the native
     use_light_tree bool was NOT read). pkg201 Stage 1 reconciles that gap: the
-    native ``use_light_tree`` bool now drives the tree-vs-non-tree axis of the
-    tri-state (native True -> 'light_tree'). With ``_native_cycles()`` carrying
-    use_light_tree=True the resolver now overrides the custom 'power'."""
+    native ``use_light_tree`` bool now drives the tree-vs-non-tree axis and is
+    resolved to the ENGINE token ('power' | 'tree'; the engine has no uniform
+    sampler). With ``_native_cycles()`` carrying use_light_tree=True the resolver
+    now yields 'tree', overriding the custom 'power'."""
     resolved = ns.resolve_native_settings(_scene(_native_cycles()))
-    assert resolved.light_sampler == 'light_tree'      # pkg201: native use_light_tree=True wins
+    assert resolved.light_sampler == 'tree'            # pkg201: native use_light_tree=True -> engine 'tree'
     assert resolved.use_adaptive_sampling is False     # not native True
     assert resolved.denoiser_backend == 'auto'         # not native 'OPTIX'
 

--- a/tests/test_pkg200_honour_matrix.py
+++ b/tests/test_pkg200_honour_matrix.py
@@ -34,9 +34,14 @@ def test_completeness_gate_passes():
 def test_every_plumbed_prop_has_a_row():
     surface = set(M.enumerate_direct_surface())
     assert len(surface) >= 20, surface
-    # use_light_tree is a KNOWN GAP, never part of the plumbed surface.
-    assert "use_light_tree" not in surface
-    assert "use_light_tree" in M.KNOWN_GAPS
+    # pkg201 Stage 1 PROMOTED use_light_tree from a KNOWN GAP to a real row: the
+    # native scene.cycles.use_light_tree bool is now reconciled onto the tri-state
+    # and reaches renderer.set_light_sampler, so it is a plumbed honour obligation.
+    # It enumerates into the surface under its settings_map native_prop
+    # ("light_sampling"), and there is a matrix row for it.
+    assert "light_sampling" in surface
+    assert M.KNOWN_GAPS == {}
+    assert "use_light_tree" in {r.name for r in M.MATRIX}
 
 
 def test_drift_detected_when_a_row_is_removed(monkeypatch):

--- a/tests/test_pkg201_stage1_settings_honour.py
+++ b/tests/test_pkg201_stage1_settings_honour.py
@@ -166,24 +166,40 @@ def _load_native_settings():
 ns = _load_native_settings()
 
 
+# The engine's set_light_sampler accepts ONLY 'power' / 'tree'. resolve_light_sampler
+# always returns one of those: native use_light_tree wins the tree-vs-non-tree axis
+# (True->tree, False->power); with no native bool the UI enum is translated
+# (light_tree->tree, else->power). uniform collapses to power (no engine uniform).
 @pytest.mark.parametrize("use_light_tree,custom,expected", [
-    (True, "power", "light_tree"),       # native enable wins over any custom
-    (True, "uniform", "light_tree"),
-    (True, "light_tree", "light_tree"),
-    (False, "uniform", "uniform"),       # native off -> defer to non-tree choice
+    (True, "power", "tree"),       # native enable -> engine 'tree' regardless of UI
+    (True, "uniform", "tree"),
+    (True, "light_tree", "tree"),
+    (False, "uniform", "power"),   # native off -> engine 'power' (no uniform sampler)
     (False, "power", "power"),
-    (False, "light_tree", "power"),      # native off overrides stale custom tree
+    (False, "light_tree", "power"),  # native off overrides a stale UI 'light_tree'
 ])
 def test_resolve_light_sampler_mapping(use_light_tree, custom, expected):
     cycles = types.SimpleNamespace(use_light_tree=use_light_tree)
     assert ns.resolve_light_sampler(cycles, custom) == expected
 
 
-def test_resolve_light_sampler_no_cycles_falls_through():
-    """No cycles datablock / no use_light_tree attr -> None (proxy keeps the
-    custom value unchanged)."""
-    assert ns.resolve_light_sampler(None, "uniform") is None
-    assert ns.resolve_light_sampler(types.SimpleNamespace(), "uniform") is None
+def test_resolve_light_sampler_no_cycles_translates_ui_enum():
+    """No cycles datablock / no use_light_tree attr -> translate the UI enum to a
+    valid engine token (never the raw enum, which the engine would reject)."""
+    assert ns.resolve_light_sampler(None, "light_tree") == "tree"
+    assert ns.resolve_light_sampler(None, "uniform") == "power"
+    assert ns.resolve_light_sampler(None, "power") == "power"
+    assert ns.resolve_light_sampler(types.SimpleNamespace(), "light_tree") == "tree"
+
+
+def test_resolve_light_sampler_only_ever_returns_engine_tokens():
+    """Guard: every path must yield a token the engine's set_light_sampler
+    accepts ('power' | 'tree') — the latent-crash regression pkg201 fixed."""
+    for cyc in (None, types.SimpleNamespace(),
+                types.SimpleNamespace(use_light_tree=True),
+                types.SimpleNamespace(use_light_tree=False)):
+        for custom in ("uniform", "power", "light_tree", "anything"):
+            assert ns.resolve_light_sampler(cyc, custom) in ("power", "tree")
 
 
 def _scene(cycles, light_sampler="power"):
@@ -194,19 +210,19 @@ def _scene(cycles, light_sampler="power"):
 def test_resolve_native_settings_folds_light_tree_on():
     scene = _scene(types.SimpleNamespace(use_light_tree=True), light_sampler="power")
     resolved = ns.resolve_native_settings(scene)
-    assert resolved.light_sampler == "light_tree"
+    assert resolved.light_sampler == "tree"
 
 
-def test_resolve_native_settings_light_tree_off_keeps_non_tree_choice():
+def test_resolve_native_settings_light_tree_off_is_power():
     scene = _scene(types.SimpleNamespace(use_light_tree=False), light_sampler="uniform")
     resolved = ns.resolve_native_settings(scene)
-    assert resolved.light_sampler == "uniform"
+    assert resolved.light_sampler == "power"
 
 
-def test_resolve_native_settings_no_cycles_keeps_custom():
-    scene = _scene(cycles=None, light_sampler="uniform")
+def test_resolve_native_settings_no_cycles_translates_ui_enum():
+    scene = _scene(cycles=None, light_sampler="light_tree")
     resolved = ns.resolve_native_settings(scene)
-    assert resolved.light_sampler == "uniform"
+    assert resolved.light_sampler == "tree"
 
 
 if __name__ == "__main__":

--- a/tests/test_pkg201_stage1_settings_honour.py
+++ b/tests/test_pkg201_stage1_settings_honour.py
@@ -1,0 +1,213 @@
+"""pkg201 Stage 1 — addon-side settings-honour fixes (pure Python, no GPU).
+
+Covers the two Stage-1 items that close pkg200 HONEST-FAIL / known-gap rows:
+
+  * Finding B: ``setup_world`` reads the world light-path bounce limit from
+    ``world.cycles.max_bounces`` (the real Cycles prop), NOT the ambient-
+    occlusion datablock ``world.light_settings.max_bounces`` (which has no such
+    member, so the pre-pkg201 read was inert and getattr(..., 1024) always won).
+
+  * use_light_tree reconciliation: ``native_settings.resolve_light_sampler``
+    maps the native Cycles ``use_light_tree`` bool onto Astroray's
+    uniform/power/light_tree tri-state, and ``resolve_native_settings`` folds it
+    into the ResolvedSettings view so both the F12 (convert_scene) and viewport
+    (sync_viewport_scene) paths honour the native toggle via the existing
+    ``renderer.set_light_sampler(settings.light_sampler)`` call sites.
+"""
+
+import importlib.util
+import pathlib
+import sys
+import types
+
+import pytest
+
+_ADDON = pathlib.Path(__file__).resolve().parents[1] / "blender_addon"
+
+
+# --------------------------------------------------------------------------- #
+# Finding B — world.cycles.max_bounces read (requires the full addon w/ mock bpy)
+# --------------------------------------------------------------------------- #
+def _load_blender_addon(monkeypatch, renderer_cls):
+    """Load blender_addon/__init__.py with mocked bpy/astroray (pattern shared
+    with test_blender_light_sampler_wiring.py)."""
+    bpy_module = types.ModuleType("bpy")
+    bpy_types_module = types.ModuleType("bpy.types")
+    bpy_props_module = types.ModuleType("bpy.props")
+
+    class _Base:
+        pass
+
+    class _RenderEngineBase:
+        def report(self, *_a, **_k):
+            return None
+
+    bpy_types_module.Panel = _Base
+    bpy_types_module.Operator = _Base
+    bpy_types_module.AddonPreferences = _Base
+    bpy_types_module.PropertyGroup = _Base
+    bpy_types_module.RenderEngine = _RenderEngineBase
+    bpy_module.types = bpy_types_module
+
+    for name in ("BoolProperty", "IntProperty", "FloatProperty", "StringProperty",
+                 "PointerProperty", "FloatVectorProperty", "EnumProperty"):
+        setattr(bpy_props_module, name, lambda **_k: None)
+
+    bpy_module.props = bpy_props_module
+    bpy_module.path = types.SimpleNamespace(abspath=lambda p: p)
+
+    shader_blending_module = types.ModuleType("shader_blending")
+    shader_blending_module.blend_shader_specs = {}
+    shader_blending_module.add_shader_specs = {}
+
+    mathutils_module = types.ModuleType("mathutils")
+    mathutils_module.Vector = lambda values: values
+
+    astroray_module = types.ModuleType("astroray")
+    astroray_module.__version__ = "test"
+    astroray_module.__features__ = {"cuda": False, "spectral": True}
+    astroray_module.__file__ = "/fake/astroray.pyd"
+    astroray_module.Renderer = renderer_cls
+    astroray_module.integrator_registry_names = lambda: ["path_tracer"]
+    astroray_module.integrator_capabilities = lambda name: {
+        "gpuSupported": True, "gpuFallbackReason": ""}
+    astroray_module.material_registry_names = lambda: ["lambertian"]
+    astroray_module.pass_registry_names = list
+
+    monkeypatch.setitem(sys.modules, "bpy", bpy_module)
+    monkeypatch.setitem(sys.modules, "bpy.types", bpy_types_module)
+    monkeypatch.setitem(sys.modules, "bpy.props", bpy_props_module)
+    monkeypatch.setitem(sys.modules, "shader_blending", shader_blending_module)
+    monkeypatch.setitem(sys.modules, "mathutils", mathutils_module)
+    monkeypatch.setitem(sys.modules, "astroray", astroray_module)
+
+    spec = importlib.util.spec_from_file_location(
+        "astroray_blender_addon_pkg201_test", _ADDON / "__init__.py")
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _world(cycles_max_bounces=None, ao_max_bounces=None):
+    """A minimal world with an empty node tree (so setup_world walks to the
+    bounce-limit read without needing HDRI/volume node mocks)."""
+    world = types.SimpleNamespace()
+    world.node_tree = types.SimpleNamespace(nodes=[])
+    if cycles_max_bounces is not None:
+        world.cycles = types.SimpleNamespace(max_bounces=cycles_max_bounces)
+    # The AO datablock. Pre-pkg201 the addon read max_bounces HERE by mistake;
+    # give it a DIFFERENT value so a regression would be caught.
+    world.light_settings = types.SimpleNamespace()
+    if ao_max_bounces is not None:
+        world.light_settings.max_bounces = ao_max_bounces
+    return world
+
+
+class _WorldRenderer:
+    def __init__(self):
+        self.world_max_bounces = None
+
+    def set_world_volume(self, *_a):
+        pass
+
+    def set_world_max_bounces(self, v):
+        self.world_max_bounces = v
+
+    def set_background_color(self, *_a):
+        pass
+
+    def load_environment_map(self, *_a):
+        return False
+
+
+def test_world_max_bounces_reads_cycles_not_ao(monkeypatch):
+    """setup_world must read world.cycles.max_bounces, ignoring the stray AO
+    world.light_settings.max_bounces (pkg201 Finding B)."""
+    addon = _load_blender_addon(monkeypatch, _WorldRenderer)
+    engine = addon.CustomRaytracerRenderEngine()
+    renderer = _WorldRenderer()
+    scene = types.SimpleNamespace(world=_world(cycles_max_bounces=7, ao_max_bounces=99))
+
+    engine.setup_world(scene, renderer)
+
+    assert renderer.world_max_bounces == 7, (
+        "world bounce limit must come from world.cycles.max_bounces (7), "
+        f"not the AO datablock (99); got {renderer.world_max_bounces}"
+    )
+
+
+def test_world_max_bounces_default_when_no_cycles(monkeypatch):
+    """A world without a cycles block falls back to the 1024 getattr default and
+    never raises (non-Cycles scene / stub)."""
+    addon = _load_blender_addon(monkeypatch, _WorldRenderer)
+    engine = addon.CustomRaytracerRenderEngine()
+    renderer = _WorldRenderer()
+    scene = types.SimpleNamespace(world=_world(cycles_max_bounces=None, ao_max_bounces=99))
+
+    engine.setup_world(scene, renderer)
+
+    assert renderer.world_max_bounces == 1024
+
+
+# --------------------------------------------------------------------------- #
+# use_light_tree reconciliation — native_settings (no bpy needed)
+# --------------------------------------------------------------------------- #
+def _load_native_settings():
+    if str(_ADDON) not in sys.path:
+        sys.path.insert(0, str(_ADDON))
+    spec = importlib.util.spec_from_file_location(
+        "pkg201_native_settings", _ADDON / "native_settings.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+ns = _load_native_settings()
+
+
+@pytest.mark.parametrize("use_light_tree,custom,expected", [
+    (True, "power", "light_tree"),       # native enable wins over any custom
+    (True, "uniform", "light_tree"),
+    (True, "light_tree", "light_tree"),
+    (False, "uniform", "uniform"),       # native off -> defer to non-tree choice
+    (False, "power", "power"),
+    (False, "light_tree", "power"),      # native off overrides stale custom tree
+])
+def test_resolve_light_sampler_mapping(use_light_tree, custom, expected):
+    cycles = types.SimpleNamespace(use_light_tree=use_light_tree)
+    assert ns.resolve_light_sampler(cycles, custom) == expected
+
+
+def test_resolve_light_sampler_no_cycles_falls_through():
+    """No cycles datablock / no use_light_tree attr -> None (proxy keeps the
+    custom value unchanged)."""
+    assert ns.resolve_light_sampler(None, "uniform") is None
+    assert ns.resolve_light_sampler(types.SimpleNamespace(), "uniform") is None
+
+
+def _scene(cycles, light_sampler="power"):
+    settings = types.SimpleNamespace(light_sampler=light_sampler)
+    return types.SimpleNamespace(custom_raytracer=settings, cycles=cycles)
+
+
+def test_resolve_native_settings_folds_light_tree_on():
+    scene = _scene(types.SimpleNamespace(use_light_tree=True), light_sampler="power")
+    resolved = ns.resolve_native_settings(scene)
+    assert resolved.light_sampler == "light_tree"
+
+
+def test_resolve_native_settings_light_tree_off_keeps_non_tree_choice():
+    scene = _scene(types.SimpleNamespace(use_light_tree=False), light_sampler="uniform")
+    resolved = ns.resolve_native_settings(scene)
+    assert resolved.light_sampler == "uniform"
+
+
+def test_resolve_native_settings_no_cycles_keeps_custom():
+    scene = _scene(cycles=None, light_sampler="uniform")
+    resolved = ns.resolve_native_settings(scene)
+    assert resolved.light_sampler == "uniform"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## pkg201 Stage 1 — addon-side settings-honour fixes

Closes the two Stage-1 items of pkg201 (spec: `.astroray_plan/packages/pkg201-gpu-wavefront-settings-honour.md`). Direct follow-up to pkg200 (#616). Full evidence: `.astroray_plan/docs/pkg201-stage1-results.md`.

### Result (verbatim corrected-driver re-run on the built addon, Blender 5.1 AND 5.2, LINEAR EXR, per-channel mean-ratio, sentinel-gated)

| Row | pkg200 (#616) | pkg201 | Measured |
|-----|--------------|--------|----------|
| `world_max_bounces` | **HONEST-FAIL** (1.0971 = 1.0971) | **PASS** | lum_mean A(0)=0.209 → B(12)=1.097, **ratio 5.24** (5.1 ≡ 5.2) |
| `use_light_tree` | **KNOWN-GAP** (inert) | **NEEDS-VISUAL → confirmed honoured** | \|dLum\| mean 0.028 (5.1) / 0.037 (5.2); multimodal Read: both A(power)/B(tree) valid lit rooms differing only in NEE sampler noise |

Control spot-check (untouched rows, unchanged vs #616): `film_exposure` PASS 2.000/2.000/2.000, `max_bounces` PASS 12.5×, `seed_repeat` PASS reproducible. `check_completeness()`: 26 plumbed props → 26 rows, OK.

### What changed & why

1. **Finding B** — `setup_world` read `world.light_settings.max_bounces` (the AO datablock, no `max_bounces` member → `getattr(...,1024)` always won, control inert). Fixed to `world.cycles.max_bounces`. The GPU wavefront already honours it (`stage_advance.cu:312` gates env contribution on `bounce <= worldMaxBounces`).
2. **use_light_tree reconciliation** — `resolve_light_sampler` maps native `scene.cycles.use_light_tree` → the engine token: **True→`'tree'`, False→`'power'`**. Folded into `resolve_native_settings` so both the F12 (`convert_scene`) and viewport (`sync_viewport_scene`) paths pick it up via the existing `set_light_sampler` call sites (no call-site edits).
3. **Latent-crash fix (caught by the empirical build/smoke)** — the engine's `set_light_sampler` accepts only `'power'`/`'tree'` (`blender_module.cpp:1531`), but the UI enum ships `'uniform'`/`'power'`/`'light_tree'`. The pre-pkg201 raw pass-through **threw** for `'uniform'`/`'light_tree'` (masked only because the default is `'power'`, and non-default samplers were never F12-rendered). `resolve_light_sampler` always returns a valid token now (uniform collapses to power — the engine has no uniform sampler; stays APPROXIMATED). The pkg103a wiring tests + one pkg176 guard test asserted the raw enum reached the engine (which would throw); updated with citations.

### Authorized surface

Spec's Stage-1 Specification names `blender_addon/__init__.py::convert_scene` and `settings_map.py`/`convert_scene`. Files actually changed:
- `blender_addon/__init__.py` — Finding B (in-scope). *(committed in d0bf90f; a speculative set_light_sampler reordering was tried and reverted — net diff is Finding B only.)*
- `blender_addon/native_settings.py`, `blender_addon/settings_map.py` — the reconciliation lives in the translator module (derived from `settings_map`); in-scope.
- **`scripts/pkg200_honour_matrix.py` + `scripts/verify_pkg200_honour_matrix.py`** — beyond the spec's literal text, but **required to close Finding B**: the pkg200 driver Row encoded the *bug* (`world.light_settings.max_bounces`) as its override path, which `_apply_overrides` skips as non-existent, so the row could never flip on a verbatim re-run. Repointed the Row/props/`_alias` to `world.cycles.max_bounces`; promoted `use_light_tree` from `KNOWN_GAPS` to a real row (`many_lights` Emission-emitter scene, `light_sampling` added to `_PLUMBED_APPROXIMATED`). Per the spec's "extend only if a new scene is genuinely needed and register it in `scripts/README.md`" clause; registered there. Coordinator-approved (do not touch the frozen #616 branch; correct it in this PR post-merge).
- Tests: `test_pkg201_stage1_settings_honour.py` (new), `test_pkg176_stage1_native_settings.py`, `test_blender_light_sampler_wiring.py`, `test_pkg200_honour_matrix.py` — behavioral-sweep updates for the flipped assertions, cited.

No engine (`.cu`/`.cpp`/`.h`) changes — Python/addon only.

### Acceptance checklist
- [x] `world_max_bounces` HONEST-FAIL → PASS, verbatim corrected-driver, 5.1 + 5.2, LINEAR, mean-ratio, sentinel-gated
- [x] `use_light_tree` known-gap → pixel change on toggle; NEEDS-VISUAL + multimodal Read verdict recorded (both frames valid, differ in sampler noise)
- [x] Control spot-check (film_exposure/max_bounces/seed_repeat) unchanged vs #616
- [x] Call-site sweep (`resolve_light_sampler`, `set_light_sampler`, `set_world_max_bounces`, both `.light_sampler` engine reads via ResolvedSettings)
- [x] Behavioral guard tests updated with citations (pkg176 `light_sampler`, pkg103a wiring, pkg200 known-gap promotion)
- [x] 96 non-GPU tests pass; lint clean (no ruff findings)

### Build / smoke evidence
`.pyd`: `dist/astroray/astroray.cp313-win_amd64.pyd`, mtime 2026-08-14 19:40:55, sm_120 (cuobjdump `--list-elf`), OpenMP-OFF. Change is Python-only, but a full engine rebuild from this branch was run (== current main):
```
[114/115] Linking CXX shared module astroray.cp313-win_amd64.pyd
Built module: astroray.cp313-win_amd64.pyd
Staged dir:    .../Astroray-pkg201s1/dist/astroray
PKG175_REGISTER_RESULT PASS
PKG175_SMOKE_RESULT PASS   (Blender 5.1 AND 5.2)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
