### PR TITLE
pkg225-S3: GPU curve geometry (wavefront ray-curve intersection)

### DIFF
--- a/include/astroray/curves.h
+++ b/include/astroray/curves.h
@@ -132,6 +132,9 @@ public:
     const Vec3* bezierHull() const { return bezier_; }
     float getRadius0() const { return radius0_; }
     float getRadius1() const { return radius1_; }
+    // pkg225 Stage 3 — GPU scene upload reads the material to dedup into the
+    // GMaterial table (mirrors Triangle::getMaterial / Sphere::getMaterial).
+    std::shared_ptr<Material> getMaterial() const { return material_; }
 
 private:
     Vec3 bezier_[4];

--- a/include/astroray/gpu_bvh.h
+++ b/include/astroray/gpu_bvh.h
@@ -8,6 +8,16 @@
 #include "gpu_curve_intersect.cuh"  // pkg225 Stage 3 — gpu_curve_intersect
 
 // ---------------------------------------------------------------------------
+// pkg225 Stage 3 — HasCurves template axis: the curve leaf (a __noinline__
+// gpu_curve_intersect call + its Frame-stack frame) measurably raises the
+// intersect kernel's register/stack footprint (127->158 REG, 616->1704 STACK on
+// stageIntersectQueuedKernel<0,0>), dropping register-limited occupancy on the
+// UNIVERSAL intersect path. `template<bool HasCurves=false>` + `if constexpr`
+// keeps every non-curve caller (photon pre-pass, TLAS-parity, and the intersect
+// kernel's <false> specialization) byte-identical — the curve branch (and its
+// call) is dead-code-eliminated. Only scenes that actually upload curve segments
+// launch the <true> intersect/shadow kernels and pay the cost.
+
 // pkg88-C.0 GPU — verify on RTX. Motion-aware triangle hit: interpolate vertices
 // at ray.time before Möller-Trumbore. Per Cycles motion_triangle.h (Apache-2.0):
 // linear blend between bracketing time steps. If motionOffset < 0, falls back to static.
@@ -170,6 +180,7 @@ __device__ inline bool gpu_sphere_hit(
 // Iterative BVH traversal — direct port of BVHAccel::hit()
 // Thread-local stack[64] matches the CPU implementation.
 // ---------------------------------------------------------------------------
+template<bool HasCurves = false>  // pkg225 Stage 3 — curve-leaf isolation (see header)
 __device__ inline bool gpu_bvh_hit(
     const GBVHNode*  nodes,
     const GPrimitive* prims,
@@ -219,13 +230,16 @@ __device__ inline bool gpu_bvh_hit(
                         }
                     } else if (p.type == GPRIM_SPHERE) {
                         isHit = gpu_sphere_hit(spheres[p.index], ray, tMin, tMax, tmpRec);
-                    } else if (curves != nullptr && p.type == GPRIM_CURVE) {
+                    } else if constexpr (HasCurves) {
                         // pkg225 Stage 3 — curve leaf (ribbon/thick swept-circle).
-                        isHit = gpu_curve_intersect(curves[p.index], ray, tMin, tMax, tmpRec);
-                    } else {
-                        // pkg85-C: GPRIM_SKIP placeholder — see gpu_types.h.
-                        isHit = false;
+                        // if constexpr: DCE'd entirely in the <false> fleet path,
+                        // so the __noinline__ gpu_curve_intersect call never enters
+                        // the non-curve intersect kernel's register/stack budget.
+                        if (curves != nullptr && p.type == GPRIM_CURVE)
+                            isHit = gpu_curve_intersect(curves[p.index], ray, tMin, tMax, tmpRec);
+                        // else GPRIM_SKIP → isHit stays false
                     }
+                    // (HasCurves=false: GPRIM_CURVE/SKIP fall through, isHit stays false)
                     if (isHit) {
                         hit  = true;
                         tMax = tmpRec.t;
@@ -263,6 +277,7 @@ __device__ inline bool gpu_bvh_hit(
 // gpu_bvh_hit above so accept/reject decisions are identical; only the
 // early-exit differs.
 // ---------------------------------------------------------------------------
+template<bool HasCurves = false>  // pkg225 Stage 3 — curve-leaf isolation (see header)
 __device__ inline bool gpu_bvh_occluded(
     const GBVHNode*  nodes,
     const GPrimitive* prims,
@@ -301,8 +316,9 @@ __device__ inline bool gpu_bvh_occluded(
                         }
                     } else if (p.type == GPRIM_SPHERE) {
                         isHit = gpu_sphere_hit(spheres[p.index], ray, tMin, tMax, tmpRec);
-                    } else if (curves != nullptr && p.type == GPRIM_CURVE) {
-                        isHit = gpu_curve_intersect(curves[p.index], ray, tMin, tMax, tmpRec);
+                    } else if constexpr (HasCurves) {
+                        if (curves != nullptr && p.type == GPRIM_CURVE)
+                            isHit = gpu_curve_intersect(curves[p.index], ray, tMin, tMax, tmpRec);
                     }
                     if (isHit) return true;  // any hit occludes
                 }
@@ -355,6 +371,7 @@ __device__ inline bool gpu_bvh_occluded(
 //  - rec.primId is remapped BLAS-local -> global (blas.primOffset + localPrimId)
 //    so prims[rec.primId] (Cryptomatte / NEE) keeps working unchanged.
 // ---------------------------------------------------------------------------
+template<bool HasCurves = false>  // pkg225 Stage 3 — forwarded to the single-level fallback
 __device__ inline bool gpu_tlas_hit(
     const GTLASNode*  tlas,
     const GInstance*  instances,
@@ -377,7 +394,7 @@ __device__ inline bool gpu_tlas_hit(
     // No TLAS uploaded -> behave exactly like the single-level path. (Lets a
     // caller route unconditionally through gpu_tlas_hit before instances exist.)
     if (!tlas || !instances || !blas) {
-        return gpu_bvh_hit(blasNodes, prims, tris, spheres, ray, tMin, tMax, rec, motionVerts, curves);
+        return gpu_bvh_hit<HasCurves>(blasNodes, prims, tris, spheres, ray, tMin, tMax, rec, motionVerts, curves);
     }
 
     bool  hit    = false;
@@ -463,6 +480,7 @@ __device__ inline bool gpu_tlas_hit(
 // gpu_bvh_occluded walk (the wavefront path). With a TLAS, v1 delegates to
 // the closest-hit instance walk and discards the record — boolean-identical;
 // a dedicated any-hit instance walk is a follow-up optimization.
+template<bool HasCurves = false>  // pkg225 Stage 3 — forwarded to the single-level fallback
 __device__ inline bool gpu_tlas_occluded(
     const GTLASNode*  tlas,
     const GInstance*  instances,
@@ -478,11 +496,11 @@ __device__ inline bool gpu_tlas_occluded(
     const GCurveSegment* curves = nullptr)
 {
     if (!tlas || !instances || !blas) {
-        return gpu_bvh_occluded(blasNodes, prims, tris, spheres,
+        return gpu_bvh_occluded<HasCurves>(blasNodes, prims, tris, spheres,
                                 ray, tMin, tMax, motionVerts, curves);
     }
     GHitRecord rec;
-    return gpu_tlas_hit(tlas, instances, blas, blasNodes, prims, tris,
+    return gpu_tlas_hit<HasCurves>(tlas, instances, blas, blasNodes, prims, tris,
                         spheres, ray, tMin, tMax, rec, motionVerts, curves);
 }
 

--- a/include/astroray/gpu_bvh.h
+++ b/include/astroray/gpu_bvh.h
@@ -5,6 +5,7 @@
 
 #include "gpu_types.h"
 #include "gpu_materials.h"  // for gpu_buildONB
+#include "gpu_curve_intersect.cuh"  // pkg225 Stage 3 — gpu_curve_intersect
 
 // ---------------------------------------------------------------------------
 // pkg88-C.0 GPU — verify on RTX. Motion-aware triangle hit: interpolate vertices
@@ -180,7 +181,12 @@ __device__ inline bool gpu_bvh_hit(
     // pkg88-C.0: device motion-vertex buffer. nullptr = no deformation motion
     // anywhere in the scene (default keeps motion-agnostic callers — photon
     // pre-pass, TLAS parity probe, wavefront — unchanged).
-    const GVec3*     motionVerts = nullptr)
+    const GVec3*     motionVerts = nullptr,
+    // pkg225 Stage 3: device curve-segment array. nullptr = no curves (default
+    // keeps every non-curve caller byte-identical — the GPRIM_CURVE leaf below
+    // is guarded on `curves`, and the intersection body is __noinline__ so it
+    // adds only a guarded call to the inlined traversal loop).
+    const GCurveSegment* curves = nullptr)
 {
     if (!nodes) return false;
 
@@ -213,6 +219,9 @@ __device__ inline bool gpu_bvh_hit(
                         }
                     } else if (p.type == GPRIM_SPHERE) {
                         isHit = gpu_sphere_hit(spheres[p.index], ray, tMin, tMax, tmpRec);
+                    } else if (curves != nullptr && p.type == GPRIM_CURVE) {
+                        // pkg225 Stage 3 — curve leaf (ribbon/thick swept-circle).
+                        isHit = gpu_curve_intersect(curves[p.index], ray, tMin, tMax, tmpRec);
                     } else {
                         // pkg85-C: GPRIM_SKIP placeholder — see gpu_types.h.
                         isHit = false;
@@ -261,7 +270,9 @@ __device__ inline bool gpu_bvh_occluded(
     const GSphere*    spheres,
     const GRay&       ray,
     float tMin, float tMax,
-    const GVec3*     motionVerts = nullptr)
+    const GVec3*     motionVerts = nullptr,
+    // pkg225 Stage 3 — curves cast shadows too (any-hit). nullptr = no curves.
+    const GCurveSegment* curves = nullptr)
 {
     if (!nodes) return false;
 
@@ -290,6 +301,8 @@ __device__ inline bool gpu_bvh_occluded(
                         }
                     } else if (p.type == GPRIM_SPHERE) {
                         isHit = gpu_sphere_hit(spheres[p.index], ray, tMin, tMax, tmpRec);
+                    } else if (curves != nullptr && p.type == GPRIM_CURVE) {
+                        isHit = gpu_curve_intersect(curves[p.index], ray, tMin, tMax, tmpRec);
                     }
                     if (isHit) return true;  // any hit occludes
                 }
@@ -356,12 +369,15 @@ __device__ inline bool gpu_tlas_hit(
     // pkg88-C.0: motion verts apply to the classic single-level path only.
     // Deformation motion on INSTANCED meshes is out of scope v1 (the BLAS
     // walk below intentionally does not receive the buffer).
-    const GVec3*      motionVerts = nullptr)
+    const GVec3*      motionVerts = nullptr,
+    // pkg225 Stage 3: curves live in the single-level BVH (addObject → orderedPrims),
+    // not in a per-mesh BLAS, so they are threaded to the null-TLAS fallback only.
+    const GCurveSegment* curves = nullptr)
 {
     // No TLAS uploaded -> behave exactly like the single-level path. (Lets a
     // caller route unconditionally through gpu_tlas_hit before instances exist.)
     if (!tlas || !instances || !blas) {
-        return gpu_bvh_hit(blasNodes, prims, tris, spheres, ray, tMin, tMax, rec, motionVerts);
+        return gpu_bvh_hit(blasNodes, prims, tris, spheres, ray, tMin, tMax, rec, motionVerts, curves);
     }
 
     bool  hit    = false;
@@ -457,15 +473,17 @@ __device__ inline bool gpu_tlas_occluded(
     const GSphere*    spheres,
     const GRay&       ray,
     float tMin, float tMax,
-    const GVec3*      motionVerts = nullptr)
+    const GVec3*      motionVerts = nullptr,
+    // pkg225 Stage 3 — curves cast shadows (single-level fallback only).
+    const GCurveSegment* curves = nullptr)
 {
     if (!tlas || !instances || !blas) {
         return gpu_bvh_occluded(blasNodes, prims, tris, spheres,
-                                ray, tMin, tMax, motionVerts);
+                                ray, tMin, tMax, motionVerts, curves);
     }
     GHitRecord rec;
     return gpu_tlas_hit(tlas, instances, blas, blasNodes, prims, tris,
-                        spheres, ray, tMin, tMax, rec, motionVerts);
+                        spheres, ray, tMin, tMax, rec, motionVerts, curves);
 }
 
 __device__ inline int gpu_lower_bound(const float* arr, int n, float target) {

--- a/include/astroray/gpu_curve_intersect.cuh
+++ b/include/astroray/gpu_curve_intersect.cuh
@@ -1,0 +1,281 @@
+#pragma once
+// pkg225 Stage 3 — GPU ray-curve intersection (device port of the CPU
+// CurveSegment::hit in include/astroray/curves.h).
+//
+// ALGORITHM (cited, not invented — CLAUDE.md §6; research note at
+// .astroray_plan/docs/pkg225-curve-intersect-research.md):
+//
+//   pbrt-v3 Curve::Intersect / Curve::recursiveIntersect. Source: mmp/pbrt-v3,
+//   src/shapes/curve.cpp, copyright Matt Pharr / Greg Humphreys / Wenzel Jakob,
+//   BSD-2-Clause. This file ports the SAME math the CPU CurveSegment already
+//   ships (which was itself the verbatim pbrt port), so GPU and CPU produce the
+//   same hit up to float ULP.
+//
+// TWO MODES (pkg225 spec Stage 3 "Ribbon vs thick on GPU"):
+//   - RIBBON (thick == 0, the GPU default): camera-facing flat strip. The same
+//     recursive Bezier-hull 2D width test, but the shading normal is the flat
+//     ray-facing perpendicular — NO Rodrigues rotation (transcendental-free
+//     leaf). Cheaper; the viewport default.
+//   - THICK  (thick == 1): pbrt CurveType::Cylinder swept-circle. The leaf
+//     additionally rotates the flat perpendicular around the true curve tangent
+//     by theta = lerp(v, -90deg, +90deg) to reconstruct a round shading normal.
+//     This is the CPU-parity mode (curves.h uses Cylinder); the Stage-3 GPU-vs-
+//     CPU mean-ratio gate renders in THICK so both backends run identical math.
+//
+// STL-free (no std::), device intrinsics only (fmaxf/fminf/sqrtf/...). The whole
+// intersection is a single __noinline__ function so the recursive-subdivision
+// locals live in ITS frame, not in the register budget of the (inlined)
+// gpu_bvh_hit traversal loop / the REG:254 shade kernel — the pkg224
+// __noinline__ isolation discipline (MEMORY noinline-runtime-flag-avoids-shade-
+// spill). Parent must register-probe the intersect kernel to confirm.
+
+#include "gpu_types.h"
+
+#ifndef M_PI_F
+#define M_PI_F 3.14159265358979323846f
+#endif
+
+namespace astroray_curve_detail {
+
+__device__ inline float gClampf(float x, float lo, float hi) {
+    return fminf(fmaxf(x, lo), hi);
+}
+
+__device__ inline GVec3 gLerp3(float t, const GVec3& a, const GVec3& b) {
+    return a + (b - a) * t;
+}
+
+// pbrt EvalBezier — de Casteljau evaluation (+ optional derivative).
+__device__ inline GVec3 gEvalBezier(const GVec3 cp[4], float u, GVec3* deriv) {
+    GVec3 cp1[3] = { gLerp3(u, cp[0], cp[1]),
+                     gLerp3(u, cp[1], cp[2]),
+                     gLerp3(u, cp[2], cp[3]) };
+    GVec3 cp2[2] = { gLerp3(u, cp1[0], cp1[1]),
+                     gLerp3(u, cp1[1], cp1[2]) };
+    if (deriv) {
+        if ((cp2[1] - cp2[0]).length2() > 0.f) *deriv = (cp2[1] - cp2[0]) * 3.f;
+        else                                    *deriv = cp[3] - cp[0];  // degenerate → chord
+    }
+    return gLerp3(u, cp2[0], cp2[1]);
+}
+
+// pbrt SubdivideBezier — de Casteljau midpoint split, 4 → 7 control points.
+__device__ inline void gSubdivideBezier(const GVec3 cp[4], GVec3 out[7]) {
+    out[0] = cp[0];
+    out[1] = (cp[0] + cp[1]) * 0.5f;
+    out[2] = (cp[0] + cp[1] * 2.f + cp[2]) * 0.25f;
+    out[3] = (cp[0] + cp[1] * 3.f + cp[2] * 3.f + cp[3]) * 0.125f;
+    out[4] = (cp[1] + cp[2] * 2.f + cp[3]) * 0.25f;
+    out[5] = (cp[2] + cp[3]) * 0.5f;
+    out[6] = cp[3];
+}
+
+// CPU raytracer.h buildOrthonormalBasis(n,u,v), ported verbatim — used only in
+// the ray-parallel-to-chord degenerate fallback (pbrt CoordinateSystem).
+__device__ inline void gBuildONB(const GVec3& n, GVec3& u, GVec3& v) {
+    u = (fabsf(n.x) > 0.9f) ? GVec3(0.f, 1.f, 0.f) : GVec3(1.f, 0.f, 0.f);
+    u = (u - n * n.dot(u)).normalized();
+    v = n.cross(u);
+}
+
+// Rodrigues' rotation (rotate v by angleRad around unit axis a).
+__device__ inline GVec3 gRotateAroundAxis(const GVec3& v, const GVec3& a, float angleRad) {
+    float c = cosf(angleRad), s = sinf(angleRad);
+    return v * c + a.cross(v) * s + a * (a.dot(v) * (1.f - c));
+}
+
+// pbrt's y-then-x-then-z ray-local-frame AABB reject.
+__device__ inline bool gBoundsOverlapRay(const GVec3 cp[4], float radius,
+                                         float tMin, float tMax) {
+    float yMax = fmaxf(fmaxf(cp[0].y, cp[1].y), fmaxf(cp[2].y, cp[3].y));
+    float yMin = fminf(fminf(cp[0].y, cp[1].y), fminf(cp[2].y, cp[3].y));
+    if (yMax + radius < 0.f || yMin - radius > 0.f) return false;
+    float xMax = fmaxf(fmaxf(cp[0].x, cp[1].x), fmaxf(cp[2].x, cp[3].x));
+    float xMin = fminf(fminf(cp[0].x, cp[1].x), fminf(cp[2].x, cp[3].x));
+    if (xMax + radius < 0.f || xMin - radius > 0.f) return false;
+    float zMax = fmaxf(fmaxf(cp[0].z, cp[1].z), fmaxf(cp[2].z, cp[3].z));
+    float zMin = fminf(fminf(cp[0].z, cp[1].z), fminf(cp[2].z, cp[3].z));
+    if (zMax + radius < tMin || zMin - radius > tMax) return false;
+    return true;
+}
+
+}  // namespace astroray_curve_detail
+
+// ---------------------------------------------------------------------------
+// Ray-curve intersection. Fills `rec` (point, front-face-oriented normal,
+// tangent/bitangent ONB, uvTangent = ∂p/∂u strand tangent, hairV = azimuthal v,
+// materialId) on the nearest hit inside [tMin, tMax]. Mirrors CurveSegment::hit.
+//
+// __noinline__: keep the recursive-subdivision frame out of the caller's
+// register budget (see file header). Return value is the hit boolean; on true
+// the caller narrows its own tMax (gpu_bvh_hit leaf contract).
+// ---------------------------------------------------------------------------
+__device__ __noinline__ inline bool gpu_curve_intersect(
+    const GCurveSegment& seg, const GRay& ray, float tMin, float tMax,
+    GHitRecord& rec)
+{
+    using namespace astroray_curve_detail;
+
+    const GVec3 bez[4] = { seg.bezier0, seg.bezier1, seg.bezier2, seg.bezier3 };
+    const float r0 = seg.radius0, r1 = seg.radius1;
+    const float maxRadius = fmaxf(r0, r1);
+    const bool  thick = (seg.thick != 0);
+
+    // ---- Ray-local orthonormal frame (z = ray dir; already normalized). ----
+    GVec3 zAxis = ray.direction;
+    GVec3 chord = bez[3] - bez[0];
+    GVec3 dxHint = zAxis.cross(chord);
+    GVec3 xAxis, yAxis;
+    if (dxHint.length2() < 1e-12f) {
+        gBuildONB(zAxis, xAxis, yAxis);
+    } else {
+        GVec3 up = dxHint.normalized();
+        xAxis = up.cross(zAxis).normalized();
+        yAxis = zAxis.cross(xAxis);
+    }
+
+    // ---- Project the Bezier hull into the ray-local frame. ----
+    GVec3 cp0[4];
+    for (int i = 0; i < 4; ++i) {
+        GVec3 d = bez[i] - ray.origin;
+        cp0[i] = GVec3(d.dot(xAxis), d.dot(yAxis), d.dot(zAxis));
+    }
+    if (!gBoundsOverlapRay(cp0, maxRadius, tMin, tMax)) return false;
+
+    // ---- Adaptive max recursion depth (pbrt L0/eps flatness heuristic). ----
+    float L0 = 0.f;
+    for (int i = 0; i < 2; ++i) {
+        L0 = fmaxf(L0, fabsf(cp0[i].x - 2.f * cp0[i + 1].x + cp0[i + 2].x));
+        L0 = fmaxf(L0, fabsf(cp0[i].y - 2.f * cp0[i + 1].y + cp0[i + 2].y));
+        L0 = fmaxf(L0, fabsf(cp0[i].z - 2.f * cp0[i + 1].z + cp0[i + 2].z));
+    }
+    float eps = maxRadius * 0.1f;
+    int maxDepth = 0;
+    if (L0 > 0.f && eps > 0.f) {
+        float val = 1.41421356f * 6.f * L0 / (8.f * eps);
+        if (val >= 1.f) {
+            int log2v = (int)floorf(log2f(val) + 0.5f);   // round-to-nearest
+            int d = log2v / 2;
+            maxDepth = d < 0 ? 0 : (d > 10 ? 10 : d);
+        }
+    }
+
+    // ---- Iterative de Casteljau subdivision (explicit stack replaces the CPU
+    // recursion; a shared running tMax reproduces the "nearest of two halves
+    // wins + narrowing prune" semantics of CurveSegment::recursiveIntersect). --
+    struct Frame { GVec3 cp[4]; float u0, u1; int depth; };
+    Frame stack[16];
+    int sp = 0;
+    stack[0].cp[0] = cp0[0]; stack[0].cp[1] = cp0[1];
+    stack[0].cp[2] = cp0[2]; stack[0].cp[3] = cp0[3];
+    stack[0].u0 = 0.f; stack[0].u1 = 1.f; stack[0].depth = maxDepth;
+    sp = 1;
+
+    bool  hitAny = false;
+    float bestT = tMax;   // narrows as closer hits are found
+    float best_u = 0.f, best_v = 0.5f;
+
+    while (sp > 0) {
+        Frame f = stack[--sp];
+
+        // Interior: split and push both halves (pruned against the running tMax).
+        if (f.depth > 0) {
+            GVec3 split[7];
+            gSubdivideBezier(f.cp, split);
+            float uMid = (f.u0 + f.u1) * 0.5f;
+            float uArr[3] = { f.u0, uMid, f.u1 };
+            const GVec3* segCp = split;
+            for (int s = 0; s < 2; ++s, segCp += 3) {
+                float ru0 = r0 + (r1 - r0) * uArr[s];
+                float ru1 = r0 + (r1 - r0) * uArr[s + 1];
+                float rMax = fmaxf(ru0, ru1);
+                if (!gBoundsOverlapRay(segCp, rMax, tMin, bestT)) continue;
+                if (sp < 16) {
+                    Frame& nf = stack[sp++];
+                    nf.cp[0] = segCp[0]; nf.cp[1] = segCp[1];
+                    nf.cp[2] = segCp[2]; nf.cp[3] = segCp[3];
+                    nf.u0 = uArr[s]; nf.u1 = uArr[s + 1]; nf.depth = f.depth - 1;
+                }
+            }
+            continue;
+        }
+
+        // Leaf: flat 2D distance-to-chord width test (pbrt flattened test).
+        const GVec3* cp = f.cp;
+        float edge0 = (cp[1].y - cp[0].y) * -cp[0].y + cp[0].x * (cp[0].x - cp[1].x);
+        if (edge0 < 0.f) continue;
+        float edge1 = (cp[2].y - cp[3].y) * -cp[3].y + cp[3].x * (cp[3].x - cp[2].x);
+        if (edge1 < 0.f) continue;
+
+        float segDirX = cp[3].x - cp[0].x, segDirY = cp[3].y - cp[0].y;
+        float denom = segDirX * segDirX + segDirY * segDirY;
+        if (denom == 0.f) continue;
+        float w = (-cp[0].x * segDirX + -cp[0].y * segDirY) / denom;
+
+        float u = gClampf(f.u0 + (f.u1 - f.u0) * w, f.u0, f.u1);
+        float hitRadius = r0 + (r1 - r0) * u;
+        if (hitRadius <= 0.f) continue;
+
+        GVec3 dpcdw;
+        GVec3 pc = gEvalBezier(cp, gClampf(w, 0.f, 1.f), &dpcdw);
+        float distSq = pc.x * pc.x + pc.y * pc.y;
+        if (distSq > hitRadius * hitRadius) continue;
+        if (pc.z < tMin || pc.z > bestT) continue;   // z == t (rayLength==1)
+
+        float dist = sqrtf(distSq);
+        float edgeFunc = dpcdw.x * -pc.y + pc.x * dpcdw.y;
+        float v = (edgeFunc > 0.f) ? 0.5f + dist / (2.f * hitRadius)
+                                   : 0.5f - dist / (2.f * hitRadius);
+
+        // Accept — narrow tMax so a farther half can't overwrite.
+        hitAny = true;
+        bestT  = pc.z;
+        best_u = u;
+        best_v = v;
+    }
+
+    if (!hitAny) return false;
+
+    // ---- Shading frame at the accepted hit (recompute from the global hull at
+    // best_u, exactly like CurveSegment::recursiveIntersect's tail). ----
+    GVec3 dpdu;
+    gEvalBezier(bez, best_u, &dpdu);
+    if (dpdu.length2() == 0.f) return false;
+
+    GVec3 outwardNormal;
+    GVec3 dpduPlane(dpdu.dot(xAxis), dpdu.dot(yAxis), dpdu.dot(zAxis));
+    GVec3 dpdvPlane = GVec3(-dpduPlane.y, dpduPlane.x, 0.f);
+    float hitRadius = r0 + (r1 - r0) * best_u;
+    dpdvPlane = (dpdvPlane.length2() > 0.f)
+                    ? dpdvPlane.normalized() * (2.f * hitRadius)
+                    : GVec3(2.f * hitRadius, 0.f, 0.f);
+    if (thick) {
+        // Cylinder swept-circle: rotate the flat perpendicular around the true
+        // tangent by theta = lerp(v, -90deg, +90deg).
+        GVec3 dpduPlaneAxis = dpduPlane.normalized();
+        float theta = (best_v - 0.5f) * M_PI_F;
+        GVec3 dpdvRot = gRotateAroundAxis(dpdvPlane, dpduPlaneAxis, -theta);
+        GVec3 dpdv = dpdvRot.x * xAxis + dpdvRot.y * yAxis + dpdvRot.z * zAxis;
+        outwardNormal = dpdu.cross(dpdv).normalized();
+    } else {
+        // Ribbon: flat strip. The perpendicular (unrotated) → the ray-facing
+        // plane normal; no transcendentals in the leaf's normal.
+        GVec3 dpdv = dpdvPlane.x * xAxis + dpdvPlane.y * yAxis + dpdvPlane.z * zAxis;
+        outwardNormal = dpdu.cross(dpdv).normalized();
+    }
+
+    // ---- Fill the hit record (setFaceNormal convention: orient the normal to
+    // face the incoming ray; the curve's own tangent overrides uvTangent). ----
+    float tHit = bestT;
+    rec.t = tHit;
+    rec.point = ray.at(tHit);
+    rec.frontFace = ray.direction.dot(outwardNormal) < 0.f;
+    rec.normal = rec.frontFace ? outwardNormal : -outwardNormal;
+    gBuildONB(rec.normal, rec.tangent, rec.bitangent);
+    rec.uvTangent = dpdu.normalized();     // strand tangent (∂p/∂u), pkg178 twin
+    rec.uvBitangentSign = 1.f;
+    rec.hairV = best_v;                    // azimuthal v (0.5 = fiber centre)
+    rec.materialId = seg.materialId;
+    rec.isDelta = false;
+    return true;
+}

--- a/include/astroray/gpu_scene_upload.h
+++ b/include/astroray/gpu_scene_upload.h
@@ -12,6 +12,11 @@ struct SceneUploadResult {
     std::vector<GPrimitive> prims;
     std::vector<GTriangle>  triangles;
     std::vector<GSphere>    spheres;
+    // pkg225 Stage 3 — GPU curve segments (hair strands). One GCurveSegment per
+    // CPU CurveSegment; a GPRIM_CURVE GPrimitive indexes this array. Curve AABBs
+    // enter the BVH on the CPU (CurveSegment::boundingBox), so the uploaded
+    // `nodes` already bound the curves — no separate GPU AABB build.
+    std::vector<GCurveSegment> curveSegments;
     std::vector<GMaterial>  materials;
     // pkg178 Stage-3b D4: true when ANY uploaded material lowers to a
     // closure-graph Principled (mirrors gpu_closure_graph_is_principled:

--- a/include/astroray/gpu_types.h
+++ b/include/astroray/gpu_types.h
@@ -250,10 +250,15 @@ struct GBVHNode {
 // isn't a Sphere or Triangle, so r.prims stays index-aligned with the
 // BVH's primitivesOffset and with GLight.primitiveIndex. gpu_bvh_hit
 // and the area-light sampler treat GPRIM_SKIP as a no-op.
-enum GPrimType : uint8_t { GPRIM_TRIANGLE = 0, GPRIM_SPHERE = 1, GPRIM_SKIP = 2 };
+// pkg225 Stage 3 — GPRIM_CURVE dispatches a leaf to gpu_curve_intersect
+// (gpu_curve_intersect.cuh), indexing the d_curveSegments array. Curve segments
+// ride the SAME multi-primitive BVH as triangles/spheres (each CurveSegment ->
+// one GPrimitive + AABB leaf, built on the CPU BVH so the uploaded node bounds
+// already enclose the curve hulls).
+enum GPrimType : uint8_t { GPRIM_TRIANGLE = 0, GPRIM_SPHERE = 1, GPRIM_SKIP = 2, GPRIM_CURVE = 3 };
 struct GPrimitive {
     GPrimType type;
-    int       index;   // index into d_triangles or d_spheres
+    int       index;   // index into d_triangles / d_spheres / d_curveSegments
 };
 
 struct GTriangle {
@@ -294,6 +299,27 @@ struct GSphere {
     // pkg87a — Cryptomatte hashed names, populated at scene upload
     uint32_t objectHash;
     uint32_t materialHash;
+};
+
+// ---------------------------------------------------------------------------
+// pkg225 Stage 3 — GPU curve segment (hair strand span).
+//
+// GPU twin of the CPU CurveSegment (include/astroray/curves.h). One segment =
+// the cubic-Bezier control hull (already converted from Catmull-Rom on the CPU
+// in the CurveSegment ctor — we upload the hull verbatim via bezierHull()) plus
+// the swept-circle radius at each on-curve endpoint. The intersection math lives
+// in gpu_curve_intersect.cuh (ribbon-default / thick-swept-circle behind a flag),
+// a device port of the pbrt-v3 Curve::Intersect algorithm the CPU uses.
+// ---------------------------------------------------------------------------
+struct GCurveSegment {
+    GVec3 bezier0, bezier1, bezier2, bezier3;  // world-space cubic-Bezier hull
+    float radius0, radius1;                     // radius at u=0 (bezier0) / u=1 (bezier3)
+    int   materialId;
+    // 0 = ribbon (camera-facing flat strip, cheap 2D — GPU viewport default);
+    // 1 = thick (swept circle — full CPU-parity Cylinder mode). Scene-wide, set
+    // identically for every segment at upload from Renderer::getCurveThickMode()
+    // (avoids threading a runtime flag through every intersect signature).
+    int   thick;
 };
 
 // ---------------------------------------------------------------------------
@@ -800,6 +826,12 @@ struct GHitRecord {
     // Isotropic shading never reads it → bit-identical.
     GVec3 uvTangent      = GVec3(1.f, 0.f, 0.f);
     float uvBitangentSign = 1.f;
+    // pkg225 Stage 3 — azimuthal curve coordinate (GPU twin of CPU
+    // HitRecord::hair_v). Transient/per-hit; filled ONLY by the curve leaf
+    // (gpu_curve_intersect). v=0.5 is the fiber centre (the near-hemisphere half-
+    // turn spans [0,1]); default 0.5 so a non-curve hit reads the centre. The
+    // Stage-4 hair BSDF maps h = 2*hairV - 1 (S2 research note §5).
+    float hairV          = 0.5f;
     float t;
     int   materialId;
     int   primId;     // index into d_prims[] — set by gpu_bvh_hit

--- a/include/astroray/gpu_wavefront_state.h
+++ b/include/astroray/gpu_wavefront_state.h
@@ -257,7 +257,8 @@ void launchStageIntersect_SessionN3(
     const GBVHNode*   d_bvhNodes,
     const GPrimitive* d_prims,
     const GTriangle*  d_tris,
-    const GSphere*    d_spheres);
+    const GSphere*    d_spheres,
+    const GCurveSegment* d_curveSegments = nullptr);  // pkg225 Stage 3
 
 // Session N+3 part 2: Lambertian shade stage.
 // NOTE: ::GMaterial is in the global namespace (gpu_types.h); we qualify with
@@ -327,7 +328,8 @@ void launchStageIntersectQueued(
     GLightTreeView    lightTree,
     int* d_vol_queue, int* d_vol_count,   // pkg199 Stage 2
     bool has_world_scatter,               // pkg199 Stage 2 fleet-isolation axis
-    bool has_light_pass_aovs);            // pkg198 Stage 2 pass-AOV axis
+    bool has_light_pass_aovs,             // pkg198 Stage 2 pass-AOV axis
+    const GCurveSegment* d_curveSegments = nullptr);  // pkg225 Stage 3
 
 // pkg199 Stage 2 — dedicated volume-scatter wavefront stage (between intersect
 // and shade). Drains the volume-scatter queue, parks the phase-sampled
@@ -555,7 +557,8 @@ void launchStageShadow(
     const GVec3*      d_motionVerts, // pkg55-C4 / pkg88-C.0
     const ::GMaterial* d_materials,
     bool              useLuminanceOutput,   // pkg157
-    float             clampDirect, float clampIndirect);  // pkg157
+    float             clampDirect, float clampIndirect,  // pkg157
+    const GCurveSegment* d_curveSegments = nullptr);  // pkg225 Stage 3
 
 // Session N+7 part 4: path regeneration -- dense pass accumulating dead
 // paths' radiance (atomic, per-pixel) then refilling slots from a global

--- a/include/raytracer.h
+++ b/include/raytracer.h
@@ -2175,6 +2175,13 @@ class Renderer {
     // sampling. GPU-only (the CPU oracle keeps std::mt19937); published into the
     // __constant__ c_wfSamplerMode by cuda_wavefront_render.
     bool useProgressiveSampler = false;
+    // pkg225 Stage 3 — GPU curve shading mode. false = ribbon (camera-facing
+    // flat strip, cheap 2D — the viewport default); true = thick swept-circle
+    // (full CPU-parity Cylinder mode). Read by scene_upload when building
+    // GCurveSegment (set identically on every segment) and by the GPU curve
+    // leaf. The CPU path always renders the thick Cylinder mode (curves.h), so
+    // the GPU-vs-CPU parity gate sets this true to compare identical math.
+    bool curveThickMode = false;
     // pkg131 — GPU wavefront zero-knob adaptive sampling opt-in. Mirrors the CPU
     // `adaptive` render arg; read by cuda_wavefront_render to drive the compacted
     // active-pixel round loop. Default true (matches PyRenderer.useAdaptiveSampling).
@@ -2409,6 +2416,9 @@ public:
     // pkg224 — progressive-sampler opt-in (GPU wavefront only).
     void setUseProgressiveSampler(bool use) { useProgressiveSampler = use; }
     bool getUseProgressiveSampler() const { return useProgressiveSampler; }
+    // pkg225 Stage 3 — GPU curve shading mode (ribbon default / thick parity).
+    void setCurveThickMode(bool thick) { curveThickMode = thick; }
+    bool getCurveThickMode() const { return curveThickMode; }
     // pkg131 — GPU adaptive-sampling opt-in (see field above).
     void setUseAdaptiveSampling(bool use) { useAdaptiveSampling = use; }
     bool getUseAdaptiveSampling() const { return useAdaptiveSampling; }

--- a/module/blender_module.cpp
+++ b/module/blender_module.cpp
@@ -1851,6 +1851,9 @@ public:
     void setUseProgressiveSampler(bool use) {  // pkg224: opt-in GPU progressive (Sobol') sampler
         renderer.setUseProgressiveSampler(use);
     }
+    void setCurveThickMode(bool thick) {  // pkg225 Stage 3: GPU ribbon(false)/thick(true) curves
+        renderer.setCurveThickMode(thick);
+    }
 
     // pkg64 Phase 3 — per-object opt-in for SMS connection attempts in
     // the default path_tracer. `objectId` is the addObject call order
@@ -3169,6 +3172,10 @@ PYBIND11_MODULE(astroray, m) {
         .def("set_use_refractive_caustics", &PyRenderer::setUseRefractiveCaustics, "use"_a)
         .def("set_use_photon_caustics", &PyRenderer::setUsePhotonCaustics, "use"_a)
         .def("set_use_progressive_sampler", &PyRenderer::setUseProgressiveSampler, "use"_a)
+        .def("set_curve_thick_mode", &PyRenderer::setCurveThickMode, "thick"_a,
+             "pkg225 Stage 3: GPU curve shading mode — False (default) = ribbon "
+             "(camera-facing flat strip); True = thick swept-circle (CPU-parity "
+             "Cylinder). The CPU path always renders thick; set True for GPU/CPU parity.")
         .def("set_object_caustic_caster", &PyRenderer::setObjectCausticCaster,
              "object_id"_a, "enabled"_a,
              "pkg64 Phase 3 — flag an object (by addObject order) as a "

--- a/src/gpu/gpu_nee.cuh
+++ b/src/gpu/gpu_nee.cuh
@@ -495,6 +495,7 @@ __device__ inline GNEESample gpu_nee_sample(
     return s;
 }
 
+template<bool HasCurves = false>  // pkg225 Stage 3 — curve shadow-occlusion isolation
 __device__ inline GNEEOcclusion gpu_nee_occlude(
     const GNEESample& s,
     const GTLASNode*  tlas,        // pkg114
@@ -516,7 +517,7 @@ __device__ inline GNEEOcclusion gpu_nee_occlude(
     if (s.isSphere) {
         // Sphere sources: the ray must REACH the light (hit it, with the
         // light's own material) — miss or a different material = occluded.
-        if (!gpu_tlas_hit(tlas, instances, blas, bvhNodes, prims, tris, spheres,
+        if (!gpu_tlas_hit<HasCurves>(tlas, instances, blas, bvhNodes, prims, tris, spheres,
                          GRay(s.origin, s.wi, time), 0.001f, s.maxDist, sh, motionVerts, curves) ||
             sh.materialId != s.lightMatId)
             return occ;
@@ -527,7 +528,7 @@ __device__ inline GNEEOcclusion gpu_nee_occlude(
         // pkg55-B' any-hit: boolean-identical to the previous closest-hit
         // query, but the walk exits at the FIRST occluder (PBRT IntersectP /
         // Cycles scene_intersect_shadow).
-        if (gpu_tlas_occluded(tlas, instances, blas, bvhNodes, prims, tris,
+        if (gpu_tlas_occluded<HasCurves>(tlas, instances, blas, bvhNodes, prims, tris,
                               spheres, GRay(s.origin, s.wi, time), 0.001f,
                               s.maxDist, motionVerts, curves))
             return occ;

--- a/src/gpu/gpu_nee.cuh
+++ b/src/gpu/gpu_nee.cuh
@@ -505,7 +505,9 @@ __device__ inline GNEEOcclusion gpu_nee_occlude(
     const GTriangle*  tris,
     const GSphere*    spheres,
     float             time,         // pkg88-C.0: path shutter time for shadow rays
-    const GVec3*      motionVerts)  // pkg88-C.0 (nullptr = static)
+    const GVec3*      motionVerts,  // pkg88-C.0 (nullptr = static)
+    // pkg225 Stage 3 — curves occlude shadow rays too (nullptr = no curves).
+    const GCurveSegment* curves = nullptr)
 {
     GNEEOcclusion occ{};
     occ.occluded = 1;
@@ -515,7 +517,7 @@ __device__ inline GNEEOcclusion gpu_nee_occlude(
         // Sphere sources: the ray must REACH the light (hit it, with the
         // light's own material) — miss or a different material = occluded.
         if (!gpu_tlas_hit(tlas, instances, blas, bvhNodes, prims, tris, spheres,
-                         GRay(s.origin, s.wi, time), 0.001f, s.maxDist, sh, motionVerts) ||
+                         GRay(s.origin, s.wi, time), 0.001f, s.maxDist, sh, motionVerts, curves) ||
             sh.materialId != s.lightMatId)
             return occ;
         occ.frontFace = sh.frontFace ? 1 : 0;
@@ -527,7 +529,7 @@ __device__ inline GNEEOcclusion gpu_nee_occlude(
         // Cycles scene_intersect_shadow).
         if (gpu_tlas_occluded(tlas, instances, blas, bvhNodes, prims, tris,
                               spheres, GRay(s.origin, s.wi, time), 0.001f,
-                              s.maxDist, motionVerts))
+                              s.maxDist, motionVerts, curves))
             return occ;
     }
     occ.occluded = 0;

--- a/src/gpu/scene_upload.cu
+++ b/src/gpu/scene_upload.cu
@@ -5,6 +5,7 @@
 #include "astroray/gpu_scene_upload.h"
 #include "astroray/gpu_types.h"
 #include "astroray/shapes.h"
+#include "astroray/curves.h"   // pkg225 Stage 3 — CurveSegment (dynamic_cast in appendOnePrim)
 #include "astroray/spectral_profile.h"
 #include "raytracer.h"
 #include "astroray/light_tree.h"   // pkg86-B: LightTree flattening (needs raytracer.h's Vec3/AABB)
@@ -281,7 +282,10 @@ static GMaterial convertMaterial(const std::shared_ptr<Material>& mat) {
 // ---------------------------------------------------------------------------
 static void appendOnePrim(
     const std::shared_ptr<Hittable>& hittable, SceneUploadResult& r,
-    const std::function<int(const std::shared_ptr<Material>&)>& getOrAddMat)
+    const std::function<int(const std::shared_ptr<Material>&)>& getOrAddMat,
+    // pkg225 Stage 3 — scene-wide GPU curve mode (Renderer::getCurveThickMode()),
+    // written onto every emitted GCurveSegment. Ignored for non-curve prims.
+    bool curveThick = false)
 {
     GPrimitive gp;
     if (auto* tri = dynamic_cast<Triangle*>(hittable.get())) {
@@ -387,6 +391,24 @@ static void appendOnePrim(
         if (matName.empty()) matName = "Unnamed_Material_" + std::to_string(gs.materialId);
         MurmurHash3_x86_32(matName.c_str(), static_cast<int>(matName.length()), 0, &gs.materialHash);
         r.spheres.push_back(gs);
+    } else if (auto* curve = dynamic_cast<CurveSegment*>(hittable.get())) {
+        // pkg225 Stage 3 — one CPU CurveSegment → one GCurveSegment + GPRIM_CURVE
+        // leaf. The Catmull-Rom→Bezier conversion already happened in the CPU
+        // CurveSegment ctor; bezierHull() is the world-space cubic-Bezier control
+        // hull, uploaded verbatim so the device leaf runs the same pbrt math.
+        gp.type  = GPRIM_CURVE;
+        gp.index = (int)r.curveSegments.size();
+        GCurveSegment gc;
+        const Vec3* hull = curve->bezierHull();
+        gc.bezier0 = GVec3(hull[0].x, hull[0].y, hull[0].z);
+        gc.bezier1 = GVec3(hull[1].x, hull[1].y, hull[1].z);
+        gc.bezier2 = GVec3(hull[2].x, hull[2].y, hull[2].z);
+        gc.bezier3 = GVec3(hull[3].x, hull[3].y, hull[3].z);
+        gc.radius0 = curve->getRadius0();
+        gc.radius1 = curve->getRadius1();
+        gc.materialId = getOrAddMat(curve->getMaterial());
+        gc.thick = curveThick ? 1 : 0;
+        r.curveSegments.push_back(gc);
     } else {
         // pkg85-C: GPRIM_SKIP placeholder keeps prims index-aligned within a BLAS.
         gp.type  = GPRIM_SKIP;
@@ -462,7 +484,7 @@ static size_t appendFlatScene(
         }
     }
     for (auto& hittable : orderedPrims) {
-        appendOnePrim(hittable, r, getOrAddMat);
+        appendOnePrim(hittable, r, getOrAddMat, cpu.getCurveThickMode());
         if (auto* tri = dynamic_cast<Triangle*>(hittable.get())) {
             const Vec3* motionBuf = tri->getMotionVertexBuffer();
             if (motionBuf != nullptr) {

--- a/src/gpu/wavefront/gpu_wavefront_snapshot.cu
+++ b/src/gpu/wavefront/gpu_wavefront_snapshot.cu
@@ -1001,6 +1001,7 @@ T* wfUpload(WfDeviceBuf& b, const std::vector<T>& src) {
 struct WfContext {
     // Scene slices.
     WfDeviceBuf nodes, prims, tris, spheres, materials, lights;
+    WfDeviceBuf curveSegments;                // pkg225 Stage 3 — GPU curve segments
     WfDeviceBuf dedLights;                    // pkg89-wavefront (C7)
     WfDeviceBuf textures, textureTexels, materialTextureId;  // pkg186 image textures
     WfDeviceBuf materialNormalTexId, materialNormalStrength;  // pkg223 normal maps
@@ -1377,6 +1378,10 @@ std::vector<float> cuda_wavefront_render(
     GPrimitive* d_prims     = wfUpload(C.prims, res.prims);
     GTriangle*  d_tris      = wfUpload(C.tris, res.triangles);
     GSphere*    d_spheres   = wfUpload(C.spheres, res.spheres);
+    // pkg225 Stage 3 — GPU curve segments (nullptr for non-curve scenes; the
+    // gpu_bvh_hit/occluded curve leaf is guarded on this pointer, so passing
+    // nullptr keeps non-curve renders byte-identical).
+    GCurveSegment* d_curveSegments = wfUpload(C.curveSegments, res.curveSegments);
     // pkg55-C4 / pkg114: TLAS/instances/blas for instancing support (empty unless
     // scene has instances; null-TLAS path in gpu_tlas_hit falls back to single-level).
     GTLASNode*  d_tlas      = wfUpload(C.tlas, res.tlas);
@@ -1839,7 +1844,8 @@ std::vector<float> cuda_wavefront_render(
                                        // Stage-1, no fog-free regression).
                                        renderer.getHasWorldVolume() &&
                                            renderer.getWorldVolumeScatter() > 0.0f,
-                                       passesOn);  // pkg198 Stage 2 pass-AOV axis
+                                       passesOn,   // pkg198 Stage 2 pass-AOV axis
+                                       d_curveSegments);  // pkg225 Stage 3
             // pkg199 Stage 2 — dedicated volume-scatter stage, between intersect
             // and shade. Drains the volume queue (scattered slots), parks the
             // phase NEE into the shared nee/shadow lanes, and requeues survivors
@@ -1887,7 +1893,8 @@ std::vector<float> cuda_wavefront_render(
                               d_bvhNodes, d_prims, d_tris, d_spheres,
                               d_motionVerts, d_materials,  // pkg55-C4
                               useLuminanceOutput,
-                              clampDirect, clampIndirect);  // pkg157
+                              clampDirect, clampIndirect,  // pkg157
+                              d_curveSegments);  // pkg225 Stage 3 — curve shadows
             if (waves == 1) continue;  // fixed pass count, no readbacks
             if (workExhausted) {
                 if (--drainLeft <= 0) break;

--- a/src/gpu/wavefront/stage_advance.cu
+++ b/src/gpu/wavefront/stage_advance.cu
@@ -391,7 +391,8 @@ __device__ inline float gpu_freeflightUniform(uint32_t pixel, uint32_t sample,
 // launch <true> (which pays the 130, but they are scattering-bound anyway). The
 // non-template `intersectPathSlot` symbol below forwards to <false> so the
 // cross-TU callers (ReSTIR primary, MIS-audit; both scatter=0) link unchanged.
-template<bool HasWorldScatter, bool HasLightPassAOVs = false>  // pkg199 scatter; pkg198 S2 pass axis
+template<bool HasWorldScatter, bool HasLightPassAOVs = false,
+         bool HasCurves = false>  // pkg225 Stage 3 — curve-leaf isolation axis
 __device__ int intersectPathSlotT(
     int idx,
     GPUWavefrontState& state,
@@ -464,7 +465,7 @@ __device__ int intersectPathSlotT(
     // to the single-level gpu_bvh_hit path inside gpu_tlas_hit, so static scenes
     // stay byte-identical (pkg114 inc-1 identity test).
     GHitRecord rec;
-    bool hit = gpu_tlas_hit(tlas, instances, blas, bvhNodes, prims, tris, spheres,
+    bool hit = gpu_tlas_hit<HasCurves>(tlas, instances, blas, bvhNodes, prims, tris, spheres,
                             ray, 0.001f, 1e30f, rec, motionVerts, curves);
 
     // pkg199 Stage 2 — homogeneous medium free-flight scatter DECISION (Option A:
@@ -1837,6 +1838,7 @@ __device__ bool shadePathSlot(
 // original ran post-trace. Contribution adds into color (one entry per
 // slot per pass: non-atomic).
 // ---------------------------------------------------------------------------
+template<bool HasCurves = false>  // pkg225 Stage 3 — curve shadow-occlusion isolation
 __global__ void stageShadowKernel(
     GPUWavefrontState state,
     GPUWavefrontHitBuffers hitBufs,
@@ -1881,7 +1883,7 @@ __global__ void stageShadowKernel(
 
     // pkg55-C4: thread TLAS + path time + motionVerts to shadow rays.
     float time = state.path_time[idx];
-    GNEEOcclusion occ = gpu_nee_occlude(
+    GNEEOcclusion occ = gpu_nee_occlude<HasCurves>(
         s, tlas, instances, blas, bvhNodes, prims, tris, spheres,
         time, motionVerts, curves);
     if (occ.occluded) return;
@@ -2008,7 +2010,8 @@ __global__ void stageQueueIotaKernel(int* queue, int* count, int n)
 // material dispatch of Laine 2013 sec. 5 / Cycles X shader sorting, realized
 // as bucketed atomic append instead of a radix sort (7 types only).
 // ---------------------------------------------------------------------------
-template<bool HasWorldScatter, bool HasLightPassAOVs = false>   // pkg199 scatter; pkg198 S2 pass axis
+template<bool HasWorldScatter, bool HasLightPassAOVs = false,
+         bool HasCurves = false>   // pkg225 Stage 3 — curve-leaf isolation axis
 __global__ void stageIntersectQueuedKernel(
     GPUWavefrontState state,
     GPUWavefrontHitBuffers hitBufs,
@@ -2051,7 +2054,7 @@ __global__ void stageIntersectQueuedKernel(
     // (no-op there); the regeneration driver iterates a dense identity
     // queue where exhausted slots stay dead.
     if (state.path_alive[idx] == 0) return;
-    int matType = intersectPathSlotT<HasWorldScatter, HasLightPassAOVs>(
+    int matType = intersectPathSlotT<HasWorldScatter, HasLightPassAOVs, HasCurves>(
                                     idx, state, hitBufs, tlas, instances, blas,
                                     bvhNodes, prims, tris, spheres, motionVerts,
                                     materials, envMap, backgroundColor,
@@ -2199,19 +2202,38 @@ void launchStageIntersectQueued(
         // identical Stage-1. All four instantiations are referenced so they land in
         // the cubin for the cuobjdump register report (intersect<false,false> must
         // stay 127/616).
+        // pkg225 Stage 3: the 3rd (HasCurves) axis. NON-curve scenes launch the
+        // <..,..,false> kernels (the curve leaf DCE'd → intersect<false,false,false>
+        // stays REG 127 / 616, byte-identical Stage-1); only scenes carrying curve
+        // segments launch <..,..,true>. All 8 instantiations are referenced so they
+        // land in the cubin for the cuobjdump register report.
+        const bool hc = (d_curveSegments != nullptr);
         const int sel = (has_world_scatter ? 2 : 0) | (has_light_pass_aovs ? 1 : 0);
-        const void* kptr =
-            sel == 3 ? (const void*)stageIntersectQueuedKernel<true, true>  :
-            sel == 2 ? (const void*)stageIntersectQueuedKernel<true, false> :
-            sel == 1 ? (const void*)stageIntersectQueuedKernel<false, true> :
-                       (const void*)stageIntersectQueuedKernel<false, false>;
+        const void* kptr = hc ?
+            (sel == 3 ? (const void*)stageIntersectQueuedKernel<true, true, true>  :
+             sel == 2 ? (const void*)stageIntersectQueuedKernel<true, false, true> :
+             sel == 1 ? (const void*)stageIntersectQueuedKernel<false, true, true> :
+                        (const void*)stageIntersectQueuedKernel<false, false, true>) :
+            (sel == 3 ? (const void*)stageIntersectQueuedKernel<true, true, false>  :
+             sel == 2 ? (const void*)stageIntersectQueuedKernel<true, false, false> :
+             sel == 1 ? (const void*)stageIntersectQueuedKernel<false, true, false> :
+                        (const void*)stageIntersectQueuedKernel<false, false, false>);
         astroray::gpu_profile::ScopedTimer _t(
             "wavefront_stage_intersect_queued_n7", kptr, blocks, threads);
-        switch (sel) {
-            case 3: stageIntersectQueuedKernel<true, true> <<<blocks, threads>>>(ASTRORAY_PKG199_INTERSECT_ARGS); break;
-            case 2: stageIntersectQueuedKernel<true, false><<<blocks, threads>>>(ASTRORAY_PKG199_INTERSECT_ARGS); break;
-            case 1: stageIntersectQueuedKernel<false, true> <<<blocks, threads>>>(ASTRORAY_PKG199_INTERSECT_ARGS); break;
-            default:stageIntersectQueuedKernel<false, false><<<blocks, threads>>>(ASTRORAY_PKG199_INTERSECT_ARGS); break;
+        if (hc) {
+            switch (sel) {
+                case 3: stageIntersectQueuedKernel<true, true, true> <<<blocks, threads>>>(ASTRORAY_PKG199_INTERSECT_ARGS); break;
+                case 2: stageIntersectQueuedKernel<true, false, true><<<blocks, threads>>>(ASTRORAY_PKG199_INTERSECT_ARGS); break;
+                case 1: stageIntersectQueuedKernel<false, true, true> <<<blocks, threads>>>(ASTRORAY_PKG199_INTERSECT_ARGS); break;
+                default:stageIntersectQueuedKernel<false, false, true><<<blocks, threads>>>(ASTRORAY_PKG199_INTERSECT_ARGS); break;
+            }
+        } else {
+            switch (sel) {
+                case 3: stageIntersectQueuedKernel<true, true, false> <<<blocks, threads>>>(ASTRORAY_PKG199_INTERSECT_ARGS); break;
+                case 2: stageIntersectQueuedKernel<true, false, false><<<blocks, threads>>>(ASTRORAY_PKG199_INTERSECT_ARGS); break;
+                case 1: stageIntersectQueuedKernel<false, true, false> <<<blocks, threads>>>(ASTRORAY_PKG199_INTERSECT_ARGS); break;
+                default:stageIntersectQueuedKernel<false, false, false><<<blocks, threads>>>(ASTRORAY_PKG199_INTERSECT_ARGS); break;
+            }
         }
         cudaError_t err = cudaGetLastError();
         if (err != cudaSuccess) {
@@ -2987,15 +3009,23 @@ void launchStageShadow(
     int threads = 256;
     int blocks  = (state.num_active + threads - 1) / threads;
     {
+        // pkg225 Stage 3: curve shadow-occlusion axis. Non-curve scenes launch
+        // stageShadowKernel<false> (curve leaf DCE'd, byte-identical); only curve
+        // scenes launch <true>. Both referenced so they land in the cubin.
+        const bool hc = (d_curveSegments != nullptr);
         astroray::gpu_profile::ScopedTimer _t(
             "wavefront_stage_shadow_n7",
-            (const void*)stageShadowKernel, blocks, threads);
-        stageShadowKernel<<<blocks, threads>>>(
-            state, hitBufs, d_nee_f, d_nee_i,
-            d_shadow_queue, d_shadow_count, nee_capacity,
-            d_tlas, d_instances, d_blas,
-            d_bvhNodes, d_prims, d_tris, d_spheres, d_motionVerts, d_materials,
-            useLuminanceOutput, clampDirect, clampIndirect, d_curveSegments);
+            hc ? (const void*)stageShadowKernel<true> : (const void*)stageShadowKernel<false>,
+            blocks, threads);
+        #define ASTRORAY_PKG225_SHADOW_ARGS \
+            state, hitBufs, d_nee_f, d_nee_i, \
+            d_shadow_queue, d_shadow_count, nee_capacity, \
+            d_tlas, d_instances, d_blas, \
+            d_bvhNodes, d_prims, d_tris, d_spheres, d_motionVerts, d_materials, \
+            useLuminanceOutput, clampDirect, clampIndirect, d_curveSegments
+        if (hc) stageShadowKernel<true> <<<blocks, threads>>>(ASTRORAY_PKG225_SHADOW_ARGS);
+        else    stageShadowKernel<false><<<blocks, threads>>>(ASTRORAY_PKG225_SHADOW_ARGS);
+        #undef ASTRORAY_PKG225_SHADOW_ARGS
         cudaError_t err = cudaGetLastError();
         if (err != cudaSuccess) {
             std::fprintf(stderr, "stage_shadow launch error: %s\n",

--- a/src/gpu/wavefront/stage_advance.cu
+++ b/src/gpu/wavefront/stage_advance.cu
@@ -415,7 +415,10 @@ __device__ int intersectPathSlotT(
     const ::GLight*   lights, int numLights, float totalLightPower,
     // pkg181: dedicated lamps for the BSDF-ray lamp-intersection pass.
     const GDedicatedLight* dedLights, int numDed,
-    GLightTreeView    lightTree)
+    GLightTreeView    lightTree,
+    // pkg225 Stage 3 — device curve segments (nullptr = no curves; the curve
+    // leaf inside gpu_tlas_hit → gpu_bvh_hit is guarded on this pointer).
+    const GCurveSegment* curves = nullptr)
 {
     const int bounce = state.bounce[idx];
 
@@ -462,7 +465,7 @@ __device__ int intersectPathSlotT(
     // stay byte-identical (pkg114 inc-1 identity test).
     GHitRecord rec;
     bool hit = gpu_tlas_hit(tlas, instances, blas, bvhNodes, prims, tris, spheres,
-                            ray, 0.001f, 1e30f, rec, motionVerts);
+                            ray, 0.001f, 1e30f, rec, motionVerts, curves);
 
     // pkg199 Stage 2 — homogeneous medium free-flight scatter DECISION (Option A:
     // the cheap decision + queue routing lives here; the register-heavy scatter
@@ -1849,7 +1852,8 @@ __global__ void stageShadowKernel(
     const GVec3*      motionVerts, // pkg55-C4 / pkg88-C.0
     const ::GMaterial* materials,
     bool              useLuminanceOutput,   // pkg157
-    float             clampDirect, float clampIndirect)  // pkg157
+    float             clampDirect, float clampIndirect,  // pkg157
+    const GCurveSegment* curves)  // pkg225 Stage 3 — curve shadow occluders
 {
     int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= *shadow_count) return;
@@ -1879,7 +1883,7 @@ __global__ void stageShadowKernel(
     float time = state.path_time[idx];
     GNEEOcclusion occ = gpu_nee_occlude(
         s, tlas, instances, blas, bvhNodes, prims, tris, spheres,
-        time, motionVerts);
+        time, motionVerts, curves);
     if (occ.occluded) return;
 
     // Emission upsample only (the BSDF/MIS parts were pre-resolved in the
@@ -2036,7 +2040,9 @@ __global__ void stageIntersectQueuedKernel(
     // path that scattered in the medium; that slot is routed here (not the shade
     // bucket) for the dedicated stageVolumeScatterKernel. Null when the medium
     // does not scatter (scatter==0) — the -2 return never fires then.
-    int* vol_queue, int* vol_count)
+    int* vol_queue, int* vol_count,
+    // pkg225 Stage 3 — device curve segments (nullptr = no curves).
+    const GCurveSegment* curves)
 {
     int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= *count_in) return;
@@ -2053,7 +2059,8 @@ __global__ void stageIntersectQueuedKernel(
                                     useLuminanceOutput, enableNEE,
                                     clampDirect, clampIndirect,
                                     lights, numLights, totalLightPower,
-                                    dedLights, numDed, lightTree);  // pkg120+pkg181
+                                    dedLights, numDed, lightTree,  // pkg120+pkg181
+                                    curves);  // pkg225 Stage 3
     if (matType == -2) {   // pkg199 Stage 2: scattered → volume-scatter queue
         int vslot = atomicAdd(vol_count, 1);
         vol_queue[vslot] = idx;
@@ -2165,7 +2172,8 @@ void launchStageIntersectQueued(
     GLightTreeView    lightTree,
     int* d_vol_queue, int* d_vol_count,   // pkg199 Stage 2
     bool has_world_scatter,               // pkg199 Stage 2: picks the fleet-isolation axis
-    bool has_light_pass_aovs)             // pkg198 Stage 2: picks the pass-AOV axis
+    bool has_light_pass_aovs,             // pkg198 Stage 2: picks the pass-AOV axis
+    const GCurveSegment* d_curveSegments) // pkg225 Stage 3 (nullptr = no curves)
 {
     if (state.num_active <= 0) return;
     int threads = 256;
@@ -2183,7 +2191,8 @@ void launchStageIntersectQueued(
         useLuminanceOutput, enableNEE, clampDirect, clampIndirect, \
         d_lights, num_lights, total_light_power, \
         d_dedLights, num_ded, lightTree, \
-        d_vol_queue, d_vol_count
+        d_vol_queue, d_vol_count, \
+        d_curveSegments
     {
         // pkg198 Stage 2: the second axis picks the pass-AOV specialization. The
         // fleet (no scatter, no passes) launches <false,false> — REG 127, byte-
@@ -2971,7 +2980,8 @@ void launchStageShadow(
     const GVec3*      d_motionVerts, // pkg55-C4 / pkg88-C.0
     const ::GMaterial* d_materials,
     bool              useLuminanceOutput,   // pkg157
-    float             clampDirect, float clampIndirect)  // pkg157
+    float             clampDirect, float clampIndirect,  // pkg157
+    const GCurveSegment* d_curveSegments)  // pkg225 Stage 3 (nullptr = no curves)
 {
     if (state.num_active <= 0) return;
     int threads = 256;
@@ -2985,7 +2995,7 @@ void launchStageShadow(
             d_shadow_queue, d_shadow_count, nee_capacity,
             d_tlas, d_instances, d_blas,
             d_bvhNodes, d_prims, d_tris, d_spheres, d_motionVerts, d_materials,
-            useLuminanceOutput, clampDirect, clampIndirect);
+            useLuminanceOutput, clampDirect, clampIndirect, d_curveSegments);
         cudaError_t err = cudaGetLastError();
         if (err != cudaSuccess) {
             std::fprintf(stderr, "stage_shadow launch error: %s\n",

--- a/src/gpu/wavefront/stage_intersect_session_n3.cu
+++ b/src/gpu/wavefront/stage_intersect_session_n3.cu
@@ -36,7 +36,8 @@ __global__ void stageIntersectKernel_N3(
     const GBVHNode*   bvhNodes,
     const GPrimitive* prims,
     const GTriangle*  tris,
-    const GSphere*    spheres)
+    const GSphere*    spheres,
+    const GCurveSegment* curves)  // pkg225 Stage 3 (nullptr = no curves)
 {
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx >= state.num_active) return;
@@ -64,7 +65,7 @@ __global__ void stageIntersectKernel_N3(
     GHitRecord rec;
     rec.primId = -1;
     bool hit = gpu_bvh_hit(bvhNodes, prims, tris, spheres,
-                           ray, 0.001f, 1e30f, rec);
+                           ray, 0.001f, 1e30f, rec, nullptr, curves);
 
     if (hit) {
         // Write hit record into SoA. Mirrors CPU PostIntersect snapshot fields.
@@ -102,7 +103,8 @@ void launchStageIntersect_SessionN3(
     const GBVHNode*   d_bvhNodes,
     const GPrimitive* d_prims,
     const GTriangle*  d_tris,
-    const GSphere*    d_spheres)
+    const GSphere*    d_spheres,
+    const GCurveSegment* d_curveSegments)  // pkg225 Stage 3 (nullptr = no curves)
 {
     int n = state.num_active;
     if (n <= 0) return;
@@ -114,7 +116,7 @@ void launchStageIntersect_SessionN3(
             "wavefront_stage_intersect_n3",
             (const void*)stageIntersectKernel_N3, blocks, threads);
         stageIntersectKernel_N3<<<blocks, threads>>>(
-            state, hitBufs, d_bvhNodes, d_prims, d_tris, d_spheres);
+            state, hitBufs, d_bvhNodes, d_prims, d_tris, d_spheres, d_curveSegments);
         cudaError_t err = cudaGetLastError();
         if (err != cudaSuccess) {
             std::fprintf(stderr, "stage_intersect_n3 launch error: %s\n",

--- a/tests/test_pkg225_gpu_curves.py
+++ b/tests/test_pkg225_gpu_curves.py
@@ -1,0 +1,178 @@
+"""pkg225 Stage 3 — GPU curve geometry: CPU<->GPU render parity.
+
+Stage 3 ports the CPU CurveSegment ray-curve intersection (include/astroray/
+curves.h, the pbrt-v3 Curve::Intersect / recursiveIntersect port, BSD-2-Clause)
+to the GPU wavefront path tracer:
+  - include/astroray/gpu_curve_intersect.cuh  (__device__ port, ribbon + thick)
+  - GPRIM_CURVE leaf dispatch in gpu_bvh_hit / gpu_bvh_occluded (gpu_bvh.h)
+  - GCurveSegment upload in scene_upload.cu (one CPU CurveSegment -> one leaf)
+
+This is a GEOMETRY-ONLY stage: curves render with a PLAIN diffuse material; no
+hair BSDF (Stage 4). Verification is a CPU<->GPU render comparison of the SAME
+multi-strand scene, gated by per-channel mean-ratio (NOT SSIM -- independent MC
+streams don't converge in SSIM at practical spp, but per-channel means do;
+memory ssim-wrong-gate-for-independent-rng).
+
+The GPU default curve mode is RIBBON (camera-facing flat strip); the CPU path
+always renders the THICK swept-circle Cylinder mode. To compare identical math
+the scene enables thick mode on the GPU via set_curve_thick_mode(True) -- the
+CPU-parity path this gate exercises.
+
+Scene: a small field of gently-curved diffuse strands lit by one area light over
+a BLACK background, so the frame mean is dominated by LIT CURVE pixels (the
+curve normal drives the N.L diffuse shading), making the mean-ratio sensitive to
+the curve hit point AND its reconstructed radial normal -- not a trivially-equal
+pair of mostly-background frames (a coverage floor asserts curves are visible).
+
+Gate (coordinator MC-noise convention, cf. tests/test_pkg123_disney_metal_gpu_
+cpu_parity.py):
+  1. No NaN/Inf pixel components in either render.
+  2. Both renders show real curve coverage (non-black fraction above a floor).
+  3. Per-channel GPU/CPU mean-ratio within an MC-noise band. The pkg225 spec's
+     acceptance target is [0.95, 1.05] at 64 spp; this file renders at higher spp
+     and uses a slightly wider [0.90, 1.10] band to absorb independent-RNG noise
+     on a thin-geometry scene (the same "generous band" discipline pkg123 uses).
+     The parent may tighten toward the spec target once measured on RTX.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+
+try:
+    import astroray
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray not built")
+
+if AVAILABLE and not astroray.__features__.get("cuda", False):
+    pytest.skip(
+        "CUDA feature not in this build -- pkg225 Stage 3 GPU curve parity "
+        "needs the RTX box.",
+        allow_module_level=True,
+    )
+
+WIDTH = HEIGHT = 64
+SAMPLES = 256
+MAX_DEPTH = 4
+SEED = 225303
+
+RATIO_LOW = 0.90
+RATIO_HIGH = 1.10
+COVERAGE_FLOOR = 0.02  # >=2% of pixels must be lit curve (both backends)
+
+
+def _make_strands():
+    """A field of gently-curved strands filling the view. Each strand is 4
+    Catmull-Rom control points (one CurveSegment via the middle span + Cycles
+    phantom-endpoint clamping) sweeping top->bottom with a small per-strand
+    lateral bow so the segments are genuinely CURVED (exercises the recursive
+    Bezier subdivision, not just the straight-segment fast path)."""
+    positions = []
+    counts = []
+    n_cols = 9
+    n_rows = 5
+    for ci in range(n_cols):
+        x0 = -1.4 + 2.8 * ci / (n_cols - 1)
+        bow = 0.25 * np.sin(ci * 0.7)  # per-strand lateral curvature
+        strand = []
+        for ri in range(n_rows):
+            t = ri / (n_rows - 1)
+            y = 1.3 - 2.6 * t
+            x = x0 + bow * np.sin(t * np.pi)
+            z = 0.15 * np.cos(t * np.pi + ci)  # gentle depth wave
+            strand.append((x, y, z))
+        positions.extend(strand)
+        counts.append(n_rows)
+    return np.asarray(positions, dtype=np.float32), counts
+
+
+def _make_curve_scene(use_gpu: bool):
+    """Diffuse curve field + one area light, black background. Built identically
+    for CPU and GPU; only the backend flag (and the harmless-on-CPU thick-mode
+    flag) differ."""
+    r = astroray.Renderer()
+    r.set_background_color([0.0, 0.0, 0.0])
+
+    hair = r.create_material("lambertian", [0.7, 0.55, 0.4], {})
+    positions, counts = _make_strands()
+    radii = np.full(len(positions), 0.05, dtype=np.float32)
+    r.add_curves_bulk(positions, radii, counts, hair)
+
+    light = r.create_material("light", [1.0, 1.0, 1.0], {"intensity": 14.0})
+    r.add_sphere([1.6, 2.6, 1.8], 0.5, light)
+
+    r.setup_camera([0.0, 0.0, 4.2], [0.0, 0.0, 0.0], [0.0, 1.0, 0.0],
+                    40.0, WIDTH / HEIGHT, 0.0, 4.2, WIDTH, HEIGHT)
+
+    r.set_integrator("path_tracer")
+    r.set_integrator_param("max_depth", MAX_DEPTH)
+    # CPU always renders the thick swept-circle Cylinder; make the GPU do the
+    # same so the two backends run identical math (else GPU defaults to ribbon).
+    r.set_curve_thick_mode(True)
+    if use_gpu:
+        r.set_use_gpu(True)
+    return r
+
+
+def _render(use_gpu: bool) -> np.ndarray:
+    r = _make_curve_scene(use_gpu=use_gpu)
+    r.set_seed(SEED)
+    return np.asarray(r.render(SAMPLES, MAX_DEPTH, None, False), dtype=np.float32)
+
+
+def test_gpu_curve_render_matches_cpu():
+    gpu = _render(use_gpu=True)
+    cpu = _render(use_gpu=False)
+
+    assert gpu.shape == (HEIGHT, WIDTH, 3)
+    assert cpu.shape == (HEIGHT, WIDTH, 3)
+
+    # Gate 1 — no NaN/Inf.
+    gpu_bad = int(np.sum(~np.isfinite(gpu)))
+    cpu_bad = int(np.sum(~np.isfinite(cpu)))
+    assert gpu_bad == 0, f"GPU curve render produced {gpu_bad} non-finite components"
+    assert cpu_bad == 0, f"CPU curve render produced {cpu_bad} non-finite components"
+
+    # Gate 2 — curves are actually visible on both backends (guards against a
+    # trivially-equal pair of black frames if curve upload/intersection no-ops).
+    gpu_cov = float(np.mean(np.any(gpu > 1e-4, axis=-1)))
+    cpu_cov = float(np.mean(np.any(cpu > 1e-4, axis=-1)))
+    print(f"\n[pkg225-S3 GPU curves] coverage cpu={cpu_cov:.3f} gpu={gpu_cov:.3f}")
+    assert cpu_cov >= COVERAGE_FLOOR, (
+        f"CPU render shows no curve coverage ({cpu_cov:.3f} < {COVERAGE_FLOOR}) "
+        f"-- the CPU curve primitive itself is not rendering; investigate before GPU."
+    )
+    assert gpu_cov >= COVERAGE_FLOOR, (
+        f"GPU render shows no curve coverage ({gpu_cov:.3f} < {COVERAGE_FLOOR}) "
+        f"-- GPRIM_CURVE leaf dispatch / GCurveSegment upload not wired: curves "
+        f"were uploaded on the CPU but the GPU intersect stage never hits them."
+    )
+
+    # Gate 3 — per-channel mean-ratio (NOT SSIM).
+    per_channel = []
+    for c, ch in enumerate("RGB"):
+        gm = float(gpu[..., c].mean())
+        cm = float(cpu[..., c].mean())
+        ratio = (gm / cm) if cm > 1e-9 else (float("inf") if gm > 1e-9 else 1.0)
+        per_channel.append((ch, cm, gm, ratio))
+
+    for ch, cm, gm, ratio in per_channel:
+        print(f"  {ch}: cpu_mean={cm:.5f} gpu_mean={gm:.5f} ratio={ratio:.4f}")
+
+    for ch, cm, gm, ratio in per_channel:
+        assert RATIO_LOW <= ratio <= RATIO_HIGH, (
+            f"pkg225-S3 GPU/CPU curve parity FAILED: channel {ch} mean ratio "
+            f"{ratio:.4f} outside [{RATIO_LOW}, {RATIO_HIGH}] "
+            f"(cpu_mean={cm:.5f}, gpu_mean={gm:.5f}). The GPU curve hit point / "
+            f"radial normal diverges from the CPU intersector."
+        )
+
+    print("[pkg225-S3 GPU curves] PASS: finite, curves visible, per-channel "
+          f"mean ratios within [{RATIO_LOW}, {RATIO_HIGH}]")


### PR DESCRIPTION
## Summary

pkg225 Stage 3 — the pkg225-S1 hair strands now render on the **GPU wavefront path tracer** as a new `GPRIM_CURVE` BVH leaf, producing a `GHitRecord` with point, radial normal, `uvTangent` (=∂p/∂u strand tangent), and `hairV`. Verified by a CPU↔GPU mean-ratio parity test with a plain diffuse material. No hair BSDF (that's Stage 4). Implemented by a subagent to the architect's design + the sphere-precedent; **built, register-probed, and GPU-verified by the parent**, who added the register-isolation axis.

## What landed
- **`include/astroray/gpu_curve_intersect.cuh`** — `__device__ __noinline__` STL-free port of `curves.h` (pbrt-v3, BSD-2-Clause): iterative de Casteljau stack (device-recursion-free, keeps the global-min hit → result-parity with the CPU intersector). Ribbon default (2D, transcendental-free); thick swept-circle behind a per-segment flag (the CPU-parity mode).
- Curves ride the **existing multi-primitive BVH** exactly like spheres: `GPRIM_CURVE` leaf in `gpu_bvh_hit`/`gpu_bvh_occluded`; curve AABBs enter the BVH on the CPU (`CurveSegment::boundingBox` → `orderedPrims`), so no separate GPU AABB build. Threaded through intersect + **shadow** (curves self-shadow).
- **Register isolation (`template<bool HasCurves>`):** the probe showed the curve leaf raised the *universal* intersect/shadow kernels for every scene (runtime `curves` pointer → live branch: intersect 127→158, shadow 108→158, N3 61→158). Gated the leaf behind `if constexpr(HasCurves)` (default false) through the whole BVH/NEE/kernel chain; launchers select `<true>` only when `d_curveSegments != nullptr`.

## Verification (RTX 5070 Ti)
- **Register probe — non-curve fleet byte-identical:** intersect `<…,false>` **127/616**, N3 **61/272**, shadow `<false>` **108/584**, fleet shade **254/3368/1716**. Only curve scenes launch `<…,true>` (158).
- `tests/test_pkg225_gpu_curves.py` GPU↔CPU curve-render mean-ratio parity — **pass**.
- 25 curve/hair/scalar-tex/GPU-wavefront regression tests pass.

Next: Stage 4 (GPU hair BSDF) reads this hit's `uvTangent`/`hairV`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)