### PR TITLE
feat(pkg199-s2b): GPU wavefront dedicated volume-scatter stage (HG in-scatter, fleet-isolated)

### DIFF
--- a/.astroray_plan/docs/pkg199-stage2-scattering-research.md
+++ b/.astroray_plan/docs/pkg199-stage2-scattering-research.md
@@ -104,6 +104,44 @@ continuation ray from `P`. `stageShadeBucketedKernel` untouched → REG 254 /
 STACK 3352 / CONSTANT[0] 1700 byte-identity carries forward. New `GWorldVolume`
 fields: `scatter` (α) and `anisotropy` (g). Snapshot moment for `P` pinned in §3.
 
+## 5b. GPU free-flight RNG + intersect register isolation (PR 2b, as built)
+
+**Counter-based free-flight sampler.** The GPU free-flight uniforms (channel pick
++ distance) are drawn by `gpu_freeflightUniform` — an OBJECT-FREE counter-based
+hash reusing the exact keying of `WavefrontRNG::GenerateForDimension` (PBRT-v4
+`MixBits` = MurmurHash3 finalizer → PCG32 SetSequence → PCG32 XSH-RR, cited),
+keyed on `(pixel, sample, seed, salt)` with `salt = G_WF_VOL_DIM_SALT (0xF0000000)
++ bounce·2 + {0,1}` — per-bounce, per-draw, and disjoint from the shade/volume
+`WavefrontRNG` dimension range (0..~depth), so the free-flight stream is
+decorrelated from all shading draws and does no `rng_dimension` round-trip. **CPU
+and GPU free-flight streams are INDEPENDENT** (the CPU draws from its `mt19937`
+inline); the CPU↔GPU parity gate is a per-channel mean-ratio at the 1e-5 MC
+convention, NOT sample-matched, so independent streams are correct and expected
+(measured god-ray parity ratio ≈ [1.004, 0.997, 0.998]).
+
+**Intersect register isolation (`HasWorldScatter` if-constexpr axis).** The
+free-flight *decision* must live in `intersectPathSlot` (it owns the
+surface-commit + shade-queue bucketing; a purely-additive kernel can't intercept
+before them — see spec Stage-2 "premise correction"). But the decision's live-set
+adds +3 REG to the intersect kernel (127→130), which at 256 threads/block crosses
+128 → 2→1 blocks/SM. A cooled, contention-controlled, interleaved A/B (burn-in to
+2887 MHz, min-of-11, three main legs 116.4–116.9 ms @ 2-blocks vs the
+always-present form 120.6 ms @ 1-block) measured a **+3.3% fog-free fleet
+regression** (mechanistically confirmed by the power-draw split: 2-block ≈ 153–156 W
+vs 1-block ≈ 147 W). Four shave attempts (object-free hash, `__noinline__`,
+scatter-math-to-volume-kernel, drop-lamp-bound) all stayed at 130 — the +3 is
+intrinsic to any inline decision. Resolution: the established fleet-isolation
+pattern (pkg178/184/189) — `template<bool HasWorldScatter>` on
+`intersectPathSlotT` + `stageIntersectQueuedKernel`, decision block behind
+`if constexpr`. The fleet `<false>` (vacuum + absorption-only fog) compiles it OUT
+→ **REG 127 / 2 blocks/SM, byte-identical Stage-1** (cooled vacuum 117.3 ms =
++0.5% vs main, within noise); only scattering fog (`scatter>0`) launches `<true>`
+(REG 130, but scattering-bound anyway). A non-template `intersectPathSlot`
+forwarder (→`<false>`) preserves the cross-TU symbol for the ReSTIR primary +
+MIS-audit kernels (both `scatter=0`). This was chosen over the spec's "Option 2"
+(volume kernel owns the surface-reached path) — same fleet-clean result, far lower
+correctness risk (the scattering logic is unchanged, only compile-gated).
+
 ## 6. Addon UI — explicit follow-up
 
 PR 2a/2b expose α only through the python binding

--- a/.astroray_plan/packages/pkg199-gpu-wavefront-volume-rendering.md
+++ b/.astroray_plan/packages/pkg199-gpu-wavefront-volume-rendering.md
@@ -169,6 +169,37 @@ untouched (Stage 1's byte-identity carries forward). Snapshot semantics: pin the
 scatter-point `ray_origin` capture moment identically on CPU and GPU at design time
 ([[wavefront-snapshot-semantics-class-of-bug]]).
 
+### Register-budget plan — premise correction (PR 2b implementation, 2026-08-14)
+
+The spec's "purely additive dedicated kernel between intersect and shade" is **not
+literally achievable**: `intersectPathSlot` already owns the surface-commit
+(role-1 free-flight `Tr`, surface emission — which *terminates* the path, never
+parked — and the dedicated-lamp MIS) **and** the shade-queue bucketing
+(`atomicAdd(&shade_counts[matType], …)`). A medium scatter must intercept the
+segment *before* all of those (the CPU runs its medium block at the top of the
+loop), so a kernel inserted *after* intersect cannot un-commit the emission
+intersect already added nor un-bucket the shade queue. **Therefore intersect must
+be `mediumScatters`-gated.** Option A as built (coordinator-approved): intersect
+does only the cheap free-flight **decision** (2 RNG draws + `Tr`/pdf) gated on
+`mediumScatters = hasVolume && density>0 && scatter>0`; a SCATTER writes the
+scatter point `P` to `ray_origin`, applies `Tr·σ_s/pdf`, and returns a `-2`
+sentinel that routes the slot to a new **volume queue**; a SURFACE applies
+`Tr/pdf` (the role-1 replacement) and falls through to the Stage-1 path with
+role-1 and role-3-lamp `Tr` gated off. The register-heavy scatter processing
+(phase NEE + HG continuation) lives entirely in the dedicated
+`stageVolumeScatterKernel`, which parks the phase NEE into the **shared**
+`nee_f/nee_i` lanes + shadow queue (so `stageShadowKernel` resolves it unchanged:
+lane-14 `geomDist` role-2 `Tr` + clamp) and requeues the HG continuation.
+**`stageShadeBucketedKernel` is never touched → byte-identical by construction**
+(scattered slots never enter its bucket). **The `scatter==0` (default) GPU path
+compiles to the identical Stage-1 behaviour** — the `-2` decision block is skipped
+at runtime (`mediumScatters` false), so vacuum and absorption-only renders are
+byte-identical to Stage 1. ReSTIR-DI publishes `scatter=0` (bounce-0 direct only,
+no volume kernel) so its shared-`intersectPathSlot` never takes the `-2` route.
+Snapshot semantics pinned: `P` captured from the pre-update ray, stored as
+`ray_origin`, `ray_direction` left as the incoming direction so the volume kernel
+recovers `woMedium = -direction` — identical to the CPU capture moment.
+
 ### Stage 2 acceptance (for the future package)
 
 - CPU spectral tracer gains a homogeneous medium-interaction loop (scatter event +

--- a/.astroray_plan/packages/pkg199-gpu-wavefront-volume-rendering.md
+++ b/.astroray_plan/packages/pkg199-gpu-wavefront-volume-rendering.md
@@ -200,6 +200,29 @@ Snapshot semantics pinned: `P` captured from the pre-update ray, stored as
 `ray_origin`, `ray_direction` left as the incoming direction so the volume kernel
 recovers `woMedium = -direction` — identical to the CPU capture moment.
 
+### Intersect register isolation — `HasWorldScatter` if-constexpr axis (PR 2b)
+
+The free-flight *decision* in `intersectPathSlot` adds **+3 REG (127→130)**, which
+at 256 threads/block crosses 128 → **2→1 blocks/SM**. A cooled, contention-
+controlled, interleaved A/B (burn-in to 2887 MHz, min-of-11; three main legs
+116.4–116.9 ms @ 2-blocks/153–156 W vs the always-present form 120.6 ms @
+1-block/147 W) measured a **+3.3% fog-free fleet regression** — unacceptable for an
+off-by-default feature. Four shave attempts (object-free counter-based hash,
+`__noinline__`, scatter-math-moved-to-volume-kernel, drop-lamp-bound) all stayed at
+130; the +3 is intrinsic to any inline decision. **Resolution (chosen over the
+"Option 2" volume-kernel-owns-surface restructure — same fleet-clean result, far
+lower correctness risk):** the established fleet-isolation pattern (pkg178/184/189)
+— `template<bool HasWorldScatter>` on `intersectPathSlotT` +
+`stageIntersectQueuedKernel`, decision block behind `if constexpr`. The fleet
+`<false>` (vacuum + absorption-only fog) compiles it OUT → **REG 127 / STACK 616 /
+2 blocks/SM, byte-identical Stage-1** (cooled vacuum 117.3 ms = +0.5% vs main,
+within noise); only scattering fog (`scatter>0`) launches `<true>` (REG 130). A
+non-template `intersectPathSlot` forwarder (→`<false>`) keeps the cross-TU symbol
+for the ReSTIR primary + MIS-audit kernels. GPU free-flight uniforms use
+`gpu_freeflightUniform` (PBRT-v4 MixBits + PCG32, cited; per-bounce salt disjoint
+from the shade stream); CPU/GPU free-flight streams are independent (parity is
+per-channel mean-ratio, not sample-matched).
+
 ### Stage 2 acceptance (for the future package)
 
 - CPU spectral tracer gains a homogeneous medium-interaction loop (scatter event +

--- a/.astroray_plan/packages/pkg199-gpu-wavefront-volume-rendering.md
+++ b/.astroray_plan/packages/pkg199-gpu-wavefront-volume-rendering.md
@@ -758,3 +758,159 @@ triage; this verifier does not decide they are acceptable.
 
 This verifier does not merge; the merge decision remains with the architect and
 gate-failure process.
+
+## Hardware verification 2026-08-14 (PR #619)
+
+Scope: independent HW re-verification of pkg199 Stage 2 PR 2b (GPU wavefront
+scattering, HasWorldScatter fleet isolation), branch pkg199-s2b, worktree
+Astroray-pkg199s2. Session resumed after an early kill; state re-established
+from disk (prior test_results, worktree at unchanged HEAD) before continuing --
+the .pyd was re-verified current before trusting anything, not assumed.
+
+Hardware/software: RTX 5070 Ti, driver 610.47, Windows 11 10.0.26200, CUDA
+12.8.61 (nvcc), sm_120 target confirmed via cuobjdump --list-elf
+(astroray.cp313-win_amd64.1.sm_120.cubin). GPU idle before every leg (1-4 percent
+util, 37-41C, no other compute-apps) -- no contention.
+
+Step 1 -- build/staleness gate: HEAD 3efb551 (docs-only commit, 2 spec/docs
+files, 0 code) sits on top of the implementer last code commit 35f5577,
+built into build_cuda/Release/astroray.cp313-win_amd64.pyd at 22:56 (predates
+HEAD docs-only commit by ~14 min -- confirmed via git show --stat HEAD that
+no source changed after the build). No rebuild needed. astroray.__file__ points
+to the canonical build_cuda/Release/astroray.cp313-win_amd64.pyd (legacy
+multi-config generator location, expected for this repo). No new Python
+binding was introduced by 2b (set_world_volume with density, color, anisotropy,
+scatter args already existed from 2a); smoke-checked import + Renderer()
+construction OK.
+
+Step 2 -- register gates (cuobjdump -res-usage on the final linked .pyd), ALL PASS:
+
+| Kernel | REG | STACK | SHARED | CONSTANT[0] | Target | Result |
+|---|---|---|---|---|---|---|
+| stageShadeBucketedKernel with all-false bool params | 254 | 3352 | 0 | 1700 | 254/3352/1700 byte-identical | PASS (exact) |
+| stageIntersectQueuedKernel false (fleet) | 127 | 616 | 0 | 1696 | 127/616, Stage-1-identical | PASS (exact) |
+| stageIntersectQueuedKernel true | 130 | 632 | 0 | 1696 | ~130 | PASS |
+| stageVolumeScatterKernel | 64 | 88 | 0 | 1382 (+CONSTANT[2]:12) | ~REG 64 | PASS (exact) |
+
+All four measured values match the spec claims exactly.
+
+Step 3 -- verbatim re-run of the PR test files (test_pkg199_stage2_scattering_gpu.py
+plus test_pkg199_stage2_scattering_cpu.py plus test_pkg199_world_volume_gpu_parity.py,
+19 tests, 10.12s, 19 passed, 0 failed):
+
+test_alpha_zero_gpu_is_absorption PASSED
+  clear=[0.0293 0.0294 0.0288] foggy=[0.0083 0.0083 0.0081]
+test_godray_cpu_gpu_parity PASSED
+  GPU=[0.0399 0.04   0.0393] CPU=[0.0398 0.0401 0.0394] ratio=[1.0044 0.9972 0.9978]
+  scatter mean=0.0397 absorb mean=0.0082
+test_forward_back_scatter_gpu PASSED
+  fwd=0.03533 back=0.02070 ratio=1.707
+test_alpha_zero_is_beer_lambert_absorption PASSED
+  dens=0.1 dist=5.0: measured Tr=0.6063 analytic=0.6065
+  dens=0.2 dist=5.0: measured Tr=0.3676 analytic=0.3679
+test_alpha_zero_deterministic PASSED
+test_single_scatter_matches_analytic_density_shape PASSED
+  measured =[0.005185 0.006688 0.00588  0.003197]
+  analytic =[0.016764 0.021482 0.018754 0.010167]  k=0.31218
+  k*analytic=[0.005233 0.006706 0.005855 0.003174]  max_resid=0.0091
+test_single_scatter_linear_in_alpha PASSED
+  L/alpha=[0.017021 0.016968 0.017059] spread=0.0022
+test_forward_back_scatter_asymmetry PASSED
+  single: ratio=2.002 ; depth4: ratio=1.477
+test_sum_to_beauty_with_volume_passes PASSED
+  ratio=[1.00004 1.00004 1.00004] rel_L1=0.0000 volume_mean=0.01149
+test_scatter_adds_energy_monotonic PASSED
+  means=[0.      0.00937 0.02581 0.04081]
+test_world_volume_absorption_only_removes_energy_cpu PASSED
+  clear=[1.29   1.2948 1.2722] foggy=[0.7844 0.9507 1.0396] foggy/clear=[0.6081 0.7343 0.8172]
+test_world_volume_cpu_gpu_parity PASSED
+  GPU=[0.8526 1.0362 1.1494] CPU=[0.7844 0.9507 1.0396] GPU/CPU=[1.0868 1.0899 1.1056]
+test_world_volume_gpu_analytic_beer_lambert PASSED
+  dist=5.0 dens=0.1: Tr=0.6064 analytic=0.6065; dist=5.0 dens=0.2: Tr=0.3677 analytic=0.3679
+  dist=10.0 dens=0.1: Tr=0.3678 analytic=0.3679; dist=10.0 dens=0.2: Tr=0.1352 analytic=0.1353
+test_world_volume_zero_density_gpu_byte_identical PASSED
+  no-vol self-noise=9.54e-07 zero-density diff=4.77e-07
+test_restir_render_not_contaminated_by_prior_fog PASSED
+  clean=[0.0153 0.0162 0.0235] after_fog=[0.0153 0.0162 0.0235] after/clean=[1. 1. 1.]
+test_world_volume_gpu_visual PASSED (PNGs written, see visual section)
+test_sphere_lamp_fogs_like_triangle_lamp_gpu PASSED
+  dens=0.02: sph/tri=[1.0358 1.0218 1.0126] ; dens=0.06: sph/tri=[1.1042 1.0627 1.037 ]
+test_sphere_lamp_fog_density_monotonic_gpu PASSED
+  dens0.005=0.9616 dens0.03=0.7938 dens0.10=0.4783
+test_sphere_lamp_fog_cpu_gpu_parity PASSED
+  dens=0.02: GPU/CPU=[1.0005 1.0003 1.0003] ; dens=0.06: GPU/CPU=[1.0018 1.001  1.0008]
+
+Headline numbers reproduce the PR claims exactly: god-ray parity
+[1.0044, 0.9972, 0.9978], forward/back 1.707, alpha=0 inertness confirmed
+(clear/foggy diverge as expected, no god-ray brightening at scatter=0).
+
+Step 4 -- perf spot-check (uncontended, burn-in, min-of-9): the spec text
+(line 325) states the 116.4-120.6ms A/B figures came from a throwaway
+diagnostic script, not committed to the repo -- it is not present in this
+worktree, so bit-exact reproduction of the 117.3ms vacuum vs 116.8ms main
+comparison is not possible this session. Two proxy measurements were run
+instead (GPU idle 1-4 percent util / 37-41C before each, 6-run burn-in, min-of-9):
+
+- Canonical committed wavefront ceiling gate (tests/wavefront_diff/test_pkg55_perf_gate.py
+  scene, cuda_wavefront_render, 256x256, 1024spp): min-of-9 = 1371.87ms,
+  median = 1377.52ms, all 9 runs in the range 1371.87 to 1448.49ms -- well under the
+  pinned 1.5s ceiling (owner-accepted post-accretion gate), no gross-regression
+  signature.
+- Ad-hoc vacuum point-light-in-fog scene (no world_volume set) at 256x256,
+  256spp via r.render() GPU path (structurally the same code the register
+  gate covers): min-of-9 = 150.14ms, median = 152.00ms, spread
+  150.1 to 152.7ms (under 2 percent) -- tight, stable, no thermal/contention artifacts.
+
+Neither proxy corresponds 1:1 to the spec specific 116-120ms figures (different
+scene/spp), so this is NOT a bit-exact confirmation of the plus 0.5 percent vs main claim.
+The authoritative evidence for the no-regression claim remains the Step 2
+register-gate byte-identity: stageIntersectQueuedKernel false measured
+REG:127/STACK:616/CONSTANT[0]:1696 -- structurally identical to the pre-PR
+Stage-1 fleet kernel, which by construction cannot regress fleet (vacuum /
+absorption-only) performance. Flagging this gap rather than asserting a number
+that was not measured.
+
+Step 5 -- visual inspection (test_results/pkg199_s2_godray_gpu.png,
+pkg199_s2_godray_cpu.png, pkg199_s2_forward_scatter.png,
+pkg199_s2_back_scatter.png, pkg199_gpu_fog_clear.png,
+pkg199_gpu_fog_dense.png, all 64x64/256x256 thumbnails):
+
+- God-ray GPU vs CPU: both show a bright point source with a soft diffuse haze
+  on the floor plane; visually consistent with each other (matches the
+  measured [1.0044, 0.9972, 0.9978] parity). No magenta/black NaN speckle, no
+  salt-and-pepper beyond expected low-spp MC grain, no banding.
+- Forward vs back scatter: forward-scatter frame is visibly brighter with a
+  larger, more diffuse halo than the back-scatter frame -- consistent with the
+  measured 1.707 ratio and g>0 forward-peaked HG lobe. No artifacts.
+- Fog clear vs dense (alpha=0 absorption-only, Stage-1 path): dense fog correctly
+  darkens/desaturates the receding spheres while the near sphere stays crisp
+  and saturated -- matches the documented expected behaviour exactly, no
+  fireflies, no NaN pixels, no mode regression (still monochrome absorption,
+  no spurious god-rays at alpha=0).
+
+No visual regression found; numbers and images agree.
+
+Step 6 -- full sweep (pytest tests/ -q, no --ignore, all markers,
+665.74s): 2010 passed, 70 skipped, 21 xfailed, 1 xpassed, 0 failed. vs the
+PR claimed 1981 passed / 0 failed: 0 failed matches; passed count is higher
+(2010 vs 1981) -- explained by intervening commits merged to main since the PR
+was authored (e.g. pkg201 #618, pkg190 follow-up #615 landed on main in the
+interim, adding tests collected by this branch suite), not an effect of this
+PR. An earlier same-session run at 10:10 (predating a same-day fix commit,
+35f5577, that resolved a separate plus 3.3 percent fleet-perf issue via the
+HasWorldScatter isolation) showed one failure,
+test_pkg64_phase3_no_regression.py::test_no_caster_cost_gate (ratio 1.478x
+vs 1.30x threshold) -- unrelated to pkg199 (a caustics-toggle cost gate). This
+re-run (post-fix, current HEAD) shows 0 failures, confirming that prior
+failure did not reproduce (transient/perf-noise), not a real regression from
+this PR.
+
+Verdict: PASS. All register gates exact-match. All 19 PR test-file
+assertions reproduce the claimed headline numbers verbatim. Full sweep is
+clean (0 failed). Visual inspection found no artifacts and matches the
+numerical parity. The one gap is the perf spot-check: the implementer exact
+committed-nowhere A/B script/scene could not be re-run bit-for-bit; two proxy
+measurements showed no gross-regression signature, and the register-gate
+byte-identity is offered as the authoritative structural evidence instead of
+an unverifiable wall-clock number. This gap is reported, not glossed over --
+gate/merge decision remains with the architect.

--- a/include/astroray/gpu_types.h
+++ b/include/astroray/gpu_types.h
@@ -654,6 +654,12 @@ struct GWorldVolume {
     int   hasVolume;              // 0 = vacuum (skip); 1 = active medium
     float density;               // worldVolumeDensity
     float colorR, colorG, colorB; // worldVolumeColor (reflectance-like tint)
+    // pkg199 Stage 2 — single-scattering albedo alpha in [0,1] and HG anisotropy g.
+    // scatter==0 (default) => absorption-only (Stage-1 behaviour, byte-identical:
+    // the free-flight scatter decision in intersectPathSlot is gated on scatter>0).
+    // sigma_s = scatter*sigma_t; g is live only when scatter>0.
+    float scatter;               // worldVolumeScatter (alpha)
+    float anisotropy;            // worldVolumeAnisotropy (HG g)
 };
 
 // Nearest-neighbour image fetch — mirrors CPU ImageTexture::value EXACTLY

--- a/include/astroray/gpu_wavefront_state.h
+++ b/include/astroray/gpu_wavefront_state.h
@@ -309,7 +309,24 @@ void launchStageIntersectQueued(
     const ::GLight*   d_lights, int num_lights, float total_light_power,
     // pkg181: dedicated lamps for the BSDF-ray lamp-intersection pass.
     const GDedicatedLight* d_dedLights, int num_ded,
-    GLightTreeView    lightTree);
+    GLightTreeView    lightTree,
+    int* d_vol_queue, int* d_vol_count);   // pkg199 Stage 2
+
+// pkg199 Stage 2 — dedicated volume-scatter wavefront stage (between intersect
+// and shade). Drains the volume-scatter queue, parks the phase-sampled
+// NEE-through-medium into the shared nee_f/nee_i lanes + shadow queue, and emits
+// the HG continuation ray, requeuing survivors into queue_out for the next bounce.
+void launchStageVolumeScatter(
+    GPUWavefrontState& state,
+    const int* d_vol_queue, const int* d_vol_count,
+    int* d_queue_out, int* d_count_out,
+    float* d_nee_f, int* d_nee_i, int* d_shadow_queue, int* d_shadow_count,
+    int nee_capacity,
+    const GPrimitive* d_prims, const GTriangle* d_tris, const GSphere* d_spheres,
+    const ::GLight* d_lights, int num_lights, float total_light_power,
+    const GDedicatedLight* d_dedLights, int num_ded,
+    GLightTreeView lightTree,
+    int max_depth, bool useLuminanceOutput, bool enableNEE);
 
 void launchStageShadeBucketed(
     GPUWavefrontState& state,
@@ -436,6 +453,7 @@ void launchStageRegen(
     int* d_count_out,       // pkg55-C7: fused per-pass counter zeroing
     int* d_shade_counts,    //   (replaces 3 cudaMemsetAsync per pass;
     int* d_shadow_count,    //   nullptr = skip)
+    int* d_vol_count,       // pkg199 Stage 2: volume-scatter queue counter (nullptr = skip)
     bool useLuminanceOutput);  // pkg55-C7: grey band-mean accumulation for
                                // non-visible bands (CMF XYZ is ~0 there)
 

--- a/include/astroray/gpu_wavefront_state.h
+++ b/include/astroray/gpu_wavefront_state.h
@@ -310,7 +310,8 @@ void launchStageIntersectQueued(
     // pkg181: dedicated lamps for the BSDF-ray lamp-intersection pass.
     const GDedicatedLight* d_dedLights, int num_ded,
     GLightTreeView    lightTree,
-    int* d_vol_queue, int* d_vol_count);   // pkg199 Stage 2
+    int* d_vol_queue, int* d_vol_count,   // pkg199 Stage 2
+    bool has_world_scatter);              // pkg199 Stage 2 fleet-isolation axis
 
 // pkg199 Stage 2 — dedicated volume-scatter wavefront stage (between intersect
 // and shade). Drains the volume-scatter queue, parks the phase-sampled

--- a/src/gpu/wavefront/gpu_wavefront_snapshot.cu
+++ b/src/gpu/wavefront/gpu_wavefront_snapshot.cu
@@ -1010,6 +1010,7 @@ struct WfContext {
     // Driver buffers.
     WfDeviceBuf accum, queueA, queueB, counts, shadeQueues, shadeCounts;
     WfDeviceBuf neeF, neeI, shadowQueue, shadowCount, work;
+    WfDeviceBuf volQueue, volCount;   // pkg199 Stage 2 volume-scatter queue
     // pkg159: per-pixel cryptomatte rank arrays (numPixels*depth*2 floats
     // each). Grow-only like the rest; only allocated once a render actually
     // enables cryptomatte, so default renders pay nothing.
@@ -1365,7 +1366,9 @@ std::vector<float> cuda_wavefront_render(
         setWavefrontWorldVolume(GWorldVolume{
             renderer.getHasWorldVolume() ? 1 : 0,
             renderer.getWorldVolumeDensity(),
-            wvc.x, wvc.y, wvc.z});
+            wvc.x, wvc.y, wvc.z,
+            renderer.getWorldVolumeScatter(),      // pkg199 Stage 2 (α)
+            renderer.getWorldVolumeAnisotropy()}); // pkg199 Stage 2 (g)
     }
     ::GLight*   d_lights    = wfUpload(C.lights, res.lights);
     // pkg89-wavefront (C7): dedicated lights join wavefront NEE (unified
@@ -1456,6 +1459,10 @@ std::vector<float> cuda_wavefront_render(
     int*   d_neeI        = wfEnsure<int>(C.neeI, size_t(G_WF_NEE_I_LANES) * total_paths);
     int*   d_shadowQueue = wfEnsure<int>(C.shadowQueue, total_paths);
     int*   d_shadowCount = wfEnsure<int>(C.shadowCount, 1);
+    // pkg199 Stage 2 — volume-scatter queue: one slot per path (a path scatters
+    // in at most one of {surface shade, volume} per bounce), one counter.
+    int*   d_volQueue    = wfEnsure<int>(C.volQueue, total_paths);
+    int*   d_volCount    = wfEnsure<int>(C.volCount, 1);
     int*   d_work        = wfEnsure<int>(C.work, 1);
 
     {
@@ -1580,7 +1587,7 @@ std::vector<float> cuda_wavefront_render(
             launchStageRegen(state, d_accum, d_work, (int)total_work,
                              total_paths, gcam, width, height, seed,
                              lambdaMin, lambdaMax,
-                             cout, d_shadeCounts, d_shadowCount,
+                             cout, d_shadeCounts, d_shadowCount, d_volCount,
                              useLuminanceOutput);
             launchStageIntersectQueued(state, hitBufs, d_queueA, d_counts + 0,
                                        d_shadeQueues, d_shadeCounts,
@@ -1597,7 +1604,23 @@ std::vector<float> cuda_wavefront_render(
                                        res.totalLightPower,
                                        d_dedLights,                  // pkg181
                                        (int)res.dedicatedLights.size(),
-                                       treeView);
+                                       treeView,
+                                       d_volQueue, d_volCount);       // pkg199 Stage 2
+            // pkg199 Stage 2 — dedicated volume-scatter stage, between intersect
+            // and shade. Drains the volume queue (scattered slots), parks the
+            // phase NEE into the shared nee/shadow lanes, and requeues survivors
+            // into d_queueB/cout alongside the shade survivors. Scattered slots
+            // never enter the shade bucket → stageShadeBucketedKernel byte-identical.
+            launchStageVolumeScatter(state, d_volQueue, d_volCount,
+                                     d_queueB, cout,
+                                     d_neeF, d_neeI, d_shadowQueue, d_shadowCount,
+                                     total_paths,
+                                     d_prims, d_tris, d_spheres,
+                                     d_lights, (int)res.lights.size(),
+                                     res.totalLightPower,
+                                     d_dedLights, (int)res.dedicatedLights.size(),
+                                     treeView, max_depth,
+                                     useLuminanceOutput, enableNEE);
             launchStageShadeBucketed(state, hitBufs,
                                      d_shadeQueues, d_shadeCounts,
                                      total_paths, d_queueB, cout,
@@ -1643,7 +1666,7 @@ std::vector<float> cuda_wavefront_render(
         launchStageRegen(state, d_accum, d_work, (int)total_work,
                          total_paths, gcam, width, height, seed,
                          lambdaMin, lambdaMax,
-                         /*d_count_out=*/nullptr, nullptr, nullptr,
+                         /*d_count_out=*/nullptr, nullptr, nullptr, nullptr,
                          useLuminanceOutput);
 
         cudaError_t syncErr = cudaDeviceSynchronize();
@@ -1818,10 +1841,17 @@ std::vector<float> cuda_wavefront_render_restir(
     // cross-render fog contamination.
     {
         Vec3 wvc = renderer.getWorldVolumeColor();
+        // pkg199 Stage 2: ReSTIR-DI is bounce-0 direct only and does NOT run the
+        // dedicated volume-scatter stage, so it MUST publish scatter=0 (absorption
+        // only). Otherwise intersectPathSlot's scatter decision would fire its -2
+        // return here (which the ReSTIR primary ignores), stranding scattered slots.
+        // In-scatter under ReSTIR is a declared follow-up (like the Stage-1 note).
         setWavefrontWorldVolume(GWorldVolume{
             renderer.getHasWorldVolume() ? 1 : 0,
             renderer.getWorldVolumeDensity(),
-            wvc.x, wvc.y, wvc.z});
+            wvc.x, wvc.y, wvc.z,
+            0.0f,                                  // pkg199 Stage 2: α=0 for ReSTIR
+            renderer.getWorldVolumeAnisotropy()}); // g (inert at α=0)
     }
 
     GLightTreeView treeView{d_treeNodes, d_treeEmitters, d_lightToEmitter,

--- a/src/gpu/wavefront/gpu_wavefront_snapshot.cu
+++ b/src/gpu/wavefront/gpu_wavefront_snapshot.cu
@@ -1605,7 +1605,13 @@ std::vector<float> cuda_wavefront_render(
                                        d_dedLights,                  // pkg181
                                        (int)res.dedicatedLights.size(),
                                        treeView,
-                                       d_volQueue, d_volCount);       // pkg199 Stage 2
+                                       d_volQueue, d_volCount,        // pkg199 Stage 2
+                                       // Launch the <true> intersect specialization
+                                       // only when the medium actually scatters; else
+                                       // the fleet <false> (127 REG, byte-identical
+                                       // Stage-1, no fog-free regression).
+                                       renderer.getHasWorldVolume() &&
+                                           renderer.getWorldVolumeScatter() > 0.0f);
             // pkg199 Stage 2 — dedicated volume-scatter stage, between intersect
             // and shade. Drains the volume queue (scattered slots), parks the
             // phase NEE into the shared nee/shadow lanes, and requeues survivors

--- a/src/gpu/wavefront/stage_advance.cu
+++ b/src/gpu/wavefront/stage_advance.cu
@@ -264,10 +264,21 @@ __device__ inline float gpu_freeflightUniform(uint32_t pixel, uint32_t sample,
     return fminf(u * 0x1p-32f, kOneMinusEpsilon);
 }
 
-// intersectPathSlot returns -1 when the path died, else the GMaterialType
+// intersectPathSlotT returns -1 when the path died, else the GMaterialType
 // of the hit (0..GMAT_CLOSURE_GRAPH) for shade-queue bucketing. The hit
 // record is parked in GPUWavefrontHitBuffers SoA at the slot index.
-__device__ int intersectPathSlot(
+//
+// pkg199 Stage 2 — templated on HasWorldScatter (the established fleet-isolation
+// pattern, pkg178/184/189): the medium free-flight decision block is behind
+// `if constexpr (HasWorldScatter)`, so the fleet <false> specialization compiles
+// it out ENTIRELY and returns to the pre-pkg199 register footprint (127 REG →
+// 2 blocks/SM at 256 threads; the always-present form measured 130 → 1 block →
+// a cooled+bracketed +3.3% fog-free fleet regression). Only scattering fog scenes
+// launch <true> (which pays the 130, but they are scattering-bound anyway). The
+// non-template `intersectPathSlot` symbol below forwards to <false> so the
+// cross-TU callers (ReSTIR primary, MIS-audit; both scatter=0) link unchanged.
+template<bool HasWorldScatter>
+__device__ int intersectPathSlotT(
     int idx,
     GPUWavefrontState& state,
     GPUWavefrontHitBuffers& hitBufs,
@@ -349,10 +360,14 @@ __device__ int intersectPathSlot(
     // balance-heuristic pdf averaged over the spectral channels. Runs BEFORE the
     // lamp-MIS / emission / role-1 blocks so a scatter intercepts the segment
     // exactly like the CPU top-of-loop medium block.
-    const bool mediumScatters = c_worldVolume.hasVolume &&
+    // HasWorldScatter folds this to a compile-time false in the fleet <false>
+    // kernel, so the block below is removed and the role-1/role-3 gates collapse
+    // to their Stage-1 form (byte-identical).
+    const bool mediumScatters = HasWorldScatter &&
+                                c_worldVolume.hasVolume &&
                                 c_worldVolume.density > 0.f &&
                                 c_worldVolume.scatter > 0.f;
-    if (mediumScatters) {
+    if constexpr (HasWorldScatter) if (mediumScatters) {
         float surfaceT = hit ? rec.t : 1e30f;
         float termT = surfaceT;
         if (bounce > 0 && numDed > 0) {
@@ -626,6 +641,42 @@ __device__ int intersectPathSlot(
     hitBufs.hit_is_delta[idx]    = rec.isDelta ? 1 : 0;
     hitBufs.hit_valid[idx]       = 1;
     return (int)mat.type;
+}
+
+// pkg199 Stage 2 — non-template `intersectPathSlot` symbol. Forwards to the
+// <false> (Stage-1, no medium scatter) specialization. This is the symbol the
+// cross-TU callers link against: the ReSTIR primary stage (stage_restir.cu, which
+// publishes scatter=0) and the MIS-audit kernel — neither runs the volume-scatter
+// stage, so <false> is correct and keeps their forward declaration valid without
+// exposing intersectPathSlotT across translation units.
+__device__ int intersectPathSlot(
+    int idx,
+    GPUWavefrontState& state,
+    GPUWavefrontHitBuffers& hitBufs,
+    const GTLASNode*  tlas,
+    const GInstance*  instances,
+    const GBLAS*      blas,
+    const GBVHNode*   bvhNodes,
+    const GPrimitive* prims,
+    const GTriangle*  tris,
+    const GSphere*    spheres,
+    const GVec3*      motionVerts,
+    const ::GMaterial* materials,
+    GEnvMap           envMap,
+    GVec3             backgroundColor, bool hasBackgroundColor,
+    int               worldMaxBounces,
+    bool              useLuminanceOutput,
+    bool              enableNEE,
+    float             clampDirect, float clampIndirect,
+    const ::GLight*   lights, int numLights, float totalLightPower,
+    const GDedicatedLight* dedLights, int numDed,
+    GLightTreeView    lightTree)
+{
+    return intersectPathSlotT<false>(idx, state, hitBufs, tlas, instances, blas,
+        bvhNodes, prims, tris, spheres, motionVerts, materials, envMap,
+        backgroundColor, hasBackgroundColor, worldMaxBounces, useLuminanceOutput,
+        enableNEE, clampDirect, clampIndirect, lights, numLights, totalLightPower,
+        dedLights, numDed, lightTree);
 }
 
 // Shade half: NEE + RR + BSDF over the parked hit record. Returns true when
@@ -1384,6 +1435,7 @@ __global__ void stageQueueIotaKernel(int* queue, int* count, int n)
 // material dispatch of Laine 2013 sec. 5 / Cycles X shader sorting, realized
 // as bucketed atomic append instead of a radix sort (7 types only).
 // ---------------------------------------------------------------------------
+template<bool HasWorldScatter>   // pkg199 Stage 2 fleet-isolation axis
 __global__ void stageIntersectQueuedKernel(
     GPUWavefrontState state,
     GPUWavefrontHitBuffers hitBufs,
@@ -1424,7 +1476,8 @@ __global__ void stageIntersectQueuedKernel(
     // (no-op there); the regeneration driver iterates a dense identity
     // queue where exhausted slots stay dead.
     if (state.path_alive[idx] == 0) return;
-    int matType = intersectPathSlot(idx, state, hitBufs, tlas, instances, blas,
+    int matType = intersectPathSlotT<HasWorldScatter>(
+                                    idx, state, hitBufs, tlas, instances, blas,
                                     bvhNodes, prims, tris, spheres, motionVerts,
                                     materials, envMap, backgroundColor,
                                     hasBackgroundColor, worldMaxBounces,
@@ -1538,25 +1591,36 @@ void launchStageIntersectQueued(
     // pkg181: dedicated lamps for the BSDF-ray lamp-intersection pass.
     const GDedicatedLight* d_dedLights, int num_ded,
     GLightTreeView    lightTree,
-    int* d_vol_queue, int* d_vol_count)   // pkg199 Stage 2
+    int* d_vol_queue, int* d_vol_count,   // pkg199 Stage 2
+    bool has_world_scatter)               // pkg199 Stage 2: picks the fleet-isolation axis
 {
     if (state.num_active <= 0) return;
     int threads = 256;
     int blocks  = (state.num_active + threads - 1) / threads;
+    // pkg199 Stage 2: the <false> specialization (the fleet, scatter==0) compiles
+    // the medium free-flight block OUT → REG 127 / 2 blocks/SM, byte-identical
+    // Stage-1. Only scattering fog scenes launch <true>. Both instantiations are
+    // referenced here so both land in the cubin for the cuobjdump register report.
+    #define ASTRORAY_PKG199_INTERSECT_ARGS \
+        state, hitBufs, d_queue_in, d_count_in, \
+        d_shade_queues, d_shade_counts, capacity, \
+        d_tlas, d_instances, d_blas, \
+        d_bvhNodes, d_prims, d_tris, d_spheres, d_motionVerts, d_materials, \
+        envMap, backgroundColor, hasBackgroundColor, worldMaxBounces, \
+        useLuminanceOutput, enableNEE, clampDirect, clampIndirect, \
+        d_lights, num_lights, total_light_power, \
+        d_dedLights, num_ded, lightTree, \
+        d_vol_queue, d_vol_count
     {
+        const void* kptr = has_world_scatter
+            ? (const void*)stageIntersectQueuedKernel<true>
+            : (const void*)stageIntersectQueuedKernel<false>;
         astroray::gpu_profile::ScopedTimer _t(
-            "wavefront_stage_intersect_queued_n7",
-            (const void*)stageIntersectQueuedKernel, blocks, threads);
-        stageIntersectQueuedKernel<<<blocks, threads>>>(
-            state, hitBufs, d_queue_in, d_count_in,
-            d_shade_queues, d_shade_counts, capacity,
-            d_tlas, d_instances, d_blas,
-            d_bvhNodes, d_prims, d_tris, d_spheres, d_motionVerts, d_materials,
-            envMap, backgroundColor, hasBackgroundColor, worldMaxBounces,
-            useLuminanceOutput, enableNEE, clampDirect, clampIndirect,
-            d_lights, num_lights, total_light_power,
-            d_dedLights, num_ded, lightTree,   // pkg120+pkg181
-            d_vol_queue, d_vol_count);          // pkg199 Stage 2
+            "wavefront_stage_intersect_queued_n7", kptr, blocks, threads);
+        if (has_world_scatter)
+            stageIntersectQueuedKernel<true><<<blocks, threads>>>(ASTRORAY_PKG199_INTERSECT_ARGS);
+        else
+            stageIntersectQueuedKernel<false><<<blocks, threads>>>(ASTRORAY_PKG199_INTERSECT_ARGS);
         cudaError_t err = cudaGetLastError();
         if (err != cudaSuccess) {
             std::fprintf(stderr, "stage_intersect_queued launch error: %s\n",
@@ -1564,6 +1628,7 @@ void launchStageIntersectQueued(
             throw std::runtime_error(cudaGetErrorString(err));
         }
     }
+    #undef ASTRORAY_PKG199_INTERSECT_ARGS
 }
 
 // ---------------------------------------------------------------------------

--- a/src/gpu/wavefront/stage_advance.cu
+++ b/src/gpu/wavefront/stage_advance.cu
@@ -178,6 +178,57 @@ __device__ inline GSampledSpectrum gpu_worldTransmittanceMW(
     return tr;
 }
 
+// pkg199 Stage 2 — per-λ extinction σ_t[λ] = upsample(color)[λ]·density (the same
+// quantity gpu_worldTransmittanceMW exponentiates; device twin of the CPU
+// Renderer::worldSigmaT). Caller guards on c_worldVolume.hasVolume.
+__device__ inline GSampledSpectrum gpu_worldSigmaT(const GSampledWavelengths& lambdas)
+{
+    GSampledSpectrum sigmaColor = gpu_rgbToSampledSpectrum(
+        GVec3(c_worldVolume.colorR, c_worldVolume.colorG, c_worldVolume.colorB),
+        lambdas, GSPEC_RGB_ALBEDO);
+    GSampledSpectrum s;
+    for (int i = 0; i < G_SPECTRUM_SAMPLES; ++i)
+        s.v[i] = fmaxf(0.f, sigmaColor.v[i]) * c_worldVolume.density;
+    return s;
+}
+
+// pkg199 Stage 2 — Henyey-Greenstein phase function (HG 1941; PBRT-v3 PhaseHG,
+// src/core/medium.cpp, BSD). cosTheta = dot(wo, wi), wo pointing back along the
+// incoming ray. Normalised over the sphere (integrates to 1); Inv4Pi = 1/(4π).
+// Device twin of Renderer::phaseHG — same sign convention for CPU↔GPU parity.
+__device__ inline float gpu_phaseHG(float cosTheta, float g)
+{
+    float denom = 1.f + g * g + 2.f * g * cosTheta;
+    denom = fmaxf(denom, 1e-6f);
+    return (0.25f / M_PI_F) * (1.f - g * g) / (denom * sqrtf(denom));
+}
+
+// pkg199 Stage 2 — importance-sample the HG phase function (PBRT-v3
+// HenyeyGreenstein::Sample_p, BSD). `wo` points back along the incoming ray
+// (= -ray.direction). Returns the sampled continuation direction; outPdf is the
+// phase value (HG is perfectly importance-sampled, pdf == value → throughput
+// factor value/pdf = 1). g>0 forward-scatters (peak at wi = -wo). Device twin of
+// Renderer::sampleHG; gpu_buildONB gives the orthonormal frame (z-axis = wo).
+__device__ inline GVec3 gpu_sampleHG(const GVec3& wo, float g, float u1, float u2,
+                                     float& outPdf)
+{
+    float cosTheta;
+    if (fabsf(g) < 1e-3f) {
+        cosTheta = 1.f - 2.f * u1;
+    } else {
+        float sqrTerm = (1.f - g * g) / (1.f + g - 2.f * g * u1);
+        cosTheta = -(1.f + g * g - sqrTerm * sqrTerm) / (2.f * g);
+    }
+    cosTheta = fmaxf(-1.f, fminf(1.f, cosTheta));
+    float sinTheta = sqrtf(fmaxf(0.f, 1.f - cosTheta * cosTheta));
+    float phi = 2.f * M_PI_F * u2;
+    GVec3 v1, v2;
+    gpu_buildONB(wo, v1, v2);
+    GVec3 wi = v1 * (sinTheta * cosf(phi)) + v2 * (sinTheta * sinf(phi)) + wo * cosTheta;
+    outPdf = gpu_phaseHG(cosTheta, g);
+    return wi.normalized();
+}
+
 // intersectPathSlot returns -1 when the path died, else the GMaterialType
 // of the hit (0..GMAT_CLOSURE_GRAPH) for shade-queue bucketing. The hit
 // record is parked in GPUWavefrontHitBuffers SoA at the slot index.
@@ -253,6 +304,87 @@ __device__ int intersectPathSlot(
     bool hit = gpu_tlas_hit(tlas, instances, blas, bvhNodes, prims, tris, spheres,
                             ray, 0.001f, 1e30f, rec, motionVerts);
 
+    // pkg199 Stage 2 — homogeneous medium free-flight scatter DECISION (Option A:
+    // the cheap decision + queue routing lives here; the register-heavy scatter
+    // processing — phase NEE + HG continuation — lives in the dedicated
+    // stageVolumeScatterKernel, so this kernel's footprint grows only by the
+    // decision). Device twin of the CPU pathTraceSpectral medium block, gated on
+    // the SAME condition so the scatter==0 path is byte-identical Stage-1. PBRT-v3
+    // HomogeneousMedium::Sample (BSD): per-channel selection distance sampling,
+    // balance-heuristic pdf averaged over the spectral channels. Runs BEFORE the
+    // lamp-MIS / emission / role-1 blocks so a scatter intercepts the segment
+    // exactly like the CPU top-of-loop medium block.
+    const bool mediumScatters = c_worldVolume.hasVolume &&
+                                c_worldVolume.density > 0.f &&
+                                c_worldVolume.scatter > 0.f;
+    if (mediumScatters) {
+        float surfaceT = hit ? rec.t : 1e30f;
+        float termT = surfaceT;
+        if (bounce > 0 && numDed > 0) {
+            float lampT, lampScale;
+            int lampIdx = gpu_dedicated_intersect_closest(
+                dedLights, numDed, ray.origin, ray.direction, 0.001f, surfaceT,
+                &lampT, &lampScale);
+            if (lampIdx >= 0) termT = lampT;
+        }
+        WavefrontRNG frng(state.rng_pixel[idx], state.rng_sample[idx],
+                          state.rng_seed[idx]);
+        frng.setDimension(state.rng_dimension[idx]);
+        GSampledSpectrum sigmaT = gpu_worldSigmaT(lambdas);
+        int ch = (int)(frng.Uniform() * G_SPECTRUM_SAMPLES);
+        if (ch >= G_SPECTRUM_SAMPLES) ch = G_SPECTRUM_SAMPLES - 1;
+        float sigTc = sigmaT.v[ch];
+        float fdist = (sigTc > 0.f) ? -__logf(1.f - frng.Uniform()) / sigTc : 1e30f;
+        state.rng_dimension[idx] = frng.dimension();
+        if (fdist < termT) {
+            // SCATTER: throughput *= Tr(fdist)·σ_s/pdf, pdf = avg(σ_t·Tr).
+            GSampledSpectrum Tr;
+            for (int i = 0; i < G_SPECTRUM_SAMPLES; ++i)
+                Tr.v[i] = __expf(-sigmaT.v[i] * fdist);
+            float pdf = 0.f;
+            for (int i = 0; i < G_SPECTRUM_SAMPLES; ++i) pdf += sigmaT.v[i] * Tr.v[i];
+            pdf /= float(G_SPECTRUM_SAMPLES);
+            if (pdf <= 0.f) { state.path_alive[idx] = 0; return -1; }
+            float invPdf = 1.f / pdf;
+            for (int i = 0; i < G_SPECTRUM_SAMPLES; ++i)
+                throughput.v[i] *= Tr.v[i] * (sigmaT.v[i] * c_worldVolume.scatter) * invPdf;
+            // Scatter point P = origin + dir·fdist. Snapshot semantics (pinned in
+            // .astroray_plan/docs/pkg199-stage2-scattering-research.md): capture P
+            // from the PRE-update ray and store it as the new ray_origin;
+            // ray_direction is LEFT as the incoming direction so the volume kernel
+            // recovers woMedium = -direction for the HG frame — mirrors the CPU.
+            GVec3 P = ray.origin + ray.direction * fdist;
+            state.ray_origin_x[idx] = P.x;
+            state.ray_origin_y[idx] = P.y;
+            state.ray_origin_z[idx] = P.z;
+            state.throughput_0[idx] = throughput.v[0];
+            state.throughput_1[idx] = throughput.v[1];
+            state.throughput_2[idx] = throughput.v[2];
+            state.throughput_3[idx] = throughput.v[3];
+            return -2;  // scattered → the wrapper enqueues to the volume queue
+        } else {
+            // Reached the terminating event (surface / lamp / env): throughput *=
+            // Tr(termT)/pdf, pdf = avg(Tr). Replaces the Stage-1 role-1 multiply
+            // (gated off below); the role-3 lamp Tr is likewise gated off since
+            // this Tr already covers the camera→lamp segment.
+            float capT = fminf(termT, 1e18f);
+            GSampledSpectrum Tr;
+            for (int i = 0; i < G_SPECTRUM_SAMPLES; ++i)
+                Tr.v[i] = __expf(-sigmaT.v[i] * capT);
+            float pdf = 0.f;
+            for (int i = 0; i < G_SPECTRUM_SAMPLES; ++i) pdf += Tr.v[i];
+            pdf /= float(G_SPECTRUM_SAMPLES);
+            if (pdf <= 0.f) { state.path_alive[idx] = 0; return -1; }
+            float invPdf = 1.f / pdf;
+            for (int i = 0; i < G_SPECTRUM_SAMPLES; ++i) throughput.v[i] *= Tr.v[i] * invPdf;
+            state.throughput_0[idx] = throughput.v[0];
+            state.throughput_1[idx] = throughput.v[1];
+            state.throughput_2[idx] = throughput.v[2];
+            state.throughput_3[idx] = throughput.v[3];
+            // fall through to lamp-MIS / env / role-1(gated) / emission.
+        }
+    }
+
     // pkg181: dedicated-light visibility to BSDF rays (Cycles lights_intersect
     // parity) — device twin of production pathTraceSpectral. Lamps are invisible
     // to camera rays (bounce == 0); a lamp closer than the surface terminates the
@@ -279,7 +411,9 @@ __device__ int intersectPathSlot(
                 // so throughput is not yet segment-attenuated; attenuate the
                 // lamp emission over the camera→lamp segment (lampT). Mirrors the
                 // CPU dedicated-lamp block (throughput·lampEmission·Tr(lh.t)).
-                if (c_worldVolume.hasVolume)
+                // pkg199 Stage 2: in scatter mode the free-flight estimator already
+                // applied Tr(termT=lampT)/pdf to throughput, so do NOT re-attenuate.
+                if (c_worldVolume.hasVolume && !mediumScatters)
                     Le *= gpu_worldTransmittanceMW(lampT, lambdas);
                 GSampledSpectrum contrib(0.f);
                 if (bounce == 0 || wasSpecular) {
@@ -376,7 +510,9 @@ __device__ int intersectPathSlot(
     // block below uses the attenuated local. Kept in THIS (intersect) kernel, not
     // the REG-254 shade kernel, so stageShadeBucketedKernel stays byte-identical.
     // Vacuum (hasVolume==0): skipped, throughput SoA untouched → byte-identical.
-    if (c_worldVolume.hasVolume) {
+    // pkg199 Stage 2: in scatter mode the free-flight estimator above already
+    // applied Tr(termT)/pdf, so skip this deterministic role-1 multiply.
+    if (c_worldVolume.hasVolume && !mediumScatters) {
         throughput *= gpu_worldTransmittanceMW(rec.t, lambdas);
         state.throughput_0[idx] = throughput.v[0];
         state.throughput_1[idx] = throughput.v[1];
@@ -1234,7 +1370,12 @@ __global__ void stageIntersectQueuedKernel(
     const ::GLight*   lights, int numLights, float totalLightPower,
     // pkg181: dedicated lamps for the BSDF-ray lamp-intersection pass.
     const GDedicatedLight* dedLights, int numDed,
-    GLightTreeView    lightTree)
+    GLightTreeView    lightTree,
+    // pkg199 Stage 2 — volume-scatter queue: intersectPathSlot returns -2 for a
+    // path that scattered in the medium; that slot is routed here (not the shade
+    // bucket) for the dedicated stageVolumeScatterKernel. Null when the medium
+    // does not scatter (scatter==0) — the -2 return never fires then.
+    int* vol_queue, int* vol_count)
 {
     int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= *count_in) return;
@@ -1251,6 +1392,11 @@ __global__ void stageIntersectQueuedKernel(
                                     clampDirect, clampIndirect,
                                     lights, numLights, totalLightPower,
                                     dedLights, numDed, lightTree);  // pkg120+pkg181
+    if (matType == -2) {   // pkg199 Stage 2: scattered → volume-scatter queue
+        int vslot = atomicAdd(vol_count, 1);
+        vol_queue[vslot] = idx;
+        return;
+    }
     if (matType < 0) return;
     if (matType >= G_WF_NUM_MAT_TYPES) matType = G_WF_NUM_MAT_TYPES - 1;
     int slot = atomicAdd(&shade_counts[matType], 1);
@@ -1351,7 +1497,8 @@ void launchStageIntersectQueued(
     const ::GLight*   d_lights, int num_lights, float total_light_power,
     // pkg181: dedicated lamps for the BSDF-ray lamp-intersection pass.
     const GDedicatedLight* d_dedLights, int num_ded,
-    GLightTreeView    lightTree)
+    GLightTreeView    lightTree,
+    int* d_vol_queue, int* d_vol_count)   // pkg199 Stage 2
 {
     if (state.num_active <= 0) return;
     int threads = 256;
@@ -1368,10 +1515,186 @@ void launchStageIntersectQueued(
             envMap, backgroundColor, hasBackgroundColor, worldMaxBounces,
             useLuminanceOutput, enableNEE, clampDirect, clampIndirect,
             d_lights, num_lights, total_light_power,
-            d_dedLights, num_ded, lightTree);  // pkg120+pkg181
+            d_dedLights, num_ded, lightTree,   // pkg120+pkg181
+            d_vol_queue, d_vol_count);          // pkg199 Stage 2
         cudaError_t err = cudaGetLastError();
         if (err != cudaSuccess) {
             std::fprintf(stderr, "stage_intersect_queued launch error: %s\n",
+                         cudaGetErrorString(err));
+            throw std::runtime_error(cudaGetErrorString(err));
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// pkg199 Stage 2 — dedicated volume-scatter wavefront stage. Scheduled between
+// stageIntersectQueued and stageShadeBucketed. Drains the volume-scatter queue
+// (slots intersectPathSlot routed via its -2 return), performs the phase-sampled
+// NEE-through-medium (parked into the SAME nee_f/nee_i lanes + shadow queue the
+// surface NEE uses, so stageShadowKernel resolves it unchanged — geomDist role-2
+// Tr + clamp), and emits the HG phase-sampled continuation ray from the scatter
+// point, requeuing the survivor for the next bounce. The REG-254 shade kernel is
+// never touched → byte-identical (this is the whole point of Option A). Device
+// twin of the CPU pathTraceSpectral scatter branch (HG NEE + phase continuation).
+// ---------------------------------------------------------------------------
+__global__ void stageVolumeScatterKernel(
+    GPUWavefrontState state,
+    const int* vol_queue, const int* vol_count,
+    int* queue_out, int* count_out,          // requeue survivors → next bounce
+    float* nee_f, int* nee_i, int* shadow_queue, int* shadow_count, int nee_capacity,
+    const GPrimitive* prims, const GTriangle* tris, const GSphere* spheres,
+    const ::GLight* lights, int numLights, float totalLightPower,
+    const GDedicatedLight* dedLights, int numDed,
+    GLightTreeView lightTree,
+    int max_depth,
+    bool useLuminanceOutput,
+    bool enableNEE)
+{
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= *vol_count) return;
+    int idx = vol_queue[i];
+    if (state.path_alive[idx] == 0) return;
+    const int bounce = state.bounce[idx];
+
+    // Reconstruct: ray_origin == scatter point P (intersect wrote it), and
+    // ray_direction == incoming direction (woMedium = -direction), per the pinned
+    // snapshot semantics. throughput already carries Tr·σ_s/pdf (applied in intersect).
+    GVec3 P     = GVec3(state.ray_origin_x[idx], state.ray_origin_y[idx],
+                        state.ray_origin_z[idx]);
+    GVec3 inDir = GVec3(state.ray_direction_x[idx], state.ray_direction_y[idx],
+                        state.ray_direction_z[idx]);
+    GVec3 woMedium = (inDir * -1.f).normalized();
+    const float g = c_worldVolume.anisotropy;
+
+    GSampledWavelengths lambdas;
+    lambdas.lambda[0] = state.lambda_0[idx]; lambdas.lambda[1] = state.lambda_1[idx];
+    lambdas.lambda[2] = state.lambda_2[idx]; lambdas.lambda[3] = state.lambda_3[idx];
+    lambdas.pdf[0] = state.lambda_pdf_0[idx]; lambdas.pdf[1] = state.lambda_pdf_1[idx];
+    lambdas.pdf[2] = state.lambda_pdf_2[idx]; lambdas.pdf[3] = state.lambda_pdf_3[idx];
+
+    GSampledSpectrum throughput;
+    throughput.v[0] = state.throughput_0[idx]; throughput.v[1] = state.throughput_1[idx];
+    throughput.v[2] = state.throughput_2[idx]; throughput.v[3] = state.throughput_3[idx];
+
+    WavefrontRNG rng(state.rng_pixel[idx], state.rng_sample[idx], state.rng_seed[idx]);
+    rng.setDimension(state.rng_dimension[idx]);
+
+    // ---- Medium NEE (phase / light MIS), parked for the shadow stage ----
+    // Mirrors the surface NEE park (stage_advance shade lines): the "f" is the HG
+    // phase value; scale = wt/lightPdf with the MIS between lightPdf and the phase
+    // pdf (== phase value). The shadow kernel multiplies lanes 7-10 by L_spec and
+    // applies Tr(geomDist) + clamp, so parked lanes stay UNCLAMPED like surface NEE.
+    if (enableNEE && (numLights + numDed) > 0 && totalLightPower > 0.f) {
+        GHitRecord mrec{};
+        mrec.point   = P;
+        mrec.normal  = woMedium;   // arbitrary; only the (disabled) light-tree path reads it
+        mrec.isDelta = false;
+        GNEESample s = gpu_nee_sample(mrec, prims, tris, spheres,
+                                      lights, numLights, totalLightPower,
+                                      dedLights, numDed, lightTree, &rng);
+        if (s.valid) {
+            float ph = gpu_phaseHG(woMedium.dot(s.wi), g);   // phase value == pdf
+            if (ph > 0.f) {
+                float a2 = s.lightPdf * s.lightPdf;
+                float b2 = ph * ph;
+                float wt = s.isDeltaLight ? 1.f : a2 / (a2 + b2 + 1e-8f);
+                float scale = s.lightPdf > 1e-8f ? wt / s.lightPdf : 0.f;
+                if (s.isDedicated) scale *= s.dedGeoScale;
+                nee_f[ 0 * nee_capacity + idx] = s.origin.x;
+                nee_f[ 1 * nee_capacity + idx] = s.origin.y;
+                nee_f[ 2 * nee_capacity + idx] = s.origin.z;
+                nee_f[ 3 * nee_capacity + idx] = s.wi.x;
+                nee_f[ 4 * nee_capacity + idx] = s.wi.y;
+                nee_f[ 5 * nee_capacity + idx] = s.wi.z;
+                nee_f[ 6 * nee_capacity + idx] = s.maxDist;
+                nee_f[ 7 * nee_capacity + idx] = throughput.v[0] * ph * scale;
+                nee_f[ 8 * nee_capacity + idx] = throughput.v[1] * ph * scale;
+                nee_f[ 9 * nee_capacity + idx] = throughput.v[2] * ph * scale;
+                nee_f[10 * nee_capacity + idx] = throughput.v[3] * ph * scale;
+                nee_f[11 * nee_capacity + idx] = s.dedEmissionRGB.x;
+                nee_f[12 * nee_capacity + idx] = s.dedEmissionRGB.y;
+                nee_f[13 * nee_capacity + idx] = s.dedEmissionRGB.z;
+                nee_f[14 * nee_capacity + idx] = s.geomDist;
+                nee_i[ 0 * nee_capacity + idx] = s.lightMatId;
+                nee_i[ 1 * nee_capacity + idx] = s.isSphere;
+                nee_i[ 2 * nee_capacity + idx] = s.isDedicated;
+                nee_i[ 3 * nee_capacity + idx] = bounce;
+                int qslot = atomicAdd(shadow_count, 1);
+                shadow_queue[qslot] = idx;
+            }
+        }
+    }
+
+    // ---- HG phase-sampled continuation from P (throughput *= phase/pdf = 1) ----
+    float phasePdf;
+    GVec3 wiCont = gpu_sampleHG(woMedium, g, rng.Uniform(), rng.Uniform(), phasePdf);
+
+    // Russian roulette (mirror the shade-kernel / CPU scatter-branch RR, kRRDepth=3).
+    if (bounce > 3) {
+        float p;
+        if (useLuminanceOutput) {
+            float L = 0.f;
+            for (int k = 0; k < G_SPECTRUM_SAMPLES; ++k) L += throughput.v[k];
+            p = fminf(0.95f, fmaxf(0.f, L / float(G_SPECTRUM_SAMPLES)));
+        } else {
+            GVec3 xyz = gpu_spectrum_to_xyz(throughput, lambdas);
+            p = fminf(0.95f, fmaxf(0.f, xyz.y));
+        }
+        if (rng.Uniform() > p) {
+            state.path_alive[idx] = 0;
+            state.rng_dimension[idx] = rng.dimension();
+            return;   // color already in SoA; regen accumulates it
+        }
+        if (p > 0.f) for (int k = 0; k < G_SPECTRUM_SAMPLES; ++k) throughput.v[k] *= (1.f / p);
+    }
+
+    // ---- Continuation write-back (ray_origin already == P from intersect) ----
+    state.ray_direction_x[idx] = wiCont.x;
+    state.ray_direction_y[idx] = wiCont.y;
+    state.ray_direction_z[idx] = wiCont.z;
+    state.throughput_0[idx] = throughput.v[0];
+    state.throughput_1[idx] = throughput.v[1];
+    state.throughput_2[idx] = throughput.v[2];
+    state.throughput_3[idx] = throughput.v[3];
+    state.was_specular[idx]  = 0;
+    state.path_bsdf_pdf[idx] = phasePdf;
+    state.rng_dimension[idx] = rng.dimension();
+    int next_bounce = bounce + 1;
+    state.bounce[idx] = next_bounce;
+    if (next_bounce >= max_depth) { state.path_alive[idx] = 0; return; }
+    int slot = atomicAdd(count_out, 1);
+    queue_out[slot] = idx;
+}
+
+void launchStageVolumeScatter(
+    GPUWavefrontState& state,
+    const int* d_vol_queue, const int* d_vol_count,
+    int* d_queue_out, int* d_count_out,
+    float* d_nee_f, int* d_nee_i, int* d_shadow_queue, int* d_shadow_count,
+    int nee_capacity,
+    const GPrimitive* d_prims, const GTriangle* d_tris, const GSphere* d_spheres,
+    const ::GLight* d_lights, int num_lights, float total_light_power,
+    const GDedicatedLight* d_dedLights, int num_ded,
+    GLightTreeView lightTree,
+    int max_depth, bool useLuminanceOutput, bool enableNEE)
+{
+    if (state.num_active <= 0) return;
+    int threads = 256;
+    int blocks  = (state.num_active + threads - 1) / threads;
+    {
+        astroray::gpu_profile::ScopedTimer _t(
+            "wavefront_stage_volume_scatter",
+            (const void*)stageVolumeScatterKernel, blocks, threads);
+        stageVolumeScatterKernel<<<blocks, threads>>>(
+            state, d_vol_queue, d_vol_count, d_queue_out, d_count_out,
+            d_nee_f, d_nee_i, d_shadow_queue, d_shadow_count, nee_capacity,
+            d_prims, d_tris, d_spheres,
+            d_lights, num_lights, total_light_power,
+            d_dedLights, num_ded, lightTree,
+            max_depth, useLuminanceOutput, enableNEE);
+        cudaError_t err = cudaGetLastError();
+        if (err != cudaSuccess) {
+            std::fprintf(stderr, "stage_volume_scatter launch error: %s\n",
                          cudaGetErrorString(err));
             throw std::runtime_error(cudaGetErrorString(err));
         }
@@ -1580,6 +1903,7 @@ __global__ void stageRegenKernel(
     int* count_out,      // pkg55-C7 perf: fused per-pass counter zeroing —
     int* shade_counts,   // replaces 3 cudaMemsetAsync launches per pass
     int* shadow_count,   // (~3.6k extra launches per 512-spp render).
+    int* vol_count,      // pkg199 Stage 2: volume-scatter queue counter (null = skip)
     bool useLuminanceOutput)  // pkg55-C7: non-visible-band accumulation —
                               // grey band-mean radiance instead of the CMF
                               // XYZ projection (which is ~0 outside 380-780,
@@ -1595,6 +1919,7 @@ __global__ void stageRegenKernel(
     if (idx == 0 && count_out != nullptr) {
         *count_out    = 0;
         *shadow_count = 0;
+        if (vol_count != nullptr) *vol_count = 0;   // pkg199 Stage 2
         #pragma unroll
         for (int m = 0; m < G_WF_NUM_MAT_TYPES; ++m) shade_counts[m] = 0;
     }
@@ -1697,6 +2022,7 @@ void launchStageRegen(
     int* d_count_out,      // pkg55-C7: fused counter zeroing (nullptr = skip)
     int* d_shade_counts,
     int* d_shadow_count,
+    int* d_vol_count,      // pkg199 Stage 2 (nullptr = skip)
     bool useLuminanceOutput)  // pkg55-C7: non-visible-band accumulation
 {
     if (state.num_active <= 0) return;
@@ -1710,7 +2036,7 @@ void launchStageRegen(
             state, d_accum_xyz, d_work_counter, total_work, numPixels,
             cam, width, height, seed,
             lambdaMin, lambdaMax,
-            d_count_out, d_shade_counts, d_shadow_count,
+            d_count_out, d_shade_counts, d_shadow_count, d_vol_count,
             useLuminanceOutput);
         cudaError_t err = cudaGetLastError();
         if (err != cudaSuccess) {

--- a/src/gpu/wavefront/stage_advance.cu
+++ b/src/gpu/wavefront/stage_advance.cu
@@ -229,6 +229,41 @@ __device__ inline GVec3 gpu_sampleHG(const GVec3& wo, float g, float u1, float u
     return wi.normalized();
 }
 
+// pkg199 Stage 2 — dimension-salt base for the free-flight sampler. Far above any
+// dimension the shade/volume WavefrontRNG stream reaches (0..~depth·draws), so the
+// free-flight draws are decorrelated from all shading draws by construction.
+static constexpr uint32_t G_WF_VOL_DIM_SALT = 0xF0000000u;
+
+// pkg199 Stage 2 — OBJECT-FREE counter-based free-flight uniform. Reuses the exact
+// published keying of WavefrontRNG::GenerateForDimension (PBRT-v4 MixBits =
+// MurmurHash3 finalizer, src/pbrt/util/hash.h; -> PCG32 SetSequence -> PCG32 XSH-RR
+// output, imneme/pcg-c-basic Apache-2.0) — a counter-based RNG in the Salmon et al.
+// 2011 ("Parallel Random Numbers", Random123) sense — but computed inline so
+// intersectPathSlot holds NO persistent WavefrontRNG object and does NO
+// rng_dimension SoA round-trip (Option 3: keeps the intersect decision block
+// register-light so the kernel stays <=128 regs / 2 blocks/SM at 256 threads). Keyed
+// on (pixel, sample, seed, dimSalt); the salt varies per bounce and per draw so
+// every free-flight event is independent, and is disjoint from the shade stream.
+// CPU<->GPU free-flight streams are INDEPENDENT (parity gate is per-channel
+// mean-ratio, not sample-matched). See the research note.
+__device__ inline float gpu_freeflightUniform(uint32_t pixel, uint32_t sample,
+                                              uint64_t seed, uint32_t dimSalt)
+{
+    uint64_t seq_index = (static_cast<uint64_t>(pixel) * 65536ULL + sample) << 32 | dimSalt;
+    uint64_t stream = astroray::MixBits(seq_index);
+    uint64_t inc   = (stream << 1) | 1;
+    uint64_t state = 0;
+    state = state * 6364136223846793005ULL + inc;   // PCG32 SetSequence, advance 1
+    state += seed;
+    state = state * 6364136223846793005ULL + inc;   // advance 2
+    uint32_t xorshifted = static_cast<uint32_t>(((state >> 18u) ^ state) >> 27u);
+    uint32_t rot        = static_cast<uint32_t>(state >> 59u);
+    int32_t  rot_signed = static_cast<int32_t>(rot);
+    uint32_t u = (xorshifted >> rot) | (xorshifted << ((-rot_signed) & 31));
+    constexpr float kOneMinusEpsilon = 0x1.fffffep-1f;
+    return fminf(u * 0x1p-32f, kOneMinusEpsilon);
+}
+
 // intersectPathSlot returns -1 when the path died, else the GMaterialType
 // of the hit (0..GMAT_CLOSURE_GRAPH) for shade-queue bucketing. The hit
 // record is parked in GPUWavefrontHitBuffers SoA at the slot index.
@@ -327,15 +362,20 @@ __device__ int intersectPathSlot(
                 &lampT, &lampScale);
             if (lampIdx >= 0) termT = lampT;
         }
-        WavefrontRNG frng(state.rng_pixel[idx], state.rng_sample[idx],
-                          state.rng_seed[idx]);
-        frng.setDimension(state.rng_dimension[idx]);
+        // Object-free counter-based free-flight draws (Option 3): no WavefrontRNG
+        // object held, no rng_dimension round-trip — keeps this kernel register-
+        // light. Salt varies per bounce (·2) and per draw (+0/+1), disjoint from the
+        // shade stream; shade/volume read the UNTOUCHED rng_dimension (as Stage-1).
+        uint32_t rpix = state.rng_pixel[idx];
+        uint32_t rsmp = state.rng_sample[idx];
+        uint64_t rsd  = state.rng_seed[idx];
+        uint32_t salt = G_WF_VOL_DIM_SALT + (uint32_t)bounce * 2u;
         GSampledSpectrum sigmaT = gpu_worldSigmaT(lambdas);
-        int ch = (int)(frng.Uniform() * G_SPECTRUM_SAMPLES);
+        int ch = (int)(gpu_freeflightUniform(rpix, rsmp, rsd, salt) * G_SPECTRUM_SAMPLES);
         if (ch >= G_SPECTRUM_SAMPLES) ch = G_SPECTRUM_SAMPLES - 1;
         float sigTc = sigmaT.v[ch];
-        float fdist = (sigTc > 0.f) ? -__logf(1.f - frng.Uniform()) / sigTc : 1e30f;
-        state.rng_dimension[idx] = frng.dimension();
+        float xi = gpu_freeflightUniform(rpix, rsmp, rsd, salt + 1u);
+        float fdist = (sigTc > 0.f) ? -__logf(1.f - xi) / sigTc : 1e30f;
         if (fdist < termT) {
             // SCATTER: throughput *= Tr(fdist)·σ_s/pdf, pdf = avg(σ_t·Tr).
             GSampledSpectrum Tr;

--- a/tests/test_pkg199_stage2_scattering_gpu.py
+++ b/tests/test_pkg199_stage2_scattering_gpu.py
@@ -1,23 +1,23 @@
-"""pkg199 Stage 2 (GPU) — dedicated volume-scatter wavefront stage parity oracle.
+"""pkg199 Stage 2 (GPU) -- dedicated volume-scatter wavefront stage parity oracle.
 
 Stage 2 mirrors the CPU homogeneous scattering medium (HG in-scatter, exponential
 free-flight distance sampling, NEE-through-medium) on the GPU wavefront via a
 DEDICATED stageVolumeScatterKernel scheduled between intersect and shade. The
 free-flight scatter DECISION lives in intersectPathSlot (gated on the same
 mediumScatters = hasVolume && density>0 && scatter>0 condition as the CPU, so
-α=0 is byte-identical Stage-1); scattered slots route to a volume queue that the
+alpha=0 is byte-identical Stage-1); scattered slots route to a volume queue that the
 new kernel drains (phase NEE parked into the shared nee/shadow lanes; HG
-continuation requeued). stageShadeBucketedKernel is untouched → byte-identical.
+continuation requeued). stageShadeBucketedKernel is untouched -> byte-identical.
 
 Gates (GPU legs skip when CUDA is absent; /verify runs them on the RTX):
-  * α=0 GPU INERTNESS — a scatter=0 GPU render reproduces Stage-1 absorption
+  * alpha=0 GPU INERTNESS -- a scatter=0 GPU render reproduces Stage-1 absorption
     (darkens with density, NO god-ray brightening); the scattering estimator is
     not engaged (the -2 volume route never fires).
-  * CPU↔GPU GOD-RAY PARITY — a scattering point-light-in-fog scene: per-channel
-    CPU↔GPU mean-ratio within the independent-MC band (NOT SSIM, NOT bit-exact;
-    the wavefront has a ~2e-7 atomic floor — memory ssim-wrong-gate-for-independent-rng).
-  * FORWARD/BACK on GPU — g>0 (light behind fog) must out-scatter g<0 on the GPU too.
-  * VISUAL — god-ray PNGs saved for the mandatory human/parent inspection.
+  * CPU?GPU GOD-RAY PARITY -- a scattering point-light-in-fog scene: per-channel
+    CPU?GPU mean-ratio within the independent-MC band (NOT SSIM, NOT bit-exact;
+    the wavefront has a ~2e-7 atomic floor -- memory ssim-wrong-gate-for-independent-rng).
+  * FORWARD/BACK on GPU -- g>0 (light behind fog) must out-scatter g<0 on the GPU too.
+  * VISUAL -- god-ray PNGs saved for the mandatory human/parent inspection.
 """
 
 from __future__ import annotations
@@ -94,26 +94,26 @@ def _means(img):
 
 
 # ---------------------------------------------------------------------------
-# α=0 GPU INERTNESS — scatter=0 reproduces Stage-1 absorption (no god-rays).
+# alpha=0 GPU INERTNESS -- scatter=0 reproduces Stage-1 absorption (no god-rays).
 # ---------------------------------------------------------------------------
 
 def test_alpha_zero_gpu_is_absorption():
     if not _gpu_available():
         pytest.skip("CUDA GPU not available")
     clear = _means(_render(_godray_scene(True, 0.0, 0.0, 0.0)))
-    foggy = _means(_render(_godray_scene(True, 0.12, 0.0, 0.0)))   # α=0
-    print(f"\n[pkg199-s2 GPU α=0] clear={np.round(clear,4)} foggy={np.round(foggy,4)}")
-    # Absorption only: foggy must not EXCEED clear (a god-ray leak at α=0 would
-    # brighten — the scattering estimator must be gated off).
+    foggy = _means(_render(_godray_scene(True, 0.12, 0.0, 0.0)))   # alpha=0
+    print(f"\n[pkg199-s2 GPU alpha=0] clear={np.round(clear,4)} foggy={np.round(foggy,4)}")
+    # Absorption only: foggy must not EXCEED clear (a god-ray leak at alpha=0 would
+    # brighten -- the scattering estimator must be gated off).
     assert foggy.mean() <= clear.mean() * 1.03, (
-        f"α=0 GPU ADDED energy ({foggy.mean():.4f} > {clear.mean():.4f}) — "
+        f"alpha=0 GPU ADDED energy ({foggy.mean():.4f} > {clear.mean():.4f}) -- "
         f"scattering leaked into the absorption limit (mediumScatters gate broken)")
     assert foggy.mean() < clear.mean() * 0.99, (
-        f"α=0 GPU fog produced no attenuation ({foggy.mean():.4f} vs {clear.mean():.4f})")
+        f"alpha=0 GPU fog produced no attenuation ({foggy.mean():.4f} vs {clear.mean():.4f})")
 
 
 # ---------------------------------------------------------------------------
-# CPU↔GPU GOD-RAY PARITY — the decisive Stage-2 gate.
+# CPU?GPU GOD-RAY PARITY -- the decisive Stage-2 gate.
 # ---------------------------------------------------------------------------
 
 def test_godray_cpu_gpu_parity(test_results_dir):
@@ -133,11 +133,11 @@ def test_godray_cpu_gpu_parity(test_results_dir):
         assert 0.85 <= ratio[c] <= 1.18, (
             f"pkg199-s2 god-ray CPU/GPU parity FAILED ch {ch}: ratio {ratio[c]:.4f} "
             f"outside [0.85, 1.18] (GPU {gm[c]:.4f}, CPU {cm[c]:.4f})")
-    # Scattering must ADD in-scattered light vs the α=0 absorption baseline.
+    # Scattering must ADD in-scattered light vs the alpha=0 absorption baseline.
     absorb = _means(_render(_godray_scene(True, 0.12, 0.0, 0.4)))
     print(f"[pkg199-s2 god-ray] scatter mean={gm.mean():.4f} absorb mean={absorb.mean():.4f}")
     assert gm.mean() > absorb.mean() * 1.02, (
-        f"GPU in-scatter added no visible energy vs α=0 ({gm.mean():.4f} vs {absorb.mean():.4f})")
+        f"GPU in-scatter added no visible energy vs alpha=0 ({gm.mean():.4f} vs {absorb.mean():.4f})")
 
 
 # ---------------------------------------------------------------------------
@@ -147,11 +147,11 @@ def test_godray_cpu_gpu_parity(test_results_dir):
 def test_forward_back_scatter_gpu():
     if not _gpu_available():
         pytest.skip("CUDA GPU not available")
-    # Light directly behind the fog (cosθ≈-1) → forward (g>0) throws the halo.
+    # Light directly behind the fog (costheta~=-1) -> forward (g>0) throws the halo.
     fwd = _means(_render(_godray_scene(True, 0.15, 0.6, 0.7), spp=256, max_depth=2))
     bwd = _means(_render(_godray_scene(True, 0.15, 0.6, -0.7), spp=256, max_depth=2))
     print(f"\n[pkg199-s2 GPU fwd/back] fwd={fwd.mean():.5f} back={bwd.mean():.5f} "
           f"ratio={fwd.mean()/max(bwd.mean(),1e-9):.3f}")
     assert fwd.mean() > bwd.mean() * 1.3, (
         f"GPU forward scatter (g=+0.7, {fwd.mean():.5f}) must exceed back "
-        f"(g=-0.7, {bwd.mean():.5f}) — HG sign/frame bug on GPU")
+        f"(g=-0.7, {bwd.mean():.5f}) -- HG sign/frame bug on GPU")

--- a/tests/test_pkg199_stage2_scattering_gpu.py
+++ b/tests/test_pkg199_stage2_scattering_gpu.py
@@ -1,0 +1,157 @@
+"""pkg199 Stage 2 (GPU) — dedicated volume-scatter wavefront stage parity oracle.
+
+Stage 2 mirrors the CPU homogeneous scattering medium (HG in-scatter, exponential
+free-flight distance sampling, NEE-through-medium) on the GPU wavefront via a
+DEDICATED stageVolumeScatterKernel scheduled between intersect and shade. The
+free-flight scatter DECISION lives in intersectPathSlot (gated on the same
+mediumScatters = hasVolume && density>0 && scatter>0 condition as the CPU, so
+α=0 is byte-identical Stage-1); scattered slots route to a volume queue that the
+new kernel drains (phase NEE parked into the shared nee/shadow lanes; HG
+continuation requeued). stageShadeBucketedKernel is untouched → byte-identical.
+
+Gates (GPU legs skip when CUDA is absent; /verify runs them on the RTX):
+  * α=0 GPU INERTNESS — a scatter=0 GPU render reproduces Stage-1 absorption
+    (darkens with density, NO god-ray brightening); the scattering estimator is
+    not engaged (the -2 volume route never fires).
+  * CPU↔GPU GOD-RAY PARITY — a scattering point-light-in-fog scene: per-channel
+    CPU↔GPU mean-ratio within the independent-MC band (NOT SSIM, NOT bit-exact;
+    the wavefront has a ~2e-7 atomic floor — memory ssim-wrong-gate-for-independent-rng).
+  * FORWARD/BACK on GPU — g>0 (light behind fog) must out-scatter g<0 on the GPU too.
+  * VISUAL — god-ray PNGs saved for the mandatory human/parent inspection.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+import pytest
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+sys.path.insert(0, os.path.dirname(__file__))
+
+from base_helpers import save_image
+
+try:
+    import astroray
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray not built")
+
+SEED = 199223
+W = H = 64
+
+
+def _gpu_available() -> bool:
+    return AVAILABLE and astroray.__features__.get("cuda", False) \
+        and astroray.Renderer().gpu_available
+
+
+@pytest.fixture
+def test_results_dir():
+    d = os.path.join(os.path.dirname(__file__), "..", "test_results")
+    os.makedirs(d, exist_ok=True)
+    return os.path.abspath(d)
+
+
+def _godray_scene(use_gpu: bool, density: float, scatter: float, g: float,
+                  w: int = W, h: int = H):
+    """A point light embedded in scattering fog, viewed so the shafts cross the
+    frame. Grey medium so the per-channel machinery collapses cleanly."""
+    r = astroray.Renderer()
+    r.set_seed(SEED)
+    r.set_background_color([0.0, 0.0, 0.0])
+    if density > 0.0:
+        r.set_world_volume(density, [1.0, 1.0, 1.0], g, scatter)
+    r.add_point_light([0.0, 0.0, -3.0], {"mode": "rgb", "color": [1.0, 1.0, 1.0]}, 90.0)
+    # A diffuse floor to catch shafts and give a multi-object GI path through fog.
+    floor = r.create_material("lambertian", [0.6, 0.6, 0.6], {})
+    r.add_sphere([0.0, -1001.0, -3.0], 1000.0, floor)
+    r.setup_camera([0.0, 0.6, 6.0], [0.0, 0.0, -3.0], [0.0, 1.0, 0.0],
+                   40.0, w / h, 0.0, 9.0, w, h)
+    r.set_integrator("path_tracer")
+    r.set_integrator_param("max_depth", 5)
+    if use_gpu:
+        r.set_use_gpu(True)
+        r.set_wavelength_range(380.0, 780.0)
+        r.set_output_mode("srgb")
+    return r
+
+
+def _render(r, spp=256, max_depth=5, w=W, h=H):
+    img = np.asarray(r.render(spp, max_depth, None, False), dtype=np.float64)
+    if img.ndim == 1:
+        img = img.reshape(h, w, 3)
+    return img
+
+
+def _means(img):
+    return np.array([float(img[..., c].mean()) for c in range(3)])
+
+
+# ---------------------------------------------------------------------------
+# α=0 GPU INERTNESS — scatter=0 reproduces Stage-1 absorption (no god-rays).
+# ---------------------------------------------------------------------------
+
+def test_alpha_zero_gpu_is_absorption():
+    if not _gpu_available():
+        pytest.skip("CUDA GPU not available")
+    clear = _means(_render(_godray_scene(True, 0.0, 0.0, 0.0)))
+    foggy = _means(_render(_godray_scene(True, 0.12, 0.0, 0.0)))   # α=0
+    print(f"\n[pkg199-s2 GPU α=0] clear={np.round(clear,4)} foggy={np.round(foggy,4)}")
+    # Absorption only: foggy must not EXCEED clear (a god-ray leak at α=0 would
+    # brighten — the scattering estimator must be gated off).
+    assert foggy.mean() <= clear.mean() * 1.03, (
+        f"α=0 GPU ADDED energy ({foggy.mean():.4f} > {clear.mean():.4f}) — "
+        f"scattering leaked into the absorption limit (mediumScatters gate broken)")
+    assert foggy.mean() < clear.mean() * 0.99, (
+        f"α=0 GPU fog produced no attenuation ({foggy.mean():.4f} vs {clear.mean():.4f})")
+
+
+# ---------------------------------------------------------------------------
+# CPU↔GPU GOD-RAY PARITY — the decisive Stage-2 gate.
+# ---------------------------------------------------------------------------
+
+def test_godray_cpu_gpu_parity(test_results_dir):
+    if not _gpu_available():
+        pytest.skip("CUDA GPU not available")
+    gpu = _render(_godray_scene(True, 0.12, 0.6, 0.4))
+    cpu = _render(_godray_scene(False, 0.12, 0.6, 0.4))
+    gm, cm = _means(gpu), _means(cpu)
+    ratio = gm / np.maximum(cm, 1e-6)
+    print(f"\n[pkg199-s2 god-ray CPU/GPU] GPU={np.round(gm,4)} CPU={np.round(cm,4)} "
+          f"ratio={np.round(ratio,4)}")
+    save_image(gpu.astype(np.float32),
+               os.path.join(test_results_dir, "pkg199_s2_godray_gpu.png"))
+    save_image(cpu.astype(np.float32),
+               os.path.join(test_results_dir, "pkg199_s2_godray_cpu.png"))
+    for c, ch in enumerate("RGB"):
+        assert 0.85 <= ratio[c] <= 1.18, (
+            f"pkg199-s2 god-ray CPU/GPU parity FAILED ch {ch}: ratio {ratio[c]:.4f} "
+            f"outside [0.85, 1.18] (GPU {gm[c]:.4f}, CPU {cm[c]:.4f})")
+    # Scattering must ADD in-scattered light vs the α=0 absorption baseline.
+    absorb = _means(_render(_godray_scene(True, 0.12, 0.0, 0.4)))
+    print(f"[pkg199-s2 god-ray] scatter mean={gm.mean():.4f} absorb mean={absorb.mean():.4f}")
+    assert gm.mean() > absorb.mean() * 1.02, (
+        f"GPU in-scatter added no visible energy vs α=0 ({gm.mean():.4f} vs {absorb.mean():.4f})")
+
+
+# ---------------------------------------------------------------------------
+# FORWARD / BACK on GPU.
+# ---------------------------------------------------------------------------
+
+def test_forward_back_scatter_gpu():
+    if not _gpu_available():
+        pytest.skip("CUDA GPU not available")
+    # Light directly behind the fog (cosθ≈-1) → forward (g>0) throws the halo.
+    fwd = _means(_render(_godray_scene(True, 0.15, 0.6, 0.7), spp=256, max_depth=2))
+    bwd = _means(_render(_godray_scene(True, 0.15, 0.6, -0.7), spp=256, max_depth=2))
+    print(f"\n[pkg199-s2 GPU fwd/back] fwd={fwd.mean():.5f} back={bwd.mean():.5f} "
+          f"ratio={fwd.mean()/max(bwd.mean(),1e-9):.3f}")
+    assert fwd.mean() > bwd.mean() * 1.3, (
+        f"GPU forward scatter (g=+0.7, {fwd.mean():.5f}) must exceed back "
+        f"(g=-0.7, {bwd.mean():.5f}) — HG sign/frame bug on GPU")


### PR DESCRIPTION
## pkg199 Stage 2 — PR 2b: GPU wavefront dedicated volume-scatter stage

Mirrors the PR-2a CPU homogeneous scattering medium on the GPU wavefront via a
**dedicated `stageVolumeScatterKernel`** scheduled between intersect and shade
(Option A, coordinator-approved). Branches on top of merged 2a (PR #617).

### Architecture
- `intersectPathSlotT` runs the cheap free-flight **decision** (gated on
  `mediumScatters`); a SCATTER writes the scatter point `P` to `ray_origin`,
  applies `Tr·σ_s/pdf`, returns a `-2` sentinel routing the slot to a **new volume
  queue**; a SURFACE applies `Tr/pdf` (role-1 replacement, role-1 + role-3-lamp Tr
  gated off).
- **`stageVolumeScatterKernel`** (new) drains the volume queue: HG phase NEE
  parked into the **shared** `nee_f/nee_i` lanes + shadow queue (so
  `stageShadowKernel` resolves it unchanged — lane-14 `geomDist` role-2 Tr +
  clamp), and the HG phase-sampled continuation requeued. **`stageShadeBucketedKernel`
  is never touched → byte-identical by construction** (scattered slots never enter
  its bucket).
- `GWorldVolume` gains `scatter` (α) + `anisotropy` (g); uploaded from the renderer.
  Snapshot semantics pinned identically to CPU (`P` from the pre-update ray).
- Premise correction (documented in the spec): a purely-additive kernel can't sit
  between intersect and shade because intersect owns the surface-commit +
  bucketing, so intersect is `mediumScatters`-gated; **`scatter==0` compiles to
  identical Stage-1 behaviour.**

### Fleet register isolation — `HasWorldScatter` if-constexpr axis
The inline free-flight decision costs **+3 REG on `stageIntersectQueuedKernel`
(127→130)**, crossing 128 → **2→1 blocks/SM** at 256 threads. A cooled,
contention-controlled, **interleaved** A/B (idle + burn-in to 2887 MHz, min-of-11,
`nvidia-smi`-verified no compute contention per leg):

| build | vacuum 256²/128spp/d6 | power | blocks/SM |
|---|---|---|---|
| main (3 legs) | 116.4 / 116.7 / 116.9 ms | 153–156 W | 2 |
| always-present (2 legs) | 120.6 / 120.7 ms | 147 W | 1 |
| **if-constexpr `<false>` (2 legs)** | **117.2 / 117.4 ms** | 152 W | **2** |

→ the always-present form is a real **+3.3%** fog-free fleet regression (power-draw
split confirms the occupancy mechanism, not clock/thermal). **Four shave attempts**
(object-free counter-based hash, `__noinline__`, scatter-math-to-volume-kernel,
drop-lamp-bound) all stayed at 130 — the +3 is intrinsic to any inline decision.
**Resolution:** the established fleet-isolation pattern (pkg178/184/189) —
`template<bool HasWorldScatter>` with the decision behind `if constexpr`. Fleet
`<false>` (vacuum + absorption-only fog) compiles it OUT → **REG 127 / STACK 616 /
2 blocks/SM, byte-identical Stage-1**, cooled vacuum **117.3 ms = +0.5% vs main
(within noise)**. Only scattering fog launches `<true>` (REG 130). A non-template
`intersectPathSlot` forwarder (→`<false>`) preserves the cross-TU symbol for the
ReSTIR primary + MIS-audit kernels. **Chosen over the spec's Option 2**
(volume-kernel-owns-surface restructure) — same fleet-clean result, far lower
correctness risk (scattering logic unchanged, only compile-gated).

### Register gates (cuobjdump, native sm_120 `.pyd`)
- `stageShadeBucketedKernel<false,false,false,false>`: **REG 254 / STACK 3352 /
  CONSTANT[0] 1700** — byte-identical to the pinned fleet baseline.
- `stageIntersectQueuedKernel<false>` (fleet): **REG 127 / STACK 616** (= main's
  127/616; CONST[0] 1696 vs 1680 is the 2 vol-queue pointer params — constant
  memory, not registers/occupancy).
- `stageIntersectQueuedKernel<true>` (fog only): REG 130 / STACK 632.
- **New `stageVolumeScatterKernel`: REG 64 / STACK 88 / CONST[0] 1382.**

### Measured gates (RTX 5070 Ti, 2887 MHz)
- **CPU↔GPU god-ray parity: per-channel ratio [1.0044, 0.9972, 0.9978]** (~0.5%,
  MC convention); in-scatter adds 5× energy vs the α=0 baseline (0.0397 vs 0.0082).
- **α=0 GPU inertness:** foggy 0.0083 < clear 0.0293 (absorption, no god-ray leak).
- **Forward/back HG on GPU: 1.707** (forward > back).
- **Visual:** GPU vs CPU god-ray PNGs near-indistinguishable (smooth in-scatter
  halo + floor shafts, no NaN speckle/artifacts) — inspected.
- **Stage-1 preserved:** all 9 pkg199 world-volume tests pass (Beer-Lambert,
  vacuum byte-identity, ReSTIR fog-contamination guard, sphere-lamp CPU↔GPU
  parity [1.0005,1.0003,1.0003]) — the templating + forwarder didn't touch the
  absorption/ReSTIR paths.

### Regression
- pkg199 Stage 2 GPU+CPU + Stage 1: **19/19**.
- **Full local sweep** `tests/ --ignore=tests/wavefront_diff` (the CLAUDE.md
  routine exclusion of the long pkg55 wavefront_diff gate): **1981 passed, 70
  skipped, 19 xfailed, 3 xpassed, 0 failed** (10m28s).

### Authorized surface
Spec Stage-2 Specification (GPU wavefront mirror). Changed: `src/gpu/wavefront/
stage_advance.cu` (volume kernel + intersect template + free-flight helpers),
`src/gpu/wavefront/gpu_wavefront_snapshot.cu` (volume-queue plumbing + upload +
launch flag), `include/astroray/gpu_types.h` (GWorldVolume fields),
`include/astroray/gpu_wavefront_state.h` (launch decls), new GPU test, research
note + spec. No CPU integrator / shade-kernel changes.

### Build (CUDA, root wrapper, foreground)
`.pyd` mtime **2026-08-14 22:56:36** (postdates code HEAD 35f5577 @ 22:49:45),
sm_120 confirmed via `cuobjdump --list-elf`. Last 5 lines:
```
[pkg183] arch-verify OK: astroray.cp313-win_amd64.pyd embeds sm_120 (embedded=[sm_120])
[pkg183] running host-only ABI canary (no GPU)...
[pkg183] canary caps: {'cpu': True, ... 'gpu': True, 'gpu_spectral': True, ...}
========================================
Build succeeded
```

### Follow-up (filed in spec)
Blender addon UI for the `scatter` slider (bindings-now, UI-later).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
