### PR TITLE
feat(pkg207): probe merged Cycles dispersion socket names in addon

### DIFF
--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -3667,17 +3667,20 @@ class CustomRaytracerRenderEngine(RenderEngine):
         put_float('thin_film_thickness', 'Thin Film Thickness')
         put_float('thin_film_ior', 'Thin Film IOR')
         put_float('thin_wall', 'Thin Wall')
-        # Dispersion (pkg187) — FORWARD-COMPATIBLE probe. No shipped Blender exposes
-        # a Dispersion socket on Principled BSDF: headless probes of 4.3.2 / 4.5.0 /
-        # 5.1.0 / 5.2.0 all return no such input. It is the unmerged upstream WIP,
-        # Blender PR #162041, which adds two sockets — 'Dispersion Scale' (in [0,1])
-        # and 'Dispersion Abbe Number' (default 20). These put_float calls are a
-        # no-op on every current build (socket absent -> key not written -> engine
-        # stays non-dispersive) and start round-tripping automatically the day that
-        # PR ships. The native material (principled.cpp) reads dispersion_scale +
-        # dispersion_abbe; a one-socket 'Dispersion' build aliases the scale.
-        put_float('dispersion_scale', 'Dispersion Scale', 'Dispersion')
-        put_float('dispersion_abbe', 'Dispersion Abbe Number')
+        # Dispersion (pkg187) — FORWARD-COMPATIBLE probe. No shipped Blender <=5.2
+        # exposes a dispersion socket on Principled BSDF: headless probes of 4.3.2 /
+        # 4.5.0 / 5.1.0 / 5.2.0 all return no such input. Blender PR #162041 (merged
+        # 2026-08-18, commit f15daf81bf7c) added the two sockets under their MERGED
+        # names — 'Transmission Dispersion Scale' (in [0,1]) and 'Transmission
+        # Dispersion Abbe Number' (default 20); see node_shader_bsdf_principled.cc.
+        # We probe the merged names first, then fall back to the older short forms an
+        # experimental/WIP build may still use (put_float takes a name list, first
+        # match wins). On every current shipped build the socket is absent -> key not
+        # written -> engine stays non-dispersive. The native material (principled.cpp)
+        # reads dispersion_scale + dispersion_abbe; a one-socket 'Dispersion' build
+        # aliases the scale.
+        put_float('dispersion_scale', 'Transmission Dispersion Scale', 'Dispersion Scale', 'Dispersion')
+        put_float('dispersion_abbe', 'Transmission Dispersion Abbe Number', 'Dispersion Abbe Number')
         # Alpha — a REAL value routed to the native transparent lobe; NOT folded
         # into transmission (that conflation is the convicted BSDF_TRANSPARENT
         # bug family the Disney path still carries).

--- a/tests/test_pkg187_addon_dispersion_probe.py
+++ b/tests/test_pkg187_addon_dispersion_probe.py
@@ -1,19 +1,25 @@
 """pkg187 — Blender addon forward-compatible Dispersion socket probe.
 
-No shipped Blender (probed: 4.3.2 / 4.5.0 / 5.1.0 / 5.2.0) exposes a Dispersion
-socket on the Principled BSDF — it is unmerged upstream WIP (Blender PR #162041).
-So the addon cannot map a live socket today. Instead `_principled_native_params`
-carries a FORWARD-COMPATIBLE probe:
+No shipped Blender <=5.2 (probed: 4.3.2 / 4.5.0 / 5.1.0 / 5.2.0) exposes a
+dispersion socket on the Principled BSDF. Blender PR #162041 (merged 2026-08-18,
+commit f15daf81bf7c) added the two sockets under their MERGED names,
+'Transmission Dispersion Scale' and 'Transmission Dispersion Abbe Number'
+(node_shader_bsdf_principled.cc). pkg207 fixes `_principled_native_params` to
+probe those merged names first, keeping the older short forms as fallbacks:
 
-    put_float('dispersion_scale', 'Dispersion Scale', 'Dispersion')
-    put_float('dispersion_abbe',  'Dispersion Abbe Number')
+    put_float('dispersion_scale', 'Transmission Dispersion Scale',
+              'Dispersion Scale', 'Dispersion')
+    put_float('dispersion_abbe', 'Transmission Dispersion Abbe Number',
+              'Dispersion Abbe Number')
 
 This test proves the probe:
-  1. is a NO-OP on a node with no dispersion inputs (today's real Blender) — so
-     the engine stays non-dispersive and nothing regresses;
-  2. maps the two-socket WIP layout ('Dispersion Scale' + 'Dispersion Abbe
-     Number') onto dispersion_scale / dispersion_abbe;
-  3. maps a single-socket 'Dispersion' alias onto dispersion_scale.
+  1. is a NO-OP on a node with no dispersion inputs (Blender 5.1/5.2 and older) —
+     so the engine stays non-dispersive and nothing regresses;
+  2. maps the MERGED 5.3 layout ('Transmission Dispersion Scale' + 'Transmission
+     Dispersion Abbe Number') onto dispersion_scale / dispersion_abbe (pkg207);
+  3. maps the older short-form two-socket layout ('Dispersion Scale' +
+     'Dispersion Abbe Number') via the fallback;
+  4. maps a single-socket 'Dispersion' alias onto dispersion_scale.
 
 Runs OUTSIDE Blender via a mocked `bpy` (the standard addon-unit-test pattern
 from tests/test_addon_dof_aperture.py), with a synthetic node carrying the
@@ -122,8 +128,22 @@ def test_probe_noop_without_dispersion_sockets(monkeypatch):
     assert "dispersion_abbe" not in p
 
 
-def test_probe_maps_two_socket_wip_layout(monkeypatch):
-    """PR #162041 two-socket layout round-trips onto the engine param names."""
+def test_probe_maps_merged_5_3_layout(monkeypatch):
+    """pkg207: merged Blender 5.3 socket names round-trip onto the engine params."""
+    eng = _engine(monkeypatch)
+    node = _StubNode({
+        "IOR": 1.5,
+        "Transmission Weight": 1.0,
+        "Transmission Dispersion Scale": 0.7,
+        "Transmission Dispersion Abbe Number": 15.0,
+    })
+    p = eng._principled_native_params(node)
+    assert p["dispersion_scale"] == pytest.approx(0.7)
+    assert p["dispersion_abbe"] == pytest.approx(15.0)
+
+
+def test_probe_maps_short_form_fallback(monkeypatch):
+    """Older short-form two-socket layout still round-trips via the fallback."""
     eng = _engine(monkeypatch)
     node = _StubNode({
         "IOR": 1.5,


### PR DESCRIPTION
## Summary

Fixes the addon's forward-compat dispersion probe so dispersion round-trips on a real Blender 5.3 build. `_principled_native_params` read the pre-merge WIP socket names (`Dispersion Scale` / `Dispersion Abbe Number`), which `node.inputs.get()` never matches on a shipped 5.3 build (the sockets shipped under different names). Blender PR #162041 (merged 2026-08-18, commit `f15daf81bf7c`) named them `Transmission Dispersion Scale` and `Transmission Dispersion Abbe Number` (`node_shader_bsdf_principled.cc`).

`put_float` already accepts a variadic name list with first-match-wins semantics, so the fix simply prepends the merged names and keeps the short forms as fallbacks — no refactor of the probe machinery (CLAUDE.md §3). The stale comment is refreshed to name the merged sockets + merge commit and drop the "unmerged PR" framing.

## Spec status

pkg207 -> done (PR #<this>, 2026-08-30 — merged-name probe + short-form fallback + comment refresh; unit test 4/4 green). Spec-file status flip deferred to the docs round to honor the spec's "diff touches only `blender_addon/__init__.py` + its unit test" acceptance criterion.

## Acceptance criteria

- [x] Merged-name node (`Transmission Dispersion Scale` / `Transmission Dispersion Abbe Number`) round-trips both values into the material.
- [x] Short-form node (`Dispersion Scale` / `Dispersion Abbe Number`) still round-trips via the fallback; single-socket `Dispersion` alias maps to scale.
- [x] Blender 5.1/5.2 (sockets absent): probe returns None for both, material unaffected (no-op test).
- [x] Diff touches only `blender_addon/__init__.py` + its unit test; no engine code, no `.pyd` rebuild, no GPU leg. CI-gate only.

## Authorized surface

Spec Specification steps 1-3 intended `blender_addon/__init__.py` (+ its unit test). Actually changed:
- `blender_addon/__init__.py` — two `put_float` socket-name args + comment refresh (in-spec).
- `tests/test_pkg187_addon_dispersion_probe.py` — added merged-name round-trip test, renamed the WIP-layout test to the short-form fallback, refreshed docstring (in-spec test surface).

Nothing outside the spec's Specification / Non-goals. The spec-file status line was intentionally left untouched to keep the diff to the two authorized files.

## Test evidence

```
tests/test_pkg187_addon_dispersion_probe.py::test_probe_noop_without_dispersion_sockets PASSED [ 25%]
tests/test_pkg187_addon_dispersion_probe.py::test_probe_maps_merged_5_3_layout PASSED [ 50%]
tests/test_pkg187_addon_dispersion_probe.py::test_probe_maps_short_form_fallback PASSED [ 75%]
tests/test_pkg187_addon_dispersion_probe.py::test_probe_single_socket_dispersion_alias PASSED [100%]
============================== 4 passed in 0.29s ==============================
```

Pure-Python addon change: no `.cu`/`.cpp`/`.h`/CMake touched, so no build log leg — CI-gate only, no GPU/HW.

🤖 Generated with [Claude Code](https://claude.com/claude-code)