### PR TITLE
feat(pkg131): GPU wavefront adaptive sampling — compacted active-pixel round

### DIFF
--- a/.astroray_plan/packages/pkg131-zero-knob-adaptive-sampling.md
+++ b/.astroray_plan/packages/pkg131-zero-knob-adaptive-sampling.md
@@ -136,12 +136,17 @@ add one.
       early-out; `maxSamples` is the auto-threshold budget. Verified: low-budget
       bit-identical no-op + high-budget unbiased/bounded
       (`tests/test_pkg131_adaptive_cpu_render.py`). (2026-08-30)
-- [ ] C (GPU) — wavefront **compacted active-pixel round** on top of the existing
-      flat work pool (`stageRegenKernel` indexes `activePixels[w % numActive]`,
-      per-pixel sample counter, per-pixel final divide; convergence-check kernel
-      between rounds). Additive, byte-identical when off, respects the flat-pool
-      perf design. Design in the research note. NOT a wave-based rewrite. HW-verify
-      on RTX (CI has no GPU).
+- [x] C (GPU) — wavefront **compacted active-pixel round** on the flat work pool:
+      `stageRegenKernel` remaps a claimed work item to `activePixels[w % numActive]`
+      / `baseSample + w/numActive` and flushes per-pixel sampleCount + the even-sample
+      half-buffer (gated `__constant__ c_wfAdaptive`, byte-identical when off); the
+      host round loop runs the convergence check + 3×3 dilation + active-pixel
+      compaction reusing the tested core; the final divide is per-pixel
+      `accum/sampleCount`. Opt-in via the pkg224 progressive sampler (adaptive needs
+      the prefix property), so the default GPU render stays byte-identical.
+      HW-verified on RTX 5070 Ti: byte-identical-off, unbiased-on, round loop engages
+      (`tests/test_pkg131_adaptive_gpu.py`); wavefront-diff parity + photon regression
+      green. (2026-08-31)
 - [ ] Sample-count AOV (report measured speedup) + addon UI: remove the `samples=N`
       knob, expose `max_samples` + optional auto-defaulted noise-threshold override.
 

--- a/include/astroray/gpu_wavefront_state.h
+++ b/include/astroray/gpu_wavefront_state.h
@@ -484,6 +484,26 @@ void setWavefrontCausticGate(bool reflective, bool refractive);
 // progressive-prefix convergence (unblocks pkg131 adaptive sampling).
 void setWavefrontSamplerMode(bool useProgressive);
 
+// pkg131 — GPU zero-knob adaptive sampling. When enabled, stageRegenKernel maps a
+// claimed work item w to pixel = activePixels[w % numActive], sample = baseSample +
+// w / numActive (instead of the flat pixel = w % numPixels), and at path death
+// increments sampleCount[pixel] and adds the even-sample luminance into
+// halfLumSum[pixel] (the scalar half-buffer for the Dammertz convergence check).
+// The host drives the round loop (convergence-check + dilation + active-pixel
+// compaction reuse the tested host core in sampling/adaptive_sampling.h). enabled=0
+// is byte-identical to the pre-pkg131 flat pool (the pointers are ignored and the
+// pixel/sample mapping is unchanged). Published ONCE per round in
+// cuda_wavefront_render via setWavefrontAdaptiveBinding.
+struct GWavefrontAdaptiveBinding {
+    const int* activePixels;   // [numActive] pixel indices still sampling (null when off)
+    int*       sampleCount;    // [numPixels] samples accumulated per pixel (device)
+    float*     halfLumSum;     // [numPixels] Σ luminance over even samples (device)
+    int        numActive;      // active pixel count this round
+    int        baseSample;     // sample index offset for this round
+    int        enabled;        // 0 = byte-identical flat pool
+};
+void setWavefrontAdaptiveBinding(const GWavefrontAdaptiveBinding& binding);
+
 // pkg55-B' shadow stage: lean occlusion + lazy resolve over the NEE
 // samples parked by the deferring bucketed shade. nee_f/nee_i lane counts
 // are G_WF_NEE_F_LANES / G_WF_NEE_I_LANES (field-major); see the

--- a/include/raytracer.h
+++ b/include/raytracer.h
@@ -2155,6 +2155,10 @@ class Renderer {
     // sampling. GPU-only (the CPU oracle keeps std::mt19937); published into the
     // __constant__ c_wfSamplerMode by cuda_wavefront_render.
     bool useProgressiveSampler = false;
+    // pkg131 — GPU wavefront zero-knob adaptive sampling opt-in. Mirrors the CPU
+    // `adaptive` render arg; read by cuda_wavefront_render to drive the compacted
+    // active-pixel round loop. Default true (matches PyRenderer.useAdaptiveSampling).
+    bool useAdaptiveSampling = true;
     // pkg201 Stage 3 (Finding A) — Cycles per-type bounce limits
     // (max_diffuse_bounce / max_glossy_bounce / max_transmission_bounce). -1 =
     // unlimited (honour only the total maxDepth — the pre-pkg201 behaviour, so
@@ -2385,6 +2389,9 @@ public:
     // pkg224 — progressive-sampler opt-in (GPU wavefront only).
     void setUseProgressiveSampler(bool use) { useProgressiveSampler = use; }
     bool getUseProgressiveSampler() const { return useProgressiveSampler; }
+    // pkg131 — GPU adaptive-sampling opt-in (see field above).
+    void setUseAdaptiveSampling(bool use) { useAdaptiveSampling = use; }
+    bool getUseAdaptiveSampling() const { return useAdaptiveSampling; }
     bool getUsePhotonCaustics() const { return usePhotonCaustics; }
     // pkg64 Phase 3 — per-object opt-in for SMS connection attempts. The
     // index is the order in which `addObject` was called (same order as

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -1452,7 +1452,10 @@ public:
         camera->shutterPosition = static_cast<Camera::ShutterPosition>(shutterPosition);
     }
 
-    void setAdaptiveSampling(bool enable) { useAdaptiveSampling = enable; }
+    void setAdaptiveSampling(bool enable) {
+        useAdaptiveSampling = enable;             // CPU render() path (arg)
+        renderer.setUseAdaptiveSampling(enable);  // pkg131: GPU wavefront reads this
+    }
 
     void setUseGPU(bool enable) {
 #ifdef ASTRORAY_CUDA_ENABLED

--- a/src/gpu/wavefront/gpu_wavefront_snapshot.cu
+++ b/src/gpu/wavefront/gpu_wavefront_snapshot.cu
@@ -1015,6 +1015,12 @@ struct WfContext {
     WfDeviceBuf accum, queueA, queueB, counts, shadeQueues, shadeCounts;
     WfDeviceBuf neeF, neeI, shadowQueue, shadowCount, work;
     WfDeviceBuf volQueue, volCount;   // pkg199 Stage 2 volume-scatter queue
+    // pkg131 — zero-knob adaptive sampling per-pixel buffers (numPixels each).
+    // Grow-only; only touched when a render enables adaptive sampling, so the
+    // uniform path pays nothing. sampleCount = samples accumulated per pixel;
+    // halfLum = Σ even-sample luminance (the Dammertz scalar half-buffer);
+    // activePixels = the compacted list of still-sampling pixel indices.
+    WfDeviceBuf adaptSampleCount, adaptHalfLum, adaptActivePixels;
     // pkg159: per-pixel cryptomatte rank arrays (numPixels*depth*2 floats
     // each). Grow-only like the rest; only allocated once a render actually
     // enables cryptomatte, so default renders pay nothing.
@@ -1674,14 +1680,87 @@ std::vector<float> cuda_wavefront_render(
     if (res.profileCount > 0)
         uploadProfileTable(res.profileTable.data(), res.profileCount);
 
+    // pkg131 — zero-knob adaptive sampling gate. `adaptiveOn` and `h_pixelSamples`
+    // are function-scoped so the resolve loop below divides beauty by the per-pixel
+    // sample count. Beauty(+guides) only: light-path passes, cryptomatte, and
+    // transparent-film coverage all divide by a uniform `samples`, so adaptive
+    // falls back to a single uniform round when any of those is requested. Guides
+    // (albedo/normal/depth) are first-hit and copied without a /samples divide, so
+    // they compose with variable per-pixel counts.
+    // Adaptive rides on the pkg224 progressive-sampler opt-in: it REQUIRES the
+    // low-discrepancy prefix property (a truncated per-pixel count must still be
+    // well-distributed), and gating on it keeps the default GPU render (progressive
+    // off) byte-identical to the pre-pkg131 flat pool. So adaptive activates only
+    // when BOTH adaptive sampling and the progressive sampler are enabled.
+    bool adaptiveOn = renderer.getUseAdaptiveSampling()
+                      && renderer.getUseProgressiveSampler()
+                      && !passesOn && !cryptoOn && alphaOut == nullptr;
+    std::vector<int> h_pixelSamples;
     {
-        const long long total_work = (long long)total_paths * samples;
+        const astroray::adaptive::AdaptiveParams ap =
+            astroray::adaptive::deriveAdaptiveParams(samples, 0.0f, 0);
+        const float filmExposure = renderer.getFilmExposure();
+
+        int*   d_sampleCount  = nullptr;
+        float* d_halfLum      = nullptr;
+        int*   d_activePixels = nullptr;
+        std::vector<int> activePixels;
+        std::vector<unsigned char> converged;  // persistent retired mask (0 = still sampling)
+        int numActive = total_paths;
+        if (adaptiveOn) {
+            d_sampleCount  = wfEnsure<int>(C.adaptSampleCount, total_paths);
+            d_halfLum      = wfEnsure<float>(C.adaptHalfLum, total_paths);
+            d_activePixels = wfEnsure<int>(C.adaptActivePixels, total_paths);
+            cudaMemset(d_sampleCount, 0, total_paths * sizeof(int));
+            cudaMemset(d_halfLum, 0, total_paths * sizeof(float));
+            activePixels.resize(total_paths);
+            for (int i = 0; i < total_paths; ++i) activePixels[i] = i;
+            cudaMemcpy(d_activePixels, activePixels.data(),
+                       total_paths * sizeof(int), cudaMemcpyHostToDevice);
+            converged.assign(total_paths, 0);
+            // The progressive sampler is already published (setWavefrontSamplerMode
+            // from renderer.getUseProgressiveSampler() above) — adaptiveOn requires
+            // it, so its prefix property is guaranteed here.
+        }
+
+        int* cout = d_counts + 1;
+        int baseSample = 0;
+        int roundIdx = 0;
+        // Round loop: round 0 samples every pixel to the min-sample floor; each
+        // later round adds adaptive_step samples to only the still-unconverged
+        // pixels (compacted host-side after each round). Uniform (adaptiveOn=false)
+        // runs exactly one round of `samples` over every pixel — byte-identical.
+        while (baseSample < samples) {
+        const int perPixel = !adaptiveOn
+            ? samples
+            : std::min((roundIdx == 0 ? ap.min_samples : ap.adaptive_step),
+                       samples - baseSample);
+        if (perPixel <= 0) break;
+        const int roundPixels = adaptiveOn ? numActive : total_paths;
+        const long long total_work = (long long)roundPixels * perPixel;
         const long long counter_slack =
             (long long)total_paths * (16 + max_depth + 2);
         if (total_work + counter_slack > 0x7FFFFFFFLL)
             throw std::runtime_error(
                 "cuda_wavefront_render: width*height*samples exceeds "
                 "the overshoot-safe 32-bit work-counter range");
+
+        // Publish this round's adaptive binding (enabled=0 = byte-identical flat
+        // pool). The __constant__ persists across calls, so publish every round to
+        // clear any prior adaptive render's state.
+        {
+            GWavefrontAdaptiveBinding ab;
+            ab.activePixels = adaptiveOn ? d_activePixels : nullptr;
+            ab.sampleCount  = d_sampleCount;
+            ab.halfLumSum   = d_halfLum;
+            ab.numActive    = numActive;
+            ab.baseSample   = baseSample;
+            ab.enabled      = adaptiveOn ? 1 : 0;
+            setWavefrontAdaptiveBinding(ab);
+        }
+
+        // Per-round scheduling reset (slots are reused across rounds; d_accum,
+        // sampleCount and halfLum persist and accumulate across rounds).
         cudaMemset(d_work, 0, sizeof(int));
         cudaMemset(state.path_alive, 0, total_paths * sizeof(int));
         cudaMemset(state.color_0, 0, total_paths * sizeof(float));
@@ -1695,7 +1774,6 @@ std::vector<float> cuda_wavefront_render(
         state.num_active = total_paths;
 
         launchStageQueueIota(d_queueA, d_counts + 0, total_paths);
-        int* cout = d_counts + 1;
 
         // Pass-count planning. waves = how many full pools the work needs.
         // SINGLE-WAVE renders (1-spp viewport chunks: total_work <= pool)
@@ -1710,7 +1788,7 @@ std::vector<float> cuda_wavefront_render(
         const int kCheckEvery = 16;
         const long long kMaxPasses = (waves == 1)
             ? max_depth
-            : (long long)samples * max_depth + max_depth + 64;
+            : (long long)perPixel * max_depth + max_depth + 64;
         bool workExhausted = false;
         int drainLeft = max_depth;
         for (long long pass = 0; pass < kMaxPasses; ++pass) {
@@ -1818,6 +1896,64 @@ std::vector<float> cuda_wavefront_render(
             throw std::runtime_error(
                 std::string("cuda_wavefront_render kernel error: ") +
                 cudaGetErrorString(syncErr));
+
+        baseSample += perPixel;
+        ++roundIdx;
+        if (!adaptiveOn) break;            // uniform: a single round
+        if (baseSample >= samples) break;  // hit the sample cap
+
+        // pkg131 — convergence check + mask dilation + active-pixel compaction on
+        // the host, reusing the tested core (sampling/adaptive_sampling.h). d_accum
+        // holds the running full-luminance sum (X+Y+Z), d_halfLum the even-sample
+        // sum; a pixel retires once its brightness-relative noise is below the auto
+        // threshold. A handful of small readbacks per round (adaptive only).
+        {
+            std::vector<float> h_accR(size_t(total_paths) * 3);
+            std::vector<float> h_halfR(total_paths);
+            std::vector<int>   h_cntR(total_paths);
+            cudaMemcpy(h_accR.data(), d_accum,
+                       size_t(total_paths) * 3 * sizeof(float), cudaMemcpyDeviceToHost);
+            cudaMemcpy(h_halfR.data(), d_halfLum,
+                       total_paths * sizeof(float), cudaMemcpyDeviceToHost);
+            cudaMemcpy(h_cntR.data(), d_sampleCount,
+                       total_paths * sizeof(int), cudaMemcpyDeviceToHost);
+            for (int p = 0; p < total_paths; ++p) {
+                if (converged[p]) continue;              // already retired
+                const int n = h_cntR[p];
+                if (n < 1) continue;
+                const float fullLum =
+                    h_accR[p * 3 + 0] + h_accR[p * 3 + 1] + h_accR[p * 3 + 2];
+                if (astroray::adaptive::pixelConverged(fullLum, h_halfR[p], n,
+                                                       ap.threshold, filmExposure))
+                    converged[p] = 1;
+            }
+            // Dilate the retired mask so neighborhoods keep sampling together.
+            std::vector<unsigned char> tmp(total_paths), dil(total_paths);
+            astroray::adaptive::dilateConvergedMaskPass(
+                converged.data(), tmp.data(), width, height, 1);
+            astroray::adaptive::dilateConvergedMaskPass(
+                tmp.data(), dil.data(), width, height, width);
+            converged.swap(dil);
+            // Rebuild the compacted active-pixel list.
+            activePixels.clear();
+            for (int p = 0; p < total_paths; ++p)
+                if (!converged[p]) activePixels.push_back(p);
+            numActive = (int)activePixels.size();
+            if (numActive == 0) break;                   // every pixel converged
+            cudaMemcpy(d_activePixels, activePixels.data(),
+                       numActive * sizeof(int), cudaMemcpyHostToDevice);
+        }
+        }  // while (round loop)
+
+        if (adaptiveOn) {
+            // Reset the binding so later renders / other entries see the flat pool.
+            GWavefrontAdaptiveBinding off = { nullptr, nullptr, nullptr, 0, 0, 0 };
+            setWavefrontAdaptiveBinding(off);
+            // Per-pixel sample counts drive the resolve divide below.
+            h_pixelSamples.resize(total_paths);
+            cudaMemcpy(h_pixelSamples.data(), d_sampleCount,
+                       total_paths * sizeof(int), cudaMemcpyDeviceToHost);
+        }
     }
 
     std::vector<float> h_accum(size_t(total_paths) * 3);
@@ -1952,9 +2088,14 @@ std::vector<float> cuda_wavefront_render(
     std::vector<float> rgb(size_t(total_paths) * 3);
     float exposure = renderer.getFilmExposure();
     for (int i = 0; i < total_paths; ++i) {
-        Vec3 colorXYZ(h_accum[i * 3 + 0] / samples,
-                      h_accum[i * 3 + 1] / samples,
-                      h_accum[i * 3 + 2] / samples);
+        // pkg131 — adaptive renders vary the per-pixel sample count, so divide by
+        // the pixel's own count; the uniform path divides by `samples` as before.
+        const float invN = (adaptiveOn && !h_pixelSamples.empty())
+            ? (h_pixelSamples[i] > 0 ? 1.0f / float(h_pixelSamples[i]) : 0.0f)
+            : 1.0f / float(samples);
+        Vec3 colorXYZ(h_accum[i * 3 + 0] * invN,
+                      h_accum[i * 3 + 1] * invN,
+                      h_accum[i * 3 + 2] * invN);
         colorXYZ *= exposure;
         Vec3 colorSRGB = xyzToLinearSRGB(colorXYZ);
         rgb[i * 3 + 0] = std::max(Renderer::finiteOrZero(colorSRGB.x), 0.0f);

--- a/src/gpu/wavefront/stage_advance.cu
+++ b/src/gpu/wavefront/stage_advance.cu
@@ -204,6 +204,11 @@ __constant__ int c_wfSamplerMode = 0;
 // default never touches it. Read by SobolDirect() in the shade + init kernels.
 __constant__ uint32_t c_sobolMatrices[kSobolNumDims][kSobolMatrixSize];
 
+// pkg131 — zero-knob adaptive sampling binding, published once per round by
+// cuda_wavefront_render (setWavefrontAdaptiveBinding). enabled=0 (the default)
+// leaves stageRegenKernel on the byte-identical flat-pool mapping.
+__constant__ GWavefrontAdaptiveBinding c_wfAdaptive = { nullptr, nullptr, nullptr, 0, 0, 0 };
+
 // Splat a spectral contribution into slot `idx`'s pass `passIdx` accumulator.
 // Per-slot (mirrors the color SoA — accumulate-at-death like beauty), so no atomics:
 // one path owns one slot for the duration of a bounce, exactly like the color_/
@@ -2328,6 +2333,14 @@ void setWavefrontSamplerMode(bool useProgressive)
     }
 }
 
+// pkg131 — publish the adaptive-round binding into __constant__ c_wfAdaptive.
+// Called once per round by cuda_wavefront_render. enabled=0 (the default binding)
+// keeps stageRegenKernel on the byte-identical flat-pool mapping.
+void setWavefrontAdaptiveBinding(const GWavefrontAdaptiveBinding& binding)
+{
+    cudaMemcpyToSymbol(c_wfAdaptive, &binding, sizeof(GWavefrontAdaptiveBinding));
+}
+
 // pkg198 Stage 2 — publish the frame's light-path pass buffers into the
 // __constant__ c_wfLpBinding symbol (read by the shade classification lock, the
 // intersect emission/env/lamp writes, the shadow-resolve NEE attribution, the
@@ -2646,6 +2659,13 @@ __global__ void stageRegenKernel(
         atomicAdd(&accum_xyz[pixel * 3 + 0], xyz.x);
         atomicAdd(&accum_xyz[pixel * 3 + 1], xyz.y);
         atomicAdd(&accum_xyz[pixel * 3 + 2], xyz.z);
+        // pkg131 — scalar-luminance half-buffer: even-indexed samples feed the
+        // Dammertz convergence check (host reads accum as the full sum, halfLumSum
+        // as the even-sample sum). Beauty luminance only (photon-caustic energy is
+        // added to accum below but not here → conservative convergence in those
+        // rare scenes). Zeroing color_* below is the double-add guard, shared.
+        if (c_wfAdaptive.enabled && (state.sample_index[idx] & 1) == 0)
+            atomicAdd(&c_wfAdaptive.halfLumSum[pixel], xyz.x + xyz.y + xyz.z);
         state.color_0[idx] = 0.f;
         state.color_1[idx] = 0.f;
         state.color_2[idx] = 0.f;
@@ -2721,8 +2741,21 @@ __global__ void stageRegenKernel(
     // ---- Claim the next work item; leave the slot dead when exhausted.
     int w = atomicAdd(work_counter, 1);
     if (w >= total_work) return;
-    int pixel  = w % numPixels;
-    int sample = w / numPixels;
+    int pixel, sample;
+    if (c_wfAdaptive.enabled) {
+        // pkg131 — adaptive round: work items index the compacted active-pixel
+        // list; the round contributes samples [baseSample, baseSample+perPixel).
+        // total_work is numActive * samplesThisRound, so w/numActive is the
+        // in-round sample offset. Count each claimed sample per pixel (the final
+        // divide is per-pixel accum/sampleCount, not the uniform /samples).
+        pixel  = c_wfAdaptive.activePixels[w % c_wfAdaptive.numActive];
+        sample = c_wfAdaptive.baseSample + w / c_wfAdaptive.numActive;
+        atomicAdd(&c_wfAdaptive.sampleCount[pixel], 1);
+    } else {
+        // Flat pool (byte-identical pre-pkg131): wave k = sample k for every pixel.
+        pixel  = w % numPixels;
+        sample = w / numPixels;
+    }
     initPathSlot(idx, pixel, sample, state, cam, width, height, seed,
                  lambdaMin, lambdaMax);
     // pkg198 Stage 2: a reused slot hosts a fresh path — reset its locked category

--- a/tests/test_pkg131_adaptive_gpu.py
+++ b/tests/test_pkg131_adaptive_gpu.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+"""pkg131 — GPU wavefront zero-knob adaptive sampling: wiring + convergence.
+
+The GPU adaptive round loop (cuda_wavefront_render) is opt-in and rides on the
+pkg224 progressive sampler: it activates only when BOTH set_use_progressive_sampler
+and set_adaptive_sampling are on. Default (progressive off) is the byte-identical
+flat work pool. Each active round samples the compacted still-unconverged pixel
+list; the host convergence check retires pixels below the auto threshold and the
+final image divides each pixel by its own sample count.
+
+Gates:
+  * test_adaptive_inactive_without_progressive — adaptive ON but progressive OFF
+    renders the same as the untouched default (adaptive is gated off, byte-identical
+    flat pool within GPU float-atomic tolerance).
+  * test_adaptive_unbiased — adaptive ON (+progressive) matches progressive-ON /
+    adaptive-OFF in the mean at matched budget: early stopping does not bias the
+    image.
+  * test_adaptive_changes_and_sane — adaptive ON differs from adaptive-OFF (proof
+    the round loop engages) yet stays a sane, non-black render of the same scene.
+
+GPU-gated: skips when no CUDA device (CI has none) — this is an RTX-box leg.
+"""
+
+import astroray
+import numpy as np
+import pytest
+from base_helpers import create_renderer, render_image, setup_camera
+
+
+def _has_cuda_gpu(renderer):
+    return bool(astroray.__features__.get("cuda", False)) and \
+        bool(getattr(renderer, "gpu_available", False))
+
+
+def _build_scene(renderer):
+    renderer.set_background_color([0.8, 0.8, 0.8])
+    mat = renderer.create_material("lambertian", [0.6, 0.6, 0.6], {})
+    A, B = [-1, -1, 0], [1, -1, 0]
+    C, D = [1, 1, 0], [-1, 1, 0]
+    n = [0, 0, 1]
+    renderer.add_triangle_layers(A, B, C, mat, {"UVMap": [[0, 0], [1, 0], [1, 1]]},
+                                 n, n, n)
+    renderer.add_triangle_layers(A, C, D, mat, {"UVMap": [[0, 0], [1, 1], [0, 1]]},
+                                 n, n, n)
+    setup_camera(renderer, look_from=[0, 0, 3], look_at=[0, 0, 0], vup=[0, 1, 0],
+                 vfov=45, width=48, height=48)
+
+
+def _render(adaptive, progressive, samples, seed=1234):
+    r = create_renderer()
+    if not _has_cuda_gpu(r):
+        pytest.skip("No CUDA GPU — pkg131 GPU adaptive gate runs on the RTX box.")
+    r.set_use_gpu(True)
+    r.set_use_progressive_sampler(progressive)
+    r.set_adaptive_sampling(adaptive)
+    _build_scene(r)
+    try:
+        r.set_seed(seed)
+    except AttributeError:
+        pass
+    return render_image(r, samples=samples, max_depth=3, apply_gamma=False)
+
+
+def test_adaptive_inactive_without_progressive():
+    """Adaptive ON but progressive OFF == the untouched flat pool (adaptive gated
+    off). Compared within GPU float-atomic tolerance (~1 ULP run-to-run)."""
+    adaptive_no_prog = _render(adaptive=True, progressive=False, samples=48, seed=7)
+    # Untouched default: adaptive off, progressive off.
+    baseline = _render(adaptive=False, progressive=False, samples=48, seed=7)
+    assert np.allclose(adaptive_no_prog, baseline, atol=1e-4), (
+        "adaptive activated without the progressive sampler — it must be gated off "
+        f"(max|diff|={np.abs(adaptive_no_prog - baseline).max():.2e})")
+
+
+def test_adaptive_unbiased():
+    """Adaptive ON (+progressive) is unbiased vs progressive-ON / adaptive-OFF at a
+    high budget: early stopping trades bounded noise for samples, not accuracy."""
+    on = _render(adaptive=True, progressive=True, samples=256)
+    off = _render(adaptive=False, progressive=True, samples=256)
+    assert on.shape == off.shape
+    assert 0.05 < on.mean(), "adaptive render came out black"
+    assert abs(float(on.mean()) - float(off.mean())) < 0.01, (
+        "adaptive early-out biased the image mean")
+
+
+def test_adaptive_changes_and_sane():
+    """Adaptive ON must differ from OFF (the round loop actually engaged) but stay a
+    sane render of the same scene."""
+    on = _render(adaptive=True, progressive=True, samples=128)
+    off = _render(adaptive=False, progressive=True, samples=128)
+    assert not np.array_equal(on, off), (
+        "adaptive produced a byte-identical image to the uniform render — the round "
+        "loop / compaction never engaged")
+    assert 0.05 < on.mean() and 0.05 < off.mean()


### PR DESCRIPTION
## pkg131 GPU leg — compacted active-pixel round (session 2)

The GPU wavefront leg of zero-knob adaptive sampling, on top of the shared cited core from #659.

### Design (why not a wave rewrite)
The wavefront is a flat persistent-thread work pool (`w % numPixels`), the deliberate launch-amortizing design behind the perf ceiling. So adaptive is a **compacted active-pixel round** layered on it, not a wave-based rewrite:
- **Device** (`stageRegenKernel`): a gated `__constant__ c_wfAdaptive` branch maps a claimed work item to `activePixels[w % numActive]` / `baseSample + w/numActive`, increments per-pixel `sampleCount`, and flushes even-sample luminance into the scalar half-buffer. `enabled=0` (default) = byte-identical flat mapping.
- **Host** (`cuda_wavefront_render`): a round loop — round 0 samples every pixel to the auto min-sample floor; each later round adds `adaptive_step` samples to only the still-unconverged pixels. Convergence check + 3×3 dilation + compaction run host-side reusing the tested core; final divide is per-pixel `accum/sampleCount`.

### Safety / gating
- **Opt-in via the pkg224 progressive sampler** (adaptive requires the low-discrepancy prefix property). Default GPU render (progressive off) is **byte-identical** to the pre-pkg131 flat pool.
- Beauty(+guides) only; falls back to the uniform single round when light-path passes / cryptomatte / transparent alpha are requested.

### Verification (RTX 5070 Ti)
- `tests/test_pkg131_adaptive_gpu.py` (3): byte-identical without progressive; unbiased mean vs uniform; round loop engages.
- Regression: wavefront-diff bit-identity (lambertian/disney) + photon-caustic wavefront green; reflection-not-black green.
- Local build clean (VS2022 / CUDA 12.8).

Follow-up (separate slice): sample-count AOV to report measured speedup + addon UI (remove `samples=N`, expose `max_samples` + auto threshold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)