### PR TITLE
pkg225-S6: Blender addon hair integration (Curves export + Principled Hair node)

### DIFF
--- a/.astroray_plan/packages/pkg225-hair-rendering.md
+++ b/.astroray_plan/packages/pkg225-hair-rendering.md
@@ -2,9 +2,33 @@
 
 **Pillar:** 3
 **Track:** A
-**Status:** open — **Stage 1 (CPU curve geometry) + Stage 2 (CPU Principled
+**Status:** COMPLETE — **all six stages landed (CPU + GPU curve geometry, CPU +
+GPU Principled Hair BSDF Chiang 2016, spectral melanin, and the Blender addon).**
+Stage 6 (2026-09-04): the addon renders Blender `Curves` (hair / geometry-nodes)
+objects as NATIVE curve primitives — `convert_objects` detects `obj.type ==
+'CURVES'` and calls `renderer.add_curves_bulk` with world-space control points +
+per-point radii + per-strand counts extracted by `_bulk_geometry.extract_curves_bulk`
+(C-speed `foreach_get`; degenerate <2-point strands dropped; radius scaled by the
+mean object-axis scale) — instead of the polygon-soup `to_mesh()` fallback (that
+`else: continue` silently skipped `CURVES`). `ShaderNodeBsdfHairPrincipled` and the
+legacy `ShaderNodeBsdfHair` translate to the native `principled_hair` material
+(`_hair_shader_spec`): all three parametrizations (Direct Coloring / Melanin /
+Absorption) + Chiang sockets map 1:1 to Cycles' node (verified against Blender 5.2's
+enum + socket set); Huang-only sockets, per-strand Random, and the Kajiya-Kay node
+degrade to APPROXIMATED. The Cycles Curves *Shape* (`scene.cycles_curves.shape`)
+drives `set_curve_thick_mode` (THICK default / RIBBON). Coverage matrix: BSDF_HAIR_PRINCIPLED
+11 sockets SUPPORTED + 8 APPROXIMATED, BSDF_HAIR 6 APPROXIMATED (was all DROPPED-SILENT).
+Headless-Blender verified (Blender 5.2, GPU): a curved-strand tuft with a Principled
+Hair material renders the anisotropic along-fiber Chiang R-lobe sheen end-to-end
+(coverage 0.45, warm-brown R/B 1.44). Unit-tested `extract_curves_bulk` (5 cases,
+headless, no bpy/engine). **NOTE — required an addon `.pyd` rebuild**: the staged
+`dist/astroray` module predated S3 (no `set_curve_thick_mode` / GPU curve rendering),
+so hair was invisible on the addon's GPU path until `build_blender_addon.py --backend
+cuda` restaged it at HEAD.
+
+Stage 1 (CPU curve geometry) + Stage 2 (CPU Principled
 Hair BSDF, Chiang 2016) + Stage 3 (GPU curve geometry) + Stage 4 (GPU Principled
-Hair BSDF) + Stage 5 (spectral melanin, CPU) LANDED. Only Stage 6 (addon) remains.**
+Hair BSDF) + Stage 5 (spectral melanin, CPU) previously LANDED.
 Stage 5 (2026-09-03): the hair BSDF's spectral path now evaluates per-wavelength
 eumelanin/pheomelanin absorption directly from physically-cited power laws
 (`include/astroray/hair_melanin_spectral.h`: eumelanin σ_a∝λ^−3.33 [Jacques 2013,
@@ -498,7 +522,9 @@ Cycles-panel settings, and render with Astroray — no manual workarounds.
 - [x] Stage 5: Spectral melanin absorption (CPU landed; GPU seam landed +
       register-verified but dormant — see Stage-5 note re: the GPU-spectral-curve
       shade blocker).
-- [ ] Stage 6: Addon integration.
+- [x] Stage 6: Addon integration — Blender `Curves` hair export + Principled
+      Hair BSDF node translation + Cycles Curves-Shape setting. Headless-Blender
+      verified (the anisotropic Chiang sheen renders end-to-end).
 
 ---
 

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -32,6 +32,7 @@ from native_settings import resolve_native_settings, report_unsupported_native_c
 from degradation import DegradationReport
 from _bulk_geometry import mesh_to_bulk_arrays  # pkg112 batched geometry upload
 from _bulk_geometry import mesh_world_positions  # pkg88-B object motion blur bake
+from _bulk_geometry import extract_curves_bulk   # pkg225 Stage 6 hair/curves export
 
 
 def _matrices_differ(m1, m2, eps=1e-6):
@@ -1235,6 +1236,16 @@ class CustomRaytracerRenderEngine(RenderEngine):
                     "Spectral Replace material",
                     "routed to multiwavelength integrator for per-λ reflectance")
             renderer.set_integrator(integrator_name)
+
+            # pkg225 Stage 6 — Curves Shape (Cycles' Curves panel). THICK =
+            # swept-circle Cylinder (final-render default, CPU-parity, higher
+            # quality); RIBBON = camera-facing flat strip (cheap). The CPU path
+            # always renders thick; this only steers the GPU curve leaf. Default
+            # thick when the scene has no Cycles curve settings.
+            if hasattr(renderer, 'set_curve_thick_mode'):
+                _cshape = getattr(getattr(scene, 'cycles_curves', None), 'shape', 'THICK')
+                renderer.set_curve_thick_mode(str(_cshape).upper() != 'RIBBONS')
+
             has_denoise_pass = False
             if settings.use_denoising and not is_outside_visible:
                 denoise_pass = _resolve_denoiser_pass(settings)
@@ -3851,7 +3862,59 @@ class CustomRaytracerRenderEngine(RenderEngine):
             rough = self.get_float_input(node, 'Roughness', 0.2)
             self._warn_shader_fallback('BSDF_METALLIC', 'F82 edge tint is approximated with Disney metallic base color')
             return {'kind': 'principled', 'base_color': color, 'params': {'metallic': 1.0, 'roughness': rough}}
+        if ntype in ('BSDF_HAIR_PRINCIPLED', 'BSDF_HAIR'):
+            # pkg225 Stage 6 — the Principled Hair BSDF (Chiang 2016) node, and the
+            # simpler Kajiya-Kay ShaderNodeBsdfHair, both map to the native
+            # `principled_hair` material (Stages 2/5). Socket set + defaults per the
+            # S2 research note §8. The material matches Cycles' parameterisation so
+            # sockets pass through with no remap; only the Huang model + the
+            # Kajiya-Kay node are approximations.
+            return self._hair_shader_spec(node, ntype)
         return None
+
+    def _hair_shader_spec(self, node, ntype):
+        params = {}
+        if ntype == 'BSDF_HAIR':
+            # Legacy Kajiya-Kay ShaderNodeBsdfHair: Color + RoughnessU/V + Offset.
+            self._warn_shader_fallback(
+                'BSDF_HAIR', 'Kajiya-Kay Hair BSDF is approximated with the '
+                'physically-based Principled Hair (Chiang 2016) in reflectance mode')
+            color = self.get_color_input(node, 'Color', [0.8, 0.8, 0.8])
+            params['parametrization'] = 'reflectance'
+            params['color'] = list(color)
+            params['roughness'] = self.get_float_input(node, 'RoughnessU', 0.1)
+            params['radial_roughness'] = self.get_float_input(node, 'RoughnessV', 0.1)
+            params['offset'] = self.get_float_input(node, 'Offset', 0.0)
+            return {'kind': 'hair', 'base_color': list(color), 'params': params}
+
+        # ShaderNodeBsdfHairPrincipled (Chiang default; Huang approximated to Chiang).
+        model = str(getattr(node, 'model', 'CHIANG')).upper()
+        if model and model != 'CHIANG':
+            self._warn_shader_fallback(
+                'BSDF_HAIR_PRINCIPLED',
+                'the Huang 2022 near-field hair model is approximated with Chiang 2016')
+        # parametrization enum: COLOR (Direct Coloring), MELANIN (Pigment
+        # Concentration), ABSORPTION (Direct Absorption). Blender 5.x enum values.
+        par = str(getattr(node, 'parametrization', 'COLOR')).upper()
+        color = self.get_color_input(node, 'Color', [0.017513, 0.005763, 0.002059])
+        if par in ('MELANIN', 'MELANIN_CONCENTRATION'):
+            params['parametrization'] = 'melanin'
+            params['melanin'] = self.get_float_input(node, 'Melanin', 0.8)
+            params['melanin_redness'] = self.get_float_input(node, 'Melanin Redness', 1.0)
+            params['tint'] = list(self.get_color_input(node, 'Tint', [1.0, 1.0, 1.0]))
+        elif par in ('ABSORPTION', 'ABSORPTION_COEFFICIENT'):
+            params['parametrization'] = 'absorption'
+            params['absorption_coefficient'] = list(
+                self.get_color_input(node, 'Absorption Coefficient', [0.245531, 0.52, 1.365]))
+        else:  # COLOR / Direct Coloring (node default)
+            params['parametrization'] = 'reflectance'
+            params['color'] = list(color)
+        params['roughness'] = self.get_float_input(node, 'Roughness', 0.3)
+        params['radial_roughness'] = self.get_float_input(node, 'Radial Roughness', 0.3)
+        params['coat'] = self.get_float_input(node, 'Coat', 0.0)
+        params['ior'] = self.get_float_input(node, 'IOR', 1.55)
+        params['offset'] = self.get_float_input(node, 'Offset', 0.0349066)  # ~2 deg
+        return {'kind': 'hair', 'base_color': list(color), 'params': params}
 
     def _shader_spec_from_node(self, node, renderer, node_tree, depth=0):
         if node is None or depth > 32:
@@ -3933,6 +3996,14 @@ class CustomRaytracerRenderEngine(RenderEngine):
                 return renderer.create_material('lambertian', color, lambert_params)
 
             return renderer.create_material('disney', color, params)
+
+        if kind == 'hair':
+            # pkg225 Stage 6 — native Principled Hair BSDF (Chiang 2016). The
+            # base_color feeds the reflectance/direct-coloring parametrization; the
+            # melanin/absorption modes read their own params and ignore it.
+            color = list(spec.get('base_color', [0.017513, 0.005763, 0.002059]))
+            params = dict(spec.get('params', {}))
+            return renderer.create_material('principled_hair', color, params)
 
         if kind == 'transparent':
             color = list(spec.get('base_color', [1.0, 1.0, 1.0]))
@@ -4570,6 +4641,44 @@ class CustomRaytracerRenderEngine(RenderEngine):
             # depsgraph.object_instances are already evaluated, so modifiers and
             # curve/text/metaball resolution apply. The temporary mesh must be freed
             # with to_mesh_clear() once its triangles are uploaded.
+            # pkg225 Stage 6 — Blender `Curves` (hair / geometry-nodes curves)
+            # render as NATIVE curve primitives (add_curves_bulk), not the
+            # polygon-soup to_mesh() fallback. Extract world-space control points +
+            # radii + per-strand counts and upload with the object's active
+            # material (one material per Curves object; Cycles-parity Shape mode is
+            # applied once per render via set_curve_thick_mode).
+            if obj.type == 'CURVES':
+                if not hasattr(renderer, 'add_curves_bulk'):
+                    continue
+                curves_data = obj.data
+                if curves_data is None or len(curves_data.points) == 0:
+                    continue
+                try:
+                    positions, radii, counts = extract_curves_bulk(
+                        curves_data, obj_instance.matrix_world)
+                except Exception as e:
+                    print(f"Astroray: curve extract failed on '{obj.name}': {e}")
+                    continue
+                if not counts:
+                    continue
+                # One material for the batch: the object's first slot (hair grooms
+                # carry a single Principled Hair material). Falls back to a default.
+                curve_mat_id = 0
+                curve_mat_pass = 0
+                for slot in obj.material_slots:
+                    if slot.material is not None:
+                        curve_mat_id = material_map.get(slot.material.name, 0)
+                        curve_mat_pass = int(getattr(slot.material, 'pass_index', 0))
+                        break
+                try:
+                    renderer.add_curves_bulk(
+                        positions, radii, counts, curve_mat_id,
+                        int(getattr(obj, 'pass_index', 0)), curve_mat_pass)
+                    obj_count += 1
+                except Exception as e:
+                    print(f"Astroray: add_curves_bulk failed on '{obj.name}': {e}")
+                continue
+
             _temp_mesh = False
             if obj.type == 'MESH':
                 mesh = obj.data

--- a/blender_addon/_bulk_geometry.py
+++ b/blender_addon/_bulk_geometry.py
@@ -95,6 +95,85 @@ def mesh_to_bulk_arrays(mesh, matrix, normal_matrix, slot_to_id, default_mat_id,
     return positions, material_ids, mat_pass, uvs, uv_names, normals
 
 
+def extract_curves_bulk(curves, matrix, default_radius=0.005):
+    """pkg225 Stage 6 — a Blender ``Curves`` (hair / geometry-nodes) data-block →
+    the arrays ``Renderer.add_curves_bulk`` consumes.
+
+    Returns (positions, radii, strand_point_counts):
+      positions            (P,3) float32 — WORLD-space control points (the engine
+                           adds them directly; add_curves_bulk applies no transform)
+      radii                (P,)  float32 — per-point world-space radius
+      strand_point_counts  list[int]     — points per strand (each >= 2)
+
+    Uses C-speed ``foreach_get`` for positions/radius. `matrix` is the 4x4 world
+    matrix; control points are transformed by its linear+translation part and the
+    per-point radius by the mean axis scale (exact for uniform scale, Cycles'
+    approximation otherwise). Kept dependency-free (numpy + the passed data-block)
+    so it is headlessly unit-testable with a fake ``foreach_get`` object.
+    """
+    points = curves.points
+    n_pts = len(points)
+    if n_pts == 0:
+        return (np.zeros((0, 3), dtype=np.float32),
+                np.zeros((0,), dtype=np.float32), [])
+
+    co = np.empty(n_pts * 3, dtype=np.float32)
+    points.foreach_get("position", co)
+    co = co.reshape(n_pts, 3)
+    M = np.asarray(matrix, dtype=np.float32)
+    positions = np.ascontiguousarray(co @ M[:3, :3].T + M[:3, 3], dtype=np.float32)
+
+    # Mean axis scale for the scalar radius (exact under uniform scale).
+    scale = float(np.mean(np.linalg.norm(M[:3, :3], axis=0))) or 1.0
+    radii = np.empty(n_pts, dtype=np.float32)
+    try:
+        points.foreach_get("radius", radii)
+    except (RuntimeError, TypeError, AttributeError, KeyError):
+        # Some Curves have radius only as a generic attribute (or none at all).
+        attrs = getattr(curves, "attributes", None)
+        rad_attr = attrs.get("radius") if attrs is not None else None
+        if rad_attr is not None and hasattr(rad_attr, "data"):
+            rad_attr.data.foreach_get("value", radii)
+        else:
+            radii.fill(default_radius)
+    radii = np.ascontiguousarray(np.abs(radii) * scale, dtype=np.float32)
+    # A zero/degenerate radius makes a strand invisible; floor it.
+    radii[radii < 1e-6] = default_radius * scale
+
+    # Per-strand point counts. Prefer the C-speed offsets; fall back to a slice
+    # loop. `Curves.curve_offsets` (Blender 3.5+) is the cumulative point index of
+    # each strand start plus a final total, so counts = diff(offsets).
+    counts = None
+    offsets_owner = getattr(curves, "curve_offsets", None)
+    if offsets_owner is not None and len(offsets_owner) >= 2:
+        try:
+            off = np.empty(len(offsets_owner), dtype=np.int32)
+            offsets_owner.foreach_get("value", off)
+            counts = np.diff(off).astype(np.int64).tolist()
+        except (RuntimeError, TypeError, AttributeError, KeyError):
+            counts = None
+    if counts is None:
+        counts = [int(s.points_length) for s in curves.curves]
+
+    # add_curves_bulk requires each strand >= 2 points; drop degenerate strands
+    # (and the points they own) so a single 1-point strand can't abort the batch.
+    if any(c < 2 for c in counts):
+        keep_pos, keep_rad, keep_counts, off = [], [], [], 0
+        for c in counts:
+            if c >= 2:
+                keep_pos.append(positions[off:off + c])
+                keep_rad.append(radii[off:off + c])
+                keep_counts.append(c)
+            off += c
+        positions = (np.concatenate(keep_pos, axis=0) if keep_pos
+                     else np.zeros((0, 3), dtype=np.float32))
+        radii = (np.concatenate(keep_rad, axis=0) if keep_rad
+                 else np.zeros((0,), dtype=np.float32))
+        counts = keep_counts
+
+    return positions, radii, counts
+
+
 def mesh_world_positions(mesh, matrix):
     """Return (Nt,3,3) world-space triangle-corner positions for `mesh` under
     `matrix`, using the SAME vertex->loop-triangle indexing as

--- a/docs/blender_parity/coverage_matrix.json
+++ b/docs/blender_parity/coverage_matrix.json
@@ -316,40 +316,40 @@
     "feature": "BSDF_HAIR",
     "bl_idname": "ShaderNodeBsdfHair",
     "socket_or_prop": "input:Color",
-    "classification": "DROPPED-SILENT",
-    "notes": "no handler in addon translation layer"
+    "classification": "APPROXIMATED",
+    "notes": "pkg225-S6: Kajiya-Kay Hair approximated with Principled Hair (Chiang) reflectance"
   },
   {
     "category": "shader_node",
     "feature": "BSDF_HAIR",
     "bl_idname": "ShaderNodeBsdfHair",
     "socket_or_prop": "input:Offset",
-    "classification": "DROPPED-SILENT",
-    "notes": "no handler in addon translation layer"
+    "classification": "APPROXIMATED",
+    "notes": "pkg225-S6: mapped to Principled Hair cuticle tilt"
   },
   {
     "category": "shader_node",
     "feature": "BSDF_HAIR",
     "bl_idname": "ShaderNodeBsdfHair",
     "socket_or_prop": "input:RoughnessU",
-    "classification": "DROPPED-SILENT",
-    "notes": "no handler in addon translation layer"
+    "classification": "APPROXIMATED",
+    "notes": "pkg225-S6: mapped to Principled Hair longitudinal roughness"
   },
   {
     "category": "shader_node",
     "feature": "BSDF_HAIR",
     "bl_idname": "ShaderNodeBsdfHair",
     "socket_or_prop": "input:RoughnessV",
-    "classification": "DROPPED-SILENT",
-    "notes": "no handler in addon translation layer"
+    "classification": "APPROXIMATED",
+    "notes": "pkg225-S6: mapped to Principled Hair radial roughness"
   },
   {
     "category": "shader_node",
     "feature": "BSDF_HAIR",
     "bl_idname": "ShaderNodeBsdfHair",
     "socket_or_prop": "input:Tangent",
-    "classification": "DROPPED-SILENT",
-    "notes": "no handler in addon translation layer"
+    "classification": "APPROXIMATED",
+    "notes": "pkg225-S6: custom tangent socket ignored; geometric curve tangent used"
   },
   {
     "category": "shader_node",
@@ -364,120 +364,120 @@
     "feature": "BSDF_HAIR",
     "bl_idname": "ShaderNodeBsdfHair",
     "socket_or_prop": "prop:component",
-    "classification": "DROPPED-SILENT",
-    "notes": "property ENUM"
+    "classification": "APPROXIMATED",
+    "notes": "pkg225-S6: Reflection/Transmission component approximated by the full R/TT/TRT model"
   },
   {
     "category": "shader_node",
     "feature": "BSDF_HAIR_PRINCIPLED",
     "bl_idname": "ShaderNodeBsdfHairPrincipled",
     "socket_or_prop": "input:Color",
-    "classification": "DROPPED-SILENT",
-    "notes": "no handler in addon translation layer"
+    "classification": "SUPPORTED",
+    "notes": "pkg225-S6: native principled_hair material (Chiang 2016) via add_curves_bulk"
   },
   {
     "category": "shader_node",
     "feature": "BSDF_HAIR_PRINCIPLED",
     "bl_idname": "ShaderNodeBsdfHairPrincipled",
     "socket_or_prop": "input:Melanin",
-    "classification": "DROPPED-SILENT",
-    "notes": "no handler in addon translation layer"
+    "classification": "SUPPORTED",
+    "notes": "pkg225-S6: native principled_hair material (Chiang 2016) via add_curves_bulk"
   },
   {
     "category": "shader_node",
     "feature": "BSDF_HAIR_PRINCIPLED",
     "bl_idname": "ShaderNodeBsdfHairPrincipled",
     "socket_or_prop": "input:Melanin Redness",
-    "classification": "DROPPED-SILENT",
-    "notes": "no handler in addon translation layer"
+    "classification": "SUPPORTED",
+    "notes": "pkg225-S6: native principled_hair material (Chiang 2016) via add_curves_bulk"
   },
   {
     "category": "shader_node",
     "feature": "BSDF_HAIR_PRINCIPLED",
     "bl_idname": "ShaderNodeBsdfHairPrincipled",
     "socket_or_prop": "input:Tint",
-    "classification": "DROPPED-SILENT",
-    "notes": "no handler in addon translation layer"
+    "classification": "SUPPORTED",
+    "notes": "pkg225-S6: native principled_hair material (Chiang 2016) via add_curves_bulk"
   },
   {
     "category": "shader_node",
     "feature": "BSDF_HAIR_PRINCIPLED",
     "bl_idname": "ShaderNodeBsdfHairPrincipled",
     "socket_or_prop": "input:Absorption Coefficient",
-    "classification": "DROPPED-SILENT",
-    "notes": "no handler in addon translation layer"
+    "classification": "SUPPORTED",
+    "notes": "pkg225-S6: native principled_hair material (Chiang 2016) via add_curves_bulk"
   },
   {
     "category": "shader_node",
     "feature": "BSDF_HAIR_PRINCIPLED",
     "bl_idname": "ShaderNodeBsdfHairPrincipled",
     "socket_or_prop": "input:Aspect Ratio",
-    "classification": "DROPPED-SILENT",
-    "notes": "no handler in addon translation layer"
+    "classification": "APPROXIMATED",
+    "notes": "pkg225-S6: Huang elliptical cross-section approximated with Chiang"
   },
   {
     "category": "shader_node",
     "feature": "BSDF_HAIR_PRINCIPLED",
     "bl_idname": "ShaderNodeBsdfHairPrincipled",
     "socket_or_prop": "input:Roughness",
-    "classification": "DROPPED-SILENT",
-    "notes": "no handler in addon translation layer"
+    "classification": "SUPPORTED",
+    "notes": "pkg225-S6: native principled_hair material (Chiang 2016) via add_curves_bulk"
   },
   {
     "category": "shader_node",
     "feature": "BSDF_HAIR_PRINCIPLED",
     "bl_idname": "ShaderNodeBsdfHairPrincipled",
     "socket_or_prop": "input:Radial Roughness",
-    "classification": "DROPPED-SILENT",
-    "notes": "no handler in addon translation layer"
+    "classification": "SUPPORTED",
+    "notes": "pkg225-S6: native principled_hair material (Chiang 2016) via add_curves_bulk"
   },
   {
     "category": "shader_node",
     "feature": "BSDF_HAIR_PRINCIPLED",
     "bl_idname": "ShaderNodeBsdfHairPrincipled",
     "socket_or_prop": "input:Coat",
-    "classification": "DROPPED-SILENT",
-    "notes": "no handler in addon translation layer"
+    "classification": "SUPPORTED",
+    "notes": "pkg225-S6: native principled_hair material (Chiang 2016) via add_curves_bulk"
   },
   {
     "category": "shader_node",
     "feature": "BSDF_HAIR_PRINCIPLED",
     "bl_idname": "ShaderNodeBsdfHairPrincipled",
     "socket_or_prop": "input:IOR",
-    "classification": "DROPPED-SILENT",
-    "notes": "no handler in addon translation layer"
+    "classification": "SUPPORTED",
+    "notes": "pkg225-S6: native principled_hair material (Chiang 2016) via add_curves_bulk"
   },
   {
     "category": "shader_node",
     "feature": "BSDF_HAIR_PRINCIPLED",
     "bl_idname": "ShaderNodeBsdfHairPrincipled",
     "socket_or_prop": "input:Offset",
-    "classification": "DROPPED-SILENT",
-    "notes": "no handler in addon translation layer"
+    "classification": "SUPPORTED",
+    "notes": "pkg225-S6: native principled_hair material (Chiang 2016) via add_curves_bulk"
   },
   {
     "category": "shader_node",
     "feature": "BSDF_HAIR_PRINCIPLED",
     "bl_idname": "ShaderNodeBsdfHairPrincipled",
     "socket_or_prop": "input:Random Color",
-    "classification": "DROPPED-SILENT",
-    "notes": "no handler in addon translation layer"
+    "classification": "APPROXIMATED",
+    "notes": "pkg225-S6: per-strand colour variation not yet plumbed (single value used)"
   },
   {
     "category": "shader_node",
     "feature": "BSDF_HAIR_PRINCIPLED",
     "bl_idname": "ShaderNodeBsdfHairPrincipled",
     "socket_or_prop": "input:Random Roughness",
-    "classification": "DROPPED-SILENT",
-    "notes": "no handler in addon translation layer"
+    "classification": "APPROXIMATED",
+    "notes": "pkg225-S6: per-strand roughness variation not yet plumbed"
   },
   {
     "category": "shader_node",
     "feature": "BSDF_HAIR_PRINCIPLED",
     "bl_idname": "ShaderNodeBsdfHairPrincipled",
     "socket_or_prop": "input:Random",
-    "classification": "DROPPED-SILENT",
-    "notes": "no handler in addon translation layer"
+    "classification": "APPROXIMATED",
+    "notes": "pkg225-S6: per-strand random attribute not yet plumbed"
   },
   {
     "category": "shader_node",
@@ -492,40 +492,40 @@
     "feature": "BSDF_HAIR_PRINCIPLED",
     "bl_idname": "ShaderNodeBsdfHairPrincipled",
     "socket_or_prop": "input:Reflection",
-    "classification": "DROPPED-SILENT",
-    "notes": "no handler in addon translation layer"
+    "classification": "APPROXIMATED",
+    "notes": "pkg225-S6: Huang R-lobe weight approximated with Chiang"
   },
   {
     "category": "shader_node",
     "feature": "BSDF_HAIR_PRINCIPLED",
     "bl_idname": "ShaderNodeBsdfHairPrincipled",
     "socket_or_prop": "input:Transmission",
-    "classification": "DROPPED-SILENT",
-    "notes": "no handler in addon translation layer"
+    "classification": "APPROXIMATED",
+    "notes": "pkg225-S6: Huang TT-lobe weight approximated with Chiang"
   },
   {
     "category": "shader_node",
     "feature": "BSDF_HAIR_PRINCIPLED",
     "bl_idname": "ShaderNodeBsdfHairPrincipled",
     "socket_or_prop": "input:Secondary Reflection",
-    "classification": "DROPPED-SILENT",
-    "notes": "no handler in addon translation layer"
+    "classification": "APPROXIMATED",
+    "notes": "pkg225-S6: Huang TRT-lobe weight approximated with Chiang"
   },
   {
     "category": "shader_node",
     "feature": "BSDF_HAIR_PRINCIPLED",
     "bl_idname": "ShaderNodeBsdfHairPrincipled",
     "socket_or_prop": "prop:model",
-    "classification": "DROPPED-SILENT",
-    "notes": "property ENUM"
+    "classification": "APPROXIMATED",
+    "notes": "pkg225-S6: Huang 2022 model approximated with Chiang 2016"
   },
   {
     "category": "shader_node",
     "feature": "BSDF_HAIR_PRINCIPLED",
     "bl_idname": "ShaderNodeBsdfHairPrincipled",
     "socket_or_prop": "prop:parametrization",
-    "classification": "DROPPED-SILENT",
-    "notes": "property ENUM"
+    "classification": "SUPPORTED",
+    "notes": "pkg225-S6: native principled_hair material (Chiang 2016) via add_curves_bulk"
   },
   {
     "category": "shader_node",

--- a/tests/test_pkg225_addon_curves_export.py
+++ b/tests/test_pkg225_addon_curves_export.py
@@ -1,0 +1,113 @@
+"""pkg225 Stage 6 — `extract_curves_bulk` headless validation.
+
+A fake Blender ``Curves`` data-block implementing the documented ``foreach_get``
+contract is fed through the helper; the world-space control points, per-point
+radii, and per-strand counts are checked against a hand-computed reference. No
+Blender, no engine .pyd (mirrors test_bulk_geometry_helper).
+"""
+import os
+import sys
+
+import numpy as np
+import pytest
+
+_ADDON_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                          "blender_addon")
+if _ADDON_DIR not in sys.path:
+    sys.path.insert(0, _ADDON_DIR)
+import _bulk_geometry  # noqa: E402
+
+
+class _Coll:
+    def __init__(self, n, attrs):
+        self._n = n
+        self._attrs = {k: np.asarray(v, dtype=np.float64) for k, v in attrs.items()}
+
+    def __len__(self):
+        return self._n
+
+    def foreach_get(self, name, buf):
+        if name not in self._attrs:
+            raise RuntimeError(f"no attribute {name}")
+        buf[:] = self._attrs[name]
+
+
+class _Curves:
+    def __init__(self, points, offsets, curve_offsets=True, attributes=None):
+        self.points = points
+        self.attributes = attributes
+        if curve_offsets:
+            self.curve_offsets = _Coll(len(offsets), {"value": offsets})
+        else:
+            self.curve_offsets = None
+            counts = np.diff(offsets)
+            self.curves = [type("S", (), {"points_length": int(c)})() for c in counts]
+
+
+def _matrix(scale=2.0):
+    # Uniform scale 2 + translation, so radius*scale and positions*scale+t are exact.
+    M = np.eye(4, dtype=np.float64)
+    M[0, 0] = M[1, 1] = M[2, 2] = scale
+    M[:3, 3] = [1.0, -2.0, 0.5]
+    return M
+
+
+def _make_curves(**kw):
+    # 2 strands: 5 points then 3 points = 8 points.
+    pos = np.array([[0, 0, 0], [0, 1, 0], [0, 2, 0], [0, 3, 0], [0, 4, 0],
+                    [1, 0, 0], [1, 1, 0], [1, 2, 0]], dtype=np.float64)
+    rad = np.array([0.01, 0.02, 0.03, 0.02, 0.01, 0.05, 0.04, 0.03], dtype=np.float64)
+    pts = _Coll(8, {"position": pos.reshape(-1), "radius": rad})
+    offsets = np.array([0, 5, 8], dtype=np.int64)
+    return _Curves(pts, offsets, **kw), pos, rad, [5, 3]
+
+
+@pytest.mark.parametrize("use_offsets", [True, False])
+def test_extract_curves_bulk_matches_reference(use_offsets):
+    curves, pos, rad, counts = _make_curves(curve_offsets=use_offsets)
+    M = _matrix(scale=2.0)
+    out_pos, out_rad, out_counts = _bulk_geometry.extract_curves_bulk(curves, M)
+
+    assert out_counts == counts
+    assert out_pos.shape == (8, 3)
+    assert out_pos.dtype == np.float32 and out_rad.dtype == np.float32
+
+    ref_pos = pos @ M[:3, :3].T + M[:3, 3]
+    np.testing.assert_allclose(out_pos, ref_pos, rtol=1e-5, atol=1e-5)
+    # Uniform scale 2 -> radius doubles.
+    np.testing.assert_allclose(out_rad, rad * 2.0, rtol=1e-5, atol=1e-6)
+
+
+def test_extract_curves_bulk_drops_degenerate_strand():
+    # 3 strands with counts [2, 1, 3] -> the 1-point strand (and its point) drop.
+    pos = np.array([[0, 0, 0], [0, 1, 0],       # strand A (2)
+                    [5, 5, 5],                   # strand B (1) - degenerate
+                    [1, 0, 0], [1, 1, 0], [1, 2, 0]], dtype=np.float64)  # strand C (3)
+    rad = np.full(6, 0.02, dtype=np.float64)
+    pts = _Coll(6, {"position": pos.reshape(-1), "radius": rad})
+    curves = _Curves(pts, np.array([0, 2, 3, 6], dtype=np.int64))
+    out_pos, out_rad, out_counts = _bulk_geometry.extract_curves_bulk(curves, np.eye(4))
+    assert out_counts == [2, 3]
+    assert out_pos.shape == (5, 3)          # the lone degenerate point is gone
+    # Surviving points are strands A + C, in order (the [5,5,5] point removed).
+    expected = np.array([[0, 0, 0], [0, 1, 0], [1, 0, 0], [1, 1, 0], [1, 2, 0]],
+                        dtype=np.float32)
+    np.testing.assert_allclose(out_pos, expected, atol=1e-6)
+
+
+def test_extract_curves_bulk_radius_fallback():
+    # No 'radius' point attribute and no attributes collection -> default radius.
+    pos = np.array([[0, 0, 0], [0, 1, 0], [0, 2, 0]], dtype=np.float64)
+    pts = _Coll(3, {"position": pos.reshape(-1)})  # no "radius"
+    curves = _Curves(pts, np.array([0, 3], dtype=np.int64), attributes=None)
+    _, out_rad, out_counts = _bulk_geometry.extract_curves_bulk(
+        curves, np.eye(4), default_radius=0.007)
+    assert out_counts == [3]
+    np.testing.assert_allclose(out_rad, np.full(3, 0.007, dtype=np.float32), atol=1e-7)
+
+
+def test_extract_curves_bulk_empty():
+    curves = _Curves(_Coll(0, {"position": np.zeros(0), "radius": np.zeros(0)}),
+                     np.array([0], dtype=np.int64))
+    out_pos, out_rad, out_counts = _bulk_geometry.extract_curves_bulk(curves, np.eye(4))
+    assert out_counts == [] and out_pos.shape == (0, 3) and out_rad.shape == (0,)


### PR DESCRIPTION
## Summary

The **final pkg225 stage** — the addon renders Blender `Curves` (hair / geometry-nodes) objects as **native curve primitives** and translates the **Principled Hair BSDF** node to the native `principled_hair` material. With this, all six stages of the hair arc are landed (CPU+GPU curve geometry, CPU+GPU Chiang 2016 hair BSDF, spectral melanin, addon).

## What was broken

`convert_objects` handled `MESH` and `to_mesh()`-able types (CURVE/SURFACE/FONT/META) but hit `else: continue` for `obj.type == 'CURVES'` — Blender's hair/geometry-nodes curves were **silently skipped**. The `BSDF_HAIR`/`BSDF_HAIR_PRINCIPLED` nodes had no handler (all `DROPPED-SILENT`).

## Geometry export

- **`_bulk_geometry.extract_curves_bulk(curves, matrix)`** — a Blender `Curves` data-block → (world-space control points, per-point radii, per-strand counts) via C-speed `foreach_get`. Radius scaled by mean object-axis scale; degenerate <2-point strands dropped; robust to Blender 5.2 having no `curve_offsets` and no default `radius` attribute.
- **`convert_objects`** gains a `CURVES` branch calling `renderer.add_curves_bulk` with the object's active material.

## Shader translation

`ShaderNodeBsdfHairPrincipled` + legacy `ShaderNodeBsdfHair` → `principled_hair`. All three parametrizations (Direct Coloring / Melanin / Absorption) and Chiang sockets map **1:1 to Cycles' node** — verified against Blender 5.2's actual enums (`model` CHIANG/HUANG, `parametrization` COLOR/MELANIN/ABSORPTION) and socket names. Huang-only sockets, per-strand Random, and the Kajiya-Kay node degrade to APPROXIMATED (degradation report).

## Settings

Cycles Curves **Shape** (`scene.cycles_curves.shape`) → `set_curve_thick_mode` (THICK default swept-circle / RIBBON flat strip).

## Coverage matrix

`BSDF_HAIR_PRINCIPLED` → 11 SUPPORTED + 8 APPROXIMATED; `BSDF_HAIR` → 6 APPROXIMATED (both were entirely `DROPPED-SILENT`).

## Verification

- **Unit** (`tests/test_pkg225_addon_curves_export.py`, 5 cases, headless, no bpy/engine): world transform, radius scale + fallback, degenerate-strand drop, offsets-vs-slice-loop, empty. Bulk-geometry helper regression green.
- **Headless Blender 5.2 (GPU)**: a curved-strand tuft with a Principled Hair material renders the **anisotropic along-fiber Chiang R-lobe sheen** end-to-end (coverage 0.45, warm-brown R/B 1.44). Render attached in the conversation.

## Note

Verifying this required rebuilding the addon `.pyd` (`build_blender_addon.py --backend cuda`) — the staged `dist/astroray` module predated S3 (no `set_curve_thick_mode` / GPU curve rendering), so hair was invisible on the addon's GPU path until restaged at HEAD. Pure-Python change; no engine source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)