### PR TITLE
docs: file Blender smoke isolation and baseline parity diagnostics

### DIFF
--- a/.astroray_plan/packages/pkg236-hermetic-blender-smoke.md
+++ b/.astroray_plan/packages/pkg236-hermetic-blender-smoke.md
@@ -1,0 +1,59 @@
+# pkg236 — Hermetic Blender dev-loop smoke
+
+**Pillar:** 5 (Blender/DCC dev-loop tooling)
+**Track:** A
+**Status:** OPEN — detailed architect review required before implementation
+**Estimated effort:** TBD at architect review
+**Depends on:** none — reuses canonical `scripts/dev_addon.ps1` and existing build/install helpers; no owner queue promotion
+
+## Evidence
+
+`tests/test_dev_loop_smoke.py::test_dev_loop_smoke_local_host` invokes
+`scripts/dev_addon.ps1 -Smoke -SkipBuild`; with Blender 5.2 installed this path
+can install into the REAL Blender 5.2 user profile. The pkg230 Phase 2 full-suite
+attempt hit a locked native `.pyd` and partially deleted addon support
+directories. Recovery restored Python/assets from the matching `1967cb5` tree
+and the unchanged runtime DLL bundle, preserving the installed native module;
+`PKG175_REGISTER_RESULT` passed. This is restored incident context, not an
+implementation result for this new package. Evidence retained in feature
+`test_results/pkg230-p2/full-suite.log`.
+
+## Goal
+
+Automate the dev-loop smoke entirely under a disposable, isolated Blender user
+profile with explicitly bounded staging/install paths. The test invocation must
+pass isolated-profile plumbing through the canonical `scripts/dev_addon.ps1` and
+existing build/install helpers; never infer safety from `-SkipBuild` (it still
+installs). Resolve and check final absolute targets before any destructive
+copy/remove/move; reject profile-escape, symlink/reparse, and path tricks. Make
+the install atomic or roll back completely on a locked `.pyd` or any failure.
+Preserve the live user addon/files/preferences and restore the process
+environment after the test.
+
+## Scoped direction
+
+Detailed architect review chooses the implementation and exact file scope. Reuse
+canonical scripts and existing build/install helpers; create no parallel
+installer. This follow-up does not change owner queue priority; Pillar 4 remains
+PAUSED.
+
+## Acceptance — all implementation gates UNRUN
+
+- [ ] Disposable-profile real Blender register/smoke, with a sentinel proving the
+      real user profile was never written.
+- [ ] Path-boundary adversarial/mocked checks: profile escape, symlink/reparse,
+      and path tricks rejected before any destructive operation.
+- [ ] Concurrent unrelated/live-profile sentinel files and content hashes unchanged
+      across the full invocation.
+- [ ] Injected locked-module or copy failure rolls back and preserves the complete
+      prior installation.
+- [ ] No leftover child processes or environment changes after the test.
+- [ ] Full-suite invocation demonstrably cannot write the real user profile.
+- [ ] GPU lock if a future smoke uses the GPU; at most two isolated implementation
+      worktrees; independent Astra/Claude review.
+
+## Non-goals
+
+No renderer feature changes; no uninstalling or replacing the live user install;
+no weakening of the existing freshness/register guards; no owner queue priority
+change; no Pillar 4 work.

--- a/.astroray_plan/packages/pkg237-hdri-cpu-gpu-ssim-diagnosis.md
+++ b/.astroray_plan/packages/pkg237-hdri-cpu-gpu-ssim-diagnosis.md
@@ -1,0 +1,58 @@
+# pkg237 — HDRI background CPU/GPU SSIM diagnosis
+
+**Pillar:** 5 (CPU/GPU parity)
+**Track:** A
+**Status:** OPEN — detailed architect review required before implementation
+**Estimated effort:** TBD at architect review
+**Depends on:** none (diagnosis of existing behavior)
+
+## Evidence
+
+`tests/test_world_hdri_parity.py::test_gpu_cpu_ssim_hdri` renders an
+environment-only scene (no geometry, no shader VM) at 8192 spp: feature SSIM
+0.7690514 vs threshold 0.97, freshly built root/main SSIM 0.77432567. The current
+test normalizes each image by its own maximum via
+`arr / max(1.0, float(arr.max()))` before SSIM, so metric validity needs
+examination. The mismatch also reproduces on baseline; pkg230 causation is not
+established. Do not assert a root cause or lower the threshold as a fix. Evidence
+files: feature `test_results/pkg230-p2/full-suite.log` and
+`baseline-full-suite-failures.log`.
+
+## Goal
+
+Diagnose the HDRI background CPU/GPU divergence before any fix or gate change.
+Preserve linear arrays and matched fixed seeds/config/imported-native-artifact
+metadata across captures. Inspect environment direction mapping/orientation,
+spectral sampling/accumulation, image filtering, and test normalization and
+statistical validity independently. Trace the actual CPU/GPU environment
+consumers, isolate component experiments, and separate plausible hypotheses from
+established causes. Coordinate filtering evidence with pkg234 only if relevant, without
+assuming dependency or cause.
+
+## Scoped direction
+
+Detailed architect review fixes the evidence-gathering scope first; only then a
+justified minimal fix or a scientifically supported gate proposal. This follow-up
+does not change owner queue priority; Pillar 4 remains PAUSED.
+
+## Acceptance — all implementation gates UNRUN
+
+- [ ] Reproducible baseline/feature matched captures preserve raw linear data plus
+      metadata (fixed seeds, config, imported native artifact identity).
+- [ ] Independent direction/spectrum/filter oracles localize the disagreement.
+- [ ] Common-exposure comparisons accompany the existing score; any metric change
+      requires justification, uncertainty, and seed-repeatability evidence.
+- [ ] Saved representative visuals qualitatively reviewed by Astra/Claude.
+- [ ] No geometry/VM confounders in any isolating experiment.
+- [ ] If the engine changes: fresh native-arch/import/ABI/resource checks and
+      caller review.
+- [ ] GPU lock and at most two isolated implementation worktrees; documented
+      focused regression tests; independent Claude root-cause analysis and sign-off.
+
+## Non-goals
+
+Per-image max normalization can manufacture agreement or loss unrelated to
+rendering; metric validity is part of the diagnosis, not a pretext for relaxing a
+gate. No arbitrary SSIM threshold relaxation; no transport/VM rewrite; no
+HDRI-filter root-cause claim before evidence; no owner queue priority change; no
+Pillar 4 work.

--- a/.astroray_plan/packages/pkg238-postinit-cpu-gpu-threshold.md
+++ b/.astroray_plan/packages/pkg238-postinit-cpu-gpu-threshold.md
@@ -1,0 +1,52 @@
+# pkg238 — PostInit CPU/GPU numerical threshold diagnosis
+
+**Pillar:** 5 (GPU numerical parity gates)
+**Track:** A
+**Status:** OPEN — detailed architect review required before implementation
+**Estimated effort:** TBD at architect review
+**Depends on:** none (diagnosis of existing behavior)
+
+## Evidence
+
+`tests/wavefront_diff/test_pkg55_cuda_threshold_gate.py::test_cpu_to_gpu_threshold_gate`
+failed PostInit max-ULP 13 against the pinned bound 4 IDENTICALLY on baseline and
+feature. PostInit is initial camera/wavelength state before shader evaluation, so
+this does not prove a pkg230 VM regression. Evidence files: feature
+`test_results/pkg230-p2/full-suite.log` and `baseline-full-suite-failures.log`.
+
+## Goal
+
+Diagnose the exact snapshot fields/pixels/lanes behind the PostInit max-ULP
+overshoot, including signed-zero/subnormal/near-zero handling in the ULP metric,
+compiler/math options (FMA, fast math, FP precision), seeding/camera/wavelength
+initialization, and the actual code paths, before proposing any bound change.
+Preserve root/feature raw snapshots and source/toolchain/options/import identity
+throughout. Do not assume 13 is acceptable or 4 is invalid; decide only on
+independent numerical evidence.
+
+## Scoped direction
+
+Detailed architect review decides the correct minimal implementation or a
+calibrated bound change only after independent numerical evidence is produced.
+This follow-up does not change owner queue priority; Pillar 4 remains PAUSED.
+
+## Acceptance — all implementation gates UNRUN
+
+- [ ] Repeated identical baseline/feature reproductions produce field-attributed
+      ULP plus relative/absolute error distributions.
+- [ ] Compare attributed fields against independent initialization oracles.
+- [ ] Matched toolchain/math flags and seed determinism documented.
+- [ ] Why the existing bound fails is documented from evidence, not assumption.
+- [ ] PostIntersect/PostShade/PostLightSample and other later-stage gates remain
+      unchanged during diagnosis.
+- [ ] Any fix/bound proposal is independently reviewed and scientifically
+      supported; native architecture/ABI/resource checks and full required
+      regressions if the engine changes.
+- [ ] GPU lock and at most two isolated implementation worktrees; independent
+      Astra/Claude sign-off.
+
+## Non-goals
+
+A blanket threshold increase could mask a genuine PostInit divergence or a later
+regression. No blanket threshold increase; no masking of later-stage failures; no
+shader VM/transport changes; no owner queue priority change; no Pillar 4 work.


### PR DESCRIPTION
Files three bounded follow-ups discovered during pkg230 Phase 2 verification: isolate the Blender dev-loop smoke from the real user profile, diagnose baseline-reproduced HDRI SSIM failures, and attribute baseline-reproduced PostInit ULP overshoot.

All remain OPEN pending detailed architecture review, with implementation gates UNRUN. No rendering thresholds or owner priorities change. The smoke incident was repaired with the original native build preserved; the two numerical failures reproduce on a freshly built main module.

Validation: Astra source/evidence review; independent Claude filing SIGN-OFF for all three; markdownlint, codespell, and diff-check report zero new findings and no unavailable/error tools. Docs-only; no runtime implementation claimed.
