### PR TITLE
feat(pkg219c): op-VM opcode fill-out — HSV/Invert/Gamma/BrightContrast/Sep-Combine Color/RGB-to-BW

### DIFF
--- a/.astroray_plan/packages/pkg219-per-texel-shader-graph.md
+++ b/.astroray_plan/packages/pkg219-per-texel-shader-graph.md
@@ -37,8 +37,10 @@ back to constant-fold, never a silent grey.
   static stack-bound check + `<bool HasProgram>` isolation + REG probe gate. Ship
   Color-Ramp / Mix / Math / MapRange opcodes (highest-frequency broken chains).
 - **pkg219c — Opcode coverage fill-out** (M, Track A/B).
-  **Status: in review (PR pending, 2026-08-23 — CPU+GPU, register-neutral true-half;
-  needs HW verify).** Shipped opcodes: Hue/Saturation/Value, Invert, Gamma,
+  **Status: in review (PR #642, 2026-08-23 — CPU+GPU, register-neutral true-half
+  identical to pkg219b max STACK 7912, no spill; 18/18 pkg219c tests pass incl.
+  CPU/GPU Invert parity ratio [1.0007, 0.9998, 0.9974]; needs HW verify).**
+  Shipped opcodes: Hue/Saturation/Value, Invert, Gamma,
   Bright/Contrast, Separate Color + Combine Color (RGB and HSV modes), RGB-to-BW —
   each with a CPU evaluator case, GPU interpreter case (shared HD `svm_eval`),
   addon compiler support, and a TDD parity test. Formulas re-verified against

--- a/.astroray_plan/packages/pkg219-per-texel-shader-graph.md
+++ b/.astroray_plan/packages/pkg219-per-texel-shader-graph.md
@@ -36,9 +36,24 @@ back to constant-fold, never a silent grey.
   Blender-tree→`uint4` compiler, CPU evaluator, GPU device evaluator with the
   static stack-bound check + `<bool HasProgram>` isolation + REG probe gate. Ship
   Color-Ramp / Mix / Math / MapRange opcodes (highest-frequency broken chains).
-- **pkg219c — Opcode coverage fill-out** (M, Track A/B). HSV / Invert / Gamma /
-  BrightContrast / Separate-Combine / Bump / NormalMap, each with a Cycles parity
-  render.
+- **pkg219c — Opcode coverage fill-out** (M, Track A/B).
+  **Status: in review (PR pending, 2026-08-23 — CPU+GPU, register-neutral true-half;
+  needs HW verify).** Shipped opcodes: Hue/Saturation/Value, Invert, Gamma,
+  Bright/Contrast, Separate Color + Combine Color (RGB and HSV modes), RGB-to-BW —
+  each with a CPU evaluator case, GPU interpreter case (shared HD `svm_eval`),
+  addon compiler support, and a TDD parity test. Formulas re-verified against
+  Cycles main (`src/util/color.h`, `svm/hsv.h`, `svm/invert.h`,
+  `svm/color_util.h`, `svm/math_util.h`, Apache-2.0).
+
+  **Deferred to a future spec (pkg219d candidate) — Bump and Normal Map.** These
+  two nodes perturb the *shading normal* (a geometry-dependent quantity that must
+  feed the BSDF's `N`), not a per-texel *colour/scalar* value. They do not fit the
+  colour op-VM (whose output is an RGB register consumed as a texture value) and
+  need their own design: normal perturbation applied in the shade path, with
+  screen-space or analytic derivatives of the upstream height/normal texture, on
+  both CPU and GPU. Forcing them into the colour VM would require the VM to write
+  back into the shading frame — out of scope for pkg219c. File pkg219d to design
+  the normal-perturbation path separately.
 
 Old `**RESEARCH SPEC**` framing below retained for context.
 **Priority:** HIGH for usability — the owner (2026-08-22) flagged that "lots of shader

--- a/.astroray_plan/packages/pkg219-per-texel-shader-graph.md
+++ b/.astroray_plan/packages/pkg219-per-texel-shader-graph.md
@@ -276,3 +276,91 @@ tests (14/14) and regression smoke (21/23 + 2 pre-existing xfail, no new
 failures), and the visual headline repro (Color Ramp on a texture renders
 correctly per-texel on both CPU and GPU, in close numerical parity). Ready for
 `pr-reviewer` merge decision.
+
+## Hardware verification 2026-08-23 (PR #642, pkg219c — op-VM opcode fill-out)
+
+Hardware: RTX 5070 Ti. OS: Windows 11 Enterprise 10.0.26200. CUDA 12.8
+(nvcc), MSVC 14.44.35207 (VS2022 BuildTools). Worktree
+`Astroray-pkg219c`, branch `pkg219c`, verified HEAD
+`63dd905a706efe35ede232266c6cd7ae03f21456`.
+
+**Build.** Clean rebuild via `build_cuda_worktree.bat` (PowerShell
+invocation) — succeeded, exit 0. SHA-guard passed. `astroray.__file__`
+resolves to the canonical `build_cuda\Release\astroray.cp313-win_amd64.pyd`
+(no shadow copy). `cuobjdump --list-elf` on the built `.pyd`: single cubin,
+`sm_120` only — no stale-arch contamination this run. ABI canary caps:
+`{cpu: True, spectral: True, gpu: True, gpu_spectral: True,
+closure_graph: True, gpu_type: 'closure_graph'}`.
+
+**Fleet register gate** (`cuobjdump -res-usage`, all 64
+`stageShadeBucketedKernel` specializations): all **REG:254, no spill**.
+Combined STACK histogram (both `HasProgram` halves summed, then verified
+by subtraction to split cleanly into the two known 32-specialization
+buckets):
+
+`HasProgram=false` (32 specializations) — exact match to pkg219a/b
+baseline:
+
+| REG | STACK | count |
+|-----|-------|-------|
+| 254 | 3352  | 8 |
+| 254 | 3608  | 4 |
+| 254 | 3672  | 4 |
+| 254 | 7720  | 6 |
+| 254 | 7784  | 2 |
+| 254 | 7848  | 8 |
+
+`HasProgram=true` (32 specializations) — bounded, unchanged from pkg219b
+despite 7 new opcodes:
+
+| REG | STACK | count |
+|-----|-------|-------|
+| 254 | 3352  | 4 |
+| 254 | 3416  | 4 |
+| 254 | 3608  | 2 |
+| 254 | 3672  | 4 |
+| 254 | 3736  | 2 |
+| 254 | 7720  | 4 |
+| 254 | 7784  | 2 |
+| 254 | 7848  | 6 |
+| 254 | 7912  | 4 |
+
+Max STACK 7912, identical bound to pkg219b — adding the 7 fill-out
+opcodes (HSV, Invert, Gamma, Bright/Contrast, Separate/Combine Color,
+RGB-to-BW) did not grow the register/stack footprint.
+
+**Gate tests** (`pytest tests/test_pkg219c_op_vm.py
+tests/test_pkg219c_addon_compiler.py tests/test_pkg219c_parity_render.py
+-v -s --tb=short`): **18 passed, 0 failed** in 1.21s.
+
+**Regression smoke** (`tests/test_material_properties.py` +
+`tests/test_disney_reflection_not_black.py`, 23 items): **21 passed,
+2 xfailed** (`test_disney_metallic_tints_specular_highlight`,
+`test_disney_roughness_changes_glossiness` — same pre-existing xfails as
+pkg219b baseline, unrelated to this PR). No new failures.
+
+**Visual spot-check — two new opcodes downstream of a texture**
+(2×2 quad texture, 64×64, 64 spp, `apply_gamma=False`; one-off script
+deleted after use per repo convention):
+
+- **Invert** (fac=1): per-quadrant colors flip to their complements
+  (red→teal, green→magenta, blue→olive, olive→navy) — confirms per-texel
+  application, not constant-folded. CPU/GPU per-channel mean-ratio:
+  `[1.0006983, 0.9997574, 0.9973535]`.
+- **HSV** (hue=0.5, sat=1.0, val=1.0, fac=1.0 — the Cycles-node identity
+  point, since the node's hue formula centers at 0.5): output reproduces
+  the source quad colors unchanged, as expected for this parameter
+  choice. CPU/GPU per-channel mean-ratio: `[0.9998741, 1.0004354,
+  0.99760056]`.
+- Visual inspection of all 4 PNGs (CPU/GPU × Invert/HSV): CPU and GPU
+  renders visually indistinguishable per opcode; no fireflies, no
+  banding/quantization artifacts, no NaN pixels (no magenta/solid-black),
+  no mode regressions.
+
+**Verdict: PASS.** Clean rebuild with correct sm_120 arch, fleet register
+gate byte-identical to pkg219b baseline (`HasProgram=false` half) with a
+bounded, unchanged max STACK for the `HasProgram=true` half, all 18
+package tests pass, no regression in material-properties/Disney-reflection
+suites, and two independently-checked new opcodes (Invert, HSV) render
+correctly per-texel with CPU/GPU parity within MC noise. Reported for
+`pr-reviewer` merge decision; not merged by this verifier.

--- a/blender_addon/shader_vm_compiler.py
+++ b/blender_addon/shader_vm_compiler.py
@@ -17,7 +17,14 @@ Opcode / sub-op enums MUST match include/astroray/shader_vm.h exactly.
 """
 
 # ---- opcode / sub-op enums (mirror include/astroray/shader_vm.h) -----------
-OP_END, OP_LOAD_TEX, OP_LOAD_CONST, OP_MATH, OP_MIX, OP_RAMP, OP_MAP_RANGE = range(7)
+(OP_END, OP_LOAD_TEX, OP_LOAD_CONST, OP_MATH, OP_MIX, OP_RAMP, OP_MAP_RANGE,
+ OP_HSV, OP_INVERT, OP_GAMMA, OP_BRIGHT_CONTRAST, OP_SEP_COLOR,
+ OP_COMBINE_COLOR, OP_RGB_TO_BW) = range(14)
+
+# Colour-space enum for Separate/Combine Color (Cycles NodeCombSepColorType).
+CS_RGB, CS_HSV = 0, 1
+_COLOR_SPACE = {'RGB': CS_RGB, 'HSV': CS_HSV}  # HSL deferred (pkg219c non-goal)
+_SEP_COMPONENT = {'Red': 0, 'Green': 1, 'Blue': 2}
 
 MATH_OPS = {
     'ADD': 0, 'SUBTRACT': 1, 'MULTIPLY': 2, 'DIVIDE': 3, 'MULTIPLY_ADD': 4,
@@ -153,7 +160,7 @@ def compile_socket(socket, builder, depth=0):
         # unlinked -> constant
         return builder.push_const(_socket_default_rgb(socket))
 
-    node, _out = src
+    node, out_name = src
     ntype = getattr(node, 'type', None)
 
     if _is_image_texture(node):
@@ -211,6 +218,69 @@ def compile_socket(socket, builder, depth=0):
         out = builder.alloc_slot()
         builder.emit(OP_MAP_RANGE, out, a=v_s, b=fmn, c=fmx, d=tmn, e=tmx,
                      imm=MAP_RANGE_OPS[interp])
+        return out
+
+    if ntype == 'HUE_SAT':  # Hue/Saturation/Value
+        hue_s = compile_socket(_get_input(node, 'Hue'), builder, depth + 1)
+        sat_s = compile_socket(_get_input(node, 'Saturation'), builder, depth + 1)
+        val_s = compile_socket(_get_input(node, 'Value'), builder, depth + 1)
+        fac_s = compile_socket(_get_input(node, 'Fac'), builder, depth + 1)
+        col_s = compile_socket(_get_input(node, 'Color'), builder, depth + 1)
+        out = builder.alloc_slot()
+        builder.emit(OP_HSV, out, a=hue_s, b=sat_s, c=val_s, d=fac_s, e=col_s)
+        return out
+
+    if ntype == 'INVERT':
+        fac_s = compile_socket(_get_input(node, 'Fac'), builder, depth + 1)
+        col_s = compile_socket(_get_input(node, 'Color'), builder, depth + 1)
+        out = builder.alloc_slot()
+        builder.emit(OP_INVERT, out, a=fac_s, b=col_s)
+        return out
+
+    if ntype == 'GAMMA':
+        col_s = compile_socket(_get_input(node, 'Color'), builder, depth + 1)
+        gam_s = compile_socket(_get_input(node, 'Gamma'), builder, depth + 1)
+        out = builder.alloc_slot()
+        builder.emit(OP_GAMMA, out, a=col_s, b=gam_s)
+        return out
+
+    if ntype == 'BRIGHTCONTRAST':
+        col_s = compile_socket(_get_input(node, 'Color'), builder, depth + 1)
+        br_s = compile_socket(_get_input(node, 'Bright'), builder, depth + 1)
+        ct_s = compile_socket(_get_input(node, 'Contrast'), builder, depth + 1)
+        out = builder.alloc_slot()
+        builder.emit(OP_BRIGHT_CONTRAST, out, a=col_s, b=br_s, c=ct_s)
+        return out
+
+    if ntype == 'SEPARATE_COLOR':
+        mode = getattr(node, 'mode', 'RGB')
+        if mode not in _COLOR_SPACE:
+            raise VMCompileError("unsupported Separate Color mode: %s" % mode)
+        comp = _SEP_COMPONENT.get(out_name)
+        if comp is None:
+            raise VMCompileError("unsupported Separate Color output: %s" % out_name)
+        col_s = compile_socket(_get_input(node, 'Color'), builder, depth + 1)
+        out = builder.alloc_slot()
+        builder.emit(OP_SEP_COLOR, out, a=col_s,
+                     imm=_COLOR_SPACE[mode] * 4 + comp)
+        return out
+
+    if ntype == 'COMBINE_COLOR':
+        mode = getattr(node, 'mode', 'RGB')
+        if mode not in _COLOR_SPACE:
+            raise VMCompileError("unsupported Combine Color mode: %s" % mode)
+        r_s = compile_socket(_get_input(node, 'Red'), builder, depth + 1)
+        g_s = compile_socket(_get_input(node, 'Green'), builder, depth + 1)
+        b_s = compile_socket(_get_input(node, 'Blue'), builder, depth + 1)
+        out = builder.alloc_slot()
+        builder.emit(OP_COMBINE_COLOR, out, a=r_s, b=g_s, c=b_s,
+                     imm=_COLOR_SPACE[mode])
+        return out
+
+    if ntype == 'RGB_TO_BW':
+        col_s = compile_socket(_get_input(node, 'Color'), builder, depth + 1)
+        out = builder.alloc_slot()
+        builder.emit(OP_RGB_TO_BW, out, a=col_s)
         return out
 
     if ntype == 'RGB':

--- a/include/astroray/shader_vm.h
+++ b/include/astroray/shader_vm.h
@@ -43,7 +43,19 @@ enum OpCode : unsigned char {
     OP_MIX        = 4,  // reg[out] = mix(imm, fac=a.x, c1=b, c2=c) svm/color_util.h
     OP_RAMP       = 5,  // reg[out] = ramp[imm].lookup(a.x)       svm/ramp.h
     OP_MAP_RANGE  = 6,  // reg[out].x = map_range(imm, a.x,b.x,c.x,d.x,e.x) svm/map_range.h
+    // pkg219c — opcode coverage fill-out (per-texel colour/scalar ops).
+    OP_HSV        = 7,  // reg[out] = hsv(hue=a.x,sat=b.x,val=c.x,fac=d.x,col=e) svm/hsv.h
+    OP_INVERT     = 8,  // reg[out] = invert(fac=a.x, col=b)      svm/invert.h
+    OP_GAMMA      = 9,  // reg[out] = gamma(col=a, gamma=b.x)     svm/math_util.h
+    OP_BRIGHT_CONTRAST = 10, // reg[out] = bc(col=a, bright=b.x, contrast=c.x) svm/color_util.h
+    OP_SEP_COLOR  = 11, // reg[out].xyz = separate(col=a, imm=space*4+comp).broadcast svm/color_util.h
+    OP_COMBINE_COLOR = 12, // reg[out] = combine(r=a.x,g=b.x,b=c.x, imm=space) svm/color_util.h
+    OP_RGB_TO_BW  = 13, // reg[out] = luma(col=a).broadcast        svm/convert.h
 };
+
+// Colour-space enum for Separate/Combine Color (Cycles NodeCombSepColorType).
+// pkg219c ships RGB + HSV (HSL deferred).
+enum ColorSpace : unsigned char { CS_RGB = 0, CS_HSV = 1 };
 
 // NodeMathType subset (Cycles svm/types.h). pkg219b ships the common subset;
 // pkg219c fills the rest. Values are the addon compiler's own enum, NOT the
@@ -197,6 +209,97 @@ HD inline float svm_map_range(unsigned char op, float value, float from_min,
     return to_min + factor * (to_max - to_min);
 }
 
+// ---- HSV colour-space conversions (Cycles util/color.h) --------------------
+HD inline float svm_fractf(float x) { return x - floorf(x); }
+
+HD inline GVec3 svm_rgb_to_hsv(GVec3 rgb) {
+    float cmax = rgb.x > rgb.y ? (rgb.x > rgb.z ? rgb.x : rgb.z)
+                               : (rgb.y > rgb.z ? rgb.y : rgb.z);
+    float cmin = rgb.x < rgb.y ? (rgb.x < rgb.z ? rgb.x : rgb.z)
+                               : (rgb.y < rgb.z ? rgb.y : rgb.z);
+    float cdelta = cmax - cmin;
+    float v = cmax;
+    float s, h;
+    if (cmax != 0.f) s = cdelta / cmax; else { s = 0.f; h = 0.f; }
+    if (s != 0.f) {
+        GVec3 c = (GVec3(cmax) - rgb) / cdelta;
+        if (rgb.x == cmax)      h = c.z - c.y;
+        else if (rgb.y == cmax) h = 2.f + c.x - c.z;
+        else                    h = 4.f + c.y - c.x;
+        h /= 6.f;
+        if (h < 0.f) h += 1.f;
+    } else {
+        h = 0.f;
+    }
+    return GVec3(h, s, v);
+}
+
+HD inline GVec3 svm_hsv_to_rgb(GVec3 hsv) {
+    float h = hsv.x, s = hsv.y, v = hsv.z;
+    if (s != 0.f) {
+        if (h == 1.f) h = 0.f;
+        h *= 6.f;
+        float i = floorf(h);
+        float f = h - i;
+        float p = v * (1.f - s);
+        float q = v * (1.f - (s * f));
+        float t = v * (1.f - (s * (1.f - f)));
+        if (i == 0.f)      return GVec3(v, t, p);
+        else if (i == 1.f) return GVec3(q, v, p);
+        else if (i == 2.f) return GVec3(p, v, t);
+        else if (i == 3.f) return GVec3(p, q, v);
+        else if (i == 4.f) return GVec3(t, p, v);
+        else               return GVec3(v, p, q);
+    }
+    return GVec3(v, v, v);
+}
+
+// ---- Hue/Saturation/Value node (Cycles svm/hsv.h svm_node_hsv) --------------
+HD inline GVec3 svm_hsv(float hue, float sat, float val, float fac, GVec3 color) {
+    GVec3 c = svm_rgb_to_hsv(color);
+    c.x = svm_fractf(c.x + hue + 0.5f);
+    c.y = svm_saturatef(c.y * sat);
+    c.z = c.z * val;
+    GVec3 out = svm_hsv_to_rgb(c);
+    out = out * fac + color * (1.f - fac);
+    // Clamp negatives from over-saturation (Cycles svm_node_hsv).
+    out.x = out.x > 0.f ? out.x : 0.f;
+    out.y = out.y > 0.f ? out.y : 0.f;
+    out.z = out.z > 0.f ? out.z : 0.f;
+    return out;
+}
+
+// ---- Invert node (Cycles svm/invert.h) -------------------------------------
+// interp(color, 1-color, fac) = (1-fac)*color + fac*(1-color), per channel.
+HD inline GVec3 svm_invert(float fac, GVec3 color) {
+    return color * (1.f - fac) + (GVec3(1.f) - color) * fac;
+}
+
+// ---- Gamma node (Cycles svm/math_util.h svm_math_gamma_color) ---------------
+HD inline GVec3 svm_gamma(GVec3 color, float gamma) {
+    if (gamma == 0.f) return GVec3(1.f, 1.f, 1.f);
+    if (color.x > 0.f) color.x = powf(color.x, gamma);
+    if (color.y > 0.f) color.y = powf(color.y, gamma);
+    if (color.z > 0.f) color.z = powf(color.z, gamma);
+    return color;
+}
+
+// ---- Bright/Contrast node (Cycles svm/color_util.h svm_brightness_contrast) -
+HD inline GVec3 svm_bright_contrast(GVec3 color, float bright, float contrast) {
+    float a = 1.f + contrast;
+    float b = bright - contrast * 0.5f;
+    GVec3 o;
+    o.x = a * color.x + b; o.x = o.x > 0.f ? o.x : 0.f;
+    o.y = a * color.y + b; o.y = o.y > 0.f ? o.y : 0.f;
+    o.z = a * color.z + b; o.z = o.z > 0.f ? o.z : 0.f;
+    return o;
+}
+
+// ---- RGB to BW (Cycles svm/convert.h; Rec.709 luma) ------------------------
+HD inline float svm_rgb_to_bw(GVec3 c) {
+    return c.x * 0.2126729f + c.y * 0.7151522f + c.z * 0.0721750f;
+}
+
 // ============================================================================
 // The evaluator. Pure, HD, byte-identical CPU<->GPU. `inputs` holds the
 // pre-sampled child-texture RGBs. Returns the program's output slot RGB.
@@ -234,6 +337,35 @@ HD inline GVec3 svm_eval(const ShaderVMProgram& p, const GVec3* inputs) {
                 reg[in.out] = GVec3(r);
                 break;
             }
+            case OP_HSV:
+                reg[in.out] = svm_hsv(reg[in.a].x, reg[in.b].x, reg[in.c].x,
+                                      reg[in.d].x, reg[in.e]);
+                break;
+            case OP_INVERT:
+                reg[in.out] = svm_invert(reg[in.a].x, reg[in.b]);
+                break;
+            case OP_GAMMA:
+                reg[in.out] = svm_gamma(reg[in.a], reg[in.b].x);
+                break;
+            case OP_BRIGHT_CONTRAST:
+                reg[in.out] = svm_bright_contrast(reg[in.a], reg[in.b].x, reg[in.c].x);
+                break;
+            case OP_SEP_COLOR: {
+                // imm = space*4 + component. RGB is identity; HSV converts.
+                unsigned char space = in.imm >> 2;
+                unsigned char comp  = in.imm & 3u;
+                GVec3 conv = (space == CS_HSV) ? svm_rgb_to_hsv(reg[in.a]) : reg[in.a];
+                reg[in.out] = GVec3(conv[comp < 3 ? comp : 0]);
+                break;
+            }
+            case OP_COMBINE_COLOR: {
+                GVec3 v(reg[in.a].x, reg[in.b].x, reg[in.c].x);
+                reg[in.out] = (in.imm == CS_HSV) ? svm_hsv_to_rgb(v) : v;
+                break;
+            }
+            case OP_RGB_TO_BW:
+                reg[in.out] = GVec3(svm_rgb_to_bw(reg[in.a]));
+                break;
             case OP_END:
             default:
                 pc = n;  // halt

--- a/tests/test_pkg219c_addon_compiler.py
+++ b/tests/test_pkg219c_addon_compiler.py
@@ -1,0 +1,238 @@
+"""pkg219c — addon node-chain compiler round-trip tests (no bpy required).
+
+Builds duck-typed fake Blender node chains for the pkg219c opcodes (HSV, Invert,
+Gamma, Bright/Contrast, Separate/Combine Color, RGB-to-BW downstream of a
+texture), compiles them with shader_vm_compiler.compile_chain, loads the emitted
+bytecode into the engine, and verifies the rendered per-texel result matches an
+independent Python reference. Exercises the compiler AND the shared HD svm_eval.
+"""
+import os
+import sys
+
+import pytest
+
+astroray = pytest.importorskip("astroray")
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "blender_addon"))
+import shader_vm_compiler as C  # noqa: E402
+
+# reuse the op-VM Python reference for HSV
+from test_pkg219c_op_vm import hsv_ref  # noqa: E402
+
+
+# ---- minimal duck-typed Blender node model ---------------------------------
+class Sock:
+    def __init__(self, name, default=0.0, link=None):
+        self.name = name
+        self.default_value = default
+        self._link = link
+
+    @property
+    def is_linked(self):
+        return self._link is not None
+
+    @property
+    def links(self):
+        return [self._link] if self._link else []
+
+
+class Link:
+    def __init__(self, from_node, from_socket_name="Color"):
+        self.from_node = from_node
+        self.from_socket = type("S", (), {"name": from_socket_name})()
+
+
+class SockList:
+    def __init__(self, socks):
+        self._socks = socks
+        self._by_name = {s.name: s for s in socks}
+
+    def get(self, name):
+        return self._by_name.get(name)
+
+    def __getitem__(self, i):
+        return self._socks[i]
+
+    def __len__(self):
+        return len(self._socks)
+
+    def __iter__(self):
+        return iter(self._socks)
+
+
+class Out:
+    def __init__(self, default):
+        self.default_value = default
+
+
+class Node:
+    def __init__(self, type, inputs=None, outputs=None, **kw):
+        self.type = type
+        self.inputs = SockList(inputs or [])
+        self.outputs = outputs or [Out(0.0)]
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
+def _load_program(r, name, compiled, input_values):
+    import numpy as np
+    r.create_program_texture(name, "UV")
+    for i, node in enumerate(compiled['inputs']):
+        tex_name = f"{name}_in{i}"
+        val = input_values[id(node)]
+        img = np.array(val, dtype="float32").reshape(1, 1, 3).ravel()
+        r.load_texture(tex_name, img, 1, 1, "UV")
+        r.program_texture_add_input(name, tex_name)
+    r.set_program_texture_program(name, compiled['num_tex'], compiled['out_slot'],
+                                  compiled['code_flat'], compiled['consts_flat'],
+                                  compiled['ramps_flat'])
+
+
+# --------------------------------------------------------------------------- #
+# 1. Hue/Saturation/Value on a texture
+# --------------------------------------------------------------------------- #
+def test_compile_hsv():
+    tex = Node('TEX_IMAGE')
+    hsv = Node('HUE_SAT',
+               inputs=[Sock('Hue', 0.6), Sock('Saturation', 1.3),
+                       Sock('Value', 0.9), Sock('Fac', 1.0),
+                       Sock('Color', [0, 0, 0], Link(tex, 'Color'))])
+    base = Sock('Base Color', [0.5, 0.5, 0.5], Link(hsv, 'Color'))
+    compiled = C.compile_chain(base)
+    assert compiled is not None and compiled['num_tex'] == 1
+    color = (0.7, 0.2, 0.4)
+    r = astroray.Renderer()
+    _load_program(r, "hsv", compiled, {id(tex): color})
+    got = r.sample_named_texture("hsv", 0.5, 0.5)
+    want = hsv_ref(0.6, 1.3, 0.9, 1.0, list(color))
+    assert got == pytest.approx(want, abs=3e-3), (got, want)
+
+
+# --------------------------------------------------------------------------- #
+# 2. Invert on a texture
+# --------------------------------------------------------------------------- #
+def test_compile_invert():
+    tex = Node('TEX_IMAGE')
+    inv = Node('INVERT',
+               inputs=[Sock('Fac', 1.0),
+                       Sock('Color', [0, 0, 0], Link(tex, 'Color'))])
+    base = Sock('Base Color', [0.5, 0.5, 0.5], Link(inv, 'Color'))
+    compiled = C.compile_chain(base)
+    assert compiled is not None
+    color = (0.2, 0.6, 0.9)
+    r = astroray.Renderer()
+    _load_program(r, "inv", compiled, {id(tex): color})
+    got = r.sample_named_texture("inv", 0.5, 0.5)
+    want = [1 - c for c in color]  # fac=1 -> full invert
+    assert got == pytest.approx(want, abs=3e-3), (got, want)
+
+
+# --------------------------------------------------------------------------- #
+# 3. Gamma on a texture
+# --------------------------------------------------------------------------- #
+def test_compile_gamma():
+    tex = Node('TEX_IMAGE')
+    gam = Node('GAMMA',
+               inputs=[Sock('Color', [0, 0, 0], Link(tex, 'Color')),
+                       Sock('Gamma', 2.0)])
+    base = Sock('Base Color', [0.5, 0.5, 0.5], Link(gam, 'Color'))
+    compiled = C.compile_chain(base)
+    assert compiled is not None
+    color = (0.25, 0.5, 0.8)
+    r = astroray.Renderer()
+    _load_program(r, "gam", compiled, {id(tex): color})
+    got = r.sample_named_texture("gam", 0.5, 0.5)
+    want = [c ** 2.0 for c in color]
+    assert got == pytest.approx(want, abs=3e-3), (got, want)
+
+
+# --------------------------------------------------------------------------- #
+# 4. Bright/Contrast on a texture
+# --------------------------------------------------------------------------- #
+def test_compile_bright_contrast():
+    tex = Node('TEX_IMAGE')
+    bc = Node('BRIGHTCONTRAST',
+              inputs=[Sock('Color', [0, 0, 0], Link(tex, 'Color')),
+                      Sock('Bright', 0.2), Sock('Contrast', 0.4)])
+    base = Sock('Base Color', [0.5, 0.5, 0.5], Link(bc, 'Color'))
+    compiled = C.compile_chain(base)
+    assert compiled is not None
+    color = (0.3, 0.5, 0.7)
+    r = astroray.Renderer()
+    _load_program(r, "bc", compiled, {id(tex): color})
+    got = r.sample_named_texture("bc", 0.5, 0.5)
+    a, b = 1.0 + 0.4, 0.2 - 0.4 * 0.5
+    want = [max(a * c + b, 0.0) for c in color]
+    assert got == pytest.approx(want, abs=3e-3), (got, want)
+
+
+# --------------------------------------------------------------------------- #
+# 5. Separate Color (Green) -> Math driving a scalar, from a texture
+# --------------------------------------------------------------------------- #
+def test_compile_separate_color_green():
+    tex = Node('TEX_IMAGE')
+    sep = Node('SEPARATE_COLOR', mode='RGB',
+               inputs=[Sock('Color', [0, 0, 0], Link(tex, 'Color'))])
+    # feed the Green output into a Math*2 node
+    mathn = Node('MATH', operation='MULTIPLY',
+                 inputs=[Sock('A', 0.0, Link(sep, 'Green')), Sock('B', 2.0)])
+    base = Sock('Roughness', 0.5, Link(mathn, 'Value'))
+    compiled = C.compile_chain(base)
+    assert compiled is not None
+    color = (0.2, 0.55, 0.9)
+    r = astroray.Renderer()
+    _load_program(r, "sep", compiled, {id(tex): color})
+    got = r.sample_named_texture("sep", 0.5, 0.5)
+    want = color[1] * 2.0  # green * 2
+    assert got == pytest.approx([want, want, want], abs=3e-3), (got, want)
+
+
+# --------------------------------------------------------------------------- #
+# 6. Combine Color (RGB) from three separated channels — channel swap
+# --------------------------------------------------------------------------- #
+def test_compile_combine_color_swap():
+    tex = Node('TEX_IMAGE')
+    sep = Node('SEPARATE_COLOR', mode='RGB',
+               inputs=[Sock('Color', [0, 0, 0], Link(tex, 'Color'))])
+    comb = Node('COMBINE_COLOR', mode='RGB',
+                inputs=[Sock('Red', 0.0, Link(sep, 'Blue')),   # R <- B
+                        Sock('Green', 0.0, Link(sep, 'Green')),
+                        Sock('Blue', 0.0, Link(sep, 'Red'))])  # B <- R
+    base = Sock('Base Color', [0.5, 0.5, 0.5], Link(comb, 'Color'))
+    compiled = C.compile_chain(base)
+    assert compiled is not None
+    color = (0.2, 0.5, 0.9)
+    r = astroray.Renderer()
+    _load_program(r, "comb", compiled, {id(tex): color})
+    got = r.sample_named_texture("comb", 0.5, 0.5)
+    want = [color[2], color[1], color[0]]
+    assert got == pytest.approx(want, abs=3e-3), (got, want)
+
+
+# --------------------------------------------------------------------------- #
+# 7. RGB to BW on a texture
+# --------------------------------------------------------------------------- #
+def test_compile_rgb_to_bw():
+    tex = Node('TEX_IMAGE')
+    bw = Node('RGB_TO_BW',
+              inputs=[Sock('Color', [0, 0, 0], Link(tex, 'Color'))])
+    base = Sock('Roughness', 0.5, Link(bw, 'Val'))
+    compiled = C.compile_chain(base)
+    assert compiled is not None
+    color = (0.4, 0.6, 0.2)
+    r = astroray.Renderer()
+    _load_program(r, "bw", compiled, {id(tex): color})
+    got = r.sample_named_texture("bw", 0.5, 0.5)
+    luma = 0.2126729 * color[0] + 0.7151522 * color[1] + 0.0721750 * color[2]
+    assert got == pytest.approx([luma, luma, luma], abs=3e-3), (got, luma)
+
+
+# --------------------------------------------------------------------------- #
+# 8. Unsupported Separate Color mode (HSL) -> VMCompileError (no silent grey)
+# --------------------------------------------------------------------------- #
+def test_hsl_mode_raises():
+    tex = Node('TEX_IMAGE')
+    sep = Node('SEPARATE_COLOR', mode='HSL',
+               inputs=[Sock('Color', [0, 0, 0], Link(tex, 'Color'))])
+    base = Sock('Base Color', [0.5, 0.5, 0.5], Link(sep, 'Red'))
+    with pytest.raises(C.VMCompileError):
+        C.compile_chain(base)

--- a/tests/test_pkg219c_op_vm.py
+++ b/tests/test_pkg219c_op_vm.py
@@ -1,0 +1,268 @@
+"""pkg219c — op-VM opcode fill-out: CPU evaluator parity tests.
+
+Each new opcode (HSV, Invert, Gamma, Bright/Contrast, Separate/Combine Color in
+RGB+HSV, RGB-to-BW) is exercised by hand-assembling the bytecode, running it
+through the CPU ProgramTexture (sample_named_texture), and comparing against an
+independent Python transcription of the Cycles SVM formula
+(pkg219c-blender-node-opcode-semantics.md; formulas re-verified against Cycles
+main src/util/color.h, svm/hsv.h, svm/invert.h, svm/color_util.h,
+svm/math_util.h on 2026-08-23).
+
+The runtime VM is the shared HD svm_eval (include/astroray/shader_vm.h), so a
+green CPU test is also the GPU evaluator's correctness oracle.
+"""
+import math
+
+import pytest
+
+astroray = pytest.importorskip("astroray")
+
+# ---- opcode / sub-op enums (mirror include/astroray/shader_vm.h) -----------
+(OP_END, OP_LOAD_TEX, OP_LOAD_CONST, OP_MATH, OP_MIX, OP_RAMP, OP_MAP_RANGE,
+ OP_HSV, OP_INVERT, OP_GAMMA, OP_BRIGHT_CONTRAST, OP_SEP_COLOR,
+ OP_COMBINE_COLOR, OP_RGB_TO_BW) = range(14)
+CS_RGB, CS_HSV = 0, 1
+
+
+def instr(op, out=0, a=0, b=0, c=0, d=0, e=0, imm=0):
+    return [op, out, a, b, c, d, e, imm]
+
+
+def flat(instrs):
+    out = []
+    for i in instrs:
+        out.extend(i)
+    return out
+
+
+def make_solid_input(r, name="in0", value=(0.4, 0.4, 0.4)):
+    import numpy as np
+    img = np.array(value, dtype="float32").reshape(1, 1, 3).ravel()
+    r.load_texture(name, img, 1, 1, "UV")
+
+
+def sat(x):
+    return min(1.0, max(0.0, x))
+
+
+# ---- Python reference (Cycles util/color.h) --------------------------------
+def rgb_to_hsv(rgb):
+    r, g, b = rgb
+    cmax = max(r, g, b)
+    cmin = min(r, g, b)
+    cdelta = cmax - cmin
+    v = cmax
+    if cmax != 0.0:
+        s = cdelta / cmax
+    else:
+        s = 0.0
+        h = 0.0
+    if s != 0.0:
+        cx = (cmax - r) / cdelta
+        cy = (cmax - g) / cdelta
+        cz = (cmax - b) / cdelta
+        if r == cmax:
+            h = cz - cy
+        elif g == cmax:
+            h = 2.0 + cx - cz
+        else:
+            h = 4.0 + cy - cx
+        h /= 6.0
+        if h < 0.0:
+            h += 1.0
+    else:
+        h = 0.0
+    return [h, s, v]
+
+
+def hsv_to_rgb(hsv):
+    h, s, v = hsv
+    if s != 0.0:
+        if h == 1.0:
+            h = 0.0
+        h *= 6.0
+        i = math.floor(h)
+        f = h - i
+        p = v * (1.0 - s)
+        q = v * (1.0 - s * f)
+        t = v * (1.0 - s * (1.0 - f))
+        if i == 0.0:
+            return [v, t, p]
+        elif i == 1.0:
+            return [q, v, p]
+        elif i == 2.0:
+            return [p, v, t]
+        elif i == 3.0:
+            return [p, q, v]
+        elif i == 4.0:
+            return [t, p, v]
+        else:
+            return [v, p, q]
+    return [v, v, v]
+
+
+# --------------------------------------------------------------------------- #
+# 1. Hue/Saturation/Value on a texture
+# --------------------------------------------------------------------------- #
+def hsv_ref(hue, s, val, fac, color):
+    c = rgb_to_hsv(color)
+    c[0] = (c[0] + hue + 0.5) % 1.0
+    c[1] = sat(c[1] * s)
+    c[2] = c[2] * val
+    tmp = hsv_to_rgb(c)
+    out = [tmp[k] * fac + color[k] * (1.0 - fac) for k in range(3)]
+    return [max(0.0, x) for x in out]
+
+
+def test_hsv_on_texture():
+    r = astroray.Renderer()
+    color = (0.8, 0.2, 0.3)
+    make_solid_input(r, "hsv_img", color)
+    r.create_program_texture("hsv_tex", "UV")
+    r.program_texture_add_input("hsv_tex", "hsv_img")
+    # consts: hue, sat, val, fac (broadcast rgb)
+    consts = [0.25, 0.25, 0.25, 1.5, 1.5, 1.5, 0.8, 0.8, 0.8, 1.0, 1.0, 1.0]
+    code = flat([
+        instr(OP_LOAD_TEX, out=0, imm=0),      # color
+        instr(OP_LOAD_CONST, out=1, imm=0),    # hue 0.25
+        instr(OP_LOAD_CONST, out=2, imm=1),    # sat 1.5
+        instr(OP_LOAD_CONST, out=3, imm=2),    # val 0.8
+        instr(OP_LOAD_CONST, out=4, imm=3),    # fac 1.0
+        instr(OP_HSV, out=5, a=1, b=2, c=3, d=4, e=0),
+    ])
+    r.set_program_texture_program("hsv_tex", 1, 5, code, consts, [])
+    got = r.sample_named_texture("hsv_tex", 0.5, 0.5)
+    want = hsv_ref(0.25, 1.5, 0.8, 1.0, list(color))
+    assert got == pytest.approx(want, abs=2e-3), (got, want)
+
+
+# --------------------------------------------------------------------------- #
+# 2. Invert on a texture
+# --------------------------------------------------------------------------- #
+def test_invert_on_texture():
+    r = astroray.Renderer()
+    color = (0.2, 0.6, 0.9)
+    make_solid_input(r, "inv_img", color)
+    r.create_program_texture("inv_tex", "UV")
+    r.program_texture_add_input("inv_tex", "inv_img")
+    consts = [0.75, 0.75, 0.75]  # fac
+    code = flat([
+        instr(OP_LOAD_TEX, out=0, imm=0),
+        instr(OP_LOAD_CONST, out=1, imm=0),
+        instr(OP_INVERT, out=2, a=1, b=0),
+    ])
+    r.set_program_texture_program("inv_tex", 1, 2, code, consts, [])
+    got = r.sample_named_texture("inv_tex", 0.5, 0.5)
+    fac = 0.75
+    want = [c * (1 - fac) + (1 - c) * fac for c in color]
+    assert got == pytest.approx(want, abs=2e-3), (got, want)
+
+
+# --------------------------------------------------------------------------- #
+# 3. Gamma on a texture
+# --------------------------------------------------------------------------- #
+def test_gamma_on_texture():
+    r = astroray.Renderer()
+    color = (0.25, 0.5, 0.8)
+    make_solid_input(r, "gam_img", color)
+    r.create_program_texture("gam_tex", "UV")
+    r.program_texture_add_input("gam_tex", "gam_img")
+    consts = [2.2, 2.2, 2.2]  # gamma
+    code = flat([
+        instr(OP_LOAD_TEX, out=0, imm=0),
+        instr(OP_LOAD_CONST, out=1, imm=0),
+        instr(OP_GAMMA, out=2, a=0, b=1),
+    ])
+    r.set_program_texture_program("gam_tex", 1, 2, code, consts, [])
+    got = r.sample_named_texture("gam_tex", 0.5, 0.5)
+    want = [c ** 2.2 for c in color]
+    assert got == pytest.approx(want, abs=2e-3), (got, want)
+
+
+# --------------------------------------------------------------------------- #
+# 4. Bright/Contrast on a texture
+# --------------------------------------------------------------------------- #
+def test_bright_contrast_on_texture():
+    r = astroray.Renderer()
+    color = (0.3, 0.5, 0.7)
+    make_solid_input(r, "bc_img", color)
+    r.create_program_texture("bc_tex", "UV")
+    r.program_texture_add_input("bc_tex", "bc_img")
+    bright, contrast = 0.1, 0.5
+    consts = [bright]*3 + [contrast]*3
+    code = flat([
+        instr(OP_LOAD_TEX, out=0, imm=0),
+        instr(OP_LOAD_CONST, out=1, imm=0),  # bright
+        instr(OP_LOAD_CONST, out=2, imm=1),  # contrast
+        instr(OP_BRIGHT_CONTRAST, out=3, a=0, b=1, c=2),
+    ])
+    r.set_program_texture_program("bc_tex", 1, 3, code, consts, [])
+    got = r.sample_named_texture("bc_tex", 0.5, 0.5)
+    a = 1.0 + contrast
+    b = bright - contrast * 0.5
+    want = [max(a * c + b, 0.0) for c in color]
+    assert got == pytest.approx(want, abs=2e-3), (got, want)
+
+
+# --------------------------------------------------------------------------- #
+# 5. Separate/Combine Color round-trip (RGB) — swap G and B channels
+# --------------------------------------------------------------------------- #
+def test_separate_combine_rgb_roundtrip():
+    r = astroray.Renderer()
+    color = (0.2, 0.5, 0.9)
+    make_solid_input(r, "sc_img", color)
+    r.create_program_texture("sc_tex", "UV")
+    r.program_texture_add_input("sc_tex", "sc_img")
+    # separate RGB -> R,G,B (slots 1,2,3); recombine as (R,B,G) -> swap G/B
+    code = flat([
+        instr(OP_LOAD_TEX, out=0, imm=0),
+        instr(OP_SEP_COLOR, out=1, a=0, imm=CS_RGB * 4 + 0),  # R
+        instr(OP_SEP_COLOR, out=2, a=0, imm=CS_RGB * 4 + 1),  # G
+        instr(OP_SEP_COLOR, out=3, a=0, imm=CS_RGB * 4 + 2),  # B
+        instr(OP_COMBINE_COLOR, out=4, a=1, b=3, c=2, imm=CS_RGB),  # R,B,G
+    ])
+    r.set_program_texture_program("sc_tex", 1, 4, code, [], [])
+    got = r.sample_named_texture("sc_tex", 0.5, 0.5)
+    want = [color[0], color[2], color[1]]
+    assert got == pytest.approx(want, abs=2e-3), (got, want)
+
+
+# --------------------------------------------------------------------------- #
+# 6. Separate/Combine Color HSV round-trip (identity)
+# --------------------------------------------------------------------------- #
+def test_separate_combine_hsv_roundtrip():
+    r = astroray.Renderer()
+    color = (0.7, 0.3, 0.5)
+    make_solid_input(r, "hsv2_img", color)
+    r.create_program_texture("hsv2_tex", "UV")
+    r.program_texture_add_input("hsv2_tex", "hsv2_img")
+    code = flat([
+        instr(OP_LOAD_TEX, out=0, imm=0),
+        instr(OP_SEP_COLOR, out=1, a=0, imm=CS_HSV * 4 + 0),  # H
+        instr(OP_SEP_COLOR, out=2, a=0, imm=CS_HSV * 4 + 1),  # S
+        instr(OP_SEP_COLOR, out=3, a=0, imm=CS_HSV * 4 + 2),  # V
+        instr(OP_COMBINE_COLOR, out=4, a=1, b=2, c=3, imm=CS_HSV),
+    ])
+    r.set_program_texture_program("hsv2_tex", 1, 4, code, [], [])
+    got = r.sample_named_texture("hsv2_tex", 0.5, 0.5)
+    # sep-HSV then combine-HSV is an identity round-trip
+    assert got == pytest.approx(list(color), abs=2e-3), (got, color)
+
+
+# --------------------------------------------------------------------------- #
+# 7. RGB to BW
+# --------------------------------------------------------------------------- #
+def test_rgb_to_bw_on_texture():
+    r = astroray.Renderer()
+    color = (0.4, 0.6, 0.2)
+    make_solid_input(r, "bw_img", color)
+    r.create_program_texture("bw_tex", "UV")
+    r.program_texture_add_input("bw_tex", "bw_img")
+    code = flat([
+        instr(OP_LOAD_TEX, out=0, imm=0),
+        instr(OP_RGB_TO_BW, out=1, a=0),
+    ])
+    r.set_program_texture_program("bw_tex", 1, 1, code, [], [])
+    got = r.sample_named_texture("bw_tex", 0.5, 0.5)
+    luma = 0.2126729 * color[0] + 0.7151522 * color[1] + 0.0721750 * color[2]
+    assert got == pytest.approx([luma, luma, luma], abs=2e-3), (got, luma)

--- a/tests/test_pkg219c_parity_render.py
+++ b/tests/test_pkg219c_parity_render.py
@@ -1,0 +1,93 @@
+"""pkg219c — CPU/GPU parity render for a fill-out opcode (Invert).
+
+Renders a quad textured with an op-VM Invert program (Fac=1 full invert) on CPU
+and GPU and checks:
+  * the VM changes the image vs the plain (no-program) texture, on BOTH backends;
+  * GPU matches CPU within MC noise (per-channel mean-ratio).
+
+The GPU leg runs the same shared HD svm_eval inside the <HasProgram=true> shade
+specialization; parity is by construction. GPU-gated (CI has no CUDA device).
+"""
+import astroray
+import numpy as np
+import pytest
+from base_helpers import create_renderer, render_image, setup_camera
+
+# opcode enums (mirror include/astroray/shader_vm.h)
+OP_LOAD_TEX, OP_LOAD_CONST, OP_INVERT = 1, 2, 8
+
+
+def _has_cuda_gpu(renderer):
+    return bool(astroray.__features__.get("cuda", False)) and \
+        bool(getattr(renderer, "gpu_available", False))
+
+
+def _quad_image():
+    img = np.array([
+        [[0.9, 0.1, 0.1], [0.1, 0.9, 0.1]],
+        [[0.1, 0.1, 0.9], [0.7, 0.7, 0.2]],
+    ], dtype=np.float32)
+    return img.reshape(-1).tolist(), 2, 2
+
+
+def _build_scene(renderer, *, with_program):
+    renderer.set_background_color([0.5, 0.5, 0.5])
+    data, w, h = _quad_image()
+    renderer.load_texture("pkg219c_img", data, w, h, "UV")
+    if with_program:
+        renderer.create_program_texture("pkg219c_prog", "UV")
+        renderer.program_texture_add_input("pkg219c_prog", "pkg219c_img")
+        # slot0=tex; slot1=const fac(1.0); slot2 = invert(fac, tex) = 1 - tex
+        consts = [1.0, 1.0, 1.0]
+        code = [OP_LOAD_TEX, 0, 0, 0, 0, 0, 0, 0,
+                OP_LOAD_CONST, 1, 0, 0, 0, 0, 0, 0,
+                OP_INVERT, 2, 1, 0, 0, 0, 0, 0]
+        renderer.set_program_texture_program("pkg219c_prog", 1, 2, code, consts, [])
+        tex_ref = "pkg219c_prog"
+    else:
+        tex_ref = "pkg219c_img"
+    mat = renderer.create_material("lambertian", [1.0, 1.0, 1.0], {"texture": tex_ref})
+    A, B = [-1, -1, 0], [1, -1, 0]
+    C, D = [1, 1, 0], [-1, 1, 0]
+    n = [0, 0, 1]
+    renderer.add_triangle_layers(A, B, C, mat, {"UVMap": [[0, 0], [1, 0], [1, 1]]},
+                                 n, n, n)
+    renderer.add_triangle_layers(A, C, D, mat, {"UVMap": [[0, 0], [1, 1], [0, 1]]},
+                                 n, n, n)
+    setup_camera(renderer, look_from=[0, 0, 3], look_at=[0, 0, 0], vup=[0, 1, 0],
+                 vfov=45, width=64, height=64)
+
+
+def _render(*, with_program, use_gpu, samples=64, seed=1):
+    r = create_renderer()
+    if use_gpu:
+        if not _has_cuda_gpu(r):
+            pytest.skip("No CUDA GPU — pkg219c GPU leg runs on the RTX box.")
+        r.set_use_gpu(True)
+    r.set_seed(seed)
+    _build_scene(r, with_program=with_program)
+    return render_image(r, samples=samples, max_depth=2, apply_gamma=False)
+
+
+def test_cpu_invert_changes_image():
+    plain = _render(with_program=False, use_gpu=False)
+    prog = _render(with_program=True, use_gpu=False)
+    mad = float(np.abs(plain - prog).mean())
+    assert mad > 0.02, f"CPU op-VM Invert had no effect (mean|diff|={mad:.4f})"
+
+
+def test_gpu_invert_changes_image():
+    plain = _render(with_program=False, use_gpu=True)
+    prog = _render(with_program=True, use_gpu=True)
+    mad = float(np.abs(plain - prog).mean())
+    assert mad > 0.02, f"GPU op-VM Invert had no effect (mean|diff|={mad:.4f})"
+
+
+def test_cpu_gpu_invert_parity():
+    cpu = _render(with_program=True, use_gpu=False)
+    gpu = _render(with_program=True, use_gpu=True)
+    mask = cpu.reshape(-1, 3).mean(axis=1) > 0.02
+    c = cpu.reshape(-1, 3)[mask]
+    g = gpu.reshape(-1, 3)[mask]
+    ratio = g.sum(axis=0) / np.maximum(c.sum(axis=0), 1e-6)
+    assert np.allclose(ratio, 1.0, atol=0.03), f"CPU/GPU op-VM parity off: {ratio}"


### PR DESCRIPTION
## pkg219c — op-VM opcode coverage fill-out

Extends the bounded per-texel op-VM (pkg219b, #641) with seven per-texel
colour/scalar opcodes so more Blender node chains downstream of a texture render
correctly instead of constant-folding to grey. Both CPU and GPU pick up the new
opcodes automatically because they share the single HD evaluator `svm_eval`
(`include/astroray/shader_vm.h`) — parity by construction.

### Opcodes added
`OP_HSV`, `OP_INVERT`, `OP_GAMMA`, `OP_BRIGHT_CONTRAST`, `OP_SEP_COLOR`,
`OP_COMBINE_COLOR` (RGB + HSV modes), `OP_RGB_TO_BW`.

### Algorithm sourcing (CLAUDE.md §6)
Every formula re-verified against Cycles `main` (Apache-2.0), fetched 2026-08-23,
and cited inline:
- `src/util/color.h` — `rgb_to_hsv` / `hsv_to_rgb`
- `src/kernel/svm/hsv.h` — `svm_node_hsv`
- `src/kernel/svm/invert.h` — invert `interp(color, 1-color, fac)`
- `src/kernel/svm/color_util.h` — `svm_brightness_contrast`, `svm_separate_color`, `svm_combine_color`
- `src/kernel/svm/math_util.h` — `svm_math_gamma_color`
- `src/kernel/svm/convert.h` — RGB-to-BW (Rec.709 luma)

### Out of scope — Bump / Normal Map (deferred to pkg219d candidate)
Both perturb the shading normal (geometry-dependent, feeds the BSDF `N`), not a
per-texel colour/scalar value, so they do not fit the colour op-VM. Deferral note
filed in the spec; they need a separate normal-perturbation-in-shade-path design.

### Authorized surface
Spec Specification touches: `shader_vm.h` (CPU+GPU evaluator), the addon compiler,
tests. Files actually changed:
- `include/astroray/shader_vm.h` — new opcodes, HD helpers, `svm_eval` switch cases (in-scope)
- `blender_addon/shader_vm_compiler.py` — compiler support for the new nodes (in-scope)
- `tests/test_pkg219c_op_vm.py`, `tests/test_pkg219c_addon_compiler.py`, `tests/test_pkg219c_parity_render.py` (in-scope)
- `.astroray_plan/packages/pkg219-per-texel-shader-graph.md` — status + Bump/NormalMap deferral note (in-scope)

No function/class signatures changed — purely additive enum values + new HD
functions + switch cases. `blender_module.cpp` and the GPU wiring
(`stage_advance.cu`, `scene_upload.cu`) are opcode-agnostic and were not touched;
the stale-call-site sweep is therefore a no-op (nothing to update).

### Acceptance criteria
- [x] Each opcode: CPU evaluator case + GPU interpreter case (shared `svm_eval`) + addon compiler support + TDD test.
- [x] Node downstream of a texture renders correctly, CPU/GPU parity.
- [x] Register budget respected (see probe below).
- [x] Bump/NormalMap deferred with a note, not forced into the VM.

### Tests (real pytest output, fresh sm_120 .pyd)
- `tests/test_pkg219c_op_vm.py` + `tests/test_pkg219c_addon_compiler.py`: **15 passed** (0.33s).
- `tests/test_pkg219c_parity_render.py`: **3 passed** (CPU + GPU legs both ran, not skipped).
- Regression: pkg219b suite **14 passed**; `test_material_properties.py` + `test_disney_reflection_not_black.py` **21 passed, 2 xfailed** (pre-existing, unrelated).

### CPU/GPU parity (Invert, Fac=1, 64 spp, seed=1, 64×64 quad)
- GPU/CPU per-channel mean-ratio: `[1.0007, 0.9998, 0.9974]` (within MC noise).
- GPU invert-vs-plain mean|diff| = `0.2145`; CPU invert-vs-plain mean|diff| = `0.2103` (op has a large, matching effect on both backends).

### Register probe (`cuobjdump -res-usage`, 64 `stageShadeBucketedKernel` specializations)
All 64: **REG:254, no spill.** Split by the `HasProgram` template bool:

`HasProgram=false` (32) — **exact match to the pkg219a/b fleet baseline**:
| REG | STACK | count |
|-----|-------|-------|
| 254 | 3352 | 8 |
| 254 | 3608 | 4 |
| 254 | 3672 | 4 |
| 254 | 7720 | 6 |
| 254 | 7784 | 2 |
| 254 | 7848 | 8 |

`HasProgram=true` (32) — **identical to pkg219b's true-half (max STACK 7912)**; adding 7 opcodes did NOT grow the bound:
| REG | STACK | count |
|-----|-------|-------|
| 254 | 3352 | 4 |
| 254 | 3416 | 4 |
| 254 | 3608 | 2 |
| 254 | 3672 | 4 |
| 254 | 3736 | 2 |
| 254 | 7720 | 4 |
| 254 | 7784 | 2 |
| 254 | 7848 | 6 |
| 254 | 7912 | 4 |

### Build (last 5 lines)
Built `../Astroray-pkg219c` @ `2e75789` via `build_cuda_worktree.bat` (PowerShell),
sm_120 embedded (`arch-verify OK: embeds sm_120`), ABI canary green
(`cpu/spectral/gpu/gpu_spectral: True`). (Post-build lint-only amend touched
test `.py` files only; compiled sources unchanged.)
```
========================================
Build succeeded
========================================

[exited with code 0]
```

**NEEDS HARDWARE VERIFICATION** (RTX 5070 Ti; CI has no GPU).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
