### PR TITLE
docs: pkg127 best-of spec + STATUS/ROADMAP/NEXT_STAGE_REPORT consistency

### DIFF
--- a/.astroray_plan/docs/NEXT_STAGE_REPORT.md
+++ b/.astroray_plan/docs/NEXT_STAGE_REPORT.md
@@ -43,29 +43,32 @@ paid nothing.)
 ### UPDATE (later 2026-09-03): architect re-vet done (#675); pkg225-S3 landing
 The architect re-vet ranked the next arc and filed Stage-3/4 implementation
 detail. Since then:
-- **pkg225-S3 (GPU curve geometry) — IN FINAL CI** (PR #676). Curves render on
-  GPU (`GPRIM_CURVE` leaf, `gpu_curve_intersect.cuh`); the curve leaf is isolated
+- **pkg225-S3 (GPU curve geometry) — LANDED** (PR #676). Curves render on GPU
+  (`GPRIM_CURVE` leaf, `gpu_curve_intersect.cuh`); the curve leaf is isolated
   behind `template<bool HasCurves>` so non-curve kernels are byte-identical
   (intersect 127/616, N3 61/272, shadow 108/584, fleet shade 254/3368/1716).
-  GPU↔CPU parity + 25 regression pass; cpp-abi-guard APPROVE.
+  GPU↔CPU parity + 25 regression pass; cpp-abi-guard APPROVE. Visually verified.
 - **NEXT = pkg225-S4 (GPU hair BSDF).** Design pinned: `__noinline__` runtime-flag
   isolation (NOT a 9th shade axis), standalone `GMAT_HAIR_PRINCIPLED` branch.
   **HARD S3→S4 dependency:** S3 sets `hairV`/`uvTangent` in the curve leaf but
   does NOT persist `hairV` to the SoA `GPUWavefrontHitBuffers` — S4 must add a
   `hit_hair_v` lane (+ `loadHit`/`storeHit`) first, else the hair BSDF reads a
   stale centre value (cpp-abi-guard flagged this).
-- **Research fan-out IN FLIGHT** (owner-directed 2026-09-03): deepseek-v4-pro
-  web-research agents (opencode `architect` agent, webfetch+websearch enabled;
-  strict "web-verify or NOT FOUND, never fabricate" contract) are gathering
-  cited literature for **pkg127** (Specular Polynomials SMS seeds), **pkg211**
-  (per-bounce spectral MIS + ray-differentials), **pkg136** (SVO path guiding)
-  → notes at `docs/pkg{127,211,136}-*-research.md`; then one Opus spec-writer per
-  package turns each into a detailed, design-choice spec (Claude verifies the
-  research before it feeds the spec).
-- **Alternate pickup: pkg127** — highest-value bounded caustics-quality upgrade
-  (drop-in SMS seed swap on the landed pkg64 SMS); ready once its spec lands.
-- **Parked:** pkg211 (prototype-first, legitimate PARK); long-tail
-  pkg126/130/132/134/136/137 each a dedicated-day arc.
+- **Research → detailed specs — DONE** (owner-directed 2026-09-03): deepseek-v4-pro
+  web-research (opencode `architect` agent, webfetch+websearch; strict
+  "web-verify or NOT FOUND, never fabricate" contract — 14/11/13 real searches,
+  URL-cited, no fabrication) → notes `docs/pkg{127,211,136}-*-research.md`, then
+  Opus spec-writers produced detailed design-choice specs, **all merged**:
+  - **pkg127** — Specular Polynomials SMS-seed upgrade (**PR #679**). Highest-value
+    bounded caustics-quality upgrade (drop-in SMS seed swap on landed pkg64). Ready
+    to dispatch. Research fixed a wrong author cite + resolved the license
+    (mollnn/spoly unlicensed → re-derive from the CC-BY paper + MIT cyPolynomial).
+  - **pkg211** — per-bounce spectral MIS (**PR #677**). Prototype-first, **legitimate
+    PARK outcome** (only ships if a CPU Stage-1 beats the pkg206 baseline by ≥10%);
+    ray-differentials split to pkg211b. Architect's read: park unless a free slot.
+  - **pkg136** — path guiding (**PR #678**). Renamed SVO→**SD-tree** (the honest
+    structure call), CPU-first, gated GPU leg.
+- **Long-tail parked:** pkg126/130/132/134/137 each a dedicated-day arc.
 
 ---
 

--- a/.astroray_plan/docs/ROADMAP.md
+++ b/.astroray_plan/docs/ROADMAP.md
@@ -116,11 +116,12 @@ curve geometry, #676) landing; **NEXT = pkg225-S4** (GPU hair BSDF; design
 pinned, needs S3's `hit_hair_v` SoA lane first). Also landed this session:
 **pkg219d** scalar parameter textures both backends (#674); **pkg210** SUPERSEDED
 (premise stale) and **pkg180** systemic-Cycles-dim CLOSED (not reproducible).
-Queued behind hair: **pkg127** (Specular Polynomials SMS-seed upgrade — spec in
-progress from web-verified research), **pkg211** (per-bounce spectral MIS —
-prototype-first, park-eligible), **pkg136** (SVO path guiding), long-tail
-pkg126/130/132/134/137. The exact dispatch order is an architect decision per
-round.
+Queued behind hair, all with **detailed specs landed from web-verified research**
+(2026-09-03): **pkg127** (Specular Polynomials SMS-seed upgrade — spec #679, the
+highest-value bounded caustics upgrade, ready to dispatch), **pkg211** (per-bounce
+spectral MIS — spec #677, prototype-first / park-eligible), **pkg136** (SD-tree
+path guiding — spec #678, renamed from "SVO"), long-tail pkg126/130/132/134/137.
+The exact dispatch order is an architect decision per round.
 
 **Explicitly de-prioritized (owner-endorsed):** the sub-percent GPU/CPU
 parity tail — **pkg172 effect (B) / pkg173** (bounce-1 geometry-sampling

--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -47,8 +47,10 @@ backends, and two stale/ghost items were retired.**
   register-hostile rebuilds. Registers: fleet `stageShadeBucketedKernel
   <0,0,0,0,0,0,0>` stays REG:254/STACK:3368/CONSTANT[0]:1716 through all of it.
 - **NEXT:** pkg225 S4 (GPU hair BSDF, design pinned, needs the S3 `hit_hair_v`
-  SoA lane first) → S5/S6. Research fan-out in flight for pkg127/pkg211/pkg136
-  (deepseek notes → Opus specs). Full handoff: NEXT_STAGE_REPORT.md.
+  SoA lane first) → S5/S6. Detailed specs LANDED for pkg127 (Specular Polynomials
+  SMS-seed, #679), pkg211 (per-bounce spectral MIS, #677, park-eligible), pkg136
+  (SD-tree path guiding, #678) — web-verified deepseek research → Opus specs, all
+  merged. Full handoff: NEXT_STAGE_REPORT.md.
 
 ---
 

--- a/.astroray_plan/packages/pkg127-specular-polynomials-sms.md
+++ b/.astroray_plan/packages/pkg127-specular-polynomials-sms.md
@@ -2,172 +2,249 @@
 
 **Pillar:** 3 (light transport / caustics) + 2 (spectral core)
 **Track:** A (CPU-first seed-stage upgrade with numerical caustic-quality gates; the GPU/wavefront SMS mirror is RTX-verified against the CPU result)
-**Status:** open — spec DETAILED 2026-09-03 from a web-verified research note (`.astroray_plan/docs/pkg127-specular-polynomials-research.md`, every citation checked against a live URL). Ready to dispatch (Claude/careful tier). The highest-value *bounded* caustics-quality upgrade on the roadmap.
-**Estimated effort:** L — single-bounce polynomial solver + seed-stage integration, then the two-bounce extension; a license phase-0, a paper re-derivation, and a before/after seed-failure measurement.
-**Depends on:** **pkg64** (SMS folded into the default spectral path — DONE; this upgrades its seed stage), **pkg106** (multi-vertex manifold-chain foundation — the two-bounce leg uses `include/astroray/manifold/manifold_chain.h`). No hard blocker: a flag-gated drop-in on landed code, Newton seeding stays the fallback.
+**Codex-paste-ready:** no (research-grade algorithm port with a license-verification gate, a math re-derivation from the paper, and a caustic-quality acceptance bar — needs judgment at each step, not a mechanical patch)
+**Status:** open — spec DETAILED 2026-09-03 from a web-verified research note (`.astroray_plan/docs/pkg127-specular-polynomials-research.md`, every citation checked against a live URL). Ready to dispatch (Claude/careful tier). The highest-value *bounded* caustics-quality upgrade on the roadmap (per `.astroray_plan/docs/2026-07-pbr-advances-research.md` headline finding 1).
+**Estimated effort:** L — single-bounce polynomial solver + integration into the existing seed stage, then the two-bounce extension; a license phase-0, a paper re-derivation, and a before/after seed-failure measurement.
+**Depends on:** **pkg64** (SMS folded into the default spectral path — DONE; this upgrades its seed stage) and **pkg106** (multi-vertex MNEE/manifold-chain foundation — the two-bounce leg builds on `include/astroray/manifold/manifold_chain.h`). No hard blocker: a flag-gated drop-in on landed code, Newton seeding stays the fallback.
 
 ---
 
 ## Goal
 
-Replace SMS's **random-init Newton seed** (uniform-on-sphere start → iterate → drop
-on non-convergence) with the **deterministic all-roots polynomial seed** of Fan et
-al. 2024: reformulate the specular-chain half-vector constraint as a polynomial
-system whose **real roots enumerate every admissible specular vertex** for a given
-triangle tuple — no seed, no convergence basin, no missed caustic branches. Newton
-is retained only as (a) a 1–2 step polish of each root and (b) the flag-off fallback.
+**Before:** Astroray's caustics come from Specular Manifold Sampling (SMS, Zeltner
+2020) folded into the default spectral path tracer (pkg64). Seed finding is a
+**stochastic-seed + Newton-solve** loop: `runSMSAttempt`
+(`include/astroray/manifold/sms_attempt.h:107-148`) draws a **uniform-on-sphere**
+seed on the caster (`nSeed`, :111-118, Zeltner 2020 §4.4), then Newton-iterates to
+convergence (`include/astroray/manifold/newton_iterate.h::solve`, called at
+`sms_attempt.h:148`). A non-converging seed is dropped —
+`if (!R.converged) return false;` (`sms_attempt.h:149`). Two failure modes the
+Specular Polynomials paper was written to kill:
 
-**Why now.** SMS-from-one-Newton-seed silently misses caustic branches when a
-receiver point has multiple specular connections (a glass sphere focusing ≥2
-paths to one point), producing grainy/incomplete caustics that no amount of spp
-fixes. The polynomial solver finds *all* branches deterministically — a bounded,
-high-value quality upgrade on the already-landed SMS path, flag-gated so it can
-never regress the fleet.
+1. **Divergence from a bad seed.** Newton has a finite convergence basin; a seed
+   outside it diverges or stalls (`newton_iterate.h:106-107` bails on a singular
+   Jacobian, `:82` on non-convergence within `maxIterations`). On triangulated
+   casters the basin shrinks further because ±h finite-difference steps cross
+   triangle edges into neighbours with different normals (the pkg106
+   SMS-fails-on-triangles failure, `newton_iterate.h:121-131`); the
+   analytic-Jacobian path (`solveAnalytic`, `:151`) mitigates but doesn't eliminate it.
+2. **One solution per seed.** Each seed reaches at most one manifold vertex.
+   Admissible paths whose vertices sit in a different basin are missed unless a
+   *different* seed happens to land near them — so multi-solution configurations (a
+   glass sphere focusing several caustic branches to one receiver point, an SF11
+   prism) need many seeds and still under-sample, showing up as seed-failure waste
+   and residual caustic noise.
+
+**After:** The SMS seed stage finds specular-chain solutions by **deterministic
+polynomial root-finding** (Fan et al. SIGGRAPH 2024) instead of a stochastic-seed
+Newton search. For the **single-bounce** case the reflection/refraction constraint
+becomes a univariate polynomial whose **real roots enumerate every admissible
+manifold vertex — no seed, no divergence, every branch found in one solve**. For
+**two bounces** a bivariate system is reduced by the hidden-variable resultant to
+univariate root-finding, robust where Newton's basin fails. Newton is retained only
+as an optional root-polish/fallback behind a flag. Caustic quality on the refbank
+glass/prism scenes is **equal-or-better at equal spp**, and the measured
+**seed-failure rate drops**.
 
 ---
 
-## Citations (web-verified 2026-09-03 — the prior spec's cite line was WRONG)
+## Context — why this is the top caustics upgrade
+
+The 2026-07-17 PBR sweep ranked four independent 2023–2026 specular/caustic lines
+and put Specular Polynomials first for Astroray specifically: *"a targeted drop-in
+upgrade for the SMS seed-finding stage (pkg64/pkg106 lineage) … the highest-value
+bounded upgrade to what we already have"*
+(`.astroray_plan/docs/2026-07-pbr-advances-research.md` finding 1). Bounded because
+it replaces exactly one stage — seed finding — inside a shipping integrator, not a
+new subsystem (unlike ReSTIR-PT or path guiding). The visual payoff is directly on
+the owner's showcase scenes: `prism-bk7-collimated`, `prism-sf11-collimated`,
+`sms-refractive-glass-sphere` — the journal-article caustic figures. Deterministic
+root-finding is also the natural GPU fit: no per-seed rejection divergence.
+
+---
+
+## Citations (web-verified 2026-09-03 — the prior filing's cite line was WRONG)
 
 - **Fan, Guo, Wang, Xiao, Zhang, Zhou, Chen, Hong, Guo, Yan 2024 — "Specular
   Polynomials."** ACM TOG 43(4) (SIGGRAPH 2024), Article 126, 13 pp.
-  **DOI 10.1145/3658132** · arXiv:2405.13409 · project https://zhiminfan.work/specPoly.html.
+  **DOI 10.1145/3658132** · arXiv:2405.13409 · https://zhiminfan.work/specPoly.html.
   ⚠️ The prior filing's "Fan, Wang, Dong, Wang, Hašan, Yan et al." is **incorrect** —
   Hašan is not an author; the authors are Zhimin **Fan**, Jie **Guo**, … Ling-Qi
-  **Yan** (10 total). Use the corrected list + DOI above in all code citations.
+  **Yan** (10 total). Use the corrected list + DOI in all code citations.
 - **Zeltner, Georgiev, Jakob 2020 — "Specular Manifold Sampling"** (SMS), ACM TOG
   39(4) Art. 149. DOI 10.1145/3386569.3392408. Ref code
-  `github.com/tizian/specular-manifold-sampling` (**BSD-3-Clause**, already the
-  basis of pkg64).
-- **Hanika, Droske, Fascione 2015 — "Manifold Next Event Estimation"** (MNEE),
-  CGF 34(4) 87–97. DOI 10.1111/cgf.12681. (The half-vector residual Astroray
-  already implements.)
+  `github.com/tizian/specular-manifold-sampling` (**BSD-3-Clause**, already the basis
+  of pkg64).
+- **Hanika, Droske, Fascione 2015 — "Manifold Next Event Estimation"** (MNEE), CGF
+  34(4) 87–97. DOI 10.1111/cgf.12681. (The half-vector residual Astroray implements.)
 - **Jakob & Marschner 2012 — "Manifold Exploration."** ACM TOG 31(4) 58. DOI
   10.1145/2185520.2185554.
 
-## License phase-0 (RESOLVED — do NOT copy the paper's reference code)
+---
+
+## Fix plan (cite — no inventions, CLAUDE.md §6)
+
+### Phase 0 — license verification (RESOLVED here; re-confirm at port)
 
 - `github.com/mollnn/spoly` (the paper's supplemental code) is **UNLICENSED** —
   GitHub API `"license": null`, no LICENSE file, README declares no terms. Under
   GitHub ToS an unlicensed public repo grants read/fork only, **not** derivative
-  rights. The prior note's "MIT-style but unverified" is confirmed **wrong**.
-  **Astroray must not copy source from mollnn/spoly.**
-- **Path taken (pkg64's Hanika precedent): re-derive the math from the paper
-  alone** — it is **CC BY 4.0** (open-access arXiv), which permits re-derivation +
-  a `DOI 10.1145/3658132` citation. Permitted supporting references:
+  rights. The 2026-07 note's "MIT-style — VERIFY" is confirmed **wrong: it is
+  unlicensed. Astroray must NOT copy source from mollnn/spoly.**
+- **Path taken (pkg64's Hanika precedent): re-derive the math from the paper alone**
+  — the paper is **CC BY 4.0** (open-access arXiv:2405.13409 carries the full math),
+  which permits re-derivation + a `DOI 10.1145/3658132` citation. Permitted
+  supporting references:
   - **cyCodeBase / `cyPolynomial.h`** (Cem Yuksel) — **MIT** — for the univariate
     real-root solver (the paper cites Yuksel 2022; spoly itself builds on it).
     http://codebase.cemyuksel.com/code.html
   - **tizian/specular-manifold-sampling** — **BSD-3-Clause** — the SMS plumbing
     already in `sms_attempt.h`.
+- [ ] Re-confirm the mollnn/spoly LICENSE state at implementation time (still absent)
+      and record the SPDX + decision in the research note; if it ever gains a
+      compatible license, cyPolynomial-first re-derivation still stands.
+
+### Phase 1 — single-bounce polynomial seed finding (CPU first)
+
+- Reformulate the single-vertex constraint currently solved by Newton
+  (`sms_attempt.h::halfVectorResidual`, `h(λ) = ω_i + η(λ)·ω_o`, ~:124-128) as the
+  paper's polynomial system (§3.2–3.5). Split the half-vector constraint into
+  *coplanarity* `(d_{i−1}×d_i)·n_i = 0` (already polynomial, Eq. 5–6) + *angularity*
+  `η_{i−1}‖d̂_{i−1}×n_i‖ = η_i‖d̂_i×n_i‖`; remove the √ with the **square form**
+  (reflection+refraction, degree 6 refraction / 4 reflection with interpolated
+  normals; 4/2 flat, Eq. 10) or the lower-degree **product form** (reflection only,
+  Eq. 13). The refracted-direction √ is a **6-piece piecewise-rational fit to √x on
+  [0,1]** (Eq. 23, error < 1e-3); reflection is exact (Eq. 19). Closed forms: **R**
+  (Eq. 25), **T** (Eq. 26).
+- **Solve** (§4): Bézout hidden-variable resultant → zeros of the determinant of a
+  univariate matrix polynomial; **Laplacian expansion (exact) for one bounce**;
+  isolate real roots with the **MIT `cyPolynomial`** solver. Map each root → surface
+  vertex; validate with the *existing* in-surface / refraction-side / TIR checks
+  (`sms_attempt.h:159-181`). **Companion-matrix eigenvalue is the paper's benchmarked
+  alternative, not the headline solver** (correcting the prior spec's paraphrase).
+- **Superfluous roots:** the square form introduces spurious sign solutions (§3.3,
+  §6) — the path-space re-check MUST filter them; a lax filter silently adds energy.
+- **Flag-gated** (pkg64 convention, `p.getInt("sms_polynomial_seed",0) != 0`),
+  default OFF ⇒ current uniform-seed Newton stays the fallback until the gates prove
+  the replacement. **Hero-wavelength decoupling carries over unchanged:** η enters
+  only through the angularity coefficients, so one solve per ray at `λ_hero`, written
+  to the hero channel — same as today. Retain Newton as an optional 1–2 step
+  `solveAnalytic` polish of each root (root-finding gives the basin; Newton polishes
+  the last digits).
+- **Verify** the 6-piece √-fit error (<1e-3) is inside the current
+  `SMSConfig::tolerance` (1e-4f) before trusting it on the spectral path — the single
+  biggest correctness risk in a spectral caustic pipeline.
+
+### Phase 2 — two-bounce (build on the pkg106 manifold chain)
+
+- Extend to the two-vertex chain (`include/astroray/manifold/manifold_chain.h`,
+  pkg106) via the **RR closed form (Eq. 27)** + the hidden-variable resultant, solved
+  by the paper's **bisection solver (§4.2)**. Largest robustness win over Newton
+  (multi-solution glass-sphere / double-refraction prism). Two-bounce bisection ~10×
+  a single Newton step (paper) — **gate on quality-at-equal-spp and seed-failure-rate,
+  NOT solver walltime.**
+
+### Phase 3 — GPU/wavefront mirror
+
+- Mirror the single-bounce solver into `include/astroray/manifold/sms_attempt_device.cuh`
+  and RTX-verify against the CPU result via the caustic parity harness
+  (`tests/test_gpu_caustic_parity.py`, `tests/test_pkg64_gpu_sms_attempt_unit.py`).
+  Deterministic roots remove per-seed rejection divergence — a natural GPU fit — but
+  keep the port CPU-gated first; GPU parity is verification, not the primary gate. The
+  resultant/eigen step is branchy for a wavefront kernel; if it perturbs the REG:254
+  shade/SMS register budget, isolate or defer.
 
 ---
 
-## Algorithm (implementation altitude — from arXiv:2405.13409 full text)
+## Acceptance criteria
 
-Connect fixed separators x0 (shading point) and x_{k+1} (light) by a specular
-chain x1…xk on triangles T_i. Per-vertex constraint = the **generalized
-half-vector** relation `h_i × n_i = 0`, `h_i = η_i·d̂_i − η_{i−1}·d̂_{i−1}` (paper
-Eq. 3) — **exactly** the residual in `sms_attempt.h::halfVectorResidual` (η per
-wavelength).
-
-1. **Polynomialize the constraint** (§3.2–3.3): split into *coplanarity*
-   `(d_{i−1}×d_i)·n_i = 0` (already polynomial) + *angularity*
-   `η_{i−1}‖d̂_{i−1}×n_i‖ = η_i‖d̂_i×n_i‖`; remove the √ via the **square form**
-   (reflection+refraction, max degree 6 refraction / 4 reflection with interpolated
-   normals; 4/2 flat) — the paper's general choice — or the lower-degree **product
-   form** (reflection only, 4/2).
-2. **Reduce to bivariate** (§3.4–3.5): "rational coordinate mapping" expresses each
-   u_{i+1} as a rational function of u_i,u_{i−1} via recursive Möller–Trumbore, so
-   the whole chain collapses to u_1. Refraction's refracted-direction √ is a
-   **6-piece piecewise-rational fit to √x on [0,1]** (Eq. 23, error < 1e-3);
-   reflection is exact (Eq. 19). Closed forms are given for **R** (Eq. 25),
-   **T** (Eq. 26), **RR** (Eq. 27).
-3. **Solve** (§4): eliminate one variable via the **Bézout hidden-variable
-   resultant** (their stability/complexity choice) → zeros of the determinant of a
-   univariate matrix polynomial; solve the univariate problem by **Laplacian
-   expansion for one bounce (exact)** and a **bisection solver for two bounces**.
-   (Companion-matrix eigenvalue decomposition is the benchmarked *alternative*, not
-   the headline method — the prior spec's "companion-matrix/Sturm" paraphrase is
-   corrected here.)
-4. **Completeness + superfluous roots.** The real roots enumerate *all* admissible
-   specular vertices — no seed. BUT the square form can introduce **superfluous
-   roots** (spurious sign solutions) that MUST be filtered by re-checking the
-   original constraint in path space (§3.3, §6) — i.e. keep the existing
-   in-surface / refraction-side / TIR checks.
-
-> **Spec-anchor correction (from the note):** the prior filing cited "§4
-> single-bounce / §5 multi-bounce". Per the real ToC, §4 = the solver, §5 =
-> Results. Correct anchors: single-bounce **§3.5 (R/T) + §4.1–4.2**; two-bounce
-> **§3.5 (RR) + §4.2 (bisection)**.
+- [ ] **Phase 0 license recorded:** mollnn/spoly LICENSE state (absent) + SPDX +
+      compatibility decision written into
+      `.astroray_plan/docs/pkg127-specular-polynomials-research.md`; the paper-only
+      re-derivation path is the one taken (no source copied under an absent license).
+- [ ] **Single-bounce exact:** the polynomial solver enumerates all admissible
+      single-bounce manifold vertices on the analytic glass-sphere caster; a unit test
+      confirms it finds solutions Newton-from-uniform-seed misses on a **multi-solution
+      configuration** (≥2 caustic branches to one receiver point).
+- [ ] **Caustic-quality gates equal-or-better at equal spp:** `prism-bk7-collimated`,
+      `prism-sf11-collimated`, `sms-refractive-glass-sphere`
+      (`benchmarks/reference_bank/scenes/*/gates.toml`) hold or improve (prism
+      `hue_spread`/`bright_coverage`; glass-sphere receiver energy / SSIM) at the same
+      spp as current Newton seeding — no regression on `sms-reflective-metal-sphere`.
+      LINEAR EXR, seed-pinned.
+- [ ] **Seed-failure rate measured before/after (headline quantitative gate):**
+      instrument the valid-path fraction (the `return false` drop rate at
+      `sms_attempt.h:149`) on glass-sphere + SF11; the polynomial rate must be
+      **strictly lower** than the Newton baseline.
+- [ ] **Superfluous-root safety:** no spurious path passes validation (the path-space
+      re-check catches all square-form artifacts); furnace/energy on a non-caustic
+      scene unchanged.
+- [ ] **Two-bounce lands second:** the RR resultant + bisection solver passes a
+      double-refraction convergence unit test where Newton stalls; a distinct phase so
+      single-bounce ships first.
+- [ ] **No regression with the flag off:** default integrator (flag off) is bit-equal
+      to the pre-pkg127 SMS path — `tests/test_sms_caustic_validation.py`,
+      `tests/test_sms_caustic_spectral.py`, `tests/test_glass_sphere_caustic.py`,
+      `tests/test_prism_caustic_rainbow.py` unchanged.
+- [ ] **GPU parity:** wavefront single-bounce solver matches the CPU result on
+      `tests/test_gpu_caustic_parity.py`; RTX-verified.
+- [ ] **Citations in code:** every polynomial-solver call site cites "Fan et al. 2024
+      (Specular Polynomials) §3.5/§4, DOI 10.1145/3658132" + the license-verified
+      provenance (paper-derived; cyPolynomial MIT for the root-finder), per CLAUDE.md §6.
 
 ---
-
-## Astroray integration (file:line anchors)
-
-`runSMSAttempt` (`include/astroray/manifold/sms_attempt.h:107-148`) today: uniform
-seed (:111-118) → `newton_iterate.h::solve` (:148) → drop on `!R.converged`
-(:149). The polynomial path replaces **only the seed+solve**; it reuses the exact
-downstream refraction/Fresnel/visibility/MIS chain (:159-201) unchanged.
-
-- **Phase 1 — single-bounce, CPU (the core deliverable).** For the caster
-  triangle / analytic sphere, build the bivariate system (Eq. 25 R / Eq. 26 T),
-  Bézout resultant (§4.1), Laplacian-expand the determinant (§4.2), isolate real
-  roots with the **MIT cyPolynomial** solver, map each root → surface vertex, run
-  the **existing** validation (`sms_attempt.h:159-181`). Newton = 1–2 step polish +
-  flag-off fallback. Flag convention per pkg64 (`p.getInt("sms_polynomial_seed",0)!=0`),
-  default OFF ⇒ byte-identical to current SMS.
-- **Hero-wavelength decoupling carries over unchanged:** η enters only through the
-  angularity coefficients, so one solve at λ_hero (pkg64 convention) is the drop-in.
-  **Verify** the 6-piece rational √-fit error (<1e-3) is inside the current Newton
-  `SMSConfig::tolerance` (1e-4f) before trusting it on the spectral path — this is
-  the single biggest correctness risk in a spectral caustic pipeline.
-- **Phase 2 — two-bounce (CPU).** RR case (Eq. 27) on `manifold_chain.h`, bisection
-  solver (§4.2). Gate on seed-failure-rate + equal-spp quality, NOT walltime.
-- **Phase 3 — GPU.** Mirror into `sms_attempt_device.cuh`; deterministic roots
-  remove per-seed rejection divergence. CPU-gate first, then RTX-verify via the
-  existing caustic parity harness. The resultant/eigen step is branchy for a
-  wavefront kernel — treat GPU as verification, not the primary gate; defer if it
-  perturbs the register budget.
-
----
-
-## Acceptance gates
-
-1. **Seed-completeness (the headline).** A new unit test builds a **multi-solution
-   configuration** (glass sphere with ≥2 caustic branches to one receiver point)
-   and asserts the polynomial solver returns **all** branches that Newton-from-one-
-   seed misses.
-2. **Seed-failure-rate down.** Fraction of SMS attempts returning false at
-   `sms_attempt.h:149` (Newton baseline) must be strictly lower for the polynomial
-   path on `sms-refractive-glass-sphere` and SF11.
-3. **Equal-spp caustic quality holds or improves.** Prism `hue_spread` /
-   `bright_coverage`, glass-sphere receiver energy / SSIM — LINEAR EXR, seed-pinned.
-4. **Superfluous-root safety.** Assert no spurious paths pass validation (the
-   path-space re-check catches all square-form artifacts); furnace / energy on a
-   non-caustic scene unchanged.
-5. **Flag-off byte-identical.** `sms_polynomial_seed=0` produces the current SMS
-   result bit-for-bit (CPU) / within-MC (GPU) — the fleet never pays.
-
----
-
-## Risks (paper §6 + practical)
-
-- **Conditioning / degree.** Refraction square-form degree 6 (interp normals) / 4
-  (flat) + resultant matrices ⇒ ill-conditioned for near-grazing/degenerate
-  configs; the paper flags "better numerical root-finding" as open.
-- **Refraction mapping is approximate** (6-piece √ fit, <1e-3) — must stay under
-  the Newton tolerance or it surfaces as caustic bias on the spectral path.
-- **Superfluous roots** — keep the path-space re-check; a lax filter silently adds
-  energy.
-- **Perf.** One bounce is faster than Newton-from-seed; two-bounce bisection ~10× a
-  Newton step (fine on CPU). GPU resultant/eigen is branchy.
-- **Non-goal: 3+ bounce chains** (paper §6 "long specular chains") — out of scope.
 
 ## Non-goals
-- No GPU-primary path in Phase 1–2 (CPU-gated; GPU is Phase 3 verification).
-- No copying mollnn/spoly source (unlicensed — re-derive from the CC-BY paper).
-- No 3+ specular bounces.
 
-## Routing
-Claude / careful tier (license judgment, math re-derivation, caustic-quality gate,
-register/ABI on the GPU leg). The cite/research phase is DONE (web-verified note).
+- **Not a replacement for SMS as a whole.** Upgrades the **seed-finding stage** only;
+  the refraction/Fresnel/visibility/MIS chain (`sms_attempt.h:159-201`) is untouched,
+  Newton stays as an optional root-polish + flagged fallback.
+- **Not the forward light-tracing prism path** (pkg106 `light_tracer_caustic`). This
+  targets the camera-side SMS seed stage (`runSMSAttempt`).
+- **Not three-plus bounces** (paper §6 "long specular chains") — single-bounce first,
+  two-bounce second.
+- **Not ReSTIR / partitioned SMS** (Hong et al. 2025, research finding 2 — presupposes
+  pkg55-C ReSTIR reservoirs; separate later package).
+- **Not glint rendering.** Out of scope, as in pkg64.
+- **Do NOT copy mollnn/spoly source** (unlicensed — re-derive from the CC-BY paper).
+- **No invented root-finder** — port the published method, cite it, verify its license
+  (CLAUDE.md §6).
+
+---
+
+## Provenance
+
+Filed from the **2026-07-17 PBR-advances research sweep**
+(`.astroray_plan/docs/2026-07-pbr-advances-research.md`, finding 1, verified 3-0),
+which ranked Specular Polynomials the top directly-adoptable caustics upgrade for
+Astroray's existing SMS pipeline and flagged the mollnn/spoly license as needing
+verification at port. Detailed 2026-09-03 from a **web-verified phase-0 research
+note** (`pkg127-specular-polynomials-research.md`) — deepseek-v4-pro via the opencode
+`architect` agent (webfetch+websearch) under a strict web-verify-or-NOT-FOUND
+contract, then this spec by Claude — which corrected the author citation, resolved
+the license (mollnn/spoly unlicensed → paper re-derivation + MIT cyPolynomial), and
+fixed the paper §-anchors. Grounded against the live SMS seed stage
+(`include/astroray/manifold/sms_attempt.h` + `newton_iterate.h`) from pkg64 (SMS in
+the default path) and pkg106 (multi-vertex manifold chain). Owner context: the prism
+rainbow and glass-sphere caustic are journal-article caustic figures and
+spectral-showcase scenes — deterministic, exact seed finding is what makes them clean
+at production spp.
+
+---
+
+## Progress
+
+- [ ] Phase 0 — mollnn/spoly license re-confirmed absent; paper-only re-derivation +
+      MIT cyPolynomial recorded.
+- [ ] Phase 1 — single-bounce univariate polynomial solver (Bézout resultant +
+      Laplacian expansion + cyPolynomial), CPU, behind a flag; Newton retained as
+      root-polish/fallback.
+- [ ] Phase 2 — two-bounce RR resultant + bisection on the pkg106 manifold chain.
+- [ ] Phase 3 — GPU/wavefront mirror; caustic parity RTX-verified.
+- [ ] Seed-failure-rate before/after measured on glass-sphere + SF11.
+
+---
+
+## Lessons
+
+*(Fill in after the package is done.)*


### PR DESCRIPTION
Folds the earlier pkg127 draft's richer detail (Newton-basin failure-mode anchors, Context ranking, acceptance test-file list, Provenance/Progress) into the web-verified version (corrected author cite, resolved license phase-0, Bezout/Laplacian solver, superfluous-root filtering).

Also makes STATUS/ROADMAP/NEXT_STAGE_REPORT consistent: the 3 research→specs are now **landed** (pkg127 #679, pkg211 #677, pkg136 #678), not 'in flight'; pkg136 noted as SD-tree (renamed from SVO), pkg211 as park-eligible.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)