### PR TITLE
docs: planning doc refresh — pkg203/204/205/213 done, pkg214 HW FAIL, pkg206 unheld

### DIFF
--- a/.astroray_plan/docs/NEXT_STAGE_REPORT.md
+++ b/.astroray_plan/docs/NEXT_STAGE_REPORT.md
@@ -1,94 +1,90 @@
 # Astroray Next Stage Report
 
-**Date:** 2026-08-15 (round closeout — 9 PRs merged, #615–#623, on top of the
-2026-08-13 → 2026-08-14 round below).
-**Prepared by:** the architect (round closeout).
-**Scope:** no open PRs at time of writing. Full detail:
-`.astroray_plan/docs/STATUS.md` (top entry "2026-08-14 → 2026-08-15 (round
-closeout...)"), `.astroray_plan/docs/ROADMAP.md` ("Current sequencing"
-unchanged — no new owner directive this round, but see the owner request
+**Date:** 2026-08-21 (mid-round refresh — NOT a round closeout: PR #629 is
+open/HW-FAIL and pkg206 is actively in progress. 6 PRs merged since the
+2026-08-15 report, #624–#628, on top of the 2026-08-14 → 2026-08-15 round
 below).
+**Prepared by:** docs closeout pass (evidence: `git log`, `gh pr list`,
+package spec Status lines).
+**Scope:** 1 open PR (#629, sodium-vapor fix, HW FAIL — fix in progress on
+branch `pkg214fix`), pkg206 re-dispatched in progress (branch
+`pkg206impl*`). Full detail: `.astroray_plan/docs/STATUS.md` (top entry
+"2026-08-19 → 2026-08-21"), `.astroray_plan/docs/ROADMAP.md` ("Current
+sequencing" unchanged — no new owner directive since 2026-08-03).
 
 > Strategic gate: **RELEASED 2026-05-10** by pkg56 Phase C. Strategy in
 > [`ROADMAP.md`](ROADMAP.md), full status in [`STATUS.md`](STATUS.md).
 
-**OWNER REQUEST for next session: a FRESH ARCHITECT-LED run.** The owner
-has asked that the next session start with the architect planning ahead
-(reviewing the full open pool, sequencing dependencies, sizing work) before
-dispatching implementers, rather than picking up ad hoc from this report's
-tail pool. Treat §2 below as input to that planning pass, not a queue to
-execute mechanically.
+**Still open from the prior report: a FRESH ARCHITECT-LED planning pass.**
+The owner's 2026-08-15 request for the architect to plan ahead (review the
+full open pool, sequence dependencies, size work) before dispatching more
+implementers has not yet been acted on — the intervening work (pkg203-206,
+pkg212-214) was picked up ad hoc. Treat §2 below as input to that planning
+pass, not a queue to execute mechanically.
 
 ---
 
 ## 1. Current state (one screen)
 
-- **The Integration Milestone stays fully closed** (unchanged this round).
-  This round's work continues closing the milestone's self-generated
-  follow-up pool: the pkg200 F12 pixel-honour matrix and its pkg201
-  GPU-plumbing closures, plus GPU wavefront capability parity (full HG
-  scattering/god-rays, light-path AOV passes) and a legacy-importer
-  correctness fix.
-- **Landed this round (9 PRs, #615–#623, no open PRs at closeout):**
-  pkg190 follow-up (Object-coord bake guard, PR #615, HW PASS), pkg200
-  (F12 pixel-honour matrix, PR #616, 8 PASS/13 HONEST-FAIL/2 NEEDS-VISUAL/2
-  LIMITATION), pkg199 Stage 2 CPU (PR #617) + GPU (PR #619) — full HG
-  scattering both backends, god-ray parity [1.0044, 0.9972, 0.9978],
-  pkg201 Stage 1 (PR #618, world_max_bounces + use_light_tree honoured),
-  pkg198 Stage 2 probe (PR #620, PROCEED) + full mirror (PR #622,
-  sum-to-beauty exact — **pkg198 now COMPLETE**), pkg202 (legacy sun GPU
-  fix, PR #621, 0.0→0.6333), pkg201 Stage 2 (PR #623, 2-of-6 rows shipped:
-  transparent-film alpha — first implementation anywhere — and
-  filter_width).
-- **Zero HW FAIL cycles this round** — every landed code PR reported HW
-  PASS on the first independent verification (contrast with the prior two
-  rounds, which each had 2 FAIL→fix→PASS cycles). Two register-gate
-  probes (pkg198 Stage 2, folded into pkg201's ordering discipline) both
-  cleared PROCEED before implementation started.
-- **pkg200's honour matrix is now the reference gap-list for the GPU
-  wavefront's settings-honour work.** Of its 13 HONEST-FAIL rows, pkg201
-  has closed 3 (`world_max_bounces`, `film_transparent`, `filter_width`)
-  and reclassified 2 more with evidence (`pixel_filter_type` → pkg203 is
-  a σ-mapping shortfall, not unwired; `caustics_reflective`/
-  `caustics_refractive` → genuinely register-hostile, deferred to Stage
-  3). **8 rows remain untouched**: the per-type bounce counts (Finding A),
-  `filter_glossy` (Finding C), and `film_transparent_glass` (F-glass,
-  reclassified as a new-feature follow-up, not a plumbing gap).
-- **Specs filed this round, disposition:** **pkg203** (Cycles-accurate
-  pixel-filter width→σ mapping, CPU+GPU parity) is filed and **now
-  dispatchable** — its dependency (pkg201 Stage 2) merged this round.
-- **Open, not blocking, carried forward:** pkg201 Stage 3 (per-type bounce
-  counters + `filter_glossy` + native caustic toggles — register-hostile,
-  probe-gated, ordering-locked behind pkg198/pkg199's register-contention
-  window which is now clear since both landed), pkg203 (filter σ parity,
-  open above), pkg131 (zero-knob adaptive sampling, wavefront leg,
-  long-standing), the F-glass (`film_transparent_glass`) world-through-
-  glass compositing follow-up (a genuine new feature, not yet filed),
-  the CPU legacy-hittable delta-sun `isDelta`/MIS gap (pkg202's fix
-  sidesteps it for the sun case via upload-time conversion, but the
-  underlying legacy non-dedicated-light MIS treatment is unaddressed),
-  pkg198's volume-pass direct/indirect split (documented limitation,
-  deferred in #622), the caustic-integrator/CPU-wavefront-reference
-  world-volume gap (still open from the pkg199 Stage 1 round), the
-  durable `GLoweredMaterial` by-value-copy fix (still prototyped,
-  uncommitted, worktree `sad-maxwell-ff99d1`), pkg180 (systemic-dim
-  diagnosis, still open).
-- **New hygiene item this round:** 3 pre-existing test failures throw
-  `UnicodeEncodeError` printing π/✓/λ console artifacts under the default
-  cp1252 Windows console encoding — a test-harness bug (force UTF-8
-  stdout or drop the glyphs), not an engine defect. Cheap, low-priority,
-  file before dispatching if picked up.
+- **The Integration Milestone stays fully closed** (unchanged). Work since
+  the 2026-08-15 report closed pkg200's last filter honour row and the
+  pkg198 volume-pass limitation, added a light-intensity UI control, and
+  is mid-fix on a spectral-lamp regression.
+- **Landed since the last report (6 PRs, #624–#628):** pkg203 (Cycles-
+  accurate pixel-filter width→σ mapping, CPU+GPU, PR #624, closes pkg200's
+  last filter HONEST-FAIL row), pkg204 (GPU wavefront volume-pass direct/
+  indirect split, PR #625, closes the pkg198 Stage-2 limitation), pkg205
+  (UnicodeEncodeError console-test hygiene, PR #626, test-only), pkg213
+  (light intensity/Power slider exposed in the Astroray panel, PR #628,
+  UI-surfacing only).
+- **Open, HW FAIL — top priority pickup:** **pkg214** (PR #629, sodium-
+  vapor emission fix). The D-doublet broadening (black→amber) works, but
+  the shared `mat_ls` peak-normalisation mechanism regressed
+  `mercury_vapor` ~4.5–8.6× too bright. A physics-correct energy-
+  normalisation fix is IN PROGRESS on branch `pkg214fix` — **finish and
+  re-verify this before picking up anything else that touches
+  `build_spectral_profiles.py` or the spectral-lamp path** (overlaps
+  pkg206's sampler work only at the "don't touch the same files
+  concurrently" level, not logically).
+- **In progress, released from hold:** **pkg206** (luminance-weighted
+  hero-wavelength importance sampling). Its first attempt, PR #627, was
+  CLOSED CI-red/biased — `test_flat_baseline_ssim` failed from a stacked
+  realization-change + genuine achromatic-flat green-cast bias (companion
+  wavelengths not divided by the importance density at their own λ). The
+  owner released the bias-hold 2026-08-21; re-dispatched fresh on branch
+  `pkg206impl*` with the triage's per-wavelength-pdf correction (spec's
+  2026-08-21 triage section has the full root-cause + distinguishing
+  diagnostic for the next attempt).
+- **pkg200's honour matrix is now fully closed on its filter-related
+  rows.** Of its original 13 HONEST-FAIL rows, pkg201 closed 3
+  (`world_max_bounces`, `film_transparent`, `filter_width`) and pkg203
+  closed the 4th (`pixel_filter_type`). Remaining rows: per-type bounce
+  counts (Finding A), `filter_glossy` (Finding C), native caustic toggles
+  (Finding E) — all register-hostile, deferred to pkg201 Stage 3; and
+  `film_transparent_glass` (F-glass), reclassified as an unfiled new-
+  feature follow-up.
+- **Open, not blocking, carried forward:** pkg201 Stage 3 (per-type
+  bounce counters + `filter_glossy` + native caustic toggles —
+  register-hostile, probe-gated, register-contention window is clear),
+  pkg131 (zero-knob adaptive sampling, wavefront leg, long-standing), the
+  F-glass (`film_transparent_glass`) world-through-glass compositing
+  follow-up (not yet filed), the CPU legacy-hittable delta-sun
+  `isDelta`/MIS gap (pkg202's fix sidesteps it for the sun case only),
+  the caustic-integrator/CPU-wavefront-reference world-volume gap (open
+  since pkg199 Stage 1), the durable `GLoweredMaterial` by-value-copy fix
+  (still prototyped, uncommitted, worktree `sad-maxwell-ff99d1`), pkg180
+  (systemic-dim diagnosis, still open).
 - **Still standing, unresolved — TOP STRATEGIC ITEM:** the **Pillar 4
   unpause decision** (pkg45/46/48/49/50/51 + pkg107, GR/astro science
-  layer). No new owner directive this round; ROADMAP.md's PAUSED marker
-  is unchanged. This has now stood unresolved across multiple round
-  closeouts — surface it explicitly at the start of the next
-  architect-led session, before any further Integration-Milestone-tail
-  dispatch.
+  layer). No new owner directive since 2026-08-03; ROADMAP.md's PAUSED
+  marker is unchanged. This has now stood unresolved across many round
+  closeouts — surface it explicitly before any further
+  Integration-Milestone-tail dispatch.
 - **Environment:** RTX 5070 Ti workstation; Blender 5.1/5.2 installed
-  locally (real-host checks mandatory for addon-facing PRs). Every code PR
-  this round was dual-gated (CI + independent RTX hardware verification);
-  zero PRs required a fix-and-re-verify cycle before merge.
+  locally (real-host checks mandatory for addon-facing PRs). Every landed
+  PR this window was dual-gated (CI + independent RTX hardware
+  verification); pkg214 (#629) is the one PR that came back HW FAIL and is
+  mid-fix, not yet re-verified.
 
 ---
 
@@ -99,56 +95,56 @@ Grep `^\*\*Status:\*\*` in each spec before dispatch (memory
 list is INPUT to the requested fresh architect planning pass, not a queue
 to execute mechanically (see the owner request banner above).
 
+**In-flight, finish before picking up anything new:**
+
+1. **pkg214fix** — finish the physics-correct energy-normalisation fix on
+   branch `pkg214fix` (PR #629 is HW FAIL, do not merge as-is). Re-verify
+   sodium (amber, unchanged) AND mercury (back within its pre-fix MC-noise
+   band) together before closing.
+2. **pkg206** — luminance-weighted hero-wavelength importance sampling,
+   re-dispatched on branch `pkg206impl*` with the per-wavelength-pdf
+   correction from the 2026-08-21 triage. Re-verify the flat-baseline SSIM
+   gate specifically (the prior attempt's failure mode) alongside the
+   convergence-win and unbiasedness gates in the spec.
+
 **Top candidate — needs an explicit owner decision, not a silent dispatch:**
 
-1. **Pillar 4 unpause** (pkg45/46/48/49/50/51 + pkg107, GR/astro science
+3. **Pillar 4 unpause** (pkg45/46/48/49/50/51 + pkg107, GR/astro science
    layer). Unchanged across multiple rounds now — ROADMAP.md's PAUSED
    marker has stood since 2026-06-08; still no explicit go-ahead.
-   **Surface this to the owner at the top of the next session, before
-   dispatching any pkg45-tier work or further Integration-Milestone-tail
-   items.**
+   **Surface this to the owner before dispatching any pkg45-tier work or
+   further Integration-Milestone-tail items.**
 
 **Integration-Milestone-tail / settings-honour closure, highest signal in
 the open pool:**
 
-2. **pkg203** — Cycles-accurate pixel-filter width→σ mapping, CPU+GPU
-   parity. Dependency (pkg201 Stage 2) landed this round — dispatchable
-   now. Closes pkg200's last filter-related HONEST-FAIL row. S–M, cite
-   Cycles' `film.cpp` filter tables per CLAUDE.md §6 before writing code.
-3. **pkg201 Stage 3** — per-type bounce counters (Finding A),
+4. **pkg201 Stage 3** — per-type bounce counters (Finding A),
    `filter_glossy` (Finding C), native caustic toggles (Finding E,
    reclassified from Stage 2). Register-hostile — MUST clear the
    up-front cuobjdump probe per item before any feature code (same
-   discipline as pkg198/pkg199). The register-contention window
-   (pkg198 Stage 2, pkg199 Stage 2) that blocked this is now clear —
-   dispatchable, but size it as its own session (3 register-hostile
-   items, each may park independently).
-4. **pkg131** — zero-knob adaptive sampling, wavefront leg. Long-standing
+   discipline as pkg198/pkg199/pkg204). The register-contention window
+   is clear — dispatchable, but size it as its own session (3
+   register-hostile items, each may park independently).
+5. **pkg131** — zero-knob adaptive sampling, wavefront leg. Long-standing
    open item, no new blockers.
 
 **Hygiene / follow-up (not yet filed as a dedicated spec):**
 
-5. **F-glass (`film_transparent_glass`) world-through-glass compositing**
+6. **F-glass (`film_transparent_glass`) world-through-glass compositing**
    — reclassified out of pkg201 Stage 2 as a genuine new feature (glass
    must show the background through it, changing beauty RGB, not just an
    alpha copy-back). File a spec before dispatching.
-6. **CPU legacy-hittable delta-sun `isDelta`/MIS gap** — pkg202's
+7. **CPU legacy-hittable delta-sun `isDelta`/MIS gap** — pkg202's
    upload-time conversion sidesteps this for GPU sun rendering, but the
    underlying legacy non-dedicated-light MIS treatment (CPU side) is
    still unaddressed for other legacy hittable-light types. Diagnosis-
    first; confirm scope before filing.
-7. **pkg198 volume-pass direct/indirect split** — documented limitation
-   in #622 (in-scatter routed to `PASS_VOLUME_INDIRECT` only). Small,
-   well-scoped follow-up if picked up.
 8. **Caustic-integrator/CPU-wavefront-reference world-volume gap** — fog
    is invisible to the caustic integrator and the CPU wavefront reference
    (pkg199 Stage 1 documented non-goal, still open). One-liner candidate:
    either extend those two paths to read `c_worldVolume`, or document the
    limitation user-facing if extending is out of scope for now.
-9. **3 UnicodeEncodeError console-artifact test failures** (cp1252 vs
-   π/✓/λ in `print()`) — hygiene, not a regression. Cheap fix (force
-   UTF-8 stdout or drop the glyphs), file before dispatching.
-10. **Durable `GLoweredMaterial` by-value-copy fix** — re-apply the
+9. **Durable `GLoweredMaterial` by-value-copy fix** — re-apply the
     prototyped PR-2-based fix from worktree
     `.claude/worktrees/sad-maxwell-ff99d1` on settled main. File a
     dedicated spec if picked up (recurring-leak pattern is evidence
@@ -156,18 +152,18 @@ the open pool:**
 
 **Re-entered / long-tail pool (still genuinely low priority):**
 
-11. **pkg180** — systemic Astroray-vs-Cycles dim, diagnosis-first, still
+10. **pkg180** — systemic Astroray-vs-Cycles dim, diagnosis-first, still
     open dispatchable.
-12. **pkg173** — bounce-1 geometry-sampling parity (pkg172 effect (B));
+11. **pkg173** — bounce-1 geometry-sampling parity (pkg172 effect (B));
     holds pkg156's 0.998 SSIM restoration clause.
-13. **pkg153** — wavefront_diff remainder, gate-failure-reviewer
+12. **pkg153** — wavefront_diff remainder, gate-failure-reviewer
     disposition in flight.
-14. **pkg155 Phase 2** — shade-stage register recovery (221 regs/thread →
+13. **pkg155 Phase 2** — shade-stage register recovery (221 regs/thread →
     ≤128 target); opportunistic GPU-lock gap-filler, not compile-only.
-15. **pkg128** — thin-film residual charter (standalone Glass/Metallic
+14. **pkg128** — thin-film residual charter (standalone Glass/Metallic
     node cells + spectral showcase), rides the shared Belcour-Barla
     utility pkg178/pkg182 already built.
-16. **pkg165** — verify-and-close. A focused confirm on pkg158's exact
+15. **pkg165** — verify-and-close. A focused confirm on pkg158's exact
     Step-0 scene at r ∈ {0.0, 0.3, 0.6, 0.9} closes the paperwork; every
     existing reading is already in-band. Trivial, non-urgent.
 
@@ -178,25 +174,25 @@ PAUSED until the owner go-ahead in item 1 above.
 
 ## 3. Drop-in prompt for the next session
 
-**First: get the owner's read on Pillar 4 unpause** (item 1) — a
-milestone-scale sequencing decision, not a code dispatch, and it has now
-stood unresolved across multiple rounds. **Second: run the fresh
-architect-led planning pass the owner requested** — review the full open
-pool (this report §2, STATUS.md, and any specs filed since), sequence
-dependencies, and size sessions explicitly before dispatching, rather than
-picking items off this list mechanically.
+**First: finish and re-verify the two in-flight items** (1–2) — pkg214fix
+(mercury regression) and pkg206 (bias re-fix) both have work already
+started; landing them is higher-value than starting anything new. **Then
+get the owner's read on Pillar 4 unpause** (item 3) — a milestone-scale
+sequencing decision, not a code dispatch, and it has now stood unresolved
+across multiple rounds. **Then run the fresh architect-led planning pass
+the owner requested 2026-08-15** — review the full open pool (this report
+§2, STATUS.md, and any specs filed since), sequence dependencies, and size
+sessions explicitly before dispatching, rather than picking items off this
+list mechanically.
 
-If the architect's plan confirms this pool as reasonable: **pkg203 (item
-2) is the standout quick pickup** — its blocker cleared this round, it's
-S–M, and it closes the last filter-related pkg200 gap. **pkg201 Stage 3
-(item 3)** is the next-highest-signal item but needs its own session
-(register-hostile, 3 independently-parkable sub-items, probe-first per
-item). pkg131 (item 4) has no blockers if a smaller pickup is wanted.
-Items 5–10 are hygiene/follow-up work that need a spec filed before
-dispatch (F-glass compositing, the legacy-light MIS gap, the volume-pass
-split, the caustic/fog gap, the UnicodeEncodeError tests, the
-`GLoweredMaterial` fix). Items 11–16 are the long-tail pool, in roughly
-that priority order.
+If the architect's plan confirms this pool as reasonable: **pkg201 Stage 3
+(item 4)** is the next-highest-signal item after the in-flight pair, but
+needs its own session (register-hostile, 3 independently-parkable
+sub-items, probe-first per item). pkg131 (item 5) has no blockers if a
+smaller pickup is wanted. Items 6–9 are hygiene/follow-up work that need a
+spec filed before dispatch (F-glass compositing, the legacy-light MIS gap,
+the caustic/fog gap, the `GLoweredMaterial` fix). Items 10–15 are the
+long-tail pool, in roughly that priority order.
 
 Rules that stay live from this round: **energy gates render LINEAR with an
 upper bound** (pkg166); **state the `.pyd` mtime next to every probe A/B

--- a/.astroray_plan/docs/ROADMAP.md
+++ b/.astroray_plan/docs/ROADMAP.md
@@ -258,6 +258,26 @@ fix:
   to pkg55 Phase B per the spec's escape clause; smaller H2/H5
   follow-ups split out as **pkg83** + **pkg84**.
 
+**In progress (2026-08-19 → 2026-08-21): 6 PRs merged (#624–#628), 1 open/HW-FAIL (#629) — pkg200's last filter honour row and the pkg198 volume-pass split both close, a test-hygiene chip lands, the light-intensity slider is exposed, and the sodium-vapor fix regressed mercury via peak-normalisation coupling.**
+**pkg203 DONE** (PR #624, 2026-08-19) — Cycles-accurate pixel-filter width→σ
+mapping, CPU+GPU byte-mirrored (cited Cycles `film.cpp` + PBRT-v4 §8.8);
+closes pkg200's last filter-related HONEST-FAIL row. **pkg204 DONE** (PR
+#625, 2026-08-19) — GPU wavefront volume-pass direct/indirect split,
+closing the pkg198 Stage-2 documented limitation (first-interaction NEE bit,
+sum-to-beauty exact). **pkg205 DONE** (PR #626, 2026-08-19) —
+UnicodeEncodeError console-test hygiene, 3 tests ASCII-ized, test-only.
+**pkg213 DONE** (PR #628, 2026-08-21) — light intensity (Power) exposed in
+the Astroray light panel, UI-surfacing only (engine already consumed
+`light.energy`); render-brighter gate ≥1.5×. **pkg214 OPEN, HW FAIL** (PR
+#629, 2026-08-21) — sodium D-doublet broadening fix (black→amber) regressed
+`mercury_vapor` ~4.5–8.6× via the shared peak-normalisation mechanism; a
+physics-correct energy-normalisation fix is in progress on branch
+`pkg214fix`, do not merge #629 as-is. **pkg206 released from its bias-hold**
+(owner, 2026-08-21) and re-dispatched fresh (branch `pkg206impl*`) after PR
+#627 was closed CI-red/biased — see the spec's 2026-08-21 triage note.
+Pillar 4 stays PAUSED, unchanged. Full detail: `.astroray_plan/docs/STATUS.md`
+top entry "2026-08-19 → 2026-08-21".
+
 **Round closeout (2026-08-14 → 2026-08-15): 9 PRs (#615–#623), no open PRs at closeout — the GPU wavefront gains real god-rays (full HG scattering, both backends) and a full light-path AOV render-pass mirror, a legacy `.blend`-importer sun fix, and 3 more addon settings-honour rows flip PASS.**
 **pkg190 follow-up DONE** (PR #615) — narrowed the GPU procedural bake to
 Generated coord-mode only; Object-coord procedurals now degrade to a

--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -1,5 +1,62 @@
 # Astroray Status
 
+**2026-08-19 → 2026-08-21 (in progress, 6 PRs merged #624–#628, 1 open #629):
+pkg200's last filter-related honour row closes, the pkg198 volume-pass split
+closes, a UnicodeEncodeError test-hygiene chip lands, the light-intensity
+(Power) slider is exposed in the Astroray panel — and the sodium-vapor
+emission fix (#629) is HW FAIL, regressing mercury_vapor via peak-normalisation
+coupling, with a physics-correct fix in progress on branch `pkg214fix`.**
+- **pkg203 DONE** (PR #624, 2026-08-19) — Cycles-accurate pixel-filter
+  width→σ mapping, CPU+GPU byte-mirrored (σ=width/4 Gaussian, ±1.5·width
+  support; BH ±1.0·width support ±2·width offset), cited against Cycles
+  `film.cpp` + PBRT-v4 §8.8. Closes pkg200's last filter-related
+  `pixel_filter_type` HONEST-FAIL row.
+- **pkg204 DONE** (PR #625, 2026-08-19) — GPU wavefront volume-pass
+  direct/indirect split, closing the pkg198 Stage-2 documented limitation:
+  a first-interaction bit in the NEE int lane distinguishes a first
+  volume scatter (`PASS_VOLUME_DIRECT`) from a deeper one
+  (`PASS_VOLUME_INDIRECT`); direct+indirect sum exactly to the combined
+  volume beauty (9 DIRECT/10 INDIRECT split measured); shade-kernel
+  register HARD gate unchanged.
+- **pkg205 DONE** (PR #626, 2026-08-19) — UnicodeEncodeError console-test
+  hygiene: ASCII-ized `print()` glyphs (λ→lambda, π/°→pi/deg, ✓→[OK]) in 3
+  tests that were crashing under cp1252 before their assertions could run;
+  4 passed, 0 UnicodeEncodeError; test-only diff, no engine change.
+- **pkg213 DONE** (PR #628, 2026-08-21) — light intensity (Power) exposed
+  in the Astroray light panel (`layout.prop(light, "energy")`); the engine
+  already consumed `light.energy` (pkg176-era wiring), this was UI-surfacing
+  only. Render-brighter gate ≥1.5× mean linear RGB at 120 vs 30 intensity;
+  headless-Blender wiring gate confirms `add_point_light` receives the set
+  value end-to-end.
+- **pkg214 OPEN, HW FAIL** (PR #629, 2026-08-21) — sodium-vapor lamp fix:
+  broadened the aliased Na D-doublet to an energy-normalised Gaussian
+  (FWHM 15 nm, area-conserving) so the sub-grid line is representable on
+  the 5 nm profile grid (black→amber, R=2.09/G=0.43/B=0.00). HW
+  verification FAILED: the same peak-normalisation change regressed
+  `mercury_vapor` ~4.5–8.6× too bright (coupling through `mat_ls`
+  peak-normalisation, not isolated to sodium as the PR claimed). **A
+  physics-correct energy-normalisation fix is IN PROGRESS on branch
+  `pkg214fix`** — do not merge #629 as-is.
+- **pkg206 released from hold, IN PROGRESS** (owner, 2026-08-21) —
+  luminance-weighted hero-wavelength importance sampling. PR #627 (its
+  first attempt) was CLOSED CI-red/biased: `test_flat_baseline_ssim` FAILED
+  from a stacked realization-change + genuine achromatic-flat green-cast
+  bias (companion wavelengths left at `pdf = 1/span` instead of each
+  divided by the importance density at its own λ). Re-dispatched fresh
+  with the triage's per-wavelength-pdf correction on branch `pkg206impl*`;
+  see the spec's 2026-08-21 triage section for the full root-cause and the
+  distinguishing diagnostic for the next attempt.
+- **Minor tooling note (not a package):** `project_index` knowledge-graph
+  viz fixes landed same window (3D force-graph, orphaned dependency-edge
+  resolution, 2D/3D toggle) — infra, no spec.
+- **Pillar 4 remains PAUSED** — no new owner directive this window; the
+  unpause decision is still standing open, unchanged.
+- **NEXT_STAGE_REPORT.md was stale** (dated 2026-08-15, top pick pkg203
+  had already shipped along with pkg204/pkg205) — regenerated this pass,
+  see that file for the current pickup queue (pkg214fix completion,
+  pkg206 re-verification, pkg201 Stage 3, pkg131, and the Pillar 4
+  unpause decision still at the top).
+
 **2026-08-14 → 2026-08-15 (round closeout, 9 PRs merged #615–#623, no open
 PRs at closeout): the GPU wavefront gains real god-rays (full HG scattering,
 both backends), a full GPU light-path AOV render-pass mirror, a legacy

--- a/.astroray_plan/packages/pkg203-cycles-accurate-pixel-filter-sigma.md
+++ b/.astroray_plan/packages/pkg203-cycles-accurate-pixel-filter-sigma.md
@@ -2,7 +2,7 @@
 
 **Pillar:** Integration Milestone (Blender/DCC integration — reconstruction-filter parity)
 **Track:** A
-**Status:** in-review (PR open 2026-08-19 — CPU+GPU byte-mirrored Cycles mapping σ=width/4, Gaussian support ±1.5·width, BH ±1.0·width; awaiting RTX pkg200 re-run for the honour-row flip).
+**Status:** done (PR #624, 2026-08-19 — CPU+GPU byte-mirrored Cycles mapping σ=width/4, Gaussian support ±1.5·width, BH ±1.0·width; closes pkg200's `pixel_filter_type` honour row).
 **Estimated effort:** S–M.
 **Depends on:** **pkg201 Stage 2** (the GPU wavefront reconstruction-filter code this package modifies — pkg201-S2 adds the GPU pixel-filter weighting: `pixelFilterType`/`pixelFilterWidth` applied in the primary-ray/splat stage, Gaussian branch). Do NOT start until pkg201-S2 has landed on main. Cross-links: **pkg200** (the honour-matrix that measured the finding — the `pixel_filter_type` row is the acceptance gate here), **pkg119-B** (numeric Cycles parity — orthogonal).
 

--- a/.astroray_plan/packages/pkg204-gpu-wavefront-volume-pass-direct-indirect-split.md
+++ b/.astroray_plan/packages/pkg204-gpu-wavefront-volume-pass-direct-indirect-split.md
@@ -2,7 +2,7 @@
 
 **Pillar:** Integration Milestone (GPU wavefront light-path AOV parity)
 **Track:** A
-**Status:** open (filed 2026-08-19).
+**Status:** done (PR #625, 2026-08-19 — closes pkg198 Stage-2 volume-pass limitation; direct+indirect sum exactly to combined volume beauty on GPU, shade-kernel register HARD gate unchanged).
 **Estimated effort:** S.
 **Depends on:** **pkg198 Stage 2** (LANDED, PR #622 — the `HasLightPassAOVs`
 fleet-isolation axis, the `lpAccumulate` global-scatter accumulators, and the

--- a/.astroray_plan/packages/pkg206-luminance-weighted-hero-wavelength-sampling.md
+++ b/.astroray_plan/packages/pkg206-luminance-weighted-hero-wavelength-sampling.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 3 (light transport / spectral rendering) + Integration Milestone (Cycles-parity)
 **Track:** A
-**Status:** open (filed 2026-08-19).
+**Status:** in progress (owner released the bias-hold 2026-08-21; re-dispatched fresh per the 2026-08-21 triage below, branch `pkg206impl`). Was held after PR #627 was closed CI-red/biased (see triage note below); not done.
 **Estimated effort:** M (CPU+GPU byte-mirrored sampler change + pdf plumbing + re-baseline).
 **Depends on:** nothing hard. Composes with pkg189 (GPU hero-λ dispersion, LANDED) and
 the existing spectral MIS caustic path (SMS). CPU/GPU byte-mirrored in the SAME PR.

--- a/.astroray_plan/packages/pkg213-light-intensity-slider.md
+++ b/.astroray_plan/packages/pkg213-light-intensity-slider.md
@@ -2,7 +2,7 @@
 
 **Pillar:** Integration Milestone (Blender/DCC integration — reuse Blender's native settings as the steering wheel)
 **Track:** A
-**Status:** open (filed 2026-08-21).
+**Status:** done (PR #628, 2026-08-21 — `layout.prop(light, "energy")` exposed in the Astroray light panel; render-brighter gate ≥1.5× mean linear RGB, headless-Blender wiring gate confirmed).
 **Estimated effort:** S.
 **Depends on:** none.
 

--- a/.astroray_plan/packages/pkg214-sodium-vapor-emission-fix.md
+++ b/.astroray_plan/packages/pkg214-sodium-vapor-emission-fix.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 3 (light transport / spectral rendering)
 **Track:** A
-**Status:** open (filed 2026-08-21).
+**Status:** in progress — HW FAIL (PR #629 open, 2026-08-21). Sodium D-line broadening fix works (black→amber), but the peak-normalisation coupling regressed `mercury_vapor` ~4.5–8.6× too bright. A physics-correct energy-normalisation fix is in progress on branch `pkg214fix`. NOT done — do not merge #629 as-is.
 **Estimated effort:** S–M (spectral-profile data-build fix + regenerate `profiles.bin` + regression test).
 **Depends on:** none.
 


### PR DESCRIPTION
## Summary
- Flips `Status:` lines: pkg203 done (PR #624), pkg204 done (PR #625), pkg213 done (PR #628). pkg214 marked in-progress/HW FAIL (PR #629 open, mercury_vapor regression, fix in progress on branch `pkg214fix`) — explicitly NOT done. pkg206 marked in-progress (owner released the bias-hold 2026-08-21, re-dispatched on branch `pkg206impl*` after PR #627 was closed CI-red/biased).
- STATUS.md: new top entry for the 2026-08-19 -> 2026-08-21 window (6 PRs merged, 1 open/HW-FAIL), preceding the previously-stale 2026-08-14->15 top entry.
- ROADMAP.md: matching round-closeout-style paragraph inserted above the 2026-08-14->15 entry in the changelog chain; Pillar 4 PAUSED marker left unchanged (still no owner directive).
- NEXT_STAGE_REPORT.md: refreshed date/state/pickup queue — its previous top pick (pkg203) had already shipped along with pkg204/pkg205; now leads with the two in-flight items (pkg214fix, pkg206) before the Pillar-4-unpause ask and the rest of the pool.

Evidence: `git log --oneline origin/main`, `gh pr list --state merged/open`, `gh pr view <n> --json body`, and each touched spec's own `**Status:**` line — no invented numbers, HW-FAIL/in-progress items left un-flipped.

## Test plan
- [x] Doc-only change under `.astroray_plan/` — no source/test/CMakeLists touched (`git diff --name-only` confirms).
- [x] Every changed status line traces to a landed PR (#624/#625/#628) or an explicit HW-FAIL/in-progress PR (#629) / owner action (pkg206 hold release) cited above.
- CI: docs-only push, should skip to green fast per the docs-skip CI rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)