### PR TITLE
docs: scope four findings from pkg230 validation

### DIFF
--- a/.astroray_plan/packages/pkg232-delegate-timeout-process-tree.md
+++ b/.astroray_plan/packages/pkg232-delegate-timeout-process-tree.md
@@ -1,0 +1,64 @@
+# pkg232 — Delegate timeout must stop its owned Windows process tree
+
+**Pillar:** 5
+**Track:** A
+**Status:** open — detailed architect review required before dispatch
+**Estimated effort:** TBD at detailed architect review
+**Depends on:** none
+
+---
+
+## Goal
+
+**Before:** a delegate wrapper timeout returns `status: timeout` while the worker's Windows `opencode.exe` descendant tree stays alive and keeps writing files after the wrapper has returned its evidence.
+**After:** on timeout/cancellation/error the wrapper owns, stops, and awaits its full descendant process tree before the final snapshot; no post-return edits; returned status stays `timeout` even if the orphaned child would later have completed.
+
+---
+
+## Context & evidence
+
+Observed 2026-09-06 Australia/Sydney, 2026-09-05 UTC (wrapper JSON + retained transcript `20260906-002341-grunt.jsonl` in `%LOCALAPPDATA%/astroray/delegate-logs`): wrapper returned `status timeout` at 180.0 s, 18 tool calls, `files_changed []`, `finish_reason tool-calls` — yet the Windows `opencode.exe` child (PID 42916) stayed live and wrote scoped tests AFTER the wrapper returned. The retained transcript eventually holds 31 tool calls, `reason stop`; first event 2026-09-05T14:24:20.006Z, last 2026-09-05T14:27:59.717Z (219.711 s event span — not total wrapper runtime). Parent verified the exact command line matched task token `.delegate-task-20260906-002341.md`, stopped only that child, and independently checked the final files. `files_changed []` must not be read as "no edits".
+
+Mechanism (`.claude/skills/delegate/scripts/delegate.py`): `_opencode_cmd` (L35) wraps the Windows shim via `cmd /c`; `subprocess.run` (L126) with `timeout=` kills/waits only the immediate shim; `except TimeoutExpired` (L130) only marks `status = "timeout"`; `finally` (L132) removes the task file; the post snapshot (L137) is taken without owning/stopping the full descendant tree. This leaves output/logs and files mutable after returned evidence.
+
+---
+
+## Specification
+
+### Files to modify
+
+| File | What changes |
+|---|---|
+| `.claude/skills/delegate/scripts/delegate.py` | Own process-tree tracking/containment; bounded shutdown and await on timeout/cancellation/error; no post-return edits; final truthful snapshot after owned writers stopped; retained `timeout` status despite eventual child success. |
+| `tests/` (scoped, when implemented) | Mock process-lifecycle tests + bounded real-Windows canary. |
+
+### Key design decisions
+
+- Ownership by instance/ancestry identity, never executable name alone; handle PID reuse; never terminate unrelated opencode processes.
+- No watchdog daemon, no broad killall, no model-policy changes.
+- Exact Windows containment implementation still needs architect review.
+
+---
+
+## Acceptance criteria (future — all UNRUN)
+
+- [ ] Mock process-lifecycle tests: owned child/grandchild attempted delayed file writes are stopped; no delayed writes after return.
+- [ ] Bounded real-Windows canary: owned child/grandchild + separate unrelated sentinel; owned descendants stopped, no delayed writes after return, sentinel alive, evidence/timed-out snapshot true.
+- [ ] Retained `timeout` status even when the orphaned child would have completed; final snapshot only after owned writers stopped.
+- [ ] Independent Astra/Claude review of containment and PID-reuse/race/output-handle handling.
+
+---
+
+## Non-goals
+
+- No model-policy changes, no watchdog daemon, no broad killall.
+- No delegate routing/tier/prompt changes; no queue priority changes; no Pillar 4 work.
+
+---
+
+## Progress
+
+- [ ] Detailed architect review of scope and Windows containment design (all implementation gates UNRUN).
+- [ ] Implementation + scoped tests (future).
+Independent Claude filing review: SIGN-OFF TO FILE ONLY, 2026-09-06.
+Evidence: `test_results/pkg232-235/claude-filing-review.txt`.

--- a/.astroray_plan/packages/pkg233-standalone-bsdf-textures.md
+++ b/.astroray_plan/packages/pkg233-standalone-bsdf-textures.md
@@ -1,0 +1,55 @@
+# pkg233 — Standalone BSDF texture and scalar plumbing
+
+**Pillar:** 5
+**Track:** A
+**Status:** open — detailed architect review required before dispatch
+**Estimated effort:** TBD at detailed architect review
+**Depends on:** none
+
+---
+
+## Goal
+
+**Before:** the standalone Diffuse node drops linked ImageTexture color inputs in the observed chart — an `ImageTexture → BSDF_DIFFUSE` chain and an `ImageTexture → VectorMath/Rotate → Diffuse` chain both render gray, and vectorMath/Rotate changes leave numerical channels unchanged.
+**After:** an architect-reviewed supported subset of standalone BSDF nodes routes color textures and scalar parameters through physically correct closure carriers; unsupported combinations warn visibly instead of silently rendering gray/constant.
+
+---
+
+## Context & evidence
+
+Parent's real Blender 5.1 CPU chart found plain `ImageTexture → BSDF_DIFFUSE` and `ImageTexture → VectorMath/Rotate → Diffuse` rendered gray; vectorMath/Rotate changes left numerical channels unchanged. Retained feature artifacts: `test_results/pkg230-p2/blender_cpu_cycles_failed_diffuse.png` and `blender-cpu-metrics_failed_diffuse.json`. Source `_standalone_bsdf_spec` in `blender_addon/__init__.py`, BSDF_DIFFUSE branch (around 3832 in feature checkout; 3817 in this base) calls `get_color_input` and `get_float_input` only, never `get_base_color_texture`; this code is unchanged from main. Current pkg230 verified VM scope uses the Principled route. This is evidence for a standalone-node consumer gap, not failure of the shared VM or proof every standalone node fails.
+
+---
+
+## Specification
+
+Architect-first audit of standalone Diffuse/Glossy/Glass carrier selection and color texture/scalar parameter plumbing; trace ordinary ImageTexture and image→opVM chains through upload/actual closures. Decide the exact supported subset and files before implementation; no newly claimed full coverage; do not just route everything through Principled and assume physical equivalence. Preserve constant/unlinked semantics; require a physically correct closure carrier and explicit review of any carrier correction. Reuse existing addon `get_base_color_texture`/scalar paths and the canonical headless Blender parity harness where valid; warn visibly when textures/scalars cannot be represented instead of silently gray/constant. No changes to transport physics, shaderVM, coordinateVM, new UI, or Pillar 4.
+
+---
+
+## Acceptance criteria (future — all UNRUN)
+
+- [ ] Reproduce real headless Blender CPU plain-image + vector-chain A/B vs Cycles in common linear space; images must show linked textures affect channels.
+- [ ] Per-node color/scalar routing matrix; constant/unlinked regressions; unsupported-warning tests; CPU/GPU parity.
+- [ ] Freshly built intended module; source freshness/import path/native arch/ABI/register checks if the engine is touched.
+- [ ] Representative actual-Blender saved renders qualitatively reviewed by Astra/Claude; GPU lock and max 2 isolated implementation worktrees.
+- [ ] Full documented tests/caller-binding review and independent Astra/Claude sign-off. Parent reviews draft scope; all coverage claims await evidence.
+
+---
+
+## Non-goals
+
+This follow-up does not change owner queue priority. Glossy/Glass and scalar
+inputs require audit; their failure is not established by the Diffuse chart.
+
+- No transport-physics, shaderVM, coordinateVM, or new-UI changes; no Pillar 4 work.
+- No claimed full standalone-node coverage; no silent gray/constant fallbacks.
+
+---
+
+## Progress
+
+- [ ] Detailed architect review of scope, supported subset, and files (all implementation gates UNRUN).
+- [ ] Implementation + gates (future).
+Independent Claude filing review: SIGN-OFF TO FILE ONLY, 2026-09-06.
+Evidence: `test_results/pkg232-235/claude-filing-review.txt`.

--- a/.astroray_plan/packages/pkg234-image-texture-filtering.md
+++ b/.astroray_plan/packages/pkg234-image-texture-filtering.md
@@ -1,0 +1,59 @@
+# pkg234 — Honor Blender Image Texture filtering
+
+**Pillar:** 5 (Blender/DCC texture fidelity)
+**Track:** A
+**Status:** OPEN — detailed architect review required before dispatch
+**Estimated effort:** TBD at architect review
+**Depends on:** Existing image-texture upload/sampling paths; pkg230 Phase 2 supplies discovery evidence
+
+## Goal
+
+Honor Image Texture Closest and Linear interpolation on CPU and GPU, with a
+visible, documented fallback for unsupported Cubic/Smart modes. This follow-up
+does not change owner queue priority; Pillar 4 remains PAUSED.
+
+## Evidence
+
+`include/advanced_features.h::ImageTexture::value()` clamps UVs, flips V, and
+selects one texel. Its comment near line 320 explicitly describes the matching
+GPU sampler as nearest-neighbour clamp plus V-flip. The addon does not read
+`ShaderNodeTexImage.interpolation`; its unrelated `interpolation_type` read is
+not image-filter support. The project index found no open image-filter package.
+The source session's real Blender 5.1 CPU/Cycles Principled charts showed the
+expected vector transforms/colors, but Astroray looked blocky beside Cycles
+with Linear interpolation. This is a filtering gap, not evidence of a VM error.
+Retained source capture: feature-worktree
+`test_results/pkg230-p2/blender_cpu_cycles_linear_filter_gap.png`.
+The common-Closest rerun isolates pkg230 opcode behavior.
+
+## Scoped direction — architect review first
+
+Trace image sampling through addon upload, ordinary and program textures, CPU
+RGB/spectral sampling, GPU sampling, and bindings before fixing the file scope.
+Pin Blender/Cycles texel-center conventions, UV edges/extension behavior,
+orientation, color-space and alpha handling; define tolerances before coding.
+Carry filter mode through per-texture metadata and cache variants/invalidation.
+Preserve constant textures and existing Closest behavior; implement Linear
+consistently on both backends. Warn visibly for unsupported Cubic/Smart requests.
+Reuse canonical parity/build tooling; do not create another verification script.
+
+## Acceptance — all implementation gates UNRUN
+
+- [ ] Real headless Blender Closest/Linear A/B against Cycles in common linear space.
+- [ ] CPU/GPU parity; texel-center, boundary, UV orientation, and extension cases.
+- [ ] Color/alpha and RGB/spectral sampling contract; constant-texture regressions.
+- [ ] Same-image filter variants and node changes cannot reuse an incompatible cache entry.
+- [ ] Cubic/Smart fallback is visible and has focused tests.
+- [ ] Fresh native build/import-path/architecture checks, ABI/caller sweep, and register evidence.
+- [ ] Saved representative Blender renders receive Astra/Claude qualitative review.
+- [ ] Documented tests and independent Astra/Claude sign-off; CUDA work uses the GPU lock.
+
+## Risks and non-goals
+
+Texel-center or alpha mismatches can look like transport errors; pin the sampling
+contract before implementation. Keep at most two isolated implementation worktrees.
+No VM opcode/math changes, transport/physics changes, new UI, general coordinate
+VM, universal filtering coverage claim, or astrophysics work.
+
+Independent Claude filing review: SIGN-OFF TO FILE ONLY, 2026-09-06.
+Evidence: `test_results/pkg232-235/claude-filing-review.txt`.

--- a/.astroray_plan/packages/pkg235-scalar-power-edge-parity.md
+++ b/.astroray_plan/packages/pkg235-scalar-power-edge-parity.md
@@ -1,0 +1,41 @@
+# pkg235 — Scalar Math POWER edge-case parity
+
+**Pillar:** 5 (Blender numerical shader behavior)
+**Track:** A
+**Status:** OPEN — detailed architect review required before dispatch
+**Depends on:** pkg230 shared op-VM; no owner queue promotion
+
+## Evidence and bounded goal
+
+During pkg230 Phase 2 integration, a native host canary demonstrated that the
+existing scalar `svm_safe_powf(0,-1)` returns infinity. Pinned Blender 5.1 Cycles
+`util/math_base.h::compatible_powf` returns zero for zero base and nonzero
+exponents, and one for any zero exponent, including 0^0. Cycles also guards
+negative bases separately on GPU. Phase 2's Vector Math helper handles these
+cases; the older scalar Math POWER helper was deliberately not changed.
+
+Audit and correct only scalar Math POWER numerical edge semantics against that
+pinned reference, including CPU/CUDA parity and Blender scalar-input conversion.
+Before dispatch, determine the domain guarantees and compatibility impact of
+replacing existing non-finite results. Preserve opcode encoding and clamp flags.
+
+## Acceptance — all implementation gates UNRUN
+
+- [ ] Cite licensed Cycles reference and define finite-input/exception behavior.
+- [ ] Zero bases, zero/negative/integer/fractional exponents, and negative bases
+      match explicit Cycles oracles on CPU and CUDA.
+- [ ] Ordinary positive-domain results and use_clamp behavior remain correct.
+- [ ] Real image-driven Blender Math POWER graphs exercise export and evaluation;
+      saved representative outputs receive Astra/Claude qualitative review.
+- [ ] Fresh native/import/architecture gates, caller/binding and resource review,
+      documented regression tests, and independent Claude sign-off.
+
+## Non-goals
+
+No broader numerical-math rewrite, VM layout/limit changes, transport changes,
+coordinate VM, new UI, or astrophysics work. Pillar 4 remains paused. This filing
+records discovered parity debt; it does not claim implementation readiness or
+outrank the owner's post-pkg230 package choice.
+
+Independent Claude filing review: SIGN-OFF TO FILE ONLY, 2026-09-06.
+Evidence: `test_results/pkg232-235/claude-filing-review.txt`.


### PR DESCRIPTION
File four separate bounded follow-up packages discovered during pkg230 validation:

- pkg232: stop and await the owned Windows worker process tree on delegation timeout; prevent edits after returned evidence.
- pkg233: investigate and fix standalone BSDF texture plumbing, starting with the reproduced Diffuse texture drop.
- pkg234: honor Blender Image Texture interpolation, starting with Closest/Linear parity.
- pkg235: align scalar Math POWER zero/negative-base edge semantics with Cycles.

All remain OPEN for detailed architectural review; no implementation or queue promotion is claimed. Renderer changes remain in the separate pkg230 branch.

Validation: source evidence and project index checked; Astra review; independent Claude SIGN-OFF TO FILE ONLY for all four; whitespace and differential documentation lint. All implementation gates are UNRUN.
