### PR TITLE
pkg227 Phase 2b-smooth: interpolated shading-normal mesh caustic

### DIFF
--- a/.astroray_plan/docs/pkg227-phase2b-smooth-research.md
+++ b/.astroray_plan/docs/pkg227-phase2b-smooth-research.md
@@ -1,0 +1,94 @@
+# pkg227 Phase 2b-smooth research note — interpolated shading normals
+
+Numpy-prototype de-risking pass for pkg227 Phase 2b-smooth (interpolated/smooth
+shading-normal support on the triangle specular solver). Same discipline as the
+2b-flat note: every claim checked numerically against the LANDED sphere solver
+(`solveSphereSpecular`) as the oracle. Prototype:
+`scratchpad/proto_mesh_smooth.py` (session scratchpad).
+
+---
+
+## The question
+
+The pkg227 spec (Finding 2) scopes 2b-smooth as its own phase because interpolated
+normals make the shading normal `n̂(u,v) = normalize(n0 + u·(n1-n0) + v·(n2-n0))`
+**nonlinear** in the barycentric coords, which (Fan §6) inflates the specular
+polynomial degree by ~2 and adds superfluous roots. The open question was whether
+Astroray must port that degree-inflated polynomial, or whether a cheaper
+realization suffices.
+
+**Tested realization:** (1) enumerate the specular *basins* with the FLAT
+degree-4 quartic (Phase 2b-flat, landed), then (2) **Newton-polish** each root on
+the flat facet plane using the true interpolated normal — the standard MNEE
+half-vector residual (Hanika 2015 / Cycles `mnee.h`), the exact machinery
+`manifold_chain.h::solveChain` already implements. Fan §6 itself recommends a
+one-step Newton polish after root-finding ("roots give the basin, Newton the
+digits").
+
+## Result — the polish reaches the oracle at COARSE tessellation
+
+Validated against the sphere oracle on an icosphere whose per-vertex normals are
+the analytic sphere normals (`n_i = normalize(vertex_i)`), so a smooth-shaded
+facet reproduces the true sphere normal field to first order. Angular error to the
+oracle vertex, **flat solver vs flat-seed+smooth-polish, at 6 subdivision levels**
+(≈ 20·4⁶ ≈ 80k-triangle-equivalent local resolution):
+
+| case | root | flat (6lvl) | smooth-polish (6lvl) | gain |
+|---|---|---|---|---|
+| refraction generic | 0 | MISS (no in-facet root) | 2.22e-06 | — |
+| refraction generic | 1 | 4.26e-02 | 1.12e-05 | ×3811 |
+| reflection Alhazen | 0 | 4.09e-02 | 2.11e-08 | ×1.9M |
+| reflection Alhazen | 1 | 3.07e-02 | 6.50e-08 | ×472k |
+| multi-branch | 0 | 9.62e-03 | 3.04e-06 | ×3169 |
+| multi-branch | 1 | 1.52e-03 | 1.45e-05 | ×105 |
+| SF11 dispersion | 0 | 5.20e-03 | 1.70e-06 | ×3066 |
+| SF11 dispersion | 1 | 2.88e-02 | 5.51e-06 | ×5226 |
+
+**All 8 roots reach the < 1e-4 rad gate with the smooth polish** (worst 1.45e-05,
+18× inside); the flat solver reaches it on NONE at this tessellation. The polish
+even RECOVERS the case where the flat quartic finds no in-facet root at all
+(refraction root0: seed the polish from the facet centroid).
+
+**Convergence order.** The interpolated normal deviates from the true (smooth)
+normal by O(edge²) at the facet centre, so the smooth-polished vertex converges
+**quadratically** in edge length — vs the flat solver's **linear** convergence
+(2b-flat note §2). This is exactly why smooth shading reaches the oracle at ~80k
+triangles where flat needs ~3e8, and the quantitative reason Cycles only shows
+caustics on smooth-shaded casters ([[cycles-caustics-need-smooth-shading]]).
+
+## Conclusion — no degree-inflated resultant needed for 2b-smooth
+
+2b-smooth is a **Newton-polish + smooth-partials wiring on top of 2b-flat**,
+reusing the existing MNEE residual/Jacobian machinery — NOT a port of the paper's
+higher-degree interpolated-normal polynomial. The flat quartic supplies the
+basins (superfluous-root filtering already correct), the smooth Newton supplies
+the digits, and `trianglePartialsSmooth` (already in `surface_partials.h`) supplies
+the analytic `dn_du/dn_dv` for both the polish Jacobian and the MNEE weight.
+
+## Implications for the C++ port
+
+- **`CausticTri` must carry per-vertex normals.** Today it is `{v0,v1,v2}` only;
+  smooth support needs `{n0,n1,n2}` too, and `gatherTriangleCasters` must pull
+  them from the `Triangle` (which already stores `setVertexNormals`). Fall back to
+  the flat facet normal when a caster has none (flat casters stay faceted — assert
+  the prism/flat references don't move).
+- **Polish location.** In `runMeshSMSAttemptPoly`, after `solveFlatTriangle
+  Specular` returns the candidate vertex, if the caster is smooth-shaded run a
+  short Newton polish (≤ ~8 iters) on the MNEE residual with the interpolated
+  normal, seeded from the flat root (or the facet centroid if the flat quartic
+  found none), staying on the facet plane. Feed the smooth `dn_du/dn_dv` into the
+  `ChainVertex` so `chainGeometryTerm` weights the smooth surface.
+- **Gate.** A smooth-shaded tessellated glass sphere should match the analytic
+  sphere-primitive poly caustic (`runSMSAttemptPoly`) far better than the flat
+  mesh does — the render-level twin of the table above. Flat casters unchanged.
+- **Damping.** The prototype clamps the (du,dv) Newton step to ±0.5 to stay in the
+  facet neighbourhood; the C++ polish should clamp similarly (cf. `solveChain`'s
+  `maxStep`). A polished vertex that leaves the facet (u,v bounds) is rejected —
+  the flat-facet in-triangle filter already does this.
+
+## Files produced this session
+
+- `scratchpad/proto_mesh_smooth.py` — the prototype (imports the 2b-flat
+  prototype's oracle + flat solver; adds the smooth normal, MNEE residual, Newton
+  polish, and the flat-vs-smooth drill-down comparison reproducing the table).
+- `.astroray_plan/docs/pkg227-phase2b-smooth-research.md` — this note.

--- a/.astroray_plan/packages/pkg227-general-specular-polynomials.md
+++ b/.astroray_plan/packages/pkg227-general-specular-polynomials.md
@@ -439,6 +439,19 @@ demand.
 - [ ] Phase 2c — triangle-tuple pruning subsystem (M-prune) — GATED on Open Decision #1.
 - [ ] Phase 2d — two-bounce mesh, supersede `runMeshSMSAttempt`.
 - [ ] Phase 3 — GPU / wavefront mirror; caustic parity RTX-verified.
+      **RE-SCOPED 2026-09-05 — greenfield, not a mirror.** The GPU wavefront path
+      has NO camera-side SMS/caustic stage (stages: intersect / shade_lambertian /
+      light_sample / RR / restir); `src/gpu/pkg64_sms_probe.cu` landed only the
+      caustic-caster flag round-trip and EXPLICITLY deferred the device SMS solve.
+      `specular_poly.h` being STL-free/portable is necessary but not sufficient:
+      there is no GPU SMS stage to mirror the solver INTO, and the spec's named
+      `tests/test_gpu_caustic_parity.py` does not exist. Phase 3 therefore requires
+      a NEW wavefront caustic stage (device caster gather + per-pixel sphere-chain
+      solve + NEE deposit) under the REG:254 shade-fleet budget
+      ([[wavefront-shade-kernels-register-saturated]]) — an XL package, not the
+      "M mirror" the spec estimated. Deferred as its own scoped package (aligns
+      with the wavefront-perf-ceiling + integration-first owner directives);
+      CPU Track S remains the research-grade path.
 
 ## Phase 2a findings (2026-09-04)
 

--- a/.astroray_plan/packages/pkg227-general-specular-polynomials.md
+++ b/.astroray_plan/packages/pkg227-general-specular-polynomials.md
@@ -424,7 +424,18 @@ demand.
       vs `solveSphereSpecular`, 3/3, CI, < 1e-4 rad) + `tests/test_pkg227_mesh_
       caustic.py` (render-level, 4/4). Branch `pkg227-s2b-flat`. See Phase 2b-flat
       findings below.
-- [ ] Phase 2b-smooth — interpolated shading-normal support (constraint + Jacobian).
+- [x] Phase 2b-smooth — interpolated shading-normal support (constraint + Jacobian).
+      **LANDED 2026-09-05.** `specpoly::polishSmoothVertex` + `mneeResidual2`
+      (`mesh_specular_poly.h`): a short Newton polish of the flat basin on the
+      MNEE half-vector residual with the interpolated normal — NO degree-inflated
+      polynomial needed (de-risked, see below). `CausticTri` carries per-vertex
+      normals (pulled in `gatherTriangleCasters`); `runMeshSMSAttemptPoly` polishes
+      + feeds smooth `dn_du/dn_dv` to `chainGeometryTerm`. Gates:
+      `tests/test_pkg227_mesh_smooth_unit.py` (numpy oracle, 2/2, CI: reaches the
+      oracle at coarse tessellation, beats flat by 10-1e6×) +
+      `tests/test_pkg227_mesh_smooth_caustic.py` (render, 4/4: smooth mesh caustic
+      NCC 0.86 vs analytic sphere, flat only 0.40). Branch `pkg227-s2b-smooth`.
+      See Phase 2b-smooth findings below.
 - [ ] Phase 2c — triangle-tuple pruning subsystem (M-prune) — GATED on Open Decision #1.
 - [ ] Phase 2d — two-bounce mesh, supersede `runMeshSMSAttempt`.
 - [ ] Phase 3 — GPU / wavefront mirror; caustic parity RTX-verified.
@@ -515,6 +526,43 @@ Parallel numpy prototype (`scratchpad/proto_mesh_specular.py`, research note
   so a finer mesh yields fewer per-pixel hits (measured attempts 267k→78k from
   subdiv 1→2) with a sharper but sparser caustic. Smooth-shaded curved casters
   are exactly Phase 2b-smooth's job; the multi-facet fold coverage is Phase 2c.
+
+## Phase 2b-smooth findings (2026-09-05)
+
+- **No degree-inflated polynomial needed.** The spec (Finding 2) anticipated
+  porting the paper's higher-degree interpolated-normal polynomial (Fan §6). The
+  de-risking prototype (`scratchpad/proto_mesh_smooth.py`,
+  `.astroray_plan/docs/pkg227-phase2b-smooth-research.md`) proved the cheaper
+  realization suffices: **enumerate basins with the landed flat degree-4 quartic,
+  then Newton-polish each on the standard MNEE half-vector residual with the
+  interpolated normal.** All 8 sphere-oracle roots reach < 1e-4 rad at 6
+  subdivision levels (~80k-tri-equiv), where the flat solver reaches NONE — gains
+  10× to 1.9M×. The polish reuses the existing manifold residual/Jacobian; the
+  smooth `dn_du/dn_dv` come from `surface_partials.h::trianglePartialsSmooth`.
+- **Convergence is quadratic (vs flat's linear).** The interpolated normal
+  deviates from the true smooth normal by O(edge²), so the polished vertex
+  converges quadratically in facet edge length — the quantitative reason smooth
+  casters reach the oracle at coarse tessellation and Cycles shows caustics only
+  on smooth-shaded casters ([[cycles-caustics-need-smooth-shading]]).
+- **Render-level: the smooth mesh caustic ≈ the analytic sphere caustic.** On a
+  subdiv-2 glass icosphere the smooth-shaded caustic correlates with the analytic
+  sphere-primitive poly caustic at **NCC 0.86**, vs the flat mesh's **0.40** — the
+  flat facets scatter the caustic into a triangular pattern, the smooth normals
+  recover the smooth focus (visually unmistakable). This is the Cycles-parity
+  intent of the phase, gated self-contained (procedural icosphere, no external
+  asset — `glass-mesh-caustic` remains the untouched forward showcase, per 2b-flat).
+- **Position stays on the flat facet; only the shading normal interpolates** —
+  matching Cycles' smooth shading (geometry faceted, normal smooth). The vertex
+  normal is oriented toward x0 and the smooth partials flip with it to keep the
+  MNEE Jacobian consistent. Flat casters (no per-vertex normals) are unchanged —
+  the flat gate still passes (`smooth=false` path byte-identical).
+
+## In-scope caustic-polynomial work remaining
+
+Per owner decisions (2026-09-04), **Phase 2c (M-prune, XL) and 2d (two-bounce
+mesh) are DEFERRED** — gated on a real multi-caster/high-poly scene demanding
+production-speed arbitrary-geometry caustics. The remaining in-scope phase is
+**Phase 3 (GPU / wavefront mirror of Track S — the exact sphere chain)**.
 
 ## Lessons
 

--- a/include/astroray/manifold/mesh_attempt.h
+++ b/include/astroray/manifold/mesh_attempt.h
@@ -43,7 +43,10 @@ inline const Material* gatherTriangleCasters(const Renderer& renderer,
         if (!tri) continue;
         const auto& m = tri->getMaterial();
         if (!m || !m->isTransmissive()) continue;
-        out.push_back(CausticTri{tri->getV0(), tri->getV1(), tri->getV2()});
+        CausticTri ct{tri->getV0(), tri->getV1(), tri->getV2()};
+        // pkg227 2b-smooth: carry per-vertex shading normals for smooth casters.
+        ct.smooth = tri->getVertexNormals(ct.n0, ct.n1, ct.n2);
+        out.push_back(ct);
         if (!mat) mat = m.get();
     }
     return mat;
@@ -224,19 +227,38 @@ inline SMSPolyResult runMeshSMSAttemptPoly(const Renderer& renderer,
 
     for (int ci = 0; ci < nCand; ++ci) {
         const CausticTri& tr = tris[cand[ci]];
-        specpoly::FlatTriSolution sols[4];
-        const int nsol = specpoly::solveFlatTriangleSpecular(
-            x0Rec.point, ls.position, tr.v0, tr.v1, tr.v2, eta,
-            /*refraction=*/true, sols, 4);
-        if (nsol <= 0) continue;   // -1 degenerate / 0 no in-facet root
-        R.nSolutions += nsol;
-
         const Vec3 e1v = tr.v1 - tr.v0;
         const Vec3 e2v = tr.v2 - tr.v0;
 
+        specpoly::FlatTriSolution sols[4];
+        int nsol = specpoly::solveFlatTriangleSpecular(
+            x0Rec.point, ls.position, tr.v0, tr.v1, tr.v2, eta,
+            /*refraction=*/true, sols, 4);
+        if (nsol < 0) continue;   // degenerate facet
+        if (nsol == 0) {
+            // pkg227 2b-smooth: the flat quartic can miss the in-facet root at
+            // coarse tessellation while the SMOOTH vertex is on this facet; seed
+            // the smooth polish from the centroid. (No flat solution => skip.)
+            if (!tr.smooth) continue;
+            sols[0].p = (tr.v0 + tr.v1 + tr.v2) * (1.0f / 3.0f);
+            sols[0].n = e1v.cross(e2v).normalized();
+            nsol = 1;
+        }
+        R.nSolutions += nsol;
+
         for (int i = 0; i < nsol; ++i) {
-            const Vec3 x1 = sols[i].p;
-            const Vec3 nEntry = sols[i].n;
+            Vec3 x1 = sols[i].p;
+            Vec3 nEntry = sols[i].n;
+            Vec3 dnDu(0.0f), dnDv(0.0f);   // flat facet => zero shading-normal partials
+            // pkg227 2b-smooth: polish the flat basin to the interpolated-normal
+            // solution and take the smooth unit-normal partials for the weight.
+            if (tr.smooth) {
+                Vec3 sp, sn, sdu, sdv;
+                if (!specpoly::polishSmoothVertex(sols[i].p, tr, x0Rec.point,
+                                                  ls.position, eta, sp, sn, sdu, sdv))
+                    continue;
+                x1 = sp; nEntry = sn; dnDu = sdu; dnDv = sdv;
+            }
 
             const Vec3 dirToX1 = x1 - x0Rec.point;
             const float distX0X1_2 = dirToX1.length2();
@@ -250,11 +272,14 @@ inline SMSPolyResult runMeshSMSAttemptPoly(const Renderer& renderer,
                 continue;
             if (!(vrec.hitObject && vrec.hitObject->isCausticCaster())) continue;
 
-            // Orient the facet normal toward x0 (a facet has no innate side).
+            // Orient the normal toward x0. A flat facet has no innate side; the
+            // smooth interpolated normal does, but the receiver-side convention is
+            // the same (cosI > 0). Flip the shading-normal partials with it so the
+            // MNEE Jacobian stays consistent with the oriented normal.
             Vec3 nOr = nEntry;
             const Vec3 wi_in = -wi_x0;
             float cosI = -wi_in.dot(nOr);
-            if (cosI < 0.0f) { nOr = nOr * -1.0f; cosI = -cosI; }
+            if (cosI < 0.0f) { nOr = nOr * -1.0f; cosI = -cosI; dnDu = dnDu * -1.0f; dnDv = dnDv * -1.0f; }
             if (cosI <= 1e-6f) continue;
             const float sin2T = eta * eta * std::max(0.0f, 1.0f - cosI * cosI);
             if (sin2T >= 1.0f) continue;  // TIR
@@ -282,14 +307,15 @@ inline SMSPolyResult runMeshSMSAttemptPoly(const Renderer& renderer,
             const astroray::SampledSpectrum fSpec =
                 x0Rec.material->evalSpectral(x0Rec, wo_eye, wi_x0, lambdas);
 
-            // MNEE generalized-geometry weight, N=1 flat vertex: surface tangents
-            // are the triangle edges, dn=0 (flat facet — trianglePartials
-            // convention). No extra receiver cosine (evalSpectral carries it); no
-            // 2.0 clamp (as runSMSAttemptPoly).
+            // MNEE generalized-geometry weight, N=1 vertex: surface tangents are
+            // the triangle edges; the shading-normal partials are 0 for a flat
+            // facet (trianglePartials) and the interpolated dn_du/dn_dv for a
+            // smooth caster (2b-smooth). No extra receiver cosine (evalSpectral
+            // carries it); no 2.0 clamp (as runSMSAttemptPoly).
             ChainVertex cv;
             cv.p = x1;  cv.n = nOr;
             cv.dp_du = e1v;  cv.dp_dv = e2v;
-            cv.dn_du = Vec3(0.0f);  cv.dn_dv = Vec3(0.0f);
+            cv.dn_du = dnDu;  cv.dn_dv = dnDv;
             cv.eta = iorHero;
             const Vec3 sunDir = dirLight;
             const float dw0_dx1 =

--- a/include/astroray/manifold/mesh_caustic.h
+++ b/include/astroray/manifold/mesh_caustic.h
@@ -22,6 +22,10 @@ namespace astroray::manifold {
 // A flat caustic-caster triangle (geometric normal derived from the winding).
 struct CausticTri {
     Vec3 v0, v1, v2;
+    // pkg227 2b-smooth: per-vertex shading normals (populated from the caster
+    // Triangle when it is smooth-shaded). `smooth` false => flat facet (dn=0).
+    Vec3 n0, n1, n2;
+    bool smooth = false;
 };
 
 // Möller-Trumbore ray-triangle intersection. Returns the front/back hit

--- a/include/astroray/manifold/mesh_specular_poly.h
+++ b/include/astroray/manifold/mesh_specular_poly.h
@@ -60,6 +60,7 @@
 
 #include "../../raytracer.h"
 #include "specular_poly.h"   // realRoots, polyMul (degree-4 subset of degree-6)
+#include "mesh_caustic.h"    // CausticTri (per-vertex normals for the smooth polish)
 #include <cmath>
 
 namespace astroray::manifold {
@@ -209,6 +210,106 @@ inline int solveFlatTriangleSpecular(const Vec3& x0, const Vec3& x2,
         ++n;
     }
     return n;
+}
+
+// ---------------------------------------------------------------------------
+// pkg227 Phase 2b-smooth — interpolated (smooth) shading-normal support.
+//
+// The flat solver above enumerates the specular BASINS (position on the facet).
+// For a smooth-shaded caster the SHADING normal is the interpolated
+//   n̂(u,v) = normalize(n0*(1-u-v) + n1*u + n2*v),
+// nonlinear in (u,v) — porting the paper's degree-inflated interpolated-normal
+// polynomial (Fan §6) is unnecessary: a short Newton polish of the flat root on
+// the standard MNEE half-vector residual (Hanika 2015 / Cycles mnee.h) reaches
+// the smooth solution. The interpolated normal deviates from the true smooth
+// normal by O(edge^2), so the polished vertex converges QUADRATICALLY in facet
+// edge length (vs the flat solver's linear) — reaching the sphere oracle at
+// ~80k triangles where flat needs ~3e8 (proven in
+// scratchpad/proto_mesh_smooth.py; note pkg227-phase2b-smooth-research.md). The
+// vertex POSITION stays on the flat facet (faceted geometry, interpolated
+// shading normal) — matching Cycles' smooth shading.
+// ---------------------------------------------------------------------------
+
+// MNEE half-vector residual (2 tangential components) at facet point p with
+// shading normal nhat: h = d1 + eta*d2 (d1 toward x0, d2 toward x2), the residual
+// is the part of h perpendicular to nhat, expressed in an nhat-orthonormal frame.
+// Zero exactly on a specular vertex (h || nhat).
+inline void mneeResidual2(const Vec3& p, const Vec3& x0, const Vec3& x2,
+                          const Vec3& nhat, float eta, float& r0, float& r1) {
+    const Vec3 d1 = (x0 - p).normalized();
+    const Vec3 d2 = (x2 - p).normalized();
+    const Vec3 h = d1 + d2 * eta;
+    const Vec3 ht = h - nhat * h.dot(nhat);
+    const Vec3 a = (std::fabs(nhat.x) < 0.9f) ? Vec3(1.0f, 0.0f, 0.0f)
+                                              : Vec3(0.0f, 1.0f, 0.0f);
+    const Vec3 t1 = (a - nhat * a.dot(nhat)).normalized();
+    const Vec3 t2 = nhat.cross(t1);
+    r0 = ht.dot(t1);
+    r1 = ht.dot(t2);
+}
+
+// Newton-polish a flat-facet specular seed vertex to the SMOOTH (interpolated-
+// normal) solution, staying on the facet plane. On convergence fills outP (the
+// polished vertex), outN (the interpolated unit shading normal there), and
+// outDnDu/outDnDv (the smooth unit-normal partials for the MNEE weight, matching
+// surface_partials.h::trianglePartialsSmooth). Returns false if it does not
+// converge or the vertex leaves the facet. `seedP` is the flat root (or the facet
+// centroid when the flat quartic found none).
+inline bool polishSmoothVertex(const Vec3& seedP, const CausticTri& tr,
+                               const Vec3& x0, const Vec3& x2, float eta,
+                               Vec3& outP, Vec3& outN, Vec3& outDnDu, Vec3& outDnDv,
+                               int iters = 8) {
+    const Vec3 e1 = tr.v1 - tr.v0;
+    const Vec3 e2 = tr.v2 - tr.v0;
+    const float d11 = e1.dot(e1), d12 = e1.dot(e2), d22 = e2.dot(e2);
+    const float den = d11 * d22 - d12 * d12;
+    if (std::fabs(den) < 1e-20f) return false;
+    const Vec3 vp = seedP - tr.v0;
+    float u = (d22 * vp.dot(e1) - d12 * vp.dot(e2)) / den;
+    float v = (d11 * vp.dot(e2) - d12 * vp.dot(e1)) / den;
+
+    for (int it = 0; it < iters; ++it) {
+        const Vec3 p = tr.v0 + e1 * u + e2 * v;
+        const Vec3 nhat = (tr.n0 * (1.0f - u - v) + tr.n1 * u + tr.n2 * v).normalized();
+        float r0, r1;
+        mneeResidual2(p, x0, x2, nhat, eta, r0, r1);
+        if (r0 * r0 + r1 * r1 < 1e-20f) break;
+        const float hs = 1e-5f;
+        const Vec3 pu = tr.v0 + e1 * (u + hs) + e2 * v;
+        const Vec3 nu = (tr.n0 * (1.0f - (u + hs) - v) + tr.n1 * (u + hs) + tr.n2 * v).normalized();
+        float ru0, ru1; mneeResidual2(pu, x0, x2, nu, eta, ru0, ru1);
+        const Vec3 pv = tr.v0 + e1 * u + e2 * (v + hs);
+        const Vec3 nv = (tr.n0 * (1.0f - u - (v + hs)) + tr.n1 * u + tr.n2 * (v + hs)).normalized();
+        float rv0, rv1; mneeResidual2(pv, x0, x2, nv, eta, rv0, rv1);
+        const float j00 = (ru0 - r0) / hs, j01 = (rv0 - r0) / hs;
+        const float j10 = (ru1 - r1) / hs, j11 = (rv1 - r1) / hs;
+        const float jdet = j00 * j11 - j01 * j10;
+        if (std::fabs(jdet) < 1e-20f) break;
+        float du = (-r0 * j11 + r1 * j01) / jdet;   // solve J*(du,dv) = -(r0,r1)
+        float dv = (r0 * j10 - r1 * j00) / jdet;
+        du = du < -0.5f ? -0.5f : (du > 0.5f ? 0.5f : du);   // damp to the facet nbhd
+        dv = dv < -0.5f ? -0.5f : (dv > 0.5f ? 0.5f : dv);
+        u += du; v += dv;
+    }
+
+    const Vec3 p = tr.v0 + e1 * u + e2 * v;
+    const Vec3 ni = tr.n0 * (1.0f - u - v) + tr.n1 * u + tr.n2 * v;
+    const float len = std::sqrt(ni.length2());
+    if (len < 1e-12f) return false;
+    const Vec3 nhat = ni * (1.0f / len);
+    float r0, r1;
+    mneeResidual2(p, x0, x2, nhat, eta, r0, r1);
+    if (r0 * r0 + r1 * r1 > 1e-12f) return false;                       // not converged
+    if (u < -1e-4f || v < -1e-4f || (u + v) > 1.0f + 1e-4f) return false;  // left facet
+
+    outP = p;
+    outN = nhat;
+    const float invLen = 1.0f / len;
+    const Vec3 dni_du = tr.n1 - tr.n0;
+    const Vec3 dni_dv = tr.n2 - tr.n0;
+    outDnDu = (dni_du - nhat * nhat.dot(dni_du)) * invLen;
+    outDnDv = (dni_dv - nhat * nhat.dot(dni_dv)) * invLen;
+    return true;
 }
 
 }  // namespace specpoly

--- a/tests/test_pkg227_mesh_smooth_caustic.py
+++ b/tests/test_pkg227_mesh_smooth_caustic.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python
+"""pkg227 Phase 2b-smooth render gate — interpolated shading normals bring the
+tessellated-mesh caustic into structural agreement with the ANALYTIC sphere
+caustic, where the flat-facet mesh is faceted and structurally wrong.
+
+Three seed-pinned renders (camera-side SMS poly, spectral_newton=1,
+sms_specular_poly=1), same glass/light/camera:
+  A) analytic sphere primitive (add_sphere)          -> runSMSAttemptPoly (oracle)
+  F) FLAT tessellated glass icosphere (no normals)   -> runMeshSMSAttemptPoly flat
+  S) SMOOTH icosphere (per-vertex sphere normals)    -> flat basin + smooth polish
+
+The caustic on the floor is compared to the analytic reference by normalized
+cross-correlation (NCC) over the floor ROI. Smooth shading recovers the smooth-
+sphere caustic (high NCC); the flat facets scatter it into a triangular pattern
+(low NCC). Self-contained (procedural icosphere, no external asset). The solver
+math is proven separately at < 1e-4 rad vs the sphere oracle (see
+scratchpad/proto_mesh_smooth.py / pkg227-phase2b-smooth-research.md).
+
+Measured (subdiv 2, 256 spp, seed 17): NCC(smooth) ~0.86, NCC(flat) ~0.40.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+import pytest
+from runtime_setup import configure_test_imports
+
+configure_test_imports()
+sys.path.insert(0, os.path.dirname(__file__))
+
+try:
+    import astroray
+    AVAILABLE = True
+except ImportError:
+    AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not AVAILABLE, reason="astroray not built")
+
+WIDTH, HEIGHT, SAMPLES, MAX_DEPTH, SEED = 320, 220, 256, 10, 17
+CENTER = np.array([0.0, -0.35, 0.15])
+RADIUS = 0.72
+SUBDIV = 2
+
+
+def _unit(v):
+    return v / np.linalg.norm(v)
+
+
+def _icosphere(subdiv):
+    t = (1.0 + np.sqrt(5.0)) / 2.0
+    verts = [_unit(v) for v in np.array([
+        [-1, t, 0], [1, t, 0], [-1, -t, 0], [1, -t, 0], [0, -1, t], [0, 1, t],
+        [0, -1, -t], [0, 1, -t], [t, 0, -1], [t, 0, 1], [-t, 0, -1], [-t, 0, 1]], float)]
+    faces = [(0, 11, 5), (0, 5, 1), (0, 1, 7), (0, 7, 10), (0, 10, 11), (1, 5, 9),
+             (5, 11, 4), (11, 10, 2), (10, 7, 6), (7, 1, 8), (3, 9, 4), (3, 4, 2),
+             (3, 2, 6), (3, 6, 8), (3, 8, 9), (4, 9, 5), (2, 4, 11), (6, 2, 10),
+             (8, 6, 7), (9, 8, 1)]
+    cache = {}
+
+    def mid(i, j):
+        key = (min(i, j), max(i, j))
+        if key not in cache:
+            verts.append(_unit((verts[i] + verts[j]) * 0.5))
+            cache[key] = len(verts) - 1
+        return cache[key]
+
+    for _ in range(subdiv):
+        nf = []
+        for a, b, c in faces:
+            ab, bc, ca = mid(a, b), mid(b, c), mid(c, a)
+            nf += [(a, ab, ca), (ab, b, bc), (ca, bc, c), (ab, bc, ca)]
+        faces = nf
+    return np.array(verts), np.array(faces, int)
+
+
+def _base(r):
+    r.set_background_color([0.02, 0.025, 0.03])
+    floor = r.create_material("lambertian", [0.72, 0.72, 0.68], {})
+    r.add_triangle([-2.4, -1.2, -2.2], [2.4, -1.2, -2.2], [2.4, -1.2, 1.6], floor)
+    r.add_triangle([-2.4, -1.2, -2.2], [2.4, -1.2, 1.6], [-2.4, -1.2, 1.6], floor)
+    light = r.create_material("light", [1.0, 0.97, 0.90], {"intensity": 12.0})
+    r.add_sphere([0.0, 1.55, 1.0], 0.22, light)
+    return r.create_material("dielectric", [1.0, 1.0, 1.0], {"ior": 1.52})
+
+
+def _cam_int(r):
+    r.set_integrator("sms_caustic_path_tracer")
+    r.set_integrator_param("max_depth", MAX_DEPTH)
+    r.set_integrator_param("caustic_chain_iters", 3)
+    r.set_integrator_param("spectral_newton", 1)
+    r.set_integrator_param("sms_specular_poly", 1)
+    r.setup_camera([0.0, 1.2, 3.4], [0.0, -0.8, 0.0], [0.0, 1.0, 0.0],
+                   38.0, WIDTH / HEIGHT, 0.0, 3.6, WIDTH, HEIGHT)
+
+
+def _scene_analytic():
+    r = astroray.Renderer()
+    glass = _base(r)
+    r.add_sphere([float(x) for x in CENTER], RADIUS, glass)
+    _cam_int(r)
+    return r
+
+
+def _scene_mesh(smooth: bool):
+    r = astroray.Renderer()
+    glass = _base(r)
+    V, F = _icosphere(SUBDIV)
+    Vw = V * RADIUS + CENTER
+    for (i0, i1, i2) in F:
+        idx = r.scene_object_count()
+        if smooth:
+            r.add_triangle([float(x) for x in Vw[i0]], [float(x) for x in Vw[i1]],
+                           [float(x) for x in Vw[i2]], glass, [], [], [],
+                           [float(x) for x in V[i0]], [float(x) for x in V[i1]],
+                           [float(x) for x in V[i2]])   # outward sphere normals
+        else:
+            r.add_triangle([float(x) for x in Vw[i0]], [float(x) for x in Vw[i1]],
+                           [float(x) for x in Vw[i2]], glass)
+        r.set_object_caustic_caster(idx, True)
+    _cam_int(r)
+    return r
+
+
+def _render(r):
+    r.set_seed(SEED)
+    pix = np.asarray(r.render(SAMPLES, MAX_DEPTH, None, False), dtype=np.float32)
+    if pix.ndim == 1:
+        pix = pix.reshape(HEIGHT, WIDTH, 3)
+    return pix, r.get_integrator_stats()
+
+
+def _lum(a):
+    return 0.2126 * a[..., 0] + 0.7152 * a[..., 1] + 0.0722 * a[..., 2]
+
+
+def _ncc(x, y):
+    x = x - x.mean()
+    y = y - y.mean()
+    d = np.sqrt((x * x).sum() * (y * y).sum())
+    return float((x * y).sum() / d) if d > 1e-12 else 0.0
+
+
+@pytest.fixture(scope="module")
+def _tri():
+    a, _sa = _render(_scene_analytic())
+    f, _sf = _render(_scene_mesh(False))
+    s, s_s = _render(_scene_mesh(True))
+    roi = (slice(int(HEIGHT * 0.55), HEIGHT), slice(0, WIDTH))
+    la, lf, ls_ = _lum(a)[roi], _lum(f)[roi], _lum(s)[roi]
+    return {
+        "ncc_flat": _ncc(lf, la),
+        "ncc_smooth": _ncc(ls_, la),
+        "e_smooth": s_s.get("sms_energy", 0),
+        "conv_smooth": s_s.get("sms_converged", 0),
+    }
+
+
+def test_smooth_fires(_tri):
+    assert _tri["conv_smooth"] > 1000, f"smooth path barely fired ({_tri['conv_smooth']})"
+    assert _tri["e_smooth"] > 3.0, f"smooth caustic energy too low ({_tri['e_smooth']:.3f})"
+
+
+def test_smooth_matches_analytic(_tri):
+    # The smooth mesh caustic structurally matches the analytic sphere caustic.
+    assert _tri["ncc_smooth"] > 0.65, (
+        f"smooth caustic not aligned with analytic (NCC {_tri['ncc_smooth']:.3f})")
+
+
+def test_smooth_beats_flat(_tri):
+    # Interpolated normals decisively out-correlate the faceted flat caustic.
+    assert _tri["ncc_smooth"] > _tri["ncc_flat"] + 0.15, (
+        f"smooth NCC {_tri['ncc_smooth']:.3f} not decisively above flat "
+        f"NCC {_tri['ncc_flat']:.3f}")
+
+
+def test_flat_is_faceted(_tri):
+    # Guard: the flat baseline really is structurally worse (a faceted caustic),
+    # so the smooth win is meaningful, not a trivially-passing comparison.
+    assert _tri["ncc_flat"] < 0.6, (
+        f"flat caustic unexpectedly well-aligned (NCC {_tri['ncc_flat']:.3f}) — "
+        f"the smooth/flat contrast is the whole point of 2b-smooth")
+
+
+if __name__ == "__main__":
+    import time
+    t0 = time.time()
+    a, _ = _render(_scene_analytic())
+    f, _ = _render(_scene_mesh(False))
+    s, _ = _render(_scene_mesh(True))
+    roi = (slice(int(HEIGHT * 0.55), HEIGHT), slice(0, WIDTH))
+    la, lf, ls_ = _lum(a)[roi], _lum(f)[roi], _lum(s)[roi]
+    print(f"[{time.time()-t0:.1f}s] NCC flat={_ncc(lf, la):.4f} smooth={_ncc(ls_, la):.4f}")

--- a/tests/test_pkg227_mesh_smooth_unit.py
+++ b/tests/test_pkg227_mesh_smooth_unit.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python
+"""pkg227 Phase 2b-smooth solver oracle — the flat-basin + smooth-normal Newton
+polish reaches the analytic sphere oracle at COARSE tessellation, where the flat
+solver (linear convergence) cannot.
+
+Pure-numpy, CI-runnable (no build). This is the algorithm-level gate for the
+smooth polish in include/astroray/manifold/mesh_specular_poly.h
+(polishSmoothVertex / mneeResidual2), a line-for-line port of the polish below.
+Reuses the flat unit test's sphere oracle + flat solver + icosphere. Full
+de-risking in .astroray_plan/docs/pkg227-phase2b-smooth-research.md /
+scratchpad/proto_mesh_smooth.py.
+
+Asserts:
+  1. ORACLE MATCH (coarse): at 6 subdivision levels the smooth-polished vertex
+     reaches every analytic-sphere root to < 1e-4 rad (the pkg227 gate) — the
+     flat solver reaches NONE at this tessellation.
+  2. SMOOTH BEATS FLAT: the smooth polish is orders of magnitude closer to the
+     oracle than the flat solver at the same coarse level.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(__file__))
+from test_pkg227_mesh_poly_unit import (
+    CASES,
+    _icosphere,
+    _unit,
+    flat_triangle_specular,
+    sphere_oracle_vertices,
+)
+
+CENTER, RADIUS = np.zeros(3), 1.0
+
+
+def _smooth_normal(u, v, n0, n1, n2):
+    return _unit(n0 * (1.0 - u - v) + n1 * u + n2 * v)
+
+
+def _bary(p, P0, P1, P2):
+    e1, e2 = P1 - P0, P2 - P0
+    d11, d12, d22 = e1 @ e1, e1 @ e2, e2 @ e2
+    den = d11 * d22 - d12 * d12
+    vp = p - P0
+    u = (d22 * (vp @ e1) - d12 * (vp @ e2)) / den
+    v = (d11 * (vp @ e2) - d12 * (vp @ e1)) / den
+    return u, v
+
+
+def _mnee_residual(p, x0, x2, nhat, eta):
+    d1 = _unit(x0 - p)
+    d2 = _unit(x2 - p)
+    h = d1 + eta * d2
+    ht = h - nhat * (h @ nhat)
+    a = np.array([1.0, 0.0, 0.0]) if abs(nhat[0]) < 0.9 else np.array([0.0, 1.0, 0.0])
+    t1 = _unit(a - nhat * (a @ nhat))
+    t2 = np.cross(nhat, t1)
+    return np.array([ht @ t1, ht @ t2])
+
+
+def _smooth_polish(seed_p, P0, P1, P2, n0, n1, n2, x0, x2, eta, iters=8):
+    e1, e2 = P1 - P0, P2 - P0
+    u, v = _bary(seed_p, P0, P1, P2)
+    for _ in range(iters):
+        p = P0 + u * e1 + v * e2
+        nhat = _smooth_normal(u, v, n0, n1, n2)
+        r0 = _mnee_residual(p, x0, x2, nhat, eta)
+        if r0 @ r0 < 1e-20:
+            break
+        h = 1e-5
+        ru = _mnee_residual(P0 + (u + h) * e1 + v * e2, x0, x2,
+                            _smooth_normal(u + h, v, n0, n1, n2), eta)
+        rv = _mnee_residual(P0 + u * e1 + (v + h) * e2, x0, x2,
+                            _smooth_normal(u, v + h, n0, n1, n2), eta)
+        J = np.column_stack([(ru - r0) / h, (rv - r0) / h])
+        try:
+            duv = np.clip(np.linalg.solve(J, -r0), -0.5, 0.5)
+        except np.linalg.LinAlgError:
+            break
+        u += duv[0]
+        v += duv[1]
+    p = P0 + u * e1 + v * e2
+    nhat = _smooth_normal(u, v, n0, n1, n2)
+    conv = (_mnee_residual(p, x0, x2, nhat, eta) @ _mnee_residual(p, x0, x2, nhat, eta)) < 1e-12
+    inside = (-1e-4 <= u) and (-1e-4 <= v) and (u + v <= 1 + 1e-4)
+    return p, (conv and inside)
+
+
+def _ang_err(p, op, center):
+    return float(np.arccos(np.clip(_unit(p - center) @ _unit(op - center), -1, 1)))
+
+
+def _drill(x0, x2, eta, op, levels=6, beam=6, smooth=True):
+    V, F = _icosphere(1)
+    fc = V[F].mean(axis=1)
+    tris = [tuple(V[F[fi]]) for fi in np.argsort(np.linalg.norm(fc - op, axis=1))[:beam]]
+    best = None
+    for _ in range(levels):
+        for (P0, P1, P2) in tris:
+            if smooth:
+                n0, n1, n2 = _unit(P0), _unit(P1), _unit(P2)
+                seed = (P0 + P1 + P2) / 3.0
+                p, ok = _smooth_polish(seed, P0, P1, P2, n0, n1, n2, x0, x2, eta)
+                if ok:
+                    e = _ang_err(p, op, CENTER)
+                    best = e if best is None else min(best, e)
+            else:
+                for s in flat_triangle_specular(x0, x2, P0, P1, P2, eta):
+                    e = _ang_err(s['position'], op, CENTER)
+                    best = e if best is None else min(best, e)
+        nt = []
+        for (P0, P1, P2) in tris:
+            ab, bc, ca = _unit((P0 + P1) / 2), _unit((P1 + P2) / 2), _unit((P2 + P0) / 2)
+            nt += [(P0, ab, ca), (ab, P1, bc), (ca, bc, P2), (ab, bc, ca)]
+        cens = np.array([_unit(sum(t) / 3) for t in nt])
+        tris = [nt[i] for i in np.argsort(np.linalg.norm(cens - op, axis=1))[:beam]]
+    return best
+
+
+def test_smooth_polish_reaches_oracle_coarse():
+    worst = 0.0
+    matched = 0
+    for _label, x0, x2, eta in CASES:
+        for op in sphere_oracle_vertices(x0, x2, CENTER, RADIUS, eta):
+            err = _drill(x0, x2, eta, op, smooth=True)
+            assert err is not None, f"[{_label}] smooth polish found no vertex near oracle"
+            assert err < 1e-4, f"[{_label}] smooth err {err:.3e} exceeds 1e-4 gate"
+            worst = max(worst, err)
+            matched += 1
+    assert matched >= 8
+    assert worst < 1e-4
+
+
+def test_smooth_beats_flat_at_coarse_tessellation():
+    for _label, x0, x2, eta in CASES:
+        for op in sphere_oracle_vertices(x0, x2, CENTER, RADIUS, eta):
+            smooth = _drill(x0, x2, eta, op, smooth=True)
+            flat = _drill(x0, x2, eta, op, smooth=False)
+            # smooth reaches the gate; flat is far above it (or misses entirely).
+            assert smooth is not None and smooth < 1e-4
+            assert flat is None or flat > 10.0 * smooth, (
+                f"[{_label}] smooth={smooth:.2e} did not decisively beat flat={flat}")
+
+
+if __name__ == "__main__":
+    test_smooth_polish_reaches_oracle_coarse()
+    test_smooth_beats_flat_at_coarse_tessellation()
+    print("pkg227 Phase 2b-smooth oracle: all checks PASS")


### PR DESCRIPTION
## pkg227 Phase 2b-smooth — smooth shading normals

**Stacked on #689 (2b-flat)** — review after that merges; base will retarget to `main`.

Smooth-shaded curved casters now produce the smooth-sphere caustic instead of a faceted one. Rather than porting the paper's degree-inflated interpolated-normal polynomial (Fan §6), this **enumerates the specular basins with the landed flat degree-4 quartic, then Newton-polishes each on the standard MNEE half-vector residual with the interpolated normal** (Hanika 2015 / Cycles `mnee.h`).

De-risked against the sphere oracle before any C++ (`scratchpad/proto_mesh_smooth.py`, research note committed): all 8 oracle roots reach < 1e-4 rad at ~80k-triangle tessellation — **quadratic** convergence in edge length — where the flat solver (linear) reaches none.

### What landed
- `mesh_specular_poly.h` — `mneeResidual2` + `polishSmoothVertex` (STL-free): polish the flat seed to the interpolated-normal solution on the facet plane, returning the smooth unit-normal partials.
- `mesh_caustic.h` — `CausticTri` carries per-vertex normals + a `smooth` flag.
- `mesh_attempt.h` — `gatherTriangleCasters` pulls vertex normals; `runMeshSMSAttemptPoly` polishes smooth casters (centroid-seeded when the flat quartic misses the in-facet root at coarse tessellation) and feeds smooth `dn_du/dn_dv` to `chainGeometryTerm`. **Flat casters unchanged.**

### Gates
- `tests/test_pkg227_mesh_smooth_unit.py` — numpy oracle, **2/2**, CI: the polish reaches every sphere-oracle root < 1e-4 rad at 6 subdivision levels, beating the flat solver by 10×–1e6×.
- `tests/test_pkg227_mesh_smooth_caustic.py` — render, **4/4**: the smooth mesh caustic correlates with the analytic sphere caustic at **NCC 0.86** vs the flat mesh's **0.40** (the flat facets scatter it into a triangular pattern; smooth normals recover the focus).

### Safety
- Position stays on the flat facet; only the shading normal interpolates (matches Cycles). CPU-only, gated behind `sms_specular_poly` + `spectral_newton`; flat/default paths unchanged (the flat gate still passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)