### PR TITLE
pkg225-S2: CPU Principled Hair BSDF (Chiang 2016)

### DIFF
--- a/.astroray_plan/packages/pkg225-hair-rendering.md
+++ b/.astroray_plan/packages/pkg225-hair-rendering.md
@@ -2,8 +2,18 @@
 
 **Pillar:** 3
 **Track:** A
-**Status:** open — **Stage 1 (CPU curve geometry primitive) LANDED** (PR #670,
-2026-09-02). The pbrt-v3-ported `CurveSegment`/`CurveStrip` (`include/astroray/
+**Status:** open — **Stage 1 (CPU curve geometry) + Stage 2 (CPU Principled
+Hair BSDF, Chiang 2016) LANDED.** Stage 2 (2026-09-03): `include/astroray/
+hair_bsdf.h` (Mp/Np/Ap/logistic/Fresnel + σ_a helpers, header-only STL-free hot
+path for GPU reuse) + `plugins/materials/principled_hair.cpp` (R/TT/TRT+residual,
+three σ_a parametrizations, view-dependent tangent frame from `uvTangent`,
+h=2·hair_v−1, coat→R-roughness, pbrt cuticle-tilt), CPU eval/pdf/sample +
+evalSpectral + overridden sampleSpectral. Gate `tests/test_pkg225_hair_bsdf.py`
+9/9: energy conservation ρ≤1 across β_m∈{0.1,0.3,0.6,1.0}, absorption-darkens,
+per-channel colour response, eval finite/≥0, non-curve regression guard, and a
+spectral-path render smoke. Stages 3–6 (GPU, spectral melanin, addon) remain
+open. Stage-1 landed via PR #670,
+2026-09-02. The pbrt-v3-ported `CurveSegment`/`CurveStrip` (`include/astroray/
 curves.h`), `add_curves_bulk` ingest, and the analytic parity gate
 (`tests/test_pkg225_curve_intersect.py`, 7/7) are merged. The 2026-08-31 "4/7,
 bug localized to curves.h" handoff was wrong on the mechanism — a standalone

--- a/include/astroray/hair_bsdf.h
+++ b/include/astroray/hair_bsdf.h
@@ -1,0 +1,212 @@
+#pragma once
+// Principled Hair BSDF — Chiang et al. 2016, "A Practical and Controllable Hair
+// and Fur Model for Production Path Tracing", CGF 35(2). DOI:10.1145/2775280.2792559.
+// Built on Marschner 2003 (DOI:10.1145/882262.882345) + d'Eon 2011
+// (DOI:10.1111/j.1467-8659.2011.01976.x).
+//
+// Reference impl (primary, cross-checked): pbrt-v3 src/materials/hair.cpp,
+//   BSD-2-Clause (Pharr/Jakob) — textbook Chiang form (pbrt §9.9 "Hair"); the
+//   Mp/Ap/Np/Logistic/I0/Phi math below is ported from it verbatim in structure.
+// Reference impl (parameter plumbing): Blender Cycles @main —
+//   intern/cycles/kernel/closure/bsdf_principled_hair_chiang.h (roughness/coat
+//   remap, hair_alpha_angles), intern/cycles/kernel/closure/bsdf_util.h
+//   (sigma_from_{concentration,reflectance}), Apache-2.0 — compatible with MIT.
+// Per-function math notes + pbrt-vs-Cycles divergence table:
+//   .astroray_plan/docs/pkg225-hair-bsdf-research.md
+//
+// Header-only, STL-free in the hot path (raw arrays), so the Stage 3/4 GPU leg
+// can #include the same functions into a .cuh unchanged. CPU-only for Stage 2.
+#include "astroray/spectrum.h"
+#include <cmath>
+#include <algorithm>
+#include <utility>
+
+namespace astroray {
+namespace hair {
+
+// Number of scattering lobes tracked explicitly: R(0), TT(1), TRT(2) + a
+// residual TRRT+ geometric tail at index pMax=3. (pbrt hair.cpp pMax=3.)
+static constexpr int kPMax = 3;
+static constexpr float kPi   = 3.14159265358979323846f;
+static constexpr float kSqrtPiOver8 = 0.626657069f;  // sqrt(pi/8)
+
+static inline float sqr(float v) { return v * v; }
+static inline float safeSqrt(float v) { return std::sqrt(std::max(0.0f, v)); }
+static inline float safeAsin(float v) { return std::asin(std::min(1.0f, std::max(-1.0f, v))); }
+
+// Modified Bessel I0 and its log (pbrt hair.cpp I0/LogI0). Series for I0; the
+// log form is used for the numerically-stable small-variance Mp branch.
+static inline float besselI0(float x) {
+    float val = 0.0f, x2i = 1.0f, ifact = 1.0f;
+    int i4 = 1;
+    // 10 terms is ample for the |x| range Mp produces (pbrt uses the same).
+    for (int i = 0; i < 10; ++i) {
+        if (i > 1) ifact *= (float)i;
+        val += x2i / (float)(i4 * ifact * ifact);
+        x2i *= x * x;
+        i4 *= 4;
+    }
+    return val;
+}
+static inline float logBesselI0(float x) {
+    if (x > 12.0f)
+        return x + 0.5f * (-std::log(2.0f * kPi) + std::log(1.0f / x) + 1.0f / (8.0f * x));
+    return std::log(besselI0(x));
+}
+
+// Longitudinal scattering Mp (d'Eon 2011 Gaussian detector via Bessel I0).
+// pbrt hair.cpp Mp(). v is the per-lobe longitudinal variance.
+static inline float Mp(float cosThetaI, float cosThetaO,
+                       float sinThetaI, float sinThetaO, float v) {
+    float a = cosThetaI * cosThetaO / v;
+    float b = sinThetaI * sinThetaO / v;
+    float mp = (v <= 0.1f)
+        ? std::exp(logBesselI0(a) - b - 1.0f / v + 0.6931f + std::log(1.0f / (2.0f * v)))
+        : (std::exp(-b) * besselI0(a)) / (std::sinh(1.0f / v) * 2.0f * v);
+    return mp;
+}
+
+// Logistic distribution + its trimmed form over [a,b] (pbrt hair.cpp).
+static inline float logistic(float x, float s) {
+    x = std::abs(x);
+    float e = std::exp(-x / s);
+    return e / (s * sqr(1.0f + e));
+}
+static inline float logisticCDF(float x, float s) {
+    return 1.0f / (1.0f + std::exp(-x / s));
+}
+static inline float trimmedLogistic(float x, float s, float a, float b) {
+    return logistic(x, s) / (logisticCDF(b, s) - logisticCDF(a, s));
+}
+static inline float sampleTrimmedLogistic(float u, float s, float a, float b) {
+    float k = logisticCDF(b, s) - logisticCDF(a, s);
+    float x = -s * std::log(1.0f / (u * k + logisticCDF(a, s)) - 1.0f);
+    return std::min(std::max(x, a), b);
+}
+
+// Azimuthal ideal-specular direction offset for order p (pbrt hair.cpp Phi()).
+static inline float deltaPhi(int p, float gammaO, float gammaT) {
+    return 2.0f * (float)p * gammaT - 2.0f * gammaO + (float)p * kPi;
+}
+
+// Wrap an angle into [-pi, pi] (pbrt hair.cpp inline in Np).
+static inline float wrapAngle(float phi) {
+    while (phi > kPi)  phi -= 2.0f * kPi;
+    while (phi < -kPi) phi += 2.0f * kPi;
+    return phi;
+}
+
+// Azimuthal scattering Np (Chiang logistic lobe; residual is isotropic 1/2pi).
+static inline float Np(float phi, int p, float s, float gammaO, float gammaT) {
+    float dphi = phi - deltaPhi(p, gammaO, gammaT);
+    dphi = wrapAngle(dphi);
+    return trimmedLogistic(dphi, s, -kPi, kPi);
+}
+
+// UI roughness (beta_m, beta_n) -> longitudinal variance v and azimuthal
+// logistic scale s (Chiang §4; identical in pbrt and Cycles — note divergence
+// table row 4). Precompute once per material.
+static inline float longitudinalVariance(float betaM) {
+    float t = 0.726f * betaM + 0.812f * sqr(betaM) + 3.7f * std::pow(betaM, 20.0f);
+    return sqr(t);
+}
+static inline float azimuthalScale(float betaN) {
+    return (0.265f * betaN + 1.194f * sqr(betaN) + 5.372f * std::pow(betaN, 22.0f)) * kSqrtPiOver8;
+}
+
+// Fresnel dielectric reflectance (unpolarized), pbrt reflection.cpp FrDielectric.
+// etaI outside, etaT inside; cosThetaI is the incidence cosine on the outside.
+static inline float frDielectric(float cosThetaI, float etaI, float etaT) {
+    cosThetaI = std::min(1.0f, std::max(-1.0f, cosThetaI));
+    if (cosThetaI < 0.0f) { std::swap(etaI, etaT); cosThetaI = -cosThetaI; }
+    float sinThetaI = safeSqrt(1.0f - cosThetaI * cosThetaI);
+    float sinThetaT = etaI / etaT * sinThetaI;
+    if (sinThetaT >= 1.0f) return 1.0f;  // TIR
+    float cosThetaT = safeSqrt(1.0f - sinThetaT * sinThetaT);
+    float rParl = ((etaT * cosThetaI) - (etaI * cosThetaT)) /
+                  ((etaT * cosThetaI) + (etaI * cosThetaT));
+    float rPerp = ((etaI * cosThetaI) - (etaT * cosThetaT)) /
+                  ((etaI * cosThetaI) + (etaT * cosThetaT));
+    return 0.5f * (rParl * rParl + rPerp * rPerp);
+}
+
+// Per-lobe absorption attenuation Ap[0..pMax], given the single-traversal
+// transmittance T for ONE channel (pbrt hair.cpp Ap()). f is the fiber-surface
+// Fresnel. Returns the (un-normalized) energy of each lobe for that channel.
+static inline void Ap(float f, float T, float ap[kPMax + 1]) {
+    ap[0] = f;                          // R
+    ap[1] = sqr(1.0f - f) * T;          // TT
+    ap[2] = ap[1] * T * f;              // TRT
+    // residual TRRT+ geometric tail (pbrt: ap[pMax] = ap[pMax-1]*f*T/(1-T*f))
+    ap[3] = ap[2] * f * T / std::max(1e-5f, 1.0f - T * f);
+}
+
+// Discrete lobe-selection pmf from a channel-luminance of Ap (pbrt ComputeApPdf).
+// Uses the given per-lobe scalar energies (already luminance-reduced).
+static inline void apPdf(const float ap[kPMax + 1], float pdf[kPMax + 1]) {
+    float sum = 0.0f;
+    for (int i = 0; i <= kPMax; ++i) sum += ap[i];
+    float inv = (sum > 0.0f) ? 1.0f / sum : 0.0f;
+    for (int i = 0; i <= kPMax; ++i) pdf[i] = ap[i] * inv;
+}
+
+// Cuticle-tilt scaled angles per lobe (Cycles hair_alpha_angles / pbrt
+// sin2kAlpha,cos2kAlpha with the 1/2/4 Marschner pattern). Precompute the base
+// sin/cos of 2^k * alpha for k=0,1,2 once. Divergence-table row 8: match this
+// convention exactly. angleShift returns (sinThetaOp, cosThetaOp) for lobe p by
+// rotating (sinThetaO, cosThetaO) by the lobe's tilt.
+struct AlphaTilt {
+    float sin2k[3];  // sin(2^k * alpha)
+    float cos2k[3];
+};
+static inline AlphaTilt makeAlphaTilt(float alpha) {
+    AlphaTilt t;
+    t.sin2k[0] = std::sin(alpha);
+    t.cos2k[0] = std::cos(alpha);
+    for (int i = 1; i < 3; ++i) {
+        t.sin2k[i] = 2.0f * t.cos2k[i - 1] * t.sin2k[i - 1];
+        t.cos2k[i] = sqr(t.cos2k[i - 1]) - sqr(t.sin2k[i - 1]);
+    }
+    return t;
+}
+// Rotate (sinThetaO, cosThetaO) by the tilt for lobe p (pbrt hair.cpp f()):
+//   R (p=0): +2 alpha ; TT (p=1): -1 alpha ; TRT (p=2): -4 alpha ; residual: 0.
+static inline void tiltThetaO(const AlphaTilt& t, int p,
+                              float sinThetaO, float cosThetaO,
+                              float& sinThetaOp, float& cosThetaOp) {
+    if (p == 0) {
+        sinThetaOp = sinThetaO * t.cos2k[1] - cosThetaO * t.sin2k[1];  // +2a
+        cosThetaOp = cosThetaO * t.cos2k[1] + sinThetaO * t.sin2k[1];
+    } else if (p == 1) {
+        sinThetaOp = sinThetaO * t.cos2k[0] + cosThetaO * t.sin2k[0];  // -1a
+        cosThetaOp = cosThetaO * t.cos2k[0] - sinThetaO * t.sin2k[0];
+    } else if (p == 2) {
+        sinThetaOp = sinThetaO * t.cos2k[2] + cosThetaO * t.sin2k[2];  // -4a
+        cosThetaOp = cosThetaO * t.cos2k[2] - sinThetaO * t.sin2k[2];
+    } else {
+        sinThetaOp = sinThetaO;
+        cosThetaOp = cosThetaO;
+    }
+}
+
+// --- sigma_a parameterizations (Cycles bsdf_util.h; divergence-table rows 1-3) ---
+
+// Direct-coloring: invert a target reflectance `color` into absorption, using
+// the radial roughness beta_n (Cycles bsdf_principled_hair_sigma_from_reflectance).
+static inline float sigmaAFromReflectanceChannel(float color, float betaN) {
+    float d = 5.969f - 0.215f * betaN + 2.532f * sqr(betaN) - 10.73f * betaN * betaN * betaN +
+              5.574f * std::pow(betaN, 4.0f) + 0.245f * std::pow(betaN, 5.0f);
+    float t = std::log(std::max(color, 1e-4f)) / d;
+    return t * t;
+}
+
+// Melanin -> absorption (Cycles coefficients; divergence-table row 1).
+// eumelanin c_e=(0.506,0.841,1.653), pheomelanin c_p=(0.343,0.733,1.924).
+static inline void melaninCoeffs(int channel, float& ce, float& cp) {
+    const float CE[3] = {0.506f, 0.841f, 1.653f};
+    const float CP[3] = {0.343f, 0.733f, 1.924f};
+    ce = CE[channel]; cp = CP[channel];
+}
+
+}  // namespace hair
+}  // namespace astroray

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -711,6 +711,60 @@ public:
         return {reflected.x, reflected.y, reflected.z};
     }
 
+    // pkg225 Stage 2 — hair-BSDF test helpers. Build a curve-style HitRecord
+    // (uvTangent = strand tangent, hair_v set) so the principled_hair branch
+    // activates (it returns 0 when hair_v < 0). eval_hair_material evaluates f;
+    // integrate_hair_reflectance is the energy gate — a FULL-SPHERE directional
+    // reflectance rho = (1/N) sum f/pdf (hair scatters to both hemispheres via
+    // the TT/TRT transmission lobes, so — unlike integrateMaterialReflectance —
+    // it does NOT cull by the normal hemisphere).
+    HitRecord makeHairTestRecord(const std::vector<float>& tangentInput, float hairV) const {
+        HitRecord rec;
+        Vec3 t(1.0f, 0.0f, 0.0f);
+        if (tangentInput.size() == 3)
+            t = Vec3(tangentInput[0], tangentInput[1], tangentInput[2]).normalized();
+        rec.uvTangent = t;
+        rec.normal = Vec3(0.0f, 1.0f, 0.0f);
+        rec.frontFace = true;
+        buildOrthonormalBasis(rec.normal, rec.tangent, rec.bitangent);
+        rec.hair_u = 0.5f;
+        rec.hair_v = hairV;
+        return rec;
+    }
+    std::vector<float> evalHairMaterial(int materialId,
+                                        const std::vector<float>& woInput,
+                                        const std::vector<float>& wiInput,
+                                        const std::vector<float>& tangentInput,
+                                        float hairV) const {
+        auto it = materials.find(materialId);
+        if (it == materials.end() || !it->second) throw std::runtime_error("Unknown material id");
+        if (woInput.size() != 3 || wiInput.size() != 3) throw std::runtime_error("wo,wi must be length 3");
+        HitRecord rec = makeHairTestRecord(tangentInput, hairV);
+        Vec3 wo(woInput[0], woInput[1], woInput[2]);
+        Vec3 wi(wiInput[0], wiInput[1], wiInput[2]);
+        Vec3 v = it->second->eval(rec, wo.normalized(), wi.normalized());
+        return {v.x, v.y, v.z};
+    }
+    std::vector<float> integrateHairReflectance(int materialId,
+                                                const std::vector<float>& woInput,
+                                                const std::vector<float>& tangentInput,
+                                                float hairV, int samples) const {
+        auto it = materials.find(materialId);
+        if (it == materials.end() || !it->second) throw std::runtime_error("Unknown material id");
+        if (woInput.size() != 3) throw std::runtime_error("wo must be length 3");
+        if (samples <= 0) throw std::runtime_error("samples must be positive");
+        HitRecord rec = makeHairTestRecord(tangentInput, hairV);
+        Vec3 wo = Vec3(woInput[0], woInput[1], woInput[2]).normalized();
+        std::mt19937 gen(0x9e3779b9u);
+        Vec3 sum(0.0f);
+        for (int i = 0; i < samples; ++i) {
+            BSDFSample s = it->second->sample(rec, wo, gen);
+            if (s.pdf > 0.0f) sum += s.f / s.pdf;   // full sphere — no normal cull
+        }
+        const Vec3 rho = sum / float(samples);
+        return {rho.x, rho.y, rho.z};
+    }
+
     // pkg121: batched BSDF sample+pdf for chi² tests (CPU-only).
     // Convention: wo = outgoing to viewer (fixed), sample() returns wi = incoming from light.
     // Returns (wi_array, pdf_array) where wi_array is (N,3) sampled incident directions.
@@ -2964,6 +3018,14 @@ PYBIND11_MODULE(astroray, m) {
         .def("integrate_material_reflectance", &PyRenderer::integrateMaterialReflectance,
              "material_id"_a, "cos_theta_o"_a, "samples"_a = 4096,
              "Halton hemisphere integration of material eval(), used for BRDF conservation tests.")
+        .def("eval_hair_material", &PyRenderer::evalHairMaterial,
+             "material_id"_a, "wo"_a, "wi"_a, "tangent"_a, "hair_v"_a,
+             "pkg225-S2: eval the hair BSDF with a curve-style HitRecord "
+             "(uvTangent=tangent, hair_v set). Returns RGB f (cosine folded in).")
+        .def("integrate_hair_reflectance", &PyRenderer::integrateHairReflectance,
+             "material_id"_a, "wo"_a, "tangent"_a, "hair_v"_a, "samples"_a = 20000,
+             "pkg225-S2: FULL-SPHERE directional reflectance rho=(1/N)sum f/pdf via "
+             "sample() (no normal-hemisphere cull — hair transmits). Energy gate: rho<=1.")
         .def("debug_bsdf_sample_batch", &PyRenderer::debug_bsdf_sample_batch,
              "material_id"_a, "wo"_a, "u2_array"_a,
              "pkg121: batched BSDF sample for chi² tests (CPU-only). "

--- a/plugins/materials/principled_hair.cpp
+++ b/plugins/materials/principled_hair.cpp
@@ -1,0 +1,286 @@
+// Principled Hair BSDF (Chiang et al. 2016) — CPU material, pkg225 Stage 2.
+// DOI:10.1145/2775280.2792559. Ported from pbrt-v3 src/materials/hair.cpp
+// (BSD-2-Clause, Pharr/Jakob) for the Mp/Ap/Np/Sample_f math skeleton, with
+// Cycles' parameter conventions (melanin coeffs, coat→R-roughness, alpha tilt)
+// per intern/cycles/kernel/closure/bsdf_principled_hair_chiang.h + bsdf_util.h
+// (Apache-2.0). Full derivation + pbrt-vs-Cycles divergence table:
+// .astroray_plan/docs/pkg225-hair-bsdf-research.md.
+//
+// Convention: Astroray materials fold the cosine into eval()/sample.f (see
+// Lambertian in raytracer.h — returns albedo*cos/pi), and the integrator does
+// NOT re-apply it. pbrt's HairBSDF::f returns fsum/AbsCosTheta(wi), so the
+// integrator's cosine cancels and the net is fsum. Hence eval() returns fsum
+// directly. Frame is view-dependent (Cycles §5): X=tangent(uvTangent),
+// Y=normalize(X×wo), Z=X×Y — rebuilt from wo in eval/sample/pdf.
+#include "astroray/register.h"
+#include "astroray/hair_bsdf.h"
+#include "raytracer.h"
+#include <cmath>
+
+using namespace astroray::hair;
+
+namespace {
+
+// View-dependent hair frame: X=tangent, Y=normalize(X×wo), Z=X×Y.
+struct HairFrame {
+    Vec3 X, Y, Z;
+    HairFrame(const Vec3& tangent, const Vec3& wo) {
+        X = tangent.normalized();
+        Vec3 y = X.cross(wo);
+        if (y.length2() < 1e-12f) {          // wo ∥ tangent — pick any ⟂ axis
+            Vec3 a = (std::abs(X.x) > 0.9f) ? Vec3(0, 1, 0) : Vec3(1, 0, 0);
+            y = X.cross(a);
+        }
+        Y = y.normalized();
+        Z = X.cross(Y);
+    }
+    void toLocal(const Vec3& d, float& sinTheta, float& phi) const {
+        float lx = d.dot(X), ly = d.dot(Y), lz = d.dot(Z);
+        sinTheta = std::min(1.0f, std::max(-1.0f, lx));
+        phi = std::atan2(lz, ly);
+    }
+    Vec3 fromAngles(float sinThetaI, float cosThetaI, float phiI) const {
+        return X * sinThetaI + Y * (cosThetaI * std::cos(phiI)) + Z * (cosThetaI * std::sin(phiI));
+    }
+};
+
+}  // namespace
+
+class PrincipledHairPlugin : public Material {
+public:
+    explicit PrincipledHairPlugin(const astroray::ParamDict& p) {
+        betaM_ = std::clamp(p.getFloat("roughness", 0.3f), 1e-3f, 1.0f);
+        betaN_ = std::clamp(p.getFloat("radial_roughness", 0.3f), 1e-3f, 1.0f);
+        float coat = std::clamp(p.getFloat("coat", 0.0f), 0.0f, 1.0f);
+        eta_ = p.getFloat("ior", 1.55f);
+        float alpha = p.getFloat("offset", 2.0f * kPi / 180.0f);  // 2° default
+
+        // Longitudinal variances: R uses a coat-smoothed roughness (Cycles
+        // m0_roughness = (1-coat) multiplier); TT/TRT/residual from base betaM.
+        float vBase = longitudinalVariance(betaM_);
+        v_[0] = longitudinalVariance(betaM_ * (1.0f - coat));  // R
+        v_[1] = 0.25f * vBase;                                 // TT
+        v_[2] = 4.0f * vBase;                                  // TRT
+        v_[3] = 4.0f * vBase;                                  // residual
+        s_ = azimuthalScale(betaN_);
+        tilt_ = makeAlphaTilt(alpha);
+
+        std::string mode = p.getString("parametrization", "reflectance");
+        if (mode == "absorption" || mode == "direct_absorption") {
+            sigmaA_ = p.getVec3("absorption_coefficient", Vec3(0.245531f, 0.52f, 1.365f));
+        } else if (mode == "melanin" || mode == "pigment" || mode == "pigment_concentration") {
+            float mel = std::clamp(p.getFloat("melanin", 0.8f), 0.0f, 1.0f);
+            float redness = std::clamp(p.getFloat("melanin_redness", 1.0f), 0.0f, 1.0f);
+            Vec3 tint = p.getVec3("tint", Vec3(1.0f));
+            float m = -std::log(std::max(1.0f - mel, 1e-4f));  // perceptual remap
+            float eu = m * (1.0f - redness), ph = m * redness;
+            for (int c = 0; c < 3; ++c) {
+                float ce, cp; melaninCoeffs(c, ce, cp);
+                float tintSigma = sigmaAFromReflectanceChannel(tint[c], betaN_);
+                (&sigmaA_.x)[c] = ce * eu + cp * ph + tintSigma;
+            }
+        } else {  // reflectance / direct coloring (node default)
+            // The Blender node's "Color" socket maps to the material base color,
+            // which createMaterial() routes into ParamDict "albedo". Prefer an
+            // explicit "color" key, else fall back to the base color ("albedo").
+            Vec3 color = p.getVec3("color", p.getVec3("albedo", Vec3(0.017513f, 0.005763f, 0.002059f)));
+            for (int c = 0; c < 3; ++c)
+                (&sigmaA_.x)[c] = sigmaAFromReflectanceChannel(color[c], betaN_);
+        }
+    }
+
+    bool isGlossy() const override { return true; }
+    bool isTransmissive() const override { return true; }
+    float getIOR() const override { return eta_; }
+    float getRoughness() const override { return betaM_; }
+    Vec3 getAlbedo() const override {
+        return Vec3(std::exp(-std::sqrt(std::max(0.0f, sigmaA_.x))),
+                    std::exp(-std::sqrt(std::max(0.0f, sigmaA_.y))),
+                    std::exp(-std::sqrt(std::max(0.0f, sigmaA_.z))));
+    }
+
+    Vec3 eval(const HitRecord& rec, const Vec3& wo, const Vec3& wi) const override {
+        if (rec.hair_v < 0.0f) return Vec3(0);
+        Geom g = setup(rec, wo);
+        float sinThetaI, phiI;
+        g.frame.toLocal(wi, sinThetaI, phiI);
+        float cosThetaI = safeSqrt(1.0f - sqr(sinThetaI));
+        float phi = phiI - g.phiO;
+        Vec3 out;
+        for (int c = 0; c < 3; ++c)
+            (&out.x)[c] = fChannel(g, (&sigmaA_.x)[c], sinThetaI, cosThetaI, phi);
+        return out;
+    }
+
+    astroray::SampledSpectrum evalSpectral(
+            const HitRecord& rec, const Vec3& wo, const Vec3& wi,
+            const astroray::SampledWavelengths& lambdas) const override {
+        if (rec.hair_v < 0.0f) return astroray::SampledSpectrum(0.0f);
+        Geom g = setup(rec, wo);
+        float sinThetaI, phiI;
+        g.frame.toLocal(wi, sinThetaI, phiI);
+        float cosThetaI = safeSqrt(1.0f - sqr(sinThetaI));
+        float phi = phiI - g.phiO;
+        astroray::SampledSpectrum out(0.0f);
+        for (int i = 0; i < astroray::kSpectrumSamples; ++i)
+            out[i] = fChannel(g, sigmaAAtLambda(lambdas.lambda(i)), sinThetaI, cosThetaI, phi);
+        return out;
+    }
+
+    float pdf(const HitRecord& rec, const Vec3& wo, const Vec3& wi) const override {
+        if (rec.hair_v < 0.0f) return 0.0f;
+        Geom g = setup(rec, wo);
+        float sinThetaI, phiI;
+        g.frame.toLocal(wi, sinThetaI, phiI);
+        float cosThetaI = safeSqrt(1.0f - sqr(sinThetaI));
+        float phi = phiI - g.phiO;
+        return pdfCore(g, sinThetaI, cosThetaI, phi);
+    }
+
+    BSDFSample sample(const HitRecord& rec, const Vec3& wo, std::mt19937& gen) const override {
+        BSDFSample bs{Vec3(0, 1, 0), Vec3(0), 0.0f, false};
+        if (rec.hair_v < 0.0f) return bs;
+        Vec3 wi = sampleDir(rec, wo, gen);
+        bs.wi = wi;
+        bs.f = eval(rec, wo, wi);
+        bs.pdf = pdf(rec, wo, wi);
+        if (bs.pdf <= 0.0f) { bs.f = Vec3(0); bs.pdf = 0.0f; }
+        return bs;
+    }
+
+    // Override: the base sampleSpectral routes RGB f through the RGBAlbedo eta²
+    // clamp (wrong for hair). Sample the direction, return spectral f directly.
+    BSDFSampleSpectral sampleSpectral(
+            const HitRecord& rec, const Vec3& wo, std::mt19937& gen,
+            astroray::SampledWavelengths& lambdas) const override {
+        BSDFSampleSpectral bss;
+        bss.isDelta = false;
+        if (rec.hair_v < 0.0f) { bss.wi = Vec3(0, 1, 0); bss.pdf = 0.0f; return bss; }
+        Vec3 wi = sampleDir(rec, wo, gen);
+        bss.wi = wi;
+        bss.f_spectral = evalSpectral(rec, wo, wi, lambdas);
+        bss.pdf = pdf(rec, wo, wi);
+        if (bss.pdf <= 0.0f) { bss.f_spectral = astroray::SampledSpectrum(0.0f); bss.pdf = 0.0f; }
+        return bss;
+    }
+
+private:
+    struct Geom {
+        HairFrame frame;
+        float h, gammaO, gammaT;
+        float sinThetaO, cosThetaO, phiO;
+        float fFresnel, cosGammaT, cosThetaT;
+    };
+
+    Geom setup(const HitRecord& rec, const Vec3& wo) const {
+        HairFrame frame(rec.uvTangent, wo);
+        float sinThetaO, phiO;
+        frame.toLocal(wo, sinThetaO, phiO);
+        float cosThetaO = safeSqrt(1.0f - sqr(sinThetaO));
+        float h = std::clamp(2.0f * rec.hair_v - 1.0f, -1.0f, 1.0f);
+        float gammaO = safeAsin(h);
+        float sinThetaT = sinThetaO / eta_;
+        float cosThetaT = safeSqrt(1.0f - sqr(sinThetaT));
+        float etap = safeSqrt(eta_ * eta_ - sqr(sinThetaO)) / std::max(cosThetaO, 1e-5f);
+        float sinGammaT = h / etap;
+        float cosGammaT = safeSqrt(1.0f - sqr(sinGammaT));
+        float gammaT = safeAsin(sinGammaT);
+        float cosGammaO = safeSqrt(1.0f - sqr(h));
+        float fFresnel = frDielectric(cosThetaO * cosGammaO, 1.0f, eta_);
+        return {frame, h, gammaO, gammaT, sinThetaO, cosThetaO, phiO, fFresnel, cosGammaT, cosThetaT};
+    }
+
+    float transmittance(float sigmaAChannel, const Geom& g) const {
+        return std::exp(-sigmaAChannel * (2.0f * g.cosGammaT / std::max(g.cosThetaT, 1e-5f)));
+    }
+
+    float fChannel(const Geom& g, float sigmaAChannel,
+                   float sinThetaI, float cosThetaI, float phi) const {
+        float T = transmittance(sigmaAChannel, g);
+        float ap[kPMax + 1];
+        Ap(g.fFresnel, T, ap);
+        float fc = 0.0f;
+        for (int pp = 0; pp < kPMax; ++pp) {
+            float sinThetaOp, cosThetaOp;
+            tiltThetaO(tilt_, pp, g.sinThetaO, g.cosThetaO, sinThetaOp, cosThetaOp);
+            cosThetaOp = std::abs(cosThetaOp);
+            fc += Mp(cosThetaI, cosThetaOp, sinThetaI, sinThetaOp, v_[pp]) * ap[pp] *
+                  Np(phi, pp, s_, g.gammaO, g.gammaT);
+        }
+        fc += Mp(cosThetaI, g.cosThetaO, sinThetaI, g.sinThetaO, v_[kPMax]) * ap[kPMax] *
+              (1.0f / (2.0f * kPi));
+        return fc;
+    }
+
+    void computeApPdf(const Geom& g, float apPdfArr[kPMax + 1]) const {
+        float apLum[kPMax + 1] = {0, 0, 0, 0};
+        for (int c = 0; c < 3; ++c) {
+            float T = transmittance((&sigmaA_.x)[c], g);
+            float ap[kPMax + 1];
+            Ap(g.fFresnel, T, ap);
+            for (int i = 0; i <= kPMax; ++i) apLum[i] += ap[i] * (1.0f / 3.0f);
+        }
+        apPdf(apLum, apPdfArr);
+    }
+
+    float pdfCore(const Geom& g, float sinThetaI, float cosThetaI, float phi) const {
+        float apPdfArr[kPMax + 1];
+        computeApPdf(g, apPdfArr);
+        float pdfSum = 0.0f;
+        for (int pp = 0; pp < kPMax; ++pp) {
+            float sinThetaOp, cosThetaOp;
+            tiltThetaO(tilt_, pp, g.sinThetaO, g.cosThetaO, sinThetaOp, cosThetaOp);
+            cosThetaOp = std::abs(cosThetaOp);
+            pdfSum += Mp(cosThetaI, cosThetaOp, sinThetaI, sinThetaOp, v_[pp]) *
+                      apPdfArr[pp] * Np(phi, pp, s_, g.gammaO, g.gammaT);
+        }
+        pdfSum += Mp(cosThetaI, g.cosThetaO, sinThetaI, g.sinThetaO, v_[kPMax]) *
+                  apPdfArr[kPMax] * (1.0f / (2.0f * kPi));
+        return pdfSum;
+    }
+
+    Vec3 sampleDir(const HitRecord& rec, const Vec3& wo, std::mt19937& gen) const {
+        Geom g = setup(rec, wo);
+        std::uniform_real_distribution<float> U(0.0f, 1.0f);
+        float apPdfArr[kPMax + 1];
+        computeApPdf(g, apPdfArr);
+        float up = U(gen), cdf = 0.0f;
+        int p = kPMax;
+        for (int i = 0; i <= kPMax; ++i) { cdf += apPdfArr[i]; if (up < cdf) { p = i; break; } }
+
+        float sinThetaOp, cosThetaOp;
+        tiltThetaO(tilt_, p, g.sinThetaO, g.cosThetaO, sinThetaOp, cosThetaOp);
+
+        float u1x = std::max(U(gen), 1e-5f), u1y = U(gen);
+        float cosTheta = 1.0f + v_[p] * std::log(u1x + (1.0f - u1x) * std::exp(-2.0f / v_[p]));
+        float sinTheta = safeSqrt(1.0f - sqr(cosTheta));
+        float cosPhi = std::cos(2.0f * kPi * u1y);
+        float sinThetaI = -cosTheta * sinThetaOp + sinTheta * cosPhi * cosThetaOp;
+        float cosThetaI = safeSqrt(1.0f - sqr(sinThetaI));
+
+        float dphi;
+        if (p < kPMax)
+            dphi = deltaPhi(p, g.gammaO, g.gammaT) + sampleTrimmedLogistic(U(gen), s_, -kPi, kPi);
+        else
+            dphi = 2.0f * kPi * U(gen);
+        float phiI = g.phiO + dphi;
+        return g.frame.fromAngles(sinThetaI, cosThetaI, phiI).normalized();
+    }
+
+    // Spectral sigma_a: piecewise-linear upsample of the RGB absorption over the
+    // 3 primaries' representative wavelengths. Stage-5 replaces this with a true
+    // melanin cross-section (the sigmaA function boundary is the seam).
+    float sigmaAAtLambda(float lambda) const {
+        if (lambda <= 450.0f) return sigmaA_.z;
+        if (lambda >= 600.0f) return sigmaA_.x;
+        if (lambda < 550.0f) { float t = (lambda - 450.0f) / 100.0f; return sigmaA_.z * (1 - t) + sigmaA_.y * t; }
+        float t = (lambda - 550.0f) / 50.0f; return sigmaA_.y * (1 - t) + sigmaA_.x * t;
+    }
+
+    float betaM_, betaN_, eta_, s_;
+    float v_[kPMax + 1];
+    AlphaTilt tilt_;
+    Vec3 sigmaA_;
+};
+
+ASTRORAY_REGISTER_MATERIAL("principled_hair", PrincipledHairPlugin)

--- a/tests/test_pkg225_hair_bsdf.py
+++ b/tests/test_pkg225_hair_bsdf.py
@@ -1,0 +1,131 @@
+"""pkg225 Stage 2 — Principled Hair BSDF (Chiang 2016) unit gates.
+
+Drives the CPU `principled_hair` material's BSDF directly (no render) via the
+`eval_hair_material` / `integrate_hair_reflectance` test bindings, which build a
+curve-style HitRecord (uvTangent = strand tangent, hair_v set) so the hair
+branch activates. See .astroray_plan/docs/pkg225-hair-bsdf-research.md §9.
+"""
+from __future__ import annotations
+
+import math
+import numpy as np
+import pytest
+
+from runtime_setup import configure_test_imports
+configure_test_imports()
+
+try:
+    import astroray
+    AVAILABLE = hasattr(astroray.Renderer, "integrate_hair_reflectance")
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray hair bindings not built")
+
+_TANGENT = [1.0, 0.0, 0.0]          # strand along +X
+_HAIR_V = 0.62                       # off-centre hit (h = 2v-1 = 0.24)
+
+
+def _hair_mat(r, **params):
+    # Reflectance colour defaults to a mid grey unless overridden.
+    color = params.pop("color", [0.5, 0.5, 0.5])
+    return r.create_material("principled_hair", color, params)
+
+
+def _wo(theta_deg=35.0, phi_deg=20.0):
+    # A generic outgoing (view) direction, not aligned to the tangent.
+    t = math.radians(theta_deg)
+    p = math.radians(phi_deg)
+    return [math.sin(t), math.cos(t) * math.cos(p), math.cos(t) * math.sin(p)]
+
+
+@pytest.mark.parametrize("betaM", [0.1, 0.3, 0.6, 1.0])
+def test_energy_conservation_white_furnace(betaM):
+    """sigma_a = 0 (absorption off): the hemispherical/spherical directional
+    reflectance rho = (1/N) sum f/pdf must be <= 1 (energy-conserving). Linear,
+    upper-bound assertion (MEMORY gamma-furnace-hides-energy-gain)."""
+    r = astroray.Renderer()
+    mat = _hair_mat(r, roughness=betaM, radial_roughness=0.3,
+                    parametrization="absorption", absorption_coefficient=[0.0, 0.0, 0.0])
+    rho = np.asarray(r.integrate_hair_reflectance(mat, _wo(), _TANGENT, _HAIR_V, 20000))
+    assert np.all(np.isfinite(rho)), f"rho not finite: {rho}"
+    assert np.all(rho <= 1.02), f"energy gain (rho>1) at betaM={betaM}: {rho}"
+    assert np.all(rho > 0.2), f"suspiciously dark hair (rho too low) at betaM={betaM}: {rho}"
+
+
+def test_absorption_darkens():
+    """Non-zero absorption must reduce reflectance vs the zero-absorption case."""
+    r = astroray.Renderer()
+    clear = _hair_mat(r, roughness=0.3, parametrization="absorption",
+                      absorption_coefficient=[0.0, 0.0, 0.0])
+    absorb = _hair_mat(r, roughness=0.3, parametrization="absorption",
+                       absorption_coefficient=[2.0, 2.0, 2.0])
+    rho_clear = np.asarray(r.integrate_hair_reflectance(clear, _wo(), _TANGENT, _HAIR_V, 20000))
+    rho_abs = np.asarray(r.integrate_hair_reflectance(absorb, _wo(), _TANGENT, _HAIR_V, 20000))
+    assert np.mean(rho_abs) < np.mean(rho_clear), \
+        f"absorption did not darken: clear={rho_clear} absorb={rho_abs}"
+
+
+def test_reflectance_color_response():
+    """Direct-coloring (reflectance) mode: a red target colour must yield a
+    redder reflectance than a blue target (the sigma_a inversion is per-channel)."""
+    r = astroray.Renderer()
+    red = _hair_mat(r, color=[0.6, 0.05, 0.05], roughness=0.3, parametrization="reflectance")
+    blue = _hair_mat(r, color=[0.05, 0.05, 0.6], roughness=0.3, parametrization="reflectance")
+    rho_red = np.asarray(r.integrate_hair_reflectance(red, _wo(), _TANGENT, _HAIR_V, 20000))
+    rho_blue = np.asarray(r.integrate_hair_reflectance(blue, _wo(), _TANGENT, _HAIR_V, 20000))
+    assert rho_red[0] > rho_red[2], f"red hair not red-dominant: {rho_red}"
+    assert rho_blue[2] > rho_blue[0], f"blue hair not blue-dominant: {rho_blue}"
+
+
+def test_eval_finite_and_nonnegative():
+    """eval must be finite and >= 0 for a spread of incoming directions."""
+    r = astroray.Renderer()
+    mat = _hair_mat(r, roughness=0.3, radial_roughness=0.3, parametrization="reflectance",
+                    color=[0.4, 0.3, 0.2])
+    wo = _wo()
+    rng = np.random.default_rng(7)
+    saw_positive = False
+    for _ in range(200):
+        d = rng.normal(size=3); d /= np.linalg.norm(d)
+        f = np.asarray(r.eval_hair_material(mat, wo, list(d), _TANGENT, _HAIR_V))
+        assert np.all(np.isfinite(f)), f"eval not finite: {f} wi={d}"
+        assert np.all(f >= -1e-6), f"eval negative: {f} wi={d}"
+        if np.any(f > 1e-4):
+            saw_positive = True
+    assert saw_positive, "hair BSDF eval was ~zero for every direction"
+
+
+def test_not_a_curve_hit_returns_zero():
+    """hair_v < 0 (non-curve hit) must return zero — the material only activates
+    on curve hits, so non-hair scenes are unaffected (regression guard)."""
+    r = astroray.Renderer()
+    mat = _hair_mat(r, roughness=0.3)
+    f = np.asarray(r.eval_hair_material(mat, _wo(), [0.0, 1.0, 0.0], _TANGENT, -1.0))
+    assert np.allclose(f, 0.0), f"expected zero for non-curve hit, got {f}"
+
+
+def test_hair_strand_renders_spectral_path():
+    """End-to-end smoke: a curve strand with the principled_hair material, lit by
+    a grey environment, must render through the SPECTRAL integrator path
+    (evalSpectral/sampleSpectral) to finite, energy-bounded, non-black pixels.
+    The RGB unit gates above never touch the spectral path, so this guards it."""
+    W = H = 96
+    r = astroray.Renderer()
+    r.set_background_color([0.5, 0.5, 0.5])            # uniform grey environment
+    mat = _hair_mat(r, roughness=0.3, radial_roughness=0.3,
+                    color=[0.55, 0.35, 0.18], parametrization="reflectance")
+    # A near-horizontal strand across the view, thick enough to cover pixels.
+    pts = np.array([[-3.0, 0.0, 0.0], [-1.0, 0.0, 0.0],
+                    [1.0, 0.0, 0.0], [3.0, 0.0, 0.0]], dtype=np.float32)
+    rad = np.full(4, 0.25, dtype=np.float32)
+    r.add_curves_bulk(pts, rad, [4], mat)
+    r.set_integrator("path_tracer")
+    r.setup_camera([0, 0, 5], [0, 0, 0], [0, 1, 0], 40.0, 1.0, 0.0, 5.0, W, H)
+    r.set_seed(7)
+    img = np.asarray(r.render(64, 6, None, True), dtype=np.float32).reshape(H, W, 3)
+    assert np.all(np.isfinite(img)), "hair render produced non-finite pixels"
+    assert float(img.max()) < 5.0, f"hair render energy runaway: max={img.max()}"
+    # The strand crosses the middle row; that band must be lit (non-black).
+    band = img[H // 2 - 3:H // 2 + 3, :, :]
+    assert float(band.max()) > 1e-3, f"hair strand rendered black (max={band.max()})"


### PR DESCRIPTION
## Summary

pkg225 Stage 2 — a CPU **Principled Hair BSDF** (Chiang et al. 2016), the hair-shading layer on top of Stage 1's ray-curve intersection. Ported from pbrt-v3 `hair.cpp` (BSD-2-Clause) for the Mp/Ap/Np/Sample_f math, with Cycles' parameter conventions (melanin coefficients, coat→R-roughness, cuticle tilt) per `bsdf_principled_hair_chiang.h` (Apache-2.0). Research contract (cite-algorithm): [`pkg225-hair-bsdf-research.md`](.astroray_plan/docs/pkg225-hair-bsdf-research.md).

## What landed
- **`include/astroray/hair_bsdf.h`** — shared, header-only, STL-free-in-hot-path math (longitudinal `Mp`, azimuthal logistic `Np`, Fresnel+Beer-Lambert `Ap`, cuticle tilt, σ_a-from-reflectance/melanin). Structured for a Stage-3/4 GPU `#include`.
- **`plugins/materials/principled_hair.cpp`** — R/TT/TRT + residual tail; three σ_a parametrizations (direct absorption / melanin / reflectance-inversion — the node default); **view-dependent frame** X=`uvTangent`(strand tangent), Y=X×wo, Z=X×Y; **h = 2·hair_v − 1**; coat smooths the R lobe. `eval`/`pdf`/`sample` (RGB) + `evalSpectral` + an **overridden `sampleSpectral`** (the base default routes RGB f through the RGBAlbedo η² clamp, wrong for hair).
- Cosine convention: `eval` returns `fsum` = pbrt's `f·cos` net, matching Astroray's cosine-folded material convention (verified against Lambertian).
- **`module/blender_module.cpp`** — `eval_hair_material` / `integrate_hair_reflectance` test bindings (full-sphere reflectance, **no** normal-hemisphere cull since hair transmits).

## Testing
`tests/test_pkg225_hair_bsdf.py` **9/9**:
- energy conservation ρ ≤ 1 across β_m ∈ {0.1, 0.3, 0.6, 1.0} (white furnace, linear upper bound)
- absorption-darkens, per-channel colour response (red/blue targets)
- eval finite/≥0, non-curve **regression guard** (material inert unless `hair_v ≥ 0`)
- spectral-path render smoke (exercises `evalSpectral`/`sampleSpectral` end-to-end)

Regression: **278** existing CPU material/curve tests pass. CPU-only — GPU (Stages 3–4), spectral melanin (Stage 5), addon (Stage 6) remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)