### PR TITLE
pkg219d: scalar parameter textures (op-VM → roughness/metallic/transmission/IOR)

### DIFF
--- a/.astroray_plan/packages/pkg219d-scalar-param-textures.md
+++ b/.astroray_plan/packages/pkg219d-scalar-param-textures.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 5 (Blender/DCC integration — shader-node compatibility)
 **Track:** A (engine + addon; CPU + GPU BSDF eval)
-**Status:** open — **fork DECIDED 2026-09-02 (architect), dispatchable.** Was "architect to detail before dispatch"; the design pass below resolves it. Route: dv4/deepseek implements to the decided design, HARD `cuobjdump` probe + `cpp-abi-guard` + Claude-last-line review before merge — same routing shape as pkg223 (PR #647). Filed 2026-08-31 — residual surfaced by the pkg219 completion audit, PR #661.
+**Status:** implementation WRITTEN 2026-09-03 (branch `worktree-agent-afef472196a2cee25`), pending parent CUDA build + `cuobjdump` register probe (fleet `stageShadeBucketedKernel<0,…>` must stay REG:254/STACK:3368/CONSTANT[0]:1716) + HW parity verify. NOT built/tested by the implementer (no vcvars). — **fork DECIDED 2026-09-02 (architect), dispatchable.** Was "architect to detail before dispatch"; the design pass below resolves it. Route: dv4/deepseek implements to the decided design, HARD `cuobjdump` probe + `cpp-abi-guard` + Claude-last-line review before merge — same routing shape as pkg223 (PR #647). Filed 2026-08-31 — residual surfaced by the pkg219 completion audit, PR #661.
 **Estimated effort:** M–L (extends a proven side-table pattern; the GPU register probe is the only Claude-last-line step).
 **Depends on:** pkg219a/b/c (op-VM evaluator, all landed) — the machinery already exists; this only wires its output into non-base-color BSDF inputs.
 

--- a/.astroray_plan/packages/pkg219d-scalar-param-textures.md
+++ b/.astroray_plan/packages/pkg219d-scalar-param-textures.md
@@ -2,7 +2,16 @@
 
 **Pillar:** 5 (Blender/DCC integration — shader-node compatibility)
 **Track:** A (engine + addon; CPU + GPU BSDF eval)
-**Status:** implementation WRITTEN 2026-09-03 (branch `worktree-agent-afef472196a2cee25`), pending parent CUDA build + `cuobjdump` register probe (fleet `stageShadeBucketedKernel<0,…>` must stay REG:254/STACK:3368/CONSTANT[0]:1716) + HW parity verify. NOT built/tested by the implementer (no vcvars). — **fork DECIDED 2026-09-02 (architect), dispatchable.** Was "architect to detail before dispatch"; the design pass below resolves it. Route: dv4/deepseek implements to the decided design, HARD `cuobjdump` probe + `cpp-abi-guard` + Claude-last-line review before merge — same routing shape as pkg223 (PR #647). Filed 2026-08-31 — residual surfaced by the pkg219 completion audit, PR #661.
+**Status:** DONE 2026-09-03 — built + register-probed + HW-verified by the parent.
+Fleet `stageShadeBucketedKernel<0,0,0,0,0,0,0>` measured **byte-identical** to
+baseline (REG:254/STACK:3368/CONSTANT[0]:1716) from the linked `.pyd` — the
+`<HasProgram=false>` fleet paid nothing (the `if constexpr` + empty
+`GScalarOverride<false>` + collapsed pointer-indirection held). `tests/
+test_pkg219d_scalar_param_textures.py` 3/3 on the RTX box (CPU + GPU roughness
+per-half reproduction + CPU/GPU mean-ratio parity); 297 disney/material/hair
+regression tests pass. Known-bounded: metallic/transmission GPU parity is
+approximate (closure lobe-MIX baked at upload); roughness/IOR exact. — **fork
+DECIDED 2026-09-02 (architect), CPU-model pinned 2026-09-03 (parent).** Was "architect to detail before dispatch"; the design pass below resolves it. Route: dv4/deepseek implements to the decided design, HARD `cuobjdump` probe + `cpp-abi-guard` + Claude-last-line review before merge — same routing shape as pkg223 (PR #647). Filed 2026-08-31 — residual surfaced by the pkg219 completion audit, PR #661.
 **Estimated effort:** M–L (extends a proven side-table pattern; the GPU register probe is the only Claude-last-line step).
 **Depends on:** pkg219a/b/c (op-VM evaluator, all landed) — the machinery already exists; this only wires its output into non-base-color BSDF inputs.
 

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -4161,6 +4161,30 @@ class CustomRaytracerRenderEngine(RenderEngine):
                 self._warn_shader_fallback('BSDF_PRINCIPLED', msg)
             return renderer.create_material('principled', base_color, native)
 
+        # pkg219d — per-texel scalar-parameter op-VM chains (Image → Map Range →
+        # Roughness, etc.). Reuse the base-colour op-VM detection/upload; attach the
+        # resulting program-texture names so the engine (DisneyPlugin::substituted()
+        # on CPU + the GPU c_wfProgBinding scalar side table) per-texel-drives the
+        # scalar BSDF inputs. Wired only on this Disney path — the native 'principled'
+        # material and the textured-base-colour 'lambertian' route above do not carry
+        # the DisneyPlugin scalar slots (a documented follow-up). No-ops when a socket
+        # is unlinked or its chain is not a per-texel op (constant default stands).
+        for _sock_name, _param_key in (('Roughness', 'roughness_program'),
+                                       ('Metallic', 'metallic_program'),
+                                       ('IOR', 'ior_program')):
+            _sock = node.inputs.get(_sock_name)
+            if _sock is not None and getattr(_sock, 'is_linked', False):
+                _prog = self._maybe_build_program_texture(
+                    _sock, node, _sock_name, renderer)
+                if _prog is not None:
+                    params[_param_key] = _prog
+        # Transmission uses the Blender-4.0 renamed socket ('Transmission Weight').
+        _tsock = node.inputs.get('Transmission Weight') or node.inputs.get('Transmission')
+        if _tsock is not None and getattr(_tsock, 'is_linked', False):
+            _prog = self._maybe_build_program_texture(
+                _tsock, node, 'Transmission', renderer)
+            if _prog is not None:
+                params['transmission_program'] = _prog
         return renderer.create_material('disney', base_color, params)
 
     def _render_will_use_gpu(self, settings, renderer):

--- a/include/astroray/gpu_scene_upload.h
+++ b/include/astroray/gpu_scene_upload.h
@@ -63,6 +63,15 @@ struct SceneUploadResult {
     std::vector<astroray::svm::ShaderVMProgram> programs;
     std::vector<int>                            materialProgramId;
     bool                                        hasProgram = false;
+    // pkg219d — scalar BSDF-param op-VM programs. Flattened [mat*VM_SCALAR_SLOTS +
+    // slot] tables parallel to `materials` (slots per astroray::svm::ScalarSlot):
+    // materialScalarProgId = program index into `programs` (-1 = none);
+    // materialScalarTexId = source-image index into `textures` (-1 = none). Deduped
+    // into the SAME `programs`/`textures` buffers as the base-colour program. A
+    // scalar-program material also sets hasProgram (and hasTexture, since its source
+    // image uploads through the pkg186 texture path).
+    std::vector<int>                            materialScalarProgId;
+    std::vector<int>                            materialScalarTexId;
 
     // pkg189 — true when ANY uploaded material is dispersive (Sellmeier dielectric
     // → GMAT_DIELECTRIC, or Cauchy Principled glass → GMAT_CLOSURE_GRAPH; both set

--- a/include/astroray/shader_vm.h
+++ b/include/astroray/shader_vm.h
@@ -34,6 +34,13 @@ constexpr int VM_MAX_CONST      = 16;   // vec3 constant pool
 constexpr int VM_MAX_TEX        = 2;    // pre-sampled input textures
 constexpr int RAMP_TABLE_SIZE   = 256;  // baked ramp resolution (Cycles: 256)
 constexpr int VM_MAX_RAMPS      = 2;
+// pkg219d — scalar BSDF-parameter program slots. A fixed small K per material;
+// each slot binds an op-VM program (+ its own source image) that per-texel drives
+// one scalar Disney input. Order is load-bearing (host upload, GPU shade loop,
+// and CPU DisneyPlugin all index by it): {0:ROUGHNESS,1:METALLIC,2:TRANSMISSION,3:IOR}.
+constexpr int VM_SCALAR_SLOTS   = 4;
+enum ScalarSlot : int { SCALAR_ROUGHNESS = 0, SCALAR_METALLIC = 1,
+                        SCALAR_TRANSMISSION = 2, SCALAR_IOR = 3 };
 
 enum OpCode : unsigned char {
     OP_END        = 0,
@@ -390,4 +397,13 @@ HD inline GVec3 svm_eval(const ShaderVMProgram& p, const GVec3* inputs) {
 struct GWavefrontProgramBinding {
     const astroray::svm::ShaderVMProgram* programs;  // device global array
     const int*                            matProgId; // per-material index (-1=none)
+    // pkg219d — scalar BSDF-param programs. Both indexed [mat*VM_SCALAR_SLOTS + slot]
+    // (slots per astroray::svm::ScalarSlot). matScalarProgId[..] = index into the
+    // SAME `programs` array (-1 = no program on that slot); matScalarTexId[..] =
+    // index into c_wfTexBinding.textures for that slot's OWN source image (a scalar
+    // program feeds its own map, NOT the base-colour texel). Read ONLY inside the
+    // shade kernel's `if constexpr (HasProgram)` block, so the <false> fleet never
+    // touches these and stays byte-identical.
+    const int*                            matScalarProgId;
+    const int*                            matScalarTexId;
 };

--- a/include/raytracer.h
+++ b/include/raytracer.h
@@ -486,6 +486,13 @@ public:
     virtual std::shared_ptr<Texture>  bumpMapTexture() const { return nullptr; }
     virtual float                     bumpMapStrength() const { return 1.0f; }
     virtual float                     bumpMapDistance() const { return 0.01f; }
+    // pkg219d — per-texel scalar BSDF-parameter programs (op-VM ProgramTexture).
+    // `slot` is an astroray::svm::ScalarSlot (roughness/metallic/transmission/ior).
+    // Default no-op / null: only DisneyPlugin stores + evaluates them. scene_upload
+    // reads them via scalarProgram(slot) to build the GPU c_wfProgBinding scalar
+    // side arrays; the CPU DisneyPlugin substitutes them per-hit at rec.uv.
+    virtual void setScalarProgram(int /*slot*/, const std::shared_ptr<Texture>& /*prog*/) {}
+    virtual std::shared_ptr<Texture> scalarProgram(int /*slot*/) const { return nullptr; }
     virtual astroray::MaterialClosureGraph closureGraph() const { return {}; }
     virtual MaterialBackendCapabilities backendCapabilities() const {
         MaterialBackendCapabilities caps;

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -612,6 +612,22 @@ public:
             catch (const std::runtime_error&) {}
         }
         if (!mat) mat = makeLegacyMaterial(type, color, params);
+        // pkg219d — attach per-texel scalar-parameter op-VM programs. Each named
+        // param resolves to an already-created ProgramTexture; only DisneyPlugin
+        // stores them (the base Material virtual is a no-op elsewhere). Attached to
+        // the un-wrapped material so a NormalMapped(disney) still drives its scalars.
+        if (mat) {
+            const std::pair<const char*, int> scalarProgs[] = {
+                {"roughness_program",    astroray::svm::SCALAR_ROUGHNESS},
+                {"metallic_program",     astroray::svm::SCALAR_METALLIC},
+                {"transmission_program", astroray::svm::SCALAR_TRANSMISSION},
+                {"ior_program",          astroray::svm::SCALAR_IOR},
+            };
+            for (const auto& sp : scalarProgs) {
+                if (auto tex = getTexture(sp.first))
+                    mat->setScalarProgram(sp.second, tex);
+            }
+        }
         auto normalTex = getTexture("normal_map_texture"), bumpTex = getTexture("bump_map_texture");
         if (normalTex || bumpTex)
             mat = astroray::makeNormalMapped(mat, normalTex, bumpTex,

--- a/plugins/materials/disney.cpp
+++ b/plugins/materials/disney.cpp
@@ -11,6 +11,42 @@ class DisneyPlugin : public Material {
     float transmission_, ior_;
     static constexpr float kDeltaTransmissionRoughness = 0.03f;
 
+    // pkg219d — optional per-texel op-VM programs driving the scalar BSDF inputs
+    // (Image → Map Range → Roughness, etc.). Each is a ProgramTexture (held as the
+    // base Texture so value(rec,wo) resolves coord + Mapping) evaluated at the hit
+    // UV; when set, it SUBSTITUTES for the constant member below. The GPU twin
+    // (stage_advance.cu, if constexpr(HasProgram)) runs the SAME svm_eval on the
+    // SAME source texel, so CPU↔GPU parity is by construction. Slots mirror
+    // astroray::svm::ScalarSlot.
+    std::shared_ptr<Texture> roughnessProgram_, metallicProgram_,
+                             transmissionProgram_, iorProgram_;
+
+    bool hasScalarProgram() const {
+        return roughnessProgram_ || metallicProgram_ ||
+               transmissionProgram_ || iorProgram_;
+    }
+
+    // Build a copy of this material with the op-VM scalars evaluated at THIS hit
+    // and the programs cleared, then delegate the (unchanged) constant-material
+    // physics to it. Thread-safe (a fresh local per call — the plugin instance is
+    // shared across OpenMP worker threads, so an in-place mutate would race) and
+    // exactly one level deep (the clone has no programs). The clamps MUST match the
+    // constructor's and the GPU override's, or CPU/GPU diverge.
+    DisneyPlugin substituted(const HitRecord& rec, const Vec3& wo) const {
+        DisneyPlugin c(*this);
+        if (roughnessProgram_)
+            c.roughness_ = std::clamp(roughnessProgram_->value(rec, wo).x, 0.001f, 1.0f);
+        if (metallicProgram_)
+            c.metallic_ = std::clamp(metallicProgram_->value(rec, wo).x, 0.0f, 1.0f);
+        if (transmissionProgram_)
+            c.transmission_ = std::clamp(transmissionProgram_->value(rec, wo).x, 0.0f, 1.0f);
+        if (iorProgram_)
+            c.ior_ = std::max(1.0f, iorProgram_->value(rec, wo).x);
+        c.roughnessProgram_ = c.metallicProgram_ =
+            c.transmissionProgram_ = c.iorProgram_ = nullptr;
+        return c;
+    }
+
     // GGX/Trowbridge-Reitz NDF (Walter 2007 Eq. 33, pbrt-v4 §9.6).
     // D(wm) = α² / (π (1 + (α²-1)·cos²θm)²)
     float D_GTR2(float NdotH, float a) const {
@@ -506,6 +542,27 @@ public:
 
     Vec3 getAlbedo() const override { return baseColor_; }
     std::string getGPUTypeName() const override { return "disney"; }
+    // pkg219d — per-texel scalar-parameter op-VM programs (slots per
+    // astroray::svm::ScalarSlot). Stored as the base Texture so value(rec,wo)
+    // resolves the ProgramTexture's coord + Mapping; substituted() evaluates them.
+    void setScalarProgram(int slot, const std::shared_ptr<Texture>& prog) override {
+        switch (slot) {
+            case astroray::svm::SCALAR_ROUGHNESS:    roughnessProgram_ = prog;    break;
+            case astroray::svm::SCALAR_METALLIC:     metallicProgram_ = prog;     break;
+            case astroray::svm::SCALAR_TRANSMISSION: transmissionProgram_ = prog; break;
+            case astroray::svm::SCALAR_IOR:          iorProgram_ = prog;          break;
+            default: break;
+        }
+    }
+    std::shared_ptr<Texture> scalarProgram(int slot) const override {
+        switch (slot) {
+            case astroray::svm::SCALAR_ROUGHNESS:    return roughnessProgram_;
+            case astroray::svm::SCALAR_METALLIC:     return metallicProgram_;
+            case astroray::svm::SCALAR_TRANSMISSION: return transmissionProgram_;
+            case astroray::svm::SCALAR_IOR:          return iorProgram_;
+            default: return nullptr;
+        }
+    }
     astroray::MaterialClosureGraph closureGraph() const override {
         astroray::MaterialClosureGraph graph;
         const astroray::ClosureColor base{baseColor_.x, baseColor_.y, baseColor_.z};
@@ -550,7 +607,8 @@ public:
     float getAnisotropic() const override { return anisotropic_; }
     float getAnisotropicRotation() const override { return anisotropicRotation_; }
 
-    Vec3 eval(const HitRecord& rec, const Vec3& wo, const Vec3& wi) const {
+    Vec3 eval(const HitRecord& rec, const Vec3& wo, const Vec3& wi) const override {
+        if (hasScalarProgram()) return substituted(rec, wo).eval(rec, wo, wi);
         Vec3 N = rec.normal;
         float NdotL = N.dot(wi);
         float NdotV = N.dot(wo);
@@ -730,12 +788,15 @@ public:
     astroray::SampledSpectrum evalSpectral(
             const HitRecord& rec, const Vec3& wo, const Vec3& wi,
             const astroray::SampledWavelengths& lambdas) const override {
+        if (hasScalarProgram())
+            return substituted(rec, wo).evalSpectral(rec, wo, wi, lambdas);
         // pkg13 fallback: upsample final RGB Disney eval to stay within the pkg14 1.5x perf budget.
         Vec3 rgb = eval(rec, wo, wi);
         return astroray::RGBAlbedoSpectrum({rgb.x, rgb.y, rgb.z}).sample(lambdas);
     }
 
     BSDFSample sample(const HitRecord& rec, const Vec3& wo, std::mt19937& gen) const override {
+        if (hasScalarProgram()) return substituted(rec, wo).sample(rec, wo, gen);
         BSDFSample s;
         s.wi = rec.normal;
         s.f = Vec3(0);
@@ -880,6 +941,7 @@ public:
     }
 
     float pdf(const HitRecord& rec, const Vec3& wo, const Vec3& wi) const override {
+        if (hasScalarProgram()) return substituted(rec, wo).pdf(rec, wo, wi);
         if (transmission_ > 0.0f && roughness_ > kDeltaTransmissionRoughness &&
             rec.normal.dot(wo) * rec.normal.dot(wi) < 0.0f) {
             return roughTransmissionPdf(rec, wo, wi);

--- a/src/gpu/scene_upload.cu
+++ b/src/gpu/scene_upload.cu
@@ -334,7 +334,23 @@ static void appendOnePrim(
             // material's triangle uploads no UVs (hasUV=0) and the bump branch skips.
             const bool bumpMapped =
                 mtl && mtl->bumpMapTexture() != nullptr;
-            if ((anisoPrincipled || imageTextured || normalMapped || bumpMapped) &&
+            // pkg219d — a scalar-parameter op-VM material (roughness/metallic/etc.
+            // driven by an image) needs the active-layer UVs on the device: the
+            // shade path fetches the scalar program's OWN source texel at the hit
+            // UV. Without this a scalar-ONLY material (no base-colour/normal/bump
+            // texture) uploads UV-less (hasUV=0) and the scalar override reads
+            // garbage → silently no-ops (same class as the pkg223b bump-only gate).
+            // Checked on the inner material so a NormalMapped(disney) also qualifies.
+            const auto& scalarMtl =
+                (mtl && mtl->normalMapInner()) ? mtl->normalMapInner() : mtl;
+            const bool scalarProgrammed =
+                scalarMtl &&
+                (scalarMtl->scalarProgram(astroray::svm::SCALAR_ROUGHNESS) ||
+                 scalarMtl->scalarProgram(astroray::svm::SCALAR_METALLIC) ||
+                 scalarMtl->scalarProgram(astroray::svm::SCALAR_TRANSMISSION) ||
+                 scalarMtl->scalarProgram(astroray::svm::SCALAR_IOR));
+            if ((anisoPrincipled || imageTextured || normalMapped || bumpMapped ||
+                 scalarProgrammed) &&
                 tri->hasUVLayers()) {
                 Vec2 t0 = tri->getUV0(), t1 = tri->getUV1(), t2 = tri->getUV2();
                 gt.uv0 = GVec2(t0.u, t0.v);
@@ -1000,6 +1016,60 @@ SceneUploadResult buildSceneArrays(const Renderer& cpu, const Camera* cam) {
         r.materialBumpDistance.push_back(bmDistance);
         r.materialTextureId.push_back(texId);
         r.materialProgramId.push_back(progId);
+        // pkg219d — scalar BSDF-parameter op-VM programs (Roughness/Metallic/
+        // Transmission/IOR). Same shape as the base-colour ProgramTexture above: a
+        // program whose single input is an ImageTexture. Source image + compiled
+        // program dedup into the SAME textures/programs buffers (texIdx/progIdx);
+        // matScalarTexId feeds the shade path's OWN per-slot texel fetch (a scalar
+        // map is a DIFFERENT image than the base colour). Non-image / multi-image
+        // program inputs fall through to -1 (GPU-degraded; CPU stays correct — the
+        // pkg186 cut). Read only in the <HasProgram=true> shade kernel.
+        auto uploadProgramTexture = [&](const std::shared_ptr<ProgramTexture>& pt,
+                                        int& outTexId, int& outProgId) {
+            std::shared_ptr<Texture> child =
+                pt->numInputs() >= 1 ? pt->getInput(0) : nullptr;
+            auto childImg = std::dynamic_pointer_cast<ImageTexture>(child);
+            if (!(childImg && !childImg->getData().empty() && pt->numInputs() == 1))
+                return;
+            auto tit = texIdx.find(childImg.get());
+            if (tit != texIdx.end()) {
+                outTexId = tit->second;
+            } else {
+                outTexId = (int)r.textures.size();
+                texIdx[childImg.get()] = outTexId;
+                GImageTexture desc;
+                desc.offset = (int)r.textureTexels.size();
+                desc.width  = childImg->getWidth();
+                desc.height = childImg->getHeight();
+                if (pt->hasMapping()) {
+                    desc.hasMapping = 1;
+                    const float* mm = pt->getMappingMatrix();
+                    for (int i = 0; i < 12; ++i) desc.mapping[i] = mm[i];
+                }
+                const std::vector<Vec3>& px = childImg->getData();
+                r.textureTexels.reserve(r.textureTexels.size() + px.size());
+                for (const Vec3& c : px)
+                    r.textureTexels.push_back(GVec3(c.x, c.y, c.z));
+                r.textures.push_back(desc);
+            }
+            auto pit = progIdx.find(pt.get());
+            if (pit != progIdx.end()) {
+                outProgId = pit->second;
+            } else {
+                outProgId = (int)r.programs.size();
+                progIdx[pt.get()] = outProgId;
+                r.programs.push_back(pt->getProgram());
+            }
+            r.hasTexture = true;
+            r.hasProgram = true;
+        };
+        for (int slot = 0; slot < astroray::svm::VM_SCALAR_SLOTS; ++slot) {
+            int sTexId = -1, sProgId = -1;
+            if (auto pt = std::dynamic_pointer_cast<ProgramTexture>(m->scalarProgram(slot)))
+                uploadProgramTexture(pt, sTexId, sProgId);
+            r.materialScalarProgId.push_back(sProgId);
+            r.materialScalarTexId.push_back(sTexId);
+        }
         return id;
     };
 

--- a/src/gpu/wavefront/gpu_wavefront_snapshot.cu
+++ b/src/gpu/wavefront/gpu_wavefront_snapshot.cu
@@ -1006,6 +1006,7 @@ struct WfContext {
     WfDeviceBuf materialNormalTexId, materialNormalStrength;  // pkg223 normal maps
     WfDeviceBuf materialBumpTexId, materialBumpStrength, materialBumpDistance;  // pkg223b bump
     WfDeviceBuf programs, materialProgramId;   // pkg219b op-VM programs
+    WfDeviceBuf materialScalarProgId, materialScalarTexId;  // pkg219d scalar-param programs
     WfDeviceBuf tlas, instances, blas;        // pkg55-C4 / pkg114
     WfDeviceBuf motionVertices;               // pkg55-C4 / pkg88-C.0
     WfDeviceBuf treeNodes, treeEmitters, lightToEmitter;
@@ -1411,8 +1412,15 @@ std::vector<float> cuda_wavefront_render(
     astroray::svm::ShaderVMProgram* d_programs =
         wfUpload(C.programs, res.programs);
     int* d_matProgId = wfUpload(C.materialProgramId, res.materialProgramId);
+    // pkg219d — scalar BSDF-param side arrays ([mat*VM_SCALAR_SLOTS+slot]). Null
+    // when no material carries a scalar program; the <…,false> shade kernel never
+    // reads them. Their source images ride the SAME c_wfTexBinding texture arrays
+    // uploaded above (res.hasTexture is set for a scalar-program material).
+    int* d_matScalarProgId = wfUpload(C.materialScalarProgId, res.materialScalarProgId);
+    int* d_matScalarTexId  = wfUpload(C.materialScalarTexId,  res.materialScalarTexId);
     if (res.hasProgram)
-        setWavefrontProgramBinding(GWavefrontProgramBinding{d_programs, d_matProgId});
+        setWavefrontProgramBinding(GWavefrontProgramBinding{
+            d_programs, d_matProgId, d_matScalarProgId, d_matScalarTexId});
     // pkg199 Stage 1 — publish the homogeneous world-volume medium every frame
     // (c_worldVolume is __constant__ and persists across calls, so set it
     // unconditionally — vacuum scenes publish hasVolume==0, which the intersect /

--- a/src/gpu/wavefront/stage_advance.cu
+++ b/src/gpu/wavefront/stage_advance.cu
@@ -879,6 +879,92 @@ __constant__ GWavefrontTextureBinding c_wfTexBinding;
 // only inside `if constexpr (HasProgram)`. The <false> fleet kernel never reads it.
 __constant__ GWavefrontProgramBinding c_wfProgBinding;
 
+// pkg219d — scalar BSDF-parameter op-VM override storage. Only the
+// <HasProgram=true> shade specialization instantiates a full GMaterial copy to
+// hold the per-hit-substituted roughness/metallic/transmission/ior;
+// GScalarOverride<false> is an EMPTY struct (zero stack), so the fleet
+// <HasProgram=false> shade kernel allocates nothing and stays byte-identical.
+template<bool> struct GScalarOverride {};
+template<> struct GScalarOverride<true> { ::GMaterial mat; };
+
+// pkg219d — fetch a scalar program's OWN source texel at the hit UV. Mirrors the
+// base-colour triangle-UV recompute (Ericson §3.4) + Mapping in shadePathSlot's
+// HasTexture block, but for the scalar program's own image (matScalarTexId, a
+// DIFFERENT image than the base colour). Returns false for non-triangle / UV-less
+// hits (the override is then skipped, exactly like the base-colour path). Reads
+// c_wfTexBinding (published this frame); only ever called from <HasProgram=true>.
+__device__ __forceinline__ bool gpu_scalarProgSourceTexel(
+    const GHitRecord& rec, const GPrimitive* prims, const GTriangle* tris,
+    int texId, GVec3& outTexel)
+{
+    if (!(rec.primId >= 0 && prims[rec.primId].type == GPRIM_TRIANGLE)) return false;
+    const GTriangle& ttri = tris[prims[rec.primId].index];
+    if (!ttri.hasUV) return false;
+    GVec3 e1 = ttri.v1 - ttri.v0, e2 = ttri.v2 - ttri.v0;
+    GVec3 ep = rec.point - ttri.v0;
+    float d00 = e1.dot(e1), d01 = e1.dot(e2), d11 = e2.dot(e2);
+    float d20 = ep.dot(e1), d21 = ep.dot(e2);
+    float denom = d00 * d11 - d01 * d01;
+    if (fabsf(denom) <= 1e-20f) return false;
+    float b1 = (d11 * d20 - d01 * d21) / denom;
+    float b2 = (d00 * d21 - d01 * d20) / denom;
+    float b0 = 1.0f - b1 - b2;
+    float uu = b0*ttri.uv0.x + b1*ttri.uv1.x + b2*ttri.uv2.x;
+    float vv = b0*ttri.uv0.y + b1*ttri.uv1.y + b2*ttri.uv2.y;
+    const GImageTexture& tdesc = c_wfTexBinding.textures[texId];
+    if (tdesc.hasMapping) {
+        const float* m = tdesc.mapping;
+        float mu = m[0]*uu + m[1]*vv + m[3];
+        float mv = m[4]*uu + m[5]*vv + m[7];
+        uu = mu; vv = mv;
+    }
+    outTexel = gpu_sampleImageTexture(tdesc, c_wfTexBinding.texelBuf, uu, vv);
+    return true;
+}
+
+// pkg219d — apply one op-VM scalar result to the LOCAL GMaterial copy. Overwrites
+// EVERY representation the closure dispatch may read: the top-level field (plain
+// lambertian/metal + the GCLOSURE_DIFFUSE path, which reads parent.roughness), the
+// native-Principled block (gpu_principled_* fast path), and every closure lobe
+// (gpu_closure_as_material reads closure.{roughness,metallic,ior,transmission}).
+// Clamps MUST match the CPU DisneyPlugin::substituted() and its constructor.
+// NOTE: closure WEIGHTS were baked at upload from the ORIGINAL metallic/transmission,
+// so metallic/transmission programs shift the per-lobe fields but not the diffuse/
+// specular/transmission MIX on GPU — exact CPU↔GPU parity holds for roughness and
+// ior (which never change lobe selection); metallic/transmission are a documented
+// closure-graph approximation (same class as other GPU closure-graph cuts).
+__device__ __forceinline__ void gpu_applyScalarOverride(
+    ::GMaterial& mat, int slot, float v)
+{
+    switch (slot) {
+        case astroray::svm::SCALAR_ROUGHNESS: {
+            float r = fminf(fmaxf(v, 0.001f), 1.0f);
+            mat.roughness = r; mat.principled.roughness = r;
+            for (int i = 0; i < mat.closureCount; ++i) mat.closures[i].roughness = r;
+            break;
+        }
+        case astroray::svm::SCALAR_METALLIC: {
+            float m = fminf(fmaxf(v, 0.0f), 1.0f);
+            mat.metallic = m; mat.principled.metallic = m;
+            for (int i = 0; i < mat.closureCount; ++i) mat.closures[i].metallic = m;
+            break;
+        }
+        case astroray::svm::SCALAR_TRANSMISSION: {
+            float t = fminf(fmaxf(v, 0.0f), 1.0f);
+            mat.transmission = t; mat.principled.transmission = t;
+            for (int i = 0; i < mat.closureCount; ++i) mat.closures[i].transmission = t;
+            break;
+        }
+        case astroray::svm::SCALAR_IOR: {
+            float io = fmaxf(v, 1.0f);
+            mat.ior = io; mat.principled.ior = io;
+            for (int i = 0; i < mat.closureCount; ++i) mat.closures[i].ior = io;
+            break;
+        }
+        default: break;
+    }
+}
+
 // pkg184 — HasPhotons isolates the bounce-0 photon-map caustic KNN gather
 // (photonGridGatherKnn, 50-neighbour live set) behind `if constexpr`. The gather
 // only ever fires at bounce 0 in scenes that carry a photon grid, yet ptxas had to
@@ -1148,7 +1234,44 @@ __device__ bool shadePathSlot(
         }
     }
 
-    const ::GMaterial& mat = materials[rec.materialId];
+    // pkg219d — scalar BSDF-parameter op-VM override. Independent of the base-colour
+    // texture (a roughness-only material has base-colour texId == -1), so it runs
+    // HERE (before the HasTexture base-colour block and before the NEE/BSDF closure
+    // is built). Each of the K slots fetches its OWN source image (matScalarTexId)
+    // and runs the SAME shared svm_eval as the CPU DisneyPlugin::substituted() twin,
+    // then overwrites a LOCAL GMaterial copy. The copy + the whole block live ONLY in
+    // the <HasProgram=true> specialization (an already-isolated axis); the fleet
+    // <false> kernel keeps `mat` a plain reference to the uploaded material and
+    // allocates ZERO extra stack (GScalarOverride<false> is empty), so it stays
+    // byte-identical (register-probe gate). matPtr never re-points in the <false>
+    // path, so the compiler collapses it back to the original reference.
+    const ::GMaterial* matPtr = &materials[rec.materialId];
+    GScalarOverride<HasProgram> matScalarOv;
+    if constexpr (HasProgram) {
+        if (c_wfProgBinding.matScalarProgId && c_wfProgBinding.matScalarTexId) {
+            const int base = rec.materialId * astroray::svm::VM_SCALAR_SLOTS;
+            bool anyOverride = false;
+            for (int slot = 0; slot < astroray::svm::VM_SCALAR_SLOTS; ++slot) {
+                int sProg = c_wfProgBinding.matScalarProgId[base + slot];
+                int sTex  = c_wfProgBinding.matScalarTexId[base + slot];
+                if (sProg < 0 || sTex < 0) continue;
+                GVec3 srcTexel;
+                if (!gpu_scalarProgSourceTexel(rec, prims, tris, sTex, srcTexel))
+                    continue;  // non-triangle / UV-less hit → skip (mirrors base colour)
+                GVec3 vmIn[astroray::svm::VM_MAX_TEX];
+                for (int t = 0; t < astroray::svm::VM_MAX_TEX; ++t) vmIn[t] = srcTexel;
+                float v = astroray::svm::svm_eval(
+                    c_wfProgBinding.programs[sProg], vmIn).x;
+                if (!anyOverride) {
+                    matScalarOv.mat = materials[rec.materialId];
+                    anyOverride = true;
+                }
+                gpu_applyScalarOverride(matScalarOv.mat, slot, v);
+            }
+            if (anyOverride) matPtr = &matScalarOv.mat;
+        }
+    }
+    const ::GMaterial& mat = *matPtr;
 
     // pkg186 — image-texture base color for a textured lambertian. The whole
     // diffuse bounce (NEE eval, BSDF throughput, continuation) is LINEAR in

--- a/tests/test_pkg219d_scalar_param_textures.py
+++ b/tests/test_pkg219d_scalar_param_textures.py
@@ -8,31 +8,30 @@ roughness. pkg219d wires the op-VM output into the scalar Disney inputs on BOTH
 backends (CPU DisneyPlugin::substituted() + GPU c_wfProgBinding scalar side table),
 behind the already-isolated <HasProgram> shade axis.
 
-Scene: a metallic Disney quad lit by a headlight point light (near the camera, so
-the specular half-vector is ≈ the surface normal for every symmetric surface point).
-A 2×1 image (left texel 0.0, right texel 1.0) drives Roughness through an op-VM
-`Image → Map Range[0,1]→[0.3,0.9]` chain, so the LEFT half renders at roughness 0.3
-(sharp, bright near-normal specular) and the RIGHT half at 0.9 (broad, dim). The quad
-is left/right symmetric, so the ONLY thing that differs between the halves is the
-per-texel roughness.
+Scene: a metallic Disney quad lit by a bright headlight point light (near the
+camera). A 2×1 image (left texel 0.0, right texel 1.0) drives Roughness through an
+op-VM `Image → Map Range[0,1]→[0.3,0.9]` chain, so the LEFT half of the quad renders
+at roughness 0.3 and the RIGHT half at 0.9. The headlight specular highlight sits at
+the quad centre — the u=0.5 roughness boundary — so the highlight's left half is
+sharp (0.3) and its right half broad (0.9); the tests sample each highlight half.
 
 Roughness low end is 0.3, NOT the spec's 0.1: metallic Disney GPU↔CPU parity in the
 NEAR-DELTA alpha band (roughness ≲ 0.1) is a PRE-EXISTING, unrelated xfail (pkg123,
-~4× GPU/CPU ratio at the 0.0064 alpha floor). 0.3 vs 0.9 keeps a strong, clearly
-directional roughness signal (near-normal GGX peak D ≈ 39 vs 0.49, an ~80× ratio)
-while both halves sit in the proven mid/high-roughness parity band.
+~4× GPU/CPU ratio at the 0.0064 alpha floor). 0.3 vs 0.9 keeps a strong roughness
+signal while both halves sit in the proven mid/high-roughness parity band.
 
-Gates:
-  * test_cpu_roughness_program_drives_specular — CPU: the low-roughness half is
-    brighter than the high-roughness half (the op-VM roughness landed in the BSDF),
-    AND a uniform-roughness control renders the two halves ~equal (isolates the
-    per-texel drive from any left/right lighting asymmetry).
-  * test_gpu_roughness_program_drives_specular — same asymmetry on GPU (proves the
-    scalar side table + shade override applied on the device, not dropped).
-  * test_cpu_gpu_roughness_parity — per-channel MEAN-RATIO of the CPU vs GPU
-    program render within band (gates the byte-mirror; NOT SSIM — independent RNG
-    streams make windowed SSIM unreachable at modest spp,
-    [[ssim-wrong-gate-for-independent-rng]]).
+Gates (per-half REFERENCE COMPARISON — robust to highlight placement): each half of
+the op-VM (program) render is compared against the UNIFORM-roughness render of the
+value it encodes. Same seed → the matching-roughness half is ~identical while the
+mismatched one differs by the real roughness change.
+  * test_cpu_roughness_program_drives_specular — CPU: the program's left half is
+    closer to a uniform-0.3 render than to uniform-0.9 (and vice-versa for the right),
+    i.e. the op-VM roughness reached the DisneyPlugin BSDF.
+  * test_gpu_roughness_program_drives_specular — same per-half reproduction on GPU
+    (proves the scalar side table + shade override applied on the device).
+  * test_cpu_gpu_roughness_parity — per-channel MEAN-RATIO of the CPU vs GPU program
+    render within band (gates the byte-mirror; NOT SSIM — independent RNG streams make
+    windowed SSIM unreachable at modest spp, [[ssim-wrong-gate-for-independent-rng]]).
 
 GPU-gated: skips when no CUDA device (CI has none); the GPU legs are an RTX-box leg.
 """
@@ -78,11 +77,16 @@ def _register_roughness_program(renderer):
     return "pkg219d_rough"
 
 
-def _build_scene(renderer, *, with_program):
+def _build_scene(renderer, *, with_program, roughness=0.5):
     """Metallic Disney quad + headlight point light. `with_program` True → Roughness
-    per-texel-driven by the op-VM chain; False → uniform roughness=0.5 control."""
-    renderer.set_background_color([0.1, 0.1, 0.1])
-    params = {"metallic": 1.0, "roughness": 0.5}
+    per-texel-driven by the op-VM chain (left 0.3 / right 0.9); False → a UNIFORM
+    `roughness` reference (used to check each program half against the constant it
+    should reproduce)."""
+    # Black background: a metallic mirror reflects the environment, so a non-zero
+    # env would wash the whole quad to the (roughness-blurred) env grey and swamp
+    # the point-light specular — the ONE thing per-texel roughness controls.
+    renderer.set_background_color([0.0, 0.0, 0.0])
+    params = {"metallic": 1.0, "roughness": roughness}
     if with_program:
         params["roughness_program"] = _register_roughness_program(renderer)
     mat = renderer.create_material("disney", [0.9, 0.9, 0.9], params)
@@ -97,57 +101,77 @@ def _build_scene(renderer, *, with_program):
                                  n, n, n)
     # Headlight: a bright point light near the camera so wi ≈ wo ≈ normal for the
     # whole (symmetric) quad — the specular response then depends only on roughness.
-    renderer.add_point_light([0, 0, 2.9], [1.0, 1.0, 1.0], 40.0, 0.05)
+    renderer.add_point_light([0, 0, 2.9], {"mode": "rgb", "color": [1.0, 1.0, 1.0]}, 1000.0, 0.05)
     setup_camera(renderer, look_from=[0, 0, 3], look_at=[0, 0, 0], vup=[0, 1, 0],
                  vfov=45, width=64, height=64)
 
 
-def _render(*, with_program, use_gpu, samples=160):
+def _render(*, with_program, use_gpu, roughness=0.5, samples=160):
     r = create_renderer()
     if use_gpu:
         if not _has_cuda_gpu(r):
             pytest.skip("No CUDA GPU — pkg219d GPU leg runs on the RTX box.")
         r.set_use_gpu(True)
     r.set_seed(7)
-    _build_scene(r, with_program=with_program)
+    _build_scene(r, with_program=with_program, roughness=roughness)
     return render_image(r, samples=samples, max_depth=3, apply_gamma=False)
 
 
-def _region_means(img):
-    """(low_roughness_left, high_roughness_right) mean brightness, seam excluded."""
-    gray = img.mean(axis=2)
-    left = float(gray[:, 4:28].mean())    # u<0.5 → roughness 0.3
-    right = float(gray[:, 36:60].mean())  # u>=0.5 → roughness 0.9
-    return left, right
+# The headlight specular highlight (and thus ALL the roughness signal) sits at the
+# quad centre (image col ~32) — which is exactly the u=0.5 roughness boundary in
+# the program render. So the highlight's LEFT half is roughness 0.3 and its RIGHT
+# half is 0.9; sample each half (skipping the ~2px seam) to see the per-texel drive.
+def _left(img):
+    return img.mean(axis=2)[:, 22:31]    # x<0 half of the highlight → program roughness 0.3
+
+
+def _right(img):
+    return img.mean(axis=2)[:, 33:42]    # x>0 half of the highlight → program roughness 0.9
+
+
+def _drives_specular(use_gpu):
+    """The op-VM roughness reaches the BSDF: each half of the program render must
+    match the UNIFORM-roughness render of the value it encodes (left→0.3, right→0.9),
+    and NOT the other value. Same seed → the matching-roughness half is ~identical
+    while the mismatched one differs by the real roughness change. Robust to where
+    the point-light highlight lands (no peak/threshold guessing)."""
+    prog = _render(with_program=True, use_gpu=use_gpu)
+    u03 = _render(with_program=False, use_gpu=use_gpu, roughness=0.3)
+    u09 = _render(with_program=False, use_gpu=use_gpu, roughness=0.9)
+    # There must BE a measurable roughness signal in each region, else nothing is gated.
+    left_signal = abs(_left(u03).mean() - _left(u09).mean())
+    right_signal = abs(_right(u03).mean() - _right(u09).mean())
+    assert left_signal > 5e-4 and right_signal > 5e-4, (
+        f"no roughness signal in the measured regions (Δleft={left_signal:.5f}, "
+        f"Δright={right_signal:.5f}) — scene cannot gate the per-texel drive")
+    # Program LEFT half (0.3) closer to uniform-0.3 than to uniform-0.9.
+    dl03 = abs(_left(prog).mean() - _left(u03).mean())
+    dl09 = abs(_left(prog).mean() - _left(u09).mean())
+    assert dl03 < dl09, (
+        f"program left half did not reproduce roughness 0.3 (|prog−u03|={dl03:.5f} "
+        f"≥ |prog−u09|={dl09:.5f}) — op-VM roughness dropped "
+        f"{'on device' if use_gpu else 'on the CPU BSDF'}")
+    # Program RIGHT half (0.9) closer to uniform-0.9 than to uniform-0.3.
+    dr09 = abs(_right(prog).mean() - _right(u09).mean())
+    dr03 = abs(_right(prog).mean() - _right(u03).mean())
+    assert dr09 < dr03, (
+        f"program right half did not reproduce roughness 0.9 (|prog−u09|={dr09:.5f} "
+        f"≥ |prog−u03|={dr03:.5f})")
+
+
 
 
 def test_cpu_roughness_program_drives_specular():
-    """CPU: the op-VM roughness reaches the Disney BSDF — the low-roughness half is
-    a brighter (sharper) headlight specular than the high-roughness half, while a
-    uniform-roughness control renders the two halves ~equal."""
-    prog = _render(with_program=True, use_gpu=False)
-    lo, hi = _region_means(prog)
-    assert lo > 0.02, f"scene too dark to gate (low-rough half mean={lo:.4f})"
-    assert lo > hi * 1.15, (
-        f"low-roughness (0.3) half not brighter than high-roughness (0.9) half — "
-        f"op-VM roughness did not reach the CPU BSDF (lo={lo:.4f}, hi={hi:.4f})")
-    # Control: uniform roughness → halves near-equal (rules out lighting asymmetry).
-    ctrl = _render(with_program=False, use_gpu=False)
-    clo, chi = _region_means(ctrl)
-    assert abs(clo - chi) < 0.15 * max(clo, chi) + 1e-3, (
-        f"uniform-roughness control halves differ too much (lo={clo:.4f}, "
-        f"hi={chi:.4f}) — the asymmetry is not from the per-texel roughness")
+    """CPU: each half of the program render reproduces the uniform-roughness render
+    of the value the op-VM encodes (left→0.3, right→0.9) — the op-VM roughness
+    reached the DisneyPlugin BSDF."""
+    _drives_specular(use_gpu=False)
 
 
 def test_gpu_roughness_program_drives_specular():
-    """GPU: same low>high asymmetry — the scalar side table + shade override applied
-    on the device (not collapsed to the constant-folded roughness)."""
-    prog = _render(with_program=True, use_gpu=True)
-    lo, hi = _region_means(prog)
-    assert lo > 0.02, f"GPU scene too dark to gate (low-rough half mean={lo:.4f})"
-    assert lo > hi * 1.15, (
-        f"GPU low-roughness half not brighter than high-roughness half — op-VM "
-        f"roughness dropped on device (lo={lo:.4f}, hi={hi:.4f})")
+    """GPU: same per-half reproduction — the scalar side table + shade override
+    applied on the device (not collapsed to the constant-folded roughness)."""
+    _drives_specular(use_gpu=True)
 
 
 def test_cpu_gpu_roughness_parity():

--- a/tests/test_pkg219d_scalar_param_textures.py
+++ b/tests/test_pkg219d_scalar_param_textures.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python
+"""pkg219d — scalar parameter textures (op-VM → Roughness), CPU + GPU parity.
+
+Before pkg219d the per-texel op-VM (pkg219a/b/c) drove ONLY Base Color; scalar
+BSDF inputs (roughness/metallic/transmission/ior) read a constant-folded float, so
+a Blender graph `Image → Map Range → Roughness` could not per-texel-drive
+roughness. pkg219d wires the op-VM output into the scalar Disney inputs on BOTH
+backends (CPU DisneyPlugin::substituted() + GPU c_wfProgBinding scalar side table),
+behind the already-isolated <HasProgram> shade axis.
+
+Scene: a metallic Disney quad lit by a headlight point light (near the camera, so
+the specular half-vector is ≈ the surface normal for every symmetric surface point).
+A 2×1 image (left texel 0.0, right texel 1.0) drives Roughness through an op-VM
+`Image → Map Range[0,1]→[0.3,0.9]` chain, so the LEFT half renders at roughness 0.3
+(sharp, bright near-normal specular) and the RIGHT half at 0.9 (broad, dim). The quad
+is left/right symmetric, so the ONLY thing that differs between the halves is the
+per-texel roughness.
+
+Roughness low end is 0.3, NOT the spec's 0.1: metallic Disney GPU↔CPU parity in the
+NEAR-DELTA alpha band (roughness ≲ 0.1) is a PRE-EXISTING, unrelated xfail (pkg123,
+~4× GPU/CPU ratio at the 0.0064 alpha floor). 0.3 vs 0.9 keeps a strong, clearly
+directional roughness signal (near-normal GGX peak D ≈ 39 vs 0.49, an ~80× ratio)
+while both halves sit in the proven mid/high-roughness parity band.
+
+Gates:
+  * test_cpu_roughness_program_drives_specular — CPU: the low-roughness half is
+    brighter than the high-roughness half (the op-VM roughness landed in the BSDF),
+    AND a uniform-roughness control renders the two halves ~equal (isolates the
+    per-texel drive from any left/right lighting asymmetry).
+  * test_gpu_roughness_program_drives_specular — same asymmetry on GPU (proves the
+    scalar side table + shade override applied on the device, not dropped).
+  * test_cpu_gpu_roughness_parity — per-channel MEAN-RATIO of the CPU vs GPU
+    program render within band (gates the byte-mirror; NOT SSIM — independent RNG
+    streams make windowed SSIM unreachable at modest spp,
+    [[ssim-wrong-gate-for-independent-rng]]).
+
+GPU-gated: skips when no CUDA device (CI has none); the GPU legs are an RTX-box leg.
+"""
+
+import astroray
+import numpy as np
+import pytest
+from base_helpers import create_renderer, render_image, setup_camera
+
+# opcode / sub-op enums (mirror include/astroray/shader_vm.h)
+OP_LOAD_TEX, OP_LOAD_CONST, OP_MAP_RANGE = 1, 2, 6
+MR_LINEAR = 0
+
+
+def _has_cuda_gpu(renderer):
+    return bool(astroray.__features__.get("cuda", False)) and \
+        bool(getattr(renderer, "gpu_available", False))
+
+
+def _register_roughness_program(renderer):
+    """Register the op-VM chain `Image(0|1) → Map Range[0,1]→[0.3,0.9]` and return
+    its program-texture name. The 2×1 source image encodes the two regions; the
+    program remaps to the roughness range."""
+    # 2x1 image: left texel 0.0 (→ roughness 0.3), right texel 1.0 (→ roughness 0.9).
+    data = [0.0, 0.0, 0.0,
+            1.0, 1.0, 1.0]
+    renderer.load_texture("pkg219d_src", data, 2, 1, "UV")
+    renderer.create_program_texture("pkg219d_rough", "UV")
+    renderer.program_texture_add_input("pkg219d_rough", "pkg219d_src")
+    # slot0 = tex; slot1..4 = consts (from_min=0, from_max=1, to_min=0.3, to_max=0.9);
+    # slot5 = map_range(LINEAR, value=s0, from_min=s1, from_max=s2, to_min=s3, to_max=s4)
+    consts = [0.0, 0.0, 0.0,   # const0 from_min
+              1.0, 0.0, 0.0,   # const1 from_max
+              0.3, 0.0, 0.0,   # const2 to_min
+              0.9, 0.0, 0.0]   # const3 to_max
+    code = [OP_LOAD_TEX,   0, 0, 0, 0, 0, 0, 0,
+            OP_LOAD_CONST, 1, 0, 0, 0, 0, 0, 0,
+            OP_LOAD_CONST, 2, 0, 0, 0, 0, 0, 1,
+            OP_LOAD_CONST, 3, 0, 0, 0, 0, 0, 2,
+            OP_LOAD_CONST, 4, 0, 0, 0, 0, 0, 3,
+            OP_MAP_RANGE,  5, 0, 1, 2, 3, 4, MR_LINEAR]
+    renderer.set_program_texture_program("pkg219d_rough", 1, 5, code, consts, [])
+    return "pkg219d_rough"
+
+
+def _build_scene(renderer, *, with_program):
+    """Metallic Disney quad + headlight point light. `with_program` True → Roughness
+    per-texel-driven by the op-VM chain; False → uniform roughness=0.5 control."""
+    renderer.set_background_color([0.1, 0.1, 0.1])
+    params = {"metallic": 1.0, "roughness": 0.5}
+    if with_program:
+        params["roughness_program"] = _register_roughness_program(renderer)
+    mat = renderer.create_material("disney", [0.9, 0.9, 0.9], params)
+
+    # Quad corners (CCW, normal +z) with UVs spanning [0,1]^2: screen-left = u=0.
+    A, B = [-1, -1, 0], [1, -1, 0]
+    C, D = [1, 1, 0], [-1, 1, 0]
+    n = [0, 0, 1]
+    renderer.add_triangle_layers(A, B, C, mat, {"UVMap": [[0, 0], [1, 0], [1, 1]]},
+                                 n, n, n)
+    renderer.add_triangle_layers(A, C, D, mat, {"UVMap": [[0, 0], [1, 1], [0, 1]]},
+                                 n, n, n)
+    # Headlight: a bright point light near the camera so wi ≈ wo ≈ normal for the
+    # whole (symmetric) quad — the specular response then depends only on roughness.
+    renderer.add_point_light([0, 0, 2.9], [1.0, 1.0, 1.0], 40.0, 0.05)
+    setup_camera(renderer, look_from=[0, 0, 3], look_at=[0, 0, 0], vup=[0, 1, 0],
+                 vfov=45, width=64, height=64)
+
+
+def _render(*, with_program, use_gpu, samples=160):
+    r = create_renderer()
+    if use_gpu:
+        if not _has_cuda_gpu(r):
+            pytest.skip("No CUDA GPU — pkg219d GPU leg runs on the RTX box.")
+        r.set_use_gpu(True)
+    r.set_seed(7)
+    _build_scene(r, with_program=with_program)
+    return render_image(r, samples=samples, max_depth=3, apply_gamma=False)
+
+
+def _region_means(img):
+    """(low_roughness_left, high_roughness_right) mean brightness, seam excluded."""
+    gray = img.mean(axis=2)
+    left = float(gray[:, 4:28].mean())    # u<0.5 → roughness 0.3
+    right = float(gray[:, 36:60].mean())  # u>=0.5 → roughness 0.9
+    return left, right
+
+
+def test_cpu_roughness_program_drives_specular():
+    """CPU: the op-VM roughness reaches the Disney BSDF — the low-roughness half is
+    a brighter (sharper) headlight specular than the high-roughness half, while a
+    uniform-roughness control renders the two halves ~equal."""
+    prog = _render(with_program=True, use_gpu=False)
+    lo, hi = _region_means(prog)
+    assert lo > 0.02, f"scene too dark to gate (low-rough half mean={lo:.4f})"
+    assert lo > hi * 1.15, (
+        f"low-roughness (0.3) half not brighter than high-roughness (0.9) half — "
+        f"op-VM roughness did not reach the CPU BSDF (lo={lo:.4f}, hi={hi:.4f})")
+    # Control: uniform roughness → halves near-equal (rules out lighting asymmetry).
+    ctrl = _render(with_program=False, use_gpu=False)
+    clo, chi = _region_means(ctrl)
+    assert abs(clo - chi) < 0.15 * max(clo, chi) + 1e-3, (
+        f"uniform-roughness control halves differ too much (lo={clo:.4f}, "
+        f"hi={chi:.4f}) — the asymmetry is not from the per-texel roughness")
+
+
+def test_gpu_roughness_program_drives_specular():
+    """GPU: same low>high asymmetry — the scalar side table + shade override applied
+    on the device (not collapsed to the constant-folded roughness)."""
+    prog = _render(with_program=True, use_gpu=True)
+    lo, hi = _region_means(prog)
+    assert lo > 0.02, f"GPU scene too dark to gate (low-rough half mean={lo:.4f})"
+    assert lo > hi * 1.15, (
+        f"GPU low-roughness half not brighter than high-roughness half — op-VM "
+        f"roughness dropped on device (lo={lo:.4f}, hi={hi:.4f})")
+
+
+def test_cpu_gpu_roughness_parity():
+    """Per-channel mean-ratio of the CPU vs GPU program render within band — gates
+    the CPU↔GPU byte-mirror of the scalar op-VM substitution."""
+    cpu = _render(with_program=True, use_gpu=False)
+    gpu = _render(with_program=True, use_gpu=True)
+    cm = np.array([float(cpu[..., c].mean()) for c in range(3)])
+    gm = np.array([float(gpu[..., c].mean()) for c in range(3)])
+    assert cm.mean() > 0.02, f"CPU reference too dark to gate: {cm}"
+    assert gm.mean() > 0.02, f"GPU render too dark to gate: {gm}"
+    ratio = gm / np.maximum(cm, 1e-6)
+    for c, rc in enumerate(ratio):
+        assert 0.80 <= rc <= 1.25, (
+            f"channel {c} CPU/GPU mean-ratio {rc:.3f} out of band [0.80,1.25]; "
+            f"cpu={cm}, gpu={gm}")


### PR DESCRIPTION
## Summary

pkg219d — per-texel op-VM programs can now drive the **scalar** Disney BSDF inputs (roughness / metallic / transmission / IOR), CPU+GPU byte-mirrored, behind the already-isolated `HasProgram` shade axis. Closes the one unmet row of the pkg219 acceptance matrix ("Math/MapRange driving roughness"). Implemented by a subagent to the architect's side-table design + the parent's CPU-model pin; **built, register-probed, and HW-verified by the parent** (subagents can't build CUDA).

## Design
- **GPU:** two new `__constant__` side-table arrays `matScalarProgId`/`matScalarTexId` (indexed `[mat*4+slot]`) on `GWavefrontProgramBinding` — NOT `GMaterial`. The shade override runs inside the existing `if constexpr(HasProgram)` block; `GScalarOverride<false>` is an **empty struct** so the fleet `<false>` kernel allocates nothing.
- **CPU:** `DisneyPlugin` holds K optional scalar `ProgramTexture`s; eval/pdf/sample delegate to a per-hit `substituted()` clone with the op-VM scalars `svm_eval`'d at `rec.uv` and clamped identically to the GPU. Self-contained — no integrator/HitRecord change.
- UV-upload gate extended (a roughness-only material still ships UVs); addon wires the four Principled sockets via the existing op-VM detection.

## Verification (RTX 5070 Ti)
- **Register gate PASSED — byte-identical:** fleet `stageShadeBucketedKernel<0,0,0,0,0,0,0>` = **REG:254 STACK:3368 CONSTANT[0]:1716** on the linked `.pyd` (the `<HasProgram=false>` fleet paid nothing — the `if constexpr` + empty-struct + collapsed pointer-indirection held).
- `tests/test_pkg219d_scalar_param_textures.py` **3/3**: CPU + GPU per-half roughness reproduction (each op-VM half matches the uniform-roughness render of the value it encodes) + CPU/GPU mean-ratio parity.
- **297** disney/material/hair regression tests pass.

## Known-bounded (documented)
metallic/transmission GPU parity is *approximate* — GPU closure lobe-MIX is baked at upload, so a metallic/transmission program shifts per-lobe fields but not the mix on GPU (roughness/IOR are exact — they never change lobe selection). The test gates roughness. Addon scalar programs are wired on the `disney` route only (follow-up for native `principled`/textured-`lambertian`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)