### PR TITLE
feat(pkg205): ASCII-ize print() glyphs that UnicodeEncodeError under cp1252

### DIFF
--- a/.astroray_plan/packages/pkg205-unicode-console-test-hygiene.md
+++ b/.astroray_plan/packages/pkg205-unicode-console-test-hygiene.md
@@ -2,7 +2,7 @@
 
 **Pillar:** Infrastructure / test hygiene
 **Track:** A (small local fix — no engine code, no GPU, no physics)
-**Status:** open (filed 2026-08-19).
+**Status:** done (PR pending, 2026-08-20 — 3 tests un-broken: test_pkg182 (λ→lambda), test_disney_diffuse_pdf (π/°→pi/deg), test_blender_parity_matrix (✓→[OK]); all now PASS under cp1252, 0 UnicodeEncodeError).
 **Estimated effort:** XS.
 **Depends on:** nothing.
 

--- a/.astroray_plan/packages/pkg205-unicode-console-test-hygiene.md
+++ b/.astroray_plan/packages/pkg205-unicode-console-test-hygiene.md
@@ -2,7 +2,7 @@
 
 **Pillar:** Infrastructure / test hygiene
 **Track:** A (small local fix — no engine code, no GPU, no physics)
-**Status:** done (PR pending, 2026-08-20 — 3 tests un-broken: test_pkg182 (λ→lambda), test_disney_diffuse_pdf (π/°→pi/deg), test_blender_parity_matrix (✓→[OK]); all now PASS under cp1252, 0 UnicodeEncodeError).
+**Status:** done (PR #626, 2026-08-20 — 3 tests un-broken: test_pkg182 (λ→lambda), test_disney_diffuse_pdf (π/°→pi/deg), test_blender_parity_matrix (✓→[OK]); all now PASS under cp1252, 0 UnicodeEncodeError).
 **Estimated effort:** XS.
 **Depends on:** nothing.
 

--- a/tests/statistical/test_disney_diffuse_pdf.py
+++ b/tests/statistical/test_disney_diffuse_pdf.py
@@ -32,7 +32,7 @@ def test_disney_diffuse_pdf_vs_lambertian():
     print(f"\nPDF at normal [0,1,0]:")
     print(f"  Lambertian: {pdf_lamb:.6f}")
     print(f"  Disney diffuse: {pdf_disney:.6f}")
-    print(f"  Expected (1/π): {1.0/np.pi:.6f}")
+    print(f"  Expected (1/pi): {1.0/np.pi:.6f}")
     print(f"  Disney/Lambertian ratio: {pdf_disney/pdf_lamb:.6f}")
 
     # Test at 45° from normal
@@ -43,8 +43,8 @@ def test_disney_diffuse_pdf_vs_lambertian():
     pdf_lamb_45 = renderer.debug_bsdf_pdf_batch(lamb_id, wo, wi_45)[0]
     pdf_disney_45 = renderer.debug_bsdf_pdf_batch(disney_id, wo, wi_45)[0]
 
-    print(f"\nPDF at 45° from normal:")
+    print(f"\nPDF at 45 deg from normal:")
     print(f"  Lambertian: {pdf_lamb_45:.6f}")
     print(f"  Disney diffuse: {pdf_disney_45:.6f}")
-    print(f"  Expected (cos45°/π): {cos_theta/np.pi:.6f}")
+    print(f"  Expected (cos45deg/pi): {cos_theta/np.pi:.6f}")
     print(f"  Disney/Lambertian ratio: {pdf_disney_45/pdf_lamb_45:.6f}")

--- a/tests/test_blender_parity_matrix.py
+++ b/tests/test_blender_parity_matrix.py
@@ -140,9 +140,9 @@ def test_blender_parity_matrix_generation():
     print(f"UNKNOWN-CRASH:   {counts['UNKNOWN-CRASH']:4d}")
     print(f"TOTAL:           {len(matrix_rows):4d}")
     print("=" * 60)
-    print(f"✓ Matrix generated: {len(matrix_rows)} features classified")
-    print(f"✓ Zero UNKNOWN-CRASH features (Phase A acceptance met)")
-    print(f"✓ Artifacts: {json_path}, {md_path}")
+    print(f"[OK] Matrix generated: {len(matrix_rows)} features classified")
+    print(f"[OK] Zero UNKNOWN-CRASH features (Phase A acceptance met)")
+    print(f"[OK] Artifacts: {json_path}, {md_path}")
     print("=" * 60 + "\n")
 
 

--- a/tests/test_pkg182_conductor_spectral_native.py
+++ b/tests/test_pkg182_conductor_spectral_native.py
@@ -99,7 +99,7 @@ def test_conductor_spectral_stays_chromatic():
             sats.append(_saturation(_roi_mean_rgb(_render(d, fior))))
     sats = np.asarray(sats)
     mean_sat, max_sat = float(sats.mean()), float(sats.max())
-    print(f"\n[pkg182 conductor per-λ] mean_sat={mean_sat:.4f} max_sat={max_sat:.4f} "
+    print(f"\n[pkg182 conductor per-lambda] mean_sat={mean_sat:.4f} max_sat={max_sat:.4f} "
           f"(RGB-upsample baseline: mean 0.0488, max 0.1842)")
     assert mean_sat >= _MEAN_SAT_FLOOR, (
         f"per-λ conductor mean saturation {mean_sat:.4f} < floor {_MEAN_SAT_FLOOR} "


### PR DESCRIPTION
## pkg205 — UnicodeEncodeError console test hygiene

Three pre-existing tests crashed in their diagnostic `print()`/f-string output when run under the default Windows **cp1252** console — before their (passing) assertions could report. This is a test-harness output bug, not an engine defect. Fix = ASCII-ize the offending cosmetic glyphs (`print()` lines only).

### The three tests (before → after)
Reproduced under cp1252 (`sys.stdout.encoding == cp1252`, no `PYTHONIOENCODING` override) with capture disabled (`-s`):

| Test | Glyph (before) | UnicodeEncodeError | After |
|------|----------------|--------------------|-------|
| `tests/test_pkg182_conductor_spectral_native.py::test_conductor_spectral_stays_chromatic` | `per-λ` (U+03BB) | `can't encode 'λ'` | `per-lambda` → PASS |
| `tests/statistical/test_disney_diffuse_pdf.py::test_disney_diffuse_pdf_vs_lambertian` | `1/π`, `45°`, `cos45°/π` (U+03C0/U+00B0) | `can't encode 'π'` | `1/pi`, `45 deg`, `cos45deg/pi` → PASS |
| `tests/test_blender_parity_matrix.py::test_blender_parity_matrix_generation` | `✓` (U+2713) | `can't encode '✓'` | `[OK]` → PASS |

**Before:** 3 × `UnicodeEncodeError` in `cp1252.py:19`.
**After:** `4 passed, 0 UnicodeEncodeError` (the pkg182 file contributes 2 tests). `py_compile` clean on all three.

### Scope / authorized surface
- **Spec-intended files touched:** exactly the three test modules above (7 `print()`-line edits) + the pkg205 spec status flip.
- **Deliberately NOT touched:** `tests/test_cryptomatte_pass.py`. Its `✓` prints (lines 455/464) live in the OpenEXR-gated manifest round-trip test, which **skips** (`OpenEXR not available`), so it never reaches the glyph and does **not** raise. Per the spec ("only touch the ones that do [raise]", minimal blast radius), it is left alone. Confirmed unchanged: `2 passed, 1 skipped`.
- **Left in place (out of scope):** the remaining `λ` in pkg182's *assertion-failure* messages (lines 105/108) — those only render on an assertion failure (the test passes), and pkg205 is a `print()`-encoding chip, not an assertion refactor. Also noted: a **pre-existing, unrelated** `UnicodeDecodeError` warning in `test_blender_parity_matrix` from a background subprocess-reader thread decoding a child process's stdout (byte 0x8f) — present before this change, a non-blocking warning, test still passes. Filed as out-of-scope observation, not addressed here.

### Acceptance
- [x] The three previously-`UnicodeEncodeError` tests are named and now PASS under cp1252 (before shows the error, after shows PASS).
- [x] No other test's pass/fail status changes (cryptomatte unchanged; affected files diffed).
- [x] Diff touches only test files, only `print()` output lines (+ spec status). No engine code, no `.pyd` rebuild, no GPU leg.
- [ ] CI green on all matrix jobs (pending).

No `.cu/.cpp/.h/CMakeLists.txt` touched → no build log required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
