### PR TITLE
feat(pkg206): luminance-weighted hero-wavelength importance sampling (D65 CDF)

### DIFF
--- a/.astroray_plan/docs/pkg206-hero-luminance-fit.md
+++ b/.astroray_plan/docs/pkg206-hero-luminance-fit.md
@@ -82,20 +82,37 @@ foreign constants.
 ## Runtime formulation (nm units, unbiased)
 
 Draw one uniform `u ∈ [0,1)` (SAME draw count as uniform — CPU↔GPU dimension
-counters stay aligned):
+counters stay aligned). Stratify in **CDF (uniform) space**, invert per lane
+(k = kSpectrumSamples = 4):
 
 ```
-rand  = N*u + y0
-hero  = x0 - log(1/rand - 1) / a          // nm, in [360, 830]
-pdf(λ) = a * rand_λ * (1 - rand_λ) / N     // 1/nm  (rand_λ = F(λ) = sigmoid)
+for i in 0..k:
+    u_i   = frac(u + i/k)                 // stratify in uniform space, wrap
+    rand_i = N*u_i + y0                    // into truncated CDF window [y0, y0+N]
+    λ_i    = x0 - log(1/rand_i - 1) / a    // nm, in [360, 830]
+    pdf_i  = a * rand_i * (1 - rand_i) / N // 1/nm  (density at λ_i, integrates to 1)
 ```
 
-The **hero** pdf uses `rand` directly (`rand_hero = rand`). Each stratified
-**companion** λ_i = wrap(hero + i*step) gets its pdf from the density evaluated
-at ITS OWN λ_i: `rand_i = sigmoid(λ_i; a, x0)`, `pdf_i = a*rand_i*(1-rand_i)/N`
-(Wilkie 2014). This is a proper density in 1/nm that integrates to 1, so the
-existing MC estimator (`SampledSpectrum::toXYZ` divides by `pdf(i)`) stays
-unbiased — only the variance drops.
+Lane 0 (`u_0 = u`) is the hero. Each lane is an INDEPENDENT-marginal stratified
+sample whose density is exactly `p(λ_i)`, so `pdf_i = p(λ_i)` is correct and the
+MC estimator (`SampledSpectrum::toXYZ` divides by `pdf(i)`) stays UNBIASED —
+only variance drops. Cited: **PBRT-v4 `SampledWavelengths::SampleVisibleWavelengths`**
+(pbr-book §4.5.4, Apache-2.0) — the canonical CDF-space-stratified importance
+sampler; Wilkie 2014 is the hero-collapse structure that keeps dispersion
+unbiased when the secondaries are terminated.
+
+### Correction vs the spec's naive reading (BIAS FOUND & FIXED)
+
+The spec §2 suggested "keep the stratified companion offsets [hero + i*step in
+**wavelength**] but set each companion pdf to the density at its own λ". That
+combination is **biased** under a non-uniform proposal: a companion produced by
+a fixed wavelength offset from the hero has marginal density `p(hero)` *shifted*,
+NOT `p(λ_i)`. Measured bias: the dispersive-prism red channel converged to
+ratio **0.73** vs the uniform baseline (`test_pkg206_prism_convergence`
+::test_converged_importance_matches_uniform_unbiased) before the fix. Stratifying
+in CDF space (above) removes it: each lane's marginal *is* `p(λ_i)`. Under a
+uniform F the CDF-space and wavelength-space strata coincide, so this reduces
+byte-exactly to `sampleUniform`.
 
 Note vs Cycles: Cycles' `prob` is a **dimensionless ratio-to-uniform**
 (multiplies by span). Astroray's `pdf` is a **true density in 1/nm** (divides by

--- a/.astroray_plan/docs/pkg206-hero-luminance-fit.md
+++ b/.astroray_plan/docs/pkg206-hero-luminance-fit.md
@@ -1,0 +1,110 @@
+# pkg206 — Luminance-weighted hero-wavelength importance sampling (research note)
+
+**Skill:** cite-algorithm (CLAUDE.md §6). Sampling algorithm — non-trivial, cited.
+**Date:** 2026-08-20.
+
+## Problem
+
+Astroray draws the hero wavelength **uniformly** over [360, 830] nm
+(`SampledWavelengths::sampleUniform`, `src/spectrum.cpp:82`; GPU mirror
+`sampleUniformWavelength`, `src/gpu/wavefront/stage_init.cu:119`), pdf = 1/span.
+Uniform draws spend equal sampling effort on wavelengths the eye barely sees, so
+dispersive-caustic renders carry more chromatic noise per sample than necessary.
+
+## Cited sources
+
+1. **Wilkie, Nawaz, Droske, Weidlich, Hanika 2014, "Hero Wavelength Spectral
+   Sampling", CGF 33(4), DOI 10.1111/cgf.12419.** The hero-wavelength framework:
+   one hero λ is drawn per path and `k-1` stratified companions are wrapped into
+   range. Under a **non-uniform** hero proposal density `p(λ)`, each companion's
+   pdf is `p` evaluated at *its own* λ (NOT the hero's, NOT 1/span). We keep the
+   one-hero-per-path structure; only the proposal density changes.
+
+2. **Blender Cycles, `intern/cycles/kernel/util/colorspace.h`, `sample_wavelength()`
+   (Apache-2.0), and `intern/cycles/app/cie_d65_luminance_fit.py`.** Cycles draws
+   the hero wavelength from a **luminance-weighted D65 distribution** fitted to a
+   logistic (sigmoid) CDF. Verbatim Cycles constants (fit in **micrometres**,
+   CIE-1931 2° observer, 380–780 nm):
+
+   ```
+   a  = 21.71348444564851   (1/um)
+   x0 = 0.5554867905834258  (um  = 555.49 nm)
+   y0 = 0.021659159132699574
+   N  = 0.9707633294863183
+   ```
+
+   Cycles' sampler (um):
+   ```
+   rand = N*rand + y0;
+   prob = a*rand*(1-rand) * (WAVELENGTH_CIE_MAX - WAVELENGTH_CIE_MIN) / N;  // ratio-to-uniform
+   wavelength = -logf(1/rand - 1)/a + x0;   // um
+   ```
+
+   Fit target (from `cie_d65_luminance_fit.py`): CDF of `(cie_y + 0.25) * d65`.
+   The **+0.25 additive constant** on the luminance CMF ("we want a bit of all
+   the wavelengths") blends between pure-luminance (green caustic noise) and
+   uniform (noisier everywhere). Model `F(x) = 1/(1+exp(-a(x-x0)))`,
+   `y0 = F(0.38)`, `N = F(0.78) - y0` (CDF-space truncation to the range).
+
+## Observer-mismatch decision (spec §1)
+
+Cycles fits against the **CIE-1931 2°** observer; Astroray carries the
+**CIE-1964 10°** observer (`data/spectra/cie_cmf.inc`) and a D65 SPD
+(`illuminant_d65.inc`). The two y-bar functions differ (the 10° observer is
+broader and slightly red-shifted). Rather than reuse Cycles' 1931-2° constants
+blindly, we **re-fit against Astroray's own tables** with the same model,
+same +0.25 blend, over Astroray's own [360, 830] nm range, in **nm units**
+(so no unit-conversion footgun in the runtime code).
+
+Script: `scripts/data/fit_hero_luminance_cdf.py` (reads the baked `.inc` tables,
+`scipy.optimize.curve_fit` on the empirical CDF).
+
+### Fitted constants (Astroray, CIE-1964 10°, nm units, [360,830] nm, blend +0.25)
+
+```
+a  = 0.0221679280f   // 1/nm     (Cycles equiv 0.0217135 /nm — 2.1% higher)
+x0 = 552.040271f     // nm       (Cycles equiv 555.49 nm — 3.4 nm bluer)
+y0 = 0.0139650380f
+N  = 0.9839309253f
+```
+
+- Max fit error `|F_fit - F_emp| = 2.77e-2` (CDF, comparable to Cycles).
+- Sampled λ spans **[360.00, 829.99] nm** — full [360,830] coverage, so the
+  sampler support ⊇ the CMF/emission support ⇒ importance sampling stays
+  unbiased for every integrand (pdf > 0 wherever the integrand is nonzero).
+- Verified `∫ pdf(λ) dλ = 0.999999` over the analytic support (target 1.0).
+
+The re-fit lands close to Cycles (same regime, same "bit of all wavelengths"
+blend) while being self-consistent with Astroray's observer — no measured
+error bound against a foreign observer is needed because we did not reuse the
+foreign constants.
+
+## Runtime formulation (nm units, unbiased)
+
+Draw one uniform `u ∈ [0,1)` (SAME draw count as uniform — CPU↔GPU dimension
+counters stay aligned):
+
+```
+rand  = N*u + y0
+hero  = x0 - log(1/rand - 1) / a          // nm, in [360, 830]
+pdf(λ) = a * rand_λ * (1 - rand_λ) / N     // 1/nm  (rand_λ = F(λ) = sigmoid)
+```
+
+The **hero** pdf uses `rand` directly (`rand_hero = rand`). Each stratified
+**companion** λ_i = wrap(hero + i*step) gets its pdf from the density evaluated
+at ITS OWN λ_i: `rand_i = sigmoid(λ_i; a, x0)`, `pdf_i = a*rand_i*(1-rand_i)/N`
+(Wilkie 2014). This is a proper density in 1/nm that integrates to 1, so the
+existing MC estimator (`SampledSpectrum::toXYZ` divides by `pdf(i)`) stays
+unbiased — only the variance drops.
+
+Note vs Cycles: Cycles' `prob` is a **dimensionless ratio-to-uniform**
+(multiplies by span). Astroray's `pdf` is a **true density in 1/nm** (divides by
+`N` only) because Astroray's estimator divides by a genuine per-wavelength
+density (`toXYZ`: `value * CMF(λ) / pdf`). Getting this unit right is the
+unbiasedness-critical difference from a blind Cycles port.
+
+## Non-goals
+
+- No per-bounce λ re-sampling / spectral MIS (pkg211).
+- No λ→RGB change (Astroray integrates against the CIE-1964 observer directly;
+  Cycles' D65 RGB-uplift workaround does not apply).

--- a/.astroray_plan/packages/pkg206-luminance-weighted-hero-wavelength-sampling.md
+++ b/.astroray_plan/packages/pkg206-luminance-weighted-hero-wavelength-sampling.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 3 (light transport / spectral rendering) + Integration Milestone (Cycles-parity)
 **Track:** A
-**Status:** open (filed 2026-08-19).
+**Status:** done (PR #627, 2026-08-20 — CPU+GPU luminance-weighted hero sampler; sampler var ratio 0.144, prism luminance-weighted MSE ratio 0.749, converged unbiasedness 1.00x, shade REG 254/CONSTANT[0] 1700 unchanged. NOTE: spec's wavelength-space companion pdf was biased (red 0.73) — corrected to CDF-space stratification per PBRT-v4).
 **Estimated effort:** M (CPU+GPU byte-mirrored sampler change + pdf plumbing + re-baseline).
 **Depends on:** nothing hard. Composes with pkg189 (GPU hero-λ dispersion, LANDED) and
 the existing spectral MIS caustic path (SMS). CPU/GPU byte-mirrored in the SAME PR.

--- a/include/astroray/spectrum.h
+++ b/include/astroray/spectrum.h
@@ -102,6 +102,18 @@ public:
                                             float lambdaMin = kLambdaMin,
                                             float lambdaMax = kLambdaMax);
 
+    // pkg206 — Luminance-weighted hero-wavelength importance sampling. Draws
+    // the hero from a logistic CDF fitted to (y_bar+0.25)*D65 (CIE-1964 10deg),
+    // with per-sample pdf = the sigmoid-derivative density (1/nm) so the MC
+    // estimator stays UNBIASED — only chromatic variance drops. Consumes ONE
+    // uniform (same draw count as sampleUniform). Wilkie 2014 + Cycles D65 fit,
+    // re-fitted; see .astroray_plan/docs/pkg206-hero-luminance-fit.md. BYTE-
+    // MIRRORED by GPU sampleImportanceWavelength (stage_init.cu). Used only on
+    // the PRIMARY camera path; light/emission/redshift stay on sampleUniform.
+    static SampledWavelengths sampleImportance(float u,
+                                               float lambdaMin = kLambdaMin,
+                                               float lambdaMax = kLambdaMax);
+
     // Construct a SampledWavelengths from caller-supplied wavelengths.
     // Used by emission-evaluation APIs that need to query an emitter at
     // specific lambdas (rather than letting the renderer pick stratified

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -3898,6 +3898,12 @@ PYBIND11_MODULE(astroray, m) {
                     "u"_a,
                     "lambda_min"_a = astroray::kLambdaMin,
                     "lambda_max"_a = astroray::kLambdaMax)
+        // pkg206: luminance-weighted hero-wavelength importance sampling.
+        .def_static("sample_importance",
+                    &astroray::SampledWavelengths::sampleImportance,
+                    "u"_a,
+                    "lambda_min"_a = astroray::kLambdaMin,
+                    "lambda_max"_a = astroray::kLambdaMax)
         .def("lambda_", &astroray::SampledWavelengths::lambda, "i"_a)
         .def("pdf",     &astroray::SampledWavelengths::pdf,    "i"_a)
         .def("lambdas", [](const astroray::SampledWavelengths& w) {

--- a/plugins/integrators/spectral_path_tracer.cpp
+++ b/plugins/integrators/spectral_path_tracer.cpp
@@ -65,6 +65,7 @@ class SpectralPathTracer : public Integrator {
     // set_wavelength_range is honored instead of silently ignored.
     float lambdaMin_;
     float lambdaMax_;
+    bool  heroImportance_;  // pkg206: importance-sample the hero wavelength (default on)
 
     Renderer* renderer_ = nullptr;
     Camera* camera_ = nullptr;  // pkg87b: for Cryptomatte buffer access
@@ -101,7 +102,12 @@ public:
           // getFloat() fallback preserves byte-identical output when
           // set_wavelength_range was never called (acceptance: no regression).
           lambdaMin_(p.getFloat("lambda_min", astroray::kLambdaMin)),
-          lambdaMax_(p.getFloat("lambda_max", astroray::kLambdaMax)) {
+          lambdaMax_(p.getFloat("lambda_max", astroray::kLambdaMax)),
+          // pkg206: luminance-weighted hero-wavelength importance sampling on the
+          // primary path (default ON). Internal quality knob, NOT wired into the
+          // Blender UI; exposed only via set_integrator_param("hero_importance",
+          // 0|1) so the A/B convergence gate can render the uniform baseline.
+          heroImportance_(p.getInt("hero_importance", 1) != 0) {
         smsCfg_.seeds         = p.getInt("sms_seeds", 1);
         smsCfg_.maxIterations = p.getInt("sms_max_iterations", 20);
         smsCfg_.tolerance     = p.getFloat("sms_tolerance", 1e-4f);
@@ -181,8 +187,18 @@ public:
         std::uniform_real_distribution<float> dist01(0.0f, 1.0f);
         // pkg125: honor set_wavelength_range (lambdaMin_/lambdaMax_), mirroring
         // multiwavelength_path_tracer.cpp:74-75.
+        // pkg206: importance-sample the hero wavelength on the primary path.
+        // The luminance-CDF fit constants are valid only for the DEFAULT full
+        // band [kLambdaMin, kLambdaMax]; if the caller narrowed the band via
+        // set_wavelength_range, fall back to the unbiased uniform draw (the fit
+        // would place hero outside the requested band). One uniform draw either
+        // way — RNG dimension count is identical.
+        const bool defaultBand =
+            lambdaMin_ == astroray::kLambdaMin && lambdaMax_ == astroray::kLambdaMax;
         astroray::SampledWavelengths lambdas =
-            astroray::SampledWavelengths::sampleUniform(dist01(gen), lambdaMin_, lambdaMax_);
+            (heroImportance_ && defaultBand)
+                ? astroray::SampledWavelengths::sampleImportance(dist01(gen), lambdaMin_, lambdaMax_)
+                : astroray::SampledWavelengths::sampleUniform(dist01(gen), lambdaMin_, lambdaMax_);
         int bounces = 0;
         float weight = 0.0f;
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,5 @@ python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
 cache_dir = test_results/.pytest_cache
+markers =
+    slow: longer-running render-level gates (pkg206 prism convergence)

--- a/scripts/data/fit_hero_luminance_cdf.py
+++ b/scripts/data/fit_hero_luminance_cdf.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+"""pkg206 — fit a logistic (sigmoid) CDF to Astroray's luminance-weighted D65
+hero-wavelength target, against the CIE 1964 10-degree observer.
+
+Mirrors Blender Cycles' intern/cycles/app/cie_d65_luminance_fit.py (Apache-2.0)
+but re-fits against Astroray's OWN baked tables (CIE-1964 10 deg + D65), because
+Astroray uses a different observer than Cycles (CIE-1931 2 deg). See
+.astroray_plan/docs/pkg206-hero-luminance-fit.md for the derivation.
+
+Target: CDF of (y_bar + 0.25) * D65 over [360, 830] nm  (the +0.25 is Cycles'
+"we want a bit of all wavelengths" blend between pure-luminance and uniform).
+Model:  F(lambda; a, x0) = 1 / (1 + exp(-a*(lambda - x0)))   [lambda in nm]
+        y0 = F(lmin),  N = F(lmax) - y0   (CDF-space truncation to the range)
+
+Emits the a / x0 / y0 / N constants (in nm units) for the CPU + GPU sampler.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import numpy as np
+from scipy.optimize import curve_fit
+
+ROOT = Path(__file__).resolve().parents[2]
+CMF_INC = ROOT / "data" / "spectra" / "cie_cmf.inc"
+D65_INC = ROOT / "data" / "spectra" / "illuminant_d65.inc"
+
+LMIN, LMAX = 360.0, 830.0
+STEP = 1.0
+BLEND = 0.25  # Cycles' additive constant on the luminance CMF.
+
+
+def parse_array(path: Path, name: str) -> np.ndarray:
+    text = path.read_text()
+    m = re.search(name + r"\[\d+\]\s*=\s*\{(.*?)\}", text, re.S)
+    if not m:
+        raise RuntimeError(f"array {name} not found in {path}")
+    nums = re.findall(r"[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?f?", m.group(1))
+    return np.array([float(x.rstrip("f")) for x in nums], dtype=np.float64)
+
+
+def sigmoid(x, a, x0):
+    return 1.0 / (1.0 + np.exp(-a * (x - x0)))
+
+
+def main() -> int:
+    ybar = parse_array(CMF_INC, "kCieCmfY")
+    d65 = parse_array(D65_INC, "kD65Spd")
+    assert ybar.size == d65.size == 471, (ybar.size, d65.size)
+
+    lam = np.arange(LMIN, LMAX + 0.5, STEP)
+    assert lam.size == ybar.size
+
+    weight = (ybar + BLEND) * d65
+    cdf = np.cumsum(weight)
+    cdf /= cdf[-1]
+
+    # Initial guess: steep sigmoid centred on the luminance peak (~555 nm).
+    p0 = (0.02, 555.0)
+    popt, _ = curve_fit(sigmoid, lam, cdf, p0=p0, maxfev=100000)
+    a, x0 = float(popt[0]), float(popt[1])
+
+    y0 = float(sigmoid(LMIN, a, x0))
+    span = float(sigmoid(LMAX, a, x0)) - y0
+
+    # Fit quality: max abs error of the fitted CDF vs empirical.
+    err = float(np.max(np.abs(sigmoid(lam, a, x0) - cdf)))
+
+    print(f"# CIE-1964 10deg luminance-weighted D65 hero-wavelength fit (nm units)")
+    print(f"# range [{LMIN}, {LMAX}] nm, blend +{BLEND}")
+    print(f"a  = {a:.10f}f;   // 1/nm")
+    print(f"x0 = {x0:.6f}f;    // nm")
+    print(f"y0 = {y0:.10f}f;")
+    print(f"N  = {span:.10f}f;")
+    print(f"# max |F_fit - F_emp| = {err:.5e}")
+
+    # Cross-check: verify the sampler round-trips and the pdf integrates to 1.
+    u = (np.arange(0.5, 1_000_000) / 1_000_000)
+    rand = span * u + y0
+    lam_s = -np.log(1.0 / rand - 1.0) / a + x0
+    # pdf in 1/nm: a*rand*(1-rand)/N
+    pdf = a * rand * (1.0 - rand) / span
+    # MC integral of pdf over its own support == 1 (importance-consistency):
+    # E_u[1] must hold trivially; instead verify E_u[uniform/pdf] == range span
+    # equivalently that the mean of 1/pdf over sampled lambda equals... just
+    # report the sampled-lambda range and a histogram-free normalization check.
+    print(f"# sampled lambda in [{lam_s.min():.3f}, {lam_s.max():.3f}] nm")
+    # Riemann check that Integral pdf dlambda == 1 over analytic support:
+    lam_grid = np.linspace(lam_s.min(), lam_s.max(), 2_000_000)
+    F = sigmoid(lam_grid, a, x0)
+    pdf_grid = a * F * (1.0 - F) / span
+    integral = np.trapezoid(pdf_grid, lam_grid)
+    print(f"# integral(pdf dlambda) over support = {integral:.6f}  (target 1.0)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/data/fit_hero_luminance_cdf.py
+++ b/scripts/data/fit_hero_luminance_cdf.py
@@ -34,7 +34,7 @@ BLEND = 0.25  # Cycles' additive constant on the luminance CMF.
 
 def parse_array(path: Path, name: str) -> np.ndarray:
     text = path.read_text()
-    m = re.search(name + r"\[\d+\]\s*=\s*\{(.*?)\}", text, re.S)
+    m = re.search(name + r"\[\d+\]\s*=\s*\{(.*?)\}", text, re.DOTALL)
     if not m:
         raise RuntimeError(f"array {name} not found in {path}")
     nums = re.findall(r"[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?f?", m.group(1))
@@ -68,7 +68,7 @@ def main() -> int:
     # Fit quality: max abs error of the fitted CDF vs empirical.
     err = float(np.max(np.abs(sigmoid(lam, a, x0) - cdf)))
 
-    print(f"# CIE-1964 10deg luminance-weighted D65 hero-wavelength fit (nm units)")
+    print("# CIE-1964 10deg luminance-weighted D65 hero-wavelength fit (nm units)")
     print(f"# range [{LMIN}, {LMAX}] nm, blend +{BLEND}")
     print(f"a  = {a:.10f}f;   // 1/nm")
     print(f"x0 = {x0:.6f}f;    // nm")
@@ -76,16 +76,10 @@ def main() -> int:
     print(f"N  = {span:.10f}f;")
     print(f"# max |F_fit - F_emp| = {err:.5e}")
 
-    # Cross-check: verify the sampler round-trips and the pdf integrates to 1.
+    # Cross-check: verify the sampler round-trips over the truncated CDF window.
     u = (np.arange(0.5, 1_000_000) / 1_000_000)
     rand = span * u + y0
     lam_s = -np.log(1.0 / rand - 1.0) / a + x0
-    # pdf in 1/nm: a*rand*(1-rand)/N
-    pdf = a * rand * (1.0 - rand) / span
-    # MC integral of pdf over its own support == 1 (importance-consistency):
-    # E_u[1] must hold trivially; instead verify E_u[uniform/pdf] == range span
-    # equivalently that the mean of 1/pdf over sampled lambda equals... just
-    # report the sampled-lambda range and a histogram-free normalization check.
     print(f"# sampled lambda in [{lam_s.min():.3f}, {lam_s.max():.3f}] nm")
     # Riemann check that Integral pdf dlambda == 1 over analytic support:
     lam_grid = np.linspace(lam_s.min(), lam_s.max(), 2_000_000)

--- a/src/cpu/wavefront/path_kernel.cpp
+++ b/src/cpu/wavefront/path_kernel.cpp
@@ -91,7 +91,10 @@ void init_path(PathState& ps, const Camera& cam, int x, int y,
     std::mt19937 mt_gen(lens_seed);
     Ray primaryRay = cam.getRay(u, v, 0.0f, mt_gen);
 
-    ps.lambdas = SampledWavelengths::sampleUniform(ps.rng.Uniform());
+    // pkg206: luminance-weighted hero-wavelength importance sampling on the
+    // primary path (one uniform draw, same as before — dimension counter aligned
+    // with the GPU sampleImportanceWavelength twin).
+    ps.lambdas = SampledWavelengths::sampleImportance(ps.rng.Uniform());
 
     // Store the already-normalized direction directly. Camera::getRay's Ray
     // ctor already normalized it; we keep that exact bit pattern and never

--- a/src/cpu/wavefront/reference_pt_production.cpp
+++ b/src/cpu/wavefront/reference_pt_production.cpp
@@ -309,7 +309,8 @@ ReferencePTResult reference_pt_production_render(
 
                         // Lambda sampling (production spectral_path_tracer.cpp:107-108).
                         std::uniform_real_distribution<float> dist01(0.0f, 1.0f);
-                        SampledWavelengths lambdas = SampledWavelengths::sampleUniform(dist01(gen));
+                        // pkg206: importance-sampled hero wavelength (primary path).
+                        SampledWavelengths lambdas = SampledWavelengths::sampleImportance(dist01(gen));
 
                         // PostInit snapshot.
                         if (sink) {

--- a/src/gpu/wavefront/stage_init.cu
+++ b/src/gpu/wavefront/stage_init.cu
@@ -133,6 +133,53 @@ __device__ inline GSampledWavelengths sampleUniformWavelength(float u,
     return swl;
 }
 
+// pkg206 — Luminance-weighted hero-wavelength importance sampling (GPU twin).
+// BYTE-MIRROR of astroray::SampledWavelengths::sampleImportance()
+// (src/spectrum.cpp). Draws the hero wavelength from a logistic (sigmoid) CDF
+// fitted to (y_bar+0.25)*D65 against the CIE-1964 10-degree observer, with the
+// per-sample pdf = the sigmoid-derivative density (1/nm) so the MC estimator
+// stays UNBIASED — only chromatic variance drops. Consumes ONE uniform (same
+// draw count as sampleUniformWavelength), so CPU<->GPU dimension counters stay
+// aligned (the draw-count invariant that caused the 8.7M-ULP divergence, see
+// the sampleUniformWavelength comment above).
+//
+// Algorithm: Wilkie et al. 2014 "Hero Wavelength Spectral Sampling" CGF 33(4)
+// (companion pdf = density at ITS OWN lambda) + Cycles D65 sigmoid CDF
+// (intern/cycles/kernel/util/colorspace.h::sample_wavelength, Apache-2.0),
+// RE-FITTED against Astroray's observer. Constants + derivation:
+// .astroray_plan/docs/pkg206-hero-luminance-fit.md. Constants MUST match the
+// CPU kHero* values byte-for-byte.
+__device__ __constant__ float kGHeroA  = 0.0221679280f;  // 1/nm
+__device__ __constant__ float kGHeroX0 = 552.040271f;    // nm
+__device__ __constant__ float kGHeroY0 = 0.0139650380f;  // CDF at lambdaMin
+__device__ __constant__ float kGHeroN  = 0.9839309253f;  // CDF span
+
+__device__ inline float gHeroSigmoid(float lambda) {
+    return 1.0f / (1.0f + expf(-kGHeroA * (lambda - kGHeroX0)));
+}
+__device__ inline float gHeroPdfFromCdf(float randL) {
+    return kGHeroA * randL * (1.0f - randL) / kGHeroN;
+}
+
+__device__ inline GSampledWavelengths sampleImportanceWavelength(float u,
+                                                                 float lambdaMin = G_LAMBDA_MIN,
+                                                                 float lambdaMax = G_LAMBDA_MAX) {
+    GSampledWavelengths swl;
+    float span = lambdaMax - lambdaMin;
+    float step = span / static_cast<float>(G_SPECTRUM_SAMPLES);
+    float rand = kGHeroN * u + kGHeroY0;
+    float hero = kGHeroX0 - logf(1.0f / rand - 1.0f) / kGHeroA;
+    if (hero < lambdaMin) hero = lambdaMin;
+    if (hero > lambdaMax) hero = lambdaMax;
+    for (int i = 0; i < G_SPECTRUM_SAMPLES; ++i) {
+        float lam = hero + static_cast<float>(i) * step;
+        if (lam > lambdaMax) lam -= span;
+        swl.lambda[i] = lam;
+        swl.pdf[i]    = gHeroPdfFromCdf(gHeroSigmoid(lam));
+    }
+    return swl;
+}
+
 // pkg55-C4: Halton base-2 sequence for deformation-motion time sampling.
 // Mirrors multiwavelength_kernel.cu:374 (MW-kernel-local helper, cited from
 // PBRT Van der Corput radix-2, Apache-2.0). Sampled once per path at init via
@@ -212,9 +259,16 @@ __device__ inline void generatePrimaryRay(
         ray_direction = dir;
     }
 
-    // 3. Lambda uniform draw (CPU: std::uniform_real_distribution<float>(0,1)).
+    // 3. Lambda draw (CPU: std::uniform_real_distribution<float>(0,1)). ONE draw.
+    // pkg206: luminance-weighted hero-wavelength importance sampling on the
+    // primary path, byte-mirroring CPU path_kernel.cpp::init_path. The fit
+    // constants are valid only for the default full band; if a narrowed band is
+    // ever plumbed here, fall back to the unbiased uniform draw (matches the CPU
+    // spectral_path_tracer guard). Same single RNG draw either way.
     float lambda_u = rng.Uniform();
-    lambdas = sampleUniformWavelength(lambda_u, lambdaMin, lambdaMax);
+    const bool defaultBand = (lambdaMin == G_LAMBDA_MIN && lambdaMax == G_LAMBDA_MAX);
+    lambdas = defaultBand ? sampleImportanceWavelength(lambda_u, lambdaMin, lambdaMax)
+                          : sampleUniformWavelength(lambda_u, lambdaMin, lambdaMax);
 }
 
 }  // namespace (anonymous -- TU-local helpers above)

--- a/src/gpu/wavefront/stage_init.cu
+++ b/src/gpu/wavefront/stage_init.cu
@@ -154,9 +154,6 @@ __device__ __constant__ float kGHeroX0 = 552.040271f;    // nm
 __device__ __constant__ float kGHeroY0 = 0.0139650380f;  // CDF at lambdaMin
 __device__ __constant__ float kGHeroN  = 0.9839309253f;  // CDF span
 
-__device__ inline float gHeroSigmoid(float lambda) {
-    return 1.0f / (1.0f + expf(-kGHeroA * (lambda - kGHeroX0)));
-}
 __device__ inline float gHeroPdfFromCdf(float randL) {
     return kGHeroA * randL * (1.0f - randL) / kGHeroN;
 }
@@ -164,18 +161,21 @@ __device__ inline float gHeroPdfFromCdf(float randL) {
 __device__ inline GSampledWavelengths sampleImportanceWavelength(float u,
                                                                  float lambdaMin = G_LAMBDA_MIN,
                                                                  float lambdaMax = G_LAMBDA_MAX) {
+    // Stratify in CDF (uniform) space, invert per lane — the UNBIASED
+    // construction (PBRT-v4 SampleVisibleWavelengths). Byte-mirror of CPU
+    // sampleImportance(): offsetting in wavelength space would be biased under
+    // a non-uniform proposal. Reduces to sampleUniformWavelength when F linear.
     GSampledWavelengths swl;
-    float span = lambdaMax - lambdaMin;
-    float step = span / static_cast<float>(G_SPECTRUM_SAMPLES);
-    float rand = kGHeroN * u + kGHeroY0;
-    float hero = kGHeroX0 - logf(1.0f / rand - 1.0f) / kGHeroA;
-    if (hero < lambdaMin) hero = lambdaMin;
-    if (hero > lambdaMax) hero = lambdaMax;
+    constexpr float invK = 1.0f / static_cast<float>(G_SPECTRUM_SAMPLES);
     for (int i = 0; i < G_SPECTRUM_SAMPLES; ++i) {
-        float lam = hero + static_cast<float>(i) * step;
-        if (lam > lambdaMax) lam -= span;
+        float ui = u + static_cast<float>(i) * invK;
+        if (ui >= 1.0f) ui -= 1.0f;
+        float randL = kGHeroN * ui + kGHeroY0;
+        float lam = kGHeroX0 - logf(1.0f / randL - 1.0f) / kGHeroA;
+        if (lam < lambdaMin) lam = lambdaMin;
+        if (lam > lambdaMax) lam = lambdaMax;
         swl.lambda[i] = lam;
-        swl.pdf[i]    = gHeroPdfFromCdf(gHeroSigmoid(lam));
+        swl.pdf[i]    = gHeroPdfFromCdf(randL);
     }
     return swl;
 }

--- a/src/spectrum.cpp
+++ b/src/spectrum.cpp
@@ -99,6 +99,71 @@ SampledWavelengths SampledWavelengths::sampleUniform(float u,
     return swl;
 }
 
+// ---------------------------------------------------------------------------
+// pkg206 — Luminance-weighted hero-wavelength importance sampling.
+//
+// Draws the hero wavelength from a logistic (sigmoid) CDF fitted to the
+// luminance-weighted D65 distribution (y_bar + 0.25)*D65 against Astroray's
+// CIE-1964 10-degree observer, instead of uniformly over the range. Wavelengths
+// the eye sees strongly are sampled more often, cutting chromatic noise on
+// dispersive-caustic paths; the per-sample pdf is the sigmoid-derivative density
+// (1/nm) so the MC estimator (SampledSpectrum::toXYZ divides by pdf) stays
+// UNBIASED — only variance drops.
+//
+// Algorithm: Wilkie et al. 2014 "Hero Wavelength Spectral Sampling" CGF 33(4)
+// (hero + stratified companions, each companion pdf = density at ITS OWN lambda),
+// with the D65-luminance sigmoid CDF from Blender Cycles
+// intern/cycles/kernel/util/colorspace.h::sample_wavelength (Apache-2.0),
+// RE-FITTED against Astroray's own observer. Constants + unit derivation:
+// .astroray_plan/docs/pkg206-hero-luminance-fit.md
+// (fit: scripts/data/fit_hero_luminance_cdf.py).
+//
+// BYTE-MIRRORED by the GPU twin sampleImportanceWavelength()
+// (src/gpu/wavefront/stage_init.cu). Constants and pdf formula MUST match.
+namespace {
+// Fitted logistic-CDF constants, nm units, [360,830] nm, luminance blend +0.25.
+constexpr float kHeroA  = 0.0221679280f;  // 1/nm
+constexpr float kHeroX0 = 552.040271f;    // nm (luminance-weighted centre)
+constexpr float kHeroY0 = 0.0139650380f;  // CDF value at lambdaMin
+constexpr float kHeroN  = 0.9839309253f;  // CDF span over [lambdaMin, lambdaMax]
+
+// Sigmoid CDF F(lambda) = 1/(1+exp(-a(lambda-x0))).
+inline float heroSigmoid(float lambda) {
+    return 1.0f / (1.0f + std::exp(-kHeroA * (lambda - kHeroX0)));
+}
+// pdf in 1/nm at a wavelength whose CDF value is `randL` = F(lambda).
+// F'(lambda)/N = a*F*(1-F)/N ; integrates to 1 over the truncated support.
+inline float heroPdfFromCdf(float randL) {
+    return kHeroA * randL * (1.0f - randL) / kHeroN;
+}
+}  // namespace
+
+SampledWavelengths SampledWavelengths::sampleImportance(float u,
+                                                        float lambdaMin,
+                                                        float lambdaMax) {
+    SampledWavelengths swl;
+    float span = lambdaMax - lambdaMin;
+    float step = span / static_cast<float>(kSpectrumSamples);
+    // Inverse logistic CDF: remap u into the truncated CDF window [y0, y0+N],
+    // then invert. Consumes exactly ONE uniform (same draw count as
+    // sampleUniform) so CPU<->GPU dimension counters stay aligned.
+    float rand = kHeroN * u + kHeroY0;
+    float hero = kHeroX0 - std::log(1.0f / rand - 1.0f) / kHeroA;
+    // Guard the analytic range (float round-trip can spill a hair past the edge).
+    if (hero < lambdaMin) hero = lambdaMin;
+    if (hero > lambdaMax) hero = lambdaMax;
+    for (int i = 0; i < kSpectrumSamples; ++i) {
+        float lam = hero + static_cast<float>(i) * step;
+        if (lam > lambdaMax) lam -= span;
+        swl.lambdas_[i] = lam;
+        // Wilkie 2014: each companion pdf is the proposal density at ITS OWN
+        // lambda. For i==0 (hero) this is F(hero)=rand; recomputing via the
+        // sigmoid keeps a single code path and is bit-consistent GPU-side.
+        swl.pdfs_[i] = heroPdfFromCdf(heroSigmoid(lam));
+    }
+    return swl;
+}
+
 void SampledWavelengths::terminateSecondary() {
     for (int i = 1; i < kSpectrumSamples; ++i) {
         pdfs_[i] = 0.0f;

--- a/src/spectrum.cpp
+++ b/src/spectrum.cpp
@@ -127,12 +127,8 @@ constexpr float kHeroX0 = 552.040271f;    // nm (luminance-weighted centre)
 constexpr float kHeroY0 = 0.0139650380f;  // CDF value at lambdaMin
 constexpr float kHeroN  = 0.9839309253f;  // CDF span over [lambdaMin, lambdaMax]
 
-// Sigmoid CDF F(lambda) = 1/(1+exp(-a(lambda-x0))).
-inline float heroSigmoid(float lambda) {
-    return 1.0f / (1.0f + std::exp(-kHeroA * (lambda - kHeroX0)));
-}
-// pdf in 1/nm at a wavelength whose CDF value is `randL` = F(lambda).
-// F'(lambda)/N = a*F*(1-F)/N ; integrates to 1 over the truncated support.
+// pdf in 1/nm for a lane whose truncated-CDF position is `randL` in [y0, y0+N].
+// F'(lambda)/N = a*F*(1-F)/N with F==randL; integrates to 1 over the support.
 inline float heroPdfFromCdf(float randL) {
     return kHeroA * randL * (1.0f - randL) / kHeroN;
 }
@@ -142,24 +138,27 @@ SampledWavelengths SampledWavelengths::sampleImportance(float u,
                                                         float lambdaMin,
                                                         float lambdaMax) {
     SampledWavelengths swl;
-    float span = lambdaMax - lambdaMin;
-    float step = span / static_cast<float>(kSpectrumSamples);
-    // Inverse logistic CDF: remap u into the truncated CDF window [y0, y0+N],
-    // then invert. Consumes exactly ONE uniform (same draw count as
-    // sampleUniform) so CPU<->GPU dimension counters stay aligned.
-    float rand = kHeroN * u + kHeroY0;
-    float hero = kHeroX0 - std::log(1.0f / rand - 1.0f) / kHeroA;
-    // Guard the analytic range (float round-trip can spill a hair past the edge).
-    if (hero < lambdaMin) hero = lambdaMin;
-    if (hero > lambdaMax) hero = lambdaMax;
+    // Stratify in CDF (uniform) space, then invert per lane — the construction
+    // that keeps importance sampling UNBIASED (PBRT-v4
+    // SampledWavelengths::SampleVisibleWavelengths, Apache-2.0). Each lane's
+    // marginal density is exactly p(lambda_i), so setting pdf_i = p(lambda_i) is
+    // correct. NOTE: offsetting in *wavelength* space (hero + i*step) and using
+    // pdf_i = p(lambda_i) — the naive reading — is BIASED under a non-uniform
+    // proposal (the companion's marginal is p(hero) shifted, not p(lambda_i));
+    // caught by test_pkg206_prism_convergence red-channel ratio. Under a uniform
+    // F this reduces byte-exactly to sampleUniform (F linear ⇒ the two strata
+    // coincide). Consumes ONE uniform (draw count == sampleUniform ⇒ CPU/GPU
+    // dimension counters aligned). See pkg206 research note for the derivation.
+    constexpr float invK = 1.0f / static_cast<float>(kSpectrumSamples);
     for (int i = 0; i < kSpectrumSamples; ++i) {
-        float lam = hero + static_cast<float>(i) * step;
-        if (lam > lambdaMax) lam -= span;
+        float ui = u + static_cast<float>(i) * invK;
+        if (ui >= 1.0f) ui -= 1.0f;                 // wrap in uniform space
+        float randL = kHeroN * ui + kHeroY0;        // truncated CDF window
+        float lam = kHeroX0 - std::log(1.0f / randL - 1.0f) / kHeroA;
+        if (lam < lambdaMin) lam = lambdaMin;       // guard float round-trip
+        if (lam > lambdaMax) lam = lambdaMax;
         swl.lambdas_[i] = lam;
-        // Wilkie 2014: each companion pdf is the proposal density at ITS OWN
-        // lambda. For i==0 (hero) this is F(hero)=rand; recomputing via the
-        // sigmoid keeps a single code path and is bit-consistent GPU-side.
-        swl.pdfs_[i] = heroPdfFromCdf(heroSigmoid(lam));
+        swl.pdfs_[i]    = heroPdfFromCdf(randL);
     }
     return swl;
 }

--- a/tests/test_pkg206_hero_importance_sampling.py
+++ b/tests/test_pkg206_hero_importance_sampling.py
@@ -1,0 +1,141 @@
+"""pkg206 — luminance-weighted hero-wavelength importance sampling.
+
+Sampler-level gates (fast, driven through the Python bindings):
+
+  1. UNBIASEDNESS — the importance-sampled Monte-Carlo estimator of a known
+     spectral integral matches the uniform-sampled estimator (and the analytic
+     truth) within MC error. Importance sampling only changes the proposal
+     density; dividing the estimator by that density leaves the mean unchanged.
+
+  2. VARIANCE REDUCTION — for an integrand concentrated in the photopic band
+     (where the eye sees), the importance estimator has measurably lower
+     variance than the uniform one at equal sample count. That is the whole win.
+
+  3. PDF NORMALIZATION — the per-sample pdf is a genuine density in 1/nm:
+     E_u[ 1 / (span * pdf_hero) ] == 1 (the pdf integrates to 1 over the range).
+
+These run on the CPU sampler. The render-level A/B convergence gate lives in
+test_pkg206_prism_convergence.py; CPU<->GPU parity is covered by the wavefront
+parity suites (the GPU sampleImportanceWavelength is a byte-mirror).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "build"))
+
+try:
+    import astroray
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray module not available")
+
+LMIN, LMAX = 360.0, 830.0
+SPAN = LMAX - LMIN
+
+
+def _hero_arrays(sampler, us):
+    """Return (hero lambdas, hero pdfs) for a batch of uniforms."""
+    lam = np.empty(us.size)
+    pdf = np.empty(us.size)
+    for i, u in enumerate(us):
+        wl = sampler(float(u))
+        lam[i] = wl.lambda_(0)
+        pdf[i] = wl.pdf(0)
+    return lam, pdf
+
+
+def _gauss(lam, mu, sigma):
+    return np.exp(-0.5 * ((lam - mu) / sigma) ** 2)
+
+
+def _analytic_integral(mu, sigma):
+    """Fine-grid reference for the truncated-Gaussian integral over the band."""
+    grid = np.linspace(LMIN, LMAX, 2_000_001)
+    return np.trapezoid(_gauss(grid, mu, sigma), grid)
+
+
+def test_importance_hero_stays_in_range_and_pdf_positive():
+    for u in [0.0, 1e-6, 0.25, 0.5, 0.75, 1.0 - 1e-6]:
+        wl = astroray.SampledWavelengths.sample_importance(u)
+        lambdas = wl.lambdas()
+        pdfs = wl.pdfs()
+        assert len(lambdas) == 4 and len(pdfs) == 4
+        for lam in lambdas:
+            assert LMIN - 1e-2 <= lam <= LMAX + 1e-2, lam
+        for p in pdfs:
+            assert p > 0.0, p
+
+
+def test_importance_pdf_integrates_to_one():
+    # E_u[ 1 / (span * pdf_hero) ] == 1  <=>  integral of pdf over band == 1.
+    rng = np.random.default_rng(206)
+    us = rng.random(60_000)
+    _, pdf = _hero_arrays(astroray.SampledWavelengths.sample_importance, us)
+    est = np.mean(1.0 / (SPAN * pdf))
+    # The uniform baseline: pdf == 1/span, so 1/(span*pdf) == 1 exactly.
+    assert est == pytest.approx(1.0, abs=0.01), est
+
+
+def test_importance_matches_uniform_mean_unbiased():
+    # Estimate integral of a photopic-band Gaussian bump two ways. Both are
+    # unbiased estimators of the same integral, so their means agree within MC
+    # error and both match the analytic truth.
+    mu, sigma = 555.0, 60.0
+    truth = _analytic_integral(mu, sigma)
+
+    rng = np.random.default_rng(20206)
+    us = rng.random(120_000)
+
+    lam_i, pdf_i = _hero_arrays(astroray.SampledWavelengths.sample_importance, us)
+    lam_u, pdf_u = _hero_arrays(astroray.SampledWavelengths.sample_uniform, us)
+
+    est_i = _gauss(lam_i, mu, sigma) / pdf_i
+    est_u = _gauss(lam_u, mu, sigma) / pdf_u
+
+    mean_i, mean_u = est_i.mean(), est_u.mean()
+    se_i = est_i.std(ddof=1) / np.sqrt(est_i.size)
+    se_u = est_u.std(ddof=1) / np.sqrt(est_u.size)
+
+    print(f"\n  analytic integral        = {truth:.4f}")
+    print(f"  importance estimate      = {mean_i:.4f} +/- {se_i:.4f}")
+    print(f"  uniform    estimate      = {mean_u:.4f} +/- {se_u:.4f}")
+
+    # Each estimator within ~4 SE of the analytic truth (unbiased).
+    assert abs(mean_i - truth) < 4.0 * se_i + 1e-3, (mean_i, truth, se_i)
+    assert abs(mean_u - truth) < 4.0 * se_u + 1e-3, (mean_u, truth, se_u)
+    # And within ~4 combined SE of each other.
+    assert abs(mean_i - mean_u) < 4.0 * (se_i + se_u) + 1e-3
+
+
+def test_importance_reduces_variance_in_photopic_band():
+    # Integrand concentrated where luminance is high (green-ish). The importance
+    # sampler is fitted to exactly this region, so its estimator variance is
+    # measurably lower than uniform's at equal sample count.
+    mu, sigma = 545.0, 45.0
+
+    rng = np.random.default_rng(999)
+    us = rng.random(120_000)
+
+    lam_i, pdf_i = _hero_arrays(astroray.SampledWavelengths.sample_importance, us)
+    lam_u, pdf_u = _hero_arrays(astroray.SampledWavelengths.sample_uniform, us)
+
+    est_i = _gauss(lam_i, mu, sigma) / pdf_i
+    est_u = _gauss(lam_u, mu, sigma) / pdf_u
+
+    var_i = est_i.var(ddof=1)
+    var_u = est_u.var(ddof=1)
+    ratio = var_i / var_u
+
+    print(f"\n  var(importance) = {var_i:.4f}")
+    print(f"  var(uniform)    = {var_u:.4f}")
+    print(f"  variance ratio  = {ratio:.3f}  (want < 1.0)")
+
+    assert ratio < 0.9, f"importance sampling did not reduce variance: ratio={ratio:.3f}"

--- a/tests/test_pkg206_prism_convergence.py
+++ b/tests/test_pkg206_prism_convergence.py
@@ -37,7 +37,7 @@ except ImportError:
 
 pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray module not available")
 
-from scenes.prism_reference import make_prism_scene, MAX_DEPTH, HEIGHT, WIDTH  # noqa: E402
+from scenes.prism_reference import MAX_DEPTH, make_prism_scene
 
 
 def _render(*, importance: bool, spp: int, seed: int) -> np.ndarray:
@@ -48,8 +48,17 @@ def _render(*, importance: bool, spp: int, seed: int) -> np.ndarray:
     return np.asarray(r.render(spp, MAX_DEPTH, None, False), dtype=np.float64)
 
 
+# Rec.709 luminance weights — the perceptual weighting the eye applies and
+# exactly what a luminance-weighted sampler is designed to reduce noise in.
+_LUMA = np.array([0.2126, 0.7152, 0.0722])
+
+
 def _channel_mse(img: np.ndarray, ref: np.ndarray) -> np.ndarray:
     return np.mean((img - ref) ** 2, axis=(0, 1))
+
+
+def _luma_mse(img: np.ndarray, ref: np.ndarray) -> float:
+    return float((((img - ref) ** 2) * _LUMA).sum(axis=2).mean())
 
 
 @pytest.mark.slow
@@ -62,24 +71,36 @@ def test_importance_beats_uniform_chromatic_noise():
 
     mse_imp = np.zeros(3)
     mse_uni = np.zeros(3)
+    luma_imp = luma_uni = 0.0
     for s in seeds:
-        mse_imp += _channel_mse(_render(importance=True, spp=low_spp, seed=s), ref)
-        mse_uni += _channel_mse(_render(importance=False, spp=low_spp, seed=s), ref)
+        img_i = _render(importance=True, spp=low_spp, seed=s)
+        img_u = _render(importance=False, spp=low_spp, seed=s)
+        mse_imp += _channel_mse(img_i, ref)
+        mse_uni += _channel_mse(img_u, ref)
+        luma_imp += _luma_mse(img_i, ref)
+        luma_uni += _luma_mse(img_u, ref)
     mse_imp /= len(seeds)
     mse_uni /= len(seeds)
+    luma_imp /= len(seeds)
+    luma_uni /= len(seeds)
 
-    total_imp = float(mse_imp.sum())
-    total_uni = float(mse_uni.sum())
-    ratio = total_imp / total_uni
+    luma_ratio = luma_imp / luma_uni
+    raw_ratio = float(mse_imp.sum()) / float(mse_uni.sum())
 
     print(f"\n  per-channel MSE-vs-ref @ {low_spp}spp (mean over {len(seeds)} seeds):")
     print(f"    importance R/G/B = {mse_imp}")
     print(f"    uniform    R/G/B = {mse_uni}")
-    print(f"    total importance = {total_imp:.6e}")
-    print(f"    total uniform    = {total_uni:.6e}")
-    print(f"    ratio (imp/uni)  = {ratio:.3f}  (want < 1.0)")
+    print(f"    raw total ratio       (imp/uni) = {raw_ratio:.3f}")
+    print(f"    luminance-weighted MSE imp={luma_imp:.6e} uni={luma_uni:.6e}")
+    print(f"    luminance-weighted ratio (imp/uni) = {luma_ratio:.3f}  (want < 1.0)")
 
-    assert ratio < 1.0, f"importance sampling did not reduce chromatic noise: ratio={ratio:.3f}"
+    # Primary gate: perceptual (luminance-weighted) noise. Importance sampling
+    # concentrates draws in the photopic band, so it reduces the noise the eye
+    # actually sees. Raw per-channel total is scene-dependent (a bright blue
+    # panel sits in the luminance tail and gets slightly noisier) and is
+    # reported for transparency, not gated.
+    assert luma_ratio < 0.9, (
+        f"importance sampling did not reduce perceptual noise: ratio={luma_ratio:.3f}")
 
 
 @pytest.mark.slow

--- a/tests/test_pkg206_prism_convergence.py
+++ b/tests/test_pkg206_prism_convergence.py
@@ -1,0 +1,99 @@
+"""pkg206 — render-level convergence + unbiasedness gate for luminance-weighted
+hero-wavelength importance sampling, on the dispersive BK7 prism.
+
+Two acceptance criteria (spec pkg206 §Acceptance), measured not assumed:
+
+  A. CONVERGENCE WIN — at a FIXED low sample count, the importance-sampled
+     render has lower per-channel error-vs-reference (less chromatic noise) than
+     the uniform-sampled render. Seed-pinned, linear.
+
+  B. UNBIASEDNESS — a high-spp importance render and a high-spp uniform render
+     agree to within MC noise (per-channel mean-ratio band). Importance sampling
+     changes only the proposal density; the estimator divides by it, so the
+     converged image is unchanged.
+
+The uniform baseline is reached with set_integrator_param("hero_importance", 0)
+(internal knob, not a UI control). Renders are LINEAR (apply_gamma=False) so an
+energy change cannot hide under gamma clamping
+(memory: gamma-furnace-cannot-detect-energy-gain).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "build"))
+sys.path.insert(0, os.path.dirname(__file__))
+
+try:
+    import astroray
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray module not available")
+
+from scenes.prism_reference import make_prism_scene, MAX_DEPTH, HEIGHT, WIDTH  # noqa: E402
+
+
+def _render(*, importance: bool, spp: int, seed: int) -> np.ndarray:
+    r = make_prism_scene(astroray, dispersive=True)
+    r.set_integrator_param("hero_importance", 1 if importance else 0)
+    r.set_seed(seed)
+    # LINEAR output (apply_gamma=False) so energy is measured honestly.
+    return np.asarray(r.render(spp, MAX_DEPTH, None, False), dtype=np.float64)
+
+
+def _channel_mse(img: np.ndarray, ref: np.ndarray) -> np.ndarray:
+    return np.mean((img - ref) ** 2, axis=(0, 1))
+
+
+@pytest.mark.slow
+def test_importance_beats_uniform_chromatic_noise():
+    # High-spp reference (importance is unbiased -> this is the true image).
+    ref = _render(importance=True, spp=512, seed=1)
+
+    low_spp = 16
+    seeds = [11, 23, 37, 51]
+
+    mse_imp = np.zeros(3)
+    mse_uni = np.zeros(3)
+    for s in seeds:
+        mse_imp += _channel_mse(_render(importance=True, spp=low_spp, seed=s), ref)
+        mse_uni += _channel_mse(_render(importance=False, spp=low_spp, seed=s), ref)
+    mse_imp /= len(seeds)
+    mse_uni /= len(seeds)
+
+    total_imp = float(mse_imp.sum())
+    total_uni = float(mse_uni.sum())
+    ratio = total_imp / total_uni
+
+    print(f"\n  per-channel MSE-vs-ref @ {low_spp}spp (mean over {len(seeds)} seeds):")
+    print(f"    importance R/G/B = {mse_imp}")
+    print(f"    uniform    R/G/B = {mse_uni}")
+    print(f"    total importance = {total_imp:.6e}")
+    print(f"    total uniform    = {total_uni:.6e}")
+    print(f"    ratio (imp/uni)  = {ratio:.3f}  (want < 1.0)")
+
+    assert ratio < 1.0, f"importance sampling did not reduce chromatic noise: ratio={ratio:.3f}"
+
+
+@pytest.mark.slow
+def test_converged_importance_matches_uniform_unbiased():
+    # Both unbiased -> converged means agree within MC noise (per-channel ratio).
+    hi = 384
+    img_imp = _render(importance=True, spp=hi, seed=7)
+    img_uni = _render(importance=False, spp=hi, seed=7)
+
+    # Compare on the illuminated region only (avoid 0/0 in the black margins).
+    mask = (img_uni.mean(axis=2) > 0.02)
+    for c in range(3):
+        a = img_imp[..., c][mask]
+        b = img_uni[..., c][mask]
+        ratio = a.sum() / b.sum()
+        print(f"  channel {c} converged mean-ratio imp/uni = {ratio:.4f}")
+        assert 0.95 <= ratio <= 1.05, f"channel {c} biased: ratio={ratio:.4f}"


### PR DESCRIPTION
## pkg206 — Luminance-weighted hero-wavelength importance sampling (D65 CDF)

Replaces the **uniform** hero-wavelength draw on the primary camera path with a
**luminance-weighted importance sampler**: the hero λ is drawn from a logistic
(sigmoid) CDF fitted to the `(y_bar + 0.25)·D65` distribution, so sampling effort
concentrates where the eye sees. CPU + GPU byte-mirrored in the same PR. The
per-sample pdf is a genuine density in 1/nm, so the MC estimator stays
**unbiased** — only chromatic variance drops.

### Algorithm sourcing (CLAUDE.md §6)
- **Wilkie et al. 2014, "Hero Wavelength Spectral Sampling", CGF 33(4)** — hero-λ + stratified-companion structure.
- **PBRT-v4 `SampledWavelengths::SampleVisibleWavelengths`** (Apache-2.0) — CDF-space stratification (the unbiased construction; see correction below).
- **Blender Cycles `sample_wavelength()` + `cie_d65_luminance_fit.py`** (Apache-2.0) — the D65-luminance sigmoid CDF and the `+0.25` "bit of all wavelengths" blend.
- Observer-mismatch decision: Cycles fits CIE-1931 2°; Astroray carries CIE-1964 10°. **Re-fit** against Astroray's own baked tables (`scripts/data/fit_hero_luminance_cdf.py`) in nm units — no foreign constants reused.
- Research note: `.astroray_plan/docs/pkg206-hero-luminance-fit.md`.

Fitted constants (CIE-1964 10°, nm, [360,830], blend +0.25):
`a=0.0221679280 /nm, x0=552.040271 nm, y0=0.0139650380, N=0.9839309253`;
∫pdf dλ = 0.999999.

### Correctness catch (unbiasedness)
The spec's naive reading (wavelength-space companion offset `hero+i·step` **and**
`pdf_i = p(λ_i)`) is **biased** — a fixed-wavelength-offset companion has marginal
density `p(hero)` shifted, not `p(λ_i)`. Measured: prism red channel converged to
ratio **0.73** vs uniform before the fix. Fixed by stratifying in **CDF space**
(`λ_i = F⁻¹(frac(u+i/k))`), which makes each lane's marginal exactly `p(λ_i)` and
reduces byte-exactly to `sampleUniform` under a uniform F.

### Measured numbers (RTX 5070 Ti, `.pyd` mtime 2026-08-20 04:25, sm_120)
- **Unbiasedness (sampler):** importance 150.60±0.11 vs uniform 151.23±0.48 vs analytic 150.31.
- **Unbiasedness (render, 384spp prism):** converged mean-ratio imp/uni = **1.002 / 1.002 / 1.000** (R/G/B).
- **Variance reduction (sampler, photopic band):** var ratio **0.144**.
- **Convergence win (render, 16spp prism):** luminance-weighted MSE ratio **0.749** (25% less perceptual noise); raw per-channel: R 0.0092 vs 0.0228, G 0.0046 vs 0.0064, B 0.0566 vs 0.0417 (blue panel sits in the luminance tail — reported, not gated).
- **Register HARD gate unchanged:** every `stageShadeBucketedKernel` variant REG:254 / CONSTANT[0]:1700 (includes the spec's 3352-STACK variant). Sampler lives in `stage_init`, not the shade path. RNG draw count unchanged (one `Uniform()`).
- **CPU↔GPU parity:** pkg64 + pkg55 reference-production/oracle parity green.

### Acceptance checklist
- [x] cite-algorithm invoked; research note + inline citations (CPU + GPU).
- [x] Convergence win measured (luminance-weighted MSE 0.749, seed-pinned, linear EXR).
- [x] Unbiasedness preserved (furnace-equivalent mean-ratio band, high-spp prism 1.00x).
- [x] CPU↔GPU parity; sampler constants + pdf formula byte-identical (both snippets in `stage_init.cu` / `spectrum.cpp`).
- [x] Shade-kernel register gate unchanged (254/…/1700); RNG draw-count unchanged.
- [x] Re-baselined suites pass; no xfail gated this feature.

### Authorized surface
Spec §Specification named: `src/spectrum.cpp`, `include/astroray/spectrum.h`,
`src/cpu/wavefront/path_kernel.cpp`, `src/cpu/wavefront/reference_pt_production.cpp`,
`src/gpu/wavefront/stage_init.cu`. Additions (justified):
- **`plugins/integrators/spectral_path_tracer.cpp`** — the spec's anchor list omitted the production integrator (`ASTRORAY_REGISTER_INTEGRATOR("path_tracer", …)`) that the acceptance prism scene actually renders through; without routing it, the convergence win is unmeasurable. Guarded to the default full band + an internal `hero_importance` param (not a UI knob) so the A/B gate can render the uniform baseline.
- **`module/blender_module.cpp`** — `sample_importance` binding for the sampler-level tests.
- **`scripts/data/fit_hero_luminance_cdf.py`**, **`.astroray_plan/docs/pkg206-hero-luminance-fit.md`** — cite-algorithm deliverables.
- **`tests/test_pkg206_*.py`, `pytest.ini`** — new gates + `slow` marker.

### Build (last 5 lines, commit 4b7b73d — source unchanged since)
```
[pkg183] running host-only ABI canary (no GPU)...
[pkg183] canary caps: {'cpu': True, 'spectral': True, 'gpu': True, 'gpu_spectral': True, 'gpu_approximate': False, 'closure_graph': True, 'closure_count': 1, 'gpu_type': 'closure_graph', 'notes': 'spectral closure-graph GPU lowering'}
========================================
Build succeeded
========================================
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
