### PR TITLE
fix(pkg212): wavefront ray-gen half-pixel center fix

### DIFF
--- a/src/cpu/wavefront/path_kernel.cpp
+++ b/src/cpu/wavefront/path_kernel.cpp
@@ -81,8 +81,14 @@ void init_path(PathState& ps, const Camera& cam, int x, int y,
     // dimension, byte-identical to the GPU sampler. See the filterSample
     // history comment above.
 
-    float u = (x + filterSample(ps.rng)) / (width - 1);
-    float v = 1.0f - (y + filterSample(ps.rng)) / (height - 1);
+    // pkg212: +0.5f pixel-center offset — filterSample() returns the filter
+    // offset centered at 0 ([-0.5,0.5]); the raster pixel-center convention
+    // (integer+0.5, matches Cycles + the megakernel raytracer.h) belongs at
+    // the call site, not inside filterSample. Mirrors the GPU wavefront edit
+    // in stage_init.cu (CPU<->GPU wavefront byte-identity invariant). See
+    // pkg212 spec.
+    float u = (x + 0.5f + filterSample(ps.rng)) / (width - 1);
+    float v = 1.0f - (y + 0.5f + filterSample(ps.rng)) / (height - 1);
 
     // Lens sampling via a temporary mt19937 seeded from the live RNG. This
     // consumes exactly one WavefrontRNG draw (dimension auto-increments).

--- a/src/gpu/wavefront/stage_init.cu
+++ b/src/gpu/wavefront/stage_init.cu
@@ -227,8 +227,12 @@ __device__ inline void generatePrimaryRay(
     float lambdaMin, float lambdaMax)
 {
     // 1. Filter u/v (CPU draws 2× std::uniform_real_distribution<float>(0,1)).
-    float u = (px + filterSample(rng)) / float(width - 1);
-    float v = 1.0f - (py + filterSample(rng)) / float(height - 1);
+    // pkg212: +0.5f pixel-center offset — filterSample() returns the filter
+    // offset centered at 0 ([-0.5,0.5]); the raster pixel-center convention
+    // (integer+0.5, matches Cycles + the megakernel raytracer.h) belongs at
+    // the call site, not inside filterSample. See pkg212 spec.
+    float u = (px + 0.5f + filterSample(rng)) / float(width - 1);
+    float v = 1.0f - (py + 0.5f + filterSample(rng)) / float(height - 1);
 
     // 2. Lens seed draw (CPU converts to mt19937; we consume the same dimension).
     uint32_t lens_seed = rng.UniformUInt32();


### PR DESCRIPTION
## Summary
- Adds the `+0.5f` raster pixel-center offset to both wavefront ray-gen `u`/`v` computations: `generatePrimaryRay` in `src/gpu/wavefront/stage_init.cu` and `init_path` in `src/cpu/wavefront/path_kernel.cpp`.
- Root cause (gate-failure-reviewer, pkg203 HW verification 2026-08-20): GPU wavefront silhouette was shifted ~0.4-0.6px right of the CPU megakernel, uniform across box/gaussian/blackman-harris pixel filters, independent of pkg203's sigma edit — because the wavefront `u`/`v` were centered at `px+0.0` instead of `px+0.5`.
- Megakernel (`include/raytracer.h`) is untouched — it already uses the correct `x+0.5` convention (matches Cycles' raster-to-camera convention).

## Exact sites changed (confirmed against current HEAD before editing; spec's line numbers had drifted from pkg224 growth)
- `src/gpu/wavefront/stage_init.cu` lines 230-231 (function `generatePrimaryRay`, not lines 169-170 as the spec listed — the file grew via pkg224):
  - Before: `float u = (px + filterSample(rng)) / float(width - 1);` / `float v = 1.0f - (py + filterSample(rng)) / float(height - 1);`
  - After: `float u = (px + 0.5f + filterSample(rng)) / float(width - 1);` / `float v = 1.0f - (py + 0.5f + filterSample(rng)) / float(height - 1);`
- `src/cpu/wavefront/path_kernel.cpp` lines 84-85 (function `init_path`, matches spec's line numbers exactly):
  - Before: `float u = (x + filterSample(ps.rng)) / (width - 1);` / `float v = 1.0f - (y + filterSample(ps.rng)) / (height - 1);`
  - After: `float u = (x + 0.5f + filterSample(ps.rng)) / (width - 1);` / `float v = 1.0f - (y + 0.5f + filterSample(ps.rng)) / (height - 1);`

## One correction to the spec's described scope
The spec's dispatch note assumed a second, separate GPU site inside `initPathSlot` in `src/gpu/wavefront/stage_advance.cu` (the regen ray-gen path). I confirmed this is NOT a separate site: `stage_advance.cu` only forward-declares `initPathSlot` (defined in `stage_init.cu`, line 284) and calls it (line 2726) when a slot claims new work. `initPathSlot` itself calls `generatePrimaryRay` (line 306), the same function already fixed above. So the single `stage_init.cu` edit covers BOTH the initial ray-gen kernel and the wavefront regen path — `stage_advance.cu` required NO source edit. This is confirmed by `git grep 'filterSample(rng)\|generatePrimaryRay('` across `src/`, which returns exactly the two files touched in this PR.

`reference_pt_wavefront.cpp` (the CPU wavefront's bit-identity oracle) calls `init_path()` from `path_kernel.cpp` directly (not a separate transcription), so it inherits the fix by construction — no edit needed there either. `reference_pt_production.cpp` uses a distinct `renderer.filterSample(gen, dist)` (the megakernel/`raytracer.h`-style convention, already `x+0.5`-correct) — untouched, out of scope per spec.

## Authorized surface
Spec named `src/gpu/wavefront/stage_init.cu` and `src/cpu/wavefront/path_kernel.cpp` (2 files). Actual diff: same 2 files, no others. `stage_advance.cu` was investigated but required no change (see above) — flagging this explicitly since the dispatch note expected it to need editing.

## Build status
**Not built or hardware-verified by this PR.** Per dispatch instructions this implementation was done source-only (no CUDA toolchain / vcvars available in this environment). The parent session (Opus, on the RTX 5070 Ti box) owns:
1. Building via `build_cuda_worktree.bat` against this branch.
2. Byte-identity re-verification: CPU-wavefront <-> GPU-wavefront PostInit snapshot check (the `tests/wavefront_diff/test_cpu_wavefront_*_bit_identity.py` suite), since it asserts EXACT bit-identity CPU-wavefront-vs-`reference_pt_wavefront` at PostInit and both share the edited `init_path()` — should stay green because both u/v computations shifted identically, but must be empirically re-run.
3. The pkg203 Gate-3 visual-centering harness: CPU-vs-GPU same-scene/same-seed silhouette edge shift should drop to <=0.2px (from ~0.5px) across box/gaussian/blackman-harris.
4. pkg200 honour matrix regression check (`pixel_filter_type` / `filter_width` rows).

## Acceptance criteria (from spec, pending HW verification by parent)
- [ ] pkg203 Gate-3 visual-centering: CPU-vs-GPU silhouette edge shift <=0.2px across box/gaussian/blackman-harris.
- [ ] CPU-wavefront <-> GPU-wavefront PostInit byte-identity check stays locked.
- [ ] pkg200 honour matrix stays PASS.

## Note re: in-flight branches
Neither edited file overlaps with the current `pkg131-gpu-adaptive` in-flight branch in the main checkout by content (that branch's recent work is pkg224 progressive-sampler infra in the same files, but at different line ranges than the two touched here) — flagging per dispatch note in case a rebase is still warranted when pkg131 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)