### PR TITLE
docs(round-close): 2026-08-30 status/tracker reconciliation

### DIFF
--- a/.astroray_plan/docs/NEXT_STAGE_REPORT.md
+++ b/.astroray_plan/docs/NEXT_STAGE_REPORT.md
@@ -1,5 +1,114 @@
 # Astroray Next Stage Report
 
+## 2026-08-30 SESSION HANDOFF — pkg224 + pkg201-S3 + pkg223b round closed; NEXT = pkg131 GPU leg
+
+**This session's own landings (2 PRs, docs-only reconciliation otherwise):**
+- **pkg207** (#658) — addon dispersion-socket probe now reads the merged
+  Cycles 5.3 socket names (`Transmission Dispersion Scale`/`...Abbe Number`),
+  short forms kept as fallback. Pure-Python, CI-gate only. **DONE.**
+- **pkg131 session 1 of 3** (#659) — zero-knob adaptive sampling shared core
+  (`include/astroray/sampling/adaptive_sampling.h`, cited to Cycles `main`,
+  byte-exact) + CPU per-pixel leg wired into `Renderer::render`. **DONE for
+  this slice; GPU leg + sample-count AOV + addon UI knob removal remain —
+  see "NEXT" below.**
+- Spec/tracker hygiene: flipped pkg207 (this session) and pkg220/pkg221/pkg222
+  (code landed 2026-08-25 via #644/#645/#646, spec headers were never
+  updated) to DONE. No engine/test changes.
+
+**Prior session's landings, confirmed merged and still accurate (do not
+re-verify): pkg224** (#657, progressive hash-Owen Sobol' sampler — the
+pkg131 prerequisite, register probe byte-identical off-path), **pkg201-S3
+items A** (#651, per-type bounce limits) **+ E** (#654, native caustic
+toggles) both backends at REG 254, **pkg223b** (#655, Bump node, shared
+`HasNormalPerturb` axis, no spill). Fleet register baseline unchanged since:
+`stageShadeBucketedKernel<0,…>` **REG 254 / STACK 3368 / CONSTANT[0] 1716**
+(pkg131's CPU-only session-1 diff and pkg224's off-path are both
+byte-identical to this — re-measure from the actual `.pyd` before trusting,
+per usual).
+
+---
+
+### NEXT (highest-priority pickup): pkg131 session 2 — GPU wavefront leg
+
+The shared core + CPU leg are DONE and the prerequisite (pkg224 progressive
+sampler) is in the tree; the natural, already-scoped next step is the GPU
+leg. From the pkg131 spec's own Progress checklist
+(`.astroray_plan/packages/pkg131-zero-knob-adaptive-sampling.md`):
+
+- **C (GPU) — compacted active-pixel round.** The wavefront is a flat
+  persistent-thread work pool (`w % numPixels`), not wave-based, so there is
+  no wave boundary to drop converged pixels the way Cycles does. Design:
+  `stageRegenKernel` indexes `activePixels[w % numActive]`, a per-pixel
+  sample counter, and a per-pixel final divide, with a convergence-check
+  kernel between rounds — additive on top of the existing flat pool, byte-
+  identical when the feature is off, does not touch the 1.5s perf ceiling
+  design (memory `wavefront-perf-ceiling-owner-decision`). NOT a wave-based
+  rewrite. Design detail: `.astroray_plan/docs/pkg131-adaptive-sampling-autothreshold-research.md`
+  (memory `pkg131-gpu-leg-compacted-active-pixel-round`). HW-verify on RTX
+  (CI has no GPU).
+- **Sample-count AOV + addon UI removal** — report measured speedup, remove
+  the `samples=N` knob, expose `max_samples` + optional auto-defaulted
+  noise-threshold override in the panel. Natural follow-up once the GPU leg
+  lands (needs the GPU leg's per-pixel counter to report a real AOV).
+
+Tier: Claude-last-line (register-hostile GPU wavefront change, same shape as
+pkg223/pkg223b/pkg224 — up-front `cuobjdump` probe on the current fleet
+baseline BEFORE feature code).
+
+### Then: fresh grounded pickup queue (each Status verified this pass)
+
+1. **pkg225 — Hair rendering** (`packages/pkg225-hair-rendering.md`, Pillar 3,
+   Status: open, filed 2026-08-29, 6-stage design). Owner-flagged gap: "hair/
+   curve rendering is entirely absent" is one of the concrete reasons the
+   Pillar 4 gate is judged NOT MET despite the Integration Milestone's
+   original scope being complete (ROADMAP.md, 2026-08-29 owner assessment).
+2. **pkg219 remainder / closure check** — 219a/b/c (coordinate+mapping,
+   op-VM core, opcode fill-out) all LANDED (#640/#641/#642, HW-verified in
+   the spec's own hardware-verification sections). The spec's own
+   "deferred to pkg219d" note (Bump/Normal Map) was implemented as **pkg223**
+   (#647) and **pkg223b** (#655) — both DONE. The parent spec
+   `packages/pkg219-per-texel-shader-graph.md` Status line still reads
+   "open (filed 2026-08-22; fork DECIDED + staged 2026-08-23)" and was
+   **left as-is this pass** (out of this round's explicit verification list)
+   — but the evidence strongly suggests it should flip to DONE next pass;
+   flagged for the architect/owner rather than flipped unilaterally here.
+3. **pkg212 — wavefront pixel-center half-pixel fix** (Pillar 5, open, filed
+   2026-08-20). Small, well-scoped, no stated blocker.
+4. **pkg208/pkg209/pkg210/pkg211** — Pillar 3 spectral-transport cluster
+   filed 2026-08-19, all still open, no stated blockers: pkg208 (chromatic
+   dispersion oracle, test-authoring only), pkg209 (pkg187 parity re-verify +
+   doc refresh), pkg210 (companion wavelengths on specular reflection,
+   register-sensitive), pkg211 (per-bounce spectral MIS + ray-differentials
+   prototype). Not yet sequenced against each other — architect call.
+5. **pkg218 — GPU spectral emission device upload** (`packages/pkg218-gpu-spectral-emission-device-upload.md`,
+   open, filed 2026-08-22). Exact CPU↔GPU lamp-colour parity (memory
+   `gpu-emission-is-rgb-approximated`); distinct from the Pillar-4-paused
+   `pkg218-spectral-colorimetry-fidelity.md` Thread B (swappable CIE
+   observer) — this one is NOT paused.
+6. **pkg180 — systemic Cycles-dim diagnosis** (open, dispatchable,
+   diagnosis-first; no fix work until the offset mechanism is localized).
+7. **Long-tail backlog, L-effort, no new urgency this pass** — pkg126
+   (mesh-emitter unification), pkg127 (specular-polynomials SMS), pkg130
+   (light-group emission decomposition), pkg132–137 (host-mapped memory
+   fallback, SRF spectral sensors, LPE automata, SVO path guiding,
+   partitioned-SMS ReSTIR caustics; pkg135 texture-overflow fallback is
+   explicitly CONDITIONAL/dormant, do not implement pre-emptively). Audited
+   2026-08-29 (#648) — still genuinely open, none superseded. Needs a
+   dedicated day arc per package, not overnight-run shaped.
+8. **De-prioritized below the Integration Milestone (owner-endorsed
+   2026-08-03, unchanged):** pkg153 (wavefront-diff env-gate disposition,
+   sub-percent tail), pkg155 (GPU absolute-slowdown investigation — the
+   1.5s ceiling stays, memory `wavefront-perf-ceiling-owner-decision`, do
+   NOT dispatch as a perf package), pkg173 (bounce-1 geometry-sampling
+   parity, sub-percent tail). Re-enters the queue only if the paper turns
+   out to require bit-level parity, or on explicit owner request.
+
+**Paused, do not queue:** Pillar 4 (pkg45/pkg46/pkg48/pkg49/pkg50/pkg51/
+pkg107 + `pkg218-spectral-colorimetry-fidelity.md` Thread B) — no unpause
+directive issued; do not self-dispatch (memory `pillar4-on-pause`).
+
+---
+
 ## 2026-08-29 SESSION HANDOFF — round complete; next = pkg224 implementation
 
 **Shipped & merged this session (7 PRs):**

--- a/.astroray_plan/docs/ROADMAP.md
+++ b/.astroray_plan/docs/ROADMAP.md
@@ -104,11 +104,12 @@ render progressive-refinement fps). **All features being built should be
 astrophysical pipeline will need from them (volumes for nebulae, curves for
 filaments, spectral for emission lines).
 
-**Current active queue (2026-08-29):** pkg224 (progressive sampler,
-owner-confirmed forks, unblocks pkg131) → pkg225 (hair rendering, 6-stage)
-→ pkg219 (per-texel shader eval, structural socket-coverage unlock) →
-pkg131 (adaptive sampling, now unblocked by pkg224). The exact dispatch
-order past pkg224 is an architect decision per round.
+**Current active queue (2026-08-30):** pkg224 DONE (#657) and pkg131 session 1
+of 3 DONE (#659, shared core + CPU leg) — next up is **pkg131's GPU wavefront
+leg** (compacted active-pixel round, HW-verify) + sample-count AOV/addon UI
+removal, then pkg225 (hair rendering, 6-stage) → pkg219 remainder (per-texel
+shader eval, structural socket-coverage unlock). The exact dispatch order past
+pkg131 is an architect decision per round.
 
 **Explicitly de-prioritized (owner-endorsed):** the sub-percent GPU/CPU
 parity tail — **pkg172 effect (B) / pkg173** (bounce-1 geometry-sampling
@@ -283,6 +284,13 @@ fix:
   pressure — pkg55-A.0's documented cliff) dominates. Phase 3 routes
   to pkg55 Phase B per the spec's escape clause; smaller H2/H5
   follow-ups split out as **pkg83** + **pkg84**.
+
+**Round closeout (2026-08-30): 2 PRs (#658/#659) — pkg207 addon dispersion
+socket probe DONE, pkg131 (zero-knob adaptive sampling) session 1 of 3 DONE
+(shared core + CPU leg); GPU leg + addon UI removal remain. A docs-only pass
+also flipped the stale pkg220/221/222 spec Status headers to DONE (code
+landed 2026-08-25, headers were never updated) and rewrote
+`NEXT_STAGE_REPORT.md`'s stale top handoff. Full detail: `STATUS.md`.**
 
 **Round closeout (2026-08-29): 7 PRs (#648–#656) — pkg201-S3 items A+E
 ship per-type bounce limits and native caustic toggles on BOTH backends,

--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -1,5 +1,42 @@
 # Astroray Status
 
+**2026-08-30 (pkg207 + pkg131 session 1, PRs #658/#659 — plus a spec/tracker
+reconciliation pass): the addon dispersion-socket probe now reads the merged
+Cycles 5.3 names, and zero-knob adaptive sampling lands its shared core + CPU
+leg (GPU leg + addon UI removal remain as follow-ups).**
+- **pkg207 DONE** (PR #658) — the forward-compat dispersion probe in
+  `blender_addon/__init__.py` read the pre-merge WIP socket names
+  (`Dispersion Scale`/`Dispersion Abbe Number`); Blender PR #162041 (merged
+  2026-08-18) shipped them as `Transmission Dispersion Scale`/`Transmission
+  Dispersion Abbe Number`. Fixed to probe the merged names first, short forms
+  as a fallback (`put_float`'s existing variadic name-list, no refactor);
+  stale "unmerged PR" comment refreshed. Pure-Python, CI-gate only, unit test
+  4/4 green.
+- **pkg131 session 1 of 3 DONE** (PR #659) — ports Cycles' zero-knob adaptive
+  sampler (Dammertz 2010 brightness-relative noise metric + auto-derived
+  threshold from the sample budget, cited to Cycles `main`) as a shared
+  `__host__ __device__` core (`include/astroray/sampling/adaptive_sampling.h`,
+  byte-exact vs Cycles' derived values; 8 GB-hardware deviation: scalar-
+  luminance half-buffer instead of Cycles' float3 aux), and wires it into the
+  **CPU** per-pixel loop (`Renderer::render`), replacing the old uncited
+  coefficient-of-variation early-out. Below the min-sample floor the check
+  never fires → bit-identical to the non-adaptive render (pinned); above it,
+  gated unbiased/bounded. 6 host unit tests + 2 CPU render gates, 63 existing
+  regression tests unaffected. **Remaining for pkg131:** the GPU wavefront
+  leg (compacted active-pixel round on top of the flat work pool — additive,
+  byte-identical when off, HW-verify required) and the sample-count AOV +
+  addon UI knob removal — see the Progress checklist in the spec and
+  `.astroray_plan/docs/pkg131-adaptive-sampling-autothreshold-research.md`.
+- **Spec/tracker reconciliation** (no code): pkg207 Status flipped open→done
+  above. pkg220/pkg221/pkg222 (GPU spectral-caustic quality round, merged
+  #644/#645/#646 on 2026-08-25) had their spec `Status:` headers still
+  reading "open" — flipped to DONE with merge PR/sha; the round itself
+  already closed out in STATUS.md on 2026-08-25→26, this only fixed the
+  stale spec headers that the orchestrator's queue-read depends on (memory
+  `orchestrator-next-stage-report-stale`). `NEXT_STAGE_REPORT.md` top handoff
+  (stale since 2026-08-29, still pointing at "implement pkg224") rewritten
+  for the next pickup.
+
 **2026-08-30 (pkg224 — progressive hash-Owen Sobol' sampler for the GPU wavefront,
 PR #657 merged 4f919b9): opt-in low-discrepancy sampler at every wavefront RNG draw,
 the prerequisite that UNBLOCKS pkg131 (adaptive sampling). Off by default →

--- a/.astroray_plan/packages/pkg207-addon-dispersion-socket-probe-names.md
+++ b/.astroray_plan/packages/pkg207-addon-dispersion-socket-probe-names.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 5
 **Track:** A (small local addon fix — pure Python, no engine code, no GPU, no HW).
-**Status:** open (filed 2026-08-19).
+**Status:** done (PR #658, 2026-08-30 — merged-name probe (`Transmission Dispersion Scale`/`Transmission Dispersion Abbe Number`) + short-form fallback + comment refresh; unit test 4/4 green, CI-gate only).
 **Estimated effort:** XS.
 **Depends on:** nothing.
 


### PR DESCRIPTION
## Summary

Docs-only reconciliation pass, no source/test changes.

- **pkg207** flipped `open` -> `done` (PR #658, merged-name dispersion-socket
  probe + short-form fallback).
- **STATUS.md** — new 2026-08-30 entry: pkg207 (#658) + pkg131 session 1 of 3
  (#659, adaptive-sampling shared core + CPU leg; GPU leg + AOV + addon-UI
  removal remain), plus a note on the pkg220/221/222 spec-header reconciliation.
- **ROADMAP.md** — "Current active queue" line updated (pkg224/pkg131-session-1
  DONE, next = pkg131 GPU leg); new 2026-08-30 round-closeout changelog entry.
- **NEXT_STAGE_REPORT.md** — top handoff rewritten (was still saying "NEXT =
  implement pkg224", long since merged). New top section states pkg131 GPU
  leg as the top pickup, plus a freshly Status-verified genuinely-open queue
  (pkg225, pkg212, pkg208-211, pkg218-device-upload, pkg180, the pkg126-137
  long tail, the de-prioritized pkg153/155/173 tail); Pillar 4 + pkg218
  Thread B reconfirmed paused, not queued.

## Left unverified / not flipped (see report below)

- **pkg219** (`pkg219-per-texel-shader-graph.md`) — evidence suggests it
  should also flip to DONE (219a/b/c landed #640/#641/#642, and its own
  "deferred to pkg219d" note was implemented as pkg223 #647 + pkg223b #655,
  both DONE) but it was **not** in this round's explicit verification list,
  so left as-is and flagged in NEXT_STAGE_REPORT.md §"Then" item 2 for the
  next pass instead of flipped unilaterally.
- pkg131's own spec file untouched — its Progress checklist already
  accurately reflects "core + CPU leg done, GPU leg + UI pending" (owner
  instruction: leave in-progress, do not mark DONE).

## Test plan

- [x] `git diff` reviewed line-by-line; every changed line traces to a
      merged PR (#658, #659) or an already-merged prior commit (5a6edd1,
      d245a24) whose changelog entry was missing.
- [ ] CI green (polling below).

🤖 Generated with [Claude Code](https://claude.com/claude-code)