### PR TITLE
fix(emission): fine CMF-grid integral for device emission RGB (kills GPU lamp red-shift)

### DIFF
--- a/.astroray_plan/packages/pkg218-gpu-spectral-emission-device-upload.md
+++ b/.astroray_plan/packages/pkg218-gpu-spectral-emission-device-upload.md
@@ -1,0 +1,131 @@
+# pkg218 — GPU spectral emission: upload emission SPDs to the device (exact CPU↔GPU lamp-colour parity)
+
+**Track:** A
+**Status:** open (filed 2026-08-22, follow-up to the deviceReference chroma fix).
+**Estimated effort:** M (new device table + NEE / emissive-hit eval + addon upload wiring; no register-hostile shade-kernel change).
+**Depends on:** the `deviceReference` fine-integration fix (same investigation — ships first, this tightens it).
+
+---
+
+## Goal
+
+Before: the GPU renders **all** non-RGB emission (measured-SPD lamps, blackbody,
+composite) as an RGB **approximation**. Each dedicated light and emissive
+material carries only `emissionRGB` (`EmissionSpectrum::deviceReference`), and
+the device upsamples it via `gpu_rgbSpectrumAt(..., GSPEC_RGB_ILLUMINANT)` —
+i.e. it renders `RGBIlluminant(rgb)·D65`, never the raw measured SPD. After the
+deviceReference fix the **chroma is close** (the reference RGB is now a fine CMF
+integral instead of a 4-sample MC), but it still cannot match the CPU's
+true-SPD render to within a few %, because:
+
+1. the Jakob–Hanika RGB→spectral round-trip is lossy, and
+2. `RGBIlluminant` bakes a **D65 spectral shape** into the emission that the raw
+   measured/blackbody SPD does not have.
+
+After this package: non-RGB emission is evaluated **spectrally on the device**
+at the render wavelengths, so CPU↔GPU emission colour matches within a few %
+(per-channel mean-ratio) for every preset lamp and blackbody temperature.
+
+---
+
+## Context
+
+Root-caused 2026-08-22 (live Blender MCP repro: `led_5000k` point light over a
+diffuse cube — CPU R/G≈1.09 correct, GPU R/G≈1.52 salmon; sodium over-orange,
+mercury reddish not blue-green). The full trace:
+
+- Dedicated lights: `PointLight::fillDeviceParams` (`src/lights/point_light.cpp:140`)
+  → `emission_.deviceReference(out.emissionRGB, out.exactIlluminant)` →
+  `GDedicatedLight.emissionRGB` → NEE `gpu_rgbSpectrumAt(dedEmissionRGB, λ,
+  ILLUMINANT)` (`src/gpu/gpu_nee.cuh:561`). No profile index on `GDedicatedLight`.
+- Emissive geometry: `gpu_material_emitted_spectral` (`include/astroray/gpu_materials.h:3415`)
+  = `gpu_rgbToSampledSpectrum(gpu_material_emitted(mat), wl, mat.spectralMode)`,
+  also pure RGB.
+
+There is **no spectral-emission path on the GPU at all** — this is a pkg89-era
+gap, not a pkg206 (importance-sampling) regression. The deviceReference fix
+removes the gross error; this package removes the residual.
+
+The "measured_spd via the raw Renderer API renders BLACK on GPU" symptom is the
+same gap surfacing differently: `deviceReference` calls `EmissionSpectrum::eval`,
+which needs `load_spectral_profiles()` on the **CPU** at upload; with a device
+SPD table the profile must instead be uploaded to the **device**, so wire the
+upload through the same path `uploadProfileTable` uses for reflectance.
+
+---
+
+## Design (recommended: one uniform "baked emission SPD" table)
+
+Do **not** add per-mode device evaluators (device planck / device JH-composite —
+register-hostile and duplicative). Instead, at scene-upload time evaluate the
+`EmissionSpectrum` once on a fixed fine λ-grid and upload the **sampled SPD** as
+an emission profile, exactly mirroring the pkg54a reflectance `g_profileTable`
+mechanism. This unifies measured / blackbody / composite behind one device
+lookup and inherits the CPU's own normalization (blackbody luminance-norm,
+composite filter multiply) for free.
+
+1. **Device table.** Add `g_emissionProfileTable[G_MAX_EMISSION_PROFILES *
+   G_EMISSION_SAMPLES]` (constant or global mem, mirror `g_profileTable`) +
+   `uploadEmissionProfileTable(host, count)` in `gpu_spectral_tables.{h,cu}`.
+   Grid: the CMF support (360–830 nm) at a step fine enough that the device
+   linear-interp matches the CPU eval to ≪1% (1–2 nm; reuse the reflectance
+   `gpu_profile_reflectance` interpolation shape).
+2. **Index fields.** Add `int emissionProfileIndex` (−1 = RGB fallback) to
+   `GDedicatedLight` and to the emissive `GMaterial` emission mode. Keep
+   `emissionRGB` as the fallback for true RGB-mode emission (`exactIlluminant`).
+3. **Upload.** In `scene_upload.cu`, for any light/material whose
+   `EmissionSpectrum` is **not** RGB mode: sample `EmissionSpectrum::eval` on the
+   grid, register it in the emission-profile table, set the index. RGB mode keeps
+   the exact `emissionRGB` path (already bit-exact — do not touch it).
+4. **Device eval.** `gpu_nee.cuh` `gpu_nee_resolve`: if `emissionProfileIndex>=0`,
+   `L_spec[i] = gpu_emission_profile(idx, lambdas.lambda[i]) * dedGeoScale`
+   instead of `gpu_rgbSpectrumAt(dedEmissionRGB,…)`. Same substitution in
+   `gpu_material_emitted_spectral` for emissive geometry. The stored pdf[i] is
+   still consumed only in the final `spectrumToXYZ` at the same lambda[i] —
+   unbiased by construction (no eval-vs-pdf skew, the property the whole
+   investigation confirmed).
+5. **Addon.** Ensure `convert_scene`/`convert_lights` triggers the emission-profile
+   upload (fixes the raw-API black-render note).
+
+## Scope guards / footguns
+
+- **Magnitude, not just chroma.** `emissionRGB` scales the NEE radiance via
+  `dedGeoScale`; the baked SPD must carry the same integrated magnitude the CPU
+  eval produces (blackbody is luminance-normalized to unit Y — verify the device
+  path reproduces that, else lamp brightness shifts). Gate energy with an upper
+  bound too (`gamma-furnace-cannot-detect-energy-gain`).
+- **Blackbody T-sweep** must be covered — it is the **default** emission mode, so
+  a chroma shift here changes every default lamp.
+- **Line lamps** (sodium ~589 nm, mercury): the 4-sample render MC still applies;
+  keep pkg206 importance sampling + the pkg195 uniform-selection CDF fallback.
+  See `spectral-profile-edit-footguns` (peak-vs-energy normalization; per-lamp
+  A/B across separate processes — `load()` is a process-wide singleton).
+- Related device-spectral precedent: `gpu-dielectric-lowers-to-closure-graph`,
+  `per-lambda-conductor-thinfilm-equals-rgb-upsample` (RGB↔per-λ deltas can be
+  small — measure, don't assume the port is visually large).
+
+---
+
+## Acceptance criteria
+
+- New CPU↔GPU emission-colour parity test (per-channel **mean-ratio**, NOT SSIM —
+  independent RNG streams; see `ssim-wrong-gate-for-independent-rng`): a point
+  lamp over a diffuse surface, rendered `set_use_gpu(False)` vs `True`, same
+  scene/seed/spp. **Every channel within a few % (target ≤5%)** for:
+  `led_5000k`, `led_3000k`, `sodium_vapor`, `mercury_vapor`, `cie_f2`, and
+  blackbody at 3000 K / 6500 K.
+- The loose regression gate shipped with the deviceReference fix is **tightened**
+  (or its `xfail`/wide band removed — `xfail-gated-features-must-unxfail`).
+- HW-verified on the RTX 5070 Ti (CI has no GPU — `ci_has_no_gpu_runtime_blindspot`);
+  visual check that mercury reads blue-green/blue-white and sodium amber-not-red.
+
+## Reference
+
+- Emission model: `include/astroray/emission_spectrum.h` (4 modes), CPU eval
+  `src/emission_spectrum.cpp`.
+- Device profile-table precedent (pkg54a): `g_profileTable` +
+  `gpu_profile_reflectance` + `uploadProfileTable` in
+  `src/gpu/gpu_spectral_tables.{h,cu}` and `scene_upload.cu`.
+- NEE emission resolve: `src/gpu/gpu_nee.cuh:550-562`. Emissive geometry:
+  `include/astroray/gpu_materials.h:3405-3420`; emissive-hit accumulation
+  `src/gpu/wavefront/stage_advance.cu:680`.

--- a/src/emission_spectrum.cpp
+++ b/src/emission_spectrum.cpp
@@ -125,11 +125,34 @@ void EmissionSpectrum::deviceReference(Vec3& outRGB, bool& exactRGB) const {
         return;
     }
     // Blackbody / MeasuredSPD / Composite: convert the evaluated SPD to a
-    // reference linear-sRGB triple (chroma + magnitude approximate). Sampled at
-    // the same uniform stratified wavelengths the CPU power() estimator uses.
-    SampledWavelengths wl = SampledWavelengths::sampleUniform(0.5f);
-    SampledSpectrum spec = eval(wl);
-    XYZ xyz = spec.toXYZ(wl);
+    // reference linear-sRGB triple (chroma + magnitude approximate).
+    //
+    // FINE CMF-grid integration, replacing a previous 4-sample Monte-Carlo
+    // toXYZ at sampleUniform(0.5). Those four fixed wavelengths (595, 712.5,
+    // 830, 477.5 nm over the default [360,830] range) badly undersampled
+    // structured lamp SPDs -- for a phosphor LED one sample (830 nm) is entirely
+    // out of band and none lands on the blue pump peak (~450 nm) -- yielding a
+    // wildly red/orange-biased RGB that the GPU RGBIlluminant upsample then
+    // rendered faithfully (salmon LEDs, over-orange sodium, reddish mercury).
+    // The 1 nm Riemann sum below is the deterministic, accurate value of the
+    // same integral (INT S(lambda)*cmf(lambda) dlambda, dlambda = 1 nm) the MC
+    // estimator was approximating, so magnitude is preserved while chroma
+    // becomes correct. Same fine-grid technique blackbodyLuminanceNorm() uses
+    // above. Each eval() mode is per-lane (result[i] depends only on lambda(i)),
+    // so packing one wavelength into all lanes and reading lane 0 yields S(lam).
+    //
+    // Approximate parity only: the GPU still renders RGBIlluminant(outRGB)*D65,
+    // not the raw SPD. Exact CPU/GPU spectral parity needs emission profiles
+    // uploaded to the device and sampled at the render wavelengths (follow-up).
+    XYZ xyz{0.0f, 0.0f, 0.0f};
+    for (int lambda = 360; lambda <= 830; ++lambda) {
+        float lam = static_cast<float>(lambda);
+        float s = eval(SampledWavelengths::fromLambdas({lam, lam, lam, lam}))[0];
+        XYZ cmf = cieCmf1964_10deg(lam);
+        xyz.X += s * cmf.X;  // implicit * 1 nm step
+        xyz.Y += s * cmf.Y;
+        xyz.Z += s * cmf.Z;
+    }
     outRGB = Vec3(
         3.2404542f * xyz.X - 1.5371385f * xyz.Y - 0.4985314f * xyz.Z,
         -0.9692660f * xyz.X + 1.8760108f * xyz.Y + 0.0415560f * xyz.Z,

--- a/tests/test_gpu_emission_colour_parity.py
+++ b/tests/test_gpu_emission_colour_parity.py
@@ -1,0 +1,147 @@
+"""CPU<->GPU emission-colour parity for preset (measured_spd) lamps.
+
+Regression gate for the deviceReference chroma bug (2026-08-22): the GPU renders
+non-RGB emission (measured_spd / blackbody / composite) as an RGB approximation
+via EmissionSpectrum::deviceReference. That reference RGB was estimated from a
+4-sample Monte-Carlo toXYZ at sampleUniform(0.5) over the default [360,830] nm
+range -- four fixed wavelengths (595, 712.5, 830, 477.5) that badly undersample
+a structured lamp SPD (830 nm is dead for a 380-780 nm LED; none lands on the
+blue pump peak). The result was a strongly red/orange-biased RGB the GPU rendered
+faithfully: salmon LEDs, over-orange sodium, reddish mercury (live Blender repro:
+led_5000k GPU R/G ~1.52 vs CPU ~1.09). The fix replaces the 4-sample MC with a
+fine 1 nm CMF-grid integral (emission_spectrum.cpp), so the reference RGB carries
+the true chroma.
+
+This asserts per-channel mean-ratio parity (NOT SSIM -- CPU and GPU draw
+independent RNG streams; see memory ssim-wrong-gate-for-independent-rng). It runs
+the dedicated-light NEE path (integrator "path_tracer"); the naive
+"multiwavelength_path_tracer" does not drive GPU dedicated-light NEE.
+
+Broadband lamps reach a few-% parity here. Narrow line lamps (sodium) keep a
+larger chroma gap that is intrinsic to the RGB approximation and is closed by the
+follow-up device-SPD upload (pkg218); this test only asserts sodium improved well
+past the old red bias, not tight parity.
+"""
+import os
+
+import numpy as np
+import pytest
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+
+try:
+    import astroray
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PROFILES_BIN = os.path.join(REPO_ROOT, "data", "spectral_profiles", "profiles.bin")
+HAS_PROFILES = os.path.exists(PROFILES_BIN)
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray module not available")
+
+if AVAILABLE and not astroray.__features__.get("cuda", False):
+    pytest.skip("CUDA feature not in this build — emission parity needs CUDA; "
+                "run on the RTX box via /verify.", allow_module_level=True)
+
+
+def _has_gpu():
+    try:
+        return bool(astroray.Renderer().gpu_available)
+    except Exception:
+        return False
+
+
+def _lamp_channels(emission, use_gpu, spp=192, width=48, height=48):
+    """White sphere lit by a point lamp; per-channel linear means. path_tracer
+    exercises the (GPU wavefront) dedicated-light NEE emission path."""
+    astroray.load_spectral_profiles(PROFILES_BIN)
+    r = astroray.Renderer()
+    r.set_use_gpu(use_gpu)
+    r.setup_camera(
+        look_from=[0, 0, 3], look_at=[0, 0, 0], vup=[0, 1, 0],
+        vfov=35, aspect_ratio=1.0, aperture=0.0, focus_dist=3.0,
+        width=width, height=height,
+    )
+    r.set_seed(101)
+    r.set_background_color([0.0, 0.0, 0.0])
+    mat = r.create_material("lambertian", [1.0, 1.0, 1.0], {})
+    r.add_sphere([0, 0, 0], 1.0, mat)
+    r.add_point_light(position=[2.0, 2.0, 2.0], emission=emission,
+                      intensity=60.0, radius=0.0)
+    r.set_wavelength_range(380.0, 780.0)
+    r.set_integrator("path_tracer")
+    pixels = np.array(r.render(spp, 6, None, False), dtype=np.float32)  # linear
+    return pixels.reshape(-1, 3).mean(axis=0)
+
+
+def _rg(v):
+    return float(v[0] / v[1]) if v[1] > 1e-9 else float("inf")
+
+
+needs = pytest.mark.skipif(not HAS_PROFILES or not (AVAILABLE and _has_gpu()),
+                           reason="profiles.bin or CUDA GPU not available")
+
+
+@needs
+@pytest.mark.parametrize("profile", ["led_5000k", "led_3000k", "mercury_vapor", "cie_f2"])
+def test_broadband_lamp_cpu_gpu_parity(profile):
+    """Broadband preset lamps: GPU per-channel mean within 8% of CPU.
+
+    (Measured ~2-4% post-fix; 8% leaves margin for MC noise + boost-clock drift.
+    Pre-fix, led_5000k red channel was ~40% hot vs its own CPU render.)
+    """
+    em = {"mode": "measured_spd", "profile_name": profile}
+    cpu = _lamp_channels(em, use_gpu=False)
+    gpu = _lamp_channels(em, use_gpu=True)
+    assert cpu.min() > 1e-3 and gpu.min() > 1e-3, (
+        f"{profile}: lamp rendered near-black CPU={cpu} GPU={gpu}"
+    )
+    ratio = gpu / np.maximum(cpu, 1e-9)
+    maxdev = float(np.abs(ratio - 1.0).max())
+    print(f"[{profile}] CPU={cpu.round(4)} GPU={gpu.round(4)} "
+          f"R/G cpu={_rg(cpu):.3f} gpu={_rg(gpu):.3f} maxdev={maxdev*100:.1f}%")
+    assert maxdev < 0.08, (
+        f"{profile}: CPU/GPU per-channel mismatch {maxdev*100:.1f}% > 8% "
+        f"(CPU={cpu}, GPU={gpu})"
+    )
+
+
+@needs
+def test_led_5000k_not_red_shifted():
+    """Direct regression guard on the salmon bug: neutral-white LED must render
+    near-neutral on GPU (R/G close to CPU), not the pre-fix salmon R/G."""
+    em = {"mode": "measured_spd", "profile_name": "led_5000k"}
+    cpu = _lamp_channels(em, use_gpu=False)
+    gpu = _lamp_channels(em, use_gpu=True)
+    rg_cpu, rg_gpu = _rg(cpu), _rg(gpu)
+    print(f"[led_5000k] R/G cpu={rg_cpu:.3f} gpu={rg_gpu:.3f}")
+    # GPU R/G within 8% of CPU, and comfortably below the pre-fix salmon regime
+    # (the live repro showed GPU R/G inflated ~40% over CPU).
+    assert abs(rg_gpu - rg_cpu) / rg_cpu < 0.08, (
+        f"led_5000k GPU R/G {rg_gpu:.3f} vs CPU {rg_cpu:.3f} -- red-shift regressed"
+    )
+    assert rg_gpu < rg_cpu * 1.15, (
+        f"led_5000k GPU R/G {rg_gpu:.3f} red-hot vs CPU {rg_cpu:.3f}"
+    )
+
+
+@needs
+def test_sodium_lamp_improved_not_red():
+    """Sodium line lamp: the RGB approximation keeps a larger chroma gap (closed
+    by pkg218's device-SPD upload), so parity is loose here -- but the GPU render
+    must still be amber and track the CPU hue direction, not the old red bias."""
+    em = {"mode": "measured_spd", "profile_name": "sodium_vapor"}
+    cpu = _lamp_channels(em, use_gpu=False)
+    gpu = _lamp_channels(em, use_gpu=True)
+    print(f"[sodium] CPU={cpu.round(4)} GPU={gpu.round(4)} "
+          f"R/G cpu={_rg(cpu):.3f} gpu={_rg(gpu):.3f}")
+    assert gpu[0] > 1e-3, f"sodium GPU render black: {gpu}"
+    # Amber: R dominant over G, G over (tiny) B.
+    assert gpu[0] > gpu[1] > gpu[2], f"sodium GPU not amber: {gpu}"
+    # Loose chroma tracking (pkg218 tightens to a few %).
+    assert abs(_rg(gpu) - _rg(cpu)) / _rg(cpu) < 0.30, (
+        f"sodium GPU R/G {_rg(gpu):.3f} far from CPU {_rg(cpu):.3f}"
+    )


### PR DESCRIPTION
## Problem
GPU-rendered non-RGB emission (measured_spd preset lamps, blackbody, composite) is strongly **red/orange-shifted** vs the CPU. Live Blender repro (2026-08-22): a `led_5000k` point light over a diffuse cube reads salmon-pink on GPU (mean sRGB R/G ~1.52) vs near-neutral on CPU (~1.09); sodium reads over-orange, mercury reads reddish instead of blue-green.

## Root cause
The GPU has **no spectral-emission path** — every dedicated light uploads a single reference RGB via `EmissionSpectrum::deviceReference`, and the device upsamples it (`RGBIlluminant`). `deviceReference` estimated that RGB from a **4-sample Monte-Carlo `toXYZ` at `sampleUniform(0.5)`** over the default **[360, 830] nm** range. Those four fixed wavelengths — **595, 712.5, 830, 477.5 nm** — badly undersample a structured lamp SPD: 830 nm is dead for a 380–780 nm LED, and none lands on the blue pump peak (~450 nm). Result: a grossly red/orange-biased RGB the GPU renders faithfully.

This is a **pkg89-era gap, not a pkg206 regression** — `deviceReference` uses `sampleUniform` (untouched by pkg206), and RGB upsampling is unbiased under both uniform and importance sampling.

## Fix
Replace the 4-sample MC with the deterministic **1 nm CMF-grid integral** (the same fine-grid technique `blackbodyLuminanceNorm` already uses, `emission_spectrum.cpp:35`). It's the accurate value of the same integral the MC was approximating, so **magnitude is preserved while chroma becomes correct** — including the **default 6500 K blackbody**, which was itself red-shifted (R/G **2.89 → 1.06**). Brightness change for broadband lamps is ±6–10%; the one large change (sodium 0.22×) corrects a 4.5× over-count of the D-line spike. Only ~28 lines, and `deviceReference`'s signature is unchanged (no call-site sweep needed). CPU rendering is untouched (it uses `eval()` directly).

## Verification (RTX 5070 Ti, `path_tracer`, CPU vs GPU per-channel mean-ratio)
| lamp | CPU R/G | GPU R/G | max channel dev |
|---|---|---|---|
| led_5000k | 1.383 | 1.378 | **3.2%** |
| led_3000k | 1.633 | 1.652 | 4.1% |
| mercury_vapor | 1.195 | 1.152 | **2.0%** |
| cie_f2 | 1.623 | 1.640 | 3.4% |
| sodium_vapor | 4.85 | 5.84 | ~20% chroma (narrow line — see pkg218) |

New gate: `tests/test_gpu_emission_colour_parity.py` (per-channel mean-ratio, not SSIM). Existing emission/spectral suite (pkg195, pkg89 g8 + dedicated NEE, pkg202, spectral_profiles) still green (41 passed, 1 skipped).

## Scope / follow-up
This is **approximate parity only** — the GPU still renders `RGBIlluminant(rgb)·D65`, not the raw SPD, so narrow line lamps (sodium) keep a larger chroma gap. **pkg218** is filed (`.astroray_plan/packages/pkg218-gpu-spectral-emission-device-upload.md`) for exact ≤5% parity via a device emission-SPD table.

Note surfaced in passing: the `multiwavelength_path_tracer` integrator does not drive GPU dedicated-light NEE (renders black on GPU); `path_tracer` does. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)