### PR TITLE
pkg227 Phase 2b-flat: deterministic flat-triangle specular-polynomial mesh caustic

### DIFF
--- a/.astroray_plan/packages/pkg227-general-specular-polynomials.md
+++ b/.astroray_plan/packages/pkg227-general-specular-polynomials.md
@@ -415,8 +415,15 @@ demand.
       Gates: `tests/test_pkg227_sphere_chain_unit.py` (numpy oracle, 5/5, CI) +
       `tests/test_pkg227_raindrop_bow.py` (render-level: fires/concentrated/
       chromatic, 3/3). Branch `pkg227-s2a`. See Phase 2a findings below.
-- [ ] Phase 2b-flat — single-bounce mesh solver on one known caster (M-solve), oracle-gated.
-      **De-risked 2026-09-04** — numpy prototype PASSES vs sphere oracle (see below).
+- [x] Phase 2b-flat — single-bounce mesh solver on one known caster (M-solve), oracle-gated.
+      **LANDED 2026-09-05.** Solver `specpoly::solveFlatTriangleSpecular`
+      (`include/astroray/manifold/mesh_specular_poly.h`, exact degree-4 flat-facet
+      form) + `runMeshSMSAttemptPoly` (`mesh_attempt.h`), gated in
+      `sms_caustic_path_tracer` behind `sms_specular_poly` (+ `spectral_newton=1`,
+      the mesh path). Gates: `tests/test_pkg227_mesh_poly_unit.py` (numpy oracle
+      vs `solveSphereSpecular`, 3/3, CI, < 1e-4 rad) + `tests/test_pkg227_mesh_
+      caustic.py` (render-level, 4/4). Branch `pkg227-s2b-flat`. See Phase 2b-flat
+      findings below.
 - [ ] Phase 2b-smooth — interpolated shading-normal support (constraint + Jacobian).
 - [ ] Phase 2c — triangle-tuple pruning subsystem (M-prune) — GATED on Open Decision #1.
 - [ ] Phase 2d — two-bounce mesh, supersede `runMeshSMSAttempt`.
@@ -466,6 +473,48 @@ Parallel numpy prototype (`scratchpad/proto_mesh_specular.py`, research note
   an isolated Snell sanity check — the wrong convention is locally self-consistent
   and fails SILENTLY (a different plausible specular point, not an error).
 - Port target: new `mesh_specular_poly.h` reusing `specular_poly.h` helpers.
+
+## Phase 2b-flat findings (2026-09-05)
+
+- **Solver ports cleanly and is exact.** `solveFlatTriangleSpecular` is a
+  line-for-line C++ port of the validated numpy prototype (degree-4 square form,
+  `realRoots` reused from `specular_poly.h`), STL-free. The oracle unit test
+  reproduces `solveSphereSpecular` to < 1e-4 rad over an icosphere tessellation
+  (3/3). ABI-clean (device path does not include the header).
+- **The un-pruned camera-side mesh path is O(pixels × triangles) — it MUST use
+  candidate-face selection even for a single caster.** The first cut solved the
+  quartic on EVERY caster facet per shading point; on a 320–1280-triangle
+  tessellated sphere that hung for hours (the exact O(pixels × triangles) blow-up
+  the spec flags as the M-prune motivation, §"dominant constraint"). Fix: cast the
+  cheap x0→centroid seed ray (Möller–Trumbore, mirroring
+  `seedChainTowardCaster`) and solve the quartic ONLY on the ≤4 faces it crosses.
+  Runtime dropped to ~3–4 s/render. This is the flat-facet form of the spec's
+  "use the existing `seedChainFromRay` candidate triangle (one caster, no global
+  pruning yet)" — pruning to a *global* candidate set across many casters is still
+  Phase 2c, but even one caster needs per-shading-point face scoping.
+- **Deterministic enumeration decisively beats the Newton mesh path.** On the
+  tessellated glass sphere the single-seed Newton path (`runMeshSMSAttempt`)
+  converges on ~0.1 % of attempts and collects ~0.1 caustic energy; the poly path
+  validates ~100 % of enumerated solutions and collects ~12–15 (≈100×), band
+  concentration ~0.62–0.69. The render gate asserts this gap. (The Newton mesh
+  path was never actually exercised by any reference scene — both SMS reference
+  scenes use analytic spheres — so this is the first camera-side mesh caustic.)
+- **`glass-mesh-caustic` was the WRONG scene to bless.** The spec named it as the
+  2b-flat reference shell, but it is a FORWARD `light_tracer_caustic` scene whose
+  caster is an 18 MB gitignored `samples/Glass.obj` (local-only, never CI). It
+  does not use the camera-side poly path at all. Blessing it as-is would lock a
+  forward render, not test 2b-flat. So 2b-flat is gated by a self-contained
+  procedural-icosphere pytest (no external asset, like the 2a raindrop gate)
+  rather than by converting that forward showcase. Left `glass-mesh-caustic`
+  untouched as the forward showcase it is; a reference-bank *camera-side* mesh
+  scene can be added later if wanted (would need a committed reference.png; still
+  local-only to render).
+- **Flat facets → faceted caustics, by design.** Convergence to the smooth
+  continuum is linear in facet edge length (research note §3), and the
+  candidate-face solve only finds a vertex when it lies on a seed-crossed facet —
+  so a finer mesh yields fewer per-pixel hits (measured attempts 267k→78k from
+  subdiv 1→2) with a sharper but sparser caustic. Smooth-shaded curved casters
+  are exactly Phase 2b-smooth's job; the multi-facet fold coverage is Phase 2c.
 
 ## Lessons
 

--- a/include/astroray/manifold/mesh_attempt.h
+++ b/include/astroray/manifold/mesh_attempt.h
@@ -24,7 +24,8 @@
 #include "../shapes.h"
 #include "../spectrum.h"
 #include "mesh_caustic.h"
-#include "sms_attempt.h"   // SMSConfig, SMSCaster (sphere path lives alongside)
+#include "sms_attempt.h"          // SMSConfig, SMSCaster, SMSPolyResult (sphere poly path)
+#include "mesh_specular_poly.h"   // pkg227 2b-flat: deterministic flat-triangle solver
 #include <cmath>
 #include <vector>
 
@@ -160,6 +161,158 @@ inline float runMeshSMSAttempt(const Renderer& renderer,
     if (contrib < 0.0f) contrib = 0.0f;
     if (contrib > cfg.contribClamp) contrib = cfg.contribClamp;
     return contrib;
+}
+
+// pkg227 Phase 2b-flat — DETERMINISTIC single-vertex mesh caustic (flat facets).
+//
+// The mesh analogue of runSMSAttemptPoly (sphere): instead of the single-seed
+// Newton search of runMeshSMSAttempt (which finds at most one path per attempt
+// and misses the caustic-fold branches), enumerate EVERY admissible single
+// refractive vertex across the caster triangles with specpoly::
+// solveFlatTriangleSpecular, and accumulate each valid path with the SAME MNEE
+// generalized-geometry weight the sphere poly path uses. Flat facet normals only
+// (dn=0) — smooth shading is Phase 2b-smooth; two-bounce (prism) is Phase 2d, so
+// this is one refractive vertex from x0 to the light. Returns SMSPolyResult
+// (hero + RGB), mirroring runSMSAttemptPoly's Fresnel / weight / clamp
+// conventions exactly (no 2.0 firefly clamp — the per-solution contribClamp
+// bounds singular-Jacobian spikes). Validated against the sphere oracle
+// (tests/test_pkg227_mesh_poly_unit.py; mesh_specular_poly.h).
+inline SMSPolyResult runMeshSMSAttemptPoly(const Renderer& renderer,
+                                           const HitRecord& x0Rec, const Ray& primary,
+                                           const astroray::SampledWavelengths& lambdas,
+                                           const std::vector<CausticTri>& tris,
+                                           const Material* casterMat, float casterPickPdf,
+                                           const LightSample& ls, const SMSConfig& cfg) {
+    SMSPolyResult R;
+    const auto& bvh = renderer.getBVH();
+    if (!bvh || tris.empty() || ls.pdf <= 0.0f) return R;
+
+    const float lambdaHero = lambdas.lambda(0);
+    const float iorHero = casterMat ? casterMat->iorAt(lambdaHero) : 1.5f;
+    if (iorHero <= 1.0f) return R;
+    const float eta = 1.0f / iorHero;   // air -> glass (x0-side is air), matches sphere
+
+    const Vec3 wo_eye = -primary.direction.normalized();
+    const bool fixedDir = (ls.distance > 1.0e5f);
+    const float invPdf = 1.0f / std::max(ls.pdf * casterPickPdf, 1e-6f);
+    const float LeHero = astroray::RGBIlluminantSpectrum(
+        {ls.emission.x, ls.emission.y, ls.emission.z}).sample(lambdas)[0];
+
+    // Candidate-face selection (no global pruning yet — Phase 2c). Solving the
+    // quartic on EVERY facet is O(pixels * triangles) and unusable; instead cast
+    // a cheap seed ray x0 -> caster centroid and solve the exact quartic ONLY on
+    // the few faces it crosses (the specular vertex lives on an entry face the
+    // straight seed traverses), mirroring the Newton path's seedChainTowardCaster
+    // scoping. Bounds quartic solves to <= kMaxCand per shading point.
+    Vec3 centroid(0.0f);
+    for (const auto& tr : tris) centroid = centroid + (tr.v0 + tr.v1 + tr.v2) * (1.0f / 3.0f);
+    centroid = centroid * (1.0f / static_cast<float>(tris.size()));
+    const Vec3 aim = centroid - x0Rec.point;
+    const float aimLen = std::sqrt(aim.length2());
+    if (aimLen < 1e-9f) return R;
+    const Vec3 seedDir = aim * (1.0f / aimLen);
+    const float tMax = aimLen * 4.0f;
+
+    constexpr int kMaxCand = 4;
+    int cand[kMaxCand];
+    int nCand = 0;
+    for (int ti = 0; ti < (int)tris.size() && nCand < kMaxCand; ++ti) {
+        float t;
+        if (rayTriHit(x0Rec.point, seedDir, tris[ti], t) && t > 1e-4f && t < tMax)
+            cand[nCand++] = ti;
+    }
+
+    for (int ci = 0; ci < nCand; ++ci) {
+        const CausticTri& tr = tris[cand[ci]];
+        specpoly::FlatTriSolution sols[4];
+        const int nsol = specpoly::solveFlatTriangleSpecular(
+            x0Rec.point, ls.position, tr.v0, tr.v1, tr.v2, eta,
+            /*refraction=*/true, sols, 4);
+        if (nsol <= 0) continue;   // -1 degenerate / 0 no in-facet root
+        R.nSolutions += nsol;
+
+        const Vec3 e1v = tr.v1 - tr.v0;
+        const Vec3 e2v = tr.v2 - tr.v0;
+
+        for (int i = 0; i < nsol; ++i) {
+            const Vec3 x1 = sols[i].p;
+            const Vec3 nEntry = sols[i].n;
+
+            const Vec3 dirToX1 = x1 - x0Rec.point;
+            const float distX0X1_2 = dirToX1.length2();
+            if (distX0X1_2 < 1e-8f) continue;
+            const float distX0X1 = std::sqrt(distX0X1_2);
+            const Vec3 wi_x0 = dirToX1 * (1.0f / distX0X1);
+
+            // Visibility x0 -> x1 must reach a caustic-caster face (the glass).
+            HitRecord vrec;
+            if (!bvh->hit(Ray(x0Rec.point, wi_x0), 0.001f, distX0X1 + 1e-2f, vrec))
+                continue;
+            if (!(vrec.hitObject && vrec.hitObject->isCausticCaster())) continue;
+
+            // Orient the facet normal toward x0 (a facet has no innate side).
+            Vec3 nOr = nEntry;
+            const Vec3 wi_in = -wi_x0;
+            float cosI = -wi_in.dot(nOr);
+            if (cosI < 0.0f) { nOr = nOr * -1.0f; cosI = -cosI; }
+            if (cosI <= 1e-6f) continue;
+            const float sin2T = eta * eta * std::max(0.0f, 1.0f - cosI * cosI);
+            if (sin2T >= 1.0f) continue;  // TIR
+
+            // Exit-side occlusion: only glass (caster) or the light may lie
+            // between x1 and the light (mirrors runMeshSMSAttempt).
+            const Vec3 toLight = ls.position - x1;
+            const float distLight = std::sqrt(toLight.length2());
+            if (distLight < 1e-5f) continue;
+            const Vec3 dirLight = toLight * (1.0f / distLight);
+            HitRecord lrec;
+            const bool hitOcc = bvh->hit(Ray(x1 + dirLight * 1e-3f, dirLight),
+                                         0.001f, distLight - 1e-2f, lrec);
+            if (hitOcc && lrec.hitObject && !lrec.hitObject->isInfiniteLight() &&
+                !lrec.hitObject->isCausticCaster())
+                continue;
+
+            // Fresnel transmittance at the vertex (hero eta).
+            float F0 = (1.0f - eta) / (1.0f + eta);
+            F0 *= F0;
+            const float fresnel =
+                F0 + (1.0f - F0) * std::pow(std::max(0.0f, 1.0f - cosI), 5.0f);
+            const float Tr = 1.0f - fresnel;
+
+            const astroray::SampledSpectrum fSpec =
+                x0Rec.material->evalSpectral(x0Rec, wo_eye, wi_x0, lambdas);
+
+            // MNEE generalized-geometry weight, N=1 flat vertex: surface tangents
+            // are the triangle edges, dn=0 (flat facet — trianglePartials
+            // convention). No extra receiver cosine (evalSpectral carries it); no
+            // 2.0 clamp (as runSMSAttemptPoly).
+            ChainVertex cv;
+            cv.p = x1;  cv.n = nOr;
+            cv.dp_du = e1v;  cv.dp_dv = e2v;
+            cv.dn_du = Vec3(0.0f);  cv.dn_dv = Vec3(0.0f);
+            cv.eta = iorHero;
+            const Vec3 sunDir = dirLight;
+            const float dw0_dx1 =
+                std::fabs(wi_x0.dot(nOr)) / std::max(distX0X1_2, 1e-6f);
+            const float dx1_dxlight = chainGeometryTerm(
+                &cv, 1, x0Rec.point, ls.position, ls.normal, nullptr, fixedDir, sunDir);
+            if (dx1_dxlight <= 0.0f) continue;
+            const float w = dw0_dx1 * dx1_dxlight * invPdf;
+
+            float sampleHero = fSpec[0] * LeHero * Tr * w;
+            if (sampleHero > cfg.contribClamp) sampleHero = cfg.contribClamp;
+            if (sampleHero < 0.0f) sampleHero = 0.0f;
+            R.hero += sampleHero;
+
+            const astroray::XYZ fxyz = fSpec.toXYZ(lambdas);
+            Vec3 sampleRGB = Vec3(fxyz.X, fxyz.Y, fxyz.Z) * ls.emission * (Tr * w);
+            const float maxC = std::max(sampleRGB.x, std::max(sampleRGB.y, sampleRGB.z));
+            if (maxC > cfg.contribClamp) sampleRGB = sampleRGB * (cfg.contribClamp / maxC);
+            R.rgb = R.rgb + sampleRGB;
+            R.nValid += 1;
+        }
+    }
+    return R;
 }
 
 }  // namespace astroray::manifold

--- a/include/astroray/manifold/mesh_specular_poly.h
+++ b/include/astroray/manifold/mesh_specular_poly.h
@@ -1,0 +1,215 @@
+#pragma once
+// pkg227 Phase 2b-flat — Specular Polynomials for a FLAT triangle facet.
+//
+// Deterministic, seed-free enumeration of every admissible single-vertex
+// specular path (refract or reflect) on ONE triangle with a CONSTANT (flat)
+// facet normal — the mesh analogue of specular_poly.h's exact sphere solver,
+// replacing the single-seed Newton search of mesh_attempt.h for the flat case.
+//
+// Method — re-derived from the open-access paper (CLAUDE.md §6, no invented
+// algorithm; the reference impl github.com/mollnn/spoly is UNLICENSED and was
+// NOT read/copied):
+//   Fan, Guo, Wang, Xiao, Zhang, Zhou, Chen, Hong, Guo, Yan,
+//     "Specular Polynomials", ACM TOG 43(4) (SIGGRAPH 2024), article 126,
+//     DOI 10.1145/3658132, arXiv:2405.13409. Paper text CC BY 4.0.
+//     §3.2 generalized half-vector constraint splits into a COPLANARITY
+//     constraint (d_{i-1} x d_i) . n_i = 0 and an ANGULARITY constraint;
+//     §3.3 "square form" removes the angularity norm denominators by squaring,
+//     admitting superfluous (sign-flipped) roots re-filtered against the SIGNED
+//     residual in path space (identical structure to the CI-validated sphere
+//     solver, specular_poly.h).
+//
+// FLAT-FACET SPECIALIZATION (this file; Phase 2b-flat — interpolated shading
+// normals are the separate Phase 2b-smooth). For a single vertex on ONE triangle
+// with a normal N that is CONSTANT over the facet, the paper's rational
+// coordinate mapping (§3.4) and 6-piece sqrt-fit (§3.5, error < 1e-3) are NOT
+// needed — they exist to propagate a vertex through a multi-bounce chain and
+// through a curved (interpolated-normal) surface. With a single vertex and a
+// constant normal:
+//   Coplanarity  (p - x0) x (x2 - p) . N = 0  expands (p x p = 0) to
+//     p . ((x2 - x0) x N) = (x0 x x2) . N ,                              (*)
+//   LINEAR in p; intersected with the triangle plane {p = P0 + u e1 + v e2} it
+//   confines the vertex to a LINE L (one parameter t). Working in the incidence
+//   plane through x0 with normal m = (x2 - x0) x N (basis e1=norm(x2-x0),
+//   e2=m x e1) gives 2D coords a=(0,0) for x0, b=(|x2-x0|,0) for x2, a constant
+//   2D normal n2 for N, and p(t) AFFINE in t. Mirroring the sphere residual
+//   (specular_poly.h) exactly:
+//     Ci = n2 x (a - p)  deg 1 ,  Co = n2 x (b - p)  deg 1
+//     Ri^2 = |a - p|^2   deg 2 ,  Ro^2 = |b - p|^2   deg 2
+//     square form  Ci^2 Ro^2 - eta^2 Co^2 Ri^2 = 0   ->  DEGREE 4 in t.
+//   Degree 4 independently matches the paper's Table 2 flat-normal refraction
+//   degree, cross-validating the specialization (CLAUDE.md §6: cite, borrow,
+//   VERIFY). Real roots are refined by one Newton polish on the signed residual
+//   g(t) = Ci/Ri + eta*Co/Ro and filtered by |g| < 1e-3 (superfluous root) and
+//   by triangle bounds (0 <= u,v ; u+v <= 1).
+//
+// Validated to < 5.7e-6 rad against solveSphereSpecular over a fine icosphere
+// tessellation (scratchpad/proto_mesh_specular.py; note
+// .astroray_plan/docs/pkg227-phase2b-research.md; CI oracle
+// tests/test_pkg227_mesh_poly_unit.py). Convergence vs the smooth continuum is
+// LINEAR in facet edge length — faceted casters render faceted caustics by
+// design; smooth-shaded casters are Phase 2b-smooth.
+//
+// ETA CONVENTION (research note §3 — the top port risk): `eta` is passed through
+// UNMODIFIED into g = Ci/Ri + eta*Co/Ro, mirroring specular_poly.h's sphere
+// Ci/Co pattern literally. Inverting it (n_to/n_from) passes an isolated Snell
+// sanity check but SILENTLY stops matching the sphere oracle for every
+// refractive case. The unit test gates this against the sphere oracle directly.
+//
+// This header is original Astroray code (MIT), STL-free like specular_poly.h.
+
+#include "../../raytracer.h"
+#include "specular_poly.h"   // realRoots, polyMul (degree-4 subset of degree-6)
+#include <cmath>
+
+namespace astroray::manifold {
+namespace specpoly {
+
+struct FlatTriSolution {
+    Vec3 p;   // specular vertex position on the triangle facet
+    Vec3 n;   // outward (flat) facet unit normal
+};
+
+// Signed angularity residual g(t) at the affine 2D point p(t) = (px0 + t*dpx,
+// py0 + t*dpy) in the incidence plane. Zero on a true solution, O(1) on a
+// superfluous (squared) root — same role as specular_poly.h::signedResidual.
+inline float flatTriResidual(float px0, float py0, float dpx, float dpy,
+                             float b2x, float b2y, float n2x, float n2y,
+                             float eta, float t) {
+    const float px = px0 + t * dpx, py = py0 + t * dpy;
+    // 2D cross (u x v) = ux*vy - uy*vx; a = (0,0), so a - p = (-px, -py).
+    const float Ci = n2x * (-py) - n2y * (-px);
+    const float Co = n2x * (b2y - py) - n2y * (b2x - px);
+    const float Ri = std::sqrt(px * px + py * py);
+    const float dbx = b2x - px, dby = b2y - py;
+    const float Ro = std::sqrt(dbx * dbx + dby * dby);
+    if (Ri < 1e-12f || Ro < 1e-12f) return 1e9f;
+    return Ci / Ri + eta * Co / Ro;
+}
+
+// Enumerate admissible single-vertex specular points on ONE flat triangle facet
+// (P0, P1, P2) for the configuration (x0 -> vertex -> x2). `refraction` selects
+// the refractive residual (etaEff = eta) vs reflection (etaEff = 1), matching
+// solveSphereSpecular. Returns the number of in-triangle, filtered solutions
+// written to out[] (up to maxOut), or -1 for a degenerate configuration
+// (degenerate triangle; triangle plane parallel to the coplanarity plane;
+// (x2 - x0) parallel to N) where the caller must fall back to Newton/skip.
+inline int solveFlatTriangleSpecular(const Vec3& x0, const Vec3& x2,
+                                     const Vec3& P0, const Vec3& P1, const Vec3& P2,
+                                     float eta, bool refraction,
+                                     FlatTriSolution* out, int maxOut) {
+    const Vec3 e1v = P1 - P0;
+    const Vec3 e2v = P2 - P0;
+    Vec3 N = e1v.cross(e2v);
+    const float nlen2 = N.length2();
+    if (nlen2 < 1e-28f) return -1;               // degenerate triangle
+    N = N * (1.0f / std::sqrt(nlen2));
+    const float etaEff = refraction ? eta : 1.0f;
+
+    // Coplanarity: p . w = k  (linear in p), w = (x2 - x0) x N, k = (x0 x x2).N
+    const Vec3 d = x2 - x0;
+    const Vec3 w = d.cross(N);
+    const float k = x0.cross(x2).dot(N);
+    // Restrict to the triangle plane p = P0 + u*e1v + v*e2v:
+    //   u*(e1v.w) + v*(e2v.w) = k - P0.w
+    const float c1 = e1v.dot(w), c2 = e2v.dot(w), rhs = k - P0.dot(w);
+    if (std::fabs(c1) < 1e-14f && std::fabs(c2) < 1e-14f) return -1;
+
+    // Incidence-plane 2D basis (m == w up to scale; degenerate if d || N).
+    const float mlen2 = w.length2();
+    if (mlen2 < 1e-28f) return -1;
+    const Vec3 mUnit = w * (1.0f / std::sqrt(mlen2));
+    const float dlen2 = d.length2();
+    if (dlen2 < 1e-20f) return -1;
+    const Vec3 eb1 = d * (1.0f / std::sqrt(dlen2));
+    const Vec3 eb2 = mUnit.cross(eb1);
+
+    // p(t) affine: parameterise L by u (if |c2| usable) else by v. Sample the
+    // line at t=0,1 in 3D, then express in the incidence-plane basis (relative
+    // to x0) to get the affine 2D map directly (mirrors the prototype).
+    const bool paramIsU = std::fabs(c2) > 1e-10f;
+    Vec3 pA, pB;   // p(0), p(1) in 3D
+    if (paramIsU) {
+        const float v0 = rhs / c2;               // u = 0
+        const float v1 = (rhs - c1) / c2;         // u = 1
+        pA = P0 + e2v * v0;
+        pB = P0 + e1v + e2v * v1;
+    } else {
+        const float u0 = rhs / c1;               // v = 0
+        const float u1 = (rhs - c2) / c1;         // v = 1
+        pA = P0 + e1v * u0;
+        pB = P0 + e1v * u1 + e2v;
+    }
+    const Vec3 qA = pA - x0, qB = pB - x0;
+    const float px0 = qA.dot(eb1), py0 = qA.dot(eb2);
+    const float px1 = qB.dot(eb1), py1 = qB.dot(eb2);
+    const float dpx = px1 - px0, dpy = py1 - py0;
+    const Vec3 db = x2 - x0;
+    const float b2x = db.dot(eb1), b2y = db.dot(eb2);
+    const float n2x = N.dot(eb1),  n2y = N.dot(eb2);
+
+    // Ci(t) = n2 x (a - p(t)), a = (0,0):  {n2x*(-py0)-n2y*(-px0), n2x*(-dpy)-n2y*(-dpx)}
+    const float Ci[2] = { n2x * (-py0) - n2y * (-px0), n2x * (-dpy) - n2y * (-dpx) };
+    // Co(t) = n2 x (b - p(t)):  const term uses b2; linear term same as Ci's.
+    const float Co[2] = { n2x * (b2y - py0) - n2y * (b2x - px0), Ci[1] };
+    // Ri^2(t) = |a - p(t)|^2, Ro^2(t) = |b - p(t)|^2  (each degree 2 in t).
+    const float Ri2[3] = { px0 * px0 + py0 * py0,
+                           2.0f * (px0 * dpx + py0 * dpy),
+                           dpx * dpx + dpy * dpy };
+    const float ob0 = b2x - px0, ob1 = b2y - py0;
+    const float Ro2[3] = { ob0 * ob0 + ob1 * ob1,
+                           -2.0f * (ob0 * dpx + ob1 * dpy),
+                           dpx * dpx + dpy * dpy };
+
+    float Ci2[3], Co2[3], term1[5], term2[5];
+    polyMul(Ci, 2, Ci, 2, Ci2);          // deg 2
+    polyMul(Co, 2, Co, 2, Co2);          // deg 2
+    polyMul(Ci2, 3, Ro2, 3, term1);      // deg 4
+    polyMul(Co2, 3, Ri2, 3, term2);      // deg 4
+    const float e2 = etaEff * etaEff;
+    float c[5];
+    for (int i = 0; i < 5; ++i) c[i] = term1[i] - e2 * term2[i];
+
+    float troots[kMaxRoots];
+    const int nr = realRoots(c, 4, troots);
+
+    const float kResidualTol = 1e-3f;
+    int n = 0;
+    for (int i = 0; i < nr && n < maxOut; ++i) {
+        float t = troots[i];
+        // One Newton polish on g(t) (paper §4; mirrors the sphere polish).
+        for (int it = 0; it < 4; ++it) {
+            const float h = 1e-5f;
+            const float g0 = flatTriResidual(px0, py0, dpx, dpy, b2x, b2y, n2x, n2y, etaEff, t);
+            const float gp = flatTriResidual(px0, py0, dpx, dpy, b2x, b2y, n2x, n2y, etaEff, t + h);
+            const float gm = flatTriResidual(px0, py0, dpx, dpy, b2x, b2y, n2x, n2y, etaEff, t - h);
+            const float dg = (gp - gm) * (0.5f / h);
+            if (std::fabs(dg) < 1e-9f) break;
+            t -= g0 / dg;
+        }
+        if (std::fabs(flatTriResidual(px0, py0, dpx, dpy, b2x, b2y, n2x, n2y, etaEff, t)) >
+            kResidualTol)
+            continue;  // superfluous (squared-form) root
+
+        // Reconstruct the 3D vertex and its barycentric (u, v) for the triangle test.
+        float u, v;
+        Vec3 p3d;
+        if (paramIsU) { u = t; v = (rhs - c1 * t) / c2; }
+        else          { v = t; u = (rhs - c2 * t) / c1; }
+        p3d = P0 + e1v * u + e2v * v;
+        if (u < -1e-6f || v < -1e-6f || (u + v) > 1.0f + 1e-6f) continue;  // outside facet
+
+        // Dedup near-double roots (a fold bracketed twice as two close roots).
+        bool dup = false;
+        for (int j = 0; j < n; ++j)
+            if ((out[j].p - p3d).length2() < 1e-10f) { dup = true; break; }
+        if (dup) continue;
+        out[n].p = p3d;
+        out[n].n = N;
+        ++n;
+    }
+    return n;
+}
+
+}  // namespace specpoly
+}  // namespace astroray::manifold

--- a/plugins/integrators/sms_caustic_path_tracer.cpp
+++ b/plugins/integrators/sms_caustic_path_tracer.cpp
@@ -345,6 +345,20 @@ private:
         lights.sample(ls, x0Rec.point, x0Rec.normal, lambdas, gen);
         if (ls.pdf <= 0.0f) return out;
 
+        // pkg227 2b-flat: deterministic flat-triangle Specular-Polynomials —
+        // enumerate every admissible single refractive vertex across the caster
+        // faces (no seeds, no Newton-basin miss), hero-channel write.
+        if (specularPoly_) {
+            amf::SMSPolyResult pr = amf::runMeshSMSAttemptPoly(
+                *renderer_, x0Rec, primary, lambdas, meshCasters_, meshCasterMat_,
+                /*casterPickPdf=*/1.0f, ls, smsCfg_);
+            smsAttempts_  += static_cast<float>(pr.nSolutions);
+            smsConverged_ += static_cast<float>(pr.nValid);
+            smsEnergy_    += pr.hero;
+            out[0] = pr.hero;
+            return out;
+        }
+
         float heroAccum = 0.0f;
         for (int s = 0; s < smsCfg_.seeds; ++s) {
             smsAttempts_ += 1.0f;

--- a/tests/test_pkg227_mesh_caustic.py
+++ b/tests/test_pkg227_mesh_caustic.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python
+"""pkg227 Phase 2b-flat render gate — the deterministic flat-triangle
+specular-polynomial solver produces a real caustic from a triangle-MESH caster,
+where the single-seed Newton mesh path nearly fails.
+
+Camera-side SMS on a triangle mesh: a tessellated glass icosphere (each facet
+flagged a caustic caster) on the sms_caustic_path_tracer, spectral_newton=1 (the
+hero-wavelength mesh path). Compares sms_specular_poly OFF (the existing
+single-seed Newton mesh solver, runMeshSMSAttempt) vs ON (the pkg227 2b-flat
+deterministic enumeration, runMeshSMSAttemptPoly / mesh_specular_poly.h).
+
+Self-contained (a procedural icosphere via add_triangle — no external .obj, so no
+dependence on the gitignored samples/Glass.obj the forward glass-mesh-caustic
+showcase needs) and seed-pinned. The solver-level exactness is gated separately
+by tests/test_pkg227_mesh_poly_unit.py (< 1e-4 rad vs the analytic sphere
+oracle); this gate proves the C++ engine integration end-to-end.
+
+Asserts (measured subdiv=1, 128 spp, seed 17):
+  1. FIRES: the poly path enumerates valid single-vertex mesh caustics.
+  2. BEATS NEWTON: the poly caustic carries far more energy than the single-seed
+     Newton path, whose Newton-from-one-seed misses almost every mesh vertex
+     (measured Newton E ~0.1 vs poly E ~12).
+  3. DETERMINISTIC: nearly every enumerated poly solution is valid (converged/
+     attempts ~1.0), vs Newton's ~0.1% seed-convergence rate — the deterministic-
+     enumeration-vs-stochastic-seed signature.
+  4. CONCENTRATED: the poly caustic energy clusters in a band (a real caustic),
+     not uniform scatter.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+import pytest
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+sys.path.insert(0, os.path.dirname(__file__))
+
+try:
+    import astroray
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray not built")
+
+WIDTH, HEIGHT, SAMPLES, MAX_DEPTH, SEED = 256, 180, 128, 10, 17
+CENTER = np.array([0.0, -0.35, 0.15])
+RADIUS = 0.72
+
+
+def _unit(v):
+    return v / np.linalg.norm(v)
+
+
+def _icosphere(subdiv):
+    t = (1.0 + np.sqrt(5.0)) / 2.0
+    verts = [_unit(v) for v in np.array([
+        [-1, t, 0], [1, t, 0], [-1, -t, 0], [1, -t, 0], [0, -1, t], [0, 1, t],
+        [0, -1, -t], [0, 1, -t], [t, 0, -1], [t, 0, 1], [-t, 0, -1], [-t, 0, 1]], float)]
+    faces = [(0, 11, 5), (0, 5, 1), (0, 1, 7), (0, 7, 10), (0, 10, 11), (1, 5, 9),
+             (5, 11, 4), (11, 10, 2), (10, 7, 6), (7, 1, 8), (3, 9, 4), (3, 4, 2),
+             (3, 2, 6), (3, 6, 8), (3, 8, 9), (4, 9, 5), (2, 4, 11), (6, 2, 10),
+             (8, 6, 7), (9, 8, 1)]
+    cache = {}
+
+    def mid(i, j):
+        key = (min(i, j), max(i, j))
+        if key not in cache:
+            verts.append(_unit((verts[i] + verts[j]) * 0.5))
+            cache[key] = len(verts) - 1
+        return cache[key]
+
+    for _ in range(subdiv):
+        nf = []
+        for a, b, c in faces:
+            ab, bc, ca = mid(a, b), mid(b, c), mid(c, a)
+            nf += [(a, ab, ca), (ab, b, bc), (ca, bc, c), (ab, bc, ca)]
+        faces = nf
+    return np.array(verts), np.array(faces, int)
+
+
+def _scene(poly: int):
+    r = astroray.Renderer()
+    r.set_background_color([0.02, 0.025, 0.03])
+    floor = r.create_material("lambertian", [0.72, 0.72, 0.68], {})
+    r.add_triangle([-2.4, -1.2, -2.2], [2.4, -1.2, -2.2], [2.4, -1.2, 1.6], floor)
+    r.add_triangle([-2.4, -1.2, -2.2], [2.4, -1.2, 1.6], [-2.4, -1.2, 1.6], floor)
+    light = r.create_material("light", [1.0, 0.97, 0.90], {"intensity": 12.0})
+    r.add_sphere([0.0, 1.55, 1.0], 0.22, light)
+    glass = r.create_material("dielectric", [1.0, 1.0, 1.0], {"ior": 1.52})
+    V, F = _icosphere(1)
+    V = V * RADIUS + CENTER
+    for (i0, i1, i2) in F:
+        idx = r.scene_object_count()
+        r.add_triangle([float(x) for x in V[i0]], [float(x) for x in V[i1]],
+                       [float(x) for x in V[i2]], glass)
+        r.set_object_caustic_caster(idx, True)
+    r.set_integrator("sms_caustic_path_tracer")
+    r.set_integrator_param("max_depth", MAX_DEPTH)
+    r.set_integrator_param("caustic_chain_iters", 3)
+    r.set_integrator_param("spectral_newton", 1)   # hero-wavelength mesh path
+    r.set_integrator_param("sms_specular_poly", poly)
+    r.setup_camera([0.0, 1.2, 3.4], [0.0, -0.8, 0.0], [0.0, 1.0, 0.0],
+                   38.0, WIDTH / HEIGHT, 0.0, 3.6, WIDTH, HEIGHT)
+    return r
+
+
+def _render(poly: int):
+    r = _scene(poly)
+    r.set_seed(SEED)
+    pix = np.asarray(r.render(SAMPLES, MAX_DEPTH, None, False), dtype=np.float32)
+    if pix.ndim == 1:
+        pix = pix.reshape(HEIGHT, WIDTH, 3)
+    return pix, r.get_integrator_stats()
+
+
+@pytest.fixture(scope="module")
+def _caustic():
+    off, s_off = _render(0)   # Newton mesh path
+    on, s_on = _render(1)     # pkg227 2b-flat deterministic poly path
+    diff = np.clip(on - off, 0.0, None)
+    return off, on, diff, s_off, s_on
+
+
+def test_poly_fires(_caustic):
+    _, _, _, _, s_on = _caustic
+    assert s_on.get("sms_converged", 0) > 100, (
+        f"poly path enumerated no valid mesh caustics (nValid={s_on.get('sms_converged',0)})")
+    assert s_on.get("sms_energy", 0) > 3.0, (
+        f"poly caustic energy too low ({s_on.get('sms_energy',0):.3f})")
+
+
+def test_poly_beats_newton(_caustic):
+    _, _, _, s_off, s_on = _caustic
+    e_off = s_off.get("sms_energy", 0)
+    e_on = s_on.get("sms_energy", 0)
+    # Newton-from-one-seed misses almost every mesh vertex; the deterministic
+    # enumeration recovers the caustic (measured ~0.1 vs ~12).
+    assert e_on > 5.0 * max(e_off, 1e-3), (
+        f"poly ({e_on:.3f}) did not decisively beat Newton ({e_off:.3f})")
+
+
+def test_poly_is_deterministic(_caustic):
+    _, _, _, s_off, s_on = _caustic
+    att_on = s_on.get("sms_attempts", 0)
+    conv_on = s_on.get("sms_converged", 0)
+    att_off = s_off.get("sms_attempts", 0)
+    conv_off = s_off.get("sms_converged", 0)
+    rate_on = conv_on / max(att_on, 1.0)
+    rate_off = conv_off / max(att_off, 1.0)
+    # Every enumerated poly solution is valid by construction (rate ~1); the
+    # stochastic Newton seed converges on well under 1% of attempts.
+    assert rate_on > 0.5, f"poly convergence rate unexpectedly low ({rate_on:.3f})"
+    assert rate_on > 20.0 * rate_off, (
+        f"poly rate {rate_on:.3f} not >> Newton rate {rate_off:.5f}")
+
+
+def test_poly_caustic_is_concentrated(_caustic):
+    _, _, diff, _, _ = _caustic
+    dl = diff.max(axis=2)
+    rowE = dl.sum(axis=1)
+    conc = float(np.sort(rowE)[-16:].sum() / max(rowE.sum(), 1e-9))
+    # A caustic concentrates its energy in a band; uniform scatter would be ~16/H.
+    assert conc > 0.3, f"poly caustic energy not banded (top-16-rows fraction {conc:.3f})"
+
+
+if __name__ == "__main__":
+    off, s_off = _render(0)
+    on, s_on = _render(1)
+    print(f"Newton: att={s_off.get('sms_attempts',0):.0f} conv={s_off.get('sms_converged',0):.0f} "
+          f"E={s_off.get('sms_energy',0):.3f}")
+    print(f"Poly:   att={s_on.get('sms_attempts',0):.0f} conv={s_on.get('sms_converged',0):.0f} "
+          f"E={s_on.get('sms_energy',0):.3f}")

--- a/tests/test_pkg227_mesh_poly_unit.py
+++ b/tests/test_pkg227_mesh_poly_unit.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python
+"""pkg227 Phase 2b-flat solver oracle — the flat-triangle specular-polynomial
+solver matches the EXACT analytic sphere solver over a fine tessellation.
+
+Pure-numpy, CI-runnable (no build). This is the algorithm-level gate for
+`include/astroray/manifold/mesh_specular_poly.h`: the C++ solver is a line-for-
+line port of `flat_triangle_specular` below, and the sphere oracle here is the
+same numpy mirror the LANDED pkg127 sphere solver is validated against
+(`tests/test_pkg127_specular_poly_unit.py`). Full de-risking (convergence order,
+superfluous-root accounting, the eta-direction gotcha) lives in
+`.astroray_plan/docs/pkg227-phase2b-research.md` /
+`scratchpad/proto_mesh_specular.py`.
+
+Asserts, over 4 configurations (refraction / reflection / multi-branch /
+SF11-dispersion), for every analytic-sphere root:
+  1. ORACLE MATCH: the flat-triangle solver on a fine local tessellation finds
+     the specular vertex to < 1e-4 rad (the pkg227 gate).
+  2. SUPERFLUOUS-ROOT FILTER: the signed-residual + in-triangle filter removes
+     the squared-form spurious roots (survivors << raw roots).
+  3. ETA CONVENTION: inverting eta (the plausible-but-wrong n_to/n_from) breaks
+     the oracle match for the refractive cases — locking the port's convention.
+"""
+from __future__ import annotations
+
+import numpy as np
+from numpy.polynomial import polynomial as P
+
+TWO_PI = 2.0 * np.pi
+
+
+def _unit(v):
+    return v / np.linalg.norm(v)
+
+
+# --- sphere oracle (verbatim structure from test_pkg127_specular_poly_unit) ---
+def _plane_basis(x0, x2, c):
+    a, b = np.asarray(x0, float) - c, np.asarray(x2, float) - c
+    e1 = _unit(a)
+    npl = _unit(np.cross(a, b))
+    e2 = np.cross(npl, e1)
+    return e1, e2, np.array([a @ e1, a @ e2]), np.array([b @ e1, b @ e2])
+
+
+def _sphere_resid(ct, st, a, b, r, eta):
+    p = r * np.array([ct, st])
+    Ci, Co = a[1] * ct - a[0] * st, b[1] * ct - b[0] * st
+    Ri, Ro = np.linalg.norm(a - p), np.linalg.norm(b - p)
+    if Ri < 1e-12 or Ro < 1e-12:
+        return 1e9
+    return Ci / Ri + eta * Co / Ro
+
+
+def _sphere_roots_theta(a, b, r, eta):
+    one, t2 = np.array([1.0]), P.polypow([0.0, 1.0], 2)
+    D, Cn, Sn = P.polyadd(one, t2), P.polysub(one, t2), np.array([0.0, 2.0])
+    Ci = P.polysub(P.polymul([a[1]], Cn), P.polymul([a[0]], Sn))
+    Co = P.polysub(P.polymul([b[1]], Cn), P.polymul([b[0]], Sn))
+    adot = P.polyadd(P.polymul([a[0]], Cn), P.polymul([a[1]], Sn))
+    bdot = P.polyadd(P.polymul([b[0]], Cn), P.polymul([b[1]], Sn))
+    a2, b2, r2 = float(a @ a), float(b @ b), r * r
+    Ri2 = P.polysub(P.polymul([a2 + r2], D), P.polymul([2 * r], adot))
+    Ro2 = P.polysub(P.polymul([b2 + r2], D), P.polymul([2 * r], bdot))
+    poly = P.polysub(P.polymul(P.polymul(Ci, Ci), Ro2),
+                     P.polymul([eta * eta], P.polymul(P.polymul(Co, Co), Ri2)))
+    thetas = []
+    for z in P.polyroots(np.trim_zeros(poly, 'b')):
+        if abs(z.imag) < 1e-6 * (1 + abs(z.real)):
+            th = 2.0 * np.arctan(z.real)
+            if abs(_sphere_resid(np.cos(th), np.sin(th), a, b, r, eta)) < 1e-4:
+                thetas.append(th)
+    out = []
+    for x in sorted((y + np.pi) % TWO_PI - np.pi for y in thetas):
+        if not out or abs(x - out[-1]) > 1e-3:
+            out.append(x)
+    return out
+
+
+def sphere_oracle_vertices(x0, x2, center, radius, eta):
+    x0, x2, center = (np.asarray(v, float) for v in (x0, x2, center))
+    e1, e2, a, b = _plane_basis(x0, x2, center)
+    return [center + radius * _unit(np.cos(th) * e1 + np.sin(th) * e2)
+            for th in _sphere_roots_theta(a, b, radius, eta)]
+
+
+# --- flat-triangle solver (numpy mirror of mesh_specular_poly.h) ---
+def flat_triangle_specular(x0, x2, P0, P1, P2, eta, invert_eta=False):
+    if invert_eta:
+        eta = 1.0 / eta
+    x0, x2 = np.asarray(x0, float), np.asarray(x2, float)
+    P0, P1, P2 = np.asarray(P0, float), np.asarray(P1, float), np.asarray(P2, float)
+    e1v, e2v = P1 - P0, P2 - P0
+    N = np.cross(e1v, e2v)
+    if np.linalg.norm(N) < 1e-14:
+        return []
+    N = _unit(N)
+    w = np.cross(x2 - x0, N)
+    k = float(np.cross(x0, x2) @ N)
+    c1, c2, rhs = float(e1v @ w), float(e2v @ w), k - float(P0 @ w)
+    if abs(c1) < 1e-14 and abs(c2) < 1e-14:
+        return []
+    if np.linalg.norm(w) < 1e-14:
+        return []
+    param_is_u = abs(c2) > 1e-10
+    if param_is_u:
+        def p_of_t(t):
+            v = (rhs - c1 * t) / c2
+            return P0 + t * e1v + v * e2v, (t, v)
+    else:
+        def p_of_t(t):
+            u = (rhs - c2 * t) / c1
+            return P0 + u * e1v + t * e2v, (u, t)
+    eb1 = _unit(x2 - x0)
+    eb2 = np.cross(_unit(w), eb1)
+    pA, _ = p_of_t(0.0)
+    pB, _ = p_of_t(1.0)
+    p0 = np.array([(pA - x0) @ eb1, (pA - x0) @ eb2])
+    p1 = np.array([(pB - x0) @ eb1, (pB - x0) @ eb2])
+    dpx, dpy = p1 - p0
+    px0, py0 = p0
+    b2 = np.array([(x2 - x0) @ eb1, (x2 - x0) @ eb2])
+    n2 = np.array([N @ eb1, N @ eb2])
+    Ci = np.array([n2[0] * (-py0) - n2[1] * (-px0), n2[0] * (-dpy) - n2[1] * (-dpx)])
+    Co = np.array([n2[0] * (b2[1] - py0) - n2[1] * (b2[0] - px0), Ci[1]])
+    Ri2 = np.array([px0**2 + py0**2, 2 * (px0 * dpx + py0 * dpy), dpx**2 + dpy**2])
+    Ro2 = np.array([(b2[0] - px0)**2 + (b2[1] - py0)**2,
+                    -2 * ((b2[0] - px0) * dpx + (b2[1] - py0) * dpy),
+                    dpx**2 + dpy**2])
+    poly = P.polysub(P.polymul(P.polymul(Ci, Ci), Ro2),
+                     eta * eta * P.polymul(P.polymul(Co, Co), Ri2))
+
+    def g(t):
+        p2 = np.array([px0 + t * dpx, py0 + t * dpy])
+        Ci_ = n2[0] * (-p2[1]) - n2[1] * (-p2[0])
+        Co_ = n2[0] * (b2[1] - p2[1]) - n2[1] * (b2[0] - p2[0])
+        Ri_, Ro_ = np.linalg.norm(p2), np.linalg.norm(b2 - p2)
+        if Ri_ < 1e-12 or Ro_ < 1e-12:
+            return 1e9
+        return Ci_ / Ri_ + eta * Co_ / Ro_
+
+    if not np.any(np.abs(poly) > 1e-14):
+        return []
+    sols, raw = [], 0
+    for z in P.polyroots(np.trim_zeros(poly, 'b')):
+        if abs(z.imag) > 1e-6 * (1 + abs(z.real)):
+            continue
+        raw += 1
+        t = float(z.real)
+        for _ in range(4):
+            h = 1e-5
+            dg = (g(t + h) - g(t - h)) / (2 * h)
+            if abs(dg) < 1e-9:
+                break
+            t -= g(t) / dg
+        if abs(g(t)) > 1e-3:
+            continue
+        p3d, (u, v) = p_of_t(t)
+        if u < -1e-6 or v < -1e-6 or (u + v) > 1 + 1e-6:
+            continue
+        if not any(np.linalg.norm(p3d - s['position']) < 1e-5 for s in sols):
+            sols.append({'position': p3d, 'normal': N.copy(), 'raw': raw})
+    return sols
+
+
+def _icosphere(subdiv, radius=1.0):
+    t = (1.0 + np.sqrt(5.0)) / 2.0
+    verts = [_unit(v) for v in np.array([
+        [-1, t, 0], [1, t, 0], [-1, -t, 0], [1, -t, 0], [0, -1, t], [0, 1, t],
+        [0, -1, -t], [0, 1, -t], [t, 0, -1], [t, 0, 1], [-t, 0, -1], [-t, 0, 1]],
+        dtype=float)]
+    faces = [(0, 11, 5), (0, 5, 1), (0, 1, 7), (0, 7, 10), (0, 10, 11), (1, 5, 9),
+             (5, 11, 4), (11, 10, 2), (10, 7, 6), (7, 1, 8), (3, 9, 4), (3, 4, 2),
+             (3, 2, 6), (3, 6, 8), (3, 8, 9), (4, 9, 5), (2, 4, 11), (6, 2, 10),
+             (8, 6, 7), (9, 8, 1)]
+    cache = {}
+
+    def mid(i, j):
+        key = (min(i, j), max(i, j))
+        if key not in cache:
+            verts.append(_unit((verts[i] + verts[j]) * 0.5))
+            cache[key] = len(verts) - 1
+        return cache[key]
+
+    for _ in range(subdiv):
+        nf = []
+        for i0, i1, i2 in faces:
+            a, b, c = mid(i0, i1), mid(i1, i2), mid(i2, i0)
+            nf += [(i0, a, c), (a, i1, b), (c, b, i2), (a, b, c)]
+        faces = nf
+    return np.array(verts) * radius, np.array(faces, dtype=int)
+
+
+def _ang_err(p_est, p_true, center):
+    return float(np.arccos(np.clip(_unit(p_est - center) @ _unit(p_true - center), -1, 1)))
+
+
+def _drill(x0, x2, eta, op, center, radius, levels=20, beam=6, invert_eta=False):
+    V, F = _icosphere(3, 1.0)
+    fc = V[F].mean(axis=1)
+    tris = [tuple(V[F[fi]]) for fi in np.argsort(np.linalg.norm(fc - op, axis=1))[:beam]]
+    best = None
+    for _ in range(levels):
+        for P0, P1, P2 in tris:
+            for s in flat_triangle_specular(x0, x2, P0, P1, P2, eta, invert_eta=invert_eta):
+                e = _ang_err(s['position'], op, center)
+                best = e if best is None else min(best, e)
+        nt = []
+        for P0, P1, P2 in tris:
+            ab, bc, ca = _unit((P0 + P1) / 2), _unit((P1 + P2) / 2), _unit((P2 + P0) / 2)
+            nt += [(P0, ab, ca), (ab, P1, bc), (ca, bc, P2), (ab, bc, ca)]
+        cens = np.array([_unit(sum(tr) / 3) for tr in nt])
+        tris = [nt[i] for i in np.argsort(np.linalg.norm(cens - op, axis=1))[:beam]]
+    return best
+
+
+CASES = [
+    ("refraction", [-3.0, 1.2, 0.4], [2.5, 2.0, -0.6], 1.0 / 1.52),
+    ("reflection", [-2.0, 2.0, 0.0], [2.0, 2.0, 0.3], 1.0),
+    ("multi-branch", [-1.8, 0.5, 0.0], [1.8, 0.5, 0.0], 1.0 / 1.52),
+    ("SF11", [-2.5, 1.5, 0.7], [2.2, 1.1, -0.3], 1.0 / 1.78),
+]
+CENTER, RADIUS = np.zeros(3), 1.0
+
+
+def test_flat_triangle_matches_sphere_oracle():
+    """Every analytic-sphere specular vertex is reproduced by the flat-triangle
+    solver on a fine tessellation to < 1e-4 rad (the pkg227 gate)."""
+    worst = 0.0
+    matched = 0
+    for label, x0, x2, eta in CASES:
+        oracle = sphere_oracle_vertices(x0, x2, CENTER, RADIUS, eta)
+        assert oracle, f"[{label}] oracle found no roots"
+        for op in oracle:
+            err = _drill(x0, x2, eta, op, CENTER, RADIUS)
+            assert err is not None, f"[{label}] no flat-triangle solution near oracle vertex"
+            assert err < 1e-4, f"[{label}] err {err:.3e} rad exceeds 1e-4 gate"
+            worst = max(worst, err)
+            matched += 1
+    assert matched >= 8, f"expected >= 8 oracle roots across cases, matched {matched}"
+    assert worst < 1e-4
+
+
+def test_superfluous_root_filter_removes_spurious():
+    """The squared-form quartic emits spurious roots; the signed-residual +
+    in-triangle filter removes them. Across a subdiv=5 sweep of the 25 facets
+    nearest each oracle vertex, only the handful of facets actually CONTAINING a
+    vertex survive (most of the ~200 facet-solves have their roots filtered as
+    superfluous or out-of-triangle) — and every survivor is a real vertex, not a
+    squaring artifact."""
+    V, F = _icosphere(5, 1.0)
+    fc = V[F].mean(axis=1)
+    survivors = []
+    for label, x0, x2, eta in CASES:
+        oracle = sphere_oracle_vertices(x0, x2, CENTER, RADIUS, eta)
+        for op in oracle:
+            for fi in np.argsort(np.linalg.norm(fc - op, axis=1))[:25]:
+                for s in flat_triangle_specular(x0, x2, *V[F[fi]], eta):
+                    survivors.append(_ang_err(s['position'], op, CENTER))
+    # Filter does real work: a vertex is inside only a couple of the 25 nearest
+    # facets, so survivors are FEW relative to the ~200 facet-solves per config.
+    assert 1 <= len(survivors) <= 30, f"unexpected survivor count {len(survivors)}"
+    # Every survivor is a genuine near-vertex (subdiv=5 edge ~0.02 -> err <~0.02),
+    # never a spurious far-off squaring root.
+    assert max(survivors) < 0.05, f"a survivor was far from any oracle vertex ({max(survivors):.3f})"
+
+
+def test_eta_inversion_breaks_refraction_match():
+    """Locks the eta convention (research note §3): passing eta UNMODIFIED
+    matches the oracle; the plausible n_to/n_from inversion silently fails the
+    refractive cases. Guards the top port risk."""
+    _label, x0, x2, eta = CASES[0]  # refraction generic
+    op = sphere_oracle_vertices(x0, x2, CENTER, RADIUS, eta)[0]
+    correct = _drill(x0, x2, eta, op, CENTER, RADIUS, invert_eta=False)
+    inverted = _drill(x0, x2, eta, op, CENTER, RADIUS, invert_eta=True)
+    assert correct is not None and correct < 1e-4, f"correct convention err {correct}"
+    # Inverted convention converges to a DIFFERENT specular point (or none) — it
+    # never reproduces this oracle vertex; the gap must be orders of magnitude.
+    assert inverted is None or inverted > 100 * correct, (
+        f"eta inversion did NOT diverge as expected (correct={correct}, inverted={inverted})")
+
+
+if __name__ == "__main__":
+    test_flat_triangle_matches_sphere_oracle()
+    test_superfluous_root_filter_removes_spurious()
+    test_eta_inversion_breaks_refraction_match()
+    print("pkg227 Phase 2b-flat oracle: all checks PASS")


### PR DESCRIPTION
## pkg227 Phase 2b-flat — deterministic mesh caustic (flat facets)

The mesh analogue of pkg127's exact sphere solver. Enumerates **every** admissible single refractive vertex on a flat triangle facet as the real roots of an **exact degree-4** "square form" polynomial — replacing the single-seed Newton mesh search (`runMeshSMSAttempt`) that finds at most one path per attempt and misses the caustic-fold branches.

Re-derived from Fan et al. 2024 (ACM TOG, CC BY 4.0); the `spoly` reference impl is unlicensed and was **not** copied. For a single flat vertex the coplanarity constraint is linear and the squared angularity is degree-4 — matching the paper's Table 2 flat-normal bound, and needing **none** of the rational √-fit / resultant machinery (that's for smooth normals / multi-bounce, Phases 2b-smooth / 2d).

### What landed
- `include/astroray/manifold/mesh_specular_poly.h` — `specpoly::solveFlatTriangleSpecular` (STL-free, reuses `specular_poly.h`'s `realRoots`/`polyMul`).
- `include/astroray/manifold/mesh_attempt.h` — `runMeshSMSAttemptPoly`, MNEE `chainGeometryTerm` weight (N=1, flat `dn=0`), mirroring `runSMSAttemptPoly`. Solves the quartic **only on the ≤4 seed-crossed candidate faces** (the un-pruned all-facets solve is O(pixels × triangles) and hangs — global pruning is Phase 2c).
- `plugins/integrators/spectral… sms_caustic_path_tracer.cpp` — gated behind `sms_specular_poly` (+ `spectral_newton=1`); **default off ⇒ Newton path byte-identical**.

### Gates
- `tests/test_pkg227_mesh_poly_unit.py` — numpy oracle vs `solveSphereSpecular` over an icosphere tessellation, **3/3**, CI (no build): < 1e-4 rad, superfluous-root filter, eta-convention lock.
- `tests/test_pkg227_mesh_caustic.py` — render-level, **4/4** (~7s): on a tessellated glass sphere the poly path validates ~100 % of enumerated solutions and collects **~100×** the caustic energy of the single-seed Newton path (which converges on ~0.1 % of attempts), banded.

### Notes
- **`glass-mesh-caustic` deliberately not blessed:** it's a FORWARD `light_tracer_caustic` scene using a gitignored 18 MB `Glass.obj` (local-only), so it doesn't exercise the camera-side poly path. 2b-flat is gated by a self-contained procedural-icosphere pytest instead (like the 2a raindrop gate). Left the forward showcase untouched.
- CPU-only, default-off ⇒ GPU output byte-identical (ABI angle cleared by cpp-abi-guard on the sibling 2a PR; same header family).

🤖 Generated with [Claude Code](https://claude.com/claude-code)