### PR TITLE
test(pkg208): chromatic-light-source dispersion oracle (sodium vs LED-6500K)

### DIFF
--- a/.astroray_plan/docs/pkg208-dispersion-oracle-research.md
+++ b/.astroray_plan/docs/pkg208-dispersion-oracle-research.md
@@ -1,0 +1,85 @@
+# pkg208 — chromatic-light-source dispersion oracle: citations
+
+No new algorithm is introduced by this package (per spec §1, Non-goals). This
+note records the physics being *asserted*, not implemented.
+
+## 1. Dispersion at a dielectric interface
+
+Standard textbook physics — refraction angle depends on wavelength through the
+material's index of refraction n(λ):
+
+- Snell's law: n1 sin(θ1) = n2 sin(θ2).
+- n(λ) for the prism glass is already computed by the shipped Sellmeier model
+  (Schott BK7 coefficients, `include/astroray/optical_presets.h`, exercised by
+  `tests/test_gpu_sellmeier_ior.py` against the Schott BK7 datasheet at the
+  d/F/C lines).
+- Reference: E. Hecht, *Optics* (5th ed.), Ch. 3 (dispersion) and Ch. 5
+  (refraction at a boundary) — standard undergraduate optics, cited here only
+  to ground the assertion, not to justify new code.
+
+## 2. Why a monochromatic (narrow-line) source disperses to a single band, not a rainbow
+
+A prism does not "create" a rainbow out of nothing — it spatially separates
+wavelengths that are already present in the incident light by refracting each
+one through a slightly different angle (n(λ) varies smoothly with λ, so exit
+angle varies smoothly with λ). If the incident spectrum has energy at only one
+narrow band of λ (e.g. the sodium D-lines, ~589 nm), then only that one exit
+angle carries measurable energy — the output is a single-hue band near the
+input wavelength, not a spread of hues. A source with broadband emission
+(energy spread across ~380–780 nm) refracts every one of those wavelengths to
+its own exit angle simultaneously, producing the familiar continuous
+ROYGBIV spread. This is textbook (Hecht, ibid., §5.5) — not a new claim.
+
+## 3. The Cycles limitation this oracle differentiates against
+
+Astroray's own dispersion-research report
+(`.astroray_plan/docs/reports/2026-08-19-cycles-dispersion-research.html`,
+"Acknowledged limitation" section) quotes the Cycles PR #162041 author
+directly on why Cycles cannot do what §2 describes:
+
+> "It's not physically correct, because we don't know the spectrum of the
+> light source … in the future if we switch to spectral, then uplifting would
+> naturally be added."
+
+Cycles' dispersion pipeline hero-samples ONE wavelength per path from a fixed
+D65-luminance CDF and renders RGB throughout — it never carries the actual
+light source's SPD to the dispersive event, so a spectrally-narrow light and a
+broadband light produce visually similar (full-spread, D65-tinted) rainbows
+through the same prism. Astroray's `multiwavelength_path_tracer` carries the
+sampled light's measured SPD (`profiles.bin`) through to the dispersive
+dielectric BSDF, so the two cases documented above are physically
+distinguishable in Astroray but are not in Cycles as shipped. This is the
+concrete differentiator pkg208 turns into a standing regression oracle
+(`tests/test_spectral_prism.py::test_narrow_line_vs_broadband_dispersion_width`
+and `::test_narrow_line_band_is_amber_hued`).
+
+## 4. Scene mechanism (why this doesn't need caustics / photon mapping)
+
+The oracle reuses `tests/scenes/prism_reference.py`'s existing "view colored
+panels through a dispersive prism" geometry (proven in `tests/test_spectral_prism.py`,
+pkg29) rather than a "beam cast onto a screen" rainbow demo. The point light
+illuminates the panels directly and unoccluded by glass (ordinary NEE); the
+camera views the panels *through* the dispersive prism. `red_blue_centroid_separation`
+already measures the pkg29-proven excess spatial separation this refraction
+distortion adds between red- and blue-dominant image regions.
+
+The new physics this oracle adds is on the illuminant side: in a hero-wavelength
+spectral path tracer, a camera path's contribution at wavelength λ is weighted
+by the light's SPD at λ. For the `sodium_vapor` narrow line, only λ near 589 nm
+carries meaningful radiance, so — in expectation — the rendered dispersion
+pattern collapses to what a *single* index of refraction n(589 nm) would
+produce (near-zero *excess* dispersion vs. a non-dispersive control). For the
+`led_6500k` broadband control, every λ in [380, 780] nm carries comparable
+radiance, so the full n(λ) spread contributes, reproducing pkg29's already-measured
+excess separation (~2.77 px). No caustics, no photon mapping, and no
+GPU-only code paths (`src/gpu/photon_caustic.cu`) are needed — this is
+ordinary unidirectional path tracing with existing NEE, run CPU-only.
+
+## Sources
+
+- Hecht, E. *Optics*, 5th ed. — standard optics textbook (dispersion, Snell's
+  law). No code borrowed; cited for the physics claim only.
+- Schott BK7 optical glass datasheet (already the Sellmeier reference in this
+  repo, `tests/test_gpu_sellmeier_ior.py`).
+- Cycles PR #162041 thread (author reply quoted in
+  `.astroray_plan/docs/reports/2026-08-19-cycles-dispersion-research.html`).

--- a/tests/scenes/prism_reference.py
+++ b/tests/scenes/prism_reference.py
@@ -69,6 +69,59 @@ def render_prism(astroray, *, dispersive: bool, seed: int = 17) -> np.ndarray:
     return np.asarray(renderer.render(SAMPLES, MAX_DEPTH, None, True), dtype=np.float32)
 
 
+SPECTRAL_WIDTH = 48
+SPECTRAL_HEIGHT = 48
+SPECTRAL_SAMPLES = 64
+SPECTRAL_MAX_DEPTH = 8
+
+
+def make_spectral_prism_scene(astroray, *, profile_name: str,
+                               width: int = SPECTRAL_WIDTH, height: int = SPECTRAL_HEIGHT,
+                               light_intensity: float = 90.0):
+    """pkg208 -- same panel/prism/camera geometry as make_prism_scene, but lit by
+    a spectral point light (measured SPD profile) on the multiwavelength path,
+    so the light's own spectrum -- not just a flat RGB colour -- reaches the
+    dispersive BK7 dielectric. The point light sits above the prism (same
+    position/role as make_prism_scene's overhead area light) with a clear line
+    of sight to the panels, so panel illumination is ordinary NEE (no glass in
+    the shadow-ray path); only the CAMERA's view of the panels passes through
+    the dispersive prism. See .astroray_plan/docs/pkg208-dispersion-oracle-research.md.
+    """
+    r = astroray.Renderer()
+    r.set_use_gpu(False)
+    r.set_integrator("multiwavelength_path_tracer")
+    r.set_wavelength_range(380.0, 780.0)
+    r.set_background_color([0.0, 0.0, 0.0])
+
+    red = r.create_material("lambertian", [1.0, 0.05, 0.03], {})
+    white = r.create_material("lambertian", [0.92, 0.92, 0.90], {})
+    blue = r.create_material("lambertian", [0.03, 0.08, 1.0], {})
+
+    _add_panel(r, red, -2.0, -0.4, -1.79)
+    _add_panel(r, white, -0.45, 0.45, -1.80)
+    _add_panel(r, blue, 0.4, 2.0, -1.78)
+
+    r.add_point_light(
+        position=[0.0, 1.8, 0.5],
+        emission={"mode": "measured_spd", "profile_name": profile_name},
+        intensity=light_intensity, radius=0.0)
+
+    glass = r.create_material("dielectric", [1.0, 1.0, 1.0], {"sellmeier_preset": "bk7"})
+    add_triangular_prism(r, glass)
+
+    r.setup_camera(
+        [0.0, 0.0, 4.2], [0.0, 0.0, 0.0], [0.0, 1.0, 0.0],
+        38.0, 1.0, 0.0, 4.2, width, height)
+    return r
+
+
+def render_spectral_prism(astroray, *, profile_name: str, seed: int = 17) -> np.ndarray:
+    renderer = make_spectral_prism_scene(astroray, profile_name=profile_name)
+    renderer.set_seed(seed)
+    pixels = renderer.render(SPECTRAL_SAMPLES, SPECTRAL_MAX_DEPTH, None, False)  # linear
+    return np.asarray(pixels, dtype=np.float32)
+
+
 def red_blue_centroid_separation(pixels: np.ndarray) -> float:
     """Measure lateral split between red- and blue-dominant energy."""
     h, w, _ = pixels.shape
@@ -84,3 +137,41 @@ def red_blue_centroid_separation(pixels: np.ndarray) -> float:
         return float(np.sum(weights * xx) / (np.sum(weights) + 1e-6))
 
     return abs(centroid(0) - centroid(2))
+
+
+def bright_region_mean_chroma_and_spread(pixels: np.ndarray, bright_percentile: float = 70.0):
+    """pkg208 -- mean normalized-RGB chromaticity and its spread over the
+    dispersed (bright) part of the panel-through-prism view.
+
+    `red_blue_centroid_separation` above is numerically unstable for this
+    oracle's narrow-line case: it centroids on (channel - mean) weights, and
+    sodium_vapor's blue channel is ~0 everywhere, so the "blue centroid" is a
+    near-0/near-0 division with no real signal (measured ~26px of centroid
+    "separation" that is pure noise, larger than the broadband control's,
+    inverting the expected relationship -- see
+    .astroray_plan/docs/pkg208-dispersion-oracle-research.md). Chromaticity
+    spread instead asks a channel-agnostic question: across the pixels that
+    the dispersed light actually lit up, how much does the HUE vary?
+    A narrow-line illuminant only has energy near one wavelength, so every
+    lit pixel -- regardless of the exact exit angle sampled -- comes out
+    close to the same hue (small spread). A broadband illuminant spreads many
+    different wavelengths (hence hues) across those same pixels (large
+    spread) -- the textbook rainbow-fringe. Returns (mean_chroma[3], spread).
+    """
+    h, w, _ = pixels.shape
+    yy, xx = np.mgrid[:h, :w]
+    center_mask = (
+        (xx > w * 0.25) & (xx < w * 0.75) &
+        (yy > h * 0.20) & (yy < h * 0.80)
+    )
+    luminance = pixels.mean(axis=2)
+    threshold = np.percentile(luminance[center_mask], bright_percentile)
+    bright = center_mask & (luminance > threshold) & (luminance > 1e-4)
+    if not np.any(bright):
+        return np.zeros(3, dtype=np.float64), 0.0
+
+    total = np.maximum(pixels.sum(axis=2, keepdims=True), 1e-8)
+    chroma = (pixels / total)[bright]  # (N, 3) normalized RGB per bright pixel
+    mean_chroma = chroma.mean(axis=0)
+    spread = float(np.linalg.norm(chroma - mean_chroma, axis=1).mean())
+    return mean_chroma, spread

--- a/tests/test_spectral_prism.py
+++ b/tests/test_spectral_prism.py
@@ -24,12 +24,18 @@ from base_helpers import save_image  # noqa: E402
 from scenes.prism_reference import (  # noqa: E402
     HEIGHT,
     WIDTH,
+    bright_region_mean_chroma_and_spread,
     red_blue_centroid_separation,
     render_prism,
+    render_spectral_prism,
 )
 
 
 pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray not built")
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PROFILES_BIN = os.path.join(REPO_ROOT, "data", "spectral_profiles", "profiles.bin")
+HAS_PROFILES = os.path.exists(PROFILES_BIN)
 
 
 def test_dispersive_prism_render_is_finite_and_saved(test_results_dir):
@@ -67,3 +73,73 @@ def test_dispersive_prism_has_measurable_color_spread(test_results_dir):
     # clear red-left/blue-right split — verified visually). See
     # .astroray_plan/docs/glass-dark-energy-bug-2026-05-30.md.
     assert dispersive_sep - flat_sep > 2.0
+
+
+# --- pkg208: chromatic-light-source dispersion oracle ---------------------
+#
+# Cycles superiority oracle (no engine change): a spectrally-narrow light
+# source refracted through a dispersive prism must disperse into a
+# single-hue band, NOT a full rainbow -- because a true spectral renderer
+# carries the source SPD to the dispersive event, unlike Cycles' RGB
+# hero-wavelength pipeline (which cannot know the source SPD; PR #162041
+# author: "we don't know the spectrum of the light source"). See
+# .astroray_plan/docs/pkg208-dispersion-oracle-research.md for the full
+# citation trail and the reason this reuses the panel-through-prism scene
+# (ordinary NEE + specular transmission, no caustics/photon-mapping needed).
+
+pytestmark_profiles = pytest.mark.skipif(not HAS_PROFILES, reason="profiles.bin not found")
+
+
+@pytestmark_profiles
+def test_narrow_line_band_is_amber_hued(test_results_dir):
+    """pkg208 predicate 1: the sodium_vapor (~589 nm) line's dispersed band is
+    amber/yellow-dominant (R > G > 3*B in chromaticity), not a rainbow."""
+    astroray.load_spectral_profiles(PROFILES_BIN)
+    sodium = render_spectral_prism(astroray, profile_name="sodium_vapor", seed=17)
+    save_image(sodium, os.path.join(test_results_dir, "pkg208_sodium_prism.png"))
+
+    assert np.isfinite(sodium).all()
+    mean_chroma, _ = bright_region_mean_chroma_and_spread(sodium)
+    R, G, B = (float(c) for c in mean_chroma)
+    print(f"\n  sodium_vapor dispersed-band mean chroma (R,G,B) = ({R:.4f}, {G:.4f}, {B:.4f})")
+    assert R > 1e-3, f"pkg208 FAIL: sodium-line band emits no light -- R={R:.4f}"
+    assert R > G > 3.0 * B, (
+        f"pkg208 FAIL: sodium-line band is not amber -- R={R:.4f} G={G:.4f} B={B:.4f} "
+        f"(need R > G > 3*B)"
+    )
+
+
+@pytestmark_profiles
+def test_narrow_line_disperses_narrower_than_broadband(test_results_dir):
+    """pkg208 predicate 2 (the crux): the sodium_vapor narrow-line prism band's
+    chromaticity spread is well below the led_6500k broadband control's --
+    reusing the same prism, only the light's SPD changes. If this INVERTS
+    (narrow-line disperses as widely as broadband, or wider), that is a real
+    engine defect -- source SPD not reaching the dispersive event -- and must
+    be filed as a separate spec, not papered over here (spec pkg208 S1)."""
+    astroray.load_spectral_profiles(PROFILES_BIN)
+    sodium = render_spectral_prism(astroray, profile_name="sodium_vapor", seed=17)
+    broadband = render_spectral_prism(astroray, profile_name="led_6500k", seed=17)
+    save_image(broadband, os.path.join(test_results_dir, "pkg208_led6500k_prism.png"))
+
+    assert np.isfinite(sodium).all()
+    assert np.isfinite(broadband).all()
+
+    _, sodium_spread = bright_region_mean_chroma_and_spread(sodium)
+    _, broadband_spread = bright_region_mean_chroma_and_spread(broadband)
+    print(f"\n  sodium_vapor chromaticity spread:  {sodium_spread:.4f}")
+    print(f"  led_6500k    chromaticity spread:  {broadband_spread:.4f}")
+
+    assert broadband_spread > 0.1, (
+        f"pkg208 FAIL: broadband control shows no measurable dispersion spread "
+        f"({broadband_spread:.4f}) -- control scene is not exercising dispersion"
+    )
+    # The crux assertion: narrow-line disperses into a MUCH tighter hue band
+    # than the broadband control through the same prism. Measured ~0.015 vs
+    # ~0.49 (~33x) during development; use a generous 3x margin so ordinary
+    # MC-noise variation across seeds/builds cannot flip this.
+    assert sodium_spread < broadband_spread / 3.0, (
+        f"pkg208 FAIL: sodium-line dispersion spread ({sodium_spread:.4f}) is not "
+        f"well below the broadband control's ({broadband_spread:.4f}) -- "
+        f"expected narrow-line spread < broadband/3"
+    )


### PR DESCRIPTION
pkg208 — a Cycles-superiority **oracle test** (no engine change): a narrow-line emitter (`sodium_vapor`, ~589 nm) disperses through the BK7 prism into a tight, amber band, while a broadband control (`led_6500k`) spreads wide — something an RGB renderer cannot reproduce.

**CPU-only** (`set_use_gpu(False)`), 48×48 @ 64 spp — CI-verifiable, no GPU.

Implementer finding (documented): the spec's suggested `red_blue_centroid_separation` doesn't fit (it divides by a near-zero blue channel for the amber sodium case → noise). Per the spec's escape hatch, replaced with a channel-agnostic chromaticity-variance proxy `bright_region_mean_chroma_and_spread`. Measured: sodium spread **0.015** vs LED **0.49** (~33×; asserted at a conservative 3× margin), sodium mean chroma (0.85, 0.15, 0.0) confirming amber.

Files: `tests/test_spectral_prism.py` (+2 tests), `tests/scenes/prism_reference.py` (spectral prism scene helper), `.astroray_plan/docs/pkg208-dispersion-oracle-research.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)