### PR TITLE
feat(pkg131): zero-knob adaptive sampling core + CPU per-pixel leg

### DIFF
--- a/.astroray_plan/docs/external-references.md
+++ b/.astroray_plan/docs/external-references.md
@@ -85,6 +85,14 @@ own because a dependency for 40 lines of code is ridiculous.
   Reference for tiny-cuda-nn inference/training pattern.
 - **Original paper**: Müller et al. 2021.
 
+### Zero-knob adaptive sampling (pkg131)
+
+- **Cycles** `src/kernel/film/adaptive_sampling.h` + `src/scene/integrator.cpp`
+  (`get_adaptive_sampling`) + `src/integrator/adaptive_sampling.cpp` — Apache-2.0.
+  Dammertz et al. WSCG 2010 error metric + zero-knob threshold auto-derivation.
+  Notes: `pkg131-adaptive-sampling-autothreshold-research.md` (fills the
+  auto-threshold gap in `2026-07-other-engines-research.md` §5).
+
 ---
 
 ## 4. Astrophysics (Pillar 4)

--- a/.astroray_plan/docs/pkg131-adaptive-sampling-autothreshold-research.md
+++ b/.astroray_plan/docs/pkg131-adaptive-sampling-autothreshold-research.md
@@ -1,0 +1,118 @@
+# pkg131 Adaptive Sampling — Cycles auto-threshold derivation (research)
+
+Fills the one gap in `.astroray_plan/docs/2026-07-other-engines-research.md §5`:
+the exact **zero-knob** `threshold = 0` → noise-threshold + min-samples derivation,
+the check cadence, and the verbatim convergence-check / dilation math. Verified
+against the live Cycles source 2026-08-30.
+
+## Paper
+- **Title:** A Hierarchical Automatic Stopping Condition for Monte Carlo Global Illumination
+- **Authors:** Holger Dammertz, Johannes Hanika, Alexander Keller, Hendrik P. A. Lensch
+- **Year / Venue:** WSCG 2010
+- **PDF:** http://jo.dreggn.org/home/2009_stopping.pdf
+- Half-buffer variance inspiration: Christensen et al., "RenderMan: An Advanced
+  Path-Tracing Architecture", ACM TOG 37(3) 2018, DOI 10.1145/3182162.
+
+## Reference implementation
+- **Repo:** https://github.com/blender/cycles (main, fetched 2026-08-30)
+- **License:** Apache-2.0 — compatible with Astroray's LICENSE (already the cited
+  basis for the wavefront RNG, JH LUT, cryptomatte post, and pkg224 Sobol').
+- **Files mirrored:**
+  - `src/scene/integrator.cpp` — `Integrator::get_adaptive_sampling()` (the zero-knob derivation)
+  - `src/integrator/adaptive_sampling.cpp` — `AdaptiveSampling::need_filter`, `::align_samples` (cadence)
+  - `src/kernel/film/adaptive_sampling.h` — `film_adaptive_sampling_convergence_check`, `_filter_x/_y` (per-pixel error + dilation)
+
+## The zero-knob derivation (verbatim logic, `get_adaptive_sampling()`)
+
+Given `aa_samples` (the sample budget = our `max_samples`) and user `adaptive_threshold`:
+
+```
+if (aa_samples > 0 && adaptive_threshold == 0)
+    threshold = max(0.001f, 1.0f / (float)aa_samples);   // auto (zero-knob)
+else
+    threshold = adaptive_threshold;                       // manual override
+
+// min_samples derived from the PRE-scale threshold (order matters):
+if (threshold > 0 && adaptive_min_samples == 0)
+    min_samples = max(4, (int)ceilf(16.0f / powf(threshold, 0.3f)));
+else
+    min_samples = max(4, adaptive_min_samples);
+
+threshold *= 5.0f;        // "arbitrary factor" applied AFTER min_samples is computed
+adaptive_step = 16;       // power of two; bitwise cadence
+```
+
+Worked values (auto path, threshold pre-scale = 1/aa_samples clamped to ≥0.001):
+- `aa_samples=64`  → thr=0.0156 → min=ceil(16/0.0156^0.3)=ceil(16/0.283)=**57**? recompute:
+  0.0156^0.3 = exp(0.3·ln0.0156)=exp(0.3·−4.16)=exp(−1.25)=0.287 → 16/0.287=55.7 → **56**; final thr=0.078.
+- `aa_samples=256` → thr=0.0039 → 0.0039^0.3=exp(0.3·−5.55)=exp(−1.66)=0.190 → 16/0.190=84.2 → min=**85**; final thr=0.0195.
+- `aa_samples=1024`→ thr=0.00098→clamp 0.001 → 0.001^0.3=exp(0.3·−6.9)=exp(−2.07)=0.126 →16/0.126=126.7→min=**127**; final thr=0.005.
+
+(The famous "0.1→32, 0.01→64, 0.001→128" comment matches: min grows ~as thr shrinks.)
+
+## Cadence (`adaptive_sampling.cpp`)
+
+```
+need_filter(sample):                       // 0-indexed sample
+    if (!use) return false;
+    if (sample <= min_samples) return false;
+    return (sample & (adaptive_step-1)) == (adaptive_step-1);   // every 16th past floor
+```
+So convergence is checked at samples 15,31,47,… but only once `sample > min_samples`.
+`align_samples` snaps a render chunk so it ends exactly on a filter sample (we drive
+our own rounds, so we replicate the intent: run to the next `k*16-1` boundary).
+
+## Convergence check (`film/adaptive_sampling.h`, verbatim math)
+
+Per pixel, `I` = full/combined buffer, `A` = auxiliary HALF-sample buffer:
+```
+intensity_scale = exposure / sample;                       // sample = count so far
+error_difference = (|I.x-A.x| + |I.y-A.y| + |I.z-A.z|) * intensity_scale;
+intensity = (I.x + I.y + I.z) * intensity_scale;           // scaled combined intensity
+error_normalize = (intensity < 1.0f) ? sqrtf(intensity) : intensity;
+error = error_difference / (0.0001f + error_normalize);    // Dammertz §2.1, brightness-relative
+converged = (error < threshold);
+```
+Cycles stores the aux buffer's alpha lane as the converged flag (0 = unconverged).
+
+## Filter dilation (`_filter_x` then `_filter_y`)
+
+Two sequential 1-D passes, radius 1: a pixel that is unconverged forces its
+immediate ±1 neighbor (row pass, then column pass) to keep sampling. Net effect is a
+3×3 dilation of the unconverged mask so early-out boundaries are not splotchy.
+
+## Astroray adaptation decisions
+
+- **Scalar-luminance half-buffer** (8 GB constraint, research §5b): store `A` as one
+  float (luminance) not float3; `error_difference` becomes `|Ilum − Alum| *
+  intensity_scale`, `intensity = Ilum * intensity_scale`. This is a deliberate,
+  documented deviation from Cycles' float3 aux — luminance noise is the stopping
+  signal Dammertz actually thresholds, and it halves-or-better the aux memory.
+- **Half-buffer accumulation:** `A` accumulates only even-indexed samples (0,2,4,…);
+  `I` accumulates all. At a check with `n` samples, `A` holds `⌈n/2⌉` samples' mean
+  and `I` holds `n` samples' mean — the |I−A| difference is the half-vs-full noise
+  estimate. (Cycles uses the same odd/even split via the aux pass.)
+- **`aa_samples` ↔ `max_samples`:** our `max_samples` cap plays the role of Cycles'
+  `aa_samples` in the auto-threshold formula.
+- **`exposure`:** Astroray applies exposure (`filmExposure`) at resolve; use 1.0f in
+  the metric unless a film exposure is set, matching where Cycles reads
+  `kernel_data.film.exposure`.
+
+## What we deliberately do NOT take
+- Cycles' tile/work scheduler and its render-buffer pass layout — Astroray has its own
+  wavefront flat-pool scheduler (GPU) and per-pixel CPU loop; we port only the metric,
+  the auto-threshold, and the dilation.
+
+## Integration plan
+- New header `include/astroray/sampling/adaptive_sampling.h` — the metric + auto-derive
+  as pure `__host__ __device__` free functions (unit-testable on CI, no GPU).
+- CPU leg: convergence check in the CPU per-pixel sample loop.
+- GPU leg: **compacted active-pixel round** on top of the existing flat work pool
+  (regen indexes `activePixels[w % numActive]`, per-pixel sample counter, per-pixel
+  final divide) — additive, byte-identical when off, respects the flat-pool perf
+  design (the 1.5 s ceiling). NOT a wave-based rewrite.
+- Package: `.astroray_plan/packages/pkg131-zero-knob-adaptive-sampling.md`.
+
+## Open questions
+- None blocking. The GPU compacted-active-list is an implementation detail of "the
+  wavefront already owns compaction" (spec), not a fork needing owner input.

--- a/.astroray_plan/packages/pkg131-zero-knob-adaptive-sampling.md
+++ b/.astroray_plan/packages/pkg131-zero-knob-adaptive-sampling.md
@@ -125,9 +125,25 @@ add one.
 
 ## Progress
 
-- [ ] A — convergence-check film kernel (scalar-luminance half-buffer, Dammertz).
-- [ ] B — auto-threshold scheduler + min floor + max cap.
-- [ ] C — wavefront compaction integration + addon UI removal; speedup measured.
+- [x] **Shared core** `include/astroray/sampling/adaptive_sampling.h` — cited
+      `__host__ __device__` Dammertz metric (scalar-luminance half-buffer), zero-knob
+      auto-threshold + min-sample floor derivation, and the two-pass 3×3 mask
+      dilation. Verified byte-exact against Cycles values (research note
+      `.astroray_plan/docs/pkg131-adaptive-sampling-autothreshold-research.md`);
+      6 host unit tests (`tests/test_pkg131_adaptive_sampling.py`). (2026-08-30)
+- [x] A (CPU) + B — CPU per-pixel leg: `Renderer::render` now stops each pixel via
+      the shared core instead of the old hand-rolled coefficient-of-variation
+      early-out; `maxSamples` is the auto-threshold budget. Verified: low-budget
+      bit-identical no-op + high-budget unbiased/bounded
+      (`tests/test_pkg131_adaptive_cpu_render.py`). (2026-08-30)
+- [ ] C (GPU) — wavefront **compacted active-pixel round** on top of the existing
+      flat work pool (`stageRegenKernel` indexes `activePixels[w % numActive]`,
+      per-pixel sample counter, per-pixel final divide; convergence-check kernel
+      between rounds). Additive, byte-identical when off, respects the flat-pool
+      perf design. Design in the research note. NOT a wave-based rewrite. HW-verify
+      on RTX (CI has no GPU).
+- [ ] Sample-count AOV (report measured speedup) + addon UI: remove the `samples=N`
+      knob, expose `max_samples` + optional auto-defaulted noise-threshold override.
 
 ---
 

--- a/include/astroray/sampling/adaptive_sampling.h
+++ b/include/astroray/sampling/adaptive_sampling.h
@@ -1,0 +1,162 @@
+// adaptive_sampling.h — pkg131 zero-knob adaptive sampling core.
+//
+// Per-pixel Monte-Carlo stopping condition (Dammertz 2010, brightness-relative
+// noise) with Cycles' zero-knob auto-threshold: replace the `samples = N` knob
+// with a `max_samples` safety cap + an auto-derived noise threshold + a minimum
+// sample floor. This header is the SHARED numeric core consumed by both the CPU
+// per-pixel sample loop and the GPU wavefront's compacted active-pixel round; it
+// is intentionally a set of pure __host__ __device__ free functions so the host
+// build exercised by the unit tests is byte-identical to the device build.
+//
+// Source: Dammertz, Hanika, Keller, Lensch, "A Hierarchical Automatic Stopping
+//   Condition for Monte Carlo Global Illumination", WSCG 2010
+//   (http://jo.dreggn.org/home/2009_stopping.pdf) — the per-pixel error metric.
+// Reference impl: github.com/blender/cycles@main (read 2026-08-30) —
+//   src/scene/integrator.cpp §Integrator::get_adaptive_sampling (auto-threshold),
+//   src/integrator/adaptive_sampling.cpp §need_filter/align_samples (cadence),
+//   src/kernel/film/adaptive_sampling.h §film_adaptive_sampling_convergence_check
+//   + _filter_x/_y (per-pixel error + mask dilation).
+// License: Apache-2.0 (compatible with Astroray's LICENSE).
+// Notes: .astroray_plan/docs/pkg131-adaptive-sampling-autothreshold-research.md
+//
+// DELIBERATE DEVIATION FROM CYCLES (documented in the research note): Cycles' aux
+// buffer is float3; Astroray stores a SCALAR-LUMINANCE half-buffer (one float per
+// pixel) to avoid doubling framebuffer memory on the 8 GB config. The stopping
+// signal Dammertz thresholds is brightness noise, which the scalar luminance
+// captures; per-channel chroma noise is not separately gated. Luminance here is
+// the sum of the three accumulator channels (matches Cycles' `(I.x+I.y+I.z)`
+// intensity reduction), the raw XYZ/linear-RGB accumulators Astroray already owns.
+
+#ifndef ASTRORAY_SAMPLING_ADAPTIVE_SAMPLING_H
+#define ASTRORAY_SAMPLING_ADAPTIVE_SAMPLING_H
+
+#if defined(__CUDACC__)
+#define ASTRORAY_ADAPTIVE_HD __host__ __device__
+#else
+#define ASTRORAY_ADAPTIVE_HD
+#endif
+
+#include <cmath>
+
+namespace astroray {
+namespace adaptive {
+
+// Cycles' adaptive_step: convergence is checked every 16th sample past the floor.
+// Power of two so `sample & (kAdaptiveStep-1)` is the cadence test.
+static constexpr int kAdaptiveStep = 16;
+
+// Resolved sampler schedule for one render (Cycles Integrator::get_adaptive_sampling).
+struct AdaptiveParams {
+    bool  use;          // adaptive sampling enabled?
+    float threshold;    // post-scale noise threshold; converged when error < threshold
+    int   min_samples;  // sampling floor — no pixel may converge before this many samples
+    int   max_samples;  // safety cap (Cycles' aa_samples); every pixel stops here
+    int   adaptive_step;// check cadence (kAdaptiveStep)
+};
+
+// Zero-knob derivation from the sample budget. `user_threshold <= 0` and
+// `user_min_samples <= 0` request the auto (zero-knob) path; positive values
+// override. Mirrors Integrator::get_adaptive_sampling() including the exact
+// ordering: min_samples is derived from the PRE-scale threshold, then the
+// "arbitrary factor" *5 is applied to the threshold.
+ASTRORAY_ADAPTIVE_HD inline AdaptiveParams deriveAdaptiveParams(
+    int max_samples, float user_threshold, int user_min_samples) {
+    AdaptiveParams p;
+    p.use = true;
+    p.max_samples = max_samples > 0 ? max_samples : 1;
+    p.adaptive_step = kAdaptiveStep;
+
+    float thr;
+    if (max_samples > 0 && user_threshold <= 0.0f) {
+        // Auto: 1/budget, clamped so a huge budget still stops at a finite noise
+        // floor (Cycles clamps to 0.001).
+        thr = 1.0f / static_cast<float>(p.max_samples);
+        if (thr < 0.001f) thr = 0.001f;
+    } else {
+        thr = user_threshold;
+    }
+
+    if (thr > 0.0f && user_min_samples <= 0) {
+        // "Threshold 0.1 -> 32, 0.01 -> 64, 0.001 -> 128" (Cycles comment).
+        int ms = static_cast<int>(std::ceil(16.0f / std::pow(thr, 0.3f)));
+        p.min_samples = ms > 4 ? ms : 4;
+    } else {
+        p.min_samples = user_min_samples > 4 ? user_min_samples : 4;
+    }
+
+    // Arbitrary factor applied AFTER min_samples derivation (Cycles order).
+    thr *= 5.0f;
+    p.threshold = thr;
+
+    // The floor can never exceed the cap.
+    if (p.min_samples > p.max_samples) p.min_samples = p.max_samples;
+    return p;
+}
+
+// Cycles need_filter: only check convergence once past the floor, and only on the
+// (adaptive_step)-aligned samples. `samples_done` is the number of samples already
+// accumulated for the pixel (so the check runs after the 16th, 32nd, … sample).
+ASTRORAY_ADAPTIVE_HD inline bool needConvergenceCheck(
+    const AdaptiveParams& p, int samples_done) {
+    if (!p.use) return false;
+    if (samples_done <= p.min_samples) return false;
+    return (samples_done & (p.adaptive_step - 1)) == 0;
+}
+
+// Per-pixel convergence test (film_adaptive_sampling_convergence_check), scalar
+// luminance variant. Inputs are the RUNNING SUMS the render already accumulates:
+//   full_lum_sum : Σ luminance over ALL samples_done samples
+//   half_lum_sum : Σ luminance over the EVEN-indexed samples only
+//   samples_done : n (>= 1)
+//   exposure     : film exposure (1.0 unless a film exposure is set)
+// Returns true when the pixel's brightness-relative noise is below `threshold`.
+ASTRORAY_ADAPTIVE_HD inline bool pixelConverged(
+    float full_lum_sum, float half_lum_sum, int samples_done,
+    float threshold, float exposure) {
+    if (samples_done < 1) return false;
+    const int n_half = (samples_done + 1) / 2;  // ceil(n/2): even indices 0,2,4,…
+    if (n_half < 1) return false;
+    const float mean_full = full_lum_sum / static_cast<float>(samples_done);
+    const float mean_half = half_lum_sum / static_cast<float>(n_half);
+
+    const float error_difference = fabsf(mean_full - mean_half) * exposure;
+    const float intensity = mean_full * exposure;
+    const float error_normalize = (intensity < 1.0f) ? sqrtf(intensity) : intensity;
+    const float error = error_difference / (0.0001f + error_normalize);
+    return error < threshold;
+}
+
+// One 1-D pass of the unconverged-mask box dilation (film_adaptive_sampling_filter_x
+// / _filter_y). `converged` is the current mask (1 = converged/retired,
+// 0 = keep sampling); `out` receives the dilated mask. A converged pixel is forced
+// back to unconverged if either 1-neighbor along `stride` is unconverged, so
+// neighborhoods keep sampling together and early-out boundaries are not splotchy.
+// Call once with stride=1 (rows) and once with stride=width (columns) for the full
+// 3x3 dilation. `out` and `converged` must not alias.
+inline void dilateConvergedMaskPass(
+    const unsigned char* converged, unsigned char* out,
+    int width, int height, int stride) {
+    const int n = width * height;
+    for (int i = 0; i < n; ++i) {
+        if (!converged[i]) { out[i] = 0; continue; }
+        // Neighbor along `stride`, guarded at the row/column boundary.
+        bool edgeLo, edgeHi;
+        if (stride == 1) {
+            const int x = i % width;
+            edgeLo = (x == 0);
+            edgeHi = (x == width - 1);
+        } else {
+            const int y = i / width;
+            edgeLo = (y == 0);
+            edgeHi = (y == height - 1);
+        }
+        const bool loUnconv = !edgeLo && !converged[i - stride];
+        const bool hiUnconv = !edgeHi && !converged[i + stride];
+        out[i] = (loUnconv || hiUnconv) ? 0 : 1;
+    }
+}
+
+}  // namespace adaptive
+}  // namespace astroray
+
+#endif  // ASTRORAY_SAMPLING_ADAPTIVE_SAMPLING_H

--- a/include/raytracer.h
+++ b/include/raytracer.h
@@ -25,6 +25,7 @@
 #include "astroray/spectral_profile.h"
 #include "astroray/light_sampler.h"
 #include "astroray/cryptomatte.h"
+#include "astroray/sampling/adaptive_sampling.h"  // pkg131 zero-knob adaptive core
 
 // Forward declaration needed by HitRecord
 class Hittable;
@@ -3579,6 +3580,14 @@ inline void Renderer::render(Camera& cam, int maxSamples, int maxDepth,
             integrator_->setMaxDepth(maxDepth);
             integrator_->beginFrame(*this, cam);
         }
+        // pkg131 — zero-knob adaptive sampling. `maxSamples` is the sample budget
+        // (Cycles' aa_samples); the noise threshold and minimum-sample floor are
+        // auto-derived from it (Integrator::get_adaptive_sampling). This replaces
+        // the previous hand-rolled coefficient-of-variation early-out. Derived once
+        // per render; the per-pixel convergence-check uses the SAME cited core the
+        // GPU wavefront leg will (include/astroray/sampling/adaptive_sampling.h).
+        const astroray::adaptive::AdaptiveParams adaptiveParams =
+            astroray::adaptive::deriveAdaptiveParams(maxSamples, /*auto*/0.0f, /*auto*/0);
         std::atomic<int> tilesCompleted{0};
         const int tileSize = 16;
         int tilesX = (cam.width + tileSize - 1) / tileSize;
@@ -3610,7 +3619,11 @@ inline void Renderer::render(Camera& cam, int maxSamples, int maxDepth,
                         float materialIndex = 0.0f;
                         // pkg87a: objectSampleCounts/materialSampleCounts removed — old placeholder
                         // cryptomatte logic deleted; pkg87b will add per-shade-point accumulation.
-                        float sumL = 0, sumL2 = 0;
+                        // pkg131 — scalar-luminance half-buffer for the Dammertz
+                        // convergence check: fullLumSum over all samples, halfLumSum
+                        // over even-indexed samples only. Luminance = X+Y+Z (matches
+                        // Cycles' (I.x+I.y+I.z) intensity reduction).
+                        float fullLumSum = 0.0f, halfLumSum = 0.0f;
                         int samples = 0;
                         // pkg72: remember the s==0 primary ray so we can recover
                         // the world-space hit point for the motion-vector write
@@ -3697,12 +3710,24 @@ inline void Renderer::render(Camera& cam, int maxSamples, int maxDepth,
                                 objectIndex = static_cast<float>(sObjectIndex);
                                 materialIndex = static_cast<float>(sMaterialIndex);
                             }
-                            if (adaptive && s >= 16 && (s + 1) % 8 == 0) {
-                                float l = luminance(sCol);
-                                sumL += l; sumL2 += l * l;
-                                float mean = sumL / (s - 15);
-                                float var = (sumL2 / (s - 15)) - mean * mean;
-                                if (std::sqrt(std::max(0.0f, var)) / (mean + 0.01f) < 0.01f) break;
+                            // pkg131 — zero-knob adaptive stopping (Cycles Dammertz
+                            // metric, scalar-luminance half-buffer). Accumulate the
+                            // full/half luminance sums every sample, then at the
+                            // step-aligned check past the min-sample floor, stop this
+                            // pixel once its brightness-relative noise falls below the
+                            // auto-derived threshold. filmExposure is the metric's
+                            // exposure (Cycles reads kernel_data.film.exposure).
+                            {
+                                const float lum = sCol.x + sCol.y + sCol.z;
+                                fullLumSum += lum;
+                                if ((s & 1) == 0) halfLumSum += lum;
+                            }
+                            if (adaptive &&
+                                astroray::adaptive::needConvergenceCheck(adaptiveParams, samples) &&
+                                astroray::adaptive::pixelConverged(
+                                    fullLumSum, halfLumSum, samples,
+                                    adaptiveParams.threshold, filmExposure)) {
+                                break;
                             }
                         }
 

--- a/module/test_helpers_module.cpp
+++ b/module/test_helpers_module.cpp
@@ -10,6 +10,7 @@
 
 #include "astroray/sampling/wavefront_rng.h"
 #include "astroray/sampling/progressive_sobol.h"
+#include "astroray/sampling/adaptive_sampling.h"
 #include "astroray/energy_compensation.h"
 
 namespace py = pybind11;
@@ -94,4 +95,44 @@ PYBIND11_MODULE(astroray_test_helpers, m) {
           "— the single host definition of the Kulla & Conty 2017 / Cycles "
           "microfacet_ggx_preserve_energy net factor 1 + Fms*(1-E)/E, called by "
           "both metal.cpp and disney.cpp. Device twin: gpu_ggxDarkeningChannel.");
+
+    // pkg131 — zero-knob adaptive sampling core (Cycles adaptive_sampling.h +
+    // integrator.cpp get_adaptive_sampling). The __host__ __device__ free
+    // functions in include/astroray/sampling/adaptive_sampling.h are the SAME
+    // ones the CPU sample loop and the GPU compacted-active-pixel round call, so
+    // pinning the host build here validates the device math directly.
+    m.def("adaptive_derive",
+          [](int max_samples, float user_threshold, int user_min_samples) {
+              astroray::adaptive::AdaptiveParams p =
+                  astroray::adaptive::deriveAdaptiveParams(
+                      max_samples, user_threshold, user_min_samples);
+              return py::make_tuple(p.threshold, p.min_samples,
+                                    p.adaptive_step, p.max_samples, p.use);
+          }, "max_samples"_a, "user_threshold"_a = 0.0f, "user_min_samples"_a = 0,
+          "Cycles zero-knob derivation → (threshold, min_samples, adaptive_step, "
+          "max_samples, use). user_threshold<=0 / user_min_samples<=0 = auto.");
+    m.def("adaptive_need_check",
+          [](float threshold, int min_samples, int samples_done) {
+              astroray::adaptive::AdaptiveParams p;
+              p.use = true; p.threshold = threshold; p.min_samples = min_samples;
+              p.max_samples = 1 << 30; p.adaptive_step = astroray::adaptive::kAdaptiveStep;
+              return astroray::adaptive::needConvergenceCheck(p, samples_done);
+          }, "threshold"_a, "min_samples"_a, "samples_done"_a,
+          "needConvergenceCheck: true only past the floor and on step-aligned counts.");
+    m.def("adaptive_pixel_converged",
+          &astroray::adaptive::pixelConverged,
+          "full_lum_sum"_a, "half_lum_sum"_a, "samples_done"_a,
+          "threshold"_a, "exposure"_a = 1.0f,
+          "film_adaptive_sampling_convergence_check (scalar-luminance half-buffer).");
+    m.def("adaptive_dilate",
+          [](const std::vector<uint8_t>& converged, int width, int height) {
+              std::vector<uint8_t> tmp(converged.size()), out(converged.size());
+              astroray::adaptive::dilateConvergedMaskPass(
+                  converged.data(), tmp.data(), width, height, 1);
+              astroray::adaptive::dilateConvergedMaskPass(
+                  tmp.data(), out.data(), width, height, width);
+              return out;
+          }, "converged"_a, "width"_a, "height"_a,
+          "Two-pass 3x3 dilation of the converged mask (1=converged/retired).");
+    m.attr("ADAPTIVE_STEP") = astroray::adaptive::kAdaptiveStep;
 }

--- a/tests/test_pkg131_adaptive_cpu_render.py
+++ b/tests/test_pkg131_adaptive_cpu_render.py
@@ -1,0 +1,69 @@
+"""pkg131 — CPU render-level: zero-knob adaptive sampling wiring + quality.
+
+The CPU per-pixel sample loop (Renderer::render, include/raytracer.h) now stops
+each pixel via the cited Cycles Dammertz metric + auto-threshold
+(include/astroray/sampling/adaptive_sampling.h) instead of the old hand-rolled
+coefficient-of-variation early-out. These render-level gates pin that:
+
+  * at a LOW sample budget the auto-derived minimum-sample floor is >= the budget,
+    so no pixel can converge early — adaptive ON is then bit-for-bit identical to
+    adaptive OFF (the early-out is a strict no-op, never perturbs a render); and
+  * at a HIGH budget the adaptive image is unbiased (means track the fully-sampled
+    render) and its per-pixel deviation stays bounded by the stopping threshold —
+    early stopping trades a little bounded noise for samples, it does not corrupt
+    the image.
+
+CPU-only (set_use_gpu False); the sampler is a CPU-loop feature.
+"""
+
+import numpy as np
+from base_helpers import create_renderer, render_image, setup_camera
+
+
+def _smooth_lit_quad(r):
+    """A diffuse quad under a bright uniform world — smooth integrand, mild MC
+    noise that an adaptive stopper handles well."""
+    r.set_use_gpu(False)
+    r.set_background_color([0.8, 0.8, 0.8])
+    mat = r.create_material("lambertian", [0.6, 0.6, 0.6], {})
+    A, B, C, D = [-1, -1, 0], [1, -1, 0], [1, 1, 0], [-1, 1, 0]
+    n = [0, 0, 1]
+    r.add_triangle_layers(A, B, C, mat, {"UVMap": [[0, 0], [1, 0], [1, 1]]}, n, n, n)
+    r.add_triangle_layers(A, C, D, mat, {"UVMap": [[0, 0], [1, 1], [0, 1]]}, n, n, n)
+    setup_camera(r, look_from=[0, 0, 3], look_at=[0, 0, 0], vup=[0, 1, 0],
+                 vfov=45, width=32, height=32)
+
+
+def _render(adaptive, samples, seed=1234):
+    r = create_renderer()
+    _smooth_lit_quad(r)
+    r.set_seed(seed)
+    r.set_adaptive_sampling(adaptive)
+    return render_image(r, samples=samples, max_depth=3, apply_gamma=False)
+
+
+def test_adaptive_lowbudget_is_bit_identical_noop():
+    """At budget 16 the auto min-sample floor clamps to the budget, so the
+    convergence check never fires and adaptive ON == OFF bit-for-bit."""
+    on = _render(adaptive=True, samples=16)
+    off = _render(adaptive=False, samples=16)
+    assert np.array_equal(on, off), (
+        "adaptive perturbed a render whose budget is below the auto min-sample "
+        f"floor (max|diff|={np.abs(on - off).max():.2e}) — the early-out must be a "
+        "strict no-op there")
+
+
+def test_adaptive_highbudget_unbiased_and_bounded():
+    """At budget 256 adaptive stops easy pixels early. Same seed => the two runs
+    share their sample prefix, so the difference is exactly the tail-noise the
+    stopping threshold deemed acceptable: mean is unbiased, per-pixel deviation
+    is small and bounded."""
+    on = _render(adaptive=True, samples=256)
+    off = _render(adaptive=False, samples=256)
+    assert on.shape == off.shape
+    assert 0.05 < on.mean(), "render came out black — scene/materials broke"
+    # Unbiased: the early-out does not shift the image mean.
+    assert abs(float(on.mean()) - float(off.mean())) < 0.01
+    # Bounded: residual per-pixel noise stays within the threshold-level tolerance
+    # (the auto threshold at budget 256 is ~0.02 brightness-relative).
+    assert float(np.abs(on - off).mean()) < 0.05

--- a/tests/test_pkg131_adaptive_sampling.py
+++ b/tests/test_pkg131_adaptive_sampling.py
@@ -1,0 +1,97 @@
+"""pkg131 — zero-knob adaptive sampling core (Cycles adaptive_sampling.h).
+
+The metric, the zero-knob auto-threshold derivation, the check cadence and the
+mask dilation are pure __host__ __device__ free functions
+(include/astroray/sampling/adaptive_sampling.h), so the host build exercised here
+is byte-identical to the GPU device build. Pinning the host output validates the
+device math directly.
+
+Sources verified 2026-08-30 against Cycles main:
+  * scene/integrator.cpp get_adaptive_sampling — auto-threshold + min-samples
+  * integrator/adaptive_sampling.cpp need_filter — cadence
+  * kernel/film/adaptive_sampling.h convergence_check + filter_x/_y — metric + dilation
+Research note: .astroray_plan/docs/pkg131-adaptive-sampling-autothreshold-research.md
+"""
+
+import pytest
+
+th = pytest.importorskip("astroray_test_helpers")
+
+
+def test_auto_threshold_matches_cycles():
+    """The zero-knob derivation reproduces Cycles' exact values (hand-verified)."""
+    # budget=64: thr_pre=1/64=0.015625; min=ceil(16/0.015625**0.3)=56; thr*=5.
+    thr, mn, step, cap, use = th.adaptive_derive(64, 0.0, 0)
+    assert use and step == 16 and cap == 64
+    assert mn == 56
+    assert thr == pytest.approx(0.078125, abs=1e-6)
+    # budget=256 -> thr 0.0195, min 85 ; budget=1024 -> thr 0.005 (clamped), min 128.
+    thr256, mn256, *_ = th.adaptive_derive(256, 0.0, 0)
+    assert mn256 == 85 and thr256 == pytest.approx(0.0195312, abs=1e-6)
+    thr1k, mn1k, *_ = th.adaptive_derive(1024, 0.0, 0)
+    assert mn1k == 128 and thr1k == pytest.approx(0.005, abs=1e-6)
+    # The 0.001 threshold floor: a huge budget can't drive the threshold below 0.005.
+    thr4k, mn4k, *_ = th.adaptive_derive(4096, 0.0, 0)
+    assert thr4k == pytest.approx(0.005, abs=1e-6) and mn4k == 128
+
+
+def test_threshold_and_floor_monotone():
+    """Bigger sample budget => tighter threshold and a higher minimum-sample floor."""
+    lo = th.adaptive_derive(64, 0.0, 0)
+    hi = th.adaptive_derive(1024, 0.0, 0)
+    assert hi[0] < lo[0]      # threshold
+    assert hi[1] > lo[1]      # min_samples
+    # Floor never exceeds the cap.
+    for budget in (8, 32, 64, 256, 1024):
+        _thr, mn, _step, cap, _use = th.adaptive_derive(budget, 0.0, 0)
+        assert 4 <= mn <= cap
+
+
+def test_manual_override():
+    """Positive user threshold / min_samples bypass the auto derivation."""
+    thr, mn, _step, _cap, _use = th.adaptive_derive(512, 0.01, 32)
+    assert mn == 32
+    assert thr == pytest.approx(0.05, abs=1e-6)  # 0.01 * 5 arbitrary factor
+
+
+def test_cadence():
+    """needConvergenceCheck: only past the floor, only on 16-aligned counts."""
+    thr, mn, *_ = th.adaptive_derive(64, 0.0, 0)  # min_samples 56
+    assert not th.adaptive_need_check(thr, mn, 16)   # below floor
+    assert not th.adaptive_need_check(thr, mn, 56)   # at floor
+    assert not th.adaptive_need_check(thr, mn, 63)   # not 16-aligned
+    assert th.adaptive_need_check(thr, mn, 64)        # first real check
+    assert not th.adaptive_need_check(thr, mn, 72)
+    assert th.adaptive_need_check(thr, mn, 80)
+
+
+def test_pixel_converged_metric():
+    """Brightness-relative Dammertz metric: flat converges, noisy doesn't."""
+    thr = 0.05
+    # Noise-free: full mean (100/100=1.0) == half mean (50/50=1.0) -> error 0.
+    assert th.adaptive_pixel_converged(100.0, 50.0, 100, thr, 1.0)
+    # Noisy: half mean (10/50=0.2) far from full mean (1.0) -> big error.
+    assert not th.adaptive_pixel_converged(100.0, 10.0, 100, thr, 1.0)
+    # Dark pixel uses sqrt(intensity) normalization (brightness-relative): a small
+    # absolute diff on a dim pixel is still relatively noisy.
+    #   full mean 0.01, half mean 0.02 -> diff 0.01, intensity 0.01, norm 0.1,
+    #   error = 0.01/(0.0001+0.1) = 0.0999 -> not converged at thr 0.05.
+    assert not th.adaptive_pixel_converged(1.0, 1.0, 100, thr, 1.0)
+
+
+def test_dilation_3x3_and_boundary():
+    """A single unconverged pixel dilates to its 3x3 neighborhood; no wrap at edges."""
+    W = H = 5
+    mask = [1] * (W * H)
+    mask[2 * W + 2] = 0  # center unconverged
+    out = th.adaptive_dilate(mask, W, H)
+    unconv = [i for i, v in enumerate(out) if v == 0]
+    expected = {y * W + x for y in (1, 2, 3) for x in (1, 2, 3)}
+    assert set(unconv) == expected
+
+    # Corner pixel must not wrap to the opposite edge.
+    mask = [1] * (W * H)
+    mask[0] = 0
+    out = th.adaptive_dilate(mask, W, H)
+    assert out[0] == 0 and out[1] == 0 and out[W] == 0 and out[W + 1] == 0
+    assert out[W - 1] == 1 and out[(H - 1) * W] == 1


### PR DESCRIPTION
## pkg131 — zero-knob adaptive sampling (session 1 of the package)

Ports Cycles' **zero-knob** adaptive sampler (Dammertz 2010 brightness-relative
noise metric + auto-derived threshold from the sample budget) as a shared
`__host__ __device__` core, and wires it into the **CPU** per-pixel sample loop —
replacing the previous hand-rolled, **uncited** coefficient-of-variation early-out.

This is the first of three slices for pkg131. It is scoped to the shared core +
CPU leg so the GPU wavefront integration (which needs HW verification) and the
addon-UI removal land as reviewable follow-ups.

### What's here
- **Shared core** `include/astroray/sampling/adaptive_sampling.h` — cited to Cycles
  `main` (Apache-2.0): `scene/integrator.cpp::get_adaptive_sampling` (auto-threshold
  `max(0.001,1/budget)*5`, `min_samples=ceil(16/thr^0.3)`, step 16),
  `kernel/film/adaptive_sampling.h` (the Dammertz convergence metric + 3×3 dilation).
  Verified **byte-exact** against Cycles' derived values.
  - Deliberate 8 GB deviation: a **scalar-luminance** half-buffer (one float), not
    Cycles' float3 aux — documented in the research note.
- **CPU leg** (`Renderer::render`, `include/raytracer.h`): `maxSamples` is the
  auto-threshold budget; each pixel stops once its brightness-relative noise drops
  below the auto threshold, past the min-sample floor. **Below the floor the check
  never fires → bit-identical to the non-adaptive render** (pinned).
- Research note + bibliography entry (`cite-algorithm`).

### Architecture note (why GPU is a separate slice)
The GPU wavefront is a **flat persistent-thread work pool** (`w % numPixels`), not
wave-based — every pixel gets exactly `samples` work items, so there is no wave
boundary to drop converged pixels. The GPU leg is therefore a **compacted
active-pixel round** on top of the flat pool (regen indexes
`activePixels[w % numActive]`, per-pixel sample counter + final divide), which is
additive, byte-identical when off, and respects the flat-pool perf design (the
1.5 s ceiling). Design captured in the research note. **Not** a wave-based rewrite.

### Tests (all green locally)
- `tests/test_pkg131_adaptive_sampling.py` — 6 host unit tests vs the exact Cycles
  values (auto-threshold, cadence, metric, dilation).
- `tests/test_pkg131_adaptive_cpu_render.py` — 2 CPU render gates (low-budget
  bit-identical no-op; high-budget unbiased + bounded per-pixel deviation).
- Regression: ran the render-level CPU gates (`*reflection_not_black`,
  `material_properties`, `lambertian`, `spectral_lambertian`, `standalone_renderer`,
  pkg219 parity, `linear_render_guard`) — no regressions from the default-behavior
  change (63 passed).

Built locally (VS 2022 / CUDA 12.8, main module + test_helpers, clean); the metric
math is host/device-identical so the host build validates the future device path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)