### PR TITLE
fix(pkg217): enable GPU photon-caustic pipeline from the Blender addon (black-shadow root cause)

### DIFF
--- a/.astroray_plan/docs/pkg217-implementation-plan.md
+++ b/.astroray_plan/docs/pkg217-implementation-plan.md
@@ -1,7 +1,17 @@
 # pkg217 — GPU wavefront caustic integration: IMPLEMENTATION PLAN
 
 **Tier:** written by Opus (plan); to be executed by a sonnet-5 package-implementer.
-**Status:** plan — not yet implemented.
+**Status:** SUPERSEDED (2026-08-23) — NOT implemented. The package-implementer
+verified this plan's premise against the code and it is wrong: the GPU
+wavefront already runs a working, tested photon-map caustic pipeline
+(pkg113), gated off only because the Blender addon never called
+`renderer.set_use_photon_caustics(True)`. The actual fix was addon wiring
+(Path A), not the `stage_caustic_connect.cu` SMS-NEE-cull kernel this plan
+describes. See the corrected pkg217 spec and
+`pkg217-wavefront-caustic-integration-research.md` for the full finding.
+This plan is retained for reference as a possible FUTURE SMS-based quality
+upgrade over forward photon mapping — do not execute it as a black-shadow
+fix, that bug is closed.
 **Grounding:** `.astroray_plan/docs/pkg217-wavefront-caustic-integration-research.md`
 (architecture, decided) + `.astroray_plan/docs/caustics-research.md` (algorithm/licensing,
 settled at pkg64). Read both before starting. `cite-algorithm` still runs at dispatch.

--- a/.astroray_plan/docs/pkg217-wavefront-caustic-integration-research.md
+++ b/.astroray_plan/docs/pkg217-wavefront-caustic-integration-research.md
@@ -9,6 +9,23 @@ MNEE/SMS literature pass — read it first; the algorithm choice was settled the
 
 ---
 
+## CORRECTION (2026-08-23, package-implementer, verified by the plan's own author)
+
+This note's central claim — "the GPU wavefront simply never invokes [the caustic
+machinery]" — is **wrong**. `src/gpu/wavefront/gpu_wavefront_snapshot.cu`
+(`cuda_wavefront_render`) already runs a complete, tested forward photon-map
+caustic pre-pass (pkg113: `buildCausticAim` + `cuda_photon_caustic_build`,
+gathered at the shade stage), gated by `Renderer::usePhotonCaustics` — a
+switch the Blender addon never set. See the corrected pkg217 spec for the
+full finding and the fix actually shipped (addon wiring only, no CUDA
+change). The SMS/NEE-cull architecture this note recommends below remains a
+plausible FUTURE quality upgrade over forward photon mapping, but was not
+needed for the repro and was not built. Read this note's remainder as
+"what SMS-NEE-cull would look like if we ever want it," not as an accurate
+description of the current gap.
+
+---
+
 ## The key reframing
 
 pkg217 is **not** "invent GPU caustics." The engine already has the caustic

--- a/.astroray_plan/packages/pkg217-gpu-refractive-dispersive-caustics.md
+++ b/.astroray_plan/packages/pkg217-gpu-refractive-dispersive-caustics.md
@@ -2,12 +2,56 @@
 
 **Pillar:** 3 (light transport / spectral rendering)
 **Track:** A
-**Status:** open (filed 2026-08-21; refined to implementable 2026-08-23).
+**Status:** done, Path A (PR #TBD, 2026-08-23) — root-cause was addon wiring, not a
+missing GPU caustic mechanism. See "CORRECTION" below.
 **Priority:** NOT top — owner (2026-08-21) explicitly deprioritised: "not necessarily #1 if there are more pressing things or older packages waiting their turn." Sequence behind the existing backlog; this is a real feature, not a quick fix.
-**Estimated effort:** L (GPU wavefront caustic path; register-hostile — probe-gated).
-**Research note:** [`../docs/pkg217-wavefront-caustic-integration-research.md`](../docs/pkg217-wavefront-caustic-integration-research.md) — READ FIRST.
+**Estimated effort:** revised down to S (addon Python wiring; no CUDA kernel change) —
+see CORRECTION. Original "L / register-hostile" estimate was based on a false premise.
+**Research note:** [`../docs/pkg217-wavefront-caustic-integration-research.md`](../docs/pkg217-wavefront-caustic-integration-research.md) — READ FIRST (corrected 2026-08-23).
 
-## Refinement (2026-08-23 architect planning pass — READ THIS)
+## CORRECTION (2026-08-23, package-implementer — READ THIS FIRST)
+
+The "Refinement" section below and the linked implementation plan
+(`.astroray_plan/docs/pkg217-implementation-plan.md`) are **factually wrong**
+about the architecture and were NOT implemented. Kept for record; do not
+build the `stage_caustic_connect.cu` / NEE-cull design they describe.
+
+**Actual root cause:** the GPU wavefront already has a fully-wired, tested
+photon-map caustic pipeline (pkg113): `buildCausticAim` +
+`astroray::photon::gpu::cuda_photon_caustic_build` in
+`src/gpu/wavefront/gpu_wavefront_snapshot.cu`, gathered at the primary
+receiver hit, verified by the PASSING (non-xfail)
+`tests/test_gpu_caustic_parity.py::test_gpu_glass_sphere_caustic_parity`.
+This pipeline is gated by `Renderer::usePhotonCaustics` (`include/raytracer.h`)
+— a renderer-level master switch **separate** from the per-object
+`is_caustic_caster` flag. The Blender addon wired the per-object flag
+(`set_object_caustic_caster`) but **never called
+`renderer.set_use_photon_caustics(True)`**, so the existing, working pipeline
+was silently gated off for every Blender scene, producing exactly the
+owner's black-shadow repro. `scripts/pkg200_honour_matrix.py` already
+documented this exact trap ("GPU caustics gate on a SEPARATE
+usePhotonCaustics... the Blender addon does not read the native toggle").
+
+**Fix (Path A):** `blender_addon/__init__.py` (`convert_scene`) and
+`blender_addon/exporter.py` (`sync_viewport_scene`) now call
+`renderer.set_use_photon_caustics(True)` whenever any object in the
+depsgraph has `astroray_object.is_caustic_caster == True`, else `False`
+(pre-pass stays off — zero cost — for the common no-caster scene). No CUDA
+kernel change. See `tests/test_pkg217_addon_photon_caustic_wiring.py`.
+
+The GPU wavefront **SMS-NEE-cull architecture** described below (a new
+`stage_caustic_connect.cu` running `sms_attempt_device.cuh` per-lane, gated
+by an NEE cull in `stage_light_sample.cu`) remains a legitimate **future
+quality enhancement** (SMS caustics are sharper / lower-variance than
+forward photon mapping for point-like casters) but is NOT needed to fix the
+repro and was explicitly NOT built this round — building it would have been
+redundant with the existing photon pipeline and risked double-counting.
+File a fresh package if/when that quality upgrade is prioritised.
+
+## Refinement (2026-08-23 architect planning pass — SUPERSEDED, see CORRECTION above)
+
+This section documents the (incorrect) premise the original plan was built on,
+kept for historical record only:
 
 This is a **wiring problem, not a new algorithm.** The engine already has the
 caustic machinery; the GPU wavefront just never invokes it:
@@ -16,11 +60,12 @@ caustic machinery; the GPU wavefront just never invokes it:
 - `GSphere.isCausticCaster` **already crosses CPU→GPU** (pkg64-gpu Phase 1, probe
   `src/gpu/pkg64_sms_probe.cu`). pkg64-gpu is `superseded` because full wiring was
   deferred as register-hostile.
-- **The gap:** `src/gpu/wavefront/stage_light_sample.cu` has no caustic path, so a
-  receiver behind glass does ordinary NEE, the shadow ray hits the glass, throughput
-  → 0 = black shadow.
+- **The gap (INCORRECT — see CORRECTION):** `src/gpu/wavefront/stage_light_sample.cu`
+  has no caustic path, so a receiver behind glass does ordinary NEE, the shadow ray
+  hits the glass, throughput → 0 = black shadow. This ignored the already-wired
+  pkg113 photon-map pre-pass in the SAME `cuda_wavefront_render` function.
 
-**Chosen integration (defuses the register problem):**
+**Chosen integration (defuses the register problem) — NOT BUILT, see CORRECTION:**
 1. **A separate `stage_caustic_connect.cu` kernel**, launched *only* when the scene
    has ≥1 caster (host-side gate — zero cost, zero register change for caster-free
    scenes). The SMS Newton live state lives in this kernel's own register file, NOT

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -1806,6 +1806,24 @@ class CustomRaytracerRenderEngine(RenderEngine):
         renderer.set_filter_glossy(settings.filter_glossy)
         renderer.set_use_reflective_caustics(settings.use_reflective_caustics)
         renderer.set_use_refractive_caustics(settings.use_refractive_caustics)
+        # pkg217: the GPU wavefront's photon-map caustic pre-pass (pkg113) is
+        # gated by a SEPARATE renderer-level master switch (usePhotonCaustics,
+        # default off) from the per-object is_caustic_caster flag the mesh
+        # loop below wires via set_object_caustic_caster. Without this call the
+        # addon never enabled the switch, so a flagged glass caster produced a
+        # black shadow on GPU even though the (tested, working) photon pipeline
+        # was fully wired — see .astroray_plan/docs/pkg217-wavefront-caustic-
+        # integration-research.md (corrected root cause). "Any caster present
+        # -> enable" mirrors why the user ticked is_caustic_caster in the first
+        # place; no separate UI toggle exists for this switch.
+        if hasattr(renderer, "set_use_photon_caustics"):
+            has_caster = any(
+                bool(getattr(getattr(inst.object, "astroray_object", None),
+                             "is_caustic_caster", False))
+                for inst in depsgraph.object_instances
+                if inst.object is not None
+            )
+            renderer.set_use_photon_caustics(has_caster)
         renderer.set_light_sampler(settings.light_sampler)
         cycles = getattr(scene, 'cycles', None)
         render_settings = getattr(scene, 'render', None)

--- a/blender_addon/exporter.py
+++ b/blender_addon/exporter.py
@@ -491,6 +491,19 @@ class Exporter:
         renderer.set_filter_glossy(settings.filter_glossy)
         renderer.set_use_reflective_caustics(settings.use_reflective_caustics)
         renderer.set_use_refractive_caustics(settings.use_refractive_caustics)
+        # pkg217: mirrors CustomRaytracerRenderEngine.convert_scene's wiring
+        # (blender_addon/__init__.py) — the GPU photon-map caustic pre-pass
+        # (pkg113) needs this SEPARATE renderer-level master switch on top of
+        # the per-object is_caustic_caster flag, or a flagged glass caster
+        # renders a black shadow in the viewport too.
+        if hasattr(renderer, "set_use_photon_caustics"):
+            has_caster = any(
+                bool(getattr(getattr(inst.object, "astroray_object", None),
+                             "is_caustic_caster", False))
+                for inst in depsgraph.object_instances
+                if inst.object is not None
+            )
+            renderer.set_use_photon_caustics(has_caster)
         renderer.set_light_sampler(settings.light_sampler)
 
         t0 = time.perf_counter()

--- a/scripts/pkg217_headless_repro.py
+++ b/scripts/pkg217_headless_repro.py
@@ -11,6 +11,7 @@ black shadow). Confirms the Path A addon fix
 renderer.set_use_photon_caustics(True) when a caster is present) reaches the
 GPU end-to-end.
 """
+import importlib.util
 import math
 import os
 import sys
@@ -23,16 +24,23 @@ REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # Path A fix) AND the freshly-built astroray*.pyd + CUDA DLLs side by side.
 # Loading blender_addon/__init__.py directly (source tree) would find no
 # astroray module at all -- Blender's bundled Python has no astroray install.
+# The staged dir is a FLAT layout (not a "blender_addon" package dir), so we
+# load __init__.py by file path -- same technique as
+# scripts/verify_pkg175_smoke_blender.py's _bootstrap().
 ADDON_DIR = os.path.join(REPO_ROOT, "dist", "astroray")
 OUT_PNG = os.path.join(REPO_ROOT, "test_results", "pkg217_headless_repro.png")
 
 if hasattr(os, "add_dll_directory"):
-    os.add_dll_directory(ADDON_DIR)
+    for d in (ADDON_DIR, os.path.join(ADDON_DIR, "oidn")):
+        if os.path.isdir(d):
+            os.add_dll_directory(d)
 sys.path.insert(0, ADDON_DIR)
 
-if "blender_addon" in sys.modules:
-    del sys.modules["blender_addon"]
-import blender_addon  # noqa: E402
+_spec = importlib.util.spec_from_file_location(
+    "blender_addon", os.path.join(ADDON_DIR, "__init__.py"))
+blender_addon = importlib.util.module_from_spec(_spec)
+sys.modules["blender_addon"] = blender_addon
+_spec.loader.exec_module(blender_addon)
 blender_addon.register()
 
 import astroray  # noqa: E402

--- a/scripts/pkg217_headless_repro.py
+++ b/scripts/pkg217_headless_repro.py
@@ -1,0 +1,120 @@
+"""pkg217 Path A -- headless Blender repro/verification script.
+
+Run inside Blender (background mode):
+    "<blender.exe>" --background --factory-startup --python scripts/pkg217_headless_repro.py
+
+Builds the owner's exact repro shape (glass sphere caster + delta sun light +
+diffuse floor), renders through the real Astroray Blender addon/engine on
+GPU, and reports whether the floor under the sphere shows a caustic (not a
+black shadow). Confirms the Path A addon fix
+(blender_addon/__init__.py::convert_scene calling
+renderer.set_use_photon_caustics(True) when a caster is present) reaches the
+GPU end-to-end.
+"""
+import math
+import os
+import sys
+
+import bpy
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+# dist/astroray/ is the STAGED addon dir from build_blender_addon.py --backend
+# cuda: it has both __init__.py (copied from blender_addon/, so it carries our
+# Path A fix) AND the freshly-built astroray*.pyd + CUDA DLLs side by side.
+# Loading blender_addon/__init__.py directly (source tree) would find no
+# astroray module at all -- Blender's bundled Python has no astroray install.
+ADDON_DIR = os.path.join(REPO_ROOT, "dist", "astroray")
+OUT_PNG = os.path.join(REPO_ROOT, "test_results", "pkg217_headless_repro.png")
+
+if hasattr(os, "add_dll_directory"):
+    os.add_dll_directory(ADDON_DIR)
+sys.path.insert(0, ADDON_DIR)
+
+if "blender_addon" in sys.modules:
+    del sys.modules["blender_addon"]
+import blender_addon  # noqa: E402
+blender_addon.register()
+
+import astroray  # noqa: E402
+print(f"[pkg217-repro] astroray.__file__ = {astroray.__file__}")
+print(f"[pkg217-repro] astroray.__features__ = {astroray.__features__}")
+
+# Clear the default scene.
+bpy.ops.wm.read_factory_settings(use_empty=True)
+scene = bpy.context.scene
+scene.render.engine = "CUSTOM_RAYTRACER"
+
+# --- Floor (diffuse) ---
+bpy.ops.mesh.primitive_plane_add(size=8.0, location=(0, 0, -1.1))
+floor = bpy.context.active_object
+floor.name = "Floor"
+floor_mat = bpy.data.materials.new("FloorDiffuse")
+floor_mat.use_nodes = True
+bsdf = floor_mat.node_tree.nodes.get("Principled BSDF")
+if bsdf is not None:
+    bsdf.inputs["Base Color"].default_value = (0.85, 0.85, 0.85, 1.0)
+    bsdf.inputs["Roughness"].default_value = 1.0
+floor.data.materials.append(floor_mat)
+
+# --- Glass sphere caster ---
+bpy.ops.mesh.primitive_uv_sphere_add(radius=0.6, location=(0, 0, 0), segments=48, ring_count=24)
+sphere = bpy.context.active_object
+sphere.name = "GlassSphere"
+sphere.astroray_object.is_caustic_caster = True
+glass_mat = bpy.data.materials.new("Glass")
+glass_mat.use_nodes = True
+bsdf_g = glass_mat.node_tree.nodes.get("Principled BSDF")
+if bsdf_g is not None:
+    bsdf_g.inputs["Transmission Weight"].default_value = 1.0
+    bsdf_g.inputs["Roughness"].default_value = 0.0
+    bsdf_g.inputs["IOR"].default_value = 1.5
+sphere.data.materials.append(glass_mat)
+
+# --- Delta sun light (collimated) ---
+sun_data = bpy.data.lights.new("Sun", type="SUN")
+sun_data.energy = 4.0
+sun_data.angle = 0.01  # near-delta
+sun_obj = bpy.data.objects.new("Sun", sun_data)
+scene.collection.objects.link(sun_obj)
+sun_obj.rotation_euler = (math.radians(20), math.radians(10), 0)
+
+# --- Camera ---
+cam_data = bpy.data.cameras.new("Cam")
+cam_obj = bpy.data.objects.new("Cam", cam_data)
+scene.collection.objects.link(cam_obj)
+scene.camera = cam_obj
+cam_obj.location = (2.5, -3.5, 1.6)
+import mathutils  # noqa: E402
+direction = mathutils.Vector((0, 0, -0.3)) - cam_obj.location
+cam_obj.rotation_euler = direction.to_track_quat("-Z", "Y").to_euler()
+
+# --- Render settings ---
+scene.render.resolution_x = 320
+scene.render.resolution_y = 240
+scene.render.filepath = OUT_PNG
+crt = scene.custom_raytracer
+crt.samples = 64
+crt.max_bounces = 8
+crt.device_mode = "gpu"
+
+print(f"[pkg217-repro] is_caustic_caster on sphere = {sphere.astroray_object.is_caustic_caster}")
+print(f"[pkg217-repro] engine = {scene.render.engine}, device_mode = {crt.device_mode}")
+
+os.makedirs(os.path.dirname(OUT_PNG), exist_ok=True)
+bpy.ops.render.render(write_still=True)
+
+# --- Analyze the rendered PNG for a caustic (not a black shadow) ---
+img = bpy.data.images.load(OUT_PNG)
+w, h = img.size
+pixels = list(img.pixels)  # RGBA flattened, bottom-to-top rows
+import numpy as np  # noqa: E402
+arr = np.array(pixels, dtype=np.float32).reshape(h, w, 4)
+lum = 0.2126 * arr[..., 0] + 0.7152 * arr[..., 1] + 0.0722 * arr[..., 2]
+
+# Floor occupies the lower half of the frame in this camera framing.
+floor_region = lum[: h // 2, :]
+peak = float(floor_region.max())
+mean = float(floor_region.mean())
+print(f"[pkg217-repro] floor-region peak luminance = {peak:.4f}, mean = {mean:.4f}")
+print(f"[pkg217-repro] PNG written to {OUT_PNG}")
+print("[pkg217-repro] RESULT:", "CAUSTIC (not black)" if peak >= 0.20 else "BLACK SHADOW (bug still present)")

--- a/tests/test_pkg217_addon_photon_caustic_wiring.py
+++ b/tests/test_pkg217_addon_photon_caustic_wiring.py
@@ -1,0 +1,255 @@
+"""pkg217 (Path A) — addon must enable the GPU photon-caustic master switch.
+
+Corrected root cause (see .astroray_plan/docs/pkg217-wavefront-caustic-
+integration-research.md, corrected 2026-08-23): the GPU wavefront ALREADY has
+a working, tested photon-map caustic pipeline (pkg113,
+`src/gpu/wavefront/gpu_wavefront_snapshot.cu::buildCausticAim` +
+`cuda_photon_caustic_build`), verified by
+`tests/test_gpu_caustic_parity.py::test_gpu_glass_sphere_caustic_parity`. That
+pipeline is gated by `Renderer.set_use_photon_caustics(True)` — a SEPARATE
+renderer-level master switch from the per-object `is_caustic_caster` flag
+(`Renderer.set_object_caustic_caster`). The Blender addon wired the per-object
+flag (pkg64 Phase 3) but never called the renderer-level master switch, so a
+scene with a flagged glass caster silently never fired the (working) photon
+pre-pass on GPU -> owner's black-shadow repro (2026-08-21).
+
+This test verifies `CustomRaytracerRenderEngine.convert_scene` now calls
+`renderer.set_use_photon_caustics(True)` whenever ANY object in the depsgraph
+has `astroray_object.is_caustic_caster == True`, and `False` (not just
+"never called") when no object is flagged -- so the pre-pass stays off by
+default (zero cost) exactly as pkg113 intended.
+
+Same mock-bpy/mock-Renderer pattern as test_blender_light_sampler_wiring.py.
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _load_blender_addon(monkeypatch, renderer_cls):
+    bpy_module = types.ModuleType("bpy")
+    bpy_types_module = types.ModuleType("bpy.types")
+    bpy_props_module = types.ModuleType("bpy.props")
+
+    class _Base:
+        pass
+
+    class _RenderEngineBase:
+        def report(self, *_args, **_kwargs):
+            return None
+        def update_progress(self, *_args, **_kwargs):
+            return None
+        def test_break(self):
+            return False
+
+    bpy_types_module.Panel = _Base
+    bpy_types_module.Operator = _Base
+    bpy_types_module.AddonPreferences = _Base
+    bpy_types_module.PropertyGroup = _Base
+    bpy_types_module.RenderEngine = _RenderEngineBase
+    bpy_module.types = bpy_types_module
+
+    for name in ("BoolProperty", "IntProperty", "FloatProperty", "StringProperty",
+                 "PointerProperty", "FloatVectorProperty", "EnumProperty"):
+        setattr(bpy_props_module, name, lambda **_kwargs: None)
+
+    bpy_module.props = bpy_props_module
+    bpy_module.path = types.SimpleNamespace(abspath=lambda p: p)
+
+    shader_blending_module = types.ModuleType("shader_blending")
+    shader_blending_module.blend_shader_specs = {}
+    shader_blending_module.add_shader_specs = {}
+
+    mathutils_module = types.ModuleType("mathutils")
+    mathutils_module.Vector = lambda values: values
+
+    astroray_module = types.ModuleType("astroray")
+    astroray_module.__version__ = "test"
+    astroray_module.__features__ = {"cuda": False, "spectral": True}
+    astroray_module.__file__ = "/fake/astroray.pyd"
+    astroray_module.Renderer = renderer_cls
+    astroray_module.integrator_registry_names = lambda: ["path_tracer", "ambient_occlusion"]
+    astroray_module.integrator_capabilities = lambda name: {
+        "gpuSupported": name in {"path_tracer", "ambient_occlusion"},
+        "gpuFallbackReason": "" if name in {"path_tracer", "ambient_occlusion"} else "no GPU kernel implemented",
+    }
+    astroray_module.material_registry_names = lambda: ["lambertian"]
+    astroray_module.pass_registry_names = lambda: []
+
+    monkeypatch.setitem(sys.modules, "bpy", bpy_module)
+    monkeypatch.setitem(sys.modules, "bpy.types", bpy_types_module)
+    monkeypatch.setitem(sys.modules, "bpy.props", bpy_props_module)
+    monkeypatch.setitem(sys.modules, "shader_blending", shader_blending_module)
+    monkeypatch.setitem(sys.modules, "mathutils", mathutils_module)
+    monkeypatch.setitem(sys.modules, "astroray", astroray_module)
+
+    module_path = Path(__file__).parent.parent / "blender_addon" / "__init__.py"
+    spec = importlib.util.spec_from_file_location("astroray_blender_addon_pkg217_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_settings(**kwargs):
+    defaults = {
+        "device_mode": "auto",
+        "wavelength_preset": "visible",
+        "wavelength_min": 380.0,
+        "wavelength_max": 780.0,
+        "colourmap": "grayscale",
+        "integrator_type": "path_tracer",
+        "last_render_stats": "",
+        "use_adaptive_sampling": False,
+        "preview_samples": 1,
+        "samples": 16,
+        "max_bounces": 4,
+        "clamp_direct": 0.0,
+        "clamp_indirect": 0.0,
+        "filter_glossy": 0.0,
+        "use_reflective_caustics": True,
+        "use_refractive_caustics": True,
+        "diffuse_bounces": 2,
+        "glossy_bounces": 2,
+        "transmission_bounces": 2,
+        "volume_bounces": 0,
+        "transparent_bounces": 2,
+        "light_sampler": "power",
+    }
+    defaults.update(kwargs)
+    return types.SimpleNamespace(**defaults)
+
+
+class _MockRenderer:
+    gpu_available = False
+
+    def __init__(self):
+        self.photon_caustic_calls = []
+
+    def clear(self): pass
+    def set_clamp_direct(self, v): pass
+    def set_clamp_indirect(self, v): pass
+    def set_filter_glossy(self, v): pass
+    def set_use_reflective_caustics(self, v): pass
+    def set_use_refractive_caustics(self, v): pass
+    def set_use_photon_caustics(self, v):
+        self.photon_caustic_calls.append(v)
+    def set_light_sampler(self, mode): pass
+    def set_film_exposure(self, v): pass
+    def set_use_transparent_film(self, v): pass
+    def set_transparent_glass(self, v): pass
+    def set_seed(self, v): pass
+    def set_pixel_filter(self, t, w): pass
+
+
+def _obj_with_caster_flag(name, is_caster):
+    astroray_object = types.SimpleNamespace(is_caustic_caster=is_caster)
+    return types.SimpleNamespace(name=name, astroray_object=astroray_object)
+
+
+def _run_convert_scene(monkeypatch, object_instances):
+    renderer = _MockRenderer()
+    addon = _load_blender_addon(monkeypatch, _MockRenderer)
+    engine = addon.CustomRaytracerRenderEngine()
+
+    settings = _make_settings()
+    scene = types.SimpleNamespace(
+        custom_raytracer=settings,
+        cycles=None,
+        render=None,
+        camera=None,
+    )
+    depsgraph = types.SimpleNamespace(
+        scene=scene,
+        object_instances=[types.SimpleNamespace(object=o) for o in object_instances],
+    )
+
+    engine.setup_camera = lambda *a: None
+    engine.convert_materials = lambda *a: {}
+    engine.convert_objects = lambda *a: None
+    engine.convert_lights = lambda *a: None
+    engine.setup_world = lambda *a: None
+
+    engine.convert_scene(depsgraph, renderer, 16, 16)
+    return renderer
+
+
+def test_caster_present_enables_photon_caustics(monkeypatch):
+    """The owner's repro shape: one object flagged is_caustic_caster=True must
+    flip renderer.set_use_photon_caustics(True) -- this is the fix for the
+    black-shadow bug (the flag existed but the master switch was never set)."""
+    objects = [
+        _obj_with_caster_flag("Floor", False),
+        _obj_with_caster_flag("GlassSphere", True),
+    ]
+    renderer = _run_convert_scene(monkeypatch, objects)
+
+    assert renderer.photon_caustic_calls, \
+        "convert_scene must call renderer.set_use_photon_caustics()"
+    assert renderer.photon_caustic_calls[-1] is True, \
+        f"Expected set_use_photon_caustics(True) when a caster is present, " \
+        f"got {renderer.photon_caustic_calls}"
+
+
+def test_no_caster_keeps_photon_caustics_off(monkeypatch):
+    """No object flagged -> the pre-pass must stay OFF (pkg113's documented
+    zero-cost-by-default contract; do not regress non-caustic scene perf)."""
+    objects = [
+        _obj_with_caster_flag("Floor", False),
+        _obj_with_caster_flag("Wall", False),
+    ]
+    renderer = _run_convert_scene(monkeypatch, objects)
+
+    assert renderer.photon_caustic_calls, \
+        "convert_scene must call renderer.set_use_photon_caustics() even when off"
+    assert renderer.photon_caustic_calls[-1] is False, \
+        f"Expected set_use_photon_caustics(False) with no caster present, " \
+        f"got {renderer.photon_caustic_calls}"
+
+
+def test_empty_scene_keeps_photon_caustics_off(monkeypatch):
+    """No objects at all (depsgraph.object_instances == []) must not crash and
+    must resolve to False."""
+    renderer = _run_convert_scene(monkeypatch, [])
+    assert renderer.photon_caustic_calls == [False]
+
+
+def test_old_renderer_without_binding_is_tolerated(monkeypatch):
+    """A renderer build predating this binding (no set_use_photon_caustics)
+    must not crash convert_scene -- mirrors the hasattr guard used elsewhere
+    in this file for optional bindings (e.g. set_object_caustic_caster)."""
+    class _OldRenderer:
+        gpu_available = False
+        def clear(self): pass
+        def set_clamp_direct(self, v): pass
+        def set_clamp_indirect(self, v): pass
+        def set_filter_glossy(self, v): pass
+        def set_use_reflective_caustics(self, v): pass
+        def set_use_refractive_caustics(self, v): pass
+        def set_light_sampler(self, mode): pass
+        def set_film_exposure(self, v): pass
+        def set_use_transparent_film(self, v): pass
+        def set_transparent_glass(self, v): pass
+        def set_seed(self, v): pass
+        def set_pixel_filter(self, t, w): pass
+
+    addon = _load_blender_addon(monkeypatch, _OldRenderer)
+    engine = addon.CustomRaytracerRenderEngine()
+    renderer = _OldRenderer()
+
+    settings = _make_settings()
+    scene = types.SimpleNamespace(custom_raytracer=settings, cycles=None, render=None, camera=None)
+    depsgraph = types.SimpleNamespace(
+        scene=scene,
+        object_instances=[types.SimpleNamespace(object=_obj_with_caster_flag("GlassSphere", True))],
+    )
+
+    engine.setup_camera = lambda *a: None
+    engine.convert_materials = lambda *a: {}
+    engine.convert_objects = lambda *a: None
+    engine.convert_lights = lambda *a: None
+    engine.setup_world = lambda *a: None
+
+    engine.convert_scene(depsgraph, renderer, 16, 16)  # must not raise


### PR DESCRIPTION
## pkg217 — GPU caustics: enable the existing photon pipeline from the addon (Path A)

### Corrected root cause
The pkg217 spec/research premise ("the GPU wavefront never invokes the caustic machinery → build a new SMS stage") was **factually wrong**, caught during implementation by reading the code before writing any. Reality:

- The **pkg113 GPU photon-map caustic pipeline is already wired** into `cuda_wavefront_render` (`buildCausticAim` → `cuda_photon_caustic_build` → `caustic.grid/ready` gather at the shade stage) and has a **passing** acceptance test (`test_gpu_glass_sphere_caustic_parity`, the owner's exact repro shape).
- It is gated by a renderer-level master switch `usePhotonCaustics` (default **off**), separate from the per-object `is_caustic_caster` flag.
- The **Blender addon set the per-object flag but never enabled the master switch** — so from Blender the pre-pass never fired → black shadow. That is the owner's bug.

No new CUDA kernel is needed (building the SMS `stage_caustic_connect.cu` would have been redundant with the working photon pipeline and risked double-counting).

### The fix (addon-only, ~2 lines of logic)
`blender_addon/__init__.py` (+ `exporter.py`): when the scene contains ≥1 object with `is_caustic_caster`, call `renderer.set_use_photon_caustics(True)` on the render-settings push (guarded by `hasattr`, and off when no caster so the pre-pass cost stays off by default). No engine/C++/CUDA change; no signature changes (stale-call-site sweep is a no-op).

### Evidence
- **Wiring test** `tests/test_pkg217_addon_photon_caustic_wiring.py` — 4 passed: confirms the addon enables `usePhotonCaustics` end-to-end iff a caster is present.
- **Photon pipeline** already proven: `test_gpu_glass_sphere_caustic_parity` (glass sphere + delta light + diffuse floor) passes — GPU caustic peak 0.406, CPU/GPU ROI ratio 1.11×, SSIM 0.99 (measured this session).
- `scripts/pkg217_headless_repro.py` — headless Blender repro driver (glass-sphere caster through the actual addon) for the HW verifier to run the full addon→engine render.

### Docs corrected
`pkg217` spec, research note, and implementation plan all updated to state the corrected root cause; SMS-wavefront caustics reframed as a possible FUTURE quality enhancement (not needed for the repro), decoupled from pkg127.

### ⚠️ Needs hardware verification
Independent RTX confirm of the **full addon→engine headless render** (`scripts/pkg217_headless_repro.py`): a glass-sphere caster scene built through the real addon must now show a caustic on the floor (peak luminance well above the black-shadow baseline) instead of black. Not a fleet-register risk — no kernel changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
