### PR TITLE
feat(pkg216): wire project-index into agent definitions

### DIFF
--- a/.astroray_plan/packages/pkg216-project-index-agent-wiring.md
+++ b/.astroray_plan/packages/pkg216-project-index-agent-wiring.md
@@ -1,7 +1,7 @@
 # pkg216 — Put the project-index in front of the agents
 
 **Track:** A
-**Status:** open (filed 2026-08-21).
+**Status:** done (PR #636, 2026-08-21 — index wired into 3 agents x 2 harnesses + AGENTS.md/KNOWLEDGE.md; twins byte-identical).
 **Estimated effort:** S.
 **Depends on:** pkg215.
 

--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -27,7 +27,10 @@ Protocol:
 1. Read the current project state SILENTLY before opening dialogue. Read
    `STATUS.md`, `ROADMAP.md`, the most recent `NEXT_STAGE_REPORT.md`, and any
    research notes relevant to the goal. Do not ask "what's in the repo" —
-   read it.
+   read it. Before proposing scope, run
+   `python scripts/project_index.py query "<topic>"` and
+   `python scripts/project_index.py deps pkgN` to ground new specs in existing
+   packages and their dependencies.
 2. Research externally if needed (`WebSearch`, `WebFetch`). Check Cycles
    changelogs, recent SIGGRAPH proceedings, OIDN/OptiX/tcnn release notes,
    papers in `.astroray_plan/docs/`.

--- a/.claude/agents/docs-updater.md
+++ b/.claude/agents/docs-updater.md
@@ -37,6 +37,10 @@ numbers, PR number, merge date.
 
 ### 2 — Flip spec statuses
 
+Before flipping statuses, run `python scripts/project_index.py owns <path>` and
+`python scripts/project_index.py deps pkgN` on the landed change to find every
+spec it affects — not just the one named in the PR title.
+
 For each package that landed: open its spec in `.astroray_plan/packages/`
 and change the `Status:` line to:
 

--- a/.claude/agents/package-implementer.md
+++ b/.claude/agents/package-implementer.md
@@ -32,6 +32,14 @@ paper over problems, and you stop when something the spec doesn't resolve.
    say so before proceeding. If a simpler approach exists than what the spec
    describes, say so and wait for confirmation.
 
+4. Before editing an existing file, run
+   `python scripts/project_index.py owns <path>` to see which packages own it
+   and their status — it surfaces prior/related work grep won't.
+
+5. Before writing ANY new script, run
+   `python scripts/project_index.py script "<task>"` (the CLAUDE.md §5b
+   no-duplicate gate) in addition to reading `scripts/README.md`.
+
 ## Worktree discipline
 
 **Do NOT rely on `EnterWorktree` — it's harness-level and doesn't propagate to subagent tool calls.** Create your own worktree as a SIBLING of the main checkout:

--- a/.opencode/agents/architect.md
+++ b/.opencode/agents/architect.md
@@ -24,7 +24,10 @@ Protocol:
 1. Read the current project state SILENTLY before opening dialogue. Read
    `STATUS.md`, `ROADMAP.md`, the most recent `NEXT_STAGE_REPORT.md`, and any
    research notes relevant to the goal. Do not ask "what's in the repo" —
-   read it.
+   read it. Before proposing scope, run
+   `python scripts/project_index.py query "<topic>"` and
+   `python scripts/project_index.py deps pkgN` to ground new specs in existing
+   packages and their dependencies.
 2. Research externally if needed (`WebSearch`, `WebFetch`). Check Cycles
    changelogs, recent SIGGRAPH proceedings, OIDN/OptiX/tcnn release notes,
    papers in `.astroray_plan/docs/`.

--- a/.opencode/agents/docs-updater.md
+++ b/.opencode/agents/docs-updater.md
@@ -35,6 +35,10 @@ numbers, PR number, merge date.
 
 ### 2 — Flip spec statuses
 
+Before flipping statuses, run `python scripts/project_index.py owns <path>` and
+`python scripts/project_index.py deps pkgN` on the landed change to find every
+spec it affects — not just the one named in the PR title.
+
 For each package that landed: open its spec in `.astroray_plan/packages/`
 and change the `Status:` line to:
 

--- a/.opencode/agents/package-implementer.md
+++ b/.opencode/agents/package-implementer.md
@@ -29,6 +29,14 @@ paper over problems, and you stop when something the spec doesn't resolve.
    say so before proceeding. If a simpler approach exists than what the spec
    describes, say so and wait for confirmation.
 
+4. Before editing an existing file, run
+   `python scripts/project_index.py owns <path>` to see which packages own it
+   and their status — it surfaces prior/related work grep won't.
+
+5. Before writing ANY new script, run
+   `python scripts/project_index.py script "<task>"` (the CLAUDE.md §5b
+   no-duplicate gate) in addition to reading `scripts/README.md`.
+
 ## Worktree discipline
 
 Create your own worktree as a SIBLING of the main checkout:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,10 @@ Astroray/
 - `AGENTS.md` is the shared repo contract for coding agents.
 - `CLAUDE.md` remains Claude Code's behavioral guide. Do not delete or replace it.
 - `.astroray_plan/docs/STATUS.md` is the current planning source of truth.
+- `KNOWLEDGE.md` is the repo routing map — it documents `scripts/project_index.py`
+  (`query`/`owns`/`script`/`deps`/`whatis`) for answering "who owns this file",
+  "what package does X", and "is there already a script for this task". Consult it
+  before grepping blind.
 - Keep agent-specific notes additive. If a rule belongs to all agents, put it here.
 - **Before writing any new script, check `scripts/README.md` (the canonical
   per-task script index) and grep `scripts/`, `benchmarks/`, `tools/` for an

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -22,6 +22,9 @@ packages, docs, tests, and optionally GitHub issues/PRs).
 ## Search & graph
 
 - `python scripts/project_index.py query "pixel filter"` — search packages + docs (word-wise).
+- `python scripts/project_index.py owns <path>` — which package(s) own a file path, plus their status.
+- `python scripts/project_index.py script "<task>"` — the canonical script for a task (the CLAUDE.md §5b no-duplicate gate; mirrors `scripts/README.md`).
+- `python scripts/project_index.py whatis pkgNNN` — compact card for one package.
 - `python scripts/project_index.py graph --html graph.html` — interactive node tree (packages ↔ docs ↔ files ↔ dependencies).
 
 ## GitHub


### PR DESCRIPTION
## Summary

Closes the owner's "agents don't use the project-index" gap (pkg216, depends on pkg215). Pure markdown/config — no code, no build.

Three navigation agents are now explicitly instructed to run `scripts/project_index.py`, in **both** `.claude/agents/` and `.opencode/agents/` (twins kept byte-identical per spec §Key-design-decisions):

- **package-implementer** — two load-bearing pre-code checklist items: `owns <path>` before editing an existing file, `script "<task>"` before writing any new script (the CLAUDE.md §5b no-duplicate gate).
- **architect** — goal-capture step 1: `query "<topic>"` / `deps pkgN` before proposing scope.
- **docs-updater** — step 2: `owns` / `deps` to find every affected spec before flipping statuses.
- **AGENTS.md** — one bullet pointing at `KNOWLEDGE.md` as the routing map.
- **KNOWLEDGE.md** — added `owns`/`script`/`whatis` to the Search & graph section.

No hook added (discovery-by-instruction only, per the design note); reviewer/verifier agents untouched.

## Authorized surface

Spec "Files to modify" table names exactly 8 files; all 8 changed, nothing else:
`.claude/agents/{package-implementer,architect,docs-updater}.md`, their `.opencode/` twins, `AGENTS.md`, `KNOWLEDGE.md`.

## Acceptance criteria

- [x] `grep -l project_index .claude/agents/*.md .opencode/agents/*.md` returns package-implementer, architect, docs-updater in BOTH dirs (6 files).
- [x] `owns` and `script` both cited in package-implementer.md (both harnesses).
- [x] Twin parity: added blocks are byte-identical (`diff` of the `+` lines for all three agents → IDENTICAL).
- [x] AGENTS.md references KNOWLEDGE.md.
- [x] KNOWLEDGE.md lists `owns`, `script`, `whatis`.
- [x] No engine/test/build change.

## Subcommand existence check

All referenced subcommands exist as argparse subparsers in `scripts/project_index.py:605-616` (`query`, `deps`, `owns`, `script`, `whatis`, `graph`); `whatis` takes a package-number arg (`whatis(db, args.num)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)