### PR TITLE
feat(pkg218): GPU spectral emission -- upload emission SPDs to the device

### DIFF
--- a/.astroray_plan/packages/pkg218-gpu-spectral-emission-device-upload.md
+++ b/.astroray_plan/packages/pkg218-gpu-spectral-emission-device-upload.md
@@ -1,7 +1,18 @@
 # pkg218 — GPU spectral emission: upload emission SPDs to the device (exact CPU↔GPU lamp-colour parity)
 
 **Track:** A
-**Status:** open (filed 2026-08-22, follow-up to the deviceReference chroma fix).
+**Status:** in review (PR #667, 2026-08-31 — device SPD table + upload +
+wired into all 3 GPU emission-eval sites for dedicated lights (point/spot/
+area/distant): immediate NEE resolve, deferred/bucketed production shadow
+stage, and direct visibility to BSDF-continuation rays. ReSTIR deferred
+(RGB-only reservoirs, not the default path). GMaterial untouched;
+material-level "emissive GMaterial mode" from the design section does not
+correspond to an actual CPU gap (verified — GCLOSURE_EMISSION is plain RGB
+both sides already), scope narrowed accordingly. Regression gate tightened
+8%/30%→5%. NOT YET BUILT OR HARDWARE-VERIFIED — implementer had no CUDA
+build access; parent must build + run
+tests/test_gpu_emission_colour_parity.py on the RTX 5070 Ti and check the
+GNEESample/nee_i register-footprint flag in the PR body before merge).
 **Estimated effort:** M (new device table + NEE / emissive-hit eval + addon upload wiring; no register-hostile shade-kernel change).
 **Depends on:** the `deviceReference` fine-integration fix (same investigation — ships first, this tightens it).
 

--- a/.astroray_plan/packages/pkg218-gpu-spectral-emission-device-upload.md
+++ b/.astroray_plan/packages/pkg218-gpu-spectral-emission-device-upload.md
@@ -1,7 +1,7 @@
 # pkg218 — GPU spectral emission: upload emission SPDs to the device (exact CPU↔GPU lamp-colour parity)
 
 **Track:** A
-**Status:** in review (PR #667, 2026-08-31 — device SPD table + upload +
+**Status:** DONE (PR #667, merged 2026-08-31 — HW-verified on RTX 5070 Ti: register probe on stageShadeBucketedKernel byte-identical to the fleet baseline REG:254/STACK:3368/CONSTANT[0]:1716 (NEE-park store is register-neutral, no spill), and CPU/GPU emission colour parity within 5% across 9 profiles incl. sodium amber — test metric fixed to compare significant channels by ratio + dark channels by absolute agreement). Original filing note below.) — device SPD table + upload +
 wired into all 3 GPU emission-eval sites for dedicated lights (point/spot/
 area/distant): immediate NEE resolve, deferred/bucketed production shadow
 stage, and direct visibility to BSDF-continuation rays. ReSTIR deferred

--- a/include/astroray/emission_spectrum.h
+++ b/include/astroray/emission_spectrum.h
@@ -33,11 +33,22 @@
 #include <string>
 #include <memory>
 #include <variant>
+#include <vector>
 
 namespace astroray {
 
 // Forward declarations
 class RGBAlbedoSpectrum;
+
+// pkg218: fixed device grid for EmissionSpectrum::bakeDeviceProfile() below —
+// 360-830 nm, 1 nm step, 471 samples. MUST stay numerically identical to
+// gpu_types.h's G_EMISSION_LAMBDA_MIN/STEP/G_EMISSION_SAMPLES (that GPU header
+// is CUDA-adjacent and not included from this plain-C++ TU, so the two grids
+// are declared independently and cross-referenced by comment — same pattern
+// already used for G_PROFILE_LAMBDA_MIN=300 vs SpectralProfile's lmin_ default).
+inline constexpr float kDeviceEmissionLambdaMin  = 360.0f;
+inline constexpr float kDeviceEmissionLambdaStep = 1.0f;
+inline constexpr int   kDeviceEmissionSamples    = 471;
 
 // --------------------------------------------------------------------------
 // EmissionSpectrum — tagged union representing spectral emission.
@@ -106,6 +117,16 @@ public:
     // moot until the pkg89 CPU blackbody normalization is fixed — see GAP 2).
     // `exactRGB` is true only for RGB mode.
     void deviceReference(Vec3& outRGB, bool& exactRGB) const;
+
+    // pkg218 — bake this emission spectrum onto the fixed device grid above
+    // (kDeviceEmissionLambdaMin/Step, kDeviceEmissionSamples samples) for GPU
+    // spectral-emission upload. Non-RGB modes only: callers gate on
+    // deviceReference's exactRGB == false (RGB mode stays on the exact
+    // RGBIlluminant device path and never needs a baked profile). Reuses
+    // deviceReference's own per-nm four-lane eval() technique, so blackbody's
+    // luminance normalization (blackbodyLuminanceNorm) and composite's filter
+    // multiply are inherited for free — see src/emission_spectrum.cpp.
+    std::vector<float> bakeDeviceProfile() const;
 
     // Accessors for the underlying variant (for UI / serialization).
     const Variant& variant() const { return data_; }

--- a/include/astroray/gpu_scene_upload.h
+++ b/include/astroray/gpu_scene_upload.h
@@ -128,6 +128,16 @@ struct SceneUploadResult {
     // profile i at lambda = G_PROFILE_LAMBDA_MIN + s * G_PROFILE_LAMBDA_STEP.
     std::vector<float> profileTable;
     int                profileCount = 0;
+
+    // pkg218: emission-profile table for dedicated-light non-RGB emission
+    // modes (blackbody/measured_spd/composite). Layout:
+    // emissionProfileTable[i * G_EMISSION_SAMPLES + s] is the baked spectral
+    // radiance of profile i at lambda = G_EMISSION_LAMBDA_MIN + s *
+    // G_EMISSION_LAMBDA_STEP (360-830 nm, 1 nm step, 471 samples). Uploaded to
+    // device GLOBAL memory (uploadEmissionProfileTable, gpu_spectral_tables.cu)
+    // — unlike profileTable above, no fixed G_MAX_* cap.
+    std::vector<float> emissionProfileTable;
+    int                emissionProfileCount = 0;
 };
 
 // Declared here; defined in scene_upload.cu

--- a/include/astroray/gpu_types.h
+++ b/include/astroray/gpu_types.h
@@ -505,6 +505,30 @@ static constexpr float G_PROFILE_LAMBDA_MIN  = 300.0f;
 static constexpr float G_PROFILE_LAMBDA_MAX  = 1000.0f;
 static constexpr float G_PROFILE_LAMBDA_STEP = 5.0f;
 
+// pkg218: layout for the device-side EMISSION profile table — a baked
+// EmissionSpectrum SPD (blackbody / measured / composite modes; RGB mode
+// keeps the exact deviceReference/RGBIlluminant path) sampled onto a fixed
+// grid for GPU spectral-emission upload. The grid matches the CIE CMF support
+// used elsewhere on the device (gpu_spectral_tables.h's G_CMF_LAMBDA_MIN/MAX/
+// STEP: 360-830 nm, 1 nm step, 471 samples) so device linear interpolation
+// tracks the CPU per-nm eval (EmissionSpectrum::bakeDeviceProfile,
+// src/emission_spectrum.cpp) to well under 1%. Values MUST stay numerically
+// identical to emission_spectrum.h's kDeviceEmissionLambdaMin/Step/Samples —
+// that CPU-side header can't include this one (CUDA-adjacent), so the two
+// grids are independently declared and cross-referenced by comment.
+//
+// Lives in device GLOBAL memory (an extern __device__ pointer, not a fixed
+// __constant__ array) — see gpu_glass_tables.cuh for the "widely-included
+// header risks either N-way __constant__ duplication or blowing the 64 KB
+// budget" rationale that already forced the Jakob-Hanika LUT and GGX glass
+// tables into global memory; the same applies here since the profile count is
+// scene-dependent (no fixed cap needed as a result — see
+// uploadEmissionProfileTable in gpu_spectral_tables.cu).
+static constexpr float G_EMISSION_LAMBDA_MIN  = 360.0f;
+static constexpr float G_EMISSION_LAMBDA_MAX  = 830.0f;
+static constexpr float G_EMISSION_LAMBDA_STEP = 1.0f;
+static constexpr int   G_EMISSION_SAMPLES     = 471;
+
 struct alignas(64) GMaterial {
     GMaterialType type;
     GSpectralMode spectralMode;
@@ -815,6 +839,12 @@ struct GNEESample {
     int   isDedicated;    // 1 = dedicated light
     GVec3 dedEmissionRGB; // reference color for the device RGBIlluminant upsample
     float dedGeoScale;    // staticScale · per-sample geometric factor (λ-independent)
+    // pkg218 — copied from the source GDedicatedLight.emissionProfileIndex at
+    // sample time (gpu_dedicated_sample) so it survives the A(sample)->
+    // B(shadow trace)->C(resolve) split the same way dedEmissionRGB/dedGeoScale
+    // already do; gpu_nee_resolve reads it instead of dedEmissionRGB when >= 0.
+    // -1 = RGB fallback (existing behaviour, unchanged).
+    int   dedEmissionProfileIndex;
     // pkg140: 1 = this sample came from a delta (zero-measure) light
     // distribution (e.g. GDED_DISTANT with angular_diameter == 0). Forces
     // gpu_nee_resolve's MIS weight to 1 instead of a power heuristic against
@@ -874,6 +904,13 @@ struct GDedicatedLight {
     float staticScale;      // intensity·invarea·(1/π) baked (distant omits 1/π)
     float power;            // this light's unified-CDF selection weight
     float cumulativePower;  // unified CDF position (after the GLight entries)
+    // pkg218 — index into the device emission-profile table (see
+    // G_EMISSION_SAMPLES above / gpu_spectral_tables.h's g_emissionProfileTable)
+    // for non-RGB emission modes (blackbody / measured_spd / composite).
+    // -1 = RGB fallback (keep the existing emissionRGB·RGBIlluminant path —
+    // exact for RGB mode, unchanged by this package). Set by scene_upload.cu
+    // from DeviceLightParams::emissionProfileSamples.
+    int   emissionProfileIndex;
 };
 
 // ---------------------------------------------------------------------------

--- a/include/astroray/gpu_wavefront_state.h
+++ b/include/astroray/gpu_wavefront_state.h
@@ -530,8 +530,16 @@ void setWavefrontAdaptiveBinding(const GWavefrontAdaptiveBinding& binding);
 // matches and correctly falls to PASS_VOLUME_INDIRECT. Read-only in the shadow
 // kernel (no scratch mutation); zeroed per render so bounce 0's first scatter
 // (enc=1) never aliases the memset default (enc=0 => -1 != any bounce).
+// pkg218: int lane 5 = dedEmissionProfileIndex — the source GDedicatedLight's
+// device emission-profile table row (-1 = RGB fallback, unchanged behaviour).
+// Parked at shade time alongside lanes 11-13 (dedEmissionRGB) so
+// stageShadowKernel can pick gpu_emission_profile() over the RGBIlluminant
+// upsample for non-RGB emission modes (blackbody/measured_spd/composite).
+// This kernel is explicitly NOT register-critical (lean occlusion + lazy
+// resolve, unlike the REG:254 bucketed shade kernel), so the extra lane read
+// here carries none of the shade-kernel spill risk.
 constexpr int G_WF_NEE_F_LANES = 15;
-constexpr int G_WF_NEE_I_LANES = 5;
+constexpr int G_WF_NEE_I_LANES = 6;
 void launchStageShadow(
     GPUWavefrontState& state,
     GPUWavefrontHitBuffers& hitBufs,

--- a/include/astroray/light.h
+++ b/include/astroray/light.h
@@ -27,6 +27,7 @@
 #include <memory>
 #include <random>
 #include <cmath>
+#include <vector>
 
 // Vec3 and AABB are assumed to be already defined (from raytracer.h).
 // Forward-declare them here to make the dependency explicit.
@@ -70,6 +71,14 @@ struct DeviceLightParams {
                                   // false for blackbody/measured (chroma-approx, energy follow-up)
     float staticScale = 1.0f;     // intensity·normalizeFactor·(1/π) baked per type
                                   // (distant omits the 1/π, matching distant_light.cpp)
+    // pkg218 — baked EmissionSpectrum SPD (EmissionSpectrum::bakeDeviceProfile,
+    // kDeviceEmissionSamples floats, 360-830 nm @ 1 nm) for non-RGB emission
+    // modes. Populated by each light's fillDeviceParams() when exactIlluminant
+    // is false; left empty for RGB mode (exactIlluminant true — that path keeps
+    // the exact deviceReference/RGBIlluminant device path, untouched).
+    // scene_upload.cu registers this into SceneUploadResult::emissionProfileTable
+    // and stamps the returned index onto GDedicatedLight::emissionProfileIndex.
+    std::vector<float> emissionProfileSamples;
 };
 
 // --------------------------------------------------------------------------

--- a/src/emission_spectrum.cpp
+++ b/src/emission_spectrum.cpp
@@ -163,6 +163,23 @@ void EmissionSpectrum::deviceReference(Vec3& outRGB, bool& exactRGB) const {
     exactRGB = false;
 }
 
+// pkg218 — bake this emission spectrum onto the fixed device grid
+// (kDeviceEmissionLambdaMin/Step, kDeviceEmissionSamples) for GPU spectral-
+// emission upload. Same per-nm four-lane eval() trick deviceReference already
+// uses for its fine CMF-grid integral above: eval() at a given lambda depends
+// only on wl.lambda(i) per lane, so packing one wavelength into all four lanes
+// and reading lane 0 yields S(lambda) exactly for any mode (Blackbody's
+// luminance normalization and Composite's recursive filter multiply both fall
+// out of eval()'s existing dispatch — no separate handling needed here).
+std::vector<float> EmissionSpectrum::bakeDeviceProfile() const {
+    std::vector<float> out(kDeviceEmissionSamples);
+    for (int i = 0; i < kDeviceEmissionSamples; ++i) {
+        float lam = kDeviceEmissionLambdaMin + static_cast<float>(i) * kDeviceEmissionLambdaStep;
+        out[i] = eval(SampledWavelengths::fromLambdas({lam, lam, lam, lam}))[0];
+    }
+    return out;
+}
+
 // Internal: evaluate Blackbody mode.
 SampledSpectrum EmissionSpectrum::evalBlackbody(const Blackbody& bb,
                                                  const SampledWavelengths& wl) const {

--- a/src/gpu/cuda_renderer.cu
+++ b/src/gpu/cuda_renderer.cu
@@ -46,6 +46,9 @@ void launchLightTreePick(
 void uploadProfileTable(const float* host, int count);
 // pkg55-C7 — device-resident profile count (owned by gpu_spectral_tables.cu).
 int uploadedProfileCount();
+// pkg218 — copies the baked dedicated-light emission-profile table into
+// device global memory (gpu_spectral_tables.cu).
+void uploadEmissionProfileTable(const float* host, int count);
 // pkg54b — one-time copy of CIE 1964 10° CMF tables into MW kernel constant memory.
 void uploadCmfTables();
 // pkg54c — one-time copy of the Jakob-Hanika sRGB sigmoid LUT into MW kernel
@@ -340,6 +343,9 @@ void CUDARenderer::uploadLights(const Renderer& cpuRenderer) {
     impl->numLights          = (int)r.lights.size();
     impl->numDedicatedLights = (int)r.dedicatedLights.size();  // pkg89-GPU / GAP 1
     impl->totalLightPower = r.totalLightPower;
+    // pkg218: dedicatedLights above may carry emissionProfileIndex into this
+    // table — re-upload it alongside the light buffer it's keyed by.
+    uploadEmissionProfileTable(r.emissionProfileTable.data(), r.emissionProfileCount);
 
     uploadLightTree(r);  // pkg86-B: tree arrays track the light buffer
 
@@ -522,9 +528,16 @@ void CUDARenderer::uploadScene(const Renderer& cpuRenderer, const Camera& cam) {
         uploadProfileTable(r.profileTable.data(), r.profileCount);
     }
 
-    printf("[CUDA] Scene uploaded: %zu nodes, %zu prims, %zu mats, %d lights, %d profiles\n",
+    // pkg218: upload the dedicated-light emission-profile table (device
+    // global memory). Always call — count==0 clears any stale table from a
+    // previous scene so a light-count-shrinking re-upload can't leave dangling
+    // indices resolving into old data.
+    uploadEmissionProfileTable(r.emissionProfileTable.data(), r.emissionProfileCount);
+
+    printf("[CUDA] Scene uploaded: %zu nodes, %zu prims, %zu mats, %d lights, %d profiles, "
+           "%d emission profiles\n",
            r.nodes.size(), r.prims.size(), r.materials.size(), impl->numLights,
-           r.profileCount);
+           r.profileCount, r.emissionProfileCount);
 }
 
 float CUDARenderer::lookupProfileReflectance(int profileIndex, float lambda) const {

--- a/src/gpu/gpu_nee.cuh
+++ b/src/gpu/gpu_nee.cuh
@@ -13,6 +13,7 @@
 #include "astroray/gpu_materials.h"
 #include "astroray/gpu_bvh.h"
 #include "light_tree_device.cuh"  // gpu_light_tree_pick (pkg86-B)
+#include "gpu_spectral_tables.h"  // pkg218: gpu_emission_profile
 
 #include <curand_kernel.h>
 
@@ -142,6 +143,7 @@ __device__ inline GNEESample gpu_dedicated_sample(
     s.isSphere    = 0;   // occlusion via the "any occluder in [eps,maxDist]" branch
     s.origin      = shadingPoint;
     s.dedEmissionRGB = d.emissionRGB;
+    s.dedEmissionProfileIndex = d.emissionProfileIndex;  // pkg218
 
     if (d.kind == GDED_POINT || d.kind == GDED_SPOT) {
         GVec3 sampledPos = d.position;
@@ -555,11 +557,22 @@ __device__ inline GSampledSpectrum gpu_nee_resolve(
     // RGBIlluminant path the CPU uses (gpu_rgbSpectrumAt == CPU
     // RGBIlluminantSpectrum::sample), scaled by the wavelength-independent
     // dedGeoScale (staticScale · per-sample geometric factor).
+    // pkg218 — non-RGB emission modes (blackbody/measured_spd/composite) carry
+    // a baked device SPD instead (dedEmissionProfileIndex >= 0): read it
+    // directly at the render wavelengths rather than upsampling the lossy
+    // RGB/RGBIlluminant reference. RGB mode (index == -1) is untouched —
+    // gpu_rgbSpectrumAt already reproduces CPU RGBIlluminantSpectrum exactly.
     GSampledSpectrum L_spec;
     if (s.isDedicated) {
-        for (int i = 0; i < G_SPECTRUM_SAMPLES; ++i)
-            L_spec[i] = gpu_rgbSpectrumAt(s.dedEmissionRGB, lambdas.lambda[i],
-                                          GSPEC_RGB_ILLUMINANT) * s.dedGeoScale;
+        if (s.dedEmissionProfileIndex >= 0) {
+            for (int i = 0; i < G_SPECTRUM_SAMPLES; ++i)
+                L_spec[i] = gpu_emission_profile(s.dedEmissionProfileIndex,
+                                                 lambdas.lambda[i]) * s.dedGeoScale;
+        } else {
+            for (int i = 0; i < G_SPECTRUM_SAMPLES; ++i)
+                L_spec[i] = gpu_rgbSpectrumAt(s.dedEmissionRGB, lambdas.lambda[i],
+                                              GSPEC_RGB_ILLUMINANT) * s.dedGeoScale;
+        }
     } else {
         L_spec = gpu_material_emitted_spectral(materials[s.lightMatId], lightFront, lambdas);
     }

--- a/src/gpu/gpu_spectral_tables.cu
+++ b/src/gpu/gpu_spectral_tables.cu
@@ -324,6 +324,69 @@ __device__ float gpu_sampleD65(float lambda) {
     return v * g_d65NormFactor;
 }
 
+// ---------------------------------------------------------------------------
+// pkg218: emission-profile table (device GLOBAL memory — see gpu_types.h's
+// G_EMISSION_* doc / gpu_spectral_tables.h's "widely-included header" note by
+// g_emissionProfileTable's declaration for why global memory, not
+// __constant__). Unlike the JH LUT / GGX glass tables (uploaded once, static
+// for the process), this is scene-dependent — the profile set changes with
+// the scene's dedicated lights — so uploadEmissionProfileTable reallocates
+// the device buffer on every call whose size grows, mirroring the devUpload<T>
+// helper's free-then-cudaMalloc pattern in cuda_renderer.cu.
+// ---------------------------------------------------------------------------
+__device__ const float* g_emissionProfileTable = nullptr;  // [count * G_EMISSION_SAMPLES]
+__device__ int          g_emissionProfileCount  = 0;
+
+static float* s_emissionProfileTableDev  = nullptr;
+static size_t s_emissionProfileTableCap  = 0;  // floats currently allocated
+
+void uploadEmissionProfileTable(const float* host, int count) {
+    size_t floats = (host && count > 0) ? size_t(count) * G_EMISSION_SAMPLES : 0;
+
+    if (floats == 0) {
+        // No emission profiles this scene: clear the device pointer/count so
+        // gpu_emission_profile rejects every index (RGB fallback for all).
+        if (s_emissionProfileTableDev) {
+            cudaFree(s_emissionProfileTableDev);
+            s_emissionProfileTableDev = nullptr;
+            s_emissionProfileTableCap = 0;
+        }
+        const float* nullPtr = nullptr;
+        int zero = 0;
+        cudaMemcpyToSymbol(g_emissionProfileTable, &nullPtr, sizeof(float*));
+        cudaMemcpyToSymbol(g_emissionProfileCount, &zero, sizeof(int));
+        return;
+    }
+
+    if (floats > s_emissionProfileTableCap) {
+        if (s_emissionProfileTableDev) cudaFree(s_emissionProfileTableDev);
+        cudaError_t e = cudaMalloc(reinterpret_cast<void**>(&s_emissionProfileTableDev),
+                                   floats * sizeof(float));
+        if (e != cudaSuccess) {
+            s_emissionProfileTableDev = nullptr;
+            s_emissionProfileTableCap = 0;
+            fprintf(stderr, "uploadEmissionProfileTable alloc failed: %s\n",
+                    cudaGetErrorString(e));
+            throw std::runtime_error(cudaGetErrorString(e));
+        }
+        s_emissionProfileTableCap = floats;
+    }
+
+    cudaError_t e = cudaMemcpy(s_emissionProfileTableDev, host, floats * sizeof(float),
+                               cudaMemcpyHostToDevice);
+    if (e == cudaSuccess) {
+        e = cudaMemcpyToSymbol(g_emissionProfileTable, &s_emissionProfileTableDev,
+                               sizeof(float*));
+    }
+    if (e == cudaSuccess) {
+        e = cudaMemcpyToSymbol(g_emissionProfileCount, &count, sizeof(int));
+    }
+    if (e != cudaSuccess) {
+        fprintf(stderr, "uploadEmissionProfileTable failed: %s\n", cudaGetErrorString(e));
+        throw std::runtime_error(cudaGetErrorString(e));
+    }
+}
+
 // pkg55-B' Session N+6: non-inline export of spectrumToXYZ for the wavefront
 // stage_advance TU (linked via -rdc=true). The inline spectrumToXYZ in
 // gpu_spectral_tables.h is TU-local over the constant CMF tables; this wrapper

--- a/src/gpu/gpu_spectral_tables.h
+++ b/src/gpu/gpu_spectral_tables.h
@@ -66,6 +66,15 @@ extern __device__ const float* g_jhLutScale;   // [res]
 extern __device__ const float* g_jhLutCoeffs;  // flat [3][res][res][res][3]
 extern __device__ int          g_jhLutRes;
 
+// pkg218: emission-profile table (baked EmissionSpectrum SPD for non-RGB
+// dedicated-light modes — blackbody/measured_spd/composite; see gpu_types.h's
+// G_EMISSION_* grid constants for the layout doc). Device GLOBAL memory, same
+// reasoning as the JH LUT above; re-uploaded per scene (unlike the static JH
+// LUT) via uploadEmissionProfileTable(). count == 0 / table == nullptr means
+// no scene profiles resident, matching the JH-LUT-style guard.
+extern __device__ const float* g_emissionProfileTable;  // [count * G_EMISSION_SAMPLES]
+extern __device__ int          g_emissionProfileCount;
+
 // ---------------------------------------------------------------------------
 // Host-callable uploads / probe (defined in gpu_spectral_tables.cu).
 // ---------------------------------------------------------------------------
@@ -78,6 +87,10 @@ void uploadJakobHanikaLut();
 void uploadProfileTable(const float* host, int count);
 // pkg55-C7: number of profiles currently resident on the device (0 = none).
 int uploadedProfileCount();
+// pkg218 — copies the baked emission-profile table (host layout: count rows
+// of G_EMISSION_SAMPLES floats) into device global memory. count == 0 clears
+// the device table (every emissionProfileIndex then falls back to RGB).
+void uploadEmissionProfileTable(const float* host, int count);
 // pkg54d — single-lookup probe binding (tests/test_gpu_profile_lookup.py).
 float launchProfileLookup(int profileIndex, float lambda);
 // pkg168 — test-only batch RGB→spectral upsampling probe. Returns nRgb*nLambda
@@ -114,6 +127,28 @@ __device__ inline float gpu_profile_reflectance(int profileIndex, float lambda_n
     const float* row = &g_profileTable[profileIndex * G_PROFILE_SAMPLES];
     if (i < 0)                       return row[0];
     if (i >= G_PROFILE_SAMPLES - 1)  return row[G_PROFILE_SAMPLES - 1];
+    return row[i] * (1.f - f) + row[i + 1] * f;
+}
+
+// pkg218 — linear-interpolated emission-profile lookup. Mirrors
+// gpu_profile_reflectance's interpolation shape above, but reads the emission
+// table (device global memory — g_emissionProfileTable, see the "widely-
+// included header" note by its declaration) on the G_EMISSION_LAMBDA_MIN/MAX/
+// STEP grid, which matches EmissionSpectrum::bakeDeviceProfile's per-nm
+// domain (src/emission_spectrum.cpp) so this reproduces the CPU eval to well
+// under 1%. profileIndex < 0 (RGB fallback) or out-of-range returns 0 — the
+// caller (gpu_nee.cuh gpu_nee_resolve) only takes this branch when
+// dedEmissionProfileIndex >= 0, so 0 here would only surface as a bug, not a
+// silently-tolerated fallback.
+__device__ inline float gpu_emission_profile(int profileIndex, float lambda_nm) {
+    if (profileIndex < 0 || profileIndex >= g_emissionProfileCount || !g_emissionProfileTable)
+        return 0.f;
+    float t = (lambda_nm - G_EMISSION_LAMBDA_MIN) / G_EMISSION_LAMBDA_STEP;
+    int   i = (int)t;
+    float f = t - (float)i;
+    const float* row = g_emissionProfileTable + profileIndex * G_EMISSION_SAMPLES;
+    if (i < 0)                        return row[0];
+    if (i >= G_EMISSION_SAMPLES - 1)  return row[G_EMISSION_SAMPLES - 1];
     return row[i] * (1.f - f) + row[i + 1] * f;
 }
 

--- a/src/gpu/scene_upload.cu
+++ b/src/gpu/scene_upload.cu
@@ -1072,6 +1072,9 @@ SceneUploadResult buildSceneArrays(const Renderer& cpu, const Camera* cam) {
             Vec3 E = sun->emittedRadiance();   // irradiance S (RGB)
             gd.emissionRGB = GVec3(E.x, E.y, E.z);
             gd.staticScale = 1.0f;             // magnitude carried in emissionRGB
+            // pkg218: the legacy hittable-sun conversion has no EmissionSpectrum
+            // (emittedRadiance() is a plain RGB) — always the RGB fallback.
+            gd.emissionProfileIndex = -1;
             convertedSuns.push_back(gd);
             convertedLegacySun = true;
             continue;                          // NO hittable GLight / no dead CDF slot
@@ -1136,6 +1139,7 @@ SceneUploadResult buildSceneArrays(const Renderer& cpu, const Camera* cam) {
             gd.power           = powerDist[k] - prev;
             gd.cumulativePower = powerDist[k];
             astroray::DeviceLightParams p;
+            gd.emissionProfileIndex = -1;  // pkg218 default: RGB fallback
             if (L && L->fillDeviceParams(p)) {
                 gd.kind        = p.kind;
                 gd.position    = GVec3(p.position.x, p.position.y, p.position.z);
@@ -1151,6 +1155,27 @@ SceneUploadResult buildSceneArrays(const Renderer& cpu, const Camera* cam) {
                 gd.cosOuter    = p.cosOuter;
                 gd.emissionRGB = GVec3(p.emissionRGB.x, p.emissionRGB.y, p.emissionRGB.z);
                 gd.staticScale = p.staticScale;
+                // pkg218: non-RGB emission modes (blackbody/measured_spd/
+                // composite) carry a baked device SPD (see light.h
+                // DeviceLightParams::emissionProfileSamples). Register it into
+                // the flat upload table and stamp the row index; RGB mode
+                // (exactIlluminant true) leaves emissionProfileSamples empty
+                // and keeps the -1 default (existing RGBIlluminant path).
+                if (!p.emissionProfileSamples.empty()) {
+                    if ((int)p.emissionProfileSamples.size() != G_EMISSION_SAMPLES) {
+                        fprintf(stderr,
+                                "[CUDA] WARNING: emission profile size %zu != "
+                                "G_EMISSION_SAMPLES %d; skipping device SPD "
+                                "(RGB fallback)\n",
+                                p.emissionProfileSamples.size(), G_EMISSION_SAMPLES);
+                    } else {
+                        gd.emissionProfileIndex =
+                            (int)(r.emissionProfileTable.size() / G_EMISSION_SAMPLES);
+                        r.emissionProfileTable.insert(r.emissionProfileTable.end(),
+                            p.emissionProfileSamples.begin(),
+                            p.emissionProfileSamples.end());
+                    }
+                }
             } else {
                 // Unsupported type (e.g. Background): keep the CDF slot aligned
                 // but flag invalid so the device sampler yields no contribution.
@@ -1158,6 +1183,9 @@ SceneUploadResult buildSceneArrays(const Renderer& cpu, const Camera* cam) {
             }
             r.dedicatedLights.push_back(gd);
         }
+        // pkg218: row count for uploadEmissionProfileTable (scene_upload.cu
+        // callers) — mirrors r.profileCount's dedicated field above.
+        r.emissionProfileCount = (int)(r.emissionProfileTable.size() / G_EMISSION_SAMPLES);
     }
 
     // pkg202: fold the converted legacy suns in as dedicated distant lights and

--- a/src/gpu/wavefront/gpu_wavefront_snapshot.cu
+++ b/src/gpu/wavefront/gpu_wavefront_snapshot.cu
@@ -33,6 +33,9 @@ void uploadJakobHanikaLut();
 // (pkg54a per-material spectral profiles).
 void uploadGgxGlassTables();
 void uploadProfileTable(const float* host, int count);
+// pkg218 — dedicated-light emission-profile table (gpu_spectral_tables.cu),
+// same reasoning as uploadProfileTable above.
+void uploadEmissionProfileTable(const float* host, int count);
 // pkg152 (#523, rebased into C7): reflection-lobe multi-scatter/layering
 // compensation tables (gpu_ggx_tables.cu) — required by gpu_disney_eval's
 // gpu_ggxCompensationFactor/DirectionalAlbedo/sheen/clearcoat lookups.
@@ -1679,6 +1682,10 @@ std::vector<float> cuda_wavefront_render(
     uploadThinFilmTable();  // pkg178 Stage 4 PR-3 — thin-film CIE sensitivity LUT
     if (res.profileCount > 0)
         uploadProfileTable(res.profileTable.data(), res.profileCount);
+    // pkg218: dedicated-light emission-profile table (device global memory).
+    // Always call — count==0 clears any stale table from a prior scene, same
+    // "clear on empty" contract cuda_renderer.cu's calls rely on.
+    uploadEmissionProfileTable(res.emissionProfileTable.data(), res.emissionProfileCount);
 
     // pkg131 — zero-knob adaptive sampling gate. `adaptiveOn` and `h_pixelSamples`
     // are function-scoped so the resolve loop below divides beauty by the per-pixel

--- a/src/gpu/wavefront/stage_advance.cu
+++ b/src/gpu/wavefront/stage_advance.cu
@@ -570,11 +570,23 @@ __device__ int intersectPathSlotT(
             dedLights, numDed, ray.origin, ray.direction, 0.001f, surfaceT,
             &lampT, &lampScale);
         if (lampIdx >= 0) {
+            // pkg218: a directly-visible dedicated light (area/distant disc hit
+            // by a BSDF-continuation ray) reads the baked device SPD for non-RGB
+            // emission modes, same substitution as the NEE paths above/below
+            // (gpu_nee.cuh gpu_nee_resolve, stageShadowKernel). This is the
+            // INTERSECT stage per the pkg181 comment above (not the REG:254
+            // shade kernel), so the extra branch is not register-critical.
+            int profIdx = dedLights[lampIdx].emissionProfileIndex;
             GSampledSpectrum Le;
-            for (int i = 0; i < G_SPECTRUM_SAMPLES; ++i)
-                Le.v[i] = gpu_rgbSpectrumAt(dedLights[lampIdx].emissionRGB,
-                                            lambdas.lambda[i], GSPEC_RGB_ILLUMINANT)
-                          * lampScale;
+            if (profIdx >= 0) {
+                for (int i = 0; i < G_SPECTRUM_SAMPLES; ++i)
+                    Le.v[i] = gpu_emission_profile(profIdx, lambdas.lambda[i]) * lampScale;
+            } else {
+                for (int i = 0; i < G_SPECTRUM_SAMPLES; ++i)
+                    Le.v[i] = gpu_rgbSpectrumAt(dedLights[lampIdx].emissionRGB,
+                                                lambdas.lambda[i], GSPEC_RGB_ILLUMINANT)
+                              * lampScale;
+            }
             if (Le.maxValue() > 0.f) {
                 // pkg199 Stage 1 (role 3): the lamp is closer than the surface,
                 // so throughput is not yet segment-attenuated; attenuate the
@@ -1368,6 +1380,7 @@ __device__ bool shadePathSlot(
                         nee_i[ 0 * nee_capacity + idx] = s.lightMatId;
                         nee_i[ 1 * nee_capacity + idx] = s.isSphere;
                         nee_i[ 2 * nee_capacity + idx] = s.isDedicated;  // pkg89-wavefront
+                        nee_i[ 5 * nee_capacity + idx] = s.dedEmissionProfileIndex;  // pkg218
                         // pkg157: park the bounce depth this NEE sample was taken
                         // at -- the shadow-resolve kernel runs in a later launch,
                         // after state.bounce[idx] may already have advanced (see
@@ -1736,6 +1749,7 @@ __global__ void stageShadowKernel(
     s.dedEmissionRGB = GVec3(nee_f[11 * nee_capacity + idx],
                              nee_f[12 * nee_capacity + idx],
                              nee_f[13 * nee_capacity + idx]);
+    s.dedEmissionProfileIndex = nee_i[5 * nee_capacity + idx];  // pkg218
     s.valid      = 1;
 
     // pkg55-C4: thread TLAS + path time + motionVerts to shadow rays.
@@ -1762,9 +1776,21 @@ __global__ void stageShadowKernel(
         // pkg89-wavefront: dedicated lights carry emission intrinsically —
         // same RGBIlluminant upsample gpu_nee_resolve uses (dedGeoScale
         // already folded into the parked lanes at shade time).
-        for (int k = 0; k < G_SPECTRUM_SAMPLES; ++k)
-            L_spec[k] = gpu_rgbSpectrumAt(s.dedEmissionRGB, lambdas.lambda[k],
-                                          GSPEC_RGB_ILLUMINANT);
+        // pkg218: non-RGB emission modes read the baked device SPD instead
+        // (dedEmissionProfileIndex >= 0) — same substitution as gpu_nee_resolve
+        // (gpu_nee.cuh), parked/read via nee_i lane 5 since this kernel resolves
+        // the emission in a LATER launch than gpu_dedicated_sample. This lean
+        // shadow-resolve kernel is explicitly not register-critical (see the
+        // file-header note above), so the branch costs nothing worth measuring.
+        if (s.dedEmissionProfileIndex >= 0) {
+            for (int k = 0; k < G_SPECTRUM_SAMPLES; ++k)
+                L_spec[k] = gpu_emission_profile(s.dedEmissionProfileIndex,
+                                                 lambdas.lambda[k]);
+        } else {
+            for (int k = 0; k < G_SPECTRUM_SAMPLES; ++k)
+                L_spec[k] = gpu_rgbSpectrumAt(s.dedEmissionRGB, lambdas.lambda[k],
+                                              GSPEC_RGB_ILLUMINANT);
+        }
     } else {
         bool lightFront = s.isSphere ? (occ.frontFace != 0) : true;
         L_spec = gpu_material_emitted_spectral(
@@ -2172,6 +2198,7 @@ __global__ void stageVolumeScatterKernel(
                 nee_i[ 1 * nee_capacity + idx] = s.isSphere;
                 nee_i[ 2 * nee_capacity + idx] = s.isDedicated;
                 nee_i[ 3 * nee_capacity + idx] = bounce;
+                nee_i[ 5 * nee_capacity + idx] = s.dedEmissionProfileIndex;  // pkg218
                 // pkg204: volume direct/indirect encoding (see G_WF_NEE_I_LANES).
                 // +(bounce+1) for a first-interaction in-scatter (=> VOLUME_DIRECT),
                 // -(bounce+1) for a deeper scatter (=> VOLUME_INDIRECT). The shadow

--- a/src/lights/area_light.cpp
+++ b/src/lights/area_light.cpp
@@ -241,6 +241,8 @@ bool AreaLight::fillDeviceParams(DeviceLightParams& out) const {
     out.areaShape = static_cast<int>(shape_);  // Rectangle=0, Disk=1, Ellipse=2
     out.spread    = spread_;
     emission_.deviceReference(out.emissionRGB, out.exactIlluminant);
+    // pkg218: baked device SPD for non-RGB emission modes (see point_light.cpp).
+    if (!out.exactIlluminant) out.emissionProfileSamples = emission_.bakeDeviceProfile();
     // staticScale = intensity·(1/area)·(1/π) = plain Lambertian radiance L_e =
     // P/(π·A); normalizeFactor_ == 1/area. pkg122: the device carries L_e directly
     // and recomputes area from shape+width+height for the SOLID-ANGLE pdf

--- a/src/lights/distant_light.cpp
+++ b/src/lights/distant_light.cpp
@@ -217,6 +217,8 @@ bool DistantLight::fillDeviceParams(DeviceLightParams& out) const {
     // cancellation the CPU fix addresses) -- see gpu_nee.cuh gpu_dedicated_sample.
     out.spread   = distantSolidAngle(angularDiameter_);
     emission_.deviceReference(out.emissionRGB, out.exactIlluminant);
+    // pkg218: baked device SPD for non-RGB emission modes (see point_light.cpp).
+    if (!out.exactIlluminant) out.emissionProfileSamples = emission_.bakeDeviceProfile();
     // Distant light omits the 1/π factor (matches distant_light.cpp sampleLi).
     out.staticScale = intensity_ * normalizeFactor_;
     return true;

--- a/src/lights/point_light.cpp
+++ b/src/lights/point_light.cpp
@@ -142,6 +142,12 @@ bool PointLight::fillDeviceParams(DeviceLightParams& out) const {
     out.position = position_;
     out.radius   = radius_;
     emission_.deviceReference(out.emissionRGB, out.exactIlluminant);
+    // pkg218: non-RGB modes (blackbody/measured_spd/composite) also get a
+    // baked device SPD so the GPU can render the exact emission spectrum
+    // instead of the RGBIlluminant approximation (see gpu_nee.cuh
+    // gpu_nee_resolve). RGB mode leaves this empty — its deviceReference path
+    // is already exact.
+    if (!out.exactIlluminant) out.emissionProfileSamples = emission_.bakeDeviceProfile();
     // pkg122 (Defect 2): staticScale = intensity·(1/(4π)) = radiant intensity
     // I = P/(4π). Matches sampleLi: emissionSpec *= intensity_ * kInvFourPiF * falloff.
     constexpr float kInvFourPiF = 0.07957747155f;  // 1/(4π)

--- a/src/lights/spot_light.cpp
+++ b/src/lights/spot_light.cpp
@@ -183,6 +183,8 @@ bool SpotLight::fillDeviceParams(DeviceLightParams& out) const {
     out.cosInner = std::cos(innerAngle_);
     out.cosOuter = std::cos(outerAngle_);
     emission_.deviceReference(out.emissionRGB, out.exactIlluminant);
+    // pkg218: baked device SPD for non-RGB emission modes (see point_light.cpp).
+    if (!out.exactIlluminant) out.emissionProfileSamples = emission_.bakeDeviceProfile();
     // pkg122: staticScale = intensity·(1/(4π)) = I = P/(4π), matching sampleLi.
     constexpr float kInvFourPiF = 0.07957747155f;  // 1/(4π)
     out.staticScale = intensity_ * kInvFourPiF;

--- a/tests/test_gpu_emission_colour_parity.py
+++ b/tests/test_gpu_emission_colour_parity.py
@@ -1,4 +1,4 @@
-"""CPU<->GPU emission-colour parity for preset (measured_spd) lamps.
+"""CPU<->GPU emission-colour parity for preset (measured_spd) and blackbody lamps.
 
 Regression gate for the deviceReference chroma bug (2026-08-22): the GPU renders
 non-RGB emission (measured_spd / blackbody / composite) as an RGB approximation
@@ -8,19 +8,22 @@ range -- four fixed wavelengths (595, 712.5, 830, 477.5) that badly undersample
 a structured lamp SPD (830 nm is dead for a 380-780 nm LED; none lands on the
 blue pump peak). The result was a strongly red/orange-biased RGB the GPU rendered
 faithfully: salmon LEDs, over-orange sodium, reddish mercury (live Blender repro:
-led_5000k GPU R/G ~1.52 vs CPU ~1.09). The fix replaces the 4-sample MC with a
-fine 1 nm CMF-grid integral (emission_spectrum.cpp), so the reference RGB carries
-the true chroma.
+led_5000k GPU R/G ~1.52 vs CPU ~1.09). The deviceReference fix (2026-08-22)
+replaced the 4-sample MC with a fine 1 nm CMF-grid integral, closing the gross
+chroma error but leaving a residual few-% gap (JH RGB round-trip + RGBIlluminant's
+baked D65 shape).
+
+pkg218 (this gate's tightening) closes that residual: non-RGB dedicated-light
+emission (blackbody / measured_spd / composite) is now baked onto a device SPD
+table (EmissionSpectrum::bakeDeviceProfile, 360-830 nm @ 1 nm) and evaluated
+directly at the render wavelengths (gpu_emission_profile, gpu_nee.cuh /
+stage_advance.cu stageShadowKernel) instead of being upsampled through
+RGBIlluminant. RGB-mode emission is untouched (already bit-exact).
 
 This asserts per-channel mean-ratio parity (NOT SSIM -- CPU and GPU draw
 independent RNG streams; see memory ssim-wrong-gate-for-independent-rng). It runs
 the dedicated-light NEE path (integrator "path_tracer"); the naive
 "multiwavelength_path_tracer" does not drive GPU dedicated-light NEE.
-
-Broadband lamps reach a few-% parity here. Narrow line lamps (sodium) keep a
-larger chroma gap that is intrinsic to the RGB approximation and is closed by the
-follow-up device-SPD upload (pkg218); this test only asserts sodium improved well
-past the old red bias, not tight parity.
 """
 import os
 
@@ -86,12 +89,16 @@ needs = pytest.mark.skipif(not HAS_PROFILES or not (AVAILABLE and _has_gpu()),
 
 
 @needs
-@pytest.mark.parametrize("profile", ["led_5000k", "led_3000k", "mercury_vapor", "cie_f2"])
+@pytest.mark.parametrize(
+    "profile", ["led_5000k", "led_3000k", "mercury_vapor", "cie_f2", "sodium_vapor"])
 def test_broadband_lamp_cpu_gpu_parity(profile):
-    """Broadband preset lamps: GPU per-channel mean within 8% of CPU.
+    """Preset (measured_spd) lamps: GPU per-channel mean within 5% of CPU.
 
-    (Measured ~2-4% post-fix; 8% leaves margin for MC noise + boost-clock drift.
-    Pre-fix, led_5000k red channel was ~40% hot vs its own CPU render.)
+    pkg218 tightened this from 8% (deviceReference-only) to 5% (target from the
+    package spec) now that non-RGB emission is evaluated from the baked device
+    SPD directly, not upsampled through RGBIlluminant. Includes sodium_vapor
+    (a narrow atomic line, previously loose-gated at 30% -- see
+    test_sodium_lamp_amber_and_tight below for the direct regression guard).
     """
     em = {"mode": "measured_spd", "profile_name": profile}
     cpu = _lamp_channels(em, use_gpu=False)
@@ -103,9 +110,32 @@ def test_broadband_lamp_cpu_gpu_parity(profile):
     maxdev = float(np.abs(ratio - 1.0).max())
     print(f"[{profile}] CPU={cpu.round(4)} GPU={gpu.round(4)} "
           f"R/G cpu={_rg(cpu):.3f} gpu={_rg(gpu):.3f} maxdev={maxdev*100:.1f}%")
-    assert maxdev < 0.08, (
-        f"{profile}: CPU/GPU per-channel mismatch {maxdev*100:.1f}% > 8% "
+    assert maxdev < 0.05, (
+        f"{profile}: CPU/GPU per-channel mismatch {maxdev*100:.1f}% > 5% "
         f"(CPU={cpu}, GPU={gpu})"
+    )
+
+
+@needs
+@pytest.mark.parametrize("temperature_k", [3000.0, 6500.0])
+def test_blackbody_cpu_gpu_parity(temperature_k):
+    """Blackbody emission (the DEFAULT lamp mode) at 3000 K / 6500 K: GPU
+    per-channel mean within 5% of CPU. pkg218 acceptance criterion -- blackbody
+    is the default emission mode, so any chroma shift here changes every
+    default-configured lamp, not just the measured_spd presets."""
+    em = {"mode": "blackbody", "temperature_K": temperature_k, "tint_rgb": [1, 1, 1]}
+    cpu = _lamp_channels(em, use_gpu=False)
+    gpu = _lamp_channels(em, use_gpu=True)
+    assert cpu.min() > 1e-3 and gpu.min() > 1e-3, (
+        f"{temperature_k}K: lamp rendered near-black CPU={cpu} GPU={gpu}"
+    )
+    ratio = gpu / np.maximum(cpu, 1e-9)
+    maxdev = float(np.abs(ratio - 1.0).max())
+    print(f"[blackbody {temperature_k}K] CPU={cpu.round(4)} GPU={gpu.round(4)} "
+          f"R/G cpu={_rg(cpu):.3f} gpu={_rg(gpu):.3f} maxdev={maxdev*100:.1f}%")
+    assert maxdev < 0.05, (
+        f"blackbody {temperature_k}K: CPU/GPU per-channel mismatch "
+        f"{maxdev*100:.1f}% > 5% (CPU={cpu}, GPU={gpu})"
     )
 
 
@@ -118,9 +148,9 @@ def test_led_5000k_not_red_shifted():
     gpu = _lamp_channels(em, use_gpu=True)
     rg_cpu, rg_gpu = _rg(cpu), _rg(gpu)
     print(f"[led_5000k] R/G cpu={rg_cpu:.3f} gpu={rg_gpu:.3f}")
-    # GPU R/G within 8% of CPU, and comfortably below the pre-fix salmon regime
-    # (the live repro showed GPU R/G inflated ~40% over CPU).
-    assert abs(rg_gpu - rg_cpu) / rg_cpu < 0.08, (
+    # GPU R/G within 5% of CPU (pkg218), and comfortably below the pre-fix
+    # salmon regime (the live repro showed GPU R/G inflated ~40% over CPU).
+    assert abs(rg_gpu - rg_cpu) / rg_cpu < 0.05, (
         f"led_5000k GPU R/G {rg_gpu:.3f} vs CPU {rg_cpu:.3f} -- red-shift regressed"
     )
     assert rg_gpu < rg_cpu * 1.15, (
@@ -129,10 +159,12 @@ def test_led_5000k_not_red_shifted():
 
 
 @needs
-def test_sodium_lamp_improved_not_red():
-    """Sodium line lamp: the RGB approximation keeps a larger chroma gap (closed
-    by pkg218's device-SPD upload), so parity is loose here -- but the GPU render
-    must still be amber and track the CPU hue direction, not the old red bias."""
+def test_sodium_lamp_amber_and_tight():
+    """Sodium line lamp: pkg218's device-SPD upload closes the residual chroma
+    gap the RGB approximation left (previously loose-gated at 30% here -- see
+    the file docstring). The GPU render must be amber (tracking the CPU hue
+    direction, not the old red bias) AND now hit the same 5% per-channel
+    mean-ratio band as the broadband lamps above."""
     em = {"mode": "measured_spd", "profile_name": "sodium_vapor"}
     cpu = _lamp_channels(em, use_gpu=False)
     gpu = _lamp_channels(em, use_gpu=True)
@@ -141,7 +173,7 @@ def test_sodium_lamp_improved_not_red():
     assert gpu[0] > 1e-3, f"sodium GPU render black: {gpu}"
     # Amber: R dominant over G, G over (tiny) B.
     assert gpu[0] > gpu[1] > gpu[2], f"sodium GPU not amber: {gpu}"
-    # Loose chroma tracking (pkg218 tightens to a few %).
-    assert abs(_rg(gpu) - _rg(cpu)) / _rg(cpu) < 0.30, (
-        f"sodium GPU R/G {_rg(gpu):.3f} far from CPU {_rg(cpu):.3f}"
+    assert abs(_rg(gpu) - _rg(cpu)) / _rg(cpu) < 0.05, (
+        f"sodium GPU R/G {_rg(gpu):.3f} vs CPU {_rg(cpu):.3f} -- pkg218 device-SPD "
+        f"gate regressed"
     )

--- a/tests/test_gpu_emission_colour_parity.py
+++ b/tests/test_gpu_emission_colour_parity.py
@@ -103,16 +103,24 @@ def test_broadband_lamp_cpu_gpu_parity(profile):
     em = {"mode": "measured_spd", "profile_name": profile}
     cpu = _lamp_channels(em, use_gpu=False)
     gpu = _lamp_channels(em, use_gpu=True)
-    assert cpu.min() > 1e-3 and gpu.min() > 1e-3, (
+    # A lamp must emit *something* — guard the near-black GPU failure mode via the
+    # brightest channel (a narrow-line lamp like sodium legitimately has a zero
+    # channel, so .min() would false-fail).
+    assert cpu.max() > 1e-3 and gpu.max() > 1e-3, (
         f"{profile}: lamp rendered near-black CPU={cpu} GPU={gpu}"
     )
-    ratio = gpu / np.maximum(cpu, 1e-9)
-    maxdev = float(np.abs(ratio - 1.0).max())
+    # CPU/GPU parity: per-channel ratio only on channels the CPU actually emits in.
+    # A channel that is ~0 on CPU (sodium's blue) is compared as absolute agreement
+    # near zero, not a 0/0 ratio artifact.
+    sig = cpu > 1e-3 * cpu.max()
+    ratio = gpu[sig] / cpu[sig]
+    maxdev = float(np.abs(ratio - 1.0).max()) if sig.any() else 0.0
+    dark_ok = bool((np.abs(gpu[~sig] - cpu[~sig]) < 1e-2).all())
     print(f"[{profile}] CPU={cpu.round(4)} GPU={gpu.round(4)} "
           f"R/G cpu={_rg(cpu):.3f} gpu={_rg(gpu):.3f} maxdev={maxdev*100:.1f}%")
-    assert maxdev < 0.05, (
+    assert maxdev < 0.05 and dark_ok, (
         f"{profile}: CPU/GPU per-channel mismatch {maxdev*100:.1f}% > 5% "
-        f"(CPU={cpu}, GPU={gpu})"
+        f"(CPU={cpu}, GPU={gpu}, dark_ok={dark_ok})"
     )
 
 


### PR DESCRIPTION
## Summary

Closes the pkg218 gap: the GPU previously rendered **all** non-RGB dedicated-light emission (blackbody / measured_spd / composite) via an RGB approximation — one reference RGB upsampled through `RGBIlluminant(rgb)·D65` (`gpu_rgbSpectrumAt(..., GSPEC_RGB_ILLUMINANT)`). After the deviceReference fix (#638) the chroma of that reference RGB was fine-integrated, but the render itself still couldn't match the CPU's true-SPD render (JH RGB round-trip + RGBIlluminant's baked D65 shape).

This PR bakes the `EmissionSpectrum` onto a fixed device grid (`EmissionSpectrum::bakeDeviceProfile`, 360-830 nm @ 1 nm, matching the CIE CMF support) at scene-upload time for any non-RGB dedicated light, uploads it to device global memory, and evaluates it directly at the render wavelengths (`gpu_emission_profile`) instead of the RGB approximation. RGB-mode emission (already bit-exact) is untouched.

## Design decisions (surfacing, since the spec left them open)

- **Global memory, not `__constant__`.** The spec's design section allowed either ("constant or global mem, mirror `g_profileTable`"). I chose global memory (mirrors the JH LUT / GGX glass-table precedent in `gpu_glass_tables.cuh`) because a fixed `__constant__` table sized `G_MAX_EMISSION_PROFILES x 471 samples` risked pushing the shared 64 KB constant-memory budget (already consumed by `g_profileTable`, CMF/D65 tables, several wavefront `__constant__` bindings, Sobol matrices) into overflow -- measurable only by actually linking, which I can't do here. Global memory sidesteps the question entirely and needs no fixed profile-count cap.
- **Scope: dedicated lights only, not "the emissive `GMaterial` mode."** The spec's step 2 says to add `emissionProfileIndex` "to `GDedicatedLight` and to the emissive `GMaterial` emission mode." I verified via grep that `EmissionSpectrum` is used only by the four dedicated-light types (point/spot/area/distant) -- the CPU's `GCLOSURE_EMISSION` shader-node closure (mesh emissive materials) is plain RGB times strength on both CPU and GPU already, with no `EmissionSpectrum` wiring at all. There is no material-side gap to close. I implemented the real gap (dedicated lights) and left materials untouched -- flagging this rather than inventing scope.
- **GMaterial / REG:254 shade kernel untouched.** Per the dispatch instructions, no field was added to `GMaterial`. Emission-profile substitution happens entirely via `GDedicatedLight.emissionProfileIndex` (a plain global-memory array element, not per-hit state) and a new `GNEESample.dedEmissionProfileIndex` int field (see Register risk below).
- **ReSTIR (`stage_restir.cu`) deferred.** `GReSTIRCandidate::emission` stores plain RGB for reservoir reuse/resampling; wiring spectral emission through would need a larger reservoir-struct change. `cuda_wavefront_render_restir` is a separate opt-in entry point, not the default `set_use_gpu(True)` path, so this doesn't affect the acceptance-criteria test.

## Files changed (authorized surface vs. actual)

Spec's reference section named: `emission_spectrum.h/.cpp`, `gpu_spectral_tables.{h,cu}`, `scene_upload.cu`, `gpu_nee.cuh`, `gpu_materials.h`, `stage_advance.cu`. Actual diff:

- `include/astroray/emission_spectrum.h`, `src/emission_spectrum.cpp` -- `bakeDeviceProfile()` + fixed CPU-side grid constants.
- `include/astroray/light.h` -- `DeviceLightParams::emissionProfileSamples`.
- `src/lights/{point,spot,area,distant}_light.cpp` -- wire `bakeDeviceProfile()` into `fillDeviceParams` (3-line addition each, mirrors the existing `deviceReference` call).
- `include/astroray/gpu_types.h` -- `G_EMISSION_*` grid constants, `GDedicatedLight.emissionProfileIndex`, `GNEESample.dedEmissionProfileIndex`.
- `include/astroray/gpu_scene_upload.h`, `src/gpu/scene_upload.cu` -- `SceneUploadResult::emissionProfileTable/Count`, registration + `-1` defaults at both `GDedicatedLight` construction sites (legacy-sun conversion and the main dedicated-light loop).
- `src/gpu/gpu_spectral_tables.{h,cu}` -- device table (`g_emissionProfileTable`/`g_emissionProfileCount`, global memory), `uploadEmissionProfileTable`, `gpu_emission_profile` lookup.
- `src/gpu/cuda_renderer.cu`, `src/gpu/wavefront/gpu_wavefront_snapshot.cu` -- wire the upload call at all 3 existing `uploadProfileTable` call sites (materials-only upload is correctly NOT one of them, mirroring how it doesn't touch `dedicatedLights` either).
- `src/gpu/gpu_nee.cuh` -- `gpu_dedicated_sample` threads the index; `gpu_nee_resolve` branches on it (the "immediate/flat" NEE path).
- **`src/gpu/wavefront/stage_advance.cu` + `include/astroray/gpu_wavefront_state.h`** -- NOT in the spec's reference list, but required: the spec's reference only names `gpu_nee_resolve`, but the actual production wavefront scheduling is "Deferred" (bucketed), which parks NEE samples into a `nee_f`/`nee_i` SoA and resolves them later in `stageShadowKernel` -- a different code path with its own independent RGB-upsample call. I traced this (not in the spec) and patched it too, plus a third site (`intersectPathSlot`, a directly-visible area/distant light hit by a BSDF-continuation ray) and the volume in-scatter NEE park site. `G_WF_NEE_I_LANES` bumped 5 to 6 for the new parked index.
- `tests/test_gpu_emission_colour_parity.py` -- tightened the deviceReference regression gate from 8%/30% to the spec's 5% target; added a blackbody 3000K/6500K sweep (the default emission mode, per acceptance criteria).

## Register-footprint risk (flagging per the dispatch instructions -- I cannot build/verify this myself)

- `GMaterial`: untouched, 0 bytes.
- `GNEESample` gained one `int` field (`dedEmissionProfileIndex`). This struct already carries `dedEmissionRGB`/`dedGeoScale` for the identical purpose (denormalized copies threaded through the pkg55-B' A(sample)->B(shadow-trace)->C(resolve) split); the new field is architecturally the same category, not a new one. It IS written inside `shadePathSlot<Deferred,...>` (instantiated into the REG:254-pinned `stageShadeBucketedKernel`) as a single extra global-memory store (`nee_i[5*cap+idx] = ...`) alongside the existing `nee_i[2*cap+idx] = s.isDedicated` store -- I believe this is register-neutral (matches the "trivial store, no retained live state" shape that's proven zero-cost elsewhere, e.g. pkg223's side-table pattern), but I cannot confirm without linking.
- **Requested gate:** please run the `cuobjdump` post-link + `ASTRORAY_PROFILE` register probe (memory `wavefront-shade-kernels-register-saturated`) on `stageShadeBucketedKernel` before/after this PR. If REG:254 regresses, the fallback is moving `dedEmissionProfileIndex` off `GNEESample` onto a `__constant__` side-table keyed by light index (the `GWavefrontTextureBinding`/pkg223 pattern) -- I did not do this preemptively to keep the diff minimal, since `GNEESample` is inherently per-hit-live state already (unlike `GMaterial`).
- `stageShadowKernel` and `intersectPathSlot` are explicitly commented in the existing code as NOT register-critical (the whole reason the pkg55-B' deferred design exists), so the substitution branches added there carry no flagged risk.

## Build target / verification the parent needs to run

- **Build:** `build_cuda_worktree.bat ../Astroray-pkg218 <head-sha>` from the main checkout. This PR touches `.cu`/`.cuh`/`.h` -- I have not built this; do not trust it until it builds clean.
- **HW gate:** `pytest tests/test_gpu_emission_colour_parity.py -v` on the RTX 5070 Ti -- 9 tests: `test_broadband_lamp_cpu_gpu_parity[led_5000k/led_3000k/mercury_vapor/cie_f2/sodium_vapor]`, `test_blackbody_cpu_gpu_parity[3000.0/6500.0]`, `test_led_5000k_not_red_shifted`, `test_sodium_lamp_amber_and_tight`. All gate at 5% per-channel mean-ratio (tightened from the prior 8%/30%, per this package's own acceptance criteria -- if measurement disagrees, the gate needs adjusting with the measured numbers cited, not silently reverted).
- **Register probe:** see above.
- **Visual check (spec's own acceptance criterion):** mercury reads blue-green/blue-white, sodium reads amber-not-red.

## Acceptance criteria (spec) checklist

- [ ] CPU<->GPU emission-colour parity test, per-channel mean-ratio <=5%, for `led_5000k`/`led_3000k`/`sodium_vapor`/`mercury_vapor`/`cie_f2`/blackbody 3000K/6500K -- implemented, needs HW run.
- [ ] The loose deviceReference regression gate is tightened (not xfail'd) -- done (8% to 5%, 30% to 5%; see test diff).
- [ ] HW-verified on RTX 5070 Ti, visual check -- pending, not run by me (no GPU access in this environment; per dispatch instructions I did not render or fabricate results).

## Algorithm sourcing (CLAUDE.md section 6)

No new physics/sampling algorithm -- this is table-baking (linear interpolation, same shape as the existing pkg54a `gpu_profile_reflectance`) plus a device-memory upload pattern already established in this codebase (pkg54c JH LUT, pkg151/pkg152 GGX tables). No `cite-algorithm` skill invocation needed.

Generated with [Claude Code](https://claude.com/claude-code)
