### PR TITLE
docs(architect): agent-ready specs + overnight routing 2026-08-30

### DIFF
--- a/.astroray_plan/packages/pkg208-chromatic-light-source-dispersion-oracle.md
+++ b/.astroray_plan/packages/pkg208-chromatic-light-source-dispersion-oracle.md
@@ -35,21 +35,55 @@ wavelength), NOT a full ROYGBIV rainbow.
 
 2. **Scene:** reuse the dispersive-prism geometry from `tests/test_spectral_prism.py`
    (BK7 Sellmeier preset), but replace the broadband/white illuminant with a
-   **narrow-line emitter** (reuse the shipped line-emitter path from the §9
-   gallery — e.g. a ~635 nm red line; parameterize the line wavelength so the test
-   can sweep at least two lines, e.g. red ~635 nm and blue ~470 nm).
+   **narrow-line emitter**.
+
+   **Agent-ready recipe (architect 2026-08-30 — the abstract "635 nm red line"
+   in the original filing does NOT exist as a profile; use the real narrow-line
+   preset below).** Astroray has no per-render monochromatic-emitter API; a
+   narrow line is delivered via the measured-SPD emission path. The ONLY genuinely
+   narrow-line light-source profile shipped in `data/spectral_profiles/profiles.bin`
+   is **`sodium_vapor`** (LPS D-lines, 588.995/589.592 nm — a ~589 nm yellow
+   spike; confirmed in `profiles_metadata.json`). Use it as the line emitter and
+   contrast it against a **broadband control** (`led_6500k`, a smooth ~380–780 nm
+   phosphor-LED SPD). `mercury_vapor` is multi-line (404/436/546/577 nm) — a useful
+   *optional* second case (its dominant 546 nm green line should throw a
+   green-dominant band), but it is NOT a single line, so keep `sodium_vapor` as the
+   primary and gate the mercury case as a documented stretch, not a hard assert.
+
+   Build the scene by adapting `tests/scenes/prism_reference.py`
+   (`add_triangular_prism` + BK7 `dielectric` + camera) but on the **spectral**
+   path, following the exact wiring in `tests/test_pkg195_stage_b_spectral_lamp.py`:
+   ```
+   astroray.load_spectral_profiles(".../data/spectral_profiles/profiles.bin")
+   r.set_integrator("multiwavelength_path_tracer")   # NOT "path_tracer" — the RGB
+                                                     # path can't carry a source SPD
+   r.set_wavelength_range(380.0, 780.0)
+   r.add_point_light(position=[...], intensity=...,  radius=...,
+                     emission={"mode": "measured_spd", "profile_name": "sodium_vapor"})
+   ```
+   Prefer a point light aimed through the prism over the broadband area-light
+   triangles in `prism_reference.make_prism_scene`; if a spectral **area** emitter is
+   needed for enough flux, confirm whether `create_material("light", …)` accepts an
+   `emission=` SPD dict before using it (it may not — the point-light path is the
+   proven one). Keep the seed pinned and render LINEAR (`apply_gamma=False`).
 
 3. **Oracle predicates** (LINEAR EXRs, seed-pinned, sentinel-gated — not exit code):
-   - The dispersed band's **dominant hue tracks the emitter wavelength** (a
-     red-line prism produces a red-dominant band; a blue-line prism a blue-dominant
-     band) — assert via a hue/centroid metric on the refracted region, contrasting
-     the two line wavelengths against each other.
-   - The **spectral spread is narrow**, not full-rainbow: measure the hue variance
-     / red-blue centroid separation in the refracted band and assert it is well
-     below what the SAME prism produces under a broadband white source (render that
-     broadband control in the same test as the wide-spread reference). This
-     "narrow << broadband" contrast is the crux — it is exactly the assertion
-     Cycles would fail.
+   - The dispersed band's **dominant hue tracks the emitter wavelength**: the
+     `sodium_vapor` (~589 nm) prism produces a **yellow/amber-dominant** refracted
+     band (R≈G, both ≫ B), NOT a full rainbow. Assert with a hue/centroid metric on
+     the refracted region. (Optional documented stretch: `mercury_vapor` → a
+     green-biased band from its 546 nm line.)
+   - The **spectral spread is narrow**, not full-rainbow: reuse
+     `prism_reference.red_blue_centroid_separation` (already the shipped spread
+     metric) and assert the sodium-line band's red-blue centroid separation is
+     **well below** what the SAME prism produces under the `led_6500k` broadband
+     control (render that broadband control in the same test as the wide-spread
+     reference). This "narrow << broadband" contrast is the crux — it is exactly the
+     assertion Cycles would fail.
+   - **If the sodium-line prism does NOT render narrow** (e.g. it throws a wide
+     rainbow anyway), that is a REAL engine defect (source-SPD not reaching the
+     dispersive event) — STOP and file it as a separate spec per §1, do not relax
+     the predicate to make it pass.
 
 4. Register the scene/driver in `scripts/README.md` if it adds a reusable harness
    entry (CLAUDE.md §5b — check the index first; prefer extending
@@ -57,10 +91,13 @@ wavelength), NOT a full ROYGBIV rainbow.
 
 ## Acceptance
 
-- [ ] The oracle test PASSES on current `main`: red-line and blue-line prisms
-  render hue-correct, narrow bands; the broadband control renders a measurably
-  wider spread. Report the measured hue-centroid / spread numbers for all three
-  (red line, blue line, broadband). State the `.pyd` mtime next to the render leg.
+- [ ] The oracle test PASSES on current `main`: the `sodium_vapor` (~589 nm)
+  line prism renders a hue-correct (yellow/amber-dominant), spectrally-narrow
+  band; the `led_6500k` broadband control renders a measurably wider red-blue
+  centroid spread. Report the measured hue-centroid / spread numbers for both
+  (sodium line, broadband; plus the optional mercury case if included). State the
+  `.pyd` mtime next to the render leg, and state which backend produced the numbers
+  (CPU vs auto-routed CUDA — memory `cpu-suites-auto-use-cuda`).
 - [ ] The test is deterministic (seed-pinned) and runs in the standard suite; the
   `.astroray_plan/docs/` note frames it as a Cycles-superiority oracle with the
   cited limitation.


### PR DESCRIPTION
Overnight triage/prep/route pass over the open-package backlog: verify each `**Status:**` against merged PRs, classify subsystem, assign a routing tier (cheap-model CI-mergeable vs GPU-parent-verify vs Claude-last-line), and make any under-specified spec agent-ready.

## Change in this PR
- **pkg208** refined to be cheap-agent-implementable. The original filing assumed a "635 nm red line" / "470 nm blue line" emitter and a broadband RGB prism scene that don't map to any shipped API. Grounded it in the real path: `sodium_vapor` (~589 nm, the only shipped narrow-line `light_source` profile) as the line emitter vs `led_6500k` broadband control, rendered on `multiwavelength_path_tracer` following the `test_pkg195_stage_b_spectral_lamp.py` wiring, reusing `prism_reference.red_blue_centroid_separation` as the spread metric. Acceptance updated to match.

All other open specs were already agent-ready for their tiers — no edits needed.

## Routing table (dispatch order)
CI-mergeable (cheap agent implements + CI-verifies, parent merges on green) first; GPU/Claude last.

| package | subsystem | tier | spec-ready | scope |
|---|---|---|---|---|
| pkg209 | CPU/docs | deepseek-CI | yes | refresh stale "WIP/unmerged" Cauchy-dispersion wording to merged Cycles commit + fix MNEE citation typo; record constant-parity (comment-only) |
| pkg208 | spectral (CPU render) | sonnet-CI | yes (refined here) | narrow-line (sodium) prism oracle test: line band narrow vs broadband wide — a Cycles-superiority oracle |
| pkg225-S1 | CPU geometry | sonnet-CI (review-heavy) | yes | Stage 1 only: CPU ray-curve intersection primitive + analytic parity test. Hard geometry math — highest cheap-model stall risk |
| pkg212 | GPU+CPU wavefront | GPU-parent-verify | yes | 2-line pixel-center +0.5 fix at both wavefront ray-gen sites; RTX visual re-gate |
| pkg218 | GPU-CUDA (spectral) | GPU-parent-verify | yes | upload emission SPDs to device (new profile table + NEE/emissive eval); register-neutral; RTX parity gate |
| pkg210 | GPU-CUDA (spectral) | Claude-last-line | yes | keep companion wavelengths on specular reflection; register-hostile, probe-first, may PARK |
| pkg180 | GPU+Blender diagnosis | Claude/HW (parent-run) | yes | diagnose systemic ~12-20% Astroray-vs-Cycles dim; Phase-1 methodology audit needs local Blender+Cycles+RTX |
| pkg211 | GPU-CUDA (research) | Claude-last-line | yes | per-bounce spectral MIS / ray-differentials prototype; L, measure-first, legit PARK outcome |

Excluded per task: pkg131 (parent owns GPU leg), pkg219 (separate Opus subagent), Pillar-4-paused (pkg45/46/48/49/50/51/107, pkg218 Thread B). Long-tail pkg126/127/130/132-137 + pkg153/155/173 confirmed still-open but day-arc-shaped, not overnight cheap-dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)