### PR TITLE
docs(architect): project-index usefulness — diagnosis + pkg215/pkg216

### DIFF
--- a/.astroray_plan/docs/2026-08-21-project-index-usefulness.md
+++ b/.astroray_plan/docs/2026-08-21-project-index-usefulness.md
@@ -1,0 +1,137 @@
+# Making the project-index actually useful to coding agents (2026-08-21)
+
+**Author:** architect (goal-capture, owner directive 2026-08-21)
+**Status:** design note → specs pkg215, pkg216
+
+## The directive
+
+`scripts/project_index.py` exists: it builds a SQLite index over packages,
+docs, and tests, plus a 3D force-graph viz. But coding agents don't
+meaningfully rely on it. Figure out *why*, then design the path to genuine
+usefulness.
+
+## Diagnosis — three independent failures, all load-bearing
+
+I read the tool end-to-end, exercised it against the live repo, and grepped
+every agent/skill/hook in both harnesses (`.claude/` and `.opencode/`). The
+tool is not one broken thing; it fails on three axes at once, and fixing any
+one alone leaves it unused.
+
+### 1. It is wired into *nothing*. (This is the crux.)
+
+`project_index` appears in exactly four files: `scripts/project_index.py`
+(itself), `scripts/README.md` (the canonical-script table), `scripts/model_bench.py`
+(unrelated), and `KNOWLEDGE.md`. It appears in **zero** agent definitions,
+**zero** skills, **zero** hooks — in *either* harness (`.claude/agents/*.md`,
+`.opencode/agents/*.md`).
+
+`KNOWLEDGE.md` is a nice routing map that points at the tool, but nothing loads
+`KNOWLEDGE.md` into an agent's context: it is not read by `session_start.ps1`,
+not referenced from `AGENTS.md` (the auto-read contract), and not cited by any
+agent definition. The `package-implementer` "before writing a single line of
+code" checklist says: read CLAUDE.md, read the spec, grep. It never mentions
+the index. So a coding agent never learns the tool exists, and reaches for
+`grep` every time — which is exactly what it does today.
+
+**No amount of query-quality improvement fixes this by itself.** A perfect tool
+nobody is told to run stays unused.
+
+### 2. When you *do* run it, the highest-value output is noise or missing.
+
+- `query "glass"` is unusable. The `status` column is populated by matching
+  `**Status:** <rest of line>`, but our specs jam entire multi-paragraph
+  post-mortems onto/after the Status line, so a single query hit prints
+  hundreds of words of resolution narrative. Fifteen hits = an unscannable
+  wall. An agent cannot skim it.
+- `query` searches only `title`/`status`/`pillar`. It does **not** search spec
+  body text, and it does **not** search files — so "which package discusses
+  photon caustics" misses any spec that doesn't say it in the title.
+- **The single most valuable coding-agent query is not exposed at all:**
+  "I'm about to edit `gpu_materials.h` — which packages own it and what
+  landed?" The schema *has* a `package_files` table, but there is no
+  `owns <path>` command. The reverse lookup exists in the data and is thrown
+  away.
+- The canonical-script map (`scripts/README.md`, the CLAUDE.md §5b
+  no-duplicate-scripts rule) is **not indexed**, even though "what's the
+  canonical script for task X?" is a first-class recurring agent question and
+  the index is exactly the right shape to answer it. Five parallel contact-sheet
+  generators already got written for want of this lookup.
+
+`deps` is the one subcommand that works well and returns clean output.
+
+### 3. It goes stale silently, so agents can't trust it.
+
+The DB (`.astroray_plan/.project-index.db`) is **gitignored** — it never
+travels, so every checkout and every fresh agent starts with *no* DB until
+someone runs `build`. Nothing rebuilds it: no commit hook, no read-time guard.
+An agent that runs `query`/`deps` against a month-old DB gets month-old answers
+with no warning. Staleness is the fastest way to make an agent stop trusting a
+tool and fall back to grep permanently — and grep is never stale.
+
+## The chosen direction
+
+There is essentially **one honest direction**, and I want to name what I
+*rejected* so the scope stays tight (CLAUDE.md §2):
+
+- **I am not building an MCP server.** It is tempting (a native `owns`/`deps`
+  tool call), but it double-wires two harnesses (opencode + Claude Code),
+  adds a server lifecycle, and does not touch the actual root cause — which is
+  that the CLI mechanism is *fine*; agents just aren't told to run it and its
+  output is noise. An MCP server is over-engineering that fixes nothing on axis
+  1 or 3. The Bash-invokable CLI already works in both harnesses.
+- **I am not (yet) building an auto-surface hook** (e.g. inject "packages that
+  own this file" on every `Edit`). It is attractive as zero-effort discovery,
+  but it is cross-harness-fragile (hook models differ between opencode and
+  Claude Code), risks context bloat on every edit, and is speculative until we
+  see whether wiring the CLI into agent checklists is enough. Deferred; revisit
+  only if pkg216's checklist wiring demonstrably fails to drive adoption.
+
+So the path is: **make the CLI answer the questions agents actually ask, keep
+it fresh automatically, then put one instruction line where agents will read
+it.** Two packages, sequenced:
+
+### pkg215 (M) — Make the index answer real questions, and never be stale
+
+Edits `scripts/project_index.py` only. Three things, one PR (one file, avoid
+two agents serializing on it):
+
+1. **Scannable output + real search.** Parse a *short* status token (first
+   word/clause: `open`/`in-progress`/`done`/`held`), not the whole narrative
+   line, so `query` prints one skimmable line per hit. Extend `query` to also
+   match spec **body** text and **file paths**.
+2. **The lookups agents ask for.** Add `owns <path>` (file → packages that
+   create/modify it, from `package_files`, with each package's status) and
+   `script <task-substring>` backed by a new index of the `scripts/README.md`
+   canonical-task table (directly serves the §5b no-duplicate rule). Add a
+   compact `whatis pkgN` card.
+3. **Read-time freshness guard.** `query`/`deps`/`owns`/`script`/`whatis`
+   auto-rebuild if the DB is missing or older than the newest source file
+   under `.astroray_plan/packages`, `.astroray_plan/docs`, `tests/`, and
+   `scripts/README.md`. Build is ~instant at 221 packages, so rebuild-on-read
+   is simpler and more robust than a commit hook and needs no cross-harness
+   wiring. Print a one-line `(index rebuilt)` note when it fires.
+
+### pkg216 (S) — Put the index in front of the agents
+
+Edits agent definitions and the routing surface, no engine code. Add a single
+explicit invocation line to the `package-implementer`, `architect`, and
+`docs-updater` definitions in **both** `.claude/agents/` and
+`.opencode/agents/`, plus tighten `KNOWLEDGE.md`:
+
+- implementer "before writing code" checklist gains: *before editing a file,
+  run `python scripts/project_index.py owns <path>`; before writing any script,
+  run `... script "<task>"` (the §5b gate).*
+- Reference `KNOWLEDGE.md` from `AGENTS.md` so the routing map is discoverable.
+
+Depends on pkg215 (don't point agents at a noisy tool). Adoption is the whole
+point of the exercise, so this package is the one that actually closes the
+owner's gap; pkg215 is the prerequisite that makes the instruction worth
+following.
+
+## Why this is the minimum that works
+
+Axis 1 (not wired) is the crux, but pointing agents at today's noisy, possibly-
+stale tool would burn the one chance to earn trust. So pkg215 makes it
+trustworthy and pkg216 makes it reached-for. Neither alone suffices; together
+they are ~1.5 sessions of pure-Python/markdown work with fully machine-
+verifiable acceptance criteria and no GPU, no ABI, no physics risk.

--- a/.astroray_plan/packages/pkg215-project-index-query-overhaul.md
+++ b/.astroray_plan/packages/pkg215-project-index-query-overhaul.md
@@ -1,0 +1,177 @@
+# pkg215 — Make the project-index answer real questions, and never be stale
+
+**Track:** A
+**Status:** open (filed 2026-08-21).
+**Estimated effort:** M.
+**Depends on:** none.
+
+---
+
+## Goal
+
+Before: `scripts/project_index.py` builds a SQLite index but its query surface
+is unusable in practice — `query` prints entire multi-paragraph Status
+post-mortems per hit, searches only title/status/pillar, exposes no file→package
+lookup despite having a `package_files` table, doesn't index the canonical-script
+map, and the DB is gitignored and never auto-rebuilt so it goes stale silently.
+After: the CLI answers the four questions a coding agent actually asks —
+"which package owns this file?", "what's the canonical script for task X?",
+"what packages relate to this topic?" (body + file search, one scannable line
+per hit), "what is pkgN?" — and every read-command auto-rebuilds when the DB is
+stale so answers are never silently out of date. Diagnosis:
+`.astroray_plan/docs/2026-08-21-project-index-usefulness.md`.
+
+---
+
+## Context
+
+The project index is the owner's designated route to genuine coding-agent
+usefulness, but agents fall back to `grep` because the tool's highest-value
+outputs are noise or missing (see the design note). This package fixes the
+*tool* so it is worth reaching for; pkg216 then wires it into agent workflow.
+Both are needed — a good tool nobody runs, or a noisy tool agents are told to
+run, each fails. This one must land first.
+
+All work is in one Python file plus its tests. No engine code, no GPU, no ABI,
+no physics.
+
+---
+
+## Reference
+
+- `scripts/project_index.py` — the tool. `_parse_package()` (`:46`) fills the
+  `status` field from `**Status:** <rest-of-line>`; `query()` (`:187`) searches
+  only `title/status/pillar`; `package_files` table (`:139`) is built but never
+  queried; `deps()` (`:201`) is the one clean subcommand (keep its style).
+- `scripts/README.md` — the canonical-task table (§ "Canonical script per
+  task") to index for the `script` lookup; serves CLAUDE.md §5b.
+- Design note: `.astroray_plan/docs/2026-08-21-project-index-usefulness.md`.
+
+---
+
+## Specification
+
+Edit `scripts/project_index.py` and add `tests/test_project_index.py`. No other
+files change.
+
+### 1. Scannable status + real search (`query`)
+
+- Add a `_status_token(raw: str) -> str` helper that reduces a Status line to a
+  short token by taking text up to the first of `(`, `—`, `.`, `,`, or newline,
+  lower-cased and stripped (e.g. `done (PR #540, ...)` → `done`;
+  `open (filed 2026-08-21).` → `open`; `Stage 2 done ...` → `stage 2 done`).
+  Store BOTH a new `status_short` column and keep the existing full `status`
+  (used by `whatis`).
+- `query` prints one line per package hit using `status_short`:
+  `  pkg169  [done] Disney Principled TRANSMISSION lobe CREATES energy ...`
+  (title truncated to ≤80 chars). No multi-paragraph dumps.
+- Extend `query` matching: index each spec's **body text** (a new
+  `package_text(package_key, body)` table or a `body` column on `packages`) and
+  match the query words against title, body, and the package's file paths, not
+  just title/status/pillar. A search for a term that appears only in a spec body
+  or only in a `Files to modify` path must return that package.
+
+### 2. File-owner lookup (`owns <path>`)
+
+- New subcommand `owns <path>`. Normalises slashes, matches `package_files.path`
+  by suffix/substring (so both `gpu_materials.h` and
+  `include/gpu_materials.h` resolve), and prints each owning package with its
+  `status_short` and the action (`create`/`modify`), e.g.:
+  `  pkg169  [done]  modify  include/gpu_materials.h`
+- If nothing owns the path, print `no package records touching <path>` (exit 0).
+
+### 3. Canonical-script lookup (`script <task>`)
+
+- New parser that reads the `scripts/README.md` "Canonical script per task"
+  markdown table into a new `scripts_map(task, script)` table during `build`.
+- New subcommand `script <task-substring>` (case-insensitive) that prints
+  matching `task → canonical script` rows. Directly answers the CLAUDE.md §5b
+  "check the index before writing a new script" gate.
+
+### 4. Compact card (`whatis pkgN`)
+
+- New subcommand `whatis pkgN` printing a compact multi-line card: title,
+  `status_short`, track, pillar, effort, depends-on, reverse-deps count, and
+  the list of owned files. Reuses `deps()` data; the FULL status narrative may
+  be shown here (this is the deliberate "give me everything about one package"
+  path, unlike `query`).
+
+### 5. Read-time freshness guard
+
+- Add `_db_is_stale() -> bool`: true if `DB_PATH` is missing OR its mtime is
+  older than the newest mtime among all files under `.astroray_plan/packages`,
+  `.astroray_plan/docs` (excluding `archive/`), `tests/test_*.py`, and
+  `scripts/README.md`.
+- `query`, `deps`, `owns`, `script`, and `whatis` call `build()` automatically
+  when `_db_is_stale()` and print a single `(index rebuilt)` line to stderr when
+  they do. `build`/`gh-sync`/`graph` keep current behaviour (explicit).
+- Keep it fast: no per-command full re-scan cost beyond the (already ~instant)
+  build; the staleness check is mtime-only.
+
+### Key design decisions
+
+- One file, one PR: the whole point is to avoid two agents serializing on
+  `project_index.py`. Freshness ships with the query overhaul, not separately.
+- Do NOT change the DB path or un-gitignore it. Read-time rebuild makes the
+  gitignore moot — the DB is a local cache that's always fresh on read.
+- Match `deps()`'s terse output style everywhere; no ANSI, ASCII-only
+  (Windows/PowerShell — CLAUDE.md shell conventions; the file already
+  `reconfigure`s stdout to utf-8).
+
+---
+
+## Acceptance criteria
+
+- [ ] **Scannable query (machine-verifiable):** `python scripts/project_index.py
+      query "glass"` prints at most one line per package hit, and no single line
+      exceeds ~120 chars; a test asserts the output for a known multi-paragraph-
+      status package (e.g. pkg169) is a single short line containing `[done]`,
+      not its full post-mortem.
+- [ ] **Body/file search:** a test picks a term that appears in a spec's *body*
+      or a *Files-to-modify path* but NOT its title/status/pillar, and asserts
+      `query <term>` returns that package (fails against current `main`).
+- [ ] **`owns` (machine-verifiable):** `owns` on a path known to appear in some
+      spec's Files table (assert against a package the test discovers by reading
+      the DB, so it can't rot) prints that package with its status and action;
+      `owns nonexistent/path.xyz` prints the empty-result line and exits 0.
+- [ ] **`script` (machine-verifiable):** `script "contact sheet"` (or another
+      substring present in `scripts/README.md`) returns the canonical
+      `benchmarks/showcase/runner.py` row; a test asserts the row count matches
+      the README table's row count for a known task.
+- [ ] **`whatis` (machine-verifiable):** `whatis pkg214` prints title, a
+      `status`, track, depends, and the owned-files list without exception.
+- [ ] **Freshness (machine-verifiable):** a test builds the DB, `touch`es a
+      package spec (or writes a temp spec) to make it newer than the DB, runs
+      `query`/`owns`, and asserts the new content is reflected AND `(index
+      rebuilt)` appeared on stderr — i.e. no manual `build` was needed.
+- [ ] **No regression:** `deps`, `build`, `graph --json`, and `gh-sync` still
+      run and produce output of the same shape; existing graph HTML still opens.
+- [ ] `scripts/README.md` row for `project_index.py` is updated to list the new
+      subcommands (`owns` / `script` / `whatis`) in the same commit.
+- [ ] CI green on all matrix jobs (`gh run view` on HEAD — memory
+      `mingw_local_vs_gcc_ci_divergence`). Pure-Python; no build required.
+
+---
+
+## Non-goals
+
+- **No MCP server.** The CLI is the mechanism; see the design note's rejected
+  alternatives. Do not add a server.
+- **No auto-surface hook** (injecting owners on every Edit). Deferred pending
+  pkg216 adoption evidence.
+- **No schema for symbol-level (function/class) indexing.** Files-granularity
+  only; symbol indexing is a separate future package if the coarse lookup
+  proves insufficient.
+- **No change to `graph`/HTML viz** beyond keeping it working.
+- **No un-gitignoring the DB**, no committing the DB, no network in the read
+  path (`gh-sync` stays the only network command).
+
+---
+
+## Progress
+
+_(none yet)_
+
+## Lessons
+
+_(none yet)_

--- a/.astroray_plan/packages/pkg216-project-index-agent-wiring.md
+++ b/.astroray_plan/packages/pkg216-project-index-agent-wiring.md
@@ -1,0 +1,129 @@
+# pkg216 — Put the project-index in front of the agents
+
+**Track:** A
+**Status:** open (filed 2026-08-21).
+**Estimated effort:** S.
+**Depends on:** pkg215.
+
+---
+
+## Goal
+
+Before: `project_index` appears in zero agent definitions, zero skills, and
+zero hooks in either harness; `KNOWLEDGE.md` mentions it but nothing loads
+`KNOWLEDGE.md` into agent context, so agents never learn the tool exists and
+fall back to `grep` every time. After: the three agents that do repo-navigation
+work — `package-implementer`, `architect`, `docs-updater` — are explicitly
+instructed, in both `.claude/agents/` and `.opencode/agents/`, to run the index
+for the two questions it now answers best (`owns <file>` before editing,
+`script "<task>"` before writing a script), and `AGENTS.md` references
+`KNOWLEDGE.md` so the routing map is discoverable. This is the package that
+actually closes the owner's "agents don't use it" gap.
+
+---
+
+## Context
+
+Wiring is the crux of the whole exercise (design note
+`.astroray_plan/docs/2026-08-21-project-index-usefulness.md` §Diagnosis-1): a
+good tool nobody is told to run stays unused. This package is deliberately
+sequenced AFTER pkg215 so agents are pointed at a tool whose output is scannable
+and fresh, not the current noisy/stale one — pointing them at today's tool would
+burn the one chance to earn trust.
+
+Pure markdown/config edits: agent definitions, `AGENTS.md`, `KNOWLEDGE.md`. No
+code, no build.
+
+---
+
+## Reference
+
+- `.claude/agents/package-implementer.md` "Before writing a single line of code"
+  checklist (`:21`) and `.opencode/agents/package-implementer.md` — the primary
+  wiring targets.
+- `.claude/agents/architect.md`, `.claude/agents/docs-updater.md` and their
+  `.opencode/` twins.
+- `KNOWLEDGE.md` (routing map, already documents the subcommands) and `AGENTS.md`
+  (the auto-read contract that currently never points at KNOWLEDGE.md).
+- CLAUDE.md §5b (no-duplicate-scripts — the `script` lookup enforces it).
+- Design note: `.astroray_plan/docs/2026-08-21-project-index-usefulness.md`.
+
+---
+
+## Specification
+
+### Files to modify
+
+| File | What changes |
+|---|---|
+| `.claude/agents/package-implementer.md` | Add index-invocation lines to the pre-code checklist |
+| `.opencode/agents/package-implementer.md` | Mirror the same lines |
+| `.claude/agents/architect.md` | Add "query the index before proposing scope" line |
+| `.opencode/agents/architect.md` | Mirror |
+| `.claude/agents/docs-updater.md` | Add "use `owns`/`deps` to find affected specs" line |
+| `.opencode/agents/docs-updater.md` | Mirror |
+| `AGENTS.md` | One line referencing `KNOWLEDGE.md` as the routing map |
+| `KNOWLEDGE.md` | Add the pkg215 subcommands (`owns`/`script`/`whatis`) to the Search & graph section |
+
+### Key design decisions
+
+- **`package-implementer`** gets the load-bearing lines, added to its
+  "Before writing a single line of code" list:
+  - *Before editing an existing file, run
+    `python scripts/project_index.py owns <path>` to see which packages own it
+    and their status — it surfaces prior/related work grep won't.*
+  - *Before writing ANY new script, run
+    `python scripts/project_index.py script "<task>"` (the CLAUDE.md §5b
+    no-duplicate gate) in addition to reading `scripts/README.md`.*
+- **`architect`** gets one line in goal-capture: *run
+  `project_index query "<topic>"` / `deps pkgN` before proposing scope, to
+  ground new specs in existing packages and dependencies.*
+- **`docs-updater`** gets one line: *use `project_index owns <path>` / `deps` to
+  find every spec affected by a landed change before flipping statuses.*
+- The lines must be **identical** across the `.claude/` and `.opencode/` twin so
+  the two harnesses don't drift.
+- Do NOT add a hook. Discovery-by-instruction first; an auto-surface hook stays
+  deferred per the design note until there's evidence the instruction is
+  insufficient.
+
+---
+
+## Acceptance criteria
+
+- [ ] **Wiring present (machine-verifiable):** `grep -l project_index
+      .claude/agents/*.md .opencode/agents/*.md` returns
+      `package-implementer`, `architect`, and `docs-updater` in BOTH directories
+      (6 files).
+- [ ] **`owns` and `script` both cited** in `package-implementer.md` (both
+      harness copies) — assert both subcommand names appear.
+- [ ] **Twin parity:** the invocation lines added to a `.claude/agents/X.md` are
+      byte-identical to those in `.opencode/agents/X.md` (a test or manual diff
+      of the added block).
+- [ ] **`AGENTS.md` references `KNOWLEDGE.md`** (grep asserts the link exists).
+- [ ] **`KNOWLEDGE.md` lists** `owns`, `script`, and `whatis`.
+- [ ] No engine/test/build change; no CI job needs a build. CI green on all
+      matrix jobs.
+
+---
+
+## Non-goals
+
+- **No hook** (auto-surface on Edit/UserPromptSubmit). Deferred.
+- **No MCP server.** The CLI is the mechanism.
+- **No change to `session_start.ps1`** to run the index — it must stay a fast
+  session banner; auto-running the index on every session start is scope creep
+  and the read-time freshness guard (pkg215) already keeps answers current.
+- **No changes to the reviewer/verifier agents** (`pr-reviewer`,
+  `hardware-verifier`, `cpp-abi-guard`, `cycles-parity-reviewer`,
+  `gate-failure-reviewer`) — they don't do exploratory navigation; keep their
+  context lean.
+
+---
+
+## Progress
+
+_(none yet)_
+
+## Lessons
+
+_(none yet)_


### PR DESCRIPTION
## Owner directive (2026-08-21)
Get the project-index database + its integration into a state where it's *actually useful for coding agents*. Diagnose why they don't use it, then file specs.

## Core diagnosis — three independent failures, all load-bearing
1. **Wired into nothing (the crux).** `project_index` appears in zero agent definitions, zero skills, zero hooks in *either* harness (`.claude/`, `.opencode/`). `KNOWLEDGE.md` points at it but nothing loads KNOWLEDGE.md into agent context (not in `AGENTS.md`, not in `session_start.ps1`, not in any agent def). Agents are told to read CLAUDE.md + spec + grep — never the index. So they grep, every time.
2. **When run, the best output is noise or missing.** `query "glass"` dumps entire multi-paragraph Status post-mortems per hit (the Status field captures the whole narrative line); it searches only title/status/pillar (not body, not files); there is **no `owns <file>` command** despite a `package_files` table (the single highest-value agent query is thrown away); the canonical-script map (`scripts/README.md`, §5b) isn't indexed. Only `deps` returns clean output.
3. **Stale silently.** DB is gitignored (never travels), nothing rebuilds it — no commit hook, no read-time guard. A stale answer with no warning permanently kills agent trust; grep is never stale.

## Chosen direction (one honest direction — MCP and auto-surface hook explicitly rejected/deferred)
Make the CLI answer the questions agents ask, keep it fresh automatically, then put one instruction line where agents read it. Not an MCP server (double-wires two harnesses, fixes neither axis 1 nor 3). Not (yet) an auto-surface hook (cross-harness-fragile, context-bloat, speculative).

## Specs filed
- **pkg215 (Track A, M)** — query/coverage/freshness overhaul of `scripts/project_index.py`: scannable status token + body/file search; `owns <path>`, `script <task>`, `whatis pkgN`; read-time staleness rebuild. One file, machine-verifiable acceptance.
- **pkg216 (Track A, S, depends on pkg215)** — wire the index into `package-implementer`/`architect`/`docs-updater` in **both** harnesses + reference KNOWLEDGE.md from AGENTS.md. This is the package that actually closes the gap.

## Files
- `.astroray_plan/docs/2026-08-21-project-index-usefulness.md`
- `.astroray_plan/packages/pkg215-project-index-query-overhaul.md`
- `.astroray_plan/packages/pkg216-project-index-agent-wiring.md`

Docs/specs only. No STATUS.md/ROADMAP.md/NEXT_STAGE_REPORT.md edits (docs-updater owns those concurrently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)