### PR TITLE
fix(addon): native Astroray nodes on stock Material Output no longer render grey

### DIFF
--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -2243,6 +2243,15 @@ class CustomRaytracerRenderEngine(RenderEngine):
             return _apply_spectral_profile(renderer.create_material('disney', [0.8, 0.8, 0.8], {}))
 
         shader_node = surface_input.links[0].from_node
+        # A native Astroray node (Sellmeier Glass, Blackbody/Spectral source,
+        # IR/UV, NRC hint) wired straight into the stock Material Output must
+        # convert identically to the AstrorayOutputNode path — otherwise it
+        # falls through to convert_shader_node and silently renders neutral grey
+        # (the #1 "spectral/dispersion nodes don't work" report). See the
+        # shared _convert_astroray_native_surface helper.
+        native = self._convert_astroray_native_surface(shader_node, mat, renderer, node_tree)
+        if native is not None:
+            return _apply_spectral_profile(native)
         return _apply_spectral_profile(self.convert_shader_node(shader_node, renderer, node_tree))
 
     # ------------------------------------------------------------------ #
@@ -2260,8 +2269,25 @@ class CustomRaytracerRenderEngine(RenderEngine):
             return renderer.create_material('disney', [0.8, 0.8, 0.8], {})
 
         wired = surface_input.links[0].from_node
-        bl_idname = getattr(wired, 'bl_idname', '')
+        native = self._convert_astroray_native_surface(wired, mat, renderer, node_tree)
+        if native is not None:
+            return native
+        # Cycles / standalone fallback: dispatch through the existing path.
+        return self.convert_shader_node(wired, renderer, node_tree)
 
+    def _convert_astroray_native_surface(self, wired, mat, renderer, node_tree):
+        """Dispatch an Astroray-native surface node to its material builder.
+
+        Returns a material id, or None when `wired` is not a recognized native
+        node (the caller then falls back to convert_shader_node). Shared by
+        convert_astroray_output (the AstrorayOutputNode path) AND
+        convert_node_material's standard Material Output path, so a native node
+        renders identically no matter which output it is wired into. This
+        matches the Cycles workflow, where users wire everything to the stock
+        "Material Output" — without this, a native node on Material Output fell
+        through to convert_shader_node and silently rendered neutral grey.
+        """
+        bl_idname = getattr(wired, 'bl_idname', '')
         if bl_idname == 'AstrorayShaderNodeSellmeierGlass':
             return self._create_astroray_material(
                 self._astroray_sellmeier_spec(wired, mat), renderer, node_tree)
@@ -2281,8 +2307,7 @@ class CustomRaytracerRenderEngine(RenderEngine):
             self._register_source_node_profile(wired, mat)
             return self._create_astroray_material(
                 {'kind': 'astroray_spectral_only'}, renderer, node_tree)
-        # Cycles / standalone fallback: dispatch through the existing path.
-        return self.convert_shader_node(wired, renderer, node_tree)
+        return None
 
     def _register_source_node_profile(self, node, mat):
         """pkg195 Stage C: resolve a spectrum source node to a profile NAME and

--- a/tests/test_blender_native_nodes.py
+++ b/tests/test_blender_native_nodes.py
@@ -424,6 +424,54 @@ def test_astroray_output_takes_precedence_with_sellmeier_glass(monkeypatch):
         f"got {params}")
 
 
+def test_sellmeier_glass_on_standard_material_output(monkeypatch):
+    """Regression (2026-08-21): a native Astroray node wired into Blender's
+    STANDARD 'Material Output' (ShaderNodeOutputMaterial) — NOT an
+    AstrorayOutputNode — must still convert to its native material, exactly as
+    the AstrorayOutputNode path does. Before the fix it fell through to
+    convert_shader_node and silently rendered neutral grey, the #1
+    'dispersion/spectral nodes don't work' report (Cycles users wire everything
+    to Material Output)."""
+    addon = _load_blender_addon(monkeypatch)
+
+    sellmeier = _Node(
+        bl_idname="AstrorayShaderNodeSellmeierGlass",
+        inputs={
+            'Sellmeier B': _Socket(default=(1.04, 0.23, 1.01)),
+            'Sellmeier C': _Socket(default=(0.006, 0.020, 103.5)),
+            'Tint':        _Socket(default=(1.0, 1.0, 1.0, 1.0)),
+        },
+        preset="bk7",
+        use_preset=True,
+        ior_design=1.5168,
+    )
+    output = _Node(
+        ntype="OUTPUT_MATERIAL",
+        bl_idname="ShaderNodeOutputMaterial",
+        inputs={
+            'Surface': _Socket(linked_to=sellmeier, output_name="BSDF"),
+            'Volume':  _Socket(),
+        },
+    )
+    tree = _NodeTree([sellmeier, output])
+    mat = _Material(tree)
+
+    renderer = _RecordingRenderer()
+    engine = addon.CustomRaytracerRenderEngine()
+    engine._volume_material_map = {}
+    mat_id = engine.convert_node_material(mat, renderer)
+    assert mat_id == 1
+    assert len(renderer.created_materials) == 1
+    mat_type, _color, params = renderer.created_materials[0]
+    assert mat_type == "dielectric", (
+        f"SellmeierGlass on the STANDARD Material Output must route to "
+        f"'dielectric' (dispersive glass), not the grey disney/principled "
+        f"fallback; got {mat_type!r}.")
+    assert params.get("sellmeier_preset") == "bk7", (
+        f"Sellmeier preset 'bk7' must reach the dielectric plugin params; "
+        f"got {params}")
+
+
 def test_astroray_output_without_surface_falls_back(monkeypatch):
     """An AstrorayOutputNode with no Surface link must produce a neutral
     material rather than crashing."""


### PR DESCRIPTION
## Bug
Native Astroray shader nodes (Sellmeier Glass, Blackbody/Spectral sources, IR/UV response, NRC hint) silently render **neutral grey** when wired into Blender's stock **Material Output** node. They were only dispatched by `convert_astroray_output`, reached solely when the material contains an `AstrorayOutputNode`. A native node on the standard `ShaderNodeOutputMaterial` fell through to `convert_shader_node`, which doesn't recognize the CUSTOM node and emitted only a console warning.

Found via live Blender MCP testing (2026-08-21). This is the **#1 reason users report "dispersion/spectral nodes don't work"** — coming from Cycles, they wire everything to Material Output and the node silently vanishes.

## Fix (Option A — matches Cycles UX)
Extracted the native-node dispatch into a shared helper `_convert_astroray_native_surface()` returning a material id or `None`, called from **both** output paths:
- `convert_astroray_output` (the `AstrorayOutputNode` path)
- `convert_node_material`'s standard Material Output surface path (wrapped in `_apply_spectral_profile` so spectral-source nodes attach their profile identically)

Non-native nodes return `None`, so stock materials route through `convert_shader_node` **unchanged** — low-risk, no behavior change for existing Cycles materials.

Scope kept surgical: dispatch fires at top-level surface resolution only, exactly matching the prior `convert_astroray_output` behavior (a native node buried inside a Mix/Add Shader was already untranslated and remains so).

## Test
Adds `test_sellmeier_glass_on_standard_material_output` — builds a Sellmeier Glass node on a standard `ShaderNodeOutputMaterial` and asserts it converts to `dielectric` with the `bk7` preset, not the grey fallback.

## Verification
- Confirmed the test **reproduces the bug**: with the addon fix reverted it fails (`got 'disney'`); with the fix it passes.
- Native-nodes file: 8 passed.
- Broader addon suite (native-nodes, pkg95 camera, pkg115 texture, principled-texture): **22 passed, 2 skipped** — confirms stock materials untouched.

Python-only (Blender addon); no CUDA rebuild needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)