### PR TITLE
pkg225-S1: ray-curve intersection (Stage 1) — primitive correct, fix test harness + position AOV

### DIFF
--- a/.astroray_plan/docs/pkg225-curve-intersect-research.md
+++ b/.astroray_plan/docs/pkg225-curve-intersect-research.md
@@ -1,0 +1,150 @@
+# pkg225 Stage 1 — ray-curve intersection: algorithm research
+
+CLAUDE.md §6 gate: no invented geometry algorithms. This note records the
+canonical sources used for `CurveSegment` (thick/swept-circle CPU ray-curve
+intersection) before any code was written, per the `cite-algorithm` skill.
+
+## Chosen primary algorithm: pbrt-v3 `Curve::Intersect` (BSD-2-Clause)
+
+Source: `mmp/pbrt-v3`, `src/shapes/curve.cpp`
+(https://github.com/mmp/pbrt-v3/blob/master/src/shapes/curve.cpp), copyright
+Matt Pharr / Greg Humphreys / Wenzel Jakob, BSD-2-Clause license (permissive,
+compatible). Fetched verbatim 2026-08-31 and diffed against the pbrt book
+text; this is the canonical "recursive Bezier-clipping" ray-curve test that
+pbrt-v4 also ships (v4 refactors the same math into `pbrt::Curve` with GPU
+variants but the CPU algorithm is unchanged).
+
+**Why this one, not Cycles' full `curve_intersect.h` or Reshetov 2017
+directly:** the pkg225 spec's own Reference section names all three as
+candidates. Cycles' current `kernel/geom/curve_intersect.h` (Apache-2.0,
+adapted from Embree's `curve_intersector_sweep.h`) additionally layers
+outer/inner bounding-cylinder pruning and a 5-iteration Newton-Raphson
+final refinement on top of the same recursive-subdivision idea, explicitly
+to hit GPU/SIMD performance targets. That refinement is a Stage-3
+(GPU/perf) concern, not a Stage-1 CPU-correctness concern. Reshetov 2017
+("Phantom Ray-Hair Intersector") is a fully-analytic single-cylinder test
+that is Cycles' *historical* OptiX/embree-adjacent reference for straight
+segments; it does not natively cover curved (non-degenerate-tangent)
+Catmull-Rom segments without the same kind of iterative correction Cycles
+now uses. pbrt's recursive Bezier-subdivision test is (a) exact to a
+controllable epsilon for ANY cubic segment including dead-straight ones
+(so it gives a clean closed-form-matching analytic parity test), (b)
+self-contained (no Newton iteration, no SIMD-specific cylinder-pruning
+machinery), and (c) already produces exactly the `u` (along-strand) and
+`v` (azimuthal, `CurveType::Cylinder` branch) parametrization the spec
+asks `HitRecord` to carry. It is the right scope for "CPU primitive +
+analytic parity test."
+
+### Algorithm, as implemented in Astroray
+
+1. **Coordinate frame.** Build a ray-local orthonormal frame with
+   `zAxis = ray.direction` (already normalized — Astroray's `Ray` ctor
+   normalizes direction, so `rayLength == 1` always; pbrt's `rayLength`
+   scaling collapses out) and `xAxis` derived from
+   `dx = cross(ray.direction, bezier[3] - bezier[0])` (pbrt's `LookAt`
+   orientation trick — keeps the curve's hull close to the local x-axis,
+   which tightens the early-out y-bound). Degenerate `dx` (ray parallel to
+   the chord) falls back to `buildOrthonormalBasis()` (existing Astroray
+   helper, used elsewhere for tangent frames) exactly as pbrt falls back to
+   `CoordinateSystem()`.
+2. **Project the 4 Bezier control points into that frame** (world-space
+   curve, so no object-to-world step — Astroray stores curves directly in
+   world space like `Triangle`/`Sphere`).
+3. **Adaptive max recursion depth** from pbrt's `L0`/`eps` heuristic
+   (second-difference flatness measure vs. `max(radius)*0.1` — pbrt uses
+   `width*0.05`; width = 2*radius so the constant carries over unchanged),
+   `maxDepth = clamp(round(log4(1.41421356 * 6 * L0 / (8*eps))), 0, 10)`.
+4. **`recursiveIntersect`**: at `depth > 0`, `SubdivideBezier` (de Casteljau
+   midpoint split, pbrt's closed-form 7-point split) into two half-segments,
+   reject each against the ray's local-frame AABB (y first, then x, then z
+   against `[0, tMax]`), recurse. At `depth == 0`: reject via the two
+   "tangent-perpendicular" edge functions at the segment ends (rejects hits
+   past the flattened segment's endpoints), find the closest point `w` on
+   the projected chord, evaluate the true Bezier point at `w` for the
+   perpendicular distance test against the interpolated radius
+   (`dist² > radius(u)²`), and the `z` (=`t`, since `rayLength==1`) bound.
+5. **Cylinder (swept-circle) shading frame.** `v ∈ [0,1]` from which side of
+   the chord the true curve point falls (edge-function sign), then
+   `theta = lerp(v, -90°, 90°)` rotates the flat perpendicular `dpdv` around
+   the true-curve tangent `dpdu` — this is pbrt's `CurveType::Cylinder`
+   branch, the one that gives a genuine round/azimuthal cross-section
+   (as opposed to `CurveType::Ribbon`, which the pkg225 spec defers to
+   Stage 3). `hair_u = u`, `hair_v = v` are stored on `HitRecord` per the
+   spec's "Key design decisions."
+
+Width vs. radius: pbrt parametrizes by `width` (diameter); Astroray's
+`CurveSegment` ctor takes `radius0, radius1` per the spec's
+"per-endpoint radius" file-table entry, so every pbrt `width`/`hitWidth`
+term is substituted with `2*radius` and the `hitWidth² * 0.25` distance
+threshold becomes `radius²` directly — algebraically identical, just
+avoids a factor-of-2-then-back-again round trip in the code.
+
+## Catmull-Rom → Bezier control-hull conversion
+
+pbrt's algorithm consumes a **Bezier** control hull; Blender's `Curves`
+data-block (and Cycles) use **Catmull-Rom** (uniform, tension 1/2) as the
+default basis, which is what the pkg225 spec requires
+("Basis: Catmull-Rom cubic (Blender's `Curves` data-block default)").
+The bridge is the standard uniform Catmull-Rom → cubic-Bezier identity
+(finite-difference tangents `m1=(P2-P0)/2, m2=(P3-P1)/2` fed through the
+textbook cubic-Hermite → Bezier conversion `B0=P1, B1=P1+m1/3, B2=P2-m2/3,
+B3=P2`) — CLAUDE.md §6 treats this as "trivial textbook math," not an
+algorithm to cite-and-borrow, but it was still cross-checked (not asserted
+from memory) against Cycles' `catmull_rom_basis_eval` in
+`kernel/geom/curve_intersect.h` (Apache-2.0, Blender Foundation):
+
+```c
+// Cycles catmull_rom_basis_eval, fetched 2026-08-31:
+ccl_device_inline float4 catmull_rom_basis_eval(const float4 curve[4], float u)
+{
+  const float t = u;
+  const float s = 1.0f - u;
+  const float n0 = -t * s * s;
+  const float n1 = 2.0f + t * t * (3.0f * t - 5.0f);
+  const float n2 = 2.0f + s * s * (3.0f * s - 5.0f);
+  const float n3 = -s * t * t;
+  return 0.5f * (curve[0] * n0 + curve[1] * n1 + curve[2] * n2 + curve[3] * n3);
+}
+```
+
+Evaluating this basis and its derivative at `u=0` and `u=1` gives
+`P(0)=P1`, `P(1)=P2`, `dP/du|_{u=0} = (P2-P0)/2`, `dP/du|_{u=1} = (P3-P1)/2`
+— confirms it is exactly the tension-1/2 uniform Catmull-Rom used above, so
+the Bezier hull built via `B0=P1, B1=P1+(P2-P0)/6, B2=P2-(P3-P1)/6, B3=P2`
+reproduces Cycles' curve position/tangent exactly (both are the same cubic
+polynomial in two different but algebraically-equivalent bases).
+
+## Phantom control points at strand endpoints (Cycles convention)
+
+The pkg225 spec requires "boundary handling (phantom points at strand
+endpoints) follows Cycles' convention." Cycles' `curve_intersect` in
+`kernel/geom/curve_intersect.h` (Apache-2.0) gathers the 4 Catmull-Rom
+keys for segment `k0` (`k1 = k0+1`) as:
+
+```c
+// Cycles curve_intersect.h, fetched 2026-08-31:
+const int k0 = kcurve.first_key + PRIMITIVE_UNPACK_SEGMENT(type);
+const int k1 = k0 + 1;
+const int ka = max(k0 - 1, kcurve.first_key);
+const int kb = min(k1 + 1, kcurve.first_key + kcurve.num_keys - 1);
+```
+
+i.e. the phantom point is a **clamped duplicate of the nearest real
+endpoint** (`ka == k0` for the first segment, `kb == k1` for the last
+segment), NOT a mirrored/extrapolated point. `CurveStrip::buildCurveSegments()`
+reproduces this exactly: segment `i` connecting `points[i]`/`points[i+1]`
+uses `P0 = (i==0) ? points[i] : points[i-1]` and
+`P3 = (i==n-2) ? points[i+1] : points[i+2]`.
+
+## Deferred to later stages (explicitly out of Stage 1 scope)
+
+- Ribbon (camera-facing flat strip) mode — spec marks it a stretch goal for
+  Stage 1, required Stage 3. `CurveType::Ribbon`'s normal-interpolation
+  branch in pbrt is not ported.
+- Newton-Raphson iterative refinement / outer-inner-cylinder pruning
+  (Cycles' `curve_intersect_iterative`, Embree-derived) — GPU perf work,
+  Stage 3.
+- Reshetov 2017 analytic single-cylinder shortcut — not needed once the
+  recursive-subdivision path is correct and fast enough for CPU; revisit
+  only if Stage 1 CPU perf profiling (dense-hair BVH, per spec "implementation-
+  time decision") demands it.

--- a/.astroray_plan/docs/pkg225-curve-intersect-research.md
+++ b/.astroray_plan/docs/pkg225-curve-intersect-research.md
@@ -165,12 +165,67 @@ Builds clean (compiles + links). But `tests/test_pkg225_curve_intersect.py` is
 
 Localization for the next session: the ray-local frame (curves.h:74-115) is
 plausible and for a straight strand `L0==0` → `maxDepth==0`, so the bug is almost
-certainly in the **depth-0 hit test (curves.h:217-282)** — the endpoint edge
-functions (`edge0`/`edge1`, :221-224), the closest-point `w` (:229, note pbrt
-clamps `w` to [0,1] — check whether this port does), the perpendicular
-`distSq > hitRadius²` test (:238), or the `pc.z` t-bound (:239) — OR the
-Catmull-Rom→Bezier hull for a collinear strand. Trace the perpendicular test's
-exact numbers (it aims through the strand centre, so the expected local (x,y) of
-the curve point at w=0.5 is (0,0); if the code computes a nonzero distSq there,
-the projection/`w`/point-eval is the culprit). Do NOT merge until 7/7 green +
-a math review vs pbrt-v3 curve.cpp.
+certainly in the **depth-0 hit test (curves.h:217-282)** ...
+
+## ROOT CAUSE — CORRECTED (2026-09-02) — the primitive is CORRECT; the bugs were in the TEST
+
+The 2026-08-31 localization above was **wrong on the mechanism**. Two facts
+overturn it:
+
+1. `L0 != 0` for a straight strand. The uniform Catmull-Rom → Bézier map of an
+   evenly-spaced straight strand produces a **non-uniformly-spaced** Bézier hull
+   (middle segment: x = −10, −5, 5, 10). The parametric second difference is 5,
+   so `L0 = 5`, `maxDepth = 4` — the straight case *does* recurse, it does not
+   take a `maxDepth==0` shortcut.
+2. A standalone native harness (compiled against the real `raytracer.h` +
+   `curves.h`, driving `CurveSegment::hit` and `BVHAccel::hit` directly, no
+   Python/render/camera in the loop) shows the primitive **hits correctly** for
+   every "failing" straight case:
+   - perpendicular straight hit → `t=60.0`, `pos(0,0,0.15)` ✓
+   - endcap-within (single 2-pt strand, x=4 inside [−5,5]) → `t=60.0`,
+     `pos(4,0,0)` ✓
+   - the outward shading normal at a near-tangent hit is **radial**, matching
+     pbrt's `theta=Lerp(v,-90,90)` reconstruction (verified: as dist/radius→1
+     the normal → normalize(P*−Q*)).
+
+The four failures were all **test-file bugs**, not primitive bugs:
+
+- **perpendicular / tangent-normal / endcap-within** — `_render_curve_probe`
+  hard-coded `vup = (0,1,0)`. These three probes look straight down `-Y`, so the
+  up vector was **(anti-)parallel to the view direction**; `u = up × w` collapses
+  to a zero vector, the camera basis is NaN, every ray is garbage, nothing hits
+  (position (0,0,0) — exactly the "no hit" the parent saw). The two straight MISS
+  tests "passed" only because a NaN camera also produces no hit — they were false
+  greens. Fix: pick an up vector non-parallel to the view dir.
+- **oblique** — the chosen geometry `o=(2,45,−6), d=(0.3,−1,0.4)` has its
+  ray↔axis closest-approach at **x ≈ 14.26**, outside the middle segment's
+  [−10,10] span (and outside the test's own `−9 < q_axis[0] < 9` guard, which
+  fires as an AssertionError). Fix: `o=(−2,40,3), d=(0.1,−1,−0.06)` → closest
+  approach x ≈ 2.0, clearance 0.60, clean hit at t=40.31.
+- **tangent-normal** — used `radius = clearance + margin` (dist/radius = 0.75,
+  v = 0.875, θ = 67.5°), which is *not* tangency, and compared the sign-oriented
+  stored normal against the outward radial. `setFaceNormal` (shared with
+  Sphere/Triangle) flips the stored normal to face the ray; at a grazing hit the
+  radial normal is ⟂ the ray so the flip sign is the degenerate-face convention.
+  Fix: probe near tangency (clearance 2, radius 2.05 → v ≈ 0.988) and assert the
+  normal is radial **sign-agnostically** (`|dot(n, radial)| > 0.99`).
+
+**Resolution:** `include/astroray/curves.h`, `module/blender_module.cpp`
+(`addCurvesBulk`), `plugins/shapes/curve_segment.cpp`, `include/astroray/shapes.h`
+and `include/raytracer.h` are UNCHANGED — the Stage-1 primitive shipped correct.
+`tests/test_pkg225_curve_intersect.py` was fixed (camera up, oblique geometry,
+sign-agnostic normal).
+
+**One adjacent engine gap surfaced and fixed:** the position AOV was never
+filled. `SpectralPathTracer` (the `path_tracer` integrator) set the albedo /
+depth / normal first-hit AOVs but never `r.position`, so `get_position_buffer()`
+returned `Vec3(0)` for **every** shape. It went unnoticed because the only prior
+consumer (`test_python_bindings::test_data_pass_buffers_exist_and_are_finite`)
+asserts shape + finiteness, not value. Added `r.position = rec.point;` (world-
+space first hit = Cycles `PASS_POSITION`) in the AOV block. The pkg225
+perpendicular / oblique / endcap-within tests probe this buffer, so they needed
+it real; the fix benefits every position-AOV consumer, not just curves.
+
+Merge gate: 7/7 green on a `.pyd` rebuilt from this branch (the parent's earlier
+4/7 was on a build since overwritten by a `main` build lacking
+`add_curves_bulk`).

--- a/.astroray_plan/docs/pkg225-curve-intersect-research.md
+++ b/.astroray_plan/docs/pkg225-curve-intersect-research.md
@@ -148,3 +148,29 @@ uses `P0 = (i==0) ? points[i] : points[i-1]` and
   recursive-subdivision path is correct and fast enough for CPU; revisit
   only if Stage 1 CPU perf profiling (dense-hair BVH, per spec "implementation-
   time decision") demands it.
+
+## VERIFY FINDING (2026-08-31, parent build+test on RTX box) — NOT MERGEABLE YET
+
+Builds clean (compiles + links). But `tests/test_pkg225_curve_intersect.py` is
+**4 failed / 3 passed**:
+- FAIL: `test_straight_cylinder_perpendicular_ray_hit_distance`,
+  `test_straight_cylinder_oblique_ray_hit_distance`,
+  `test_straight_cylinder_tangent_grazing_normal`,
+  `test_endcap_within_segment_extent_hits` — all expect a HIT on a straight
+  cylinder at the closed-form distance; the primitive returns **no hit**
+  (position (0,0,0)).
+- PASS: the two MISS cases + the curved-strand smoke (a curved strand DOES hit,
+  40<depth<70). So miss-logic and the curved path work; **straight-cylinder hits
+  are wrongly rejected.**
+
+Localization for the next session: the ray-local frame (curves.h:74-115) is
+plausible and for a straight strand `L0==0` → `maxDepth==0`, so the bug is almost
+certainly in the **depth-0 hit test (curves.h:217-282)** — the endpoint edge
+functions (`edge0`/`edge1`, :221-224), the closest-point `w` (:229, note pbrt
+clamps `w` to [0,1] — check whether this port does), the perpendicular
+`distSq > hitRadius²` test (:238), or the `pc.z` t-bound (:239) — OR the
+Catmull-Rom→Bezier hull for a collinear strand. Trace the perpendicular test's
+exact numbers (it aims through the strand centre, so the expected local (x,y) of
+the curve point at w=0.5 is (0,0); if the code computes a nonzero distSq there,
+the projection/`w`/point-eval is the culprit). Do NOT merge until 7/7 green +
+a math review vs pbrt-v3 curve.cpp.

--- a/include/astroray/curves.h
+++ b/include/astroray/curves.h
@@ -1,0 +1,310 @@
+#pragma once
+// pkg225 Stage 1 — CPU ray-curve (swept-circle "thick" cross-section) intersection.
+//
+// ALGORITHM (cited, not invented — CLAUDE.md §6; full research note at
+// .astroray_plan/docs/pkg225-curve-intersect-research.md):
+//
+//   pbrt-v3 Curve::Intersect / Curve::recursiveIntersect, CurveType::Cylinder
+//   branch. Source: mmp/pbrt-v3, src/shapes/curve.cpp
+//   (https://github.com/mmp/pbrt-v3/blob/master/src/shapes/curve.cpp),
+//   copyright Matt Pharr / Greg Humphreys / Wenzel Jakob, BSD-2-Clause.
+//   Fetched and diffed verbatim against the upstream source 2026-08-31.
+//
+// SUMMARY: build a ray-local orthonormal frame (z = ray direction, x/y chosen
+// so the curve's control hull has minimal y-extent — pbrt's LookAt trick);
+// project the curve's cubic-Bezier control hull into that frame; recursively
+// split the Bezier hull (de Casteljau) to an adaptively-chosen depth; at the
+// leaf, treat the now-near-flat sub-segment as a 2D "distance to chord" width
+// test (perpendicular distance in the local x/y plane vs. the interpolated
+// radius). The "Cylinder" (a.k.a. thick / swept-circle, per the pkg225 spec)
+// curve type additionally reconstructs a genuinely-round shading normal by
+// rotating the flat perpendicular derivative around the true curve tangent by
+// an angle proportional to which side of the ray-facing plane the true curve
+// point falls on (theta = lerp(v, -90deg, +90deg) — a single ray intersection
+// can only ever see the near hemisphere of a round fiber, so v spans a half
+// turn, not a full 0-360 azimuth; see the HitRecord::hair_v comment in
+// raytracer.h).
+//
+// Astroray stores curves directly in WORLD SPACE (like Triangle/Sphere — no
+// object-to-world Transform step, unlike pbrt's general Shape), so the
+// WorldToObject/ObjectToWorld transform steps in pbrt's algorithm are
+// dropped; the ray-local frame is built directly from world-space points.
+// Astroray's Ray direction is always normalized (Ray ctor), so pbrt's
+// `rayLength` scaling is always 1 and drops out.
+//
+// pbrt's algorithm is parametrized by WIDTH (diameter). The pkg225 spec's
+// CurveSegment stores per-endpoint RADIUS ("One segment = 4 control points +
+// per-endpoint radius"), so every pbrt `width`/`hitWidth` term below is
+// substituted 1:1 with `2*radius` (hitWidth*hitWidth*0.25 == radius*radius).
+//
+// CATMULL-ROM -> BEZIER: Blender's `Curves` data-block (and Cycles) use
+// uniform Catmull-Rom (tension 1/2); pbrt's algorithm consumes a Bezier
+// control hull. The bridge is the standard cubic-Hermite -> Bezier identity
+// (CLAUDE.md §6 "trivial textbook math"), cross-checked against Cycles'
+// `catmull_rom_basis_eval` (kernel/geom/curve_intersect.h, Apache-2.0) in the
+// research note.
+//
+// PHANTOM ENDPOINTS: `CurveStrip::buildCurveSegments()` follows Cycles'
+// convention exactly — Cycles' curve_intersect.h clamps the adjacent-key
+// index to the segment's own endpoint (`ka = max(k0-1, first_key)`,
+// `kb = min(k1+1, last_key)`), i.e. the phantom point is a DUPLICATE of the
+// nearest real endpoint, not a mirrored extrapolation.
+#include "raytracer.h"
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+class CurveSegment : public Hittable {
+public:
+    // p0..p3: Catmull-Rom control window (on-curve span is p1 -> p2, per the
+    // strand's parent-strip phantom-endpoint handling). radius0/radius1: the
+    // swept-circle radius at p1 (u=0) and p2 (u=1), linearly interpolated.
+    CurveSegment(const Vec3& p0, const Vec3& p1, const Vec3& p2, const Vec3& p3,
+                 float radius0, float radius1, std::shared_ptr<Material> material)
+        : radius0_(radius0), radius1_(radius1), material_(material),
+          emissive_(material ? material->isEmissive() : false) {
+        // Uniform (tension 1/2) Catmull-Rom -> cubic Bezier hull:
+        // B0=P1, B1=P1+(P2-P0)/6, B2=P2-(P3-P1)/6, B3=P2.
+        bezier_[0] = p1;
+        bezier_[1] = p1 + (p2 - p0) * (1.0f / 6.0f);
+        bezier_[2] = p2 - (p3 - p1) * (1.0f / 6.0f);
+        bezier_[3] = p2;
+    }
+
+    bool hit(const Ray& r, float tMin, float tMax, HitRecord& rec) const override {
+        Vec3 zAxis = r.direction;  // already normalized (Ray ctor)
+        Vec3 chord = bezier_[3] - bezier_[0];
+        Vec3 dxHint = zAxis.cross(chord);
+        Vec3 xAxis, yAxis;
+        if (dxHint.length2() < 1e-12f) {
+            // Ray parallel to the chord (or degenerate zero-length hull) — pbrt
+            // falls back to an arbitrary orthonormal frame (CoordinateSystem()).
+            buildOrthonormalBasis(zAxis, xAxis, yAxis);
+        } else {
+            Vec3 up = dxHint.normalized();
+            xAxis = up.cross(zAxis).normalized();
+            yAxis = zAxis.cross(xAxis);
+        }
+
+        Vec3 cp[4];
+        for (int i = 0; i < 4; ++i) {
+            Vec3 d = bezier_[i] - r.origin;
+            cp[i] = Vec3(d.dot(xAxis), d.dot(yAxis), d.dot(zAxis));
+        }
+
+        float maxRadius = std::max(radius0_, radius1_);
+        if (!boundsOverlapRay(cp, maxRadius, tMin, tMax)) return false;
+
+        // Adaptive max recursion depth (pbrt's L0/eps flatness heuristic).
+        float L0 = 0.0f;
+        for (int i = 0; i < 2; ++i) {
+            L0 = std::max(L0, std::abs(cp[i].x - 2 * cp[i + 1].x + cp[i + 2].x));
+            L0 = std::max(L0, std::abs(cp[i].y - 2 * cp[i + 1].y + cp[i + 2].y));
+            L0 = std::max(L0, std::abs(cp[i].z - 2 * cp[i + 1].z + cp[i + 2].z));
+        }
+        float eps = maxRadius * 0.1f;  // pbrt: max(width)*0.05, width = 2*radius
+        int maxDepth = 0;
+        if (L0 > 0.0f && eps > 0.0f) {
+            float val = 1.41421356f * 6.0f * L0 / (8.0f * eps);
+            if (val >= 1.0f) {
+                int log2v = static_cast<int>(std::floor(std::log2(val) + 0.5f));  // round-to-nearest
+                maxDepth = std::clamp(log2v / 2, 0, 10);
+            }
+        }
+
+        return recursiveIntersect(r, tMin, tMax, cp, xAxis, yAxis, zAxis, 0.0f, 1.0f, maxDepth, rec);
+    }
+
+    bool boundingBox(AABB& box) const override {
+        Vec3 minP = bezier_[0], maxP = bezier_[0];
+        for (int i = 1; i < 4; ++i) {
+            minP = Vec3::min(minP, bezier_[i]);
+            maxP = Vec3::max(maxP, bezier_[i]);
+        }
+        float maxRadius = std::max(radius0_, radius1_);
+        box = AABB(minP - Vec3(maxRadius), maxP + Vec3(maxRadius));
+        return true;
+    }
+
+    bool isLight() const override { return emissive_; }
+    Vec3 emittedRadiance() const override { return material_->getEmission(); }
+
+    const Vec3* bezierHull() const { return bezier_; }
+    float getRadius0() const { return radius0_; }
+    float getRadius1() const { return radius1_; }
+
+private:
+    Vec3 bezier_[4];
+    float radius0_, radius1_;
+    std::shared_ptr<Material> material_;
+    bool emissive_;
+
+    float lerpRadius(float u) const { return radius0_ + (radius1_ - radius0_) * u; }
+
+    static Vec3 lerp3(float t, const Vec3& a, const Vec3& b) { return a + (b - a) * t; }
+
+    // pbrt SubdivideBezier — de Casteljau midpoint split, 4 -> 7 control points.
+    static void subdivideBezier(const Vec3 cp[4], Vec3 out[7]) {
+        out[0] = cp[0];
+        out[1] = (cp[0] + cp[1]) * 0.5f;
+        out[2] = (cp[0] + cp[1] * 2.0f + cp[2]) * 0.25f;
+        out[3] = (cp[0] + cp[1] * 3.0f + cp[2] * 3.0f + cp[3]) * 0.125f;
+        out[4] = (cp[1] + cp[2] * 2.0f + cp[3]) * 0.25f;
+        out[5] = (cp[2] + cp[3]) * 0.5f;
+        out[6] = cp[3];
+    }
+
+    // pbrt EvalBezier — de Casteljau evaluation + derivative.
+    static Vec3 evalBezier(const Vec3 cp[4], float u, Vec3* deriv = nullptr) {
+        Vec3 cp1[3] = { lerp3(u, cp[0], cp[1]), lerp3(u, cp[1], cp[2]), lerp3(u, cp[2], cp[3]) };
+        Vec3 cp2[2] = { lerp3(u, cp1[0], cp1[1]), lerp3(u, cp1[1], cp1[2]) };
+        if (deriv) {
+            if ((cp2[1] - cp2[0]).length2() > 0.0f) *deriv = (cp2[1] - cp2[0]) * 3.0f;
+            else *deriv = cp[3] - cp[0];  // degenerate: punt to chord (pbrt's own comment)
+        }
+        return lerp3(u, cp2[0], cp2[1]);
+    }
+
+    // Rodrigues' rotation formula (standard; rotates vector v by angleRad
+    // around unit axis axisUnit).
+    static Vec3 rotateAroundAxis(const Vec3& v, const Vec3& axisUnit, float angleRad) {
+        float c = std::cos(angleRad), s = std::sin(angleRad);
+        return v * c + axisUnit.cross(v) * s + axisUnit * (axisUnit.dot(v) * (1.0f - c));
+    }
+
+    // pbrt's y-then-x-then-z ray-local-frame AABB reject, shared by the top
+    // level and each recursion step's per-half-segment prune.
+    static bool boundsOverlapRay(const Vec3 cp[4], float radius, float tMin, float tMax) {
+        float yMax = std::max({cp[0].y, cp[1].y, cp[2].y, cp[3].y});
+        float yMin = std::min({cp[0].y, cp[1].y, cp[2].y, cp[3].y});
+        if (yMax + radius < 0 || yMin - radius > 0) return false;
+        float xMax = std::max({cp[0].x, cp[1].x, cp[2].x, cp[3].x});
+        float xMin = std::min({cp[0].x, cp[1].x, cp[2].x, cp[3].x});
+        if (xMax + radius < 0 || xMin - radius > 0) return false;
+        float zMax = std::max({cp[0].z, cp[1].z, cp[2].z, cp[3].z});
+        float zMin = std::min({cp[0].z, cp[1].z, cp[2].z, cp[3].z});
+        if (zMax + radius < tMin || zMin - radius > tMax) return false;
+        return true;
+    }
+
+    // pbrt Curve::recursiveIntersect, ported to Astroray's Vec3/HitRecord.
+    // tMax is narrowed as closer hits are found (both half-segments are still
+    // tested — a curve segment isn't guaranteed front-to-back split — so the
+    // nearer of the two candidate hits wins, matching a normal Hittable::hit
+    // tMax-narrowing contract).
+    bool recursiveIntersect(const Ray& r, float tMin, float tMax, const Vec3 cp[4],
+                             const Vec3& xAxis, const Vec3& yAxis, const Vec3& zAxis,
+                             float u0, float u1, int depth, HitRecord& rec) const {
+        if (depth > 0) {
+            Vec3 split[7];
+            subdivideBezier(cp, split);
+            float uMid = (u0 + u1) * 0.5f;
+            float uArr[3] = {u0, uMid, u1};
+            bool hitAny = false;
+            const Vec3* segCp = split;
+            for (int seg = 0; seg < 2; ++seg, segCp += 3) {
+                float rMax = std::max(lerpRadius(uArr[seg]), lerpRadius(uArr[seg + 1]));
+                if (!boundsOverlapRay(segCp, rMax, tMin, tMax)) continue;
+                HitRecord sub;
+                if (recursiveIntersect(r, tMin, tMax, segCp, xAxis, yAxis, zAxis,
+                                        uArr[seg], uArr[seg + 1], depth - 1, sub)) {
+                    hitAny = true;
+                    tMax = sub.t;   // tighten so the other half can't report a farther hit
+                    rec = sub;
+                }
+            }
+            return hitAny;
+        }
+
+        // Leaf: flat 2D "distance to chord" width test (pbrt's flattened
+        // ray-curve test).
+        float edge0 = (cp[1].y - cp[0].y) * -cp[0].y + cp[0].x * (cp[0].x - cp[1].x);
+        if (edge0 < 0) return false;
+        float edge1 = (cp[2].y - cp[3].y) * -cp[3].y + cp[3].x * (cp[3].x - cp[2].x);
+        if (edge1 < 0) return false;
+
+        float segDirX = cp[3].x - cp[0].x, segDirY = cp[3].y - cp[0].y;
+        float denom = segDirX * segDirX + segDirY * segDirY;
+        if (denom == 0.0f) return false;
+        float w = (-cp[0].x * segDirX + -cp[0].y * segDirY) / denom;
+
+        float u = std::clamp(u0 + (u1 - u0) * w, u0, u1);
+        float hitRadius = lerpRadius(u);
+        if (hitRadius <= 0.0f) return false;
+
+        Vec3 dpcdw;
+        Vec3 pc = evalBezier(cp, std::clamp(w, 0.0f, 1.0f), &dpcdw);
+        float distSq = pc.x * pc.x + pc.y * pc.y;
+        if (distSq > hitRadius * hitRadius) return false;
+        if (pc.z < tMin || pc.z > tMax) return false;
+
+        float dist = std::sqrt(distSq);
+        float edgeFunc = dpcdw.x * -pc.y + pc.x * dpcdw.y;
+        float v = (edgeFunc > 0.0f) ? 0.5f + dist / (2.0f * hitRadius)
+                                     : 0.5f - dist / (2.0f * hitRadius);
+
+        Vec3 dpdu;
+        evalBezier(bezier_, u, &dpdu);  // full-hull (world-space) tangent at global u
+        if (dpdu.length2() == 0.0f) return false;  // degenerate curve; pbrt CHECK_NE's, we bail
+
+        // Cylinder (swept-circle) shading frame: rotate the flat perpendicular
+        // around the true tangent by theta = lerp(v, -90deg, +90deg).
+        Vec3 dpduPlane(dpdu.dot(xAxis), dpdu.dot(yAxis), dpdu.dot(zAxis));
+        Vec3 dpduPlaneAxis = dpduPlane.normalized();
+        Vec3 dpdvPlane = Vec3(-dpduPlane.y, dpduPlane.x, 0.0f);
+        dpdvPlane = (dpdvPlane.length2() > 0.0f) ? dpdvPlane.normalized() * (2.0f * hitRadius)
+                                                  : Vec3(2.0f * hitRadius, 0, 0);
+        float theta = (v - 0.5f) * static_cast<float>(M_PI);  // lerp(v,-90,90) in radians
+        Vec3 dpdvPlaneRot = rotateAroundAxis(dpdvPlane, dpduPlaneAxis, -theta);
+        Vec3 dpdv = dpdvPlaneRot.x * xAxis + dpdvPlaneRot.y * yAxis + dpdvPlaneRot.z * zAxis;
+
+        rec.t = pc.z;
+        rec.point = r.at(rec.t);
+        rec.objectPoint = rec.point;
+        Vec3 outwardNormal = dpdu.cross(dpdv).normalized();
+        // setFaceNormal (raytracer.h) flips outwardNormal to face the incoming
+        // ray and derives frontFace/tangent/bitangent — the same convention
+        // Sphere/Triangle use, so downstream materials (Lambertian etc.) see a
+        // consistently-oriented normal regardless of which side of the fiber
+        // the ray approached from.
+        rec.setFaceNormal(r, outwardNormal);
+        // pkg178-style override: the curve's own tangent (dpdu, along the
+        // strand) is the physically meaningful shading tangent, replacing
+        // setFaceNormal's arbitrary buildOrthonormalBasis fallback — needed by
+        // the Stage-2 hair BSDF for its longitudinal/azimuthal frame.
+        rec.uvTangent = dpdu.normalized();
+        rec.uvBitangentSign = 1.0f;
+        rec.uv = Vec2(u, v);
+        rec.hair_u = u;
+        rec.hair_v = v;
+        rec.material = material_;
+        rec.hitObject = this;
+        return true;
+    }
+};
+
+// CurveStrip — an ordered strand of positions + per-point radii. Splits into
+// CurveSegment objects, one per consecutive point pair, using Cycles'
+// clamped-duplicate phantom-endpoint convention (see file-header comment).
+class CurveStrip {
+public:
+    std::vector<Vec3> points;
+    std::vector<float> radii;  // same length as points
+
+    std::vector<std::shared_ptr<CurveSegment>> buildCurveSegments(
+            std::shared_ptr<Material> material) const {
+        std::vector<std::shared_ptr<CurveSegment>> segments;
+        int n = static_cast<int>(points.size());
+        if (n < 2 || static_cast<int>(radii.size()) != n) return segments;
+        segments.reserve(n - 1);
+        for (int i = 0; i < n - 1; ++i) {
+            const Vec3& p1 = points[i];
+            const Vec3& p2 = points[i + 1];
+            const Vec3& p0 = (i == 0) ? points[i] : points[i - 1];
+            const Vec3& p3 = (i == n - 2) ? points[i + 1] : points[i + 2];
+            segments.push_back(std::make_shared<CurveSegment>(
+                p0, p1, p2, p3, radii[i], radii[i + 1], material));
+        }
+        return segments;
+    }
+};

--- a/include/astroray/shapes.h
+++ b/include/astroray/shapes.h
@@ -2,6 +2,13 @@
 // Shape class definitions moved from raytracer.h and advanced_features.h (pkg04).
 // Include this header wherever Sphere, Triangle, Mesh, or ConstantMedium are
 // instantiated directly (blender_module.cpp, shape plugins).
+//
+// Shapes: Sphere, Triangle, ConstantMedium, Mesh (all below, this file) —
+// plus CurveSegment / CurveStrip (pkg225 Stage 1, "astroray/curves.h" —
+// ray-thick-curve/hair-strand primitive; not defined here since it needs no
+// manifold/surface_partials dependency, but forward-declared below so headers
+// that only need the type name don't have to pull in the full curve-math header).
+class CurveSegment;
 #include "raytracer.h"
 #include "manifold/surface_partials.h"  // pkg178 PR-3 — trianglePartials (dp_du/dp_dv)
 #include <fstream>

--- a/include/raytracer.h
+++ b/include/raytracer.h
@@ -348,6 +348,17 @@ struct HitRecord {
     std::shared_ptr<Material> material;
     bool isDelta;
     const Hittable* hitObject = nullptr;  // set by hit() for GR dispatch
+    // pkg225 Stage 1 — CurveSegment (ray-thick-curve) parametrization, needed by
+    // the future hair BSDF (Stage 2) for cuticle tilt / tangent-frame construction.
+    // hair_u: position along the strand segment, 0 (start) -> 1 (end). hair_v:
+    // azimuthal proxy around the swept-circle cross-section, 0.5 = grazing edge
+    // facing the ray, 0/1 = the visible-hemisphere extremes (maps to a +-90 deg
+    // rotation of the flat perpendicular around the curve tangent — a single ray
+    // hit can only ever see the near hemisphere of a round fiber, so this is NOT
+    // a full 0-360 wraparound). pbrt-v3 curve.cpp CurveType::Cylinder convention
+    // — see .astroray_plan/docs/pkg225-curve-intersect-research.md. -1 sentinel
+    // on any non-curve hit (Sphere/Triangle/Mesh never touch these fields).
+    float hair_u = -1.0f, hair_v = -1.0f;
 
     HitRecord() : t(std::numeric_limits<float>::max()), frontFace(true), isDelta(false), hitObject(nullptr) {}
 

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -11,6 +11,7 @@
 #include "raytracer.h"
 #include "advanced_features.h"
 #include "astroray/shapes.h"
+#include "astroray/curves.h"  // pkg225 Stage 1 — CurveSegment / CurveStrip
 #include "astroray/black_hole.h"
 #include "astroray/register.h"
 #include "astroray/metric.h"
@@ -1093,6 +1094,55 @@ public:
             tri->setObjectPassIndex(objectPassIndex);
             tri->setMaterialPassIndex(mpi(t));
             renderer.addObject(tri);
+        }
+    }
+
+    // pkg225 Stage 1 — bulk hair/curve-strand ingest. Mirrors addTrianglesBulk's
+    // flat-NumPy-array pattern (pkg112): loops in C++ to avoid per-segment
+    // pybind overhead. positions (P,3) world-space, ALL strands concatenated
+    // back-to-back; radii (P,) per-point swept-circle radius; strand_point_counts
+    // (S,) point count per strand (must sum to P). Each strand becomes a chain
+    // of CurveSegment objects via CurveStrip::buildCurveSegments() — Catmull-Rom
+    // basis, Cycles-convention clamped phantom endpoints (see curves.h). One
+    // material for the whole batch (Stage 1 scope; per-strand materials are an
+    // addon-integration concern, Stage 6).
+    void addCurvesBulk(
+            py::array_t<float, py::array::c_style | py::array::forcecast> positions,
+            py::array_t<float, py::array::c_style | py::array::forcecast> radii,
+            std::vector<int> strandPointCounts,
+            int materialId,
+            int objectPassIndex = 0,
+            int materialPassIndex = 0) {
+        auto pos = positions.unchecked<2>();  // (P,3)
+        auto rad = radii.unchecked<1>();      // (P,)
+        const py::ssize_t nPts = pos.shape(0);
+        if (pos.shape(1) != 3)
+            throw std::runtime_error("add_curves_bulk: positions must be (P,3)");
+        if (rad.shape(0) != nPts)
+            throw std::runtime_error("add_curves_bulk: radii must match positions point count");
+        auto mat = materials.count(materialId) ? materials[materialId] : std::make_shared<Lambertian>(Vec3(0.5f));
+
+        py::ssize_t offset = 0;
+        for (int count : strandPointCounts) {
+            if (count < 2)
+                throw std::runtime_error("add_curves_bulk: each strand needs >= 2 points");
+            if (offset + count > nPts)
+                throw std::runtime_error("add_curves_bulk: strand_point_counts sum exceeds positions length");
+            CurveStrip strip;
+            strip.points.reserve(count);
+            strip.radii.reserve(count);
+            for (int i = 0; i < count; ++i) {
+                py::ssize_t p = offset + i;
+                strip.points.emplace_back(pos(p, 0), pos(p, 1), pos(p, 2));
+                strip.radii.push_back(rad(p));
+            }
+            auto segments = strip.buildCurveSegments(mat);
+            for (auto& seg : segments) {
+                seg->setObjectPassIndex(objectPassIndex);
+                seg->setMaterialPassIndex(materialPassIndex);
+                renderer.addObject(seg);
+            }
+            offset += count;
         }
     }
 
@@ -2974,6 +3024,14 @@ PYBIND11_MODULE(astroray, m) {
              "pkg88-C.0: bulk motion triangle ingest. positions_start (N,3,3) is center step, "
              "positions_end (N,3,3) is shutter close. Linear interpolation per Cycles (Apache-2.0). "
              "motionSteps=2 (pre+post). uvs/normals same as add_triangles_bulk.")
+        .def("add_curves_bulk", &PyRenderer::addCurvesBulk,
+             "positions"_a, "radii"_a, "strand_point_counts"_a, "material_id"_a,
+             "object_pass_index"_a = 0, "material_pass_index"_a = 0,
+             "pkg225 Stage 1: bulk hair/curve-strand ingest. positions (P,3) world-space, "
+             "ALL strands concatenated; radii (P,); strand_point_counts (S,) sums to P. "
+             "Builds CurveSegment (swept-circle thick mode, Catmull-Rom basis, "
+             "pbrt-v3 Curve::Intersect algorithm, BSD-2-Clause) via "
+             "CurveStrip::buildCurveSegments() (Cycles-convention clamped phantom endpoints).")
         .def("register_mesh_triangles", &PyRenderer::registerMeshTriangles,
              "triangles"_a, "material_id"_a, "object_name"_a = "",
              "pkg114: register a mesh's OBJECT-LOCAL flat-shaded triangles (list of "

--- a/plugins/integrators/spectral_path_tracer.cpp
+++ b/plugins/integrators/spectral_path_tracer.cpp
@@ -184,6 +184,13 @@ public:
                 r.albedo = rec.material->getAlbedo();
                 r.depth = rec.t;
                 r.normal = rec.normal;
+                // World-space first-hit position (Cycles PASS_POSITION,
+                // intern/cycles/integrator/pass.cpp; Apache-2.0). Was never
+                // filled — get_position_buffer returned Vec3(0) for every shape;
+                // the only prior consumer (test_python_bindings) asserted shape/
+                // finiteness, not value, so the gap went unnoticed. Misses keep
+                // Vec3(0), matching depth/normal here.
+                r.position = rec.point;
             }
         }
         std::uniform_real_distribution<float> dist01(0.0f, 1.0f);

--- a/plugins/shapes/curve_segment.cpp
+++ b/plugins/shapes/curve_segment.cpp
@@ -1,0 +1,23 @@
+#include "astroray/register.h"
+#include "astroray/curves.h"
+
+// pkg225 Stage 1 — ShapeRegistry entry for a single CurveSegment (one cubic
+// Catmull-Rom window). Mirrors SpherePlugin/MeshPlugin (plugins/shapes/*.cpp):
+// pulls its params from ParamDict and delegates to the real shape class.
+// Strand-level construction (phantom endpoints, many segments) goes through
+// CurveStrip::buildCurveSegments() instead — see module/blender_module.cpp
+// PyRenderer::addCurvesBulk, the actual bulk ingest path used by the addon.
+class CurveSegmentPlugin : public CurveSegment {
+public:
+    explicit CurveSegmentPlugin(const astroray::ParamDict& p)
+        : CurveSegment(p.getVec3("p0", Vec3(-1.0f, 0.0f, 0.0f)),
+                       p.getVec3("p1", Vec3(0.0f, 0.0f, 0.0f)),
+                       p.getVec3("p2", Vec3(1.0f, 0.0f, 0.0f)),
+                       p.getVec3("p3", Vec3(2.0f, 0.0f, 0.0f)),
+                       p.getFloat("radius0", 0.05f),
+                       p.getFloat("radius1", 0.05f),
+                       astroray::MaterialRegistry::instance().create(
+                           p.getString("material_type", "lambertian"), p)) {}
+};
+
+ASTRORAY_REGISTER_SHAPE("curve_segment", CurveSegmentPlugin)

--- a/tests/test_pkg225_curve_intersect.py
+++ b/tests/test_pkg225_curve_intersect.py
@@ -1,0 +1,249 @@
+"""pkg225 Stage 1 — CPU ray-curve (swept-circle) intersection: analytic parity.
+
+CurveSegment ports pbrt-v3's Curve::Intersect / recursiveIntersect (Pharr,
+Humphreys, Jakob — src/shapes/curve.cpp, BSD-2-Clause), CurveType::Cylinder
+branch (see include/astroray/curves.h and
+.astroray_plan/docs/pkg225-curve-intersect-research.md for the full citation
+and derivation this test relies on).
+
+KEY FACT this test exploits (proved in the research note, re-derived below):
+for a STRAIGHT (colinear-control-point) curve segment, the algorithm's
+reported hit distance `t` is EXACTLY the ray-parameter depth of Q* — the
+point on the curve's AXIS LINE closest to the ray's infinite line — a
+textbook closed-form quantity (the classic two-skew-lines closest-point
+formula). This holds for ANY ray/radius combination that lands within the
+segment's finite span (not just the tangent/grazing case): the reported `t`
+is the algorithm's *defined* semantics (depth of the axis-closest-point), not
+an attempt at "true cylinder-surface entry" (which would require a slower
+per-ray quadratic solve pbrt/Cycles deliberately avoid for this style of
+fast hair-fiber intersector). At EXACT tangency (radius == distance(P*, Q*))
+P* (closest point ON the ray) is provably exactly ON the true cylindrical
+surface too (the P*-Q* segment is perpendicular to both lines, hence lies in
+the cross-sectional plane at Q*), which is what the "tangent-grazing" cases
+below also check against the reconstructed shading normal.
+
+Geometry is probed via the existing depth/position/normal AOV buffers
+(get_depth_buffer / get_position_buffer / get_normal_buffer) rather than a
+full noisy render: aperture=0 (pinhole, so the ray ORIGIN is exact, no lens
+jitter) and the AOV buffers are captured from the FIRST sample only
+(include/raytracer.h, "if (s == 0) { depth = sDepth; position = sPosition; }"
+— confirmed by reading the render loop), so each probe is exactly ONE
+(sub-pixel-jittered) ray. The jitter is bounded by one pixel's angular
+footprint; with a narrow vfov and large resolution that footprint is chosen
+to be far smaller than the numeric tolerance used below (see
+_PIXEL_FOOTPRINT_BOUND). Hit/miss test radii are offset from the exact
+tangent radius by a margin well above that bound, so pass/fail is
+deterministic (not a coin-flip on which side of the boundary the single
+jittered sample lands).
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+
+try:
+    import astroray  # noqa: E402
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray not built")
+
+# Odd resolution -> a true single centre pixel; narrow vfov -> tiny angular
+# footprint per pixel. At the ~50-120 unit distances used below, footprint
+# ~= distance * radians(VFOV_DEG)/RESOLUTION, i.e. well under 1e-2 world
+# units. Tolerances chosen with a wide safety margin over that bound.
+_RESOLUTION = 401
+_VFOV_DEG = 0.6
+_PIXEL_FOOTPRINT_BOUND = 0.02  # generous upper bound on sub-pixel position error
+_T_TOL = 0.05
+_POS_TOL = 0.05
+_NORMAL_TOL = 0.05
+_MARGIN = 0.05  # >> _PIXEL_FOOTPRINT_BOUND; separates "clearly hit" / "clearly miss"
+
+
+def _closest_points(ray_o, ray_d, axis_o, axis_d):
+    """Standard closed-form closest points between two (non-parallel) 3D
+    lines (e.g. Ericson, "Real-Time Collision Detection" S5.1.9). Returns
+    (p_ray, q_axis, s_ray): the closest point on each line, and the ray
+    parameter of the closest point on the ray (== the analytic hit distance
+    CurveSegment must reproduce, per the module docstring)."""
+    ray_o = np.asarray(ray_o, dtype=np.float64)
+    ray_d = np.asarray(ray_d, dtype=np.float64)
+    axis_o = np.asarray(axis_o, dtype=np.float64)
+    axis_d = np.asarray(axis_d, dtype=np.float64)
+    ray_d = ray_d / np.linalg.norm(ray_d)
+    axis_d = axis_d / np.linalg.norm(axis_d)
+    w0 = ray_o - axis_o
+    b = float(np.dot(ray_d, axis_d))
+    d = float(np.dot(ray_d, w0))
+    e = float(np.dot(axis_d, w0))
+    denom = 1.0 - b * b
+    assert abs(denom) > 1e-6, "ray (near-)parallel to axis; pick different test geometry"
+    s_ray = (b * e - d) / denom
+    s_axis = (e - b * d) / denom
+    p_ray = ray_o + s_ray * ray_d
+    q_axis = axis_o + s_axis * axis_d
+    return p_ray, q_axis, s_ray
+
+
+def _render_curve_probe(points, radii, ray_origin, ray_target, radius_override=None):
+    """Build a scene with one hair strand (via add_curves_bulk) and probe a
+    single camera ray (ray_origin -> ray_target) for depth/position/normal.
+    Returns (depth, position(3,), normal(3,))."""
+    r = astroray.Renderer()
+    r.set_background_color([0.0, 0.0, 0.0])
+    mat = r.create_material("lambertian", [0.6, 0.6, 0.6], {})
+    pts = np.asarray(points, dtype=np.float32)
+    if radius_override is not None:
+        rad = np.full(len(points), radius_override, dtype=np.float32)
+    else:
+        rad = np.asarray(radii, dtype=np.float32)
+    r.add_curves_bulk(pts, rad, [len(points)], mat)
+    r.set_integrator("path_tracer")
+    ray_origin = np.asarray(ray_origin, dtype=np.float64)
+    ray_target = np.asarray(ray_target, dtype=np.float64)
+    dist = float(np.linalg.norm(ray_target - ray_origin))
+    r.setup_camera(list(ray_origin), list(ray_target), [0.0, 1.0, 0.0],
+                    _VFOV_DEG, 1.0, 0.0, dist, _RESOLUTION, _RESOLUTION)
+    r.set_seed(7)
+    r.render(2, 2, None, False)
+    cx = cy = (_RESOLUTION - 1) // 2
+    depth = float(np.asarray(r.get_depth_buffer())[cy, cx])
+    position = np.asarray(r.get_position_buffer())[cy, cx].astype(np.float64)
+    normal = np.asarray(r.get_normal_buffer())[cy, cx].astype(np.float64)
+    return depth, position, normal
+
+
+# A single straight strand (4 collinear points along +X) — exercises
+# CurveStrip::buildCurveSegments()'s Cycles-convention phantom-endpoint
+# clamping at both ends (3 segments), while the whole strand stays one
+# straight line so every segment shares the same closed-form axis. Aim probes
+# at the MIDDLE segment's real span [-10, 10] to stay comfortably clear of
+# either end.
+_STRAIGHT_POINTS = [(-20.0, 0.0, 0.0), (-10.0, 0.0, 0.0), (10.0, 0.0, 0.0), (20.0, 0.0, 0.0)]
+_AXIS_O = (0.0, 0.0, 0.0)
+_AXIS_D = (1.0, 0.0, 0.0)
+
+
+def test_straight_cylinder_perpendicular_ray_hit_distance():
+    """Ray perpendicular to the strand axis, aimed through it: t must match
+    the closed-form axis-closest-point depth exactly (module docstring)."""
+    ray_o = (0.0, 60.0, 0.15)
+    ray_d = (0.0, -1.0, 0.0)
+    p_ray, q_axis, s_ray = _closest_points(ray_o, ray_d, _AXIS_O, _AXIS_D)
+    radius = float(np.linalg.norm(p_ray - q_axis)) + _MARGIN  # comfortably inside
+    ray_target = tuple(np.asarray(ray_o) + np.asarray(ray_d))
+    depth, position, normal = _render_curve_probe(
+        _STRAIGHT_POINTS, None, ray_o, ray_target, radius_override=radius)
+    assert depth == pytest.approx(s_ray, abs=_T_TOL), f"depth {depth} != analytic {s_ray}"
+    assert np.linalg.norm(position - p_ray) < _POS_TOL, f"position {position} != analytic {p_ray}"
+
+
+def test_straight_cylinder_oblique_ray_hit_distance():
+    """Same closed-form check with a ray neither perpendicular nor parallel
+    to the axis — confirms the match isn't an artifact of the perpendicular
+    special case (the underlying skew-line theorem is fully general)."""
+    ray_o = (2.0, 45.0, -6.0)
+    ray_d = (0.3, -1.0, 0.4)
+    p_ray, q_axis, s_ray = _closest_points(ray_o, ray_d, _AXIS_O, _AXIS_D)
+    assert -9.0 < q_axis[0] < 9.0, "test geometry drifted outside the middle segment's span"
+    radius = float(np.linalg.norm(p_ray - q_axis)) + _MARGIN
+    ray_target = tuple(np.asarray(ray_o) + np.asarray(ray_d))
+    depth, position, normal = _render_curve_probe(
+        _STRAIGHT_POINTS, None, ray_o, ray_target, radius_override=radius)
+    assert depth == pytest.approx(s_ray, abs=_T_TOL), f"depth {depth} != analytic {s_ray}"
+    assert np.linalg.norm(position - p_ray) < _POS_TOL, f"position {position} != analytic {p_ray}"
+
+
+def test_straight_cylinder_miss():
+    """Radius pulled below the true clearance distance: must miss."""
+    ray_o = (0.0, 60.0, 0.15)
+    ray_d = (0.0, -1.0, 0.0)
+    p_ray, q_axis, _s_ray = _closest_points(ray_o, ray_d, _AXIS_O, _AXIS_D)
+    true_clearance = float(np.linalg.norm(p_ray - q_axis))
+    radius = max(true_clearance - _MARGIN, 1e-4)
+    ray_target = tuple(np.asarray(ray_o) + np.asarray(ray_d))
+    depth, _position, _normal = _render_curve_probe(
+        _STRAIGHT_POINTS, None, ray_o, ray_target, radius_override=radius)
+    assert depth < 1.0, f"expected a clean miss (depth~=0), got depth={depth}"
+
+
+def test_straight_cylinder_tangent_grazing_normal():
+    """Radius set to (clearance + a small-but-safe margin): P* is provably
+    within numerical tolerance of the TRUE cylinder surface at tangency (the
+    P*-Q* segment is perpendicular to both the ray and the axis — module
+    docstring), so the reconstructed shading normal must point along
+    normalize(P* - Q*), the true geometric outward radial direction."""
+    ray_o = (0.0, 60.0, 0.15)
+    ray_d = (0.0, -1.0, 0.0)
+    p_ray, q_axis, s_ray = _closest_points(ray_o, ray_d, _AXIS_O, _AXIS_D)
+    true_clearance = float(np.linalg.norm(p_ray - q_axis))
+    radius = true_clearance + _MARGIN
+    expected_normal = (p_ray - q_axis) / np.linalg.norm(p_ray - q_axis)
+    ray_target = tuple(np.asarray(ray_o) + np.asarray(ray_d))
+    depth, position, normal = _render_curve_probe(
+        _STRAIGHT_POINTS, None, ray_o, ray_target, radius_override=radius)
+    assert depth == pytest.approx(s_ray, abs=_T_TOL)
+    normal = normal / (np.linalg.norm(normal) + 1e-12)
+    assert np.linalg.norm(normal - expected_normal) < _NORMAL_TOL, (
+        f"normal {normal} != analytic outward radial {expected_normal}")
+
+
+def test_endcap_beyond_segment_extent_misses():
+    """A ray aimed dead-centre through the axis (clearance == 0, which would
+    hit an INFINITE cylinder trivially) but beyond the strand's finite [P1,
+    P2] extent must miss — this is pbrt's endpoint edge-function reject
+    (curves.h recursiveIntersect leaf test)."""
+    points = [(-5.0, 0.0, 0.0), (5.0, 0.0, 0.0)]  # single segment, no phantom ambiguity
+    ray_o = (8.0, 60.0, 0.0)   # x=8 is well beyond the [-5, 5] real span
+    ray_target = (8.0, 0.0, 0.0)
+    depth, _position, _normal = _render_curve_probe(
+        points, None, ray_o, ray_target, radius_override=0.3)
+    assert depth < 1.0, f"expected endcap miss (x=8 outside [-5,5] span), got depth={depth}"
+
+
+def test_endcap_within_segment_extent_hits():
+    """Sanity twin of the endcap-miss test: the same aim, but x=4 IS inside
+    the finite [-5, 5] span, must hit at the expected closed-form distance."""
+    points = [(-5.0, 0.0, 0.0), (5.0, 0.0, 0.0)]
+    axis_o, axis_d = (0.0, 0.0, 0.0), (1.0, 0.0, 0.0)
+    ray_o = (4.0, 60.0, 0.0)
+    ray_d = (0.0, -1.0, 0.0)
+    p_ray, q_axis, s_ray = _closest_points(ray_o, ray_d, axis_o, axis_d)
+    radius = float(np.linalg.norm(p_ray - q_axis)) + _MARGIN
+    ray_target = (4.0, 0.0, 0.0)
+    depth, position, _normal = _render_curve_probe(
+        points, None, ray_o, ray_target, radius_override=radius)
+    assert depth == pytest.approx(s_ray, abs=_T_TOL)
+    assert np.linalg.norm(position - p_ray) < _POS_TOL
+
+
+def test_curved_strand_smoke():
+    """Qualitative regression check for a genuinely curved (non-collinear)
+    strand — no simple closed form exists for a general curved segment (that
+    is exactly why pbrt/Cycles use the recursive-subdivision approximation
+    under test), so this only asserts a sane hit: finite positive depth, and
+    the hit position lands within the strand's own loose bounding region."""
+    # A quarter-circle-ish bent poly-line (not a true circle; the point is
+    # non-collinear curvature, not analytic exactness).
+    points = [(-10.0, 0.0, 0.0), (-5.0, 3.0, 0.0), (0.0, 5.0, 0.0),
+              (5.0, 3.0, 0.0), (10.0, 0.0, 0.0)]
+    radius = 0.4
+    ray_o = (0.0, 5.0, 60.0)
+    ray_target = (0.0, 5.0, 0.0)
+    depth, position, normal = _render_curve_probe(
+        points, None, ray_o, ray_target, radius_override=radius)
+    assert 40.0 < depth < 70.0, f"unreasonable depth for a near-frontal strand hit: {depth}"
+    # Loose AABB check: every strand point is within [-10,10]x[0,5]x[-radius,radius].
+    assert -10.5 <= position[0] <= 10.5
+    assert -0.5 <= position[1] <= 5.5
+    assert -1.0 <= position[2] <= 1.0
+    assert np.linalg.norm(normal) == pytest.approx(1.0, abs=0.05)

--- a/tests/test_pkg225_curve_intersect.py
+++ b/tests/test_pkg225_curve_intersect.py
@@ -111,7 +111,16 @@ def _render_curve_probe(points, radii, ray_origin, ray_target, radius_override=N
     ray_origin = np.asarray(ray_origin, dtype=np.float64)
     ray_target = np.asarray(ray_target, dtype=np.float64)
     dist = float(np.linalg.norm(ray_target - ray_origin))
-    r.setup_camera(list(ray_origin), list(ray_target), [0.0, 1.0, 0.0],
+    # LookAt is degenerate when the up vector is (anti-)parallel to the view
+    # direction (u = up x w collapses to a zero vector -> NaN camera basis ->
+    # every ray is garbage and nothing hits). Several probes below look straight
+    # down -Y, so pick an up vector that is safely non-parallel to the view dir.
+    forward = ray_target - ray_origin
+    forward = forward / np.linalg.norm(forward)
+    up = np.array([0.0, 1.0, 0.0])
+    if abs(float(np.dot(forward, up))) > 0.99:
+        up = np.array([0.0, 0.0, 1.0])
+    r.setup_camera(list(ray_origin), list(ray_target), list(up),
                     _VFOV_DEG, 1.0, 0.0, dist, _RESOLUTION, _RESOLUTION)
     r.set_seed(7)
     r.render(2, 2, None, False)
@@ -151,8 +160,8 @@ def test_straight_cylinder_oblique_ray_hit_distance():
     """Same closed-form check with a ray neither perpendicular nor parallel
     to the axis — confirms the match isn't an artifact of the perpendicular
     special case (the underlying skew-line theorem is fully general)."""
-    ray_o = (2.0, 45.0, -6.0)
-    ray_d = (0.3, -1.0, 0.4)
+    ray_o = (-2.0, 40.0, 3.0)
+    ray_d = (0.1, -1.0, -0.06)
     p_ray, q_axis, s_ray = _closest_points(ray_o, ray_d, _AXIS_O, _AXIS_D)
     assert -9.0 < q_axis[0] < 9.0, "test geometry drifted outside the middle segment's span"
     radius = float(np.linalg.norm(p_ray - q_axis)) + _MARGIN
@@ -177,24 +186,37 @@ def test_straight_cylinder_miss():
 
 
 def test_straight_cylinder_tangent_grazing_normal():
-    """Radius set to (clearance + a small-but-safe margin): P* is provably
-    within numerical tolerance of the TRUE cylinder surface at tangency (the
-    P*-Q* segment is perpendicular to both the ray and the axis — module
-    docstring), so the reconstructed shading normal must point along
-    normalize(P* - Q*), the true geometric outward radial direction."""
-    ray_o = (0.0, 60.0, 0.15)
+    """Swept-circle ("Cylinder") normal reconstruction: a ray passing close to
+    the fiber's edge (radius only slightly above the ray-axis clearance) must
+    get a shading normal that lies along the RADIAL direction normalize(P*-Q*),
+    not along the strand tangent — that radial tilt is the whole point of the
+    Cylinder curve type (pbrt-v3 curve.cpp: theta = Lerp(v, -90, +90) rotation
+    of the flat perpendicular around the tangent; as dist/radius -> 1 the normal
+    -> radial). We probe near tangency (clearance/radius = 2/2.05 = 0.976, so
+    v ~ 0.988, theta ~ 87.8 deg) with a jitter-safe absolute margin.
+
+    The comparison is sign-agnostic: HitRecord::setFaceNormal (shared with
+    Sphere/Triangle) orients the STORED normal to face the incoming ray, and at
+    a near-grazing hit the radial normal is ~perpendicular to the ray, so the
+    stored sign is the degenerate-face convention (dot(ray_dir, N) ~ 0). The
+    physically meaningful assertion is that the normal is radial, i.e. parallel
+    to +-(P*-Q*)."""
+    ray_o = (0.0, 60.0, 2.0)
     ray_d = (0.0, -1.0, 0.0)
     p_ray, q_axis, s_ray = _closest_points(ray_o, ray_d, _AXIS_O, _AXIS_D)
     true_clearance = float(np.linalg.norm(p_ray - q_axis))
     radius = true_clearance + _MARGIN
-    expected_normal = (p_ray - q_axis) / np.linalg.norm(p_ray - q_axis)
+    expected_radial = (p_ray - q_axis) / np.linalg.norm(p_ray - q_axis)
     ray_target = tuple(np.asarray(ray_o) + np.asarray(ray_d))
     depth, position, normal = _render_curve_probe(
         _STRAIGHT_POINTS, None, ray_o, ray_target, radius_override=radius)
     assert depth == pytest.approx(s_ray, abs=_T_TOL)
+    assert np.linalg.norm(normal) == pytest.approx(1.0, abs=_NORMAL_TOL), (
+        f"shading normal must be unit length, got |n|={np.linalg.norm(normal)}")
     normal = normal / (np.linalg.norm(normal) + 1e-12)
-    assert np.linalg.norm(normal - expected_normal) < _NORMAL_TOL, (
-        f"normal {normal} != analytic outward radial {expected_normal}")
+    assert abs(float(np.dot(normal, expected_radial))) > 0.99, (
+        f"normal {normal} not radial: |dot| with {expected_radial} = "
+        f"{abs(float(np.dot(normal, expected_radial)))}")
 
 
 def test_endcap_beyond_segment_extent_misses():


### PR DESCRIPTION
## Summary

pkg225 Stage 1 (CPU ray-thick-curve / hair-strand intersection, pbrt-v3 `Curve::Intersect` port). The primitive landed on this branch already; this PR **verifies it and gets the gate green**.

The 2026-08-31 verify finding mislocalized a bug to `curves.h` ("straight-cylinder hits wrongly rejected"). A standalone native harness driving `CurveSegment::hit` / `BVHAccel::hit` directly (no camera/render) proves the primitive **hits correctly** in every case — t, position, and the radial swept-circle normal all match pbrt. The 4 failures were **test-harness bugs**:

- `_render_curve_probe` hard-coded `vup=(0,1,0)`; three probes look straight down −Y, so up was (anti-)parallel to the view dir → `u = up×w` collapses → NaN camera → nothing hits. The two straight *miss* tests "passed" only because a NaN camera also produces no hit (false greens). Fixed by picking a non-parallel up.
- **oblique** geometry put the ray/axis closest approach at x≈14.3, outside the segment span (tripping its own `−9<qx<9` guard). Replaced with valid geometry.
- **tangent-normal** used `radius=clearance+margin` (not tangent) and compared the `setFaceNormal`-oriented normal against the unsigned radial. Now probes near tangency and asserts radial sign-agnostically.

## Adjacent gap fixed
`SpectralPathTracer` (the `path_tracer` integrator) never filled `r.position`, so `get_position_buffer()` returned `Vec3(0)` for **every** shape — unnoticed because the only prior consumer asserts finiteness, not value. Added `r.position = rec.point` (world-space first hit = Cycles `PASS_POSITION`). Verified: a sphere render now returns the correct front-face position.

## Testing
- `tests/test_pkg225_curve_intersect.py` **7/7** green (was 4-fail).
- `test_python_bindings` AOV/normal/depth/position subset: 6/6 green.
- Engine intersection code (`curves.h`, `addCurvesBulk`, `shapes.h`, `raytracer.h`) **unchanged** — CPU-only change, no GPU kernel touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)