### PR TITLE
pkg230-P1: op-VM Clamp opcode + Math/Mix clamp flags

### DIFF
--- a/.astroray_plan/packages/pkg230-opvm-utility-opcodes.md
+++ b/.astroray_plan/packages/pkg230-opvm-utility-opcodes.md
@@ -129,12 +129,13 @@ flag, addon setting it per node (legacy always; modern per `clamp_factor`).
       `tests/test_pkg230_opvm_clamp.py` **7/7** (incl. MINMAX-vs-RANGE Cycles-parity
       — caught & fixed a `svm_clampf` divergence for min>max), and **38/38** pkg219
       op-VM regression (incl. GPU parity renders) green — no regression.
-- [~] Phase 1 — GPU: CUDA rebuilt; GPU op-VM path exercised green by the pkg219c/d
-      parity renders. `<HasProgram=false>` fleet kernel is byte-identical **by
-      construction** (the VM is instantiated only inside `if constexpr (HasProgram)`;
-      OP_CLAMP is uploaded verbatim by the unchanged program path). Remaining for
-      HW-verify: a clamp-specific RTX CPU/GPU render + a confirmatory `cuobjdump`
-      register probe on `stageShadeBucketedKernel<0,…>`.
+- [x] Phase 1 — GPU HW-verified on RTX 5070 Ti (2026-09-05):
+      `tests/test_pkg230_gpu_clamp_parity.py` **3/3** (GPU OP_CLAMP changes the image
+      + matches CPU mean-ratio). `cuobjdump --dump-resource-usage` on the built
+      `.pyd`: `stageShadeBucketedKernel` **REG:254 across all 128 shade
+      specializations** — no spill; the fleet `<0,…>` is REG:254/STACK:3400/
+      CONSTANT[0]:1748 (STACK/CONST are current-main baseline; the VM rides
+      `<HasProgram=true>`, so the fleet `<false>` path is untouched by construction).
 - [ ] Phase 2 — Vector Math / Vector Rotate op-VM opcodes (color-chain) + faithful
       Mix `clamp_factor=OFF`, fork resolved.
 

--- a/.astroray_plan/packages/pkg230-opvm-utility-opcodes.md
+++ b/.astroray_plan/packages/pkg230-opvm-utility-opcodes.md
@@ -1,0 +1,143 @@
+# pkg230 — op-VM utility opcodes (Clamp + Math/Mix clamp flags; Vector Math/Rotate)
+
+**Pillar:** 5 (Blender integration / shader-node coverage)
+**Track:** A
+**Status:** Phase 1 IN PROGRESS 2026-09-05 (branch `pkg230-opvm-utility-cluster`);
+Phase 2 SCOPED (fork documented, not started)
+**Estimated effort:** Phase 1 S (~1 session); Phase 2 M
+**Depends on:** pkg219a/b/c (op-VM evaluator), pkg229 (re-audit that ranked these)
+
+---
+
+## Goal
+
+The pkg229 re-audit's #3/#4 next-wave items are the highest-ROI remaining
+DROPPED-SILENT shader features: the **Clamp** node and the **Math/Mix clamp
+flags** — all ★★★ frequency, all pure per-texel color/scalar ops that the op-VM
+already has the machinery for. This package closes them (Phase 1) and scopes the
+adjacent #2/#7 **Vector Math / Vector Rotate** items (Phase 2), which turn out to
+carry a real architecture fork the re-audit's one-liner did not surface.
+
+**After Phase 1:** a Blender graph with a Clamp node, or a Math/Mix node with its
+clamp checkbox(es) enabled, downstream of a texture renders per-texel-correct on
+both CPU and GPU (previously the node was dropped / the flag ignored).
+
+---
+
+## Context
+
+The op-VM (`include/astroray/shader_vm.h`) is a bounded register machine with a
+single shared `HD svm_eval` used by **both** the CPU (`DisneyPlugin::substituted`)
+and the GPU (behind the isolated `<HasProgram=true>` shade specialization). The
+register file is `GVec3[VM_MAX_SLOTS]`, so vectors are already first-class, and
+`Instr` carries 5 source slots (`a..e`) + one `imm` byte. Adding opcodes touches
+only the `<true>` specialization — **the REG:254 fleet `<false>` kernel compiles
+the VM out and is byte-identical by construction** (no register probe needed
+beyond a confirmatory `<false>` check). The addon compiler
+(`blender_addon/shader_vm_compiler.py`) mirrors the opcode/sub-op enums exactly;
+its `compile_socket` is the single dispatch point.
+
+The **fork** (Phase 2): node translation has two paths — the op-VM color/scalar
+chain (`compile_socket`) and the coordinate/mapping chain
+(`_resolve_vector_input` / `_resolve_mapping_matrix`, which resolve to an **affine
+matrix** at upload, not per-texel math). Vector Math / Vector Rotate can appear in
+either. The color-chain case is a clean op-VM opcode; the coordinate-chain case
+(vector math on UVs *before* a texture lookup) cannot be expressed by the affine
+matrix resolver and needs a separate design. Phase 2 must pick a path per case,
+not assume "just add an opcode."
+
+---
+
+## Specification — Phase 1 (this PR)
+
+### Sub-op enum (Cycles NodeClampType)
+
+`CLAMP_MINMAX = 0` (clamp to [min,max], swapping if min>max is **not** done by
+Cycles — MINMAX clamps to the literal [min,max]) / `CLAMP_RANGE = 1` (order-agnostic:
+clamp to [min(min,max), max(min,max)]). Verified against Cycles `svm_clamp` /
+`node_clamp.osl`.
+
+### Files to modify
+
+| File | Change |
+|---|---|
+| `include/astroray/shader_vm.h` | Add `OP_CLAMP` to `OpCode`; add `enum ClampType`; add `HD inline float svm_clamp(type,v,min,max)` (reuse the existing `svm_clampf`/`svm_saturatef`). Add `case OP_CLAMP` to `svm_eval`. Add `SVM_MATH_CLAMP` (0x80) handling in `case OP_MATH` (mask sub-op with 0x7F, saturate result if set) and `SVM_MIX_CLAMP_RESULT` (0x80) in `case OP_MIX` (mask sub-op with 0x3F, saturate result if set). |
+| `blender_addon/shader_vm_compiler.py` | Extend the opcode tuple to `range(15)` incl. `OP_CLAMP`; add `CLAMP` handler in `compile_socket` (Value/Min/Max + `clamp_type`); set `imm |= 0x80` on MATH when `node.use_clamp`; set `SVM_MIX_CLAMP_RESULT` from `clamp_result` (modern Mix) or `use_clamp` (legacy MixRGB). |
+| `tests/test_pkg230_opvm_clamp.py` (new) | CPU render/parity + unit-level bytecode tests (see gates). |
+
+### Key design decisions
+
+- **Flags in the free `imm` high bits, not new opcodes.** MathOp ≤17 (bit 7 free);
+  MixOp ≤8 (bit 7 free). This keeps `Instr` at 8 bytes and adds zero opcodes for
+  the flag features — only Clamp gets an opcode.
+- **`clamp_factor` is deferred to Phase 2, not shipped as a bit.** `svm_mix`
+  already saturates the factor unconditionally (`t = svm_saturatef(t)`), which
+  equals Blender's *default* `clamp_factor=ON`. A `clamp_factor=OFF` (unclamped
+  factor) would require gating that shared saturate — a base-mix behavior change
+  for a rare case — so Phase 1 ships only the genuinely-new `clamp_result` and
+  documents the always-saturated factor.
+- **Clamp result broadcasts scalar → GVec3** like OP_MATH/OP_MAP_RANGE (Clamp is a
+  scalar node).
+- **Shared evaluator ⇒ CPU and GPU are correct from one edit.** GPU still needs a
+  full CUDA rebuild + an RTX parity render (the shared header is compiled into the
+  device kernel), and a confirmatory `<HasProgram=false>` register probe.
+
+### Acceptance criteria — Phase 1
+
+- [ ] Clamp node (both `clamp_type`s) downstream of a texture renders per-texel;
+      CPU/GPU mean-ratio parity within tolerance.
+- [ ] Math `use_clamp` and Mix `clamp_result` change the render in the correct
+      direction vs the flag-off baseline; off ⇒ byte-identical to pre-pkg230.
+      (Mix factor is always saturated = Blender default clamp_factor; asserted.)
+- [ ] `<HasProgram=false>` fleet shade kernel byte-identical (REG:254/STACK/CONST).
+- [ ] Enum parity: addon tuple ↔ `shader_vm.h` verified (a test asserts the values).
+- [ ] No new socket read is silently dropped by the pkg229 coverage scanner
+      (CLAMP is auto-credited; regenerate is optional, not required).
+
+---
+
+## Specification — Phase 2 (scoped, not started)
+
+Vector Math (`VECT_MATH`) + Vector Rotate (`VECTOR_ROTATE`) op-VM opcodes for the
+**color/scalar-chain case** (`OP_VEC_MATH` with a `VecMathOp` family over full
+GVec3 slots; `OP_VEC_ROTATE` axis-angle Rodrigues + Euler, `imm`=rotation_type).
+`Instr` a..e already suffice (vec1/vec2/vec3/scale, and vector/center/axis/angle).
+**Open fork:** the coordinate-chain case (vector math on texture coordinates before
+the lookup) is not expressible by `_resolve_mapping_matrix`'s affine model — decide
+per node whether to (a) compose into the matrix for the affine subset only and
+`VMCompileError`/degrade otherwise, or (b) extend the coordinate path to a per-texel
+vector op-VM. Recommend (a) first (cheap, honest degradation), (b) as a later
+package if usage warrants. cite-algorithm: Rodrigues rotation is trivial; Vector
+Math op semantics cite Cycles `svm_vector_math`. Also in Phase 2: faithful Mix
+**`clamp_factor=OFF`** — gate `svm_mix`'s unconditional factor saturate behind a
+flag, addon setting it per node (legacy always; modern per `clamp_factor`).
+
+---
+
+## Non-goals
+
+- No new coordinate-chain per-texel vector VM in Phase 1 (that's the Phase 2 fork).
+- No touching the fleet `<false>` shade kernel or `GMaterial` layout.
+- No Principled advanced-inputs (separate, higher-effort spec).
+
+---
+
+## Progress
+
+- [x] Phase 1 — Clamp opcode + Math `use_clamp` + Mix `clamp_result` (engine +
+      addon + tests). CPU-verified via the shared `svm_eval`:
+      `tests/test_pkg230_opvm_clamp.py` **7/7** (incl. MINMAX-vs-RANGE Cycles-parity
+      — caught & fixed a `svm_clampf` divergence for min>max), and **38/38** pkg219
+      op-VM regression (incl. GPU parity renders) green — no regression.
+- [~] Phase 1 — GPU: CUDA rebuilt; GPU op-VM path exercised green by the pkg219c/d
+      parity renders. `<HasProgram=false>` fleet kernel is byte-identical **by
+      construction** (the VM is instantiated only inside `if constexpr (HasProgram)`;
+      OP_CLAMP is uploaded verbatim by the unchanged program path). Remaining for
+      HW-verify: a clamp-specific RTX CPU/GPU render + a confirmatory `cuobjdump`
+      register probe on `stageShadeBucketedKernel<0,…>`.
+- [ ] Phase 2 — Vector Math / Vector Rotate op-VM opcodes (color-chain) + faithful
+      Mix `clamp_factor=OFF`, fork resolved.
+
+## Lessons
+
+*(Fill in after the package is done.)*

--- a/blender_addon/shader_vm_compiler.py
+++ b/blender_addon/shader_vm_compiler.py
@@ -19,7 +19,15 @@ Opcode / sub-op enums MUST match include/astroray/shader_vm.h exactly.
 # ---- opcode / sub-op enums (mirror include/astroray/shader_vm.h) -----------
 (OP_END, OP_LOAD_TEX, OP_LOAD_CONST, OP_MATH, OP_MIX, OP_RAMP, OP_MAP_RANGE,
  OP_HSV, OP_INVERT, OP_GAMMA, OP_BRIGHT_CONTRAST, OP_SEP_COLOR,
- OP_COMBINE_COLOR, OP_RGB_TO_BW) = range(14)
+ OP_COMBINE_COLOR, OP_RGB_TO_BW, OP_CLAMP) = range(15)
+
+# pkg230 — Clamp node type (Cycles NodeClampType) + clamp FLAG bits packed into
+# the free high bits of an op's imm (mirror include/astroray/shader_vm.h).
+CLAMP_MINMAX, CLAMP_RANGE = 0, 1
+CLAMP_TYPES = {'MINMAX': CLAMP_MINMAX, 'RANGE': CLAMP_RANGE}
+SVM_MATH_CLAMP = 0x80        # OP_MATH: clamp result to [0,1]
+SVM_MIX_CLAMP_RESULT = 0x80  # OP_MIX:  clamp result to [0,1] (factor always
+#                              saturated in svm_mix = Blender default clamp_factor)
 
 # Colour-space enum for Separate/Combine Color (Cycles NodeCombSepColorType).
 CS_RGB, CS_HSV = 0, 1
@@ -188,8 +196,14 @@ def compile_socket(socket, builder, depth=0):
                 c2_in = c2_in or ins[-1]
         c1_s = compile_socket(c1_in, builder, depth + 1)
         c2_s = compile_socket(c2_in, builder, depth + 1)
+        imm = MIX_OPS[blend]
+        # pkg230 — clamp the result: modern Mix node clamp_result, or legacy
+        # MixRGB use_clamp. (The factor is always saturated in svm_mix, matching
+        # Blender's default clamp_factor; faithful clamp_factor=OFF is Phase 2.)
+        if getattr(node, 'clamp_result', False) or getattr(node, 'use_clamp', False):
+            imm |= SVM_MIX_CLAMP_RESULT
         out = builder.alloc_slot()
-        builder.emit(OP_MIX, out, a=fac_s, b=c1_s, c=c2_s, imm=MIX_OPS[blend])
+        builder.emit(OP_MIX, out, a=fac_s, b=c1_s, c=c2_s, imm=imm)
         return out
 
     if ntype == 'MATH':
@@ -202,8 +216,22 @@ def compile_socket(socket, builder, depth=0):
         c_s = 0
         if op in MATH_TERNARY and len(node.inputs) > 2:
             c_s = compile_socket(node.inputs[2], builder, depth + 1)
+        imm = MATH_OPS[op]
+        if getattr(node, 'use_clamp', False):  # pkg230
+            imm |= SVM_MATH_CLAMP
         out = builder.alloc_slot()
-        builder.emit(OP_MATH, out, a=a_s, b=b_s, c=c_s, imm=MATH_OPS[op])
+        builder.emit(OP_MATH, out, a=a_s, b=b_s, c=c_s, imm=imm)
+        return out
+
+    if ntype == 'CLAMP':  # pkg230
+        ctype = getattr(node, 'clamp_type', 'MINMAX')
+        if ctype not in CLAMP_TYPES:
+            raise VMCompileError("unsupported Clamp type: %s" % ctype)
+        v_s = compile_socket(_get_input(node, 'Value'), builder, depth + 1)
+        mn_s = compile_socket(_get_input(node, 'Min'), builder, depth + 1)
+        mx_s = compile_socket(_get_input(node, 'Max'), builder, depth + 1)
+        out = builder.alloc_slot()
+        builder.emit(OP_CLAMP, out, a=v_s, b=mn_s, c=mx_s, imm=CLAMP_TYPES[ctype])
         return out
 
     if ntype == 'MAP_RANGE':

--- a/include/astroray/shader_vm.h
+++ b/include/astroray/shader_vm.h
@@ -58,7 +58,20 @@ enum OpCode : unsigned char {
     OP_SEP_COLOR  = 11, // reg[out].xyz = separate(col=a, imm=space*4+comp).broadcast svm/color_util.h
     OP_COMBINE_COLOR = 12, // reg[out] = combine(r=a.x,g=b.x,b=c.x, imm=space) svm/color_util.h
     OP_RGB_TO_BW  = 13, // reg[out] = luma(col=a).broadcast        svm/convert.h
+    // pkg230 — utility opcodes.
+    OP_CLAMP      = 14, // reg[out].x = clamp(imm=type, v=a.x, min=b.x, max=c.x) svm/clamp
 };
+
+// pkg230 — Clamp node type (Cycles NodeClampType, svm_clamp / node_clamp.osl).
+enum ClampType : unsigned char { CLAMP_MINMAX = 0, CLAMP_RANGE = 1 };
+
+// pkg230 — clamp FLAG bits packed into the free high bits of an op's `imm`
+// (the sub-op enums are small: MathOp <= 17 uses bits 0..6; MixOp <= 8 uses
+// bits 0..3). OP_MATH honours use_clamp; OP_MIX honours clamp_result (the mix
+// factor is already saturated in svm_mix = Blender's default clamp_factor).
+// The addon compiler sets these bits; both sides MUST agree.
+static const unsigned char SVM_MATH_CLAMP        = 0x80u; // OP_MATH: clamp result to [0,1]
+static const unsigned char SVM_MIX_CLAMP_RESULT  = 0x80u; // OP_MIX:  clamp result to [0,1]
 
 // Colour-space enum for Separate/Combine Color (Cycles NodeCombSepColorType).
 // pkg219c ships RGB + HSV (HSL deferred).
@@ -307,6 +320,17 @@ HD inline float svm_rgb_to_bw(GVec3 c) {
     return c.x * 0.2126729f + c.y * 0.7151522f + c.z * 0.0721750f;
 }
 
+// ---- Clamp node (pkg230) ---------------------------------------------------
+// Cycles svm_clamp (svm/svm_clamp.h) uses clamp(v,lo,hi) = min(max(v,lo),hi).
+// MINMAX passes min/max literally (so min>max collapses to max, matching
+// Cycles); RANGE first orders the bounds. NOTE: this deliberately does NOT use
+// svm_clampf's `v<lo?lo:...` form, which diverges from Cycles when lo>hi.
+HD inline float svm_clamp(unsigned char type, float v, float lo, float hi) {
+    if (type == CLAMP_RANGE && lo > hi) { float t = lo; lo = hi; hi = t; }
+    float mx = v > lo ? v : lo;   // max(v, lo)
+    return mx < hi ? mx : hi;     // min(max(v,lo), hi)
+}
+
 // ============================================================================
 // The evaluator. Pure, HD, byte-identical CPU<->GPU. `inputs` holds the
 // pre-sampled child-texture RGBs. Returns the program's output slot RGB.
@@ -327,12 +351,25 @@ HD inline GVec3 svm_eval(const ShaderVMProgram& p, const GVec3* inputs) {
                 reg[in.out] = p.consts[in.imm < VM_MAX_CONST ? in.imm : 0];
                 break;
             case OP_MATH: {
-                float r = svm_math(in.imm, reg[in.a].x, reg[in.b].x, reg[in.c].x);
+                // low 7 bits = MathOp; bit 7 = use_clamp (pkg230)
+                float r = svm_math(in.imm & 0x7Fu, reg[in.a].x, reg[in.b].x, reg[in.c].x);
+                if (in.imm & SVM_MATH_CLAMP) r = svm_saturatef(r);
                 reg[in.out] = GVec3(r);
                 break;
             }
-            case OP_MIX:
-                reg[in.out] = svm_mix(in.imm, reg[in.a].x, reg[in.b], reg[in.c]);
+            case OP_MIX: {
+                // low 6 bits = MixOp; bit 7 = clamp_result (pkg230). The factor is
+                // already saturated inside svm_mix (Blender's default clamp_factor);
+                // faithful clamp_factor=OFF is a Phase-2 item.
+                GVec3 m = svm_mix(in.imm & 0x3Fu, reg[in.a].x, reg[in.b], reg[in.c]);
+                if (in.imm & SVM_MIX_CLAMP_RESULT)
+                    m = GVec3(svm_saturatef(m.x), svm_saturatef(m.y), svm_saturatef(m.z));
+                reg[in.out] = m;
+                break;
+            }
+            case OP_CLAMP:
+                reg[in.out] = GVec3(svm_clamp(in.imm, reg[in.a].x, reg[in.b].x,
+                                              reg[in.c].x));
                 break;
             case OP_RAMP:
                 reg[in.out] = svm_ramp_lookup(p.ramp[in.imm < VM_MAX_RAMPS ? in.imm : 0],

--- a/tests/test_pkg230_gpu_clamp_parity.py
+++ b/tests/test_pkg230_gpu_clamp_parity.py
@@ -1,0 +1,100 @@
+"""pkg230 — CPU/GPU parity render for the Clamp opcode (OP_CLAMP).
+
+Renders a quad textured with an op-VM Clamp program (MINMAX, max=0.3 so bright
+texels are pulled down) on CPU and GPU and checks:
+  * the VM changes the image vs the plain (no-program) texture, on BOTH backends;
+  * GPU matches CPU within MC noise (per-channel mean-ratio).
+
+The GPU leg runs the same shared HD svm_eval inside the <HasProgram=true> shade
+specialization; parity is by construction. GPU-gated (CI has no CUDA device).
+"""
+import astroray
+import numpy as np
+import pytest
+from base_helpers import create_renderer, render_image, setup_camera
+
+# opcode enums (mirror include/astroray/shader_vm.h)
+OP_LOAD_TEX, OP_LOAD_CONST, OP_CLAMP = 1, 2, 14
+CLAMP_MINMAX = 0
+
+
+def _has_cuda_gpu(renderer):
+    return bool(astroray.__features__.get("cuda", False)) and \
+        bool(getattr(renderer, "gpu_available", False))
+
+
+def _quad_image():
+    img = np.array([
+        [[0.9, 0.1, 0.1], [0.1, 0.9, 0.1]],
+        [[0.1, 0.1, 0.9], [0.7, 0.7, 0.2]],
+    ], dtype=np.float32)
+    return img.reshape(-1).tolist(), 2, 2
+
+
+def _build_scene(renderer, *, with_program):
+    renderer.set_background_color([0.5, 0.5, 0.5])
+    data, w, h = _quad_image()
+    renderer.load_texture("pkg230_img", data, w, h, "UV")
+    if with_program:
+        renderer.create_program_texture("pkg230_prog", "UV")
+        renderer.program_texture_add_input("pkg230_prog", "pkg230_img")
+        # slot0=tex; slot1=const min(0.0); slot2=const max(0.3);
+        # slot3 = clamp_MINMAX(v=tex.x, min, max)  (scalar, broadcast)
+        consts = [0.0, 0.0, 0.0, 0.3, 0.3, 0.3]
+        code = [OP_LOAD_TEX, 0, 0, 0, 0, 0, 0, 0,
+                OP_LOAD_CONST, 1, 0, 0, 0, 0, 0, 0,
+                OP_LOAD_CONST, 2, 0, 0, 0, 0, 0, 1,
+                OP_CLAMP, 3, 0, 1, 2, 0, 0, CLAMP_MINMAX]
+        renderer.set_program_texture_program("pkg230_prog", 1, 3, code, consts, [])
+        tex_ref = "pkg230_prog"
+    else:
+        tex_ref = "pkg230_img"
+    mat = renderer.create_material("lambertian", [1.0, 1.0, 1.0], {"texture": tex_ref})
+    A, B = [-1, -1, 0], [1, -1, 0]
+    C, D = [1, 1, 0], [-1, 1, 0]
+    n = [0, 0, 1]
+    renderer.add_triangle_layers(A, B, C, mat, {"UVMap": [[0, 0], [1, 0], [1, 1]]},
+                                 n, n, n)
+    renderer.add_triangle_layers(A, C, D, mat, {"UVMap": [[0, 0], [1, 1], [0, 1]]},
+                                 n, n, n)
+    setup_camera(renderer, look_from=[0, 0, 3], look_at=[0, 0, 0], vup=[0, 1, 0],
+                 vfov=45, width=64, height=64)
+
+
+def _render(*, with_program, use_gpu, samples=64, seed=1):
+    r = create_renderer()
+    if use_gpu:
+        if not _has_cuda_gpu(r):
+            pytest.skip("No CUDA GPU — pkg230 GPU leg runs on the RTX box.")
+        r.set_use_gpu(True)
+    r.set_seed(seed)
+    _build_scene(r, with_program=with_program)
+    return render_image(r, samples=samples, max_depth=2, apply_gamma=False)
+
+
+def test_cpu_clamp_changes_image():
+    plain = _render(with_program=False, use_gpu=False)
+    prog = _render(with_program=True, use_gpu=False)
+    mad = float(np.abs(plain - prog).mean())
+    assert mad > 0.02, f"CPU op-VM Clamp had no effect (mean|diff|={mad:.4f})"
+
+
+def test_gpu_clamp_changes_image():
+    plain = _render(with_program=False, use_gpu=True)
+    prog = _render(with_program=True, use_gpu=True)
+    mad = float(np.abs(plain - prog).mean())
+    assert mad > 0.02, f"GPU op-VM Clamp had no effect (mean|diff|={mad:.4f})"
+
+
+def test_gpu_matches_cpu_clamp():
+    cpu = _render(with_program=True, use_gpu=False)
+    gpu = _render(with_program=True, use_gpu=True)
+    # per-channel mean-ratio parity (independent MC streams; see memory
+    # ssim-wrong-gate-for-independent-rng)
+    for ch in range(3):
+        c = float(cpu[..., ch].mean())
+        g = float(gpu[..., ch].mean())
+        if c < 1e-4:
+            continue
+        ratio = g / c
+        assert 0.95 < ratio < 1.05, f"channel {ch} CPU/GPU mean-ratio {ratio:.3f}"

--- a/tests/test_pkg230_opvm_clamp.py
+++ b/tests/test_pkg230_opvm_clamp.py
@@ -1,0 +1,211 @@
+"""pkg230 — op-VM Clamp opcode + Math/Mix clamp-flag tests (no bpy required).
+
+Builds duck-typed Blender node chains for the pkg230 utility features (a Clamp
+node, and the use_clamp / clamp_factor / clamp_result flags on Math/Mix),
+compiles them with shader_vm_compiler, loads the bytecode into the engine, and
+verifies the rendered per-texel result via sample_named_texture — which runs the
+SAME shared HD svm_eval the GPU shade kernel uses. Also asserts addon<->engine
+enum/flag parity against include/astroray/shader_vm.h.
+"""
+import os
+import re
+import sys
+
+import pytest
+
+astroray = pytest.importorskip("astroray")
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "blender_addon"))
+import shader_vm_compiler as C
+
+_HEADER = os.path.join(os.path.dirname(__file__), "..", "include", "astroray",
+                       "shader_vm.h")
+
+
+# ---- minimal duck-typed Blender node model (shared with pkg219c tests) ------
+class Sock:
+    def __init__(self, name, default=0.0, link=None):
+        self.name = name
+        self.default_value = default
+        self._link = link
+
+    @property
+    def is_linked(self):
+        return self._link is not None
+
+    @property
+    def links(self):
+        return [self._link] if self._link else []
+
+
+class Link:
+    def __init__(self, from_node, from_socket_name="Color"):
+        self.from_node = from_node
+        self.from_socket = type("S", (), {"name": from_socket_name})()
+
+
+class SockList:
+    def __init__(self, socks):
+        self._socks = socks
+        self._by_name = {s.name: s for s in socks}
+
+    def get(self, name):
+        return self._by_name.get(name)
+
+    def __getitem__(self, i):
+        return self._socks[i]
+
+    def __len__(self):
+        return len(self._socks)
+
+    def __iter__(self):
+        return iter(self._socks)
+
+
+class Node:
+    def __init__(self, type, inputs=None, **kw):
+        self.type = type
+        self.inputs = SockList(inputs or [])
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
+def _load_program(r, name, compiled, input_values):
+    import numpy as np
+    r.create_program_texture(name, "UV")
+    for i, node in enumerate(compiled['inputs']):
+        tex_name = f"{name}_in{i}"
+        val = input_values[id(node)]
+        img = np.array(val, dtype="float32").reshape(1, 1, 3).ravel()
+        r.load_texture(tex_name, img, 1, 1, "UV")
+        r.program_texture_add_input(name, tex_name)
+    r.set_program_texture_program(name, compiled['num_tex'], compiled['out_slot'],
+                                  compiled['code_flat'], compiled['consts_flat'],
+                                  compiled['ramps_flat'])
+
+
+def _render(name, compiled, tex, color):
+    r = astroray.Renderer()
+    _load_program(r, name, compiled, {id(tex): color})
+    return r.sample_named_texture(name, 0.5, 0.5)
+
+
+# --------------------------------------------------------------------------- #
+# 1. Clamp node, MINMAX: value above max is clamped down
+# --------------------------------------------------------------------------- #
+def test_clamp_minmax():
+    tex = Node('TEX_IMAGE')
+    clamp = Node('CLAMP', clamp_type='MINMAX',
+                 inputs=[Sock('Value', 0.0, Link(tex, 'Color')),
+                         Sock('Min', 0.2), Sock('Max', 0.7)])
+    base = Sock('Roughness', 0.5, Link(clamp, 'Result'))
+    compiled = C.compile_chain(base)
+    assert compiled is not None
+    got = _render("clamp_mm", compiled, tex, (0.9, 0.5, 0.1))  # R=0.9 -> 0.7
+    assert got == pytest.approx([0.7, 0.7, 0.7], abs=3e-3), got
+
+
+# --------------------------------------------------------------------------- #
+# 2. Clamp MINMAX vs RANGE differ when min > max (RANGE is order-agnostic)
+# --------------------------------------------------------------------------- #
+def test_clamp_range_order_agnostic():
+    # value 0.5, min=0.7, max=0.2
+    for ctype, want in (('MINMAX', 0.2), ('RANGE', 0.5)):
+        tex = Node('TEX_IMAGE')
+        clamp = Node('CLAMP', clamp_type=ctype,
+                     inputs=[Sock('Value', 0.0, Link(tex, 'Color')),
+                             Sock('Min', 0.7), Sock('Max', 0.2)])
+        base = Sock('Roughness', 0.5, Link(clamp, 'Result'))
+        compiled = C.compile_chain(base)
+        got = _render(f"clamp_{ctype}", compiled, tex, (0.5, 0.5, 0.5))
+        assert got == pytest.approx([want, want, want], abs=3e-3), (ctype, got)
+
+
+# --------------------------------------------------------------------------- #
+# 3. Math use_clamp: result clamped to [0,1]
+# --------------------------------------------------------------------------- #
+def test_math_use_clamp():
+    def build(use_clamp):
+        tex = Node('TEX_IMAGE')
+        m = Node('MATH', operation='ADD', use_clamp=use_clamp,
+                 inputs=[Sock('A', 0.0, Link(tex, 'Color')), Sock('B', 0.8)])
+        base = Sock('Roughness', 0.5, Link(m, 'Value'))
+        return tex, C.compile_chain(base)
+
+    tex, comp = build(True)
+    got = _render("math_clamp_on", comp, tex, (0.5, 0.5, 0.5))  # 1.3 -> 1.0
+    assert got == pytest.approx([1.0, 1.0, 1.0], abs=3e-3), got
+
+    tex, comp = build(False)
+    got = _render("math_clamp_off", comp, tex, (0.5, 0.5, 0.5))  # 1.3, no clamp
+    assert got == pytest.approx([1.3, 1.3, 1.3], abs=3e-3), got
+
+
+# --------------------------------------------------------------------------- #
+# 4. Mix clamp_result (legacy MixRGB use_clamp): output clamped to [0,1]
+# --------------------------------------------------------------------------- #
+def test_mix_clamp_result():
+    def build(clamp):
+        tex = Node('TEX_IMAGE')
+        mix = Node('MIX_RGB', blend_type='ADD', use_clamp=clamp,
+                   inputs=[Sock('Fac', 1.0),
+                           Sock('Color1', [0, 0, 0], Link(tex, 'Color')),
+                           Sock('Color2', [0.6, 0.6, 0.6])])
+        base = Sock('Base Color', [0.5, 0.5, 0.5], Link(mix, 'Color'))
+        return tex, C.compile_chain(base)
+
+    tex, comp = build(True)
+    got = _render("mix_clamp_on", comp, tex, (0.7, 0.7, 0.7))  # 0.7+0.6=1.3 -> 1.0
+    assert got == pytest.approx([1.0, 1.0, 1.0], abs=3e-3), got
+
+    tex, comp = build(False)
+    got = _render("mix_clamp_off", comp, tex, (0.7, 0.7, 0.7))  # 1.3
+    assert got == pytest.approx([1.3, 1.3, 1.3], abs=3e-3), got
+
+
+# --------------------------------------------------------------------------- #
+# 5. Mix factor is always saturated (svm_mix = Blender default clamp_factor=ON).
+#    Faithful clamp_factor=OFF is a Phase-2 item.
+# --------------------------------------------------------------------------- #
+def test_mix_factor_always_saturated():
+    tex = Node('TEX_IMAGE')
+    mix = Node('MIX', blend_type='MIX',
+               inputs=[Sock('Factor', 0.0, Link(tex, 'Color')),
+                       Sock('A', [0.0, 0.0, 0.0]),
+                       Sock('B', [1.0, 1.0, 1.0])])
+    base = Sock('Base Color', [0.5, 0.5, 0.5], Link(mix, 'Result'))
+    comp = C.compile_chain(base)
+    got = _render("mix_fac_sat", comp, tex, (1.5, 1.5, 1.5))  # fac 1.5 -> 1.0
+    assert got == pytest.approx([1.0, 1.0, 1.0], abs=3e-3), got
+
+
+# --------------------------------------------------------------------------- #
+# 6. Off-path is byte-identical: a plain Math ADD emits no clamp bit
+# --------------------------------------------------------------------------- #
+def test_flags_off_emit_no_bits():
+    tex = Node('TEX_IMAGE')
+    m = Node('MATH', operation='ADD',  # no use_clamp attr at all
+             inputs=[Sock('A', 0.0, Link(tex, 'Color')), Sock('B', 0.1)])
+    base = Sock('Roughness', 0.5, Link(m, 'Value'))
+    comp = C.compile_chain(base)
+    math_instrs = [ins for ins in
+                   [comp['code_flat'][i:i + 8]
+                    for i in range(0, len(comp['code_flat']), 8)]
+                   if ins[0] == C.OP_MATH]
+    assert math_instrs, comp['code_flat']
+    for ins in math_instrs:
+        assert ins[7] & C.SVM_MATH_CLAMP == 0, ins  # imm high bit clear
+
+
+# --------------------------------------------------------------------------- #
+# 7. Addon <-> engine enum/flag parity (mirror shader_vm.h exactly)
+# --------------------------------------------------------------------------- #
+def test_enum_parity_with_header():
+    assert (C.OP_CLAMP, C.CLAMP_MINMAX, C.CLAMP_RANGE) == (14, 0, 1)
+    assert C.SVM_MATH_CLAMP == 0x80
+    assert C.SVM_MIX_CLAMP_RESULT == 0x80
+    with open(_HEADER, "r", encoding="utf-8") as f:
+        src = f.read()
+    assert re.search(r"OP_CLAMP\s*=\s*14", src)
+    assert re.search(r"CLAMP_MINMAX\s*=\s*0", src)
+    assert re.search(r"SVM_MATH_CLAMP\s*=\s*0x80", src)
+    assert re.search(r"SVM_MIX_CLAMP_RESULT\s*=\s*0x80", src)


### PR DESCRIPTION
## What

Phase 1 of pkg230 — the pkg229 re-audit's highest-ROI next-wave items (#3 Clamp node, #4 Math/Mix clamp flags), all ★★★-frequency per-texel color/scalar ops the op-VM already had the machinery for.

- **`shader_vm.h`**: `OP_CLAMP` (14) + `ClampType` (MINMAX/RANGE); `svm_clamp` uses the exact Cycles `min(max(v,lo),hi)` form (deliberately **not** the existing `svm_clampf`, which diverges from Cycles when `min>max`). `SVM_MATH_CLAMP` (0x80) on `OP_MATH` and `SVM_MIX_CLAMP_RESULT` (0x80) on `OP_MIX`, packed into free `imm` high bits — `Instr` stays 8 bytes, **zero** new opcodes for the flags.
- **`shader_vm_compiler.py`**: `CLAMP` node handler + `use_clamp`/`clamp_result` wiring; enum tuple synced to `range(15)`.

## Register safety

Everything is inside the isolated `if constexpr (HasProgram)` shade path. The `<HasProgram=false>` REG:254 fleet kernel never instantiates the VM, so it is **byte-identical by construction**; `OP_CLAMP` is uploaded verbatim by the unchanged program path.

## Scope / deferrals (Phase 2)

- The Mix factor is always saturated in `svm_mix` (= Blender's default `clamp_factor=ON`). Faithful `clamp_factor=OFF` needs gating that shared saturate → **Phase 2**.
- **Vector Math / Vector Rotate** op-VM opcodes → Phase 2 (a real coordinate-chain-vs-op-VM fork is documented in the spec).

## Verification

Shared HD `svm_eval` = the same code CPU and GPU compile.
- `tests/test_pkg230_opvm_clamp.py` **7/7** (incl. MINMAX-vs-RANGE Cycles-parity — caught & fixed the `svm_clampf` `min>max` divergence).
- pkg219 op-VM regression **38/38** (incl. GPU parity renders + pkg219d) — no regression.
- **Remaining for HW-verify:** a clamp-specific RTX CPU/GPU render + a confirmatory `cuobjdump` register probe on `stageShadeBucketedKernel<0,…>` (both low-risk by construction).

Spec: `.astroray_plan/packages/pkg230-opvm-utility-opcodes.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)