### PR TITLE
pkg223: GPU tangent-space normal maps (+ CPU UV-aligned frame fix)

### DIFF
--- a/.astroray_plan/docs/pkg223-normal-map-research.md
+++ b/.astroray_plan/docs/pkg223-normal-map-research.md
@@ -1,0 +1,117 @@
+# pkg223 — Tangent-space normal-map decode convention (Blender/Cycles) — research note
+
+**Date:** 2026-08-26
+**Package:** pkg223 — Normal Map node (pkg219d part 1), spec
+`.astroray_plan/packages/pkg223-normal-map-node.md`.
+**Policy:** CLAUDE.md §6 — no invented algorithms. Reference = Blender/Cycles
+Normal Map node semantics (Apache-2.0) + Mikkelsen Mikk-TSpace (BSD-3-Clause).
+
+## References
+
+- **Cycles:** `intern/cycles/kernel/svm/svm_tex_coord.h` — `svm_node_normal_map`
+  (Blender main, Apache-2.0). The local vendored copy `external/cycles_light_tree/`
+  is a light-tree-only snapshot and does NOT contain this file — cite upstream.
+- **Mikkelsen, M. S., "Simulation of Wrinkled Surfaces Revisited", Master's
+  thesis, University of Copenhagen (DIKU), 2008.**
+  PDF: http://image.diku.dk/projects/media/morten.mikkelsen.08.pdf
+- **Mikk-TSpace impl:** `https://github.com/mmikk/MikkTSpace` — `mikktspace.h`/
+  `mikktspace.c` (BSD-3-Clause); Blender vendors it at `extern/mikktspace/`
+  (`BKE_mesh_calc_loop_tangents` → `ATTR_STD_UV_TANGENT`/`_SIGN`).
+- **Lengyel, E., "Computing Tangent Space Basis Vectors for an Arbitrary Mesh",
+  Terathon Software, 2001.** https://terathon.com/code/tangent.html
+
+## 1. Decode: n_ts = 2·rgb − 1
+
+Cycles `svm_node_normal_map` (svm_tex_coord.h):
+
+```c
+float3 color = stack_load_float3(stack, color_offset);
+color = 2.0f * make_float3(color.x - 0.5f, color.y - 0.5f, color.z - 0.5f);
+```
+
+i.e. `n_ts = 2·rgb − 1`: unpack [0,1] texture RGB into a [-1,1] tangent-space
+vector. The flat/identity texel (0.5, 0.5, 1.0) → (0, 0, 1) = the geometric
+normal. Cycles skips the node when the decoded vector is exactly zero (a
+mid-gray texel (0.5,0.5,0.5)), leaving `sd->N` untouched.
+
+## 2. The tangent frame MUST be UV-aligned — not an arbitrary ONB
+
+A tangent-space normal map is an *encoding* relative to the baker's frame: the
+perturbation azimuth (the compass direction the relief leans) is locked to the
+texture's UV parameterization. Decoding requires the exact inverse of the frame
+the baker used — Mikkelsen 2008 / mikktspace.com: "the transformation used to
+decode would have to be the exact inverse of that which was used to encode".
+Mikk-TSpace computes per-vertex tangents consistent with the UVs
+(order-independent, welded); the pixel-shader decode is:
+
+```c
+vB = sign * cross(vN, vT);
+vNout = normalize(vNt.x * vT + vNt.y * vB + vNt.z * vN);
+```
+
+(mikktspace.h `m_setTSpaceBasic` docs). The per-triangle fallback is the Lengyel
+inverse-UV-Jacobian: Q1=P1−P0, Q2=P2−P0, (s1,t1)=uv1−uv0, (s2,t2)=uv2−uv0,
+`r = 1/(s1·t2 − s2·t1)`, `T = r·(t2·Q1 − t1·Q2)`, `B = r·(s1·Q2 − s2·Q1)` — T
+along +U, B along +V (Lengyel 2001).
+
+An arbitrary ONB (e.g. `make_orthonormals(N)`) has NO relation to the UVs: the
+same texel decodes to a different world direction per surface, rotating the
+relief to a random compass direction and breaking parity with any Cycles-baked
+map. The frame must come from the UV parameterization.
+
+## 3. Green channel / handedness: OpenGL-style +Y-up green; B = sign·cross(N, T)
+
+Cycles tangent-space branch (svm_tex_coord.h):
+
+```c
+float3 tangent = primitive_attribute_float3(kg, sd, desc);  // ATTR_STD_UV_TANGENT
+float sign = primitive_attribute_float(kg, sd, sign_desc);  // ATTR_STD_UV_TANGENT_SIGN
+float3 N_geom = sd->N;
+float3 B = sign * cross(N_geom, tangent);
+N = safe_normalize(tangent * color.x + B * color.y + N_geom * color.z);
+```
+
+- The green channel (color.y) multiplies the **bitangent B** with **no
+  negation** → Blender/Cycles use the **OpenGL convention: +Y (green) points
+  "up" along +B**. DirectX-style maps store green flipped (−Y down); feeding
+  one unflipped inverts the relief (Mikkelsen 2008 discusses the mismatch).
+- `sign` is the **UV-winding handedness** from Mikk-TSpace
+  (`fSign = bIsOrientationPreserving ? 1.0f : -1.0f` in mikktspace.h): +1 for
+  orientation-preserving UVs, −1 for mirrored UVs. It keeps `B = sign·cross(N,T)`
+  continuous across mirrored UV islands — without it, islands get inverted relief.
+
+## 4. Strength: n = normalize(lerp(N_geom, mapped, clamp(strength, 0, 1)))
+
+Cycles applies Strength after the space transform (svm_tex_coord.h):
+
+```c
+float3 strength = stack_load_float3(stack, strength_offset);
+strength.x = saturatef(strength.x);   // clamp to [0,1]
+...
+N = safe_normalize(sd->N + (N - sd->N) * strength);
+```
+
+`sd->N + (N − sd->N)·s = (1−s)·sd->N + s·N` — a lerp between the geometric
+normal and the mapped normal, renormalized:
+`n = normalize(lerp(N_geom, mapped, clamp(strength, 0, 1)))`. Strength 0 →
+geometric normal (flat); Strength 1 → full perturbation; monotone in between.
+(OSL twin: `node_normal_map.osl` — `Normal = normalize(NormalIn + (Normal -
+NormalIn) * max(Strength, 0.0))`.)
+
+## What we reproduce / differences
+
+- Reproduce: decode, UV-aligned TBN rotate, handedness, Strength lerp —
+  byte-mirrored CPU/GPU (GPU shade path behind `template<bool HasNormalPerturb>`).
+- Difference: Cycles' `ensure_valid_reflection` reflection-fix (D2574) runs
+  downstream at closure setup; pkg223 does not port it — file a follow-up if
+  grazing-angle black speculars appear.
+- Difference: Cycles falls back to `primitive_tangent` (derivative-based) when
+  no tangent attribute exists; pkg223's fallback is the UV-gradient Lengyel
+  tangent (same family).
+
+## Integration plan in Astroray
+
+- Package: pkg223 (`pkg223-normal-map-node.md`). CPU shade path + GPU wavefront
+  shade path; addon emits the normal-map spec (texture handle, Strength, space).
+- Parity check: Cycles-baked normal map on a quad/sphere — lighting direction
+  must match (not inverted); Strength 0 ≈ flat render.

--- a/include/astroray/gpu_scene_upload.h
+++ b/include/astroray/gpu_scene_upload.h
@@ -33,6 +33,20 @@ struct SceneUploadResult {
     std::vector<int>           materialTextureId;
     bool                       hasTexture = false;
 
+    // pkg223 — tangent-space normal maps. Parallel to `materials`:
+    // `materialNormalTexId[i]` indexes `textures` for material i's normal map
+    // (-1 = none), `materialNormalStrength[i]` its Cycles Strength. Uploaded onto
+    // the c_wfTexBinding side table (matNormalTexId/matNormalStrength) so
+    // GMaterial stays 640 B. `hasNormalPerturb` selects the
+    // stageShadeBucketedKernel<…,HasNormalPerturb=true> instantiation; false keeps
+    // the fleet byte-identical (register-probe gate). A NormalMapped decorator's
+    // INNER material supplies the GMaterial + base-colour texture; the normal
+    // texture rides here. bump-only decorators unwrap to the base with id -1
+    // (bump deferred to a follow-up — GPU renders the base BSDF).
+    std::vector<int>           materialNormalTexId;
+    std::vector<float>         materialNormalStrength;
+    bool                       hasNormalPerturb = false;
+
     // pkg219b — per-texel op-VM programs. `programs` holds each unique compiled
     // ShaderVMProgram (deduped by ProgramTexture*); `materialProgramId` is
     // parallel to `materials` (-1 = no program). `hasProgram` selects the

--- a/include/astroray/gpu_types.h
+++ b/include/astroray/gpu_types.h
@@ -623,6 +623,13 @@ struct GWavefrontTextureBinding {
     const GImageTexture* textures;
     const GVec3*         texelBuf;
     const int*           matTexId;
+    // pkg223 — tangent-space normal map, published on the SAME __constant__ side
+    // table so GMaterial stays exactly 640 B and the fleet <…,false> shade kernel
+    // (HasNormalPerturb=false) is byte-identical. matNormalTexId[mat] indexes into
+    // `textures` (-1 = no normal map); matNormalStrength[mat] is the Cycles
+    // Strength. Read ONLY inside the HasNormalPerturb=true specialization.
+    const int*           matNormalTexId;    // per-material normal-texture id, -1 absent
+    const float*         matNormalStrength;  // per-material Strength [0,1]
 };
 
 // pkg197 — wavefront first-hit denoise-guide AOV binding. Published ONCE per

--- a/include/astroray/gpu_wavefront_state.h
+++ b/include/astroray/gpu_wavefront_state.h
@@ -396,7 +396,13 @@ void launchStageShadeBucketed(
     // to the pre-pkg219b kernels (the register-probe gate). The program array +
     // per-material index ride in the __constant__ c_wfProgBinding, not this
     // signature.
-    bool hasProgram);
+    bool hasProgram,
+    // pkg223: hasNormalPerturb=true selects stageShadeBucketedKernel<…,true>,
+    // which carries the tangent-space normal-map perturbation; false selects
+    // <…,false>, byte-identical to the pre-pkg223 kernels (register-probe gate).
+    // The normal-texture arrays ride c_wfTexBinding (matNormalTexId/Strength),
+    // NOT this signature.
+    bool hasNormalPerturb);
 
 // pkg186 — publish the frame's image-texture arrays into the shade kernel's
 // __constant__ binding. Call ONCE per frame before launchStageShadeBucketed (only

--- a/include/raytracer.h
+++ b/include/raytracer.h
@@ -316,6 +316,7 @@ struct Ray {
 };
 
 class Material;
+class Texture;  // pkg223 — normalMapTexture() returns shared_ptr<Texture>
 
 struct HitRecord {
     Vec3 point, normal, tangent, bitangent;
@@ -455,6 +456,16 @@ public:
     virtual bool isGlossy() const { return false; }
     virtual Vec3 getAlbedo() const { return Vec3(0.5f); }
     virtual std::string getGPUTypeName() const { return ""; }
+    // pkg223 — normal-map decorator unwrap for GPU upload. A NormalMapped
+    // decorator returns its INNER material (whose BSDF becomes the GMaterial and
+    // whose base-colour texture uploads as usual) plus the tangent-space normal
+    // texture + Cycles Strength. scene_upload rides the normal texture on the
+    // parallel c_wfTexBinding side arrays (matNormalTexId / matNormalStrength),
+    // so GMaterial stays exactly 640 B and the fleet <false> shade kernel is
+    // byte-identical. A plain material returns null/1 and uploads unchanged.
+    virtual std::shared_ptr<Material> normalMapInner() const { return nullptr; }
+    virtual std::shared_ptr<Texture>  normalMapTexture() const { return nullptr; }
+    virtual float                     normalMapStrength() const { return 1.0f; }
     virtual astroray::MaterialClosureGraph closureGraph() const { return {}; }
     virtual MaterialBackendCapabilities backendCapabilities() const {
         MaterialBackendCapabilities caps;

--- a/plugins/materials/normal_mapped.cpp
+++ b/plugins/materials/normal_mapped.cpp
@@ -20,7 +20,19 @@ class NormalMappedPlugin : public Material {
         if (normalTexture_) {
             Vec3 rgb = normalTexture_->value(rec, Vec3(0));
             Vec3 nTS = (rgb * 2.0f) - Vec3(1.0f);
-            Vec3 mapped = (rec.tangent * nTS.x + rec.bitangent * nTS.y + rec.normal * nTS.z).normalized();
+            // pkg223 — tangent-space normal mapping REQUIRES the UV-aligned
+            // (Mikk-TSpace / Lengyel) frame, NOT the arbitrary
+            // buildOrthonormalBasis `tangent`/`bitangent`: the map's X/Y axes
+            // must track the texture's UV parameterization, else the relief tilts
+            // to an arbitrary compass direction (highlight moves the wrong way vs
+            // Cycles). rec.uvTangent is the Gram-Schmidt-orthonormalized UV
+            // tangent (Triangle::hit via manifold::uvAlignedTangent); the
+            // bitangent handedness rides rec.uvBitangentSign as
+            // B = sign * cross(N, T). The GPU shade path (HasNormalPerturb)
+            // recomputes the identical frame (gpu_pr_uvAlignedTangent) for parity.
+            Vec3 T = rec.uvTangent;
+            Vec3 B = rec.normal.cross(T) * rec.uvBitangentSign;
+            Vec3 mapped = (T * nTS.x + B * nTS.y + rec.normal * nTS.z).normalized();
             float t = std::clamp(normalStrength_, 0.0f, 1.0f);
             n = (rec.normal * (1.0f - t) + mapped * t).normalized();
         }
@@ -75,6 +87,14 @@ public:
     float pdf(const HitRecord& rec, const Vec3& wo, const Vec3& wi) const override {
         return baseMaterial_->pdf(perturbNormal(rec), wo, wi);
     }
+
+    // pkg223 — GPU-upload unwrap. scene_upload converts the INNER material to the
+    // GMaterial (BSDF + base-colour texture) and rides the tangent-space normal
+    // texture + Strength on the parallel c_wfTexBinding side arrays. Only the
+    // normal texture is exposed (bump is CPU-only / deferred, memory pkg223).
+    std::shared_ptr<Material> normalMapInner() const override { return baseMaterial_; }
+    std::shared_ptr<Texture>  normalMapTexture() const override { return normalTexture_; }
+    float                     normalMapStrength() const override { return normalStrength_; }
 };
 
 ASTRORAY_REGISTER_MATERIAL("normal_mapped", NormalMappedPlugin)

--- a/src/gpu/scene_upload.cu
+++ b/src/gpu/scene_upload.cu
@@ -321,7 +321,15 @@ static void appendOnePrim(
                 mtl->getAnisotropic() > 0.0f;
             const bool imageTextured =
                 mtl && dynamic_cast<TexturedLambertian*>(mtl.get()) != nullptr;
-            if ((anisoPrincipled || imageTextured) && tri->hasUVLayers()) {
+            // pkg223 — a normal-mapped material needs the active-layer UVs on the
+            // device for the tangent-space decode (HasNormalPerturb). Checked on the
+            // DECORATOR (mtl is the NormalMapped wrapper, whose inner TexturedLambertian
+            // the imageTextured cast above cannot see) — this also restores the base-
+            // colour texture UVs for a NormalMapped(TexturedLambertian).
+            const bool normalMapped =
+                mtl && mtl->normalMapTexture() != nullptr;
+            if ((anisoPrincipled || imageTextured || normalMapped) &&
+                tri->hasUVLayers()) {
                 Vec2 t0 = tri->getUV0(), t1 = tri->getUV1(), t2 = tri->getUV2();
                 gt.uv0 = GVec2(t0.u, t0.v);
                 gt.uv1 = GVec2(t1.u, t1.v);
@@ -681,11 +689,25 @@ SceneUploadResult buildSceneArrays(const Renderer& cpu, const Camera* cam) {
     std::unordered_map<Texture*, int> texIdx;
     // pkg219b — op-VM program dedup: one ShaderVMProgram slot per ProgramTexture*.
     std::unordered_map<Texture*, int> progIdx;
-    auto getOrAddMat = [&](const std::shared_ptr<Material>& m) -> int {
-        auto it = matIdx.find(m.get());
+    auto getOrAddMat = [&](const std::shared_ptr<Material>& mIn) -> int {
+        auto it = matIdx.find(mIn.get());
         if (it != matIdx.end()) return it->second;
         int id = (int)r.materials.size();
-        matIdx[m.get()] = id;
+        matIdx[mIn.get()] = id;
+        // pkg223 — unwrap a NormalMapped decorator: the GMaterial + base-colour
+        // texture come from the INNER material; the tangent-space normal texture +
+        // Strength ride the parallel side arrays (materialNormalTexId/Strength),
+        // read ONLY in the GPU shade path's HasNormalPerturb=true kernel so
+        // GMaterial stays 640 B. A bump-only decorator unwraps to the base with
+        // normalTexId -1 (bump deferred — GPU renders the base BSDF).
+        std::shared_ptr<Material> m = mIn;
+        std::shared_ptr<Texture>  nmTex;
+        float nmStrength = 1.0f;
+        if (auto inner = mIn->normalMapInner()) {
+            m = inner;
+            nmTex = mIn->normalMapTexture();
+            nmStrength = mIn->normalMapStrength();
+        }
         r.materials.push_back(convertMaterial(m));
         // pkg178 Stage-3b D4: flag scenes carrying a closure-graph Principled
         // material so the wavefront launchers select the <true> shade-kernel
@@ -895,6 +917,41 @@ SceneUploadResult buildSceneArrays(const Renderer& cpu, const Camera* cam) {
             if (texId >= 0)
                 r.materials[id].baseColor = GVec3(1.f, 1.f, 1.f);
         }
+        // pkg223 — register the tangent-space normal texture (always a plain
+        // ImageTexture from load_blender_image) on the parallel side arrays,
+        // deduped via the same texIdx map. Mirrors the pkg186 ImageTexture upload;
+        // the shade path's HasNormalPerturb kernel fetches it via matNormalTexId.
+        // Uses the SAME device texel data as the CPU TextureManager texture, so
+        // CPU/GPU parity holds regardless of the image's colour management.
+        int normalTexId = -1;
+        if (auto nimg = std::dynamic_pointer_cast<ImageTexture>(nmTex)) {
+            if (!nimg->getData().empty()) {
+                auto nit = texIdx.find(nimg.get());
+                if (nit != texIdx.end()) {
+                    normalTexId = nit->second;
+                } else {
+                    normalTexId = (int)r.textures.size();
+                    texIdx[nimg.get()] = normalTexId;
+                    GImageTexture ndesc;
+                    ndesc.offset = (int)r.textureTexels.size();
+                    ndesc.width  = nimg->getWidth();
+                    ndesc.height = nimg->getHeight();
+                    if (nimg->hasMapping()) {
+                        ndesc.hasMapping = 1;
+                        const float* mm = nimg->getMappingMatrix();
+                        for (int i = 0; i < 12; ++i) ndesc.mapping[i] = mm[i];
+                    }
+                    const std::vector<Vec3>& px = nimg->getData();
+                    r.textureTexels.reserve(r.textureTexels.size() + px.size());
+                    for (const Vec3& c : px)
+                        r.textureTexels.push_back(GVec3(c.x, c.y, c.z));
+                    r.textures.push_back(ndesc);
+                }
+                r.hasNormalPerturb = true;
+            }
+        }
+        r.materialNormalTexId.push_back(normalTexId);
+        r.materialNormalStrength.push_back(nmStrength);
         r.materialTextureId.push_back(texId);
         r.materialProgramId.push_back(progId);
         return id;

--- a/src/gpu/wavefront/gpu_wavefront_snapshot.cu
+++ b/src/gpu/wavefront/gpu_wavefront_snapshot.cu
@@ -1000,6 +1000,7 @@ struct WfContext {
     WfDeviceBuf nodes, prims, tris, spheres, materials, lights;
     WfDeviceBuf dedLights;                    // pkg89-wavefront (C7)
     WfDeviceBuf textures, textureTexels, materialTextureId;  // pkg186 image textures
+    WfDeviceBuf materialNormalTexId, materialNormalStrength;  // pkg223 normal maps
     WfDeviceBuf programs, materialProgramId;   // pkg219b op-VM programs
     WfDeviceBuf tlas, instances, blas;        // pkg55-C4 / pkg114
     WfDeviceBuf motionVertices;               // pkg55-C4 / pkg88-C.0
@@ -1382,8 +1383,14 @@ std::vector<float> cuda_wavefront_render(
     GImageTexture* d_textures  = wfUpload(C.textures, res.textures);
     GVec3*         d_texelBuf  = wfUpload(C.textureTexels, res.textureTexels);
     int*           d_matTexId  = wfUpload(C.materialTextureId, res.materialTextureId);
-    if (res.hasTexture)
-        setWavefrontTextureBinding(GWavefrontTextureBinding{d_textures, d_texelBuf, d_matTexId});
+    // pkg223 — normal-map side arrays, published on the SAME binding. Set the
+    // binding when EITHER a base-colour texture OR a normal map is present (a
+    // normal map on a non-textured Principled/Disney BSDF has hasTexture=false).
+    int*   d_matNormalTexId   = wfUpload(C.materialNormalTexId, res.materialNormalTexId);
+    float* d_matNormalStrength = wfUpload(C.materialNormalStrength, res.materialNormalStrength);
+    if (res.hasTexture || res.hasNormalPerturb)
+        setWavefrontTextureBinding(GWavefrontTextureBinding{
+            d_textures, d_texelBuf, d_matTexId, d_matNormalTexId, d_matNormalStrength});
     // pkg219b — op-VM program device arrays (all null when no material carries a
     // program; res.hasProgram=false then selects the <…,false> shade kernel).
     astroray::svm::ShaderVMProgram* d_programs =
@@ -1758,7 +1765,8 @@ std::vector<float> cuda_wavefront_render(
                                      res.hasTexture,      // pkg186 (data via c_wfTexBinding)
                                      res.hasDispersive,  // pkg189 hero-λ collapse write-back
                                      passesOn,  // pkg198 Stage 2 pass-AOV axis
-                                     res.hasProgram);  // pkg219b per-texel op-VM axis
+                                     res.hasProgram,  // pkg219b per-texel op-VM axis
+                                     res.hasNormalPerturb);  // pkg223 normal-map axis
             launchStageShadow(state, hitBufs, d_neeF, d_neeI,
                               d_shadowQueue, d_shadowCount, total_paths,
                               d_tlas, d_instances, d_blas,  // pkg55-C4

--- a/src/gpu/wavefront/stage_advance.cu
+++ b/src/gpu/wavefront/stage_advance.cu
@@ -856,7 +856,8 @@ __constant__ GWavefrontProgramBinding c_wfProgBinding;
 // .astroray_plan/packages/pkg189-gpu-wavefront-dispersion-enablement.md.
 template<bool Deferred, bool HasPrincipled, bool HasTexture = false, bool HasPhotons = false,
          bool HasDispersion = false, bool HasLightPassAOVs = false,  // pkg198 S2 pass axis
-         bool HasProgram = false>  // pkg219b — per-texel op-VM axis
+         bool HasProgram = false,   // pkg219b — per-texel op-VM axis
+         bool HasNormalPerturb = false>  // pkg223 — tangent-space normal-map axis
 __device__ bool shadePathSlot(
     int idx,
     GPUWavefrontState& state,
@@ -972,6 +973,64 @@ __device__ bool shadePathSlot(
                                             rec.normal, uvT, uvSign)) {
                     rec.uvTangent = uvT;
                     rec.uvBitangentSign = uvSign;
+                }
+            }
+        }
+    }
+
+    // pkg223 — tangent-space normal-map perturbation of the shading normal.
+    // Behind `if constexpr (HasNormalPerturb)` so every fleet <…,false> shade
+    // specialization compiles this out ENTIRELY and stays byte-identical
+    // (GMaterial is untouched — the normal map rides the __constant__
+    // c_wfTexBinding side arrays, memory wavefront-shade-kernels-register-
+    // saturated). Mirrors the CPU NormalMappedPlugin::perturbNormal EXACTLY for
+    // parity: build the UV-aligned (Mikk-TSpace / Lengyel) frame from the hit
+    // triangle (gpu_pr_uvAlignedTangent — the lambertian path has no precomputed
+    // uvTangent, that is HasPrincipled-only), decode n_ts = 2·rgb − 1, rotate,
+    // and lerp toward the geometric normal by the Cycles Strength. Rebuilds the
+    // ONB so the BSDF sample/eval below shade against the perturbed frame.
+    if constexpr (HasNormalPerturb) {
+        const int nmTexId = c_wfTexBinding.matNormalTexId[rec.materialId];
+        if (nmTexId >= 0 && rec.primId >= 0 &&
+            prims[rec.primId].type == GPRIM_TRIANGLE) {
+            const GTriangle& ntri = tris[prims[rec.primId].index];
+            if (ntri.hasUV) {
+                GVec3 nT; float nSign;
+                if (gpu_pr_uvAlignedTangent(ntri.v0, ntri.v1, ntri.v2,
+                                            ntri.uv0, ntri.uv1, ntri.uv2,
+                                            rec.normal, nT, nSign)) {
+                    // Barycentric UV at the hit (same recompute as the texture
+                    // path; short-lived, folded into the perturbed normal).
+                    GVec3 e1 = ntri.v1 - ntri.v0, e2 = ntri.v2 - ntri.v0;
+                    GVec3 ep = rec.point - ntri.v0;
+                    float d00 = e1.dot(e1), d01 = e1.dot(e2), d11 = e2.dot(e2);
+                    float d20 = ep.dot(e1), d21 = ep.dot(e2);
+                    float denom = d00 * d11 - d01 * d01;
+                    if (fabsf(denom) > 1e-20f) {
+                        float b1 = (d11 * d20 - d01 * d21) / denom;
+                        float b2 = (d00 * d21 - d01 * d20) / denom;
+                        float b0 = 1.0f - b1 - b2;
+                        float uu = b0*ntri.uv0.x + b1*ntri.uv1.x + b2*ntri.uv2.x;
+                        float vv = b0*ntri.uv0.y + b1*ntri.uv1.y + b2*ntri.uv2.y;
+                        const GImageTexture& ndesc = c_wfTexBinding.textures[nmTexId];
+                        if (ndesc.hasMapping) {
+                            const float* m = ndesc.mapping;
+                            float mu = m[0]*uu + m[1]*vv + m[3];
+                            float mv = m[4]*uu + m[5]*vv + m[7];
+                            uu = mu; vv = mv;
+                        }
+                        GVec3 rgb = gpu_sampleImageTexture(
+                            ndesc, c_wfTexBinding.texelBuf, uu, vv);
+                        GVec3 nTS = rgb * 2.0f - GVec3(1.0f);
+                        GVec3 B = rec.normal.cross(nT) * nSign;
+                        GVec3 mapped = (nT * nTS.x + B * nTS.y +
+                                        rec.normal * nTS.z).normalized();
+                        float t = fminf(fmaxf(
+                            c_wfTexBinding.matNormalStrength[rec.materialId], 0.0f), 1.0f);
+                        rec.normal = (rec.normal * (1.0f - t) +
+                                      mapped * t).normalized();
+                        gpu_buildONB(rec.normal, rec.tangent, rec.bitangent);
+                    }
                 }
             }
         }
@@ -1710,7 +1769,8 @@ __global__ void stageIntersectQueuedKernel(
 
 template<bool HasPrincipled, bool HasTexture, bool HasPhotons, bool HasDispersion,
          bool HasLightPassAOVs = false,  // pkg178 D4; pkg186 texture; pkg184 photons; pkg189 dispersion; pkg198 S2 pass axis
-         bool HasProgram = false>  // pkg219b — per-texel op-VM axis
+         bool HasProgram = false,   // pkg219b — per-texel op-VM axis
+         bool HasNormalPerturb = false>  // pkg223 — tangent-space normal-map axis
 __global__ void stageShadeBucketedKernel(
     GPUWavefrontState state,
     GPUWavefrontHitBuffers hitBufs,
@@ -1746,7 +1806,7 @@ __global__ void stageShadeBucketedKernel(
     // pkg186: texture data comes from the __constant__ c_wfTexBinding symbol, NOT
     // kernel params — keeps the untextured <false,false> signature at its
     // pre-pkg186 footprint (see c_wfTexBinding note above).
-    bool alive = shadePathSlot<true, HasPrincipled, HasTexture, HasPhotons, HasDispersion, HasLightPassAOVs, HasProgram>(idx, state, hitBufs, tlas, instances, blas,
+    bool alive = shadePathSlot<true, HasPrincipled, HasTexture, HasPhotons, HasDispersion, HasLightPassAOVs, HasProgram, HasNormalPerturb>(idx, state, hitBufs, tlas, instances, blas,
                                bvhNodes, prims, tris, spheres, motionVerts,
                                materials, lights, numLights,
                                totalLightPower, dedLights, numDed,
@@ -2153,7 +2213,12 @@ void launchStageShadeBucketed(
     // pkg219b: selects the <*,*,*,*,*,true> instantiation carrying the per-texel
     // op-VM. The fleet (no material carries a VM program) passes false and stays
     // byte-identical — the register probe gate for this package.
-    bool              hasProgram)
+    bool              hasProgram,
+    // pkg223: selects the <…,true> instantiation carrying the tangent-space
+    // normal-map perturbation. The fleet (no material carries a normal map)
+    // passes false and reaches the byte-identical <…,false> kernel — the
+    // register-probe gate. Data (matNormalTexId/Strength) rides c_wfTexBinding.
+    bool              hasNormalPerturb)
 {
     if (capacity <= 0) return;
     // One launch covers all buckets: grid = NUM_TYPES * capacity threads;
@@ -2215,12 +2280,23 @@ void launchStageShadeBucketed(
         // all 4 (LP × Program) specializations of each combo land in the cubin.
         // The fleet path (hasProgram==false) reaches the same <…,false>
         // instantiations as before → byte-identical register/stack.
+        // pkg223: the 7th axis (HasNormalPerturb) nests OUTSIDE the pkg198/pkg219b
+        // LP×Program runtime selection. The false-NP branch reaches the EXACT same
+        // <…,false> instantiations as before (explicit 7th `false` == the 6-arg
+        // default) → the fleet stays byte-identical; only hasNormalPerturb scenes
+        // take the <…,true> kernels carrying the normal-map codegen.
         #define ASTRORAY_PKG198_KPTR(P,T,Ph,D) \
-                (hasLightPassAOVs \
-                   ? (hasProgram ? (const void*)stageShadeBucketedKernel<P,T,Ph,D,true,true> \
-                                 : (const void*)stageShadeBucketedKernel<P,T,Ph,D,true,false>) \
-                   : (hasProgram ? (const void*)stageShadeBucketedKernel<P,T,Ph,D,false,true> \
-                                 : (const void*)stageShadeBucketedKernel<P,T,Ph,D,false,false>))
+            (hasNormalPerturb \
+              ? (hasLightPassAOVs \
+                   ? (hasProgram ? (const void*)stageShadeBucketedKernel<P,T,Ph,D,true ,true ,true > \
+                                 : (const void*)stageShadeBucketedKernel<P,T,Ph,D,true ,false,true >) \
+                   : (hasProgram ? (const void*)stageShadeBucketedKernel<P,T,Ph,D,false,true ,true > \
+                                 : (const void*)stageShadeBucketedKernel<P,T,Ph,D,false,false,true >)) \
+              : (hasLightPassAOVs \
+                   ? (hasProgram ? (const void*)stageShadeBucketedKernel<P,T,Ph,D,true ,true ,false> \
+                                 : (const void*)stageShadeBucketedKernel<P,T,Ph,D,true ,false,false>) \
+                   : (hasProgram ? (const void*)stageShadeBucketedKernel<P,T,Ph,D,false,true ,false> \
+                                 : (const void*)stageShadeBucketedKernel<P,T,Ph,D,false,false,false>)))
         const void* kptr = nullptr;
         switch (sel) {
             case  0: kptr = ASTRORAY_PKG198_KPTR(false,false,false,false); break;
@@ -2243,18 +2319,23 @@ void launchStageShadeBucketed(
         #undef ASTRORAY_PKG198_KPTR
         astroray::gpu_profile::ScopedTimer _t(
             "wavefront_stage_shade_bucketed_n7", kptr, blocks, threads);
-        #define ASTRORAY_PKG198_LAUNCH(P,T,Ph,D) \
+        // pkg223: mirror the KPTR nesting — hasNormalPerturb selects the <…,true>
+        // normal-map kernels; the else-branch is the pre-pkg223 fleet path.
+        #define ASTRORAY_PKG223_LP_PROG(P,T,Ph,D,NP) \
                 do { if (hasLightPassAOVs) { \
                     if (hasProgram) \
-                        stageShadeBucketedKernel<P,T,Ph,D,true ,true ><<<blocks, threads>>>(ASTRORAY_PKG186_SHADE_ARGS); \
+                        stageShadeBucketedKernel<P,T,Ph,D,true ,true ,NP><<<blocks, threads>>>(ASTRORAY_PKG186_SHADE_ARGS); \
                     else \
-                        stageShadeBucketedKernel<P,T,Ph,D,true ,false><<<blocks, threads>>>(ASTRORAY_PKG186_SHADE_ARGS); \
+                        stageShadeBucketedKernel<P,T,Ph,D,true ,false,NP><<<blocks, threads>>>(ASTRORAY_PKG186_SHADE_ARGS); \
                 } else { \
                     if (hasProgram) \
-                        stageShadeBucketedKernel<P,T,Ph,D,false,true ><<<blocks, threads>>>(ASTRORAY_PKG186_SHADE_ARGS); \
+                        stageShadeBucketedKernel<P,T,Ph,D,false,true ,NP><<<blocks, threads>>>(ASTRORAY_PKG186_SHADE_ARGS); \
                     else \
-                        stageShadeBucketedKernel<P,T,Ph,D,false,false><<<blocks, threads>>>(ASTRORAY_PKG186_SHADE_ARGS); \
+                        stageShadeBucketedKernel<P,T,Ph,D,false,false,NP><<<blocks, threads>>>(ASTRORAY_PKG186_SHADE_ARGS); \
                 } } while (0)
+        #define ASTRORAY_PKG198_LAUNCH(P,T,Ph,D) \
+                do { if (hasNormalPerturb) ASTRORAY_PKG223_LP_PROG(P,T,Ph,D,true ); \
+                     else                  ASTRORAY_PKG223_LP_PROG(P,T,Ph,D,false); } while (0)
         switch (sel) {
             case  0: ASTRORAY_PKG198_LAUNCH(false,false,false,false); break;
             case  1: ASTRORAY_PKG198_LAUNCH(false,false,false,true ); break;
@@ -2274,6 +2355,7 @@ void launchStageShadeBucketed(
             case 15: ASTRORAY_PKG198_LAUNCH(true ,true ,true ,true ); break;
         }
         #undef ASTRORAY_PKG198_LAUNCH
+        #undef ASTRORAY_PKG223_LP_PROG
         #undef ASTRORAY_PKG186_SHADE_ARGS
         cudaError_t err = cudaGetLastError();
         if (err != cudaSuccess) {

--- a/tests/test_pkg223_gpu_normal_map.py
+++ b/tests/test_pkg223_gpu_normal_map.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python
+"""pkg223 — GPU tangent-space normal maps: visible relief, Strength, CPU/GPU parity.
+
+The addon already exports a normal map (normal_map_texture + normal_strength) and
+the CPU `NormalMappedPlugin` decodes it, but the GPU wavefront dropped it: a
+NormalMapped decorator is a CPU shared_ptr wrapper that does not survive GMaterial
+upload, so a normal-mapped material rendered flat on the device. pkg223 uploads the
+normal texture on the c_wfTexBinding side arrays (matNormalTexId/matNormalStrength)
+and perturbs the shading normal in the wavefront shade stage behind
+`template<bool HasNormalPerturb>` — so scenes without a normal map stay
+byte-identical (register-probe gate) and pay zero cost.
+
+Decode mirrors the CPU oracle exactly (Cycles svm_node_normal_map, cite note
+.astroray_plan/docs/pkg223-normal-map-research.md):
+    n_ts   = 2*rgb - 1
+    B      = uvBitangentSign * cross(N, uvTangent)         # Mikk-TSpace handedness
+    mapped = normalize(T*n_ts.x + B*n_ts.y + N*n_ts.z)     # UV-aligned frame
+    n      = normalize(lerp(N, mapped, clamp(strength,0,1)))
+
+A Lambertian's shading is invisible to normal perturbation under a UNIFORM world
+(it integrates the normal away), so the scene uses a BLACK world + a single grazing
+sun: the diffuse response is then ~ albedo * max(0, N.L), directly sensitive to the
+mapped normal's direction.
+
+GPU-gated: skips when no CUDA device (CI has none); this is an RTX-box leg.
+"""
+
+import math
+
+import astroray
+import numpy as np
+import pytest
+from base_helpers import create_renderer, render_image, setup_camera
+
+
+def _has_cuda_gpu(renderer):
+    return bool(astroray.__features__.get("cuda", False)) and \
+        bool(getattr(renderer, "gpu_available", False))
+
+
+def _norm(v):
+    v = np.asarray(v, np.float32)
+    return (v / np.linalg.norm(v)).tolist()
+
+
+def _normal_image(nx, ny, nz):
+    """A constant 2x2 tangent-space normal texture encoding (nx,ny,nz) normalized:
+    rgb = n_ts*0.5 + 0.5. The identity (0,0,1) -> (0.5,0.5,1.0) = geometric normal."""
+    v = np.asarray([nx, ny, nz], np.float32)
+    v = v / np.linalg.norm(v)
+    rgb = (v * 0.5 + 0.5).astype(np.float32)
+    img = np.empty((2, 2, 3), np.float32)
+    img[:] = rgb
+    return img
+
+
+# A strong tangent-space tilt toward +U (~45 deg): with the UVMap below, +U maps to
+# world +x, and the grazing sun comes from +x, so the tilt swings N.L hard vs flat.
+_TILT = (0.7071, 0.0, 0.7071)
+
+
+def _build(renderer, normal=None, strength=1.0):
+    renderer.set_background_color([0.0, 0.0, 0.0])  # sun-only lighting
+    params = {}
+    if normal is not None:
+        renderer.load_texture("pkg223_nrm", _normal_image(*normal), 2, 2, "UV")
+        params["normal_map_texture"] = "pkg223_nrm"
+        params["normal_strength"] = float(strength)
+    mat = renderer.create_material("lambertian", [0.8, 0.8, 0.8], params)
+
+    # Quad at z=0, geometric normal +z; UVMap makes +U -> world +x, +V -> world +y.
+    A, B = [-1, -1, 0], [1, -1, 0]
+    C, D = [1, 1, 0], [-1, 1, 0]
+    n = [0, 0, 1]
+    renderer.add_triangle_layers(A, B, C, mat, {"UVMap": [[0, 0], [1, 0], [1, 1]]},
+                                 n, n, n)
+    renderer.add_triangle_layers(A, C, D, mat, {"UVMap": [[0, 0], [1, 1], [0, 1]]},
+                                 n, n, n)
+
+    # Grazing sun coming from +x and slightly in front (travel dir toward -x,-z),
+    # so a +U(+x)-tilted normal faces INTO the light and brightens vs the flat quad.
+    ang = 0.02
+    omega = 2.0 * math.pi * (1.0 - math.cos(ang * 0.5))
+    renderer.add_sun_light_dedicated(_norm([-1.0, 0.0, -0.4]), ang,
+                                     {"mode": "rgb", "color": [1.0, 1.0, 1.0]},
+                                     3.0)
+
+    setup_camera(renderer, look_from=[0, 0, 3], look_at=[0, 0, 0], vup=[0, 1, 0],
+                 vfov=45, width=64, height=64)
+
+
+def _render(normal=None, strength=1.0, use_gpu=False, samples=96):
+    r = create_renderer()
+    if use_gpu:
+        if not _has_cuda_gpu(r):
+            pytest.skip("No CUDA GPU — pkg223 normal-map gate runs on the RTX box.")
+        r.set_use_gpu(True)
+    _build(r, normal=normal, strength=strength)
+    return render_image(r, samples=samples, max_depth=2, apply_gamma=False)
+
+
+def _mean(img):
+    return float(np.asarray(img).mean())
+
+
+def test_gpu_normal_map_visible_relief():
+    """A GPU render with the tilted normal map must differ substantially from the
+    same quad with NO normal map (geometric normal) — proof the map is applied on
+    the device rather than dropped."""
+    mapped = _render(normal=_TILT, strength=1.0, use_gpu=True)
+    flat = _render(normal=None, use_gpu=True)
+    mean_abs_diff = float(np.abs(np.asarray(mapped) - np.asarray(flat)).mean())
+    assert _mean(flat) > 0.02, f"flat render too dark to gate ({_mean(flat):.4f})"
+    assert mean_abs_diff > 0.03, (
+        f"GPU normal-mapped render too close to flat (mean|diff|={mean_abs_diff:.4f}); "
+        f"the normal map was likely dropped on GPU."
+    )
+
+
+def test_gpu_normal_strength_monotonic():
+    """Strength 0 ~= flat (geometric normal); |effect| grows monotonically with
+    Strength. Sign-agnostic so it does not depend on the exact light geometry."""
+    flat = _mean(_render(normal=None, use_gpu=True))
+    s0 = _mean(_render(normal=_TILT, strength=0.0, use_gpu=True))
+    s05 = _mean(_render(normal=_TILT, strength=0.5, use_gpu=True))
+    s1 = _mean(_render(normal=_TILT, strength=1.0, use_gpu=True))
+    # Strength 0 collapses the lerp to the geometric normal.
+    assert abs(s0 - flat) < 0.015, (
+        f"Strength 0 should match the flat render (s0={s0:.4f}, flat={flat:.4f})"
+    )
+    d05, d1 = s05 - flat, s1 - flat
+    assert abs(d1) > 0.02, f"Strength 1 shows no relief (d1={d1:.4f})"
+    # Same direction, and full strength moves further than half.
+    assert (d05 == 0.0) or (np.sign(d05) == np.sign(d1)), (
+        f"Strength 0.5 and 1.0 perturb in opposite directions (d05={d05:.4f}, d1={d1:.4f})"
+    )
+    assert abs(d1) > abs(d05) + 0.005, (
+        f"effect not monotonic in Strength (|d05|={abs(d05):.4f}, |d1|={abs(d1):.4f})"
+    )
+
+
+def test_cpu_gpu_normal_map_parity():
+    """Per-channel mean-ratio of the CPU oracle vs GPU normal-mapped render within
+    band — the GPU decode + UV-aligned TBN must byte-mirror NormalMappedPlugin."""
+    gpu = _render(normal=_TILT, strength=1.0, use_gpu=True)
+    cpu = _render(normal=_TILT, strength=1.0, use_gpu=False)
+    gm = np.array([float(np.asarray(gpu)[..., c].mean()) for c in range(3)])
+    cm = np.array([float(np.asarray(cpu)[..., c].mean()) for c in range(3)])
+    assert cm.mean() > 0.02, f"CPU reference too dark to gate: {cm}"
+    assert gm.mean() > 0.02, f"GPU render too dark to gate: {gm}"
+    ratio = gm / np.maximum(cm, 1e-6)
+    for c, rc in enumerate(ratio):
+        assert 0.80 <= rc <= 1.25, (
+            f"channel {c} CPU/GPU mean-ratio {rc:.3f} out of band [0.80,1.25]; "
+            f"cpu={cm}, gpu={gm}"
+        )


### PR DESCRIPTION
## Summary

Normal maps were exported by the addon and decoded on the CPU, but the **GPU wavefront silently dropped them** — a `NormalMapped` decorator is a CPU `shared_ptr` wrapper that doesn't survive `GMaterial` upload. This wires the tangent-space perturbation through the GPU shade stage and fixes a latent CPU frame bug.

The spec (pkg223) was written blind; investigation found the addon export, CPU decode, and UV-aligned tangent infra (`uvTangent`/`gpu_pr_uvAlignedTangent`) **already existed**, so the real work was GPU consumption only.

## Changes

**GPU consumption (the gap):**
- `scene_upload` unwraps the `NormalMapped` decorator → inner material becomes the `GMaterial` (+ its base texture); the normal texture + Strength ride the parallel `c_wfTexBinding` side arrays (`matNormalTexId`/`matNormalStrength`). **`GMaterial` stays exactly 640 B** so the fleet `<…,false>` kernel is byte-identical. Also uploads the active-UV layer for normal-mapped triangles (the pkg178/pkg186 predicate missed them).
- `shadePathSlot` perturbs `rec.normal` behind `template<bool HasNormalPerturb>`: UV-aligned (Mikk-TSpace/Lengyel) frame, decode `n_ts=2*rgb-1`, `B=sign*cross(N,T)`, lerp toward N by the Cycles Strength. Compiled out entirely in the fleet.

**CPU correctness fix:** `NormalMappedPlugin` used the arbitrary ONB, not the UV-aligned `uvTangent` — a Cycles-incorrect azimuth. Fixed (also the GPU parity oracle).

## Verification (RTX 5070 Ti, sm_120)

- **Register probe (hard gate):** 64 `HasNormalPerturb=false` specializations **byte-identical to main** (REG+STACK); 64 `=true` have **no REG spill** (max 254) and **no STACK increase** (60 identical, 4 smaller). `GMaterial` untouched.
- `tests/test_pkg223_gpu_normal_map.py`: visible relief, Strength monotonic, CPU/GPU mean-ratio parity — **all pass**.
- No regressions: pkg186 texture parity, pkg190 procedural, pkg219a mapping, material plugins (19+9 passed).

Cite: `.astroray_plan/docs/pkg223-normal-map-research.md` (Cycles `svm_node_normal_map` + Mikk-TSpace; handedness/decode/Strength cross-checked against the CPU oracle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)