### PR TITLE
feat(pkg215): project-index query/coverage/freshness overhaul

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -26,7 +26,7 @@ new reusable script, register it here in the same commit.
 | Render-output triage | `scripts/diagnostics/render_output_triage.py` |
 | Denoiser A/B | `scripts/diagnostics/oidn_comparison.py` |
 | Roadmap orchestrator tick | `scripts/orchestrator_tick.ps1` → `python -m roadmap_orchestrator.cli` |
-| Project knowledge index (search / deps / node-tree graph) | `scripts/project_index.py` (SQLite; `build` / `query` / `deps` / `graph` / `gh-sync`) |
+| Project knowledge index (search / owns / deps / node-tree graph) | `scripts/project_index.py` (SQLite; `build` / `query` / `owns <path>` / `script <task>` / `whatis <pkg>` / `deps` / `graph` / `gh-sync`; auto-rebuilds when a spec is newer than the DB) |
 | Open-weight model evaluation bench | `scripts/model_bench.py` (`--dry-run`, `--models`, `--timeout`; read-only, writes `docs/model-bench-results.json`) |
 | Native-settings F12 pixel-honour A/B matrix (does each adopted Blender/Cycles control actually change the render?) | `scripts/verify_pkg200_honour_matrix_run.py` (outer, cv2/per-channel mean-ratio) + `verify_pkg200_honour_matrix.py` (in-Blender A/B leg) + `pkg200_honour_matrix.py` (pure contract/predicate layer, enumerated from `settings_map.py`) |
 | Import a .blend without Blender | `tools/blend_import/blend_to_astroray.py` |

--- a/scripts/project_index.py
+++ b/scripts/project_index.py
@@ -13,13 +13,19 @@ staleness amplification.
 
 Usage:
   python -m project_index build              # (re)build the index (default)
-  python -m project_index query "pixel filter"
+  python -m project_index query "pixel filter"   # scannable title/body/file search
   python -m project_index deps pkg203        # dependencies + reverse deps
+  python -m project_index owns include/gpu_materials.h  # which package owns a file
+  python -m project_index script "contact sheet"        # canonical script for a task
+  python -m project_index whatis pkg214      # compact card for one package
   python -m project_index graph --json out.json   # nodes/edges for the viz
   python -m project_index graph --html graph.html # self-contained node tree
   python -m project_index gh-sync            # pull issues/PRs via gh CLI (network)
 
-The DB is written to .astroray_plan/.project-index.db (gitignored).
+The DB is written to .astroray_plan/.project-index.db (gitignored). Read
+commands (query/deps/owns/script/whatis) auto-rebuild it when a source file is
+newer than the DB and print "(index rebuilt)" to stderr, so answers are never
+silently stale.
 """
 from __future__ import annotations
 
@@ -34,9 +40,21 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 PLAN = ROOT / ".astroray_plan"
 DB_PATH = PLAN / ".project-index.db"
+README_PATH = ROOT / "scripts" / "README.md"
 
 PKG_ID_RE = re.compile(r"^pkg(\d+[a-z]?)", re.IGNORECASE)
 DEP_RE = re.compile(r"pkg\d+[a-z]?", re.IGNORECASE)
+
+
+def _status_token(raw: str) -> str:
+    """Reduce a Status line to a short scannable token.
+
+    Takes the text up to the first of '(', em-dash, '.', ',', or newline,
+    lower-cased and stripped. e.g. "done (PR #540, ...)" -> "done";
+    "open (filed 2026-08-21)." -> "open"; "Stage 2 done ..." -> "stage 2 done".
+    """
+    token = re.split(r"[(—.,\n]", raw, maxsplit=1)[0]
+    return token.strip().lower()
 
 
 def _pkg_files() -> list[Path]:
@@ -86,16 +104,19 @@ def _parse_package(path: Path) -> dict:
             if cells and cells[0] and not cells[0].startswith("---") and cells[0] != "File":
                 files.append((cells[0], section))
 
+    status = field_line("Status")
     return {
         "key": key,
         "num": num,
         "title": title,
         "pillar": field_line("Pillar"),
         "track": field_line("Track"),
-        "status": field_line("Status"),
+        "status": status,
+        "status_short": _status_token(status),
         "effort": field_line("Estimated effort"),
         "depends": depends,
         "files": files,
+        "body": text,
     }
 
 
@@ -124,6 +145,34 @@ def _parse_tests() -> list[dict]:
     return out
 
 
+def _parse_scripts_map() -> list[dict]:
+    """Parse the "Canonical script per task" table from scripts/README.md.
+
+    Serves the CLAUDE.md 5b no-duplicate-scripts gate: one (task, script) row
+    per table row so `script <substring>` can answer "what's the canonical
+    script for task X?".
+    """
+    out: list[dict] = []
+    if not README_PATH.exists():
+        return out
+    in_table = False
+    for line in README_PATH.read_text(encoding="utf-8", errors="replace").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("## "):
+            in_table = stripped.lower().startswith("## canonical script per task")
+            continue
+        if not in_table or not stripped.startswith("|"):
+            continue
+        cells = [c.strip() for c in stripped.strip("|").split("|")]
+        if len(cells) < 2:
+            continue
+        task, script = cells[0], cells[1]
+        if not task or task == "Task" or task.startswith("---"):
+            continue
+        out.append({"task": task, "script": script})
+    return out
+
+
 def build(db: sqlite3.Connection) -> None:
     db.executescript(
         """
@@ -132,21 +181,25 @@ def build(db: sqlite3.Connection) -> None:
         DROP TABLE IF EXISTS docs;
         DROP TABLE IF EXISTS tests;
         DROP TABLE IF EXISTS issues;
+        DROP TABLE IF EXISTS scripts_map;
         CREATE TABLE packages (
             key TEXT PRIMARY KEY, num TEXT, title TEXT, pillar TEXT,
-            track TEXT, status TEXT, effort TEXT, depends TEXT
+            track TEXT, status TEXT, status_short TEXT, effort TEXT,
+            depends TEXT, body TEXT
         );
         CREATE TABLE package_files (package_key TEXT, path TEXT, action TEXT);
         CREATE TABLE docs (file TEXT PRIMARY KEY, title TEXT);
         CREATE TABLE tests (file TEXT PRIMARY KEY, count INTEGER, names TEXT);
         CREATE TABLE issues (kind TEXT, number INTEGER, title TEXT, state TEXT, url TEXT);
+        CREATE TABLE scripts_map (task TEXT, script TEXT);
         """
     )
     for p in _pkg_files():
         d = _parse_package(p)
         db.execute(
-            "INSERT OR REPLACE INTO packages VALUES (?,?,?,?,?,?,?,?)",
-            (d["key"], d["num"], d["title"], d["pillar"], d["track"], d["status"], d["effort"], ",".join(d["depends"])),
+            "INSERT OR REPLACE INTO packages VALUES (?,?,?,?,?,?,?,?,?,?)",
+            (d["key"], d["num"], d["title"], d["pillar"], d["track"], d["status"],
+             d["status_short"], d["effort"], ",".join(d["depends"]), d["body"]),
         )
         for fpath, action in d["files"]:
             db.execute("INSERT INTO package_files VALUES (?,?,?)", (d["key"], fpath, action))
@@ -154,6 +207,8 @@ def build(db: sqlite3.Connection) -> None:
         db.execute("INSERT OR REPLACE INTO docs VALUES (?,?)", (d["file"], d["title"]))
     for t in _parse_tests():
         db.execute("INSERT INTO tests VALUES (?,?,?)", (t["file"], t["count"], json.dumps(t["names"])))
+    for s in _parse_scripts_map():
+        db.execute("INSERT INTO scripts_map VALUES (?,?)", (s["task"], s["script"]))
     db.commit()
 
 
@@ -184,18 +239,120 @@ def _connect() -> sqlite3.Connection:
     return sqlite3.connect(DB_PATH)
 
 
+def _freshness_sources() -> list[Path]:
+    """Every source file whose change should invalidate the DB."""
+    srcs: list[Path] = []
+    srcs += (PLAN / "packages").glob("*.md")
+    for p in (PLAN / "docs").rglob("*.md"):
+        rel = str(p.relative_to(PLAN))
+        if "/archive/" in rel or "\\archive\\" in rel:
+            continue
+        srcs.append(p)
+    srcs += (ROOT / "tests").glob("test_*.py")
+    if README_PATH.exists():
+        srcs.append(README_PATH)
+    return srcs
+
+
+def _db_is_stale() -> bool:
+    """True if the DB is missing or older than the newest source file."""
+    if not DB_PATH.exists():
+        return True
+    db_mtime = DB_PATH.stat().st_mtime
+    for p in _freshness_sources():
+        try:
+            if p.stat().st_mtime > db_mtime:
+                return True
+        except OSError:
+            continue
+    return False
+
+
 def query(db: sqlite3.Connection, text: str) -> None:
     words = re.findall(r"[\w]+", text)
     like = "%" + "%".join(words) + "%"
     print(f"== packages matching {text!r}")
+    seen: set[str] = set()
     for row in db.execute(
-        "SELECT num, title, status, pillar FROM packages WHERE title LIKE ? OR status LIKE ? OR pillar LIKE ? ORDER BY num",
+        "SELECT DISTINCT key, num, title, status_short FROM packages "
+        "WHERE title LIKE ? OR body LIKE ? "
+        "OR key IN (SELECT package_key FROM package_files WHERE path LIKE ?) "
+        "ORDER BY num",
         (like, like, like),
     ):
-        print(f"  {row[0]:>8}  [{row[2]}] {row[1]}")
+        key, num, title, status_short = row
+        if key in seen:
+            continue
+        seen.add(key)
+        title = (title or "")[:80]
+        # Cap the token too: a handful of specs jam narrative onto the Status
+        # line with no early delimiter, so the raw token can be long. Keeps
+        # every query line scannable (<=120 chars).
+        tok = status_short if len(status_short) <= 24 else status_short[:22] + ".."
+        print(f"  {num:>8}  [{tok}] {title}")
     print(f"== docs matching {text!r}")
     for row in db.execute("SELECT file, title FROM docs WHERE title LIKE ? OR file LIKE ? ORDER BY file", (like, like)):
-        print(f"  {row[0]:<50} {row[1]}")
+        line = f"  {row[0]:<50} {row[1] or ''}"
+        print(line[:118])
+
+
+def owns(db: sqlite3.Connection, path: str) -> None:
+    needle = "%" + path.replace("\\", "/").strip("/") + "%"
+    print(f"== packages owning {path!r}")
+    rows = db.execute(
+        "SELECT f.package_key, p.status_short, f.action, f.path "
+        "FROM package_files f JOIN packages p ON p.key = f.package_key "
+        "WHERE REPLACE(f.path, '\\', '/') LIKE ? ORDER BY f.package_key",
+        (needle,),
+    ).fetchall()
+    if not rows:
+        print(f"  no package records touching {path}")
+        return
+    for key, status_short, action, fpath in rows:
+        print(f"  {key:>10}  [{status_short}]  {action:<6}  {fpath}")
+
+
+def script(db: sqlite3.Connection, task: str) -> None:
+    needle = "%" + task.lower() + "%"
+    print(f"== canonical scripts for task {task!r}")
+    rows = db.execute(
+        "SELECT task, script FROM scripts_map WHERE LOWER(task) LIKE ? ORDER BY task",
+        (needle,),
+    ).fetchall()
+    if not rows:
+        print(f"  no canonical script registered for {task}")
+        return
+    for t, s in rows:
+        print(f"  {t} -> {s}")
+
+
+def whatis(db: sqlite3.Connection, num: str) -> None:
+    num = num.lower()
+    row = db.execute(
+        "SELECT key, title, status, status_short, track, pillar, effort, depends FROM packages WHERE num = ?",
+        (num,),
+    ).fetchone()
+    if not row:
+        print(f"no package with num {num}")
+        return
+    key, title, status, status_short, track, pillar, effort, dep_str = row
+    deps_list = dep_str.split(",") if dep_str else []
+    rev = [r[0] for r in db.execute("SELECT key FROM packages WHERE depends LIKE ?", (f"%{num}%",)).fetchall()
+           if r[0] != key]
+    files = db.execute(
+        "SELECT action, path FROM package_files WHERE package_key = ? ORDER BY action, path", (key,)
+    ).fetchall()
+    print(f"{key}  [{status_short}] {title}")
+    print(f"  status : {status}")
+    print(f"  track  : {track or '(none)'}    pillar: {pillar or '(none)'}    effort: {effort or '(none)'}")
+    print(f"  depends on: {', '.join(deps_list) or '(none)'}")
+    print(f"  depended on by ({len(rev)}): {', '.join(rev) or '(none)'}")
+    if files:
+        print(f"  owned files ({len(files)}):")
+        for action, fpath in files:
+            print(f"    {action:<6}  {fpath}")
+    else:
+        print("  owned files (0): (none)")
 
 
 def deps(db: sqlite3.Connection, num: str) -> None:
@@ -446,21 +603,35 @@ def main() -> None:
     sub = ap.add_subparsers(dest="cmd")
 
     sub.add_parser("build", help="build the index")
-    p_q = sub.add_parser("query", help="search the index")
+    p_q = sub.add_parser("query", help="search title/body/file paths (scannable)")
     p_q.add_argument("text")
     p_d = sub.add_parser("deps", help="show a package's dependencies")
     p_d.add_argument("num")
+    p_o = sub.add_parser("owns", help="which package owns a file path")
+    p_o.add_argument("path")
+    p_s = sub.add_parser("script", help="canonical script for a task (scripts/README.md)")
+    p_s.add_argument("task")
+    p_w = sub.add_parser("whatis", help="compact card for one package")
+    p_w.add_argument("num")
     p_g = sub.add_parser("graph", help="emit nodes/edges JSON or an HTML node tree")
     p_g.add_argument("--json", dest="json_out")
     p_g.add_argument("--html", dest="html_out")
     sub.add_parser("gh-sync", help="sync GitHub issues/PRs")
 
     args = ap.parse_args()
+    # Capture staleness BEFORE connecting: sqlite3.connect() creates an empty
+    # file, which would otherwise look "fresh" (mtime=now) but have no tables.
+    stale = _db_is_stale()
     if not DB_PATH.exists():
         Path(DB_PATH).parent.mkdir(parents=True, exist_ok=True)
     db = _connect()
 
     cmd = args.cmd or "build"
+    # Read commands auto-rebuild when a source file is newer than the DB.
+    if cmd in ("query", "deps", "owns", "script", "whatis") and stale:
+        build(db)
+        print("(index rebuilt)", file=sys.stderr)
+
     if cmd == "build":
         build(db)
         print(f"indexed {db.execute('SELECT COUNT(*) FROM packages').fetchone()[0]} packages, "
@@ -470,6 +641,12 @@ def main() -> None:
         query(db, args.text)
     elif cmd == "deps":
         deps(db, args.num)
+    elif cmd == "owns":
+        owns(db, args.path)
+    elif cmd == "script":
+        script(db, args.task)
+    elif cmd == "whatis":
+        whatis(db, args.num)
     elif cmd == "graph":
         graph(db, args.json_out, args.html_out)
     elif cmd == "gh-sync":

--- a/tests/test_project_index.py
+++ b/tests/test_project_index.py
@@ -1,0 +1,223 @@
+"""Tests for scripts/project_index.py — pkg215 query/coverage/freshness overhaul.
+
+Pure-Python; drives the CLI via subprocess against the live repo so the tests
+can't rot (they discover the packages/paths they assert on from the built DB).
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "project_index.py"
+DB_PATH = ROOT / ".astroray_plan" / ".project-index.db"
+PACKAGES_DIR = ROOT / ".astroray_plan" / "packages"
+README = ROOT / "scripts" / "README.md"
+
+
+def run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+    )
+
+
+@pytest.fixture(scope="module")
+def built_db():
+    r = run("build")
+    assert r.returncode == 0, r.stderr
+    assert DB_PATH.exists()
+    yield DB_PATH
+
+
+def _connect():
+    return sqlite3.connect(DB_PATH)
+
+
+# --- 1. Scannable query -----------------------------------------------------
+
+def test_query_is_scannable_single_line(built_db):
+    r = run("query", "TRANSMISSION lobe CREATES")
+    assert r.returncode == 0, r.stderr
+    pkg_lines = [ln for ln in r.stdout.splitlines() if ln.strip().startswith("pkg169")]
+    assert len(pkg_lines) == 1, f"pkg169 should be one line, got {pkg_lines}"
+    line = pkg_lines[0]
+    assert "[done]" in line
+    # NOT the full multi-paragraph post-mortem.
+    assert "PBRT-v4" not in line and "furnace after fix" not in line.lower()
+
+
+def test_no_query_line_exceeds_120_chars(built_db):
+    r = run("query", "glass")
+    assert r.returncode == 0, r.stderr
+    for ln in r.stdout.splitlines():
+        assert len(ln) <= 120, f"line too long ({len(ln)}): {ln}"
+    # one line per matching spec, none repeated. (A single pkg *number* may own
+    # several distinct spec files — e.g. pkg64 has four — so the invariant is
+    # "no duplicate hit line", not "unique pkg number".)
+    hits = [ln for ln in r.stdout.splitlines() if ln.strip().startswith("pkg")]
+    assert len(hits) == len(set(hits))
+
+
+# --- 2. Body / file-path search --------------------------------------------
+
+def test_query_matches_file_path_not_in_title(built_db):
+    """A term present only in a Files-to-modify path must return the package."""
+    con = _connect()
+    # Find a (package, path-token) where the token is absent from title/status/pillar.
+    chosen = None
+    for key, path in con.execute("SELECT package_key, path FROM package_files"):
+        title, status, pillar = con.execute(
+            "SELECT title, status, pillar FROM packages WHERE key = ?", (key,)
+        ).fetchone()
+        blob = f"{title} {status} {pillar}".lower()
+        # a distinctive filename stem token
+        stem = re.split(r"[\\/]", path)[-1]
+        token = re.sub(r"\.[a-z0-9]+$", "", stem).lower()
+        if len(token) >= 6 and token not in blob and token.isidentifier() is False:
+            # prefer a token with an underscore/dash (clearly a path fragment)
+            if "_" in token or "-" in token:
+                chosen = (key, token)
+                break
+    assert chosen, "expected at least one file-path-only token in the repo"
+    key, token = chosen
+    con.close()
+    r = run("query", token)
+    assert r.returncode == 0, r.stderr
+    num = key  # package hit lines print num; num is a prefix of key
+    assert any(token_line_matches(ln, key) for ln in r.stdout.splitlines()), \
+        f"query {token!r} should return {key}; got:\n{r.stdout}"
+
+
+def token_line_matches(line: str, key: str) -> bool:
+    line = line.strip()
+    if not line.startswith("pkg"):
+        return False
+    num = line.split()[0]
+    return key.startswith(num)
+
+
+# --- 3. owns ----------------------------------------------------------------
+
+def test_owns_hit(built_db):
+    con = _connect()
+    key, path, action = con.execute(
+        "SELECT package_key, path, action FROM package_files LIMIT 1"
+    ).fetchone()
+    con.close()
+    base = re.split(r"[\\/]", path)[-1]
+    r = run("owns", base)
+    assert r.returncode == 0, r.stderr
+    assert key in r.stdout, f"owns {base!r} should list {key}:\n{r.stdout}"
+
+
+def test_owns_miss_exits_zero(built_db):
+    r = run("owns", "nonexistent/path.xyz")
+    assert r.returncode == 0
+    assert "no package records touching nonexistent/path.xyz" in r.stdout
+
+
+# --- 4. script --------------------------------------------------------------
+
+def _readme_table_rows_matching(substr: str) -> int:
+    substr = substr.lower()
+    count = 0
+    in_table = False
+    for line in README.read_text(encoding="utf-8").splitlines():
+        s = line.strip()
+        if s.startswith("## "):
+            in_table = s.lower().startswith("## canonical script per task")
+            continue
+        if not in_table or not s.startswith("|"):
+            continue
+        cells = [c.strip() for c in s.strip("|").split("|")]
+        if len(cells) < 2 or not cells[0] or cells[0] == "Task" or cells[0].startswith("---"):
+            continue
+        if substr in cells[0].lower():
+            count += 1
+    return count
+
+
+def test_script_lookup_contact_sheet(built_db):
+    r = run("script", "contact sheet")
+    assert r.returncode == 0, r.stderr
+    assert "benchmarks/showcase/runner.py" in r.stdout
+    printed_rows = [ln for ln in r.stdout.splitlines() if " -> " in ln]
+    assert len(printed_rows) == _readme_table_rows_matching("contact sheet")
+
+
+# --- 5. whatis --------------------------------------------------------------
+
+def test_whatis_pkg214(built_db):
+    r = run("whatis", "pkg214")
+    assert r.returncode == 0, r.stderr
+    out = r.stdout
+    assert "pkg214" in out
+    assert "status :" in out
+    assert "track" in out
+    assert "depends on:" in out
+    assert "owned files" in out
+
+
+# --- 6. Read-time freshness -------------------------------------------------
+
+def test_freshness_autorebuild_on_stale(built_db):
+    # Ensure DB exists and is current.
+    run("build")
+    token = f"freshprobe{int(time.time())}zzz"
+    probe = PACKAGES_DIR / "pkg998-freshness-probe.md"
+    probe.write_text(
+        f"# pkg998 - freshness probe\n\n**Status:** open.\n\nbody term {token}\n",
+        encoding="utf-8",
+    )
+    try:
+        # Make the probe unambiguously newer than the DB.
+        future = time.time() + 20
+        os.utime(probe, (future, future))
+        r = run("query", token)
+        assert r.returncode == 0, r.stderr
+        assert "(index rebuilt)" in r.stderr, f"expected rebuild note; stderr={r.stderr!r}"
+        assert any(ln.strip().startswith("pkg998") for ln in r.stdout.splitlines()), \
+            f"new spec content not reflected:\n{r.stdout}"
+    finally:
+        probe.unlink()
+        run("build")  # restore a clean DB without the probe
+
+
+# --- 7. No regression -------------------------------------------------------
+
+def test_build_deps_graph_still_work(built_db, tmp_path):
+    r = run("build")
+    assert r.returncode == 0
+    assert "indexed" in r.stdout and "packages" in r.stdout
+
+    r = run("deps", "pkg214")
+    assert r.returncode == 0, r.stderr
+    assert "depends on:" in r.stdout
+    assert "depended on by" in r.stdout
+
+    out_json = tmp_path / "g.json"
+    r = run("graph", "--json", str(out_json))
+    assert r.returncode == 0, r.stderr
+    payload = json.loads(out_json.read_text(encoding="utf-8"))
+    assert "nodes" in payload and "edges" in payload
+    assert len(payload["nodes"]) > 0 and len(payload["edges"]) > 0
+
+
+def test_graph_html_is_wellformed(built_db, tmp_path):
+    out_html = tmp_path / "g.html"
+    r = run("graph", "--html", str(out_html))
+    assert r.returncode == 0, r.stderr
+    html = out_html.read_text(encoding="utf-8")
+    assert html.startswith("<!doctype html>")
+    assert html.rstrip().endswith("</html>")
+    assert "3d-force-graph" in html
+    assert "__DATA__" not in html  # template placeholder was substituted


### PR DESCRIPTION
Implements pkg215 (architect diagnosis #630): makes the project-index actually useful for coding agents.

## What changed (all in `scripts/project_index.py`, pure Python)
- **Scannable `query`** — one short `[status]` line per hit, not the full multi-paragraph Status post-mortem.
- **Body + Files-path search** — matches terms in a spec body / Files-to-modify path, not just title/status/pillar.
- **New `owns <path>`** — which package owns a file (e.g. `owns src/spectrum.cpp` → pkg10-spectral-types).
- **New `script <task>`** — canonical script from scripts/README (the §5b no-duplicate map).
- **New `whatis <pkg>`** — title/status/track/depends/owned-files.
- **Read-time freshness** — auto-rebuild when a spec is newer than the DB (`(index rebuilt)` on stderr).
- No regression: `deps`/`build`/`graph` intact (knowledge-graph viz w/ doc edges + 2D/3D toggle preserved); `scripts/README.md` row updated.

## Tests
`tests/test_project_index.py` — **10/10 pass** (scannable single-line, body/file search, owns hit+miss, script row count, whatis, freshness auto-rebuild, no-regression smoke).

Note: pkg216 (wiring the index into agent definitions) is a separate, owner-gated follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)