### PR TITLE
docs(architect): next-stage roadmap 2026-08-23 (pkg217/pkg219 refined + research)

### DIFF
--- a/.astroray_plan/docs/NEXT_STAGE_REPORT.md
+++ b/.astroray_plan/docs/NEXT_STAGE_REPORT.md
@@ -1,284 +1,148 @@
 # Astroray Next Stage Report
 
-**Date:** 2026-08-22 (round closeout — 0 open PRs). The spectral milestone
-landed + shipped (pkg213/214/215/206/216 + fixes #635/#637/#638); a fresh
-`dist/astroray-4.0.0-cuda.zip` was built and verified. Full detail:
-`.astroray_plan/docs/STATUS.md` (top entry "2026-08-21 → 2026-08-22").
-**Prepared by:** docs closeout pass (evidence: `git log`, `gh pr list`, spec
-Status lines).
+**Date:** 2026-08-23 (FRESH ARCHITECT-LED planning pass — goal-capture mode).
+**Prepared by:** architect. This regenerates the stale prior report and is the
+canonical pickup queue for the orchestrator / dispatch-next. Every item below is
+grounded in the live project index (`scripts/project_index.py`) or a cited
+research note; grep `^**Status:**` in each spec before dispatch (memory
+`orchestrator-next-stage-report-stale`).
 
-**TOP OF THE OPEN POOL — three fresh research specs from the 2026-08-22
-Blender-MCP debugging session, for the architect to sequence:**
-- **pkg219 — per-texel shader-graph evaluator** (INTEGRATION-FIRST priority; the
-  addon constant-folds node trees, so Color Ramp / Mix / Mapping / non-UV coords
-  downstream of a texture silently break). Biggest usability lever. SVM/OSL fork.
-- **pkg218 — spectral colorimetry fidelity** (Pillar 4, owner-deprioritized):
-  (A) mercury stored SPD is chromatically magenta not blue-green; (B) make the
-  CIE observer / camera response function swappable.
-- **pkg217 — GPU refractive/dispersive caustics** (glass casts a black shadow;
-  owner-deprioritized). Register-hostile.
-Also still open from older rounds: pkg201 Stage 3, pkg131, the F-glass
-compositing follow-up, pkg180. Treat §2 below as older input; the three specs
-above are the current live surface.
-
-> Strategic gate: **RELEASED 2026-05-10** by pkg56 Phase C. Strategy in
-> [`ROADMAP.md`](ROADMAP.md), full status in [`STATUS.md`](STATUS.md).
-
-**Still open from the prior report: a FRESH ARCHITECT-LED planning pass.**
-The owner's 2026-08-15 request for the architect to plan ahead (review the
-full open pool, sequence dependencies, size work) before dispatching more
-implementers has not yet been acted on — the intervening work (pkg203-206,
-pkg212-214) was picked up ad hoc. Treat §2 below as input to that planning
-pass, not a queue to execute mechanically.
+> Strategy gate RELEASED (pkg56 Phase C, 2026-05-10). Strategy: `ROADMAP.md`.
+> Full state: `STATUS.md` (top entry 2026-08-21→22).
 
 ---
 
-## 1. Current state (one screen)
+## 0. Pending-state facts the orchestrator must carry (NOT tasks to redo here)
 
-- **The Integration Milestone stays fully closed** (unchanged). Work since
-  the 2026-08-15 report closed pkg200's last filter honour row and the
-  pkg198 volume-pass limitation, added a light-intensity UI control, and
-  is mid-fix on a spectral-lamp regression.
-- **Landed since the last report (6 PRs, #624–#628):** pkg203 (Cycles-
-  accurate pixel-filter width→σ mapping, CPU+GPU, PR #624, closes pkg200's
-  last filter HONEST-FAIL row), pkg204 (GPU wavefront volume-pass direct/
-  indirect split, PR #625, closes the pkg198 Stage-2 limitation), pkg205
-  (UnicodeEncodeError console-test hygiene, PR #626, test-only), pkg213
-  (light intensity/Power slider exposed in the Astroray panel, PR #628,
-  UI-surfacing only).
-- **Open, HW FAIL — top priority pickup:** **pkg214** (PR #629, sodium-
-  vapor emission fix). The D-doublet broadening (black→amber) works, but
-  the shared `mat_ls` peak-normalisation mechanism regressed
-  `mercury_vapor` ~4.5–8.6× too bright. A physics-correct energy-
-  normalisation fix is IN PROGRESS on branch `pkg214fix` — **finish and
-  re-verify this before picking up anything else that touches
-  `build_spectral_profiles.py` or the spectral-lamp path** (overlaps
-  pkg206's sampler work only at the "don't touch the same files
-  concurrently" level, not logically).
-- **In progress, released from hold:** **pkg206** (luminance-weighted
-  hero-wavelength importance sampling). Its first attempt, PR #627, was
-  CLOSED CI-red/biased — `test_flat_baseline_ssim` failed from a stacked
-  realization-change + genuine achromatic-flat green-cast bias (companion
-  wavelengths not divided by the importance density at their own λ). The
-  owner released the bias-hold 2026-08-21; re-dispatched fresh on branch
-  `pkg206impl*` with the triage's per-wavelength-pdf correction (spec's
-  2026-08-21 triage section has the full root-cause + distinguishing
-  diagnostic for the next attempt).
-- **pkg200's honour matrix is now fully closed on its filter-related
-  rows.** Of its original 13 HONEST-FAIL rows, pkg201 closed 3
-  (`world_max_bounces`, `film_transparent`, `filter_width`) and pkg203
-  closed the 4th (`pixel_filter_type`). Remaining rows: per-type bounce
-  counts (Finding A), `filter_glossy` (Finding C), native caustic toggles
-  (Finding E) — all register-hostile, deferred to pkg201 Stage 3; and
-  `film_transparent_glass` (F-glass), reclassified as an unfiled new-
-  feature follow-up.
-- **Open, not blocking, carried forward:** pkg201 Stage 3 (per-type
-  bounce counters + `filter_glossy` + native caustic toggles —
-  register-hostile, probe-gated, register-contention window is clear),
-  pkg131 (zero-knob adaptive sampling, wavefront leg, long-standing), the
-  F-glass (`film_transparent_glass`) world-through-glass compositing
-  follow-up (not yet filed), the CPU legacy-hittable delta-sun
-  `isDelta`/MIS gap (pkg202's fix sidesteps it for the sun case only),
-  the caustic-integrator/CPU-wavefront-reference world-volume gap (open
-  since pkg199 Stage 1), the durable `GLoweredMaterial` by-value-copy fix
-  (still prototyped, uncommitted, worktree `sad-maxwell-ff99d1`), pkg180
-  (systemic-dim diagnosis, still open).
-- **Still standing, unresolved — TOP STRATEGIC ITEM:** the **Pillar 4
-  unpause decision** (pkg45/46/48/49/50/51 + pkg107, GR/astro science
-  layer). No new owner directive since 2026-08-03; ROADMAP.md's PAUSED
-  marker is unchanged. This has now stood unresolved across many round
-  closeouts — surface it explicitly before any further
-  Integration-Milestone-tail dispatch.
-- **Environment:** RTX 5070 Ti workstation; Blender 5.1/5.2 installed
-  locally (real-host checks mandatory for addon-facing PRs). Every landed
-  PR this window was dual-gated (CI + independent RTX hardware
-  verification); pkg214 (#629) is the one PR that came back HW FAIL and is
-  mid-fix, not yet re-verified.
+- **PR #638 (GPU lamp red-shift fix) is OPEN, CI-green, NOT merged** — needs RTX
+  hardware verification before merge. Dispatch a `hardware-verifier` on it.
+- **The `build_cuda` `.pyd` is STALE vs HEAD** — rebuild before ANY GPU
+  verification this session (memory `stale_pyd_locations`,
+  `incremental-build-signature-staleness`; verify `astroray.__file__` +
+  `cuobjdump --list-elf` sm_120 before trusting a gate).
+- **Pillar 4 remains PAUSED** (pkg45/46/48/49/50/51/107, incl. pkg218 spectral
+  colorimetry) — no new unpause directive; skip for autonomous work. Surface the
+  unpause decision to the owner but do not self-dispatch it.
 
 ---
 
-## 2. Deployable set (prioritized)
+## 1. State in one screen
 
-Grep `^\*\*Status:\*\*` in each spec before dispatch (memory
-`orchestrator-next-stage-report-stale`) — this report can go stale. This
-list is INPUT to the requested fresh architect planning pass, not a queue
-to execute mechanically (see the owner request banner above).
-
-**In-flight, finish before picking up anything new:**
-
-1. **pkg214fix** — finish the physics-correct energy-normalisation fix on
-   branch `pkg214fix` (PR #629 is HW FAIL, do not merge as-is). Re-verify
-   sodium (amber, unchanged) AND mercury (back within its pre-fix MC-noise
-   band) together before closing.
-2. **pkg206** — luminance-weighted hero-wavelength importance sampling,
-   re-dispatched on branch `pkg206impl*` with the per-wavelength-pdf
-   correction from the 2026-08-21 triage. Re-verify the flat-baseline SSIM
-   gate specifically (the prior attempt's failure mode) alongside the
-   convergence-win and unbiasedness gates in the spec.
-
-**Top candidate — needs an explicit owner decision, not a silent dispatch:**
-
-3. **Pillar 4 unpause** (pkg45/46/48/49/50/51 + pkg107, GR/astro science
-   layer). Unchanged across multiple rounds now — ROADMAP.md's PAUSED
-   marker has stood since 2026-06-08; still no explicit go-ahead.
-   **Surface this to the owner before dispatching any pkg45-tier work or
-   further Integration-Milestone-tail items.**
-
-**Integration-Milestone-tail / settings-honour closure, highest signal in
-the open pool:**
-
-4. **pkg201 Stage 3** — per-type bounce counters (Finding A),
-   `filter_glossy` (Finding C), native caustic toggles (Finding E,
-   reclassified from Stage 2). Register-hostile — MUST clear the
-   up-front cuobjdump probe per item before any feature code (same
-   discipline as pkg198/pkg199/pkg204). The register-contention window
-   is clear — dispatchable, but size it as its own session (3
-   register-hostile items, each may park independently).
-5. **pkg131** — zero-knob adaptive sampling, wavefront leg. Long-standing
-   open item, no new blockers.
-
-**Hygiene / follow-up (not yet filed as a dedicated spec):**
-
-6. **F-glass (`film_transparent_glass`) world-through-glass compositing**
-   — reclassified out of pkg201 Stage 2 as a genuine new feature (glass
-   must show the background through it, changing beauty RGB, not just an
-   alpha copy-back). File a spec before dispatching.
-7. **CPU legacy-hittable delta-sun `isDelta`/MIS gap** — pkg202's
-   upload-time conversion sidesteps this for GPU sun rendering, but the
-   underlying legacy non-dedicated-light MIS treatment (CPU side) is
-   still unaddressed for other legacy hittable-light types. Diagnosis-
-   first; confirm scope before filing.
-8. **Caustic-integrator/CPU-wavefront-reference world-volume gap** — fog
-   is invisible to the caustic integrator and the CPU wavefront reference
-   (pkg199 Stage 1 documented non-goal, still open). One-liner candidate:
-   either extend those two paths to read `c_worldVolume`, or document the
-   limitation user-facing if extending is out of scope for now.
-9. **Durable `GLoweredMaterial` by-value-copy fix** — re-apply the
-    prototyped PR-2-based fix from worktree
-    `.claude/worktrees/sad-maxwell-ff99d1` on settled main. File a
-    dedicated spec if picked up (recurring-leak pattern is evidence
-    enough for a CLAUDE.md §6-citable structural fix).
-
-**Re-entered / long-tail pool (still genuinely low priority):**
-
-10. **pkg180** — systemic Astroray-vs-Cycles dim, diagnosis-first, still
-    open dispatchable.
-11. **pkg173** — bounce-1 geometry-sampling parity (pkg172 effect (B));
-    holds pkg156's 0.998 SSIM restoration clause.
-12. **pkg153** — wavefront_diff remainder, gate-failure-reviewer
-    disposition in flight.
-13. **pkg155 Phase 2** — shade-stage register recovery (221 regs/thread →
-    ≤128 target); opportunistic GPU-lock gap-filler, not compile-only.
-14. **pkg128** — thin-film residual charter (standalone Glass/Metallic
-    node cells + spectral showcase), rides the shared Belcour-Barla
-    utility pkg178/pkg182 already built.
-15. **pkg165** — verify-and-close. A focused confirm on pkg158's exact
-    Step-0 scene at r ∈ {0.0, 0.3, 0.6, 0.9} closes the paperwork; every
-    existing reading is already in-band. Trivial, non-urgent.
-
-**Not this phase:** anything not explicitly named above; Pillar 4 stays
-PAUSED until the owner go-ahead in item 1 above.
+- Spectral milestone shipped (pkg213/214/215/206/216 + #635/#637/#638); fresh
+  `dist/astroray-4.0.0-cuda.zip` built + headless-verified. 0 open PRs at closeout
+  except #638 (above).
+- The Integration Milestone is closed; the owner's live priorities are now
+  **Blender shader-node compatibility, caustics, Cycles + CPU/GPU parity, and
+  opportunistic perf** (perf ceiling of 1.5s STAYS — no dedicated perf packages,
+  memory `wavefront-perf-ceiling-owner-decision`).
+- **Key discovery this pass:** the two headline "hard" items are *less* hard than
+  their stubs implied. pkg217 caustics is a **wiring** problem (CPU SMS + device
+  solver + caster-flag plumbing all already exist — see research note); pkg219
+  shader-graph is **decomposable** into an independently-useful pkg219a plus a
+  bounded op-VM. Both specs are now refined to implementable and their forks decided.
 
 ---
 
-## 3. Drop-in prompt for the next session
+## 2. Prioritized roadmap for THIS session (ordered, by owner theme)
 
-**First: finish and re-verify the two in-flight items** (1–2) — pkg214fix
-(mercury regression) and pkg206 (bias re-fix) both have work already
-started; landing them is higher-value than starting anything new. **Then
-get the owner's read on Pillar 4 unpause** (item 3) — a milestone-scale
-sequencing decision, not a code dispatch, and it has now stood unresolved
-across multiple rounds. **Then run the fresh architect-led planning pass
-the owner requested 2026-08-15** — review the full open pool (this report
-§2, STATUS.md, and any specs filed since), sequence dependencies, and size
-sessions explicitly before dispatching, rather than picking items off this
-list mechanically.
+Effort key: S<M<L<XL. Tier: **grunt** = open-weight via `delegate` skill,
+evidence-verified; **impl** = `package-implementer`; **Claude** = judgment-heavy
+implementer/parity; **research/architect** = me; **hw** = `hardware-verifier`.
 
-If the architect's plan confirms this pool as reasonable: **pkg201 Stage 3
-(item 4)** is the next-highest-signal item after the in-flight pair, but
-needs its own session (register-hostile, 3 independently-parkable
-sub-items, probe-first per item). pkg131 (item 5) has no blockers if a
-smaller pickup is wanted. Items 6–9 are hygiene/follow-up work that need a
-spec filed before dispatch (F-glass compositing, the legacy-light MIS gap,
-the caustic/fog gap, the `GLoweredMaterial` fix). Items 10–15 are the
-long-tail pool, in roughly that priority order.
+### THEME A — Blender shader-node compatibility (BIGGEST usability lever; owner-named #1)
 
-Rules that stay live from this round: **energy gates render LINEAR with an
-upper bound** (pkg166); **state the `.pyd` mtime next to every probe A/B
-number**; **verify `cuobjdump` resource-gate readings against the TRUE
-compiled arch, not the CMakeCache line** (pkg183's `arch-verify` gate
-catches this automatically); **mirror the CONDITION, not just the term, in
-every CPU→GPU port**; **CPU/GPU material work is byte-mirrored in the same
-PR, never split across sessions**; **any new lobe/closure/kernel axis that
-touches the shade path must be measured against the
-`template<bool HasPrincipled>` / `template<bool HasPhotons>` /
-`template<bool HasWorldScatter>` / `template<bool HasLightPassAOVs>`
-isolation boundaries**; **eval and pdf must use the SAME functional form
-for the same NDF** (the pkg182 class of bug); **never trust a CSV/CLI
-deliverable's own claimed numbers — re-run the documented command verbatim
-and read the actual output**; **grep the spec for git-archaeology before
-trusting an inherited premise** (pkg199's "the CPU already has this" claim
-was false); **occlusion-sentinel distances (1e30) are not geometric
-distances — never feed one into a Beer-Lambert/absorption term** (pkg199
-Stage 1's HW-611 class of bug); **register-hostile work needs an up-front
-cuobjdump probe before any feature code, per item if multiple items share
-a spec** (pkg198/pkg199/pkg201-Stage-3 discipline). Cite per CLAUDE.md §6
-(`/cite-algorithm`) for any new algorithm.
+1. **pkg219a — Coordinate + Mapping unification.** Full 3-D Mapping matrix (incl.
+   X/Y rotation) + real Generated/Object/Camera/Window TexCoord. *Why now:* fixes
+   half the owner's `Material.001` repro on its own, needed regardless of the VM
+   fork, unblocks 219b. *Effort:* M. *Tier:* impl. *Gating:* none. **Dispatch first.**
+2. **pkg219b — Bounded op-VM core.** `uint4` bytecode compiler + CPU + GPU
+   evaluator, static stack bound, `<bool HasProgram>` isolation, REG probe gate.
+   Ships Color-Ramp / Mix / Math / MapRange. *Why now:* kills the single biggest
+   usability gap (Color-Ramp-on-texture always greys). *Effort:* L. *Tier:* Claude
+   (register budget + GPU device interpreter = last-line-of-defense judgment).
+   *Gating:* after 219a (shares the coordinate path); needs `cite-algorithm`
+   (Cycles SVM) + `cpp-abi-guard` + REG probe.
+3. **pkg219c — Opcode coverage fill-out.** HSV/Invert/Gamma/BrightContrast/
+   Separate-Combine/Bump/NormalMap, each a Cycles parity render. *Effort:* M.
+   *Tier:* impl. *Gating:* after 219b (extends its opcode table).
 
----
+### THEME B — Cycles + CPU/GPU parity (owner-named; unblocks honour-matrix debt)
 
-## 4. Coordination
+4. **pkg201 Stage 3 — per-type bounce counters + `filter_glossy` + native caustic
+   toggles.** Closes the last register-hostile pkg200 honour-matrix rows. *Why now:*
+   register-contention window is clear per its own Status; direct Cycles-parity debt.
+   *Effort:* L. *Tier:* Claude (register-hostile, probe-gated). *Gating:* the
+   `caustics_reflective/refractive` toggle rows LOGICALLY OVERLAP pkg217 — sequence
+   201-S3's caustic-toggle row *with or after* pkg217, do not implement the toggle
+   twice. Non-caustic rows (bounce counters, filter_glossy) can go independently.
 
-- **One PR per package**, doc-only closeouts auto-merge on green CI
-  (pr-reviewer doc-only rule). Source PRs need the independent-review
-  SIGN-OFF/BLOCK gate (pkg98) before push.
-- **`src/gpu/wavefront/stage_advance.cu` / `stage_init.cu` / the shade
-  kernel are serialization points** for any GPU-lane package (pkg201
-  Stage 3, pkg131, a Pillar-4 GPU package, etc.) — check for other
-  in-flight touches before dispatching. The pkg198/pkg199 register-
-  contention window that blocked pkg201 Stage 3 is now clear (both
-  landed this round), but confirm no new contender has appeared.
-- **CI is blind to GPU correctness** — never declare a round clean on CI
-  green alone; run the full RTX hardware sweep at closeout (memory:
-  `ci_has_no_gpu_runtime_blindspot`).
-- **`apply_gamma=True` cannot detect energy GAIN** — render energy gates
-  linear with floor+ceiling (memory:
-  `gamma-furnace-cannot-detect-energy-gain`).
-- **Addon-facing PRs need a real-Blender leg** — `dev_addon.ps1 -Smoke`
-  (pkg175) is the standing mechanism; gate on the printed sentinel, not
-  the exit code.
-- **The GPU wavefront is NOT run-to-run bit-exact** (~1.19e-07–2e-7
-  atomic floor) — gate at the 1e-5 Monte-Carlo convention, not exact
-  equality.
-- **Watch the shadow-`.pyd` trap** — verify `astroray.__file__` resolves
-  to the canonical build output and check `.pyd` mtime vs HEAD (memory:
-  `stale_pyd_locations`).
-- **Watch the stale-CMakeCache CUDA-arch trap** — the cache line can lie;
-  trust `cuobjdump --list-elf` on the linked `.pyd`, which pkg183's
-  `arch-verify` gate now does automatically in all three build wrappers.
-- **CLI/script deliverables need the documented command re-run verbatim,
-  not the PR's own claimed numbers trusted.**
-- **Grep `^Status:` (or `**Status:**`) in the spec before dispatching** —
-  this report's §2 prose can go stale vs the spec header (memory:
-  `orchestrator-next-stage-report-stale`).
-- **Cite papers/reference repos per CLAUDE.md §6** for any new algorithm.
-- **Cost routing (2026-08):** bounded grunt work (docs flips, lint fixes,
-  report assembly, pre-review critique, well-specified gated
-  implementation) routes to the `delegate` skill's open-weight tiers,
-  evidence-verified, never trusted. Claude stays on architect/specs,
-  cycles-parity, ABI reachability, gate-failure root-cause, merge
-  decisions, and visual inspection.
+### THEME C — Caustics (owner-named; real feature, owner-deprioritized vs above)
+
+5. **pkg217 — GPU refractive/dispersive caustics (wiring).** New
+   `stage_caustic_connect.cu`, ordinary-NEE cull, reuse `sms_attempt_device.cuh`.
+   *Why now:* the black-shadow-through-glass is a visible correctness bug and the
+   machinery already exists; owner deprioritized vs shader nodes but it is L not XL.
+   *Effort:* L. *Tier:* Claude (wavefront + register gate + NEE-cull correctness =
+   judgment). *Gating:* `cite-algorithm`, REG probe HARD gate, visual+parity gates;
+   verify the CPU refractive-caustic path first (may already work post-#637).
+6. **pkg127 — Specular Polynomials for SMS seed finding (deferred seed upgrade).**
+   *Why now:* only AFTER pkg217 lands and shows residual seed-failure noise; it is a
+   quality upgrade, not a prerequisite. *Effort:* L. *Tier:* Claude. *Gating:* do
+   NOT couple to pkg217; dispatch only if 217's caustics show seed-waste.
+
+### THEME D — Opportunistic quality (no dedicated perf packages — ceiling stays)
+
+7. **pkg131 — Zero-knob adaptive sampling, wavefront leg.** Long-standing open;
+   convergence quality win, not a raw-perf lever (respects the 1.5s ceiling).
+   *Effort:* L. *Tier:* impl. *Gating:* none; low priority — pick up if a slot is
+   free behind Themes A–C.
+
+### IN-FLIGHT / carried (finish before starting new work in the same files)
+
+- **#638 HW verify + merge** — `hardware-verifier`, then `pr-reviewer`. **Do first.**
+- **pkg214fix** — physics-correct energy-normalisation on branch `pkg214fix` (PR
+  #629 HW-FAIL, do NOT merge as-is). Re-verify sodium AND mercury together. *Tier:*
+  Claude + hw. Blocks anything touching `build_spectral_profiles.py`.
+- **pkg206** — re-verify the flat-baseline SSIM gate specifically (prior failure
+  mode) on branch `pkg206impl*`. *Tier:* hw.
 
 ---
 
-## 5. After the round
+## 3. Real forks for the owner (not an artificial ballot)
 
-- Flip landed spec `Status:` lines to `done (PR #N, date — headline
-  numbers)`.
-- Update STATUS.md (new round section + next pickup queue), ROADMAP.md
-  (round-closeout entry; "Current sequencing" only changes on a new owner
-  directive), and rewrite this report's §1/§2 for the next round.
-- Run the RTX hardware sweep; record the full test-suite state.
-- Do not bulk-promote flaky xfails on a lucky run.
-- Open ONE doc PR (or direct doc-only commit per repo rule) for the
-  closeout.
+- **pkg219 depth:** ship 219a+219b now (bounded VM) vs commit to full-SVM (a) as
+  one XL. I chose the staged bounded-VM (research note) — it delivers usable value
+  in M+L and is a strict on-ramp to (a). Owner can override toward full-SVM if the
+  op-VM coverage proves insufficient in practice.
+- **pkg217 vs pkg201-S3 caustic-toggle ordering:** these two touch the same
+  caustic-honour surface. Either (i) do pkg217 first then 201-S3 wires the toggle to
+  it, or (ii) 201-S3 lands the toggle as a no-op stub then pkg217 fills it. (i) is
+  cleaner — recommended.
+- **Sequencing pressure:** Theme A (shader nodes) is the owner's stated #1 usability
+  lever; Theme C (caustics) is owner-deprioritized. If implementer slots are scarce,
+  spend them A → B → C, not C first.
+
+---
+
+## 4. Top 3 to dispatch first (with routing)
+
+1. **#638 HW-verify + merge** → `hardware-verifier` then `pr-reviewer`. (Rebuild the
+   stale `.pyd` first.)
+2. **pkg219a — Coordinate + Mapping unification** → `package-implementer` (impl
+   tier). Independently useful, unblocks 219b, no gating.
+3. **pkg219b — Bounded op-VM core** → Claude-implementer (register + GPU
+   interpreter judgment), after 219a; run `cite-algorithm` (Cycles SVM) +
+   `cpp-abi-guard` + REG probe.
+
+Research fan-out / breadth scouring (opcode-semantics enumeration for 219c, extra
+caustic-scene collection) → delegate to open-weight models via the `delegate`
+skill, evidence-verified.
+
+---
+
+## 5. Specs filed / refined + research saved this pass
+
+- Refined `pkg217` → implementable (wiring reframing, separate-stage design).
+- Decided + staged `pkg219` → 219a/219b/219c, fork (c) bounded op-VM.
+- Research note `docs/pkg217-wavefront-caustic-integration-research.md`.
+- Research note `docs/pkg219-per-texel-svm-evaluator-research.md`.

--- a/.astroray_plan/docs/pkg217-wavefront-caustic-integration-research.md
+++ b/.astroray_plan/docs/pkg217-wavefront-caustic-integration-research.md
@@ -1,0 +1,112 @@
+# pkg217 — GPU wavefront caustic integration research note
+
+**Date:** 2026-08-23
+**Author:** architect planning pass (goal-capture).
+**Policy:** [CLAUDE.md §6](../../CLAUDE.md) — no invented algorithms. This note
+selects an approach and its citations; `cite-algorithm` still runs at dispatch.
+**Builds on:** [`caustics-research.md`](caustics-research.md) (the original pkg64
+MNEE/SMS literature pass — read it first; the algorithm choice was settled there).
+
+---
+
+## The key reframing
+
+pkg217 is **not** "invent GPU caustics." The engine already has the caustic
+machinery; the GPU wavefront simply never invokes it. Evidence gathered this pass:
+
+- **CPU SMS caustics: DONE** (pkg64, `include/astroray/manifold/sms_attempt.h`,
+  `newton_iterate.h`, `mesh_attempt.h`). Prism-accurate spectral caustics work on CPU.
+- **Device SMS header exists:** `include/astroray/manifold/sms_attempt_device.cuh`,
+  `mesh_attempt.h` is device-compilable.
+- **The caster flag already crosses CPU→GPU:** `GSphere.isCausticCaster` survives
+  scene upload (pkg64-gpu Phase 1, verified by `src/gpu/pkg64_sms_probe.cu` — a
+  probe harness, *not* a production path). pkg64-gpu is marked **superseded**
+  because the full wavefront wiring was deferred as register-hostile.
+- **The gap:** `src/gpu/wavefront/stage_light_sample.cu` and
+  `stage_shade_lambertian.cu` contain **no caustic/SMS reference** (grep confirms
+  only `stage_advance.cu` / snapshot mention it, incidentally). So a diffuse
+  receiver behind glass connects to the delta light by ordinary NEE, the glass
+  occludes the shadow ray, throughput → 0, and the floor renders a **black
+  shadow**. Exactly the owner's 2026-08-21 Blender-MCP repro.
+
+So the work is: **wire the existing device SMS solve into a wavefront caustic
+connection, gated by `isCausticCaster`, without spilling the REG:254 shade kernels.**
+
+## Cycles' reference behaviour (parity target)
+
+Cycles' "Shadow Caustics" is **MNEE** (Manifold Next Event Estimation, Hanika et
+al. 2015), contributed by Reality Labs, inserted **at the light-sampling stage**
+(commit `1fb0247497`, task T94120). Mechanics worth mirroring for parity:
+
+- MNEE is a **specialised NEE connection**: from a receiver shading point, through
+  a refractive caster, to a caustic-flagged light, solved on the specular manifold.
+- A **cascading flag mechanism** (`PATH_MNEE_SUCCESS`) *culls ordinary NEE* to
+  caustic lights for rays that should resolve through MNEE — MNEE becomes the *only*
+  connection technique receiver→caster→light. This is the design detail that turns
+  the black shadow into a caustic: you must both (a) add the manifold connection AND
+  (b) suppress the doomed ordinary shadow ray, else you double-count or keep the
+  black.
+- On MNEE success Cycles disables path regularization (roughness blur) downstream.
+- Known Cycles limitations to *not* replicate blindly: MNEE caustics are
+  mis-classified as direct light (T96992) and there is no fallback when the walk
+  fails (T96991). Astroray should classify caustic contribution as indirect and
+  keep brute-force PT as the silent fallback.
+
+**Astroray uses SMS, not MNEE**, for licensing reasons already litigated in
+`caustics-research.md` (Cycles MNEE is Apache-2.0-mirror-able but the project chose
+the BSD-3 SMS skeleton + per-λ Newton). That is fine: SMS and MNEE solve the same
+specular-manifold constraint; Cycles is the *visual* parity oracle, not the code
+source. The wavefront integration pattern (connection at light-sample stage +
+ordinary-NEE culling through casters) is an *architecture-level* borrow, not code.
+
+## Recommended wavefront integration
+
+1. **New optional stage, not a fatter shade kernel.** Add a
+   `stage_caustic_connect.cu` that runs *only* when the scene has ≥1 caster
+   (host-side gate: skip the launch entirely otherwise — zero cost for the 99% of
+   scenes with no caster). This sidesteps the REG:254 problem: the SMS Newton
+   solve's live state lives in a *separate* kernel with its own register file, not
+   spilled into `stageShadeBucketed`.
+2. **Per-receiver-hit predicate.** In the existing light-sample stage, when the
+   sampled light is a delta caustic light AND the scene has casters, route that
+   lane to the caustic stage instead of emitting an ordinary shadow ray (the
+   `PATH_MNEE_SUCCESS`-style cull). Keep this to a single lane-flag bit.
+3. **Reuse `sms_attempt_device.cuh`.** Do not re-derive the solver. The device
+   header exists; the two-bounce robustness upgrade is **pkg127** (Specular
+   Polynomials) — file pkg217 to consume whatever seed stage is current and let
+   pkg127 improve it later. Do not couple them.
+4. **Spectral:** the manifold constraint is per-λ (Sellmeier), so the caustic is
+   dispersion-coloured for free once the solve runs per hero-λ. Leverage pkg206
+   hero-λ importance sampling for convergence (already merged).
+5. **Register gate is a HARD acceptance gate** (memory
+   `wavefront-shade-kernels-register-saturated`): probe `stageShadeBucketed` /
+   `stageAdvance` REG count *unchanged* after the change (the new kernel is
+   separate, so this should hold trivially — that is the whole point of choosing a
+   separate stage over an inline branch). Use `cuobjdump` post-link + template
+   `<bool HasCaustics>` if any shared code is touched.
+
+## Effort / risk
+
+- **Effort:** L. The solver exists; the work is wavefront plumbing (a new stage,
+  a lane predicate, queue management) + the NEE-cull + spectral verification +
+  CPU/GPU parity gate. Register-hostile *only if* implemented as an inline branch —
+  the separate-stage design defuses that.
+- **Top risk:** the ordinary-NEE cull. Get it wrong and you either keep the black
+  shadow (cull too much, no fallback) or double-count (cull too little). The
+  distinguishing test: caustic-region radiance must exceed the black-shadow
+  baseline by a stated factor AND the lit-pool region outside the caster shadow
+  must be unchanged vs pre-change (no energy added elsewhere).
+- **Second risk:** salt-and-pepper false-positive on the dispersion gate (memory
+  `general-photon-loop-needs-solid-glass`) — require a solid closed prism with
+  outward normals and a visual hue-spread + bright-coverage check, not just a
+  variance metric.
+
+## Citations to lock at dispatch
+- Zeltner, Georgiev, Jakob, "Specular Manifold Sampling for Rendering
+  High-Frequency Caustics and Glints", SIGGRAPH 2020 (Astroray's method; BSD-3 ref
+  code skeleton already in-tree via pkg64).
+- Hanika, Droske, Manakov, "Manifold Next Event Estimation", EGSR 2015, DOI
+  10.1111/cgf.12681 (per-λ Newton math + Cycles parity architecture).
+- Cycles `1fb0247497` shadow-caustics commit + T94120 (parity oracle; architecture
+  borrow only — GPL kernel not mirrored).
+- Fan et al., "Specular Polynomials", SIGGRAPH 2024 (deferred seed upgrade = pkg127).

--- a/.astroray_plan/docs/pkg219-per-texel-svm-evaluator-research.md
+++ b/.astroray_plan/docs/pkg219-per-texel-svm-evaluator-research.md
@@ -1,0 +1,110 @@
+# pkg219 — Per-texel shader-graph evaluator research note
+
+**Date:** 2026-08-23
+**Author:** architect planning pass (goal-capture).
+**Policy:** [CLAUDE.md §6](../../CLAUDE.md) — architecture reference is Cycles SVM
+(Apache-2.0); design borrow, not code mirror. `cite-algorithm` runs at dispatch.
+**Builds on:** [`blender-shader-nodes-research.md`](blender-shader-nodes-research.md)
+(custom-node UX — orthogonal; that note is about node *authoring*, this is about
+node-tree *evaluation*).
+
+---
+
+## Problem restated (grounded)
+
+The addon **constant-folds** the Blender node tree
+(`blender_addon/__init__.py::convert_shader_node`, ~L2700+). Any node needing
+per-shading-point evaluation *downstream of a texture* silently degrades to a
+constant/grey (memory `addon-constant-folds-shader-graph`). Confirmed broken:
+`VALTORGB`/Color-Ramp on a texture (L2772 — `evaluate(fac)` on a single constant
+returns `None` → grey), MixRGB/Math/MapRange/HSV/Invert/Gamma/Separate-Combine on
+a texture, full 3-D `MAPPING` (L2961, only Z-rotation kept), non-UV `TEX_COORD`
+(L2993, Camera/Window/Reflection/Normal → UV fallback).
+
+## Reference architecture: Cycles SVM
+
+Cycles' default shader system is **SVM** (Shader Virtual Machine): the node tree is
+compiled to a **bytecode stream of `uint4` instructions** stored in a 1-D texture;
+`svm_eval_nodes` is a templated GPU kernel that walks the stream with a node
+counter and a **float stack** holding intermediate socket values (GitHub
+`blender/cycles/src/kernel/svm/svm.h`, Apache-2.0). OSL is the alternative (JIT,
+CPU-strong, heavier). Two facts that drive the Astroray design:
+
+- **The stack is the bottleneck, not the opcode count.** Cycles has repeated
+  reports of "SVM stack full with relatively few nodes" (#117706, T46872) and the
+  stack is what "breaks LLVM optimization in many ways." On a GPU wavefront pinned
+  at REG:254 (memory `wavefront-shade-kernels-register-saturated`), an *unbounded*
+  per-shading-point float stack is exactly the spill risk we cannot take inline.
+- **Half-baked bytecode** (compile on build server, specialize per scene) is a
+  Cycles perf trick we do **not** need — Astroray compiles the tree host-side per
+  material at scene-upload, which is fine.
+
+## The fork — decision
+
+The spec's three options were (a) full SVM/OSL evaluator, (b) incremental
+special-casing, (c) hybrid op-VM. **Decision: (c), staged, as the path to (a).**
+
+Rationale:
+- (b) is the "reinvent the wheel 100 times" anti-pattern the owner explicitly
+  rejected. Off the table except as throwaway.
+- (a) full-SVM is correct but XL and register-hostile if done as one inline GPU
+  interpreter. Doing it in one shot risks the REG:254 spill with no incremental
+  value delivered.
+- (c) delivers most of (a)'s real-world coverage (the broken chains above are all
+  **scalar/colour ops on ≤4-wide values**) with a **bounded** op-VM, and the same
+  bytecode format extends to full (a) later. It is a strict prefix of (a).
+
+**Concrete (c) design:**
+1. **Bytecode format = a small `uint4` op stream per material**, Cycles-shaped, so
+   it is forward-compatible with (a). ~20 opcodes cover the confirmed-broken set:
+   `TEX_IMAGE`, `TEX_COORD` (UV/Generated/Object/Camera/Window), `MAPPING` (full
+   3-D loc/rot/scale matrix), `COLOR_RAMP`, `MIX`/`MIX_COLOR`, `MATH`, `MAP_RANGE`,
+   `HSV`, `INVERT`, `GAMMA`, `BRIGHT_CONTRAST`, `SEPARATE_COLOR`, `COMBINE_COLOR`,
+   `BUMP`, `NORMAL_MAP`, plus load/store-constant.
+2. **Bounded stack.** Cap the value stack at a compile-time small N (e.g. 8×float4)
+   and *statically verify at compile time* that the compiled program fits — if a
+   material overflows, emit a **visible degradation entry** (reuse the existing
+   `_degradation_report` mechanism) and fall back to constant-fold for that
+   material. This keeps the GPU register budget provable, unlike Cycles' dynamic
+   stack. This is the single most important design constraint.
+3. **One evaluator, two backends:** a CPU evaluator and a GPU device function that
+   walk the same bytecode. Keep the GPU evaluator in a **separate device function**
+   invoked from the shade stage only for materials with a non-trivial program;
+   pure-constant materials keep the current fast path (no VM). Template
+   `<bool HasProgram>` isolation so non-VM scenes see zero register change (memory
+   `closure-graph-lobe-count-spills-the-fused-kernel`).
+4. **Unify the coordinate path regardless of fork** (spec item 3): full 3-D
+   Mapping incl. X/Y rotation, real Generated/Object/Camera/Window coords. This is
+   needed even for constant-folded materials and is a clean first sub-package.
+
+## Recommended staging (so value lands incrementally, register budget stays proven)
+
+- **pkg219a — Coordinate + Mapping unification** (M, no VM yet): full 3-D Mapping
+  matrix + real TexCoord outputs, wired into the existing texture special-case.
+  Fixes the "mapping only partly applied" half of the repro. Deliverable on its own.
+- **pkg219b — Bounded op-VM core** (L): the `uint4` bytecode compiler (Blender
+  tree → op stream, host-side), the CPU evaluator, the GPU device evaluator with
+  the static stack-bound check + degradation fallback. Ship with the Color-Ramp,
+  Mix, Math, MapRange opcodes — the highest-frequency broken chains.
+- **pkg219c — Opcode coverage fill-out** (M): HSV/Invert/Gamma/BrightContrast/
+  Separate-Combine/Bump/NormalMap, each with a Cycles parity render.
+- **(a) full-SVM** stays a *future* option; (c)'s bytecode is its on-ramp. Do not
+  file (a) now.
+
+## Effort / risk
+- **Effort:** L–XL total, but **decomposable** — 219a alone is M and independently
+  useful. That decomposition is the main win of this planning pass.
+- **Top risk:** GPU register/stack budget. Mitigation = static compile-time stack
+  bound + separate device function + `<bool HasProgram>` template + a REG probe
+  gate identical to pkg198/pkg199. If a program can't be proven-bounded, it falls
+  back to constant-fold with a visible degradation entry — never a silent grey.
+- **Second risk:** Cycles parity of individual ops (Color Ramp interpolation
+  modes, Mix blend types, Math operations). Mirror Cycles' `svm_*` semantics
+  op-by-op; each opcode gets a parity render in the acceptance matrix.
+
+## Citations to lock at dispatch
+- Cycles SVM: `blender/cycles/src/kernel/svm/svm.h` + `svm/*` (Apache-2.0;
+  architecture + per-op semantics reference, not mirrored).
+- Cycles SVM stack-budget lessons: T46872 (stack optimization), #117706 (stack
+  full with few nodes) — motivate the bounded-stack design.
+- OSL (alternative, rejected for GPU-wavefront weight): documented for the record.

--- a/.astroray_plan/packages/pkg217-gpu-refractive-dispersive-caustics.md
+++ b/.astroray_plan/packages/pkg217-gpu-refractive-dispersive-caustics.md
@@ -2,9 +2,39 @@
 
 **Pillar:** 3 (light transport / spectral rendering)
 **Track:** A
-**Status:** open (filed 2026-08-21).
+**Status:** open (filed 2026-08-21; refined to implementable 2026-08-23).
 **Priority:** NOT top — owner (2026-08-21) explicitly deprioritised: "not necessarily #1 if there are more pressing things or older packages waiting their turn." Sequence behind the existing backlog; this is a real feature, not a quick fix.
 **Estimated effort:** L (GPU wavefront caustic path; register-hostile — probe-gated).
+**Research note:** [`../docs/pkg217-wavefront-caustic-integration-research.md`](../docs/pkg217-wavefront-caustic-integration-research.md) — READ FIRST.
+
+## Refinement (2026-08-23 architect planning pass — READ THIS)
+
+This is a **wiring problem, not a new algorithm.** The engine already has the
+caustic machinery; the GPU wavefront just never invokes it:
+- CPU SMS caustics = **DONE** (pkg64, `include/astroray/manifold/sms_attempt.h`).
+- Device SMS solver header **exists** (`manifold/sms_attempt_device.cuh`).
+- `GSphere.isCausticCaster` **already crosses CPU→GPU** (pkg64-gpu Phase 1, probe
+  `src/gpu/pkg64_sms_probe.cu`). pkg64-gpu is `superseded` because full wiring was
+  deferred as register-hostile.
+- **The gap:** `src/gpu/wavefront/stage_light_sample.cu` has no caustic path, so a
+  receiver behind glass does ordinary NEE, the shadow ray hits the glass, throughput
+  → 0 = black shadow.
+
+**Chosen integration (defuses the register problem):**
+1. **A separate `stage_caustic_connect.cu` kernel**, launched *only* when the scene
+   has ≥1 caster (host-side gate — zero cost, zero register change for caster-free
+   scenes). The SMS Newton live state lives in this kernel's own register file, NOT
+   spilled into `stageShadeBucketed` (REG:254). This is the whole reason to pick a
+   separate stage over an inline branch.
+2. **Ordinary-NEE cull** (Cycles `PATH_MNEE_SUCCESS` pattern, architecture borrow
+   only): when the sampled light is a delta caustic light and casters exist, route
+   the lane to the caustic stage instead of emitting the doomed shadow ray. One
+   lane-flag bit. Getting this wrong = keep-black (cull too much, no fallback) or
+   double-count (cull too little). Keep brute-force PT as silent fallback; classify
+   caustic contribution as INDIRECT (unlike Cycles' T96992 bug).
+3. **Reuse `sms_attempt_device.cuh`** — do NOT re-derive the solver, and do NOT
+   couple to pkg127 (the Specular-Polynomials seed upgrade lands later independently).
+4. Spectral dispersion comes for free (per-hero-λ manifold solve; leverages pkg206).
 
 ## Goal
 

--- a/.astroray_plan/packages/pkg219-per-texel-shader-graph.md
+++ b/.astroray_plan/packages/pkg219-per-texel-shader-graph.md
@@ -3,7 +3,35 @@
 **Pillar:** Blender/DCC integration (integration-first directive, 2026-08 — this comes
 BEFORE Pillar 4; memory `integration-first-directive-2026-08`).
 **Track:** A (architect researches the fork + sizes before implementation).
-**Status:** open (filed 2026-08-22). **RESEARCH SPEC.**
+**Status:** open (filed 2026-08-22; fork DECIDED + staged 2026-08-23).
+**Research note:** [`../docs/pkg219-per-texel-svm-evaluator-research.md`](../docs/pkg219-per-texel-svm-evaluator-research.md) — READ FIRST.
+
+## Decision (2026-08-23 architect planning pass)
+
+**Fork (c) — bounded hybrid op-VM, staged, as the on-ramp to full (a).** (b)
+special-casing is the rejected "reinvent the wheel 100 times" anti-pattern; (a)
+full-SVM in one shot is XL and register-hostile with no incremental delivery. (c)
+covers the confirmed-broken chains (all scalar/colour ops ≤4-wide downstream of a
+texture) with a **bounded** `uint4` bytecode VM whose format is a strict prefix of
+full SVM. **The critical constraint vs Cycles SVM: a STATIC compile-time stack
+bound** (Cycles' dynamic float stack overflows "with relatively few nodes" and is
+untenable on the REG:254 wavefront) — overflow → visible degradation entry + fall
+back to constant-fold, never a silent grey.
+
+**Staging (dispatch as three sub-packages; 219a is independently useful):**
+- **pkg219a — Coordinate + Mapping unification** (M, Track A, no VM). Full 3-D
+  Mapping matrix (incl. X/Y rotation) + real Generated/Object/Camera/Window
+  TexCoord, wired into the existing texture special-case. Fixes the "mapping only
+  partly applied" repro half on its own.
+- **pkg219b — Bounded op-VM core** (L, Track A, Claude-implementer). Host-side
+  Blender-tree→`uint4` compiler, CPU evaluator, GPU device evaluator with the
+  static stack-bound check + `<bool HasProgram>` isolation + REG probe gate. Ship
+  Color-Ramp / Mix / Math / MapRange opcodes (highest-frequency broken chains).
+- **pkg219c — Opcode coverage fill-out** (M, Track A/B). HSV / Invert / Gamma /
+  BrightContrast / Separate-Combine / Bump / NormalMap, each with a Cycles parity
+  render.
+
+Old `**RESEARCH SPEC**` framing below retained for context.
 **Priority:** HIGH for usability — the owner (2026-08-22) flagged that "lots of shader
 nodes don't really work" and that this must be fixed "if we ever want good useability and
 Blender integration without reinventing the wheel 100 times."


### PR DESCRIPTION
Fresh architect-led planning pass (goal-capture mode).

## What changed
- **Regenerated `NEXT_STAGE_REPORT.md`** as the canonical dispatch queue: prioritized roadmap grouped by the owner's pressing themes (shader-node compat, Cycles/CPU-GPU parity, caustics, opportunistic quality), each with effort + model-tier routing + gating.
- **Refined pkg217** (GPU caustics) to implementable: it is a *wavefront-wiring* problem — CPU SMS (pkg64), the device solver (`sms_attempt_device.cuh`), and the caster-flag CPU→GPU plumbing all already exist. Chosen design: a separate `stage_caustic_connect.cu` (defuses the REG:254 spill) + ordinary-NEE cull.
- **Decided + staged pkg219** (shader graph) toward fork (c): a bounded `uint4` op-VM with a *static* stack bound, split into 219a (coord/mapping unification, independently useful), 219b (VM core), 219c (opcode fill-out).
- **Two research notes** saved (Cycles MNEE/SMS caustic integration; Cycles SVM per-texel evaluator), each with citations and register-budget analysis.

## Pending-state facts recorded (not fixed here)
- PR #638 open/CI-green, needs HW verify before merge.
- `build_cuda` .pyd is stale vs HEAD — rebuild before any GPU verify.
- Pillar 4 (incl. pkg218) remains paused.

## Top 3 to dispatch
1. #638 HW-verify + merge (hardware-verifier → pr-reviewer)
2. pkg219a coord/mapping unification (package-implementer)
3. pkg219b bounded op-VM core (Claude-implementer, after 219a)

Docs-only; no engine change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)