### PR TITLE
feat(pkg230): vector shader operations and faithful Mix factors

### DIFF
--- a/.astroray_plan/docs/external-references.md
+++ b/.astroray_plan/docs/external-references.md
@@ -224,3 +224,5 @@ Astroray targets MIT (or Apache 2.0). Compatible:
   only. GYOTO, GRay2, CLOUDY fall here.
 
 When in doubt, ask before adding a dependency.
+
+- Cycles Blender v5.1.0 vector math, Vector Rotate and Mix factor semantics (Apache-2.0), pinned at adfe2921d5f3: [pkg230 Phase 2 research](pkg230-phase2-vector-semantics-research.md).

--- a/.astroray_plan/docs/pkg230-phase2-delivery-evidence.md
+++ b/.astroray_plan/docs/pkg230-phase2-delivery-evidence.md
@@ -1,0 +1,163 @@
+# pkg230 Phase 2 delivery evidence
+
+Verified implementation, 2026-09-06; final independent sign-off and CI/merge pending.
+Base: `31f30298c79dad151b270bef448184b598995137`.
+
+## Architecture and scope
+
+[The research note](pkg230-phase2-vector-semantics-research.md) pins Blender 5.1
+Cycles sources and resolves the color/scalar-versus-coordinate fork. Phase 2
+adds all 30 Vector Math operations, five Vector Rotate modes (center/invert),
+and faithful modern Mix factor clamping. Coordinate chains visibly degrade;
+pkg230b owns their later extension. Legacy raw Mix retains its default clamp.
+
+Integration corrected real Blender socket/type handling, operand placement,
+Cycles power/wrap edge cases, Euler inversion, implicit color/vector-to-scalar
+conversion, and indexable `mathutils.Euler` defaults. Tests cover compiler output
+through the native evaluator, beyond mocks. Independent Claude architecture and
+source reviews accepted the math, scope, ABI and callers.
+
+## Builds and runtime identity
+
+- Hardware: RTX 5070 Ti, 16303 MiB, driver 616.56, Windows; CUDA 12.8,
+  MSVC 14.44.35207, native sm_120, wavefront N3 ON.
+- Fresh baseline: main `build_cuda/Release/astroray.cp313-win_amd64.pyd`,
+  153047040 bytes; imported path/features and baseline VM canary confirmed.
+  Baseline Phase 1 tests: **10 passed**. OpenMP ON.
+- CPU-only addon: MinGW, CUDA OFF, OpenMP OFF; native tests **96 passed**;
+  image programs **3 passed / 6 GPU-only skipped**. Final Blender CPU charts
+  import this module from `build_blender_addon`, with its packaged thread DLL.
+- Feature CUDA: first sccache attempt failed with connection reset 10054 in
+  stage_advance; direct compiler retry passed with the same feature options.
+  Initial native focused run: **118 passed**. OpenMP ON for the full-suite run.
+- Final Blender CUDA addon: canonical backend flags, OpenMP OFF, build ID
+  `31f3029+20260905T153751Z`, module 153293312 bytes, built 2026-09-05 16:03 UTC.
+  Intended import path, matching package build ID, native sm_120, host ABI canary,
+  and header stamp PASS. Canonical staging bundles OIDN/CUDA DLLs.
+  Final focused pkg219/pkg230 run: **158 passed in 10.99 s**.
+- Linked resources: **128 shade variants**; all **64 HasProgram=false** variants
+  match every recorded baseline resource field. Fleet: REG 254 / STACK 3400 /
+  CONSTANT[0] 1748 / LOCAL 0. These are measured resource identities, not a
+  claim that complete machine-code byte streams were compared.
+
+## Visual and numerical gates
+
+Final charts use real Blender 5.1.0 (`adfe2921d5f3`), 128x128, 256 samples,
+raw linear float32 arrays, no denoising or adaptive sampling. Fifteen legs PASS:
+plain image, MULTIPLY_ADD, inverted Euler XYZ, clamped Mix and unclamped Mix,
+each through CPU-only Astroray, RTX Astroray and Cycles. The carrier is textured
+Principled with specular zero, perspective camera, Closest filtering; Astroray
+reports its existing textured-Base-Color lambertian approximation explicitly.
+
+- CPU/Cycles interior RGB mean ratios: **0.976648-1.018138**.
+- GPU/Cycles interior RGB mean ratios: **0.976268-1.017924**.
+- GPU/CPU interior RGB mean ratios: **0.999458-1.000073**.
+- All lie inside the declared **[0.95,1.05]** gate. ROI is pixels `[24:104,24:104]`.
+- Clamped Mix matches the plain control (maximum GPU difference 1.19e-7;
+  CPU/Cycles exact). Unclamped Mix visibly extrapolates; mean control difference
+  is 0.02685 CPU/GPU and 0.02793 Cycles.
+- Astra qualitative PASS on `final_blender_cpu_gpu_cycles.png`: corresponding
+  color patterns and transformations, CPU/GPU agreement, no new spatial defects,
+  modest spectral color differences/noise relative to Cycles.
+- Native program image tests also PASS: ratios 0.997252-1.000201 and program
+  effects above 0.02 mean absolute difference on both backends. Astra inspected
+  `native_cpu_gpu.png` and accepted the representative math/rotation/Mix effects.
+
+Initial Diffuse-carrier and Linear-filter comparisons exposed existing consumer
+and nearest-only filtering gaps. Their `_failed_diffuse` and `_linear_filter_gap`
+artifacts are retained; pkg233 and pkg234 own these gaps. They are not counted as
+pkg230 coverage. The final carrier and filtering restriction are intentional and
+were independently reviewed.
+
+## Full suite and investigated failures
+
+The full split run recorded **1642 passed, 56 skipped, 9 xfailed** in the CPU
+pass (342.08 s), then **684 passed, 16 skipped, 8 xfailed, 6 xpassed, 4 failed**
+in the serial pass (239.70 s). This original full-suite run is not green.
+
+Two failures are baseline renderer/test debt, with unchanged assertions:
+
+| Gate | Fresh main | Feature | Existing bound |
+| --- | --- | --- | --- |
+| HDRI SSIM, original failure runs | 0.77432567 | 0.7690514 | >=0.97 |
+| PostInit maximum ULP | 13 | 13 | <=4 |
+
+Independent Claude gate-failure review accepts their baseline reproduction and
+exclusion from new-VM reachability, conditional on extra measurements. Those
+measurements are now recorded without changing or bypassing source assertions:
+all snapshots were already captured before the failure, so the diagnostic driver
+uses the failing frame's values and the original numerical helper functions.
+
+| Stage | Main and feature measured identically | Result |
+| --- | --- | --- |
+| PostInit | origin ULP 0, direction 2, wavelength 13; p99.9 4.88660e-7 | ULP fails; p99.9 passes |
+| PostIntersect | ULP 46; p99.9 3.82908e-6 | Pass |
+| PostShade | 134 rows; p99.9 1.15045e-6 | Pass |
+| PostLightSample | 95 rows; p99.9 8.10758e-7 | Pass |
+| PostRR | No bounce-zero CPU rows | Inactive, not a measured pass |
+
+The overshoot is in wavelengths, not camera direction. Its precise cause remains
+pkg238 work. Captured HDRI images show noisier CPU output on both branches;
+new scores are 0.769988 main / 0.768899 feature. All peaks are below 1, so the
+`max(1, image.max())` normalization is inactive in these captures. No exact HDRI
+cause is claimed; pkg237 retains that diagnosis. Astra inspected
+`baseline_hdri_failure.png` as failure evidence, not a passing visual gate.
+
+The other two failures were investigated and corrected for reruns:
+
+- The non-hermetic dev-loop test attempted installation into the running Blender
+  5.2 profile and hit a locked older module after partially removing support
+  directories. Recovery restored the matching `1967cb5` Python/assets and
+  unchanged runtime DLL bundle, preserving the original native module. Background
+  registration PASS. The unmodified smoke test then **passed** with all Blender
+  user-resource paths redirected to a verified worktree test directory. pkg236
+  owns permanent isolation/rollback; this round did not install the new build
+  into the live profile. Recovery evidence is in the root workspace's
+  `test_results/pkg230-p2/installed-recovery/`.
+- Backdrop initially failed DLL loading, then selected the CPU-only build while
+  requesting GPU. Providing the byte-identical staged CUDA artifact at the
+  canonical addon discovery path let the stock test reach its actual assertion.
+  The faithful sample/denoising configuration exposed insufficient sampling:
+  both main and feature score **0.8395174 at 64 spp**, **0.9141075 at 256 spp**.
+  The test now requests 256 on both engines and retains its 0.90 threshold.
+  **All 37 harness tests pass in 7.68 s.** Astra inspected the convergence sheet:
+  noise decreases and baseline/feature structure agrees. A small bright patch on
+  the green backdrop persists in both Astroray builds and is absent in Cycles;
+  this local baseline discrepancy is a separate diagnostic follow-up, not a
+  claim of perfect backdrop parity.
+
+## Callers, hygiene and independent review
+
+`svm_mix` adds a defaulted boolean; its sole production caller decodes the new
+negative flag. `_resolve_vector_input` adds an optional warning callback, passed
+by all three production callers and recursion. Old tests/mocks remain valid.
+`compile_socket` keeps its public signature; its internal value helper leaves
+recursive implicit conversions intact. The render configurator's optional
+backend argument is passed by its CLI caller; the backdrop test is its real
+harness consumer. No bindings, POD layouts, slot limits, specialization axes or
+material layouts change. Final caller sweep is saved.
+
+Differential Ruff/cppcheck/markdownlint/codespell/diff-check reports zero new
+findings, no unavailable/error tools. clang-format is skipped because the repo
+has no style configuration. Final harness/evidence edits will receive the same
+scoped check before commit.
+
+Two early cheap source-critic attempts timed out: incomplete, never counted as
+PASS. Later bounded opencode call-path and settings traces completed; Astra
+corrected their mistaken inferences before use. Claude architecture, source and
+conditional failure reviews are retained. Final independent judgment and CI
+remain release gates.
+
+## Follow-ups and artifacts
+
+Separately filed after independent Claude review and docs CI: pkg230b (#697),
+pkg231 (#698), pkg232-235 (#699), pkg236-238 (#700). All new follow-ups remain OPEN
+with implementation gates UNRUN, no queue promotion. Pillar 4 remains PAUSED.
+
+`test_results/pkg230-p2/` retains builds, import proofs, raw resource dumps,
+linear arrays, contact sheets, test logs, compiler/real-Blender probes, caller
+sweep, and Claude transcripts. Key final files are `final-module-proof.json`,
+`final-resource-comparison.json`, `final-blender-metrics.json`,
+`final_blender_cpu_gpu_cycles.png`, `backdrop-convergence.json`,
+`backdrop_convergence.png`, `baseline_hdri_failure.png`, and the
+`main/feature-baseline-diagnostics.json` pair.

--- a/.astroray_plan/docs/pkg230-phase2-vector-semantics-research.md
+++ b/.astroray_plan/docs/pkg230-phase2-vector-semantics-research.md
@@ -1,0 +1,94 @@
+# pkg230 Phase 2 — vector semantics and delivery decision
+
+Architect decision, 2026-09-05, base `31f3029`.
+
+The live STATUS, NEXT_STAGE_REPORT, and ROADMAP all select this phase. No open
+PRs or other worktrees were present at selection. pkg219a/b/c and pkg229 are
+landed; pkg230 Phase 1 landed in #696 despite its stale Status header.
+This closes common Blender shader gaps ahead of the owner-choice research and
+larger Principled arcs. Pillar 4 remains paused.
+
+## Reference checked before implementation
+
+The existing pkg219c semantics research already covers Vector Math. This refresh
+pins Blender v5.1.0, commit `adfe2921d5f3c0fe699149bcd9bc347543bbd82e`:
+
+- https://github.com/blender/blender/blob/adfe2921d5f3c0fe699149bcd9bc347543bbd82e/intern/cycles/kernel/svm/math_util.h
+- https://github.com/blender/blender/blob/adfe2921d5f3c0fe699149bcd9bc347543bbd82e/intern/cycles/kernel/svm/vector_rotate.h
+- https://github.com/blender/blender/blob/adfe2921d5f3c0fe699149bcd9bc347543bbd82e/intern/cycles/util/math_float3.h
+- https://github.com/blender/blender/blob/adfe2921d5f3c0fe699149bcd9bc347543bbd82e/intern/cycles/util/math_base.h
+- https://github.com/blender/blender/blob/adfe2921d5f3c0fe699149bcd9bc347543bbd82e/intern/cycles/util/transform.h
+- https://github.com/blender/blender/blob/adfe2921d5f3c0fe699149bcd9bc347543bbd82e/intern/cycles/kernel/svm/color_util.h
+- https://github.com/blender/blender/blob/adfe2921d5f3c0fe699149bcd9bc347543bbd82e/intern/cycles/kernel/svm/convert.h
+
+All these files declare Apache-2.0. Preserve attribution in the adapted helpers;
+this is compatible with the repository's MIT license. These are node semantics
+and textbook vector/rotation formulas, not a new light transport algorithm; no
+paper claim is made. The Cycles implementation is the normative reference.
+
+## Bounded architecture
+
+Add OP_VEC_MATH=15 and OP_VEC_ROTATE=16 in the existing shared HD evaluator and
+Python compiler. Keep Instr, ShaderVMProgram, GMaterial, slot limits, bindings,
+and shader specialization axes unchanged. Implement the 30 vector operations
+in the pinned reference. Dot/distance/length broadcast their scalar result.
+Read duplicate Vector inputs by position and compile only operands used by the
+selected operation, avoiding dead hidden sockets and unnecessary slot pressure.
+
+Rotate supports AXIS_ANGLE, X_AXIS, Y_AXIS, Z_AXIS, EULER_XYZ, center and invert.
+Axis-angle and single-axis invert negate the angle.
+Use the Cycles Euler XYZ transform, transposed for invert (negating all Euler
+angles in the same order is incorrect). A zero axis returns the input vector.
+
+Mix uses bit 0x40 as SVM_MIX_UNCLAMP_FACTOR (set means unclamped), preserving
+existing raw bytecode with bit clear. Modern Mix obeys
+clamp_factor, legacy MixRGB always clamps its factor. Select the enabled
+data-type sockets in real Blender, where names Factor/A/B are duplicated.
+Preserve default and legacy results. Unsupported data modes must visibly
+degrade rather than select an inactive socket. Sweep hand-written bytecode
+callers if introducing a positive clamp flag changes the old encoding.
+
+Scope is the color/scalar chain after image sampling. The affine coordinate
+resolver remains a separate path: do not claim general per-texel coordinate
+support. Its existing affine subset and warning/degradation behavior must be
+checked. Vector Math/Rotate in this path must emit a visible fallback warning,
+covered by an addon regression test. Affine vector support and general per-texel
+coordinate evaluation become a separate follow-up spec,
+not an expansion of this phase.
+
+## Acceptance gates and risks
+
+1. Enum/flag synchronization and all vector operations evaluated against
+   explicit expected values, including zero division/normalization, negative
+   modulo, wrap bounds, projection, reflection and refraction edge cases.
+2. All rotation modes, nonzero centers, zero axis, multi-axis Euler inverse,
+   linked operands, and default/clamped/unclamped Mix factors tested.
+3. CPU and RTX 5070 Ti representative image-program renders change from the
+   plain-texture control and agree per-channel mean within 5%; save images.
+4. Build both backends from current sources; verify module path and a new-op
+   canary. Compare linked non-program fleet kernel REG/STACK/CONST to a fresh
+   baseline from the same compiler/configuration. No new specialization axis.
+5. Run focused regressions, full local suite, differential lint, and caller/
+   binding review. Investigate failures against baseline without weakening gates.
+6. Headless Blender exercises real sockets, exporter and renderer; compare
+   representative output to Cycles in a common linear space. Astra visually
+   inspects exposure, color, artifacts and expected transforms.
+7. Independent Claude architecture and final ABI/parity/PR sign-off before
+   autonomous merge; CI green. Planning records contain actual evidence only.
+
+Main risks: operand selection, Euler inverse convention, limited VM slots,
+silent coordinate degradation, Mix bytecode compatibility, and stale OneDrive
+build products. Spectral/dispersion/IR paths are preserved by the bounded VM
+change; no transport or scientific-output behavior is redesigned.
+
+Independent Claude architecture review: SIGN-OFF, with the three conditions
+above (coordinate warning gate, negative Mix flag, per-type inverse) accepted.
+Transcript: `test_results/pkg230-p2/architecture-claude.txt`.
+
+Integration finding: real Blender links expose socket types. The compiler now
+converts linked RGBA to scalar with the existing linear luminance opcode and
+VECTOR to scalar with a dot product against (1/3,1/3,1/3), following pinned
+Cycles `kernel/svm/convert.h` (Apache-2.0). This is needed for vector -> Math,
+modern FLOAT Mix, factors and angles; VM bounds still apply. Bare image paths
+remain owned by pkg186. FLOAT and uniform VECTOR Mix interpolate linearly;
+ROTATION and non-uniform factors visibly degrade.

--- a/.astroray_plan/packages/pkg230-opvm-utility-opcodes.md
+++ b/.astroray_plan/packages/pkg230-opvm-utility-opcodes.md
@@ -2,8 +2,8 @@
 
 **Pillar:** 5 (Blender integration / shader-node coverage)
 **Track:** A
-**Status:** Phase 1 IN PROGRESS 2026-09-05 (branch `pkg230-opvm-utility-cluster`);
-Phase 2 SCOPED (fork documented, not started)
+**Status:** Phase 1 LANDED (#696); Phase 2 VERIFIED 2026-09-06; final sign-off/CI/merge pending
+(branch `codex/pkg230-p2`, architecture independently signed off)
 **Estimated effort:** Phase 1 S (~1 session); Phase 2 M
 **Depends on:** pkg219a/b/c (op-VM evaluator), pkg229 (re-audit that ranked these)
 
@@ -96,27 +96,50 @@ clamp to [min(min,max), max(min,max)]). Verified against Cycles `svm_clamp` /
 
 ---
 
-## Specification — Phase 2 (scoped, not started)
+## Specification — Phase 2 (architecture resolved 2026-09-05)
 
-Vector Math (`VECT_MATH`) + Vector Rotate (`VECTOR_ROTATE`) op-VM opcodes for the
-**color/scalar-chain case** (`OP_VEC_MATH` with a `VecMathOp` family over full
-GVec3 slots; `OP_VEC_ROTATE` axis-angle Rodrigues + Euler, `imm`=rotation_type).
-`Instr` a..e already suffice (vec1/vec2/vec3/scale, and vector/center/axis/angle).
-**Open fork:** the coordinate-chain case (vector math on texture coordinates before
-the lookup) is not expressible by `_resolve_mapping_matrix`'s affine model — decide
-per node whether to (a) compose into the matrix for the affine subset only and
-`VMCompileError`/degrade otherwise, or (b) extend the coordinate path to a per-texel
-vector op-VM. Recommend (a) first (cheap, honest degradation), (b) as a later
-package if usage warrants. cite-algorithm: Rodrigues rotation is trivial; Vector
-Math op semantics cite Cycles `svm_vector_math`. Also in Phase 2: faithful Mix
-**`clamp_factor=OFF`** — gate `svm_mix`'s unconditional factor saturate behind a
-flag, addon setting it per node (legacy always; modern per `clamp_factor`).
+Implement Vector Math (`OP_VEC_MATH=15`, all 30 Blender 5.1 operations) and
+Vector Rotate (`OP_VEC_ROTATE=16`, axis-angle, X/Y/Z, Euler XYZ, center/invert)
+in the shared HD VM for image-driven **color/scalar chains**. Read only used
+operands; index duplicate Vector sockets positionally. Keep VM limits and POD
+layouts unchanged. Scalar vector-math outputs broadcast; Euler inverse uses
+transpose, axis-angle inverse negates angle, zero axis is identity.
+
+Mix uses negative-polarity `SVM_MIX_UNCLAMP_FACTOR=0x40`: legacy/default raw
+bytecode keeps clamping; modern Mix obeys `clamp_factor`. Select enabled typed
+sockets, and visibly reject unsupported modes. `clamp_result` remains bit 0x80.
+
+**Coordinate fork resolved:** retain the existing affine Mapping path and make
+unsupported Vector Math/Rotate chains emit a visible degradation warning.
+Affine vector operations and general per-texel coordinate evaluation are a
+separate follow-up; this phase does not claim their support.
+
+Pinned sources, rationale, dependencies and risks:
+[`pkg230-phase2-vector-semantics-research.md`](../docs/pkg230-phase2-vector-semantics-research.md).
+Independent Claude architecture SIGN-OFF accepted with the warning, negative
+flag and inverse-convention conditions included above.
+
+### Acceptance criteria — Phase 2
+
+- [x] All 30 vector operations, all 5 rotation modes, linked operands and edge
+      cases evaluated against explicit mathematical oracles; enum/flag parity.
+- [x] Legacy/default Mix unchanged; unclamped factors below zero/above one;
+      duplicate real Blender socket layout and unsupported-mode rejection.
+- [x] Coordinate-chain Vector Math/Rotate emits visible degradation (test).
+- [x] CPU/GPU image programs change the control render and per-channel mean
+      ratios lie in [0.95,1.05]; saved outputs inspected qualitatively.
+- [x] Fresh canonical builds, intended import path, new-op canary, unchanged
+      non-program fleet kernel REG/STACK/CONST against same-toolchain baseline.
+- [x] Headless Blender real graphs render through exporter; compare saved
+      vector/Mix charts with Cycles in common linear space.
+- [ ] Full local suite, focused regressions, differential lint and caller/binding
+      sweep recorded; independent Claude final sign-off and green CI.
 
 ---
 
 ## Non-goals
 
-- No new coordinate-chain per-texel vector VM in Phase 1 (that's the Phase 2 fork).
+- No new coordinate-chain per-texel vector VM; Phase 2 explicitly warns/degrades.
 - No touching the fleet `<false>` shade kernel or `GMaterial` layout.
 - No Principled advanced-inputs (separate, higher-effort spec).
 
@@ -141,4 +164,8 @@ flag, addon setting it per node (legacy always; modern per `clamp_factor`).
 
 ## Lessons
 
-*(Fill in after the package is done.)*
+Hardware/visual verification and investigated baseline failures are recorded in
+[Phase 2 delivery evidence](../docs/pkg230-phase2-delivery-evidence.md).
+The full suite recorded 2326 passes and four failures; corrected Blender/harness
+reruns pass, while HDRI SSIM and PostInit ULP remain baseline-reproduced failures.
+No rendering thresholds were weakened. Final independent sign-off and CI pending.

--- a/benchmarks/blender_parity/render_leg.py
+++ b/benchmarks/blender_parity/render_leg.py
@@ -68,7 +68,7 @@ def _bootstrap_astroray_addon(repo_root: Path):
             raise
 
 
-def _configure_render(scene, engine, res, samples):
+def _configure_render(scene, engine, res, samples, device="gpu"):
     scene.render.resolution_x = res
     scene.render.resolution_y = res
     scene.render.resolution_percentage = 100
@@ -80,18 +80,21 @@ def _configure_render(scene, engine, res, samples):
     scene.render.image_settings.color_depth = "32"
     scene.render.image_settings.exr_codec = "NONE"
     scene.render.engine = engine
-    if engine == "CYCLES":
+    # Astroray also consumes these native Cycles settings (pkg176).
+    if hasattr(scene, "cycles"):
         scene.cycles.samples = samples
         scene.cycles.use_denoising = False
         scene.cycles.use_adaptive_sampling = False
         scene.cycles.seed = 7
-    elif hasattr(scene, "custom_raytracer"):
+    if engine == "CUSTOM_RAYTRACER" and hasattr(scene, "custom_raytracer"):
         cr = scene.custom_raytracer
         cr.samples = samples
         if hasattr(cr, "preview_samples"):
             cr.preview_samples = samples
         if hasattr(cr, "device_mode"):
-            cr.device_mode = "gpu"
+            cr.device_mode = device
+        # Adaptive sampling remains an Astroray-only setting in the resolver.
+        cr.use_adaptive_sampling = False
 
 
 def _render_to_npy(bpy, scene, out_stem: Path, res: int):
@@ -143,6 +146,8 @@ def main():
     p.add_argument("--out", required=True, help="output stem (no extension)")
     p.add_argument("--res", type=int, default=128)
     p.add_argument("--samples", type=int, default=64)
+    p.add_argument("--device", choices=("cpu", "gpu", "auto"), default="gpu",
+                   help="Astroray backend (default: gpu; Cycles stays on CPU)")
     args = p.parse_args(argv)
 
     repo_root = Path(__file__).resolve().parents[2]
@@ -157,7 +162,7 @@ def main():
 
         scene = scene_library.build_scene(
             bpy, args.category, args.feature, args.bl_idname, engine=args.engine)
-        _configure_render(scene, args.engine, args.res, args.samples)
+        _configure_render(scene, args.engine, args.res, args.samples, args.device)
         out_stem = Path(args.out)
         out_stem.parent.mkdir(parents=True, exist_ok=True)
         npy = _render_to_npy(bpy, scene, out_stem, args.res)

--- a/benchmarks/blender_parity/scene_library.py
+++ b/benchmarks/blender_parity/scene_library.py
@@ -32,7 +32,11 @@ LIGHT_CONFIGS = {
     "SUN": dict(energy=5.0, height=10.0, extra={"angle": math.radians(0.526)}),
 }
 
-COMPOSITE_SCENES = ("mix_shader_stack", "texture_driven_roughness", "bump_plus_normal")
+COMPOSITE_SCENES = (
+    "mix_shader_stack", "texture_driven_roughness", "bump_plus_normal",
+    "opvm_plain", "opvm_vector_math", "opvm_vector_rotate",
+    "opvm_mix_clamped", "opvm_mix_unclamped",
+)
 
 
 # --------------------------------------------------------------------------- #
@@ -412,10 +416,89 @@ def build_bump_plus_normal(bpy):
     return scene
 
 
+def build_vector_opvm_scene(bpy, variant):
+    """pkg230: image-driven vector/color chains on a Principled UV chart.
+
+    The plain image and clamped Mix are controls. Fixed linear image values,
+    white world illumination and a front-facing plane isolate node semantics
+    from geometry, glossy lobes and color-management differences.
+    """
+    scene = _reset(bpy)
+    _add_world(bpy, scene, strength=1.0, color=(0.5, 0.5, 0.5))
+    bpy.ops.mesh.primitive_plane_add(size=2.0)
+    plane = bpy.context.active_object
+    mat = bpy.data.materials.new('VectorChartMaterial')
+    mat.use_nodes = True
+    plane.data.materials.append(mat)
+    nt = mat.node_tree
+    diffuse = next(n for n in nt.nodes if n.type == 'BSDF_PRINCIPLED')
+    diffuse.inputs['Specular IOR Level'].default_value = 0.0
+    diffuse.inputs['Roughness'].default_value = 0.0
+    img = bpy.data.images.new("VectorChart", width=8, height=8, float_buffer=True)
+    img.colorspace_settings.name = 'Non-Color'
+    pixels = []
+    for y in range(8):
+        for x in range(8):
+            pixels.extend((0.15 + 0.6 * x / 7, 0.15 + 0.6 * y / 7,
+                           0.25 + 0.3 * ((x // 2 + y // 2) % 2), 1.0))
+    img.pixels[:] = pixels
+    img.pack()
+    tex = nt.nodes.new('ShaderNodeTexImage')
+    tex.image = img
+    # pkg186 image sampling currently supports nearest on both backends.
+    # Match that explicitly; Linear/Cubic filtering belongs to pkg234.
+    tex.interpolation = 'Closest'
+    source = tex.outputs['Color']
+    if variant == 'vector_math':
+        node = nt.nodes.new('ShaderNodeVectorMath')
+        node.operation = 'MULTIPLY_ADD'
+        nt.links.new(source, node.inputs[0])
+        node.inputs[1].default_value = (0.6, 0.85, 0.45)
+        node.inputs[2].default_value = (0.12, 0.04, 0.18)
+        source = node.outputs['Vector']
+    elif variant == 'vector_rotate':
+        node = nt.nodes.new('ShaderNodeVectorRotate')
+        node.rotation_type = 'EULER_XYZ'
+        node.invert = True
+        node.inputs['Center'].default_value = (0.5, 0.5, 0.5)
+        node.inputs['Rotation'].default_value = (0.2, -0.3, 0.5)
+        nt.links.new(source, node.inputs['Vector'])
+        source = node.outputs['Vector']
+    elif variant in ('mix_clamped', 'mix_unclamped'):
+        node = nt.nodes.new('ShaderNodeMix')
+        node.data_type = 'RGBA'
+        node.blend_type = 'MIX'
+        node.clamp_factor = variant == 'mix_clamped'
+        node.clamp_result = False
+        # Real Blender has duplicate Factor/A/B names for each data type.
+        enabled = {s.name: s for s in node.inputs if s.enabled}
+        enabled['Factor'].default_value = 1.4
+        enabled['A'].default_value = (0.3, 0.3, 0.3, 1.0)
+        nt.links.new(source, enabled['B'])
+        source = next(s for s in node.outputs if s.enabled)
+    elif variant != 'plain':
+        raise ValueError(f'unknown vector op-VM variant: {variant}')
+    nt.links.new(source, diffuse.inputs['Base Color'])
+    camera_data = bpy.data.cameras.new('VectorChartCamera')
+    camera_data.type = 'PERSP'
+    camera_data.lens = 47.0
+    camera = bpy.data.objects.new('VectorChartCamera', camera_data)
+    scene.collection.objects.link(camera)
+    camera.location = (0, 0, 3)
+    scene.camera = camera
+    scene.cycles.max_bounces = 2
+    return scene
+
+
 COMPOSITE_BUILDERS = {
     "mix_shader_stack": build_mix_shader_stack,
     "texture_driven_roughness": build_texture_driven_roughness,
     "bump_plus_normal": build_bump_plus_normal,
+    "opvm_plain": lambda bpy: build_vector_opvm_scene(bpy, 'plain'),
+    "opvm_vector_math": lambda bpy: build_vector_opvm_scene(bpy, 'vector_math'),
+    "opvm_vector_rotate": lambda bpy: build_vector_opvm_scene(bpy, 'vector_rotate'),
+    "opvm_mix_clamped": lambda bpy: build_vector_opvm_scene(bpy, 'mix_clamped'),
+    "opvm_mix_unclamped": lambda bpy: build_vector_opvm_scene(bpy, 'mix_unclamped'),
 }
 
 

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -2952,7 +2952,8 @@ class CustomRaytracerRenderEngine(RenderEngine):
     # ------------------------------------------------------------------ #
 
     @staticmethod
-    def _resolve_vector_input(vector_socket, depth=0, default_coord_mode="UV"):
+    def _resolve_vector_input(vector_socket, depth=0, default_coord_mode="UV",
+                              warn=None):
         """Walk the Vector input on a TEX_IMAGE / procedural texture node and
         return ``(coord_mode, scale_xy, offset_xy, rotation_z, uv_layer_name)``:
 
@@ -2968,6 +2969,11 @@ class CustomRaytracerRenderEngine(RenderEngine):
         - ``default_coord_mode``: fallback when vector_socket is unlinked.
           Per pkg115 Blender parity audit: procedural textures default to
           "GENERATED", Image Texture defaults to "UV".
+        - ``warn``: optional callable ``(node_type, message)`` — pkg230 Phase 2
+          surfaces a visible ``_warn_shader_fallback`` when a VECT_MATH /
+          VECTOR_ROTATE node appears on the coordinate chain (a per-texel
+          coordinate op the affine resolver cannot express). Static method, so
+          it cannot warn on its own; instance callers pass their warn hook.
 
         Limit chain depth to avoid pathological node graphs (Mapping → Mapping
         → Mapping…).
@@ -3016,7 +3022,7 @@ class CustomRaytracerRenderEngine(RenderEngine):
             # Recurse to find the upstream coord source.
             inner_socket = src.inputs.get('Vector') if hasattr(src, 'inputs') else None
             inner_coord, _inner_scale, _inner_offset, _inner_rot, inner_layer = \
-                CustomRaytracerRenderEngine._resolve_vector_input(inner_socket, depth + 1, default_coord_mode)
+                CustomRaytracerRenderEngine._resolve_vector_input(inner_socket, depth + 1, default_coord_mode, warn)
             return inner_coord, scale, offset, rotation, inner_layer
 
         if ntype == 'TEX_COORD':
@@ -3041,6 +3047,15 @@ class CustomRaytracerRenderEngine(RenderEngine):
 
         if ntype == 'UVMAP':
             return "UV", scale, offset, rotation, getattr(src, 'uv_map', '') or ""
+
+        # pkg230 Phase 2 — a Vector Math / Vector Rotate node on the coordinate
+        # chain is a per-texel coordinate op the affine resolver cannot express.
+        # Surface a VISIBLE degradation entry (never a silent plain-UV fallback);
+        # the actual coordinate behaviour stays the deferred follow-up.
+        if ntype in ('VECT_MATH', 'VECTOR_ROTATE') and warn is not None:
+            warn(ntype, "per-texel Vector Math/Rotate on texture coordinates is "
+                        "unsupported — using default %s coordinates; outer Mapping nodes remain"
+                        % default_coord_mode)
 
         return coord_mode, scale, offset, rotation, uv_layer_name
 
@@ -3218,7 +3233,7 @@ class CustomRaytracerRenderEngine(RenderEngine):
         if bpy_image is None:
             return None
         # Image Texture defaults to UV when Vector socket is unconnected.
-        coord_mode, uv_scale, offset, rotation, uv_layer_name = self._resolve_vector_input(vector_input, default_coord_mode="UV")
+        coord_mode, uv_scale, offset, rotation, uv_layer_name = self._resolve_vector_input(vector_input, default_coord_mode="UV", warn=self._warn_shader_fallback)
         mapping_matrix = self._resolve_mapping_matrix(vector_input)
         cache_key = self._texture_variant_key(bpy_image.name, coord_mode, uv_scale, offset, rotation, uv_layer_name, mapping_matrix)
 
@@ -3282,7 +3297,7 @@ class CustomRaytracerRenderEngine(RenderEngine):
         # combination is always identical — the variant key is defensive.
         # pkg115 parity fix: procedural textures default to GENERATED when
         # Vector socket is unconnected (Blender standard behavior).
-        coord_mode, uv_scale, offset, rotation, uv_layer_name = self._resolve_vector_input(vector_input, default_coord_mode="GENERATED")
+        coord_mode, uv_scale, offset, rotation, uv_layer_name = self._resolve_vector_input(vector_input, default_coord_mode="GENERATED", warn=self._warn_shader_fallback)
         # pkg115 residual fix (black gradient/magic spheres): id(node) is NOT a
         # stable key — convert_node_material works on a temporary
         # inline_shader_nodes() tree that is freed after each material, and
@@ -3522,7 +3537,7 @@ class CustomRaytracerRenderEngine(RenderEngine):
         first = compiled['inputs'][0]
         vinp = first.inputs.get('Vector') if hasattr(first, 'inputs') else None
         coord_mode, scale, offset, rot, uvlayer = self._resolve_vector_input(
-            vinp, default_coord_mode="UV")
+            vinp, default_coord_mode="UV", warn=self._warn_shader_fallback)
         mapping_matrix = self._resolve_mapping_matrix(vinp)
         try:
             renderer.create_program_texture(prog_name, coord_mode)

--- a/blender_addon/shader_vm_compiler.py
+++ b/blender_addon/shader_vm_compiler.py
@@ -19,15 +19,19 @@ Opcode / sub-op enums MUST match include/astroray/shader_vm.h exactly.
 # ---- opcode / sub-op enums (mirror include/astroray/shader_vm.h) -----------
 (OP_END, OP_LOAD_TEX, OP_LOAD_CONST, OP_MATH, OP_MIX, OP_RAMP, OP_MAP_RANGE,
  OP_HSV, OP_INVERT, OP_GAMMA, OP_BRIGHT_CONTRAST, OP_SEP_COLOR,
- OP_COMBINE_COLOR, OP_RGB_TO_BW, OP_CLAMP) = range(15)
+ OP_COMBINE_COLOR, OP_RGB_TO_BW, OP_CLAMP, OP_VEC_MATH, OP_VEC_ROTATE) = range(17)
 
 # pkg230 — Clamp node type (Cycles NodeClampType) + clamp FLAG bits packed into
 # the free high bits of an op's imm (mirror include/astroray/shader_vm.h).
 CLAMP_MINMAX, CLAMP_RANGE = 0, 1
 CLAMP_TYPES = {'MINMAX': CLAMP_MINMAX, 'RANGE': CLAMP_RANGE}
 SVM_MATH_CLAMP = 0x80        # OP_MATH: clamp result to [0,1]
-SVM_MIX_CLAMP_RESULT = 0x80  # OP_MIX:  clamp result to [0,1] (factor always
-#                              saturated in svm_mix = Blender default clamp_factor)
+SVM_MIX_CLAMP_RESULT = 0x80  # OP_MIX:  clamp result to [0,1]
+# pkg230 Phase 2 — negative-polarity Mix factor flag (bit SET = skip the factor
+# saturation svm_mix otherwise applies). Legacy MixRGB and modern Mix
+# clamp_factor=true leave it clear (factor always saturated); modern Mix
+# clamp_factor=false sets it. Existing bytecode (bit clear) is preserved exactly.
+SVM_MIX_UNCLAMP_FACTOR = 0x40
 
 # Colour-space enum for Separate/Combine Color (Cycles NodeCombSepColorType).
 CS_RGB, CS_HSV = 0, 1
@@ -48,6 +52,37 @@ MIX_OPS = {
 }
 MAP_RANGE_OPS = {'LINEAR': 0, 'STEPPED': 1, 'SMOOTHSTEP': 2, 'SMOOTHERSTEP': 3}
 
+# pkg230 Phase 2 — Vector Math (Cycles NodeVectorMathType; the 30 operations in
+# compiler-owned ordering — see include/astroray/shader_vm.h VecMathOp).
+VEC_MATH_OPS = {
+    'ADD': 0, 'SUBTRACT': 1, 'MULTIPLY': 2, 'DIVIDE': 3,
+    'CROSS_PRODUCT': 4, 'PROJECT': 5, 'REFLECT': 6, 'REFRACT': 7,
+    'FACEFORWARD': 8, 'MULTIPLY_ADD': 9, 'DOT_PRODUCT': 10,
+    'DISTANCE': 11, 'LENGTH': 12, 'SCALE': 13, 'NORMALIZE': 14,
+    'SNAP': 15, 'ROUND': 16, 'FLOOR': 17, 'CEIL': 18, 'MODULO': 19,
+    'WRAP': 20, 'FRACTION': 21, 'ABSOLUTE': 22, 'POWER': 23,
+    'SIGN': 24, 'MINIMUM': 25, 'MAXIMUM': 26, 'SINE': 27,
+    'COSINE': 28, 'TANGENT': 29,
+}
+# Which Vector Math input sockets each operation actually consumes. The node
+# declares three `Vector` sockets (indices 0/1/2) plus a float `Scale` (index 3);
+# the compiler must only compile the operands the op reads so hidden/dead inputs
+# don't consume the 8 register slots. Scalar-result ops (dot/distance/length) are
+# broadcast by the evaluator.
+_VECMATH_USE_B = {
+    'ADD', 'SUBTRACT', 'MULTIPLY', 'DIVIDE', 'CROSS_PRODUCT', 'PROJECT',
+    'REFLECT', 'REFRACT', 'FACEFORWARD', 'MULTIPLY_ADD', 'DOT_PRODUCT',
+    'DISTANCE', 'SNAP', 'MODULO', 'WRAP', 'POWER', 'MINIMUM', 'MAXIMUM',
+}
+_VECMATH_USE_C = {'FACEFORWARD', 'MULTIPLY_ADD', 'WRAP'}
+_VECMATH_USE_SCALE = {'REFRACT', 'SCALE'}
+
+# pkg230 Phase 2 — Vector Rotate (Cycles NodeVectorRotateType).
+VEC_ROTATE_TYPES = {
+    'AXIS_ANGLE': 0, 'X_AXIS': 1, 'Y_AXIS': 2, 'Z_AXIS': 3, 'EULER_XYZ': 4,
+}
+VEC_ROTATE_INVERT = 0x08  # OP_VEC_ROTATE imm bit 3 (above the low 3 type bits)
+
 VM_MAX_INSTR = 32
 VM_MAX_SLOTS = 8
 VM_MAX_CONST = 16
@@ -61,9 +96,11 @@ class VMCompileError(Exception):
 
 def _socket_default_rgb(socket):
     val = socket.default_value
-    if hasattr(val, '__iter__'):
+    # mathutils.Euler supports indexing but does not advertise __iter__.
+    try:
+        f = float(val)
+    except (TypeError, ValueError):
         return [float(val[0]), float(val[1]), float(val[2])]
-    f = float(val)
     return [f, f, f]
 
 
@@ -154,7 +191,92 @@ def _get_input(node, *names):
     return None
 
 
+def _mix_enabled_inputs(node):
+    """Select the modern Mix node's enabled (data-type-active) input sockets.
+
+    Blender's ShaderNodeMix declares every data type's sockets (Factor/A/B across
+    FLOAT/VECTOR/RGBA/ROTATION) with an ``enabled`` flag; only the sockets matching
+    the node's current data_type are enabled. Name lookup returns the FIRST match
+    (e.g. the disabled FLOAT ``A`` when data_type is RGBA), so enabled + position
+    wins. Legacy MixRGB / test mocks without ``enabled`` metadata return None so
+    the name-based path is used instead.
+    """
+    try:
+        ins = list(getattr(node, 'inputs', []))
+    except (TypeError, AttributeError):
+        return None
+    if not ins or not any(hasattr(s, 'enabled') for s in ins):
+        return None
+    return [s for s in ins if getattr(s, 'enabled', False)]
+
+
+def _compile_mix_modern(node, builder, depth):
+    """Compile a modern ShaderNodeMix (data_type / factor_mode aware).
+
+    ROTATION and non-uniform VECTOR factors are unsupported (honest
+    VMCompileError). FLOAT and uniform VECTOR use a linear mix regardless of
+    blend_type; only RGBA honours blend_type / clamp_result. The factor follows
+    clamp_factor (default true → saturated; false sets SVM_MIX_UNCLAMP_FACTOR).
+    """
+    data_type = getattr(node, 'data_type', 'RGBA')
+    if data_type not in ('RGBA', 'FLOAT', 'VECTOR'):
+        raise VMCompileError("unsupported Mix data_type: %s" % data_type)
+    if data_type == 'VECTOR' and getattr(node, 'factor_mode', 'UNIFORM') != 'UNIFORM':
+        raise VMCompileError("unsupported Mix non-uniform VECTOR factor")
+    enabled = _mix_enabled_inputs(node)
+    if enabled is not None and len(enabled) >= 3:
+        fac_in, a_in, b_in = enabled[0], enabled[1], enabled[2]
+    else:
+        fac_in = _get_input(node, 'Factor', 'Fac')
+        a_in = _get_input(node, 'A')
+        b_in = _get_input(node, 'B')
+    fac_s = compile_socket(fac_in, builder, depth + 1)
+    a_s = compile_socket(a_in, builder, depth + 1)
+    b_s = compile_socket(b_in, builder, depth + 1)
+    if data_type == 'RGBA':
+        blend = getattr(node, 'blend_type', 'MIX')
+        if blend not in MIX_OPS:
+            raise VMCompileError("unsupported Mix blend: %s" % blend)
+        imm = MIX_OPS[blend]
+        if getattr(node, 'clamp_result', False):
+            imm |= SVM_MIX_CLAMP_RESULT
+    else:
+        # FLOAT / uniform VECTOR: linear mix, blend_type not applicable.
+        imm = MIX_OPS['MIX']
+    # Modern Mix follows clamp_factor (default true). False -> unclamp bit.
+    if not getattr(node, 'clamp_factor', True):
+        imm |= SVM_MIX_UNCLAMP_FACTOR
+    out = builder.alloc_slot()
+    builder.emit(OP_MIX, out, a=fac_s, b=a_s, c=b_s, imm=imm)
+    return out
+
+
 def compile_socket(socket, builder, depth=0):
+    """Compile a value and apply Blender's implicit conversion to scalar sockets.
+
+    Cycles svm/convert.h: color -> linear luminance, vector -> component average.
+    Float results are already broadcast by the VM. Explicit socket metadata is
+    required; lightweight callers without it retain their historical behavior.
+    """
+    slot = _compile_socket_value(socket, builder, depth)
+    if (getattr(socket, 'type', None) != 'VALUE'
+            or not getattr(socket, 'is_linked', False)):
+        return slot
+    source_type = getattr(socket.links[0].from_socket, 'type', None)
+    if source_type == 'RGBA':
+        out = builder.alloc_slot()
+        builder.emit(OP_RGB_TO_BW, out, a=slot)
+        return out
+    if source_type == 'VECTOR':
+        weight = builder.push_const([1.0 / 3.0] * 3)
+        out = builder.alloc_slot()
+        builder.emit(OP_VEC_MATH, out, a=slot, b=weight,
+                     imm=VEC_MATH_OPS['DOT_PRODUCT'])
+        return out
+    return slot
+
+
+def _compile_socket_value(socket, builder, depth=0):
     """Compile the node feeding `socket` into the VM; return its result slot.
 
     Any value that is constant-foldable becomes an OP_LOAD_CONST; a texture
@@ -181,14 +303,13 @@ def compile_socket(socket, builder, depth=0):
         builder.emit(OP_RAMP, out, a=fac_slot, imm=builder.add_ramp(table))
         return out
 
-    if ntype in ('MIX_RGB', 'MIX'):
+    if ntype == 'MIX_RGB':  # legacy MixRGB node (factor always saturated)
         blend = getattr(node, 'blend_type', 'MIX')
         if blend not in MIX_OPS:
             raise VMCompileError("unsupported Mix blend: %s" % blend)
-        fac_s = compile_socket(_get_input(node, 'Fac', 'Factor'), builder, depth + 1)
-        c1_in = _get_input(node, 'Color1', 'A')
-        c2_in = _get_input(node, 'Color2', 'B')
-        # positional fallback for the modern Mix node (Factor, A, B / …)
+        fac_s = compile_socket(_get_input(node, 'Fac'), builder, depth + 1)
+        c1_in = _get_input(node, 'Color1')
+        c2_in = _get_input(node, 'Color2')
         if c1_in is None or c2_in is None:
             ins = list(getattr(node, 'inputs', []))
             if len(ins) >= 3:
@@ -197,13 +318,71 @@ def compile_socket(socket, builder, depth=0):
         c1_s = compile_socket(c1_in, builder, depth + 1)
         c2_s = compile_socket(c2_in, builder, depth + 1)
         imm = MIX_OPS[blend]
-        # pkg230 — clamp the result: modern Mix node clamp_result, or legacy
-        # MixRGB use_clamp. (The factor is always saturated in svm_mix, matching
-        # Blender's default clamp_factor; faithful clamp_factor=OFF is Phase 2.)
-        if getattr(node, 'clamp_result', False) or getattr(node, 'use_clamp', False):
+        # Legacy MixRGB ALWAYS saturates the factor (SVM_MIX_UNCLAMP_FACTOR stays
+        # clear); use_clamp clamps the result (bit 7).
+        if getattr(node, 'use_clamp', False):
             imm |= SVM_MIX_CLAMP_RESULT
         out = builder.alloc_slot()
         builder.emit(OP_MIX, out, a=fac_s, b=c1_s, c=c2_s, imm=imm)
+        return out
+
+    if ntype == 'MIX':  # modern ShaderNodeMix
+        return _compile_mix_modern(node, builder, depth)
+
+    if ntype == 'VECT_MATH':  # pkg230 Phase 2 — Vector Math
+        op = getattr(node, 'operation', None)
+        if op not in VEC_MATH_OPS:
+            raise VMCompileError("unsupported Vector Math op: %s" % op)
+        ins = list(getattr(node, 'inputs', []))
+        # Positional reads: the node declares three `Vector` sockets (0/1/2) and a
+        # float `Scale` (3). Compile ONLY the operands the op consumes so hidden
+        # inputs don't burn register slots.
+        a_s = compile_socket(ins[0], builder, depth + 1) if len(ins) > 0 \
+            else builder.push_const([0, 0, 0])
+        b_s = 0
+        if op in _VECMATH_USE_B and len(ins) > 1:
+            b_s = compile_socket(ins[1], builder, depth + 1)
+        c_s = 0
+        if op in _VECMATH_USE_C and len(ins) > 2:
+            c_s = compile_socket(ins[2], builder, depth + 1)
+        d_s = 0
+        if op in _VECMATH_USE_SCALE and len(ins) > 3:
+            d_s = compile_socket(ins[3], builder, depth + 1)
+        out = builder.alloc_slot()
+        builder.emit(OP_VEC_MATH, out, a=a_s, b=b_s, c=c_s, d=d_s,
+                     imm=VEC_MATH_OPS[op])
+        return out
+
+    if ntype == 'VECTOR_ROTATE':  # pkg230 Phase 2 — Vector Rotate
+        rtype = getattr(node, 'rotation_type', 'AXIS_ANGLE')
+        if rtype not in VEC_ROTATE_TYPES:
+            raise VMCompileError("unsupported Vector Rotate type: %s" % rtype)
+        ins = list(getattr(node, 'inputs', []))
+        # Positional: Vector(0), Center(1), Axis(2), Angle(3), Rotation(4).
+        # Operand routing: a=vector, b=center, c=axis (AXIS_ANGLE) | rotation
+        # (EULER_XYZ) | unused, d=angle (AXIS_ANGLE + X/Y/Z) | unused.
+        vec_s = compile_socket(ins[0], builder, depth + 1) if len(ins) > 0 \
+            else builder.push_const([0, 0, 0])
+        ctr_s = compile_socket(ins[1], builder, depth + 1) if len(ins) > 1 \
+            else builder.push_const([0, 0, 0])
+        c_s = 0
+        d_s = 0
+        if rtype == 'AXIS_ANGLE':
+            c_s = compile_socket(ins[2], builder, depth + 1) if len(ins) > 2 \
+                else builder.push_const([0, 0, 0])
+            d_s = compile_socket(ins[3], builder, depth + 1) if len(ins) > 3 \
+                else builder.push_const([0, 0, 0])
+        elif rtype == 'EULER_XYZ':
+            c_s = compile_socket(ins[4], builder, depth + 1) if len(ins) > 4 \
+                else builder.push_const([0, 0, 0])
+        else:  # X/Y/Z axis: angle in d, axis slot (c) unused
+            d_s = compile_socket(ins[3], builder, depth + 1) if len(ins) > 3 \
+                else builder.push_const([0, 0, 0])
+        imm = VEC_ROTATE_TYPES[rtype]
+        if getattr(node, 'invert', False):
+            imm |= VEC_ROTATE_INVERT
+        out = builder.alloc_slot()
+        builder.emit(OP_VEC_ROTATE, out, a=vec_s, b=ctr_s, c=c_s, d=d_s, imm=imm)
         return out
 
     if ntype == 'MATH':

--- a/include/astroray/shader_vm.h
+++ b/include/astroray/shader_vm.h
@@ -60,6 +60,10 @@ enum OpCode : unsigned char {
     OP_RGB_TO_BW  = 13, // reg[out] = luma(col=a).broadcast        svm/convert.h
     // pkg230 — utility opcodes.
     OP_CLAMP      = 14, // reg[out].x = clamp(imm=type, v=a.x, min=b.x, max=c.x) svm/clamp
+    // pkg230 Phase 2 — vector opcodes (Cycles svm/math_util.h + svm/vector_rotate.h).
+    OP_VEC_MATH   = 15, // reg[out] = vec_math(imm=op, a, b, c, scale=d.x)  svm/math_util.h
+    OP_VEC_ROTATE = 16, // reg[out] = vec_rotate(imm=type|invert, a=vec, b=center,
+                        //                      c=axis|rotation, d=angle) svm/vector_rotate.h
 };
 
 // pkg230 — Clamp node type (Cycles NodeClampType, svm_clamp / node_clamp.osl).
@@ -72,6 +76,15 @@ enum ClampType : unsigned char { CLAMP_MINMAX = 0, CLAMP_RANGE = 1 };
 // The addon compiler sets these bits; both sides MUST agree.
 static const unsigned char SVM_MATH_CLAMP        = 0x80u; // OP_MATH: clamp result to [0,1]
 static const unsigned char SVM_MIX_CLAMP_RESULT  = 0x80u; // OP_MIX:  clamp result to [0,1]
+// pkg230 Phase 2 — negative-polarity Mix factor flag (bit 6 = SKIP the factor
+// saturation svm_mix otherwise applies). Existing/default bytecode keeps the bit
+// clear and saturates the factor EXACTLY as before (legacy MixRGB + modern Mix
+// clamp_factor=true); modern clamp_factor=false sets it. The existing OP_MIX
+// sub-op mask `imm & 0x3F` already excludes this bit (and bit 7 stays CLAMP_RESULT).
+static const unsigned char SVM_MIX_UNCLAMP_FACTOR = 0x40u;
+// pkg230 Phase 2 — Vector Rotate invert bit (packed in OP_VEC_ROTATE imm bit 3,
+// above the low 3 bits carrying VecRotateType). Set = invert the rotation.
+static const unsigned char VEC_ROTATE_INVERT = 0x08u;
 
 // Colour-space enum for Separate/Combine Color (Cycles NodeCombSepColorType).
 // pkg219c ships RGB + HSV (HSL deferred).
@@ -90,6 +103,29 @@ enum MathOp : unsigned char {
 enum MixOp : unsigned char {
     MIX_BLEND = 0, MIX_ADD, MIX_MUL, MIX_SUB, MIX_SCREEN, MIX_DIFF,
     MIX_DARKEN, MIX_LIGHTEN, MIX_OVERLAY,
+};
+
+// Vector Math — 30 operations from Cycles svm/math_util.h. Dot/Distance/Length
+// write a scalar result broadcast across xyz. Values are the addon
+// compiler's own enum (the compiler maps Blender `operation` strings -> these).
+// Adapted from Cycles intern/cycles/kernel/svm/math_util.h, Apache-2.0, commit
+// adfe2921d5f3c0fe699149bcd9bc347543bbd82e.
+enum VecMathOp : unsigned char {
+    VECMATH_ADD = 0, VECMATH_SUBTRACT, VECMATH_MULTIPLY, VECMATH_DIVIDE,
+    VECMATH_CROSS_PRODUCT, VECMATH_PROJECT, VECMATH_REFLECT, VECMATH_REFRACT,
+    VECMATH_FACEFORWARD, VECMATH_MULTIPLY_ADD, VECMATH_DOT_PRODUCT,
+    VECMATH_DISTANCE, VECMATH_LENGTH, VECMATH_SCALE, VECMATH_NORMALIZE,
+    VECMATH_SNAP, VECMATH_ROUND, VECMATH_FLOOR, VECMATH_CEIL, VECMATH_MODULO,
+    VECMATH_WRAP, VECMATH_FRACTION, VECMATH_ABSOLUTE, VECMATH_POWER,
+    VECMATH_SIGN, VECMATH_MINIMUM, VECMATH_MAXIMUM, VECMATH_SINE,
+    VECMATH_COSINE, VECMATH_TANGENT,
+};
+
+// NodeVectorRotateType (Cycles svm/vector_rotate.h) — 5 modes. The op's `imm`
+// low 3 bits carry the type; bit 3 (0x08) is the invert flag.
+enum VecRotateType : unsigned char {
+    VECROT_AXIS_ANGLE = 0, VECROT_X_AXIS, VECROT_Y_AXIS, VECROT_Z_AXIS,
+    VECROT_EULER_XYZ,
 };
 
 // NodeMapRangeType subset (Cycles svm/map_range.h).
@@ -173,9 +209,11 @@ HD inline float svm_math(unsigned char op, float a, float b, float c) {
 }
 
 // ---- colour Mix (Cycles svm/color_util.h svm_mix) --------------------------
-HD inline GVec3 svm_mix(unsigned char op, float t, GVec3 c1, GVec3 c2) {
-    // factor clamp mirrors legacy NODE_MIX (svm_mix_clamped_factor).
-    t = svm_saturatef(t);
+HD inline GVec3 svm_mix(unsigned char op, float t, GVec3 c1, GVec3 c2,
+                        bool unclamp_factor = false) {
+    // factor saturation is the DEFAULT (legacy MixRGB + modern clamp_factor=true);
+    // SVM_MIX_UNCLAMP_FACTOR (pkg230 P2) skips it for modern clamp_factor=false.
+    if (!unclamp_factor) t = svm_saturatef(t);
     float mt = 1.f - t;
     switch (op) {
         case MIX_BLEND:   return c1 * mt + c2 * t;
@@ -331,6 +369,157 @@ HD inline float svm_clamp(unsigned char type, float v, float lo, float hi) {
     return mx < hi ? mx : hi;     // min(max(v,lo), hi)
 }
 
+// ---- Vector Math (pkg230 P2) — Cycles svm/math_util.h svm_vector_math -------
+// Copyright 2011-2022 Blender Foundation. Component-wise helpers mirror Cycles util/math_float3.h + util/math_base.h
+// (Apache-2.0, commit adfe2921d5f3c0fe699149bcd9bc347543bbd82e).
+HD inline GVec3 svm_safe_normalize(GVec3 a) {
+    float t = a.length();
+    return t != 0.f ? a * (1.f / t) : a;   // zero vector stays itself (Cycles safe_normalize)
+}
+HD inline GVec3 svm_safe_divide3(GVec3 a, GVec3 b) {
+    return GVec3(b.x != 0.f ? a.x / b.x : 0.f,
+                 b.y != 0.f ? a.y / b.y : 0.f,
+                 b.z != 0.f ? a.z / b.z : 0.f);
+}
+HD inline GVec3 svm_floor3(GVec3 a) { return GVec3(floorf(a.x), floorf(a.y), floorf(a.z)); }
+HD inline GVec3 svm_ceil3(GVec3 a)  { return GVec3(ceilf(a.x), ceilf(a.y), ceilf(a.z)); }
+HD inline GVec3 svm_fabs3(GVec3 a)  { return GVec3(fabsf(a.x), fabsf(a.y), fabsf(a.z)); }
+HD inline GVec3 svm_sin3(GVec3 a)   { return GVec3(sinf(a.x), sinf(a.y), sinf(a.z)); }
+HD inline GVec3 svm_cos3(GVec3 a)   { return GVec3(cosf(a.x), cosf(a.y), cosf(a.z)); }
+HD inline GVec3 svm_tan3(GVec3 a)   { return GVec3(tanf(a.x), tanf(a.y), tanf(a.z)); }
+HD inline GVec3 svm_safe_fmod3(GVec3 a, GVec3 b) {
+    return GVec3(b.x != 0.f ? fmodf(a.x, b.x) : 0.f,
+                 b.y != 0.f ? fmodf(a.y, b.y) : 0.f,
+                 b.z != 0.f ? fmodf(a.z, b.z) : 0.f);
+}
+HD inline float svm_vec_wrapf(float value, float mx, float mn) {
+    float range = mx - mn;
+    return range != 0.f ? value - range * floorf((value - mn) / range) : mn;
+}
+HD inline GVec3 svm_wrap3(GVec3 value, GVec3 mx, GVec3 mn) {
+    return GVec3(svm_vec_wrapf(value.x, mx.x, mn.x),
+                 svm_vec_wrapf(value.y, mx.y, mn.y),
+                 svm_vec_wrapf(value.z, mx.z, mn.z));
+}
+HD inline float svm_vec_safe_powf(float a, float b) {
+    if (b == 0.f) return 1.f; // Cycles compatible_powf includes 0^0.
+    if (a == 0.f || (a < 0.f && b != floorf(b))) return 0.f;
+    // CUDA powf does not accept a negative base, even for integer exponents.
+    if (a < 0.f) return fmodf(b, 2.f) == 0.f ? powf(-a, b) : -powf(-a, b);
+    return powf(a, b);
+}
+HD inline GVec3 svm_safe_pow3(GVec3 a, GVec3 b) {
+    return GVec3(svm_vec_safe_powf(a.x, b.x), svm_vec_safe_powf(a.y, b.y),
+                 svm_vec_safe_powf(a.z, b.z));
+}
+HD inline GVec3 svm_sign3(GVec3 a) {
+    // Cycles compatible_sign: +1 / -1 / 0 (zero maps to zero).
+    float sx = a.x == 0.f ? 0.f : (a.x < 0.f ? -1.f : 1.f);
+    float sy = a.y == 0.f ? 0.f : (a.y < 0.f ? -1.f : 1.f);
+    float sz = a.z == 0.f ? 0.f : (a.z < 0.f ? -1.f : 1.f);
+    return GVec3(sx, sy, sz);
+}
+HD inline GVec3 svm_project(GVec3 v, GVec3 v_proj) {
+    float len2 = v_proj.length2();
+    return len2 != 0.f ? v_proj * (v.dot(v_proj) / len2) : GVec3(0.f);
+}
+HD inline GVec3 svm_reflect(GVec3 incident, GVec3 unit_normal) {
+    return incident - unit_normal * (2.f * incident.dot(unit_normal));
+}
+HD inline GVec3 svm_refract(GVec3 incident, GVec3 normal, float eta) {
+    float d = normal.dot(incident);
+    float k = 1.f - eta * eta * (1.f - d * d);
+    if (k < 0.f) return GVec3(0.f);   // total internal reflection
+    return incident * eta - normal * (eta * d + sqrtf(k));
+}
+
+HD inline GVec3 svm_vec_math(unsigned char op, GVec3 a, GVec3 b, GVec3 c, float param1) {
+    switch (op) {
+        case VECMATH_ADD:           return a + b;
+        case VECMATH_SUBTRACT:      return a - b;
+        case VECMATH_MULTIPLY:      return a * b;
+        case VECMATH_DIVIDE:        return svm_safe_divide3(a, b);
+        case VECMATH_CROSS_PRODUCT: return a.cross(b);
+        case VECMATH_PROJECT:       return svm_project(a, b);
+        case VECMATH_REFLECT:       return svm_reflect(a, svm_safe_normalize(b));
+        case VECMATH_REFRACT:       return svm_refract(a, svm_safe_normalize(b), param1);
+        case VECMATH_FACEFORWARD:   return c.dot(b) < 0.f ? a : -a;
+        case VECMATH_MULTIPLY_ADD:  return a * b + c;
+        case VECMATH_DOT_PRODUCT:   return GVec3(a.dot(b));
+        case VECMATH_DISTANCE:      return GVec3((a - b).length());
+        case VECMATH_LENGTH:        return GVec3(a.length());
+        case VECMATH_SCALE:         return a * param1;
+        case VECMATH_NORMALIZE:     return svm_safe_normalize(a);
+        case VECMATH_SNAP:          return svm_floor3(svm_safe_divide3(a, b)) * b;
+        case VECMATH_ROUND:         return svm_floor3(a + GVec3(0.5f));
+        case VECMATH_FLOOR:         return svm_floor3(a);
+        case VECMATH_CEIL:          return svm_ceil3(a);
+        case VECMATH_MODULO:        return svm_safe_fmod3(a, b);
+        case VECMATH_WRAP:          return svm_wrap3(a, b, c);
+        case VECMATH_FRACTION:      return a - svm_floor3(a);
+        case VECMATH_ABSOLUTE:      return svm_fabs3(a);
+        case VECMATH_POWER:         return svm_safe_pow3(a, b);
+        case VECMATH_SIGN:          return svm_sign3(a);
+        case VECMATH_MINIMUM:       return gvec3_min(a, b);
+        case VECMATH_MAXIMUM:       return gvec3_max(a, b);
+        case VECMATH_SINE:          return svm_sin3(a);
+        case VECMATH_COSINE:        return svm_cos3(a);
+        case VECMATH_TANGENT:       return svm_tan3(a);
+        default:                    return GVec3(0.f);
+    }
+}
+
+// ---- Vector Rotate (pkg230 P2) — Cycles svm/vector_rotate.h -----------------
+// Copyright 2011-2022 Blender Foundation. Adapted from
+// Cycles intern/cycles/kernel/svm/vector_rotate.h and
+// util/transform.h (Apache-2.0, commit adfe2921d5f3c0fe699149bcd9bc347543bbd82e).
+HD inline GVec3 svm_rotate_around_axis(GVec3 p, GVec3 axis, float angle) {
+    float ct = cosf(angle), st = sinf(angle), u = 1.f - ct;
+    GVec3 r;
+    r.x = (ct + u * axis.x * axis.x) * p.x
+        + (u * axis.x * axis.y - axis.z * st) * p.y
+        + (u * axis.x * axis.z + axis.y * st) * p.z;
+    r.y = (u * axis.x * axis.y + axis.z * st) * p.x
+        + (ct + u * axis.y * axis.y) * p.y
+        + (u * axis.y * axis.z - axis.x * st) * p.z;
+    r.z = (u * axis.x * axis.z - axis.y * st) * p.x
+        + (u * axis.y * axis.z + axis.x * st) * p.y
+        + (ct + u * axis.z * axis.z) * p.z;
+    return r;
+}
+
+HD inline GVec3 svm_vec_rotate(unsigned char type, bool invert, GVec3 vector,
+                               GVec3 center, GVec3 axis_or_rot, float angle) {
+    if (type == VECROT_EULER_XYZ) {
+        // Cycles euler_to_transform (XYZ order) + transform_direction; INVERT uses
+        // transform_direction_transposed (== the rotation inverse), NOT negating
+        // the same-order angles.
+        GVec3 e = axis_or_rot;
+        float cx = cosf(e.x), cy = cosf(e.y), cz = cosf(e.z);
+        float sx = sinf(e.x), sy = sinf(e.y), sz = sinf(e.z);
+        GVec3 v = vector - center;
+        if (invert) {
+            GVec3 c0(cy * cz, cy * sz, -sy);
+            GVec3 c1(sy * sx * cz - cx * sz, sy * sx * sz + cx * cz, cy * sx);
+            GVec3 c2(sy * cx * cz + sx * sz, sy * cx * sz - sx * cz, cy * cx);
+            return GVec3(c0.dot(v), c1.dot(v), c2.dot(v)) + center;
+        }
+        GVec3 r0(cy * cz, sy * sx * cz - cx * sz, sy * cx * cz + sx * sz);
+        GVec3 r1(cy * sz, sy * sx * sz + cx * cz, sy * cx * sz - sx * cz);
+        GVec3 r2(-sy, cy * sx, cy * cx);
+        return GVec3(r0.dot(v), r1.dot(v), r2.dot(v)) + center;
+    }
+    // Axis-angle / single-axis: INVERT negates the angle (not a transpose).
+    GVec3 axis = axis_or_rot;
+    float axis_len = axis.length();
+    if (type == VECROT_X_AXIS)      { axis = GVec3(1.f, 0.f, 0.f); axis_len = 1.f; }
+    else if (type == VECROT_Y_AXIS) { axis = GVec3(0.f, 1.f, 0.f); axis_len = 1.f; }
+    else if (type == VECROT_Z_AXIS) { axis = GVec3(0.f, 0.f, 1.f); axis_len = 1.f; }
+    if (axis_len == 0.f) return vector;   // zero axis -> input unchanged
+    float a = invert ? -angle : angle;
+    return svm_rotate_around_axis(vector - center, axis / axis_len, a) + center;
+}
+
 // ============================================================================
 // The evaluator. Pure, HD, byte-identical CPU<->GPU. `inputs` holds the
 // pre-sampled child-texture RGBs. Returns the program's output slot RGB.
@@ -358,10 +547,11 @@ HD inline GVec3 svm_eval(const ShaderVMProgram& p, const GVec3* inputs) {
                 break;
             }
             case OP_MIX: {
-                // low 6 bits = MixOp; bit 7 = clamp_result (pkg230). The factor is
-                // already saturated inside svm_mix (Blender's default clamp_factor);
-                // faithful clamp_factor=OFF is a Phase-2 item.
-                GVec3 m = svm_mix(in.imm & 0x3Fu, reg[in.a].x, reg[in.b], reg[in.c]);
+                // low 6 bits = MixOp; bit 6 = unclamp_factor (pkg230 P2); bit 7 =
+                // clamp_result (pkg230). The factor is saturated inside svm_mix
+                // unless the unclamp bit is set (modern Mix clamp_factor=false).
+                GVec3 m = svm_mix(in.imm & 0x3Fu, reg[in.a].x, reg[in.b], reg[in.c],
+                                  (in.imm & SVM_MIX_UNCLAMP_FACTOR) != 0);
                 if (in.imm & SVM_MIX_CLAMP_RESULT)
                     m = GVec3(svm_saturatef(m.x), svm_saturatef(m.y), svm_saturatef(m.z));
                 reg[in.out] = m;
@@ -371,6 +561,17 @@ HD inline GVec3 svm_eval(const ShaderVMProgram& p, const GVec3* inputs) {
                 reg[in.out] = GVec3(svm_clamp(in.imm, reg[in.a].x, reg[in.b].x,
                                               reg[in.c].x));
                 break;
+            case OP_VEC_MATH:
+                reg[in.out] = svm_vec_math(in.imm, reg[in.a], reg[in.b], reg[in.c],
+                                           reg[in.d].x);
+                break;
+            case OP_VEC_ROTATE: {
+                unsigned char type = in.imm & 7u;
+                bool invert = (in.imm & 8u) != 0;
+                reg[in.out] = svm_vec_rotate(type, invert, reg[in.a], reg[in.b],
+                                             reg[in.c], reg[in.d].x);
+                break;
+            }
             case OP_RAMP:
                 reg[in.out] = svm_ramp_lookup(p.ramp[in.imm < VM_MAX_RAMPS ? in.imm : 0],
                                               reg[in.a].x);

--- a/tests/test_blender_parity_harness.py
+++ b/tests/test_blender_parity_harness.py
@@ -470,8 +470,11 @@ def test_backdrop_is_parity_safe(tmp_path):
     renders.mkdir()
 
     feat = H.Feature("backdrop_probe", "backdrop", "", "SUPPORTED")
+    # Both engines now honor the requested native sample count without denoising.
+    # At 64 spp, main and pkg230 both score 0.8395; 256 spp gives 0.9141 on both.
+    # Keep the structural threshold unchanged and budget enough samples for it.
     arrays, bad_engine, log_tail = H._render_pair(
-        blender, feat, renders, 128, 64, 300, env)
+        blender, feat, renders, 128, 256, 300, env)
     assert arrays is not None, f"backdrop probe {bad_engine} leg crashed:\n{log_tail}"
     _ssim, delta_e, ratio = H._metrics(
         arrays["CUSTOM_RAYTRACER"], arrays["CYCLES"])

--- a/tests/test_pkg230_opvm_clamp.py
+++ b/tests/test_pkg230_opvm_clamp.py
@@ -163,10 +163,12 @@ def test_mix_clamp_result():
 
 
 # --------------------------------------------------------------------------- #
-# 5. Mix factor is always saturated (svm_mix = Blender default clamp_factor=ON).
-#    Faithful clamp_factor=OFF is a Phase-2 item.
+# 5. Mix factor is saturated by DEFAULT (modern Mix clamp_factor=True, and legacy
+#    MixRGB always). Unclamped factors (modern clamp_factor=False -> the
+#    SVM_MIX_UNCLAMP_FACTOR bit, pkg230 Phase 2) are covered in
+#    tests/test_pkg230_opvm_vectors.py.
 # --------------------------------------------------------------------------- #
-def test_mix_factor_always_saturated():
+def test_mix_factor_default_clamped():
     tex = Node('TEX_IMAGE')
     mix = Node('MIX', blend_type='MIX',
                inputs=[Sock('Factor', 0.0, Link(tex, 'Color')),

--- a/tests/test_pkg230_opvm_vectors.py
+++ b/tests/test_pkg230_opvm_vectors.py
@@ -1,0 +1,941 @@
+"""pkg230 Phase 2 — Vector Math (OP_VEC_MATH) + Vector Rotate (OP_VEC_ROTATE) tests.
+
+Two halves, both no-bpy:
+
+  * Compiler half (``test_compile_*`` / ``test_parity_*``): duck-typed Blender
+    node chains compiled by shader_vm_compiler; asserts emitted bytecode, enum/
+    flag parity with include/astroray/shader_vm.h, and that only the operands an
+    op reads are compiled (dead hidden sockets cost no register slot).
+
+  * Eval half (``test_eval_*``): hand-assembled bytecode run through the shared
+    HD ``svm_eval`` (via sample_named_texture) and compared against an independent
+    Python transcription of the Cycles vector formulas. Pinned Cycles reference:
+    intern/cycles/kernel/svm/math_util.h + svm/vector_rotate.h + util/transform.h,
+    Apache-2.0, commit adfe2921d5f3c0fe699149bcd9bc347543bbd82e.
+
+The eval half needs the freshly built module (new native opcodes); run with
+``-k "not eval"`` until the parent rebuilds.
+"""
+import math
+import os
+import re
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "blender_addon"))
+import shader_vm_compiler as C
+
+_HEADER = os.path.join(os.path.dirname(__file__), "..", "include", "astroray",
+                       "shader_vm.h")
+
+
+def _renderer():
+    # Lazy import: the compiler/parity tests run without the built module; only
+    # the eval tests need astroray (which must be freshly rebuilt for opcodes
+    # 15/16). importorskip inside the helper skips just the eval test.
+    return pytest.importorskip("astroray").Renderer()
+
+# ---- opcode / sub-op enums (mirror include/astroray/shader_vm.h) -----------
+OP_LOAD_TEX, OP_LOAD_CONST = 1, 2
+OP_MIX, OP_VEC_MATH, OP_VEC_ROTATE = 4, 15, 16
+
+
+# --------------------------------------------------------------------------- #
+# Minimal duck-typed Blender node model (with `enabled` socket metadata)
+# --------------------------------------------------------------------------- #
+class Sock:
+    def __init__(self, name, default=0.0, link=None, enabled=True, type=None):
+        self.name = name
+        self.type = type
+        self.default_value = default
+        self._link = link
+        self.enabled = enabled
+
+    @property
+    def is_linked(self):
+        return self._link is not None
+
+    @property
+    def links(self):
+        return [self._link] if self._link else []
+
+
+class Link:
+    def __init__(self, from_node, from_socket_name="Color", type=None):
+        self.from_node = from_node
+        self.from_socket = SimpleNamespace(name=from_socket_name, type=type)
+
+
+class SockList:
+    def __init__(self, socks):
+        self._socks = socks
+        self._by_name = {s.name: s for s in socks}
+
+    def get(self, name):
+        return self._by_name.get(name)
+
+    def __getitem__(self, i):
+        return self._socks[i]
+
+    def __len__(self):
+        return len(self._socks)
+
+    def __iter__(self):
+        return iter(self._socks)
+
+
+class Node:
+    def __init__(self, type, inputs=None, **kw):
+        self.type = type
+        self.inputs = SockList(inputs or [])
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
+def _load_program(r, name, compiled, input_values):
+    import numpy as np
+    r.create_program_texture(name, "UV")
+    for i, node in enumerate(compiled['inputs']):
+        tex_name = f"{name}_in{i}"
+        val = input_values[id(node)]
+        img = np.array(val, dtype="float32").reshape(1, 1, 3).ravel()
+        r.load_texture(tex_name, img, 1, 1, "UV")
+        r.program_texture_add_input(name, tex_name)
+    r.set_program_texture_program(name, compiled['num_tex'], compiled['out_slot'],
+                                  compiled['code_flat'], compiled['consts_flat'],
+                                  compiled['ramps_flat'])
+
+
+# --------------------------------------------------------------------------- #
+# hand-bytecode helpers
+# --------------------------------------------------------------------------- #
+def instr(op, out=0, a=0, b=0, c=0, d=0, e=0, imm=0):
+    return [op, out, a, b, c, d, e, imm]
+
+
+def flat(instrs):
+    out = []
+    for i in instrs:
+        out.extend(i)
+    return out
+
+
+def make_solid_input(r, name="in0", value=(0.4, 0.4, 0.4)):
+    import numpy as np
+    img = np.array(value, dtype="float32").reshape(1, 1, 3).ravel()
+    r.load_texture(name, img, 1, 1, "UV")
+
+
+def _instrs(compiled):
+    return [compiled['code_flat'][i:i + 8]
+            for i in range(0, len(compiled['code_flat']), 8)]
+
+
+# --------------------------------------------------------------------------- #
+# Independent Python transcription of Cycles vector math (Apache-2.0, pinned
+# adfe2921d5f3c0fe699149bcd9bc347543bbd82e). Kept separate from the C++ so the
+# expected values are not a restatement of the implementation.
+# --------------------------------------------------------------------------- #
+def _safe_divide(v, w):
+    return [v[i] / w[i] if w[i] != 0.0 else 0.0 for i in range(3)]
+
+
+def _safe_normalize(v):
+    n = math.sqrt(sum(x * x for x in v))
+    return [x / n for x in v] if n != 0.0 else list(v)
+
+
+def _cross(a, b):
+    return [a[1] * b[2] - a[2] * b[1],
+            a[2] * b[0] - a[0] * b[2],
+            a[0] * b[1] - a[1] * b[0]]
+
+
+def _dot(a, b):
+    return a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+
+
+def _project(v, p):
+    l2 = _dot(p, p)
+    if l2 == 0.0:
+        return [0.0, 0.0, 0.0]
+    f = _dot(v, p) / l2
+    return [p[i] * f for i in range(3)]
+
+
+def _reflect(i, n):
+    d = _dot(i, n)
+    return [i[k] - 2.0 * d * n[k] for k in range(3)]
+
+
+def _refract(i, n, eta):
+    d = _dot(n, i)
+    k = 1.0 - eta * eta * (1.0 - d * d)
+    if k < 0.0:
+        return [0.0, 0.0, 0.0]
+    return [eta * i[j] - (eta * d + math.sqrt(k)) * n[j] for j in range(3)]
+
+
+def _fmod(a, b):
+    return [math.fmod(a[i], b[i]) if b[i] != 0.0 else 0.0 for i in range(3)]
+
+
+def _wrap(value, mx, mn):
+    out = []
+    for i in range(3):
+        rng = mx[i] - mn[i]
+        if rng == 0.0:
+            out.append(mn[i])
+        else:
+            out.append(value[i] - math.floor((value[i] - mn[i]) / rng) * rng)
+    return out
+
+
+def _safe_pow(a, b):
+    def sp(x, y):
+        if y == 0.0:
+            return 1.0
+        if x == 0.0:
+            return 0.0
+        if x < 0.0 and y != math.floor(y):
+            return 0.0
+        return math.pow(x, y)
+    return [sp(a[i], b[i]) for i in range(3)]
+
+
+def vec_math_ref(op, a, b, c, param1):
+    if op == 'ADD':
+        return [a[i] + b[i] for i in range(3)]
+    if op == 'SUBTRACT':
+        return [a[i] - b[i] for i in range(3)]
+    if op == 'MULTIPLY':
+        return [a[i] * b[i] for i in range(3)]
+    if op == 'DIVIDE':
+        return _safe_divide(a, b)
+    if op == 'CROSS_PRODUCT':
+        return _cross(a, b)
+    if op == 'PROJECT':
+        return _project(a, b)
+    if op == 'REFLECT':
+        return _reflect(a, _safe_normalize(b))
+    if op == 'REFRACT':
+        return _refract(a, _safe_normalize(b), param1)
+    if op == 'FACEFORWARD':
+        return list(a) if _dot(c, b) < 0.0 else [-x for x in a]
+    if op == 'MULTIPLY_ADD':
+        return [a[i] * b[i] + c[i] for i in range(3)]
+    if op == 'DOT_PRODUCT':
+        return [_dot(a, b)] * 3
+    if op == 'DISTANCE':
+        return [math.sqrt(sum((a[i] - b[i]) ** 2 for i in range(3)))] * 3
+    if op == 'LENGTH':
+        return [math.sqrt(sum(x * x for x in a))] * 3
+    if op == 'SCALE':
+        return [a[i] * param1 for i in range(3)]
+    if op == 'NORMALIZE':
+        return _safe_normalize(a)
+    if op == 'SNAP':
+        return [math.floor(_safe_divide(a, b)[i]) * b[i] for i in range(3)]
+    if op == 'ROUND':
+        return [math.floor(x + 0.5) for x in a]
+    if op == 'FLOOR':
+        return [math.floor(x) for x in a]
+    if op == 'CEIL':
+        return [math.ceil(x) for x in a]
+    if op == 'MODULO':
+        return _fmod(a, b)
+    if op == 'WRAP':
+        return _wrap(a, b, c)
+    if op == 'FRACTION':
+        return [x - math.floor(x) for x in a]
+    if op == 'ABSOLUTE':
+        return [abs(x) for x in a]
+    if op == 'POWER':
+        return _safe_pow(a, b)
+    if op == 'SIGN':
+        return [0.0 if x == 0.0 else (1.0 if x > 0.0 else -1.0) for x in a]
+    if op == 'MINIMUM':
+        return [min(a[i], b[i]) for i in range(3)]
+    if op == 'MAXIMUM':
+        return [max(a[i], b[i]) for i in range(3)]
+    if op == 'SINE':
+        return [math.sin(x) for x in a]
+    if op == 'COSINE':
+        return [math.cos(x) for x in a]
+    if op == 'TANGENT':
+        return [math.tan(x) for x in a]
+    raise ValueError(op)
+
+
+def _rotate_around_axis(p, axis, angle):
+    ct, st, u = math.cos(angle), math.sin(angle), 1.0 - math.cos(angle)
+    x, y, z = axis
+    return [
+        (ct + u * x * x) * p[0] + (u * x * y - z * st) * p[1] + (u * x * z + y * st) * p[2],
+        (u * x * y + z * st) * p[0] + (ct + u * y * y) * p[1] + (u * y * z - x * st) * p[2],
+        (u * x * z - y * st) * p[0] + (u * y * z + x * st) * p[1] + (ct + u * z * z) * p[2],
+    ]
+
+
+def _euler_matrix(e):
+    cx, cy, cz = math.cos(e[0]), math.cos(e[1]), math.cos(e[2])
+    sx, sy, sz = math.sin(e[0]), math.sin(e[1]), math.sin(e[2])
+    return [
+        [cy * cz, sy * sx * cz - cx * sz, sy * cx * cz + sx * sz],
+        [cy * sz, sy * sx * sz + cx * cz, sy * cx * sz - sx * cz],
+        [-sy, cy * sx, cy * cx],
+    ]
+
+
+def vec_rotate_ref(rtype, invert, vec, center, axis, angle, rotation):
+    if rtype == 'EULER_XYZ':
+        R = _euler_matrix(rotation)
+        v = [vec[i] - center[i] for i in range(3)]
+        if invert:  # transposed rotation matrix (== inverse)
+            out = [sum(R[j][i] * v[j] for j in range(3)) for i in range(3)]
+        else:
+            out = [sum(R[i][j] * v[j] for j in range(3)) for i in range(3)]
+        return [out[i] + center[i] for i in range(3)]
+    ax = {'X_AXIS': [1, 0, 0], 'Y_AXIS': [0, 1, 0], 'Z_AXIS': [0, 0, 1]}.get(rtype, axis)
+    alen = math.sqrt(sum(x * x for x in ax))
+    if alen == 0.0:
+        return list(vec)
+    a = -angle if invert else angle
+    axn = [x / alen for x in ax]
+    r = _rotate_around_axis([vec[i] - center[i] for i in range(3)], axn, a)
+    return [r[i] + center[i] for i in range(3)]
+
+
+# --------------------------------------------------------------------------- #
+# enum / flag parity with the header
+# --------------------------------------------------------------------------- #
+def test_parity_opcodes_and_flags():
+    assert (C.OP_VEC_MATH, C.OP_VEC_ROTATE) == (15, 16)
+    assert C.SVM_MIX_UNCLAMP_FACTOR == 0x40
+    assert C.VEC_ROTATE_INVERT == 0x08
+    with open(_HEADER, "r", encoding="utf-8") as f:
+        src = f.read()
+    assert re.search(r"OP_VEC_MATH\s*=\s*15", src)
+    assert re.search(r"OP_VEC_ROTATE\s*=\s*16", src)
+    assert re.search(r"SVM_MIX_UNCLAMP_FACTOR\s*=\s*0x40", src)
+    assert re.search(r"VEC_ROTATE_INVERT\s*=\s*0x08", src)
+    assert re.search(r"VECROT_AXIS_ANGLE\s*=\s*0", src)
+
+
+def _header_enum_names(src, enum_name):
+    m = re.search(r"enum\s+" + enum_name + r"\s*:\s*unsigned char\s*\{(.*?)\};",
+                  src, re.DOTALL)
+    assert m, f"enum {enum_name} not found in header"
+    body = m.group(1)
+    names = re.findall(r"\b([A-Z_][A-Z0-9_]*)\b", body)
+    # drop the first explicit "= N" initializer and trailing commas are ignored
+    return names
+
+
+def test_parity_vec_math_enum_order():
+    with open(_HEADER, "r", encoding="utf-8") as f:
+        src = f.read()
+    header_names = _header_enum_names(src, "VecMathOp")
+    header_keys = [n[len("VECMATH_"):] for n in header_names]
+    assert header_keys == sorted(C.VEC_MATH_OPS, key=lambda k: C.VEC_MATH_OPS[k])
+    assert len(header_keys) == 30
+
+
+def test_parity_vec_rotate_enum_order():
+    with open(_HEADER, "r", encoding="utf-8") as f:
+        src = f.read()
+    header_names = _header_enum_names(src, "VecRotateType")
+    header_keys = [n[len("VECROT_"):] for n in header_names]
+    assert header_keys == sorted(C.VEC_ROTATE_TYPES, key=lambda k: C.VEC_ROTATE_TYPES[k])
+    assert header_keys == ['AXIS_ANGLE', 'X_AXIS', 'Y_AXIS', 'Z_AXIS', 'EULER_XYZ']
+
+
+# --------------------------------------------------------------------------- #
+# compiler: Vector Math
+# --------------------------------------------------------------------------- #
+def test_compile_vec_math_add_by_position():
+    # Duplicate "Vector" sockets must be read BY POSITION, not by name.
+    texA = Node('TEX_IMAGE')
+    texB = Node('TEX_IMAGE')
+    vm = Node('VECT_MATH', operation='ADD',
+              inputs=[Sock('Vector', 0.0, Link(texA, 'Color')),
+                      Sock('Vector', 0.0, Link(texB, 'Color')),
+                      Sock('Vector', 0.0),
+                      Sock('Scale', 1.0)])
+    base = Sock('Base Color', [0.5, 0.5, 0.5], Link(vm, 'Vector'))
+    compiled = C.compile_chain(base)
+    assert compiled is not None and compiled['num_tex'] == 2
+    assert [id(n) for n in compiled['inputs']] == [id(texA), id(texB)]
+    vec = [i for i in _instrs(compiled) if i[0] == C.OP_VEC_MATH]
+    assert len(vec) == 1
+    _op, _out, a, b, _c, _d, _e, imm = vec[0]
+    assert imm == C.VEC_MATH_OPS['ADD']
+    assert a != b  # Vector0 and Vector1 routed to different slots
+
+
+def test_compile_vec_math_only_used_operands():
+    # NORMALIZE reads only Vector0. The dead Vector1/Vector2/Scale link to an
+    # unsupported node; they must not be compiled (no VMCompileError, no slots).
+    tex = Node('TEX_IMAGE')
+    weird = Node('BUMP', inputs=[Sock('Height', 0.0, Link(tex, 'Color'))])
+    vm = Node('VECT_MATH', operation='NORMALIZE',
+              inputs=[Sock('Vector', 0.0, Link(tex, 'Color')),
+                      Sock('Vector', 0.0, Link(weird, 'Normal')),
+                      Sock('Vector', 0.0, Link(weird, 'Normal')),
+                      Sock('Scale', 1.0, Link(weird, 'Normal'))])
+    base = Sock('Base Color', [0.5, 0.5, 0.5], Link(vm, 'Vector'))
+    compiled = C.compile_chain(base)
+    assert compiled is not None
+    assert compiled['num_tex'] == 1
+    assert len(compiled['code_flat']) == 16  # LOAD_TEX + VEC_MATH only
+
+
+def test_compile_vec_math_used_subset():
+    # MULTIPLY_ADD reads Vector0+Vector1+Vector2 but not Scale (dead Scale links
+    # to an unsupported node and must be skipped).
+    tex = Node('TEX_IMAGE')
+    weird = Node('BUMP', inputs=[Sock('Height', 0.0, Link(tex, 'Color'))])
+    vm = Node('VECT_MATH', operation='MULTIPLY_ADD',
+              inputs=[Sock('Vector', 0.0, Link(tex, 'Color')),
+                      Sock('Vector', 1.0),
+                      Sock('Vector', 2.0),
+                      Sock('Scale', 1.0, Link(weird, 'Normal'))])
+    base = Sock('Base Color', [0.5, 0.5, 0.5], Link(vm, 'Vector'))
+    compiled = C.compile_chain(base)
+    assert compiled is not None
+    # LOAD_TEX + 2 LOAD_CONST (Vector1/Vector2) + VEC_MATH = 4 instrs (32 ints);
+    # a compiled Scale would add a 5th.
+    assert len(compiled['code_flat']) == 32
+    # Instr layout: [op, out, a, b, c, d, e, imm]
+    vec = next(i for i in _instrs(compiled) if i[0] == C.OP_VEC_MATH)
+    assert vec[3] != 0  # b = Vector1 (compiled)
+    assert vec[4] != 0  # c = Vector2 (compiled)
+    assert vec[5] == 0  # d = Scale (dead, left unused)
+
+
+def test_compile_vec_math_unknown_op_raises():
+    tex = Node('TEX_IMAGE')
+    vm = Node('VECT_MATH', operation='NOPE',
+              inputs=[Sock('Vector', 0.0, Link(tex, 'Color'))])
+    base = Sock('Base Color', [0.5, 0.5, 0.5], Link(vm, 'Vector'))
+    with pytest.raises(C.VMCompileError):
+        C.compile_chain(base)
+
+
+# --------------------------------------------------------------------------- #
+# compiler: Vector Rotate
+# --------------------------------------------------------------------------- #
+def test_compile_vec_rotate_types_and_invert():
+    tex = Node('TEX_IMAGE')
+    for rtype, want_imm in [('AXIS_ANGLE', 0), ('X_AXIS', 1), ('Y_AXIS', 2),
+                            ('Z_AXIS', 3), ('EULER_XYZ', 4)]:
+        vr = Node('VECTOR_ROTATE', rotation_type=rtype, invert=False,
+                  inputs=[Sock('Vector', 0.0, Link(tex, 'Color')),
+                          Sock('Center', [0, 0, 0]),
+                          Sock('Axis', [0, 0, 1]),
+                          Sock('Angle', 0.0),
+                          Sock('Rotation', [0, 0, 0])])
+        base = Sock('Base Color', [0.5, 0.5, 0.5], Link(vr, 'Vector'))
+        compiled = C.compile_chain(base)
+        rot = [i for i in _instrs(compiled) if i[0] == C.OP_VEC_ROTATE]
+        assert len(rot) == 1, rtype
+        assert rot[0][7] == want_imm, rtype
+        vr.invert = True
+        compiled_inv = C.compile_chain(base)
+        rot_inv = next(i for i in _instrs(compiled_inv) if i[0] == C.OP_VEC_ROTATE)
+        assert rot_inv[7] == (want_imm | 0x08), rtype
+
+
+def test_compile_vec_rotate_operand_routing():
+    tex = Node('TEX_IMAGE')
+    # EULER_XYZ reads Rotation (index 4) into c, Angle (index 3) is dead.
+    vr = Node('VECTOR_ROTATE', rotation_type='EULER_XYZ', invert=False,
+              inputs=[Sock('Vector', 0.0, Link(tex, 'Color')),
+                      Sock('Center', [0, 0, 0]),
+                      Sock('Axis', [1, 0, 0]),
+                      Sock('Angle', 1.0),
+                      Sock('Rotation', [0, 0, 0])])
+    base = Sock('Base Color', [0.5, 0.5, 0.5], Link(vr, 'Vector'))
+    compiled = C.compile_chain(base)
+    rot = next(i for i in _instrs(compiled) if i[0] == C.OP_VEC_ROTATE)
+    # Instr layout: [op, out, a, b, c, d, e, imm]
+    assert rot[4] != 0  # c slot carries rotation
+    assert rot[5] == 0  # d slot unused (no axis-angle)
+
+    # X/Y/Z axis reads Angle (index 3) into d; the axis slot (c) is unused.
+    vr2 = Node('VECTOR_ROTATE', rotation_type='Z_AXIS', invert=False,
+               inputs=[Sock('Vector', 0.0, Link(tex, 'Color')),
+                       Sock('Center', [0, 0, 0]),
+                       Sock('Axis', [1, 0, 0]),
+                       Sock('Angle', 0.5),
+                       Sock('Rotation', [0, 0, 0])])
+    base2 = Sock('Base Color', [0.5, 0.5, 0.5], Link(vr2, 'Vector'))
+    compiled2 = C.compile_chain(base2)
+    rot2 = next(i for i in _instrs(compiled2) if i[0] == C.OP_VEC_ROTATE)
+    assert rot2[4] == 0  # c slot unused
+    assert rot2[5] != 0  # d slot carries angle
+
+
+def test_compile_vec_rotate_unknown_type_raises():
+    tex = Node('TEX_IMAGE')
+    vr = Node('VECTOR_ROTATE', rotation_type='QUATERNION',
+              inputs=[Sock('Vector', 0.0, Link(tex, 'Color'))])
+    base = Sock('Base Color', [0.5, 0.5, 0.5], Link(vr, 'Vector'))
+    with pytest.raises(C.VMCompileError):
+        C.compile_chain(base)
+
+
+# --------------------------------------------------------------------------- #
+# compiler: modern Mix socket selection + factor flag
+# --------------------------------------------------------------------------- #
+def _modern_mix_rgba(factor, a, b, blend='MIX', clamp_factor=True,
+                     clamp_result=False):
+    """A real Blender-5.1-shaped ShaderNodeMix: 10 sockets, RGBA enables 0/6/7."""
+    tex_a = a if isinstance(a, Node) else None
+    tex_b = b if isinstance(b, Node) else None
+    return Node('MIX', data_type='RGBA', blend_type=blend,
+                clamp_factor=clamp_factor, clamp_result=clamp_result,
+                inputs=[
+                    Sock('Factor', factor, None, enabled=True),            # 0 float
+                    Sock('Factor', factor, None, enabled=False),           # 1 vector
+                    Sock('A', 0.0, Link(a, 'Color') if tex_a else None, enabled=False),  # 2 FLOAT
+                    Sock('B', 0.0, None, enabled=False),                   # 3 FLOAT
+                    Sock('A', 0.0, None, enabled=False),                   # 4 VECTOR
+                    Sock('B', 0.0, None, enabled=False),                   # 5 VECTOR
+                    Sock('A', 0.0, Link(a, 'Color') if tex_a else None, enabled=True),   # 6 RGBA
+                    Sock('B', 0.0, Link(b, 'Color') if tex_b else None, enabled=True),   # 7 RGBA
+                    Sock('A', 0.0, None, enabled=False),                   # 8 ROTATION
+                    Sock('B', 0.0, None, enabled=False),                   # 9 ROTATION
+                ])
+
+
+def test_compile_mix_selects_enabled_rgba_sockets():
+    tex_float_a = Node('TEX_IMAGE')   # linked to the DISABLED float A (index 2)
+    tex_rgba_a = Node('TEX_IMAGE')    # linked to the ENABLED rgba A (index 6)
+    tex_b = Node('TEX_IMAGE')         # linked to the ENABLED rgba B (index 7)
+    mix = _modern_mix_rgba(0.5, tex_rgba_a, tex_b)
+    # override the disabled float-A socket to point at tex_float_a
+    mix.inputs._socks[2] = Sock('A', 0.0, Link(tex_float_a, 'Color'), enabled=False)
+    mix.inputs._by_name = {s.name: s for s in mix.inputs._socks}
+    base = Sock('Base Color', [0.5, 0.5, 0.5], Link(mix, 'Result'))
+    compiled = C.compile_chain(base)
+    assert compiled is not None
+    input_ids = [id(n) for n in compiled['inputs']]
+    assert id(tex_rgba_a) in input_ids   # enabled A used
+    assert id(tex_b) in input_ids        # enabled B used
+    assert id(tex_float_a) not in input_ids  # disabled float A ignored
+
+
+def test_compile_mix_unclamp_factor_flag():
+    texA = Node('TEX_IMAGE')
+    texB = Node('TEX_IMAGE')
+    for clamp_factor, want_bit in [(True, 0), (False, C.SVM_MIX_UNCLAMP_FACTOR)]:
+        mix = Node('MIX', data_type='RGBA', blend_type='MIX',
+                   clamp_factor=clamp_factor,
+                   inputs=[Sock('Factor', 1.5),
+                           Sock('A', [0, 0, 0], Link(texA, 'Color')),
+                           Sock('B', [1, 1, 1], Link(texB, 'Color'))])
+        base = Sock('Base Color', [0.5, 0.5, 0.5], Link(mix, 'Result'))
+        compiled = C.compile_chain(base)
+        m = next(i for i in _instrs(compiled) if i[0] == C.OP_MIX)
+        assert (m[7] & C.SVM_MIX_UNCLAMP_FACTOR) == want_bit, clamp_factor
+
+
+def test_compile_mix_legacy_never_unclamps():
+    tex = Node('TEX_IMAGE')
+    mix = Node('MIX_RGB', blend_type='MIX',  # legacy node has no clamp_factor
+               inputs=[Sock('Fac', 1.5),
+                       Sock('Color1', [0, 0, 0], Link(tex, 'Color')),
+                       Sock('Color2', [1, 1, 1])])
+    base = Sock('Base Color', [0.5, 0.5, 0.5], Link(mix, 'Color'))
+    compiled = C.compile_chain(base)
+    m = next(i for i in _instrs(compiled) if i[0] == C.OP_MIX)
+    assert (m[7] & C.SVM_MIX_UNCLAMP_FACTOR) == 0
+
+
+def test_compile_mix_float_uses_linear_ignores_blend():
+    # FLOAT data_type: linear mix regardless of the stale blend_type property.
+    tex = Node('TEX_IMAGE')
+    mix = Node('MIX', data_type='FLOAT', blend_type='ADD',
+               inputs=[Sock('Factor', 0.5, None, enabled=True),
+                       Sock('A', 0.2, Link(tex, 'Color'), enabled=True),
+                       Sock('B', 0.6, None, enabled=True)])
+    base = Sock('Base Color', [0.5, 0.5, 0.5], Link(mix, 'Result'))
+    compiled = C.compile_chain(base)
+    assert compiled is not None
+    m = next(i for i in _instrs(compiled) if i[0] == C.OP_MIX)
+    assert (m[7] & 0x3F) == C.MIX_OPS['MIX']   # linear, not ADD
+    assert (m[7] & C.SVM_MIX_CLAMP_RESULT) == 0  # clamp_result only applies to RGBA
+
+
+def test_compile_mix_rotation_raises():
+    mix = Node('MIX', data_type='ROTATION',
+               inputs=[Sock('Factor', 0.5, None, enabled=True),
+                       Sock('A', 0.0, None, enabled=True),
+                       Sock('B', 0.0, None, enabled=True)])
+    base = Sock('Base Color', [0.5, 0.5, 0.5], Link(mix, 'Result'))
+    with pytest.raises(C.VMCompileError):
+        C.compile_chain(base)
+
+
+def test_compile_mix_nonuniform_vector_raises():
+    mix = Node('MIX', data_type='VECTOR', factor_mode='NON_UNIFORM',
+               inputs=[Sock('Factor', 0.5, None, enabled=True),
+                       Sock('A', 0.0, None, enabled=True),
+                       Sock('B', 0.0, None, enabled=True)])
+    base = Sock('Base Color', [0.5, 0.5, 0.5], Link(mix, 'Result'))
+    with pytest.raises(C.VMCompileError):
+        C.compile_chain(base)
+
+
+# --------------------------------------------------------------------------- #
+# eval: all 30 vector math ops against the independent reference
+# --------------------------------------------------------------------------- #
+def _run_vec_math(r, name, op, a, b, c, scale):
+    make_solid_input(r, name + "_img", a)
+    r.create_program_texture(name, "UV")
+    r.program_texture_add_input(name, name + "_img")
+    consts = list(b) + list(c) + [scale] * 3
+    code = flat([
+        instr(OP_LOAD_TEX, out=0, imm=0),
+        instr(OP_LOAD_CONST, out=1, imm=0),   # b
+        instr(OP_LOAD_CONST, out=2, imm=1),   # c
+        instr(OP_LOAD_CONST, out=3, imm=2),   # scale (param1)
+        instr(OP_VEC_MATH, out=4, a=0, b=1, c=2, d=3, imm=C.VEC_MATH_OPS[op]),
+    ])
+    r.set_program_texture_program(name, 1, 4, code, consts, [])
+    return r.sample_named_texture(name, 0.5, 0.5)
+
+
+@pytest.mark.parametrize("op", sorted(C.VEC_MATH_OPS))
+def test_eval_all_vec_math_ops(op):
+    a = (0.7, -0.3, 1.25)
+    b = (0.4, 0.8, -0.6)
+    c = (0.2, 0.5, 0.9)
+    scale = 2.0
+    r = _renderer()
+    got = _run_vec_math(r, "vm_" + op, op, a, b, c, scale)
+    want = vec_math_ref(op, a, b, c, scale)
+    assert got == pytest.approx(want, abs=3e-3), (op, got, want)
+
+
+def test_eval_divide_by_zero():
+    r = _renderer()
+    got = _run_vec_math(r, "div0", 'DIVIDE', (1.0, 2.0, 3.0), (0.0, 2.0, 0.0),
+                        (0, 0, 0), 1.0)
+    assert got == pytest.approx([0.0, 1.0, 0.0], abs=1e-6), got
+
+
+def test_eval_normalize_zero_and_length_distance_dot():
+    r = _renderer()
+    got = _run_vec_math(r, "norm0", 'NORMALIZE', (0.0, 0.0, 0.0), (0, 0, 0),
+                        (0, 0, 0), 1.0)
+    assert got == pytest.approx([0.0, 0.0, 0.0], abs=1e-6), got
+    got = _run_vec_math(r, "len", 'LENGTH', (3.0, 4.0, 0.0), (0, 0, 0), (0, 0, 0), 1.0)
+    assert got == pytest.approx([5.0, 5.0, 5.0], abs=1e-5), got
+    got = _run_vec_math(r, "dist", 'DISTANCE', (1.0, 2.0, 3.0), (4.0, 6.0, 3.0),
+                        (0, 0, 0), 1.0)
+    assert got == pytest.approx([5.0, 5.0, 5.0], abs=1e-5), got
+    got = _run_vec_math(r, "dot", 'DOT_PRODUCT', (1.0, 2.0, 3.0), (4.0, 5.0, 6.0),
+                        (0, 0, 0), 1.0)
+    assert got == pytest.approx([32.0, 32.0, 32.0], abs=1e-5), got
+
+
+def test_eval_project_and_cross():
+    r = _renderer()
+    got = _run_vec_math(r, "proj0", 'PROJECT', (1.0, 2.0, 3.0), (0.0, 0.0, 0.0),
+                        (0, 0, 0), 1.0)
+    assert got == pytest.approx([0.0, 0.0, 0.0], abs=1e-6), got
+    got = _run_vec_math(r, "cross", 'CROSS_PRODUCT', (1.0, 0.0, 0.0), (0.0, 1.0, 0.0),
+                        (0, 0, 0), 1.0)
+    assert got == pytest.approx([0.0, 0.0, 1.0], abs=1e-6), got
+
+
+def test_eval_modulo_negative_and_wrap():
+    r = _renderer()
+    got = _run_vec_math(r, "mod", 'MODULO', (-5.0, 5.0, -7.0), (2.0, 2.0, 3.0),
+                        (0, 0, 0), 1.0)
+    assert got == pytest.approx([-1.0, 1.0, -1.0], abs=1e-5), got
+    # wrap(value, max, min): 5.5 -> 1.5, -3.0 -> 1.0, 0.0 -> 0.0 in [min=-2, max=2)
+    got = _run_vec_math(r, "wrap", 'WRAP', (5.5, -3.0, 0.0), (2.0, 2.0, 2.0),
+                        (-2.0, -2.0, -2.0), 1.0)
+    assert got == pytest.approx([1.5, 1.0, 0.0], abs=1e-5), got
+
+
+def test_eval_reflect_and_refract():
+    r = _renderer()
+    got = _run_vec_math(r, "refl", 'REFLECT', (1.0, -1.0, 0.0), (0.0, 1.0, 0.0),
+                        (0, 0, 0), 1.0)
+    assert got == pytest.approx([1.0, 1.0, 0.0], abs=1e-5), got
+    # straight-on refract: incident (0,-1,0), normal (0,1,0), eta=1.5 -> (0,-1,0)
+    got = _run_vec_math(r, "refr", 'REFRACT', (0.0, -1.0, 0.0), (0.0, 1.0, 0.0),
+                        (0, 0, 0), 1.5)
+    assert got == pytest.approx([0.0, -1.0, 0.0], abs=1e-5), got
+    # TIR: incident perpendicular to normal, eta=1.5 -> k = 1-2.25 < 0 -> zero
+    got = _run_vec_math(r, "tir", 'REFRACT', (1.0, 0.0, 0.0), (0.0, 1.0, 0.0),
+                        (0, 0, 0), 1.5)
+    assert got == pytest.approx([0.0, 0.0, 0.0], abs=1e-6), got
+
+
+def test_eval_faceforward():
+    r = _renderer()
+    got = _run_vec_math(r, "ff1", 'FACEFORWARD', (1.0, 2.0, 3.0), (1.0, 0.0, 0.0),
+                        (1.0, 0.0, 0.0), 1.0)
+    assert got == pytest.approx([-1.0, -2.0, -3.0], abs=1e-5), got
+    got = _run_vec_math(r, "ff2", 'FACEFORWARD', (1.0, 2.0, 3.0), (1.0, 0.0, 0.0),
+                        (-1.0, 0.0, 0.0), 1.0)
+    assert got == pytest.approx([1.0, 2.0, 3.0], abs=1e-5), got
+
+
+def test_eval_round_floor_ceil_fraction_sign():
+    r = _renderer()
+    got = _run_vec_math(r, "round", 'ROUND', (1.4, 1.5, -1.5), (0, 0, 0), (0, 0, 0), 1.0)
+    assert got == pytest.approx([1.0, 2.0, -1.0], abs=1e-5), got  # floor(x+0.5)
+    got = _run_vec_math(r, "floor", 'FLOOR', (1.8, -1.2, 0.5), (0, 0, 0), (0, 0, 0), 1.0)
+    assert got == pytest.approx([1.0, -2.0, 0.0], abs=1e-5), got
+    got = _run_vec_math(r, "ceil", 'CEIL', (1.8, -1.2, 0.5), (0, 0, 0), (0, 0, 0), 1.0)
+    assert got == pytest.approx([2.0, -1.0, 1.0], abs=1e-5), got
+    got = _run_vec_math(r, "fract", 'FRACTION', (1.8, -1.2, 0.5), (0, 0, 0), (0, 0, 0), 1.0)
+    assert got == pytest.approx([0.8, 0.8, 0.5], abs=1e-5), got
+    got = _run_vec_math(r, "sign", 'SIGN', (-3.0, 0.0, 4.0), (0, 0, 0), (0, 0, 0), 1.0)
+    assert got == pytest.approx([-1.0, 0.0, 1.0], abs=1e-6), got
+
+
+def test_eval_scale_multiply_add_power():
+    r = _renderer()
+    got = _run_vec_math(r, "scale", 'SCALE', (1.0, 2.0, -3.0), (0, 0, 0), (0, 0, 0), 2.5)
+    assert got == pytest.approx([2.5, 5.0, -7.5], abs=1e-5), got
+    got = _run_vec_math(r, "madd", 'MULTIPLY_ADD', (1.0, 2.0, 3.0), (4.0, 5.0, 6.0),
+                        (0.5, -1.0, 2.0), 1.0)
+    assert got == pytest.approx([4.5, 9.0, 20.0], abs=1e-5), got
+    got = _run_vec_math(r, "pow", 'POWER', (2.0, 4.0, 9.0), (0.5, 0.5, 0.5), (0, 0, 0), 1.0)
+    assert got == pytest.approx([math.sqrt(2), 2.0, 3.0], abs=1e-5), got
+
+
+# --------------------------------------------------------------------------- #
+# eval: Vector Rotate
+# --------------------------------------------------------------------------- #
+def _run_rotate(r, name, rtype, invert, vec, center, axis, angle, rotation):
+    make_solid_input(r, name + "_img", vec)
+    r.create_program_texture(name, "UV")
+    r.program_texture_add_input(name, name + "_img")
+    # consts: center(0), axis(1), angle(2), rotation(3)
+    consts = list(center) + list(axis) + [angle] * 3 + list(rotation)
+    imm = C.VEC_ROTATE_TYPES[rtype] | (0x08 if invert else 0)
+    if rtype == 'AXIS_ANGLE':
+        code = flat([
+            instr(OP_LOAD_TEX, out=0, imm=0),
+            instr(OP_LOAD_CONST, out=1, imm=0),
+            instr(OP_LOAD_CONST, out=2, imm=1),
+            instr(OP_LOAD_CONST, out=3, imm=2),
+            instr(OP_VEC_ROTATE, out=4, a=0, b=1, c=2, d=3, imm=imm),
+        ])
+        out_slot = 4
+    elif rtype == 'EULER_XYZ':
+        code = flat([
+            instr(OP_LOAD_TEX, out=0, imm=0),
+            instr(OP_LOAD_CONST, out=1, imm=0),
+            instr(OP_LOAD_CONST, out=2, imm=3),
+            instr(OP_VEC_ROTATE, out=3, a=0, b=1, c=2, d=0, imm=imm),
+        ])
+        out_slot = 3
+    else:
+        code = flat([
+            instr(OP_LOAD_TEX, out=0, imm=0),
+            instr(OP_LOAD_CONST, out=1, imm=0),   # center
+            instr(OP_LOAD_CONST, out=2, imm=2),   # angle (goes in d slot)
+            instr(OP_VEC_ROTATE, out=3, a=0, b=1, c=0, d=2, imm=imm),
+        ])
+        out_slot = 3
+    r.set_program_texture_program(name, 1, out_slot, code, consts, [])
+    return r.sample_named_texture(name, 0.5, 0.5)
+
+
+def test_eval_rotate_axis_angle_90_deg():
+    r = _renderer()
+    got = _run_rotate(r, "raa", 'AXIS_ANGLE', False, (1.0, 0.0, 0.0), (0, 0, 0),
+                      (0.0, 0.0, 1.0), math.pi / 2, (0, 0, 0))
+    assert got == pytest.approx([0.0, 1.0, 0.0], abs=1e-5), got
+
+
+def test_eval_rotate_single_axes():
+    r = _renderer()
+    got = _run_rotate(r, "rx", 'X_AXIS', False, (0.0, 1.0, 0.0), (0, 0, 0),
+                      (0, 0, 0), math.pi / 2, (0, 0, 0))
+    assert got == pytest.approx([0.0, 0.0, 1.0], abs=1e-5), got
+    got = _run_rotate(r, "ry", 'Y_AXIS', False, (1.0, 0.0, 0.0), (0, 0, 0),
+                      (0, 0, 0), math.pi / 2, (0, 0, 0))
+    assert got == pytest.approx([0.0, 0.0, -1.0], abs=1e-5), got
+    got = _run_rotate(r, "rz", 'Z_AXIS', False, (1.0, 0.0, 0.0), (0, 0, 0),
+                      (0, 0, 0), math.pi / 2, (0, 0, 0))
+    assert got == pytest.approx([0.0, 1.0, 0.0], abs=1e-5), got
+
+
+def test_eval_rotate_invert_negates_angle():
+    r = _renderer()
+    # Z-axis 90° then invert -> -90° -> (0,-1,0)
+    got = _run_rotate(r, "rzinv", 'Z_AXIS', True, (1.0, 0.0, 0.0), (0, 0, 0),
+                      (0, 0, 0), math.pi / 2, (0, 0, 0))
+    assert got == pytest.approx([0.0, -1.0, 0.0], abs=1e-5), got
+    # axis-angle invert negates the angle too
+    got = _run_rotate(r, "aainv", 'AXIS_ANGLE', True, (1.0, 0.0, 0.0), (0, 0, 0),
+                      (0.0, 0.0, 1.0), math.pi / 2, (0, 0, 0))
+    assert got == pytest.approx([0.0, -1.0, 0.0], abs=1e-5), got
+
+
+def test_eval_rotate_zero_axis_returns_input():
+    r = _renderer()
+    got = _run_rotate(r, "zeroax", 'AXIS_ANGLE', False, (1.0, 2.0, 3.0), (0, 0, 0),
+                      (0.0, 0.0, 0.0), math.pi / 2, (0, 0, 0))
+    assert got == pytest.approx([1.0, 2.0, 3.0], abs=1e-6), got
+
+
+def test_eval_rotate_nonzero_center():
+    r = _renderer()
+    # rotate the point (2,0,0) around center (1,0,0) by +90° about Z -> (1,1,0)
+    got = _run_rotate(r, "ctr", 'Z_AXIS', False, (2.0, 0.0, 0.0), (1.0, 0.0, 0.0),
+                      (0, 0, 0), math.pi / 2, (0, 0, 0))
+    assert got == pytest.approx([1.0, 1.0, 0.0], abs=1e-5), got
+
+
+def test_eval_rotate_euler_single_axis():
+    r = _renderer()
+    got = _run_rotate(r, "eulz", 'EULER_XYZ', False, (1.0, 0.0, 0.0), (0, 0, 0),
+                      (0, 0, 0), 0.0, (0.0, 0.0, math.pi / 2))
+    assert got == pytest.approx([0.0, 1.0, 0.0], abs=1e-5), got
+
+
+def test_eval_rotate_euler_multi_axis_inverse_matrix_oracle():
+    import numpy as np
+    rotation = (0.3, -0.5, 0.8)   # all three axes nonzero
+    vec = (1.0, 0.5, -0.7)
+    center = (0.25, -0.4, 0.6)
+    # Independent oracle: R = Rz @ Ry @ Rx (Blender XYZ), invert = R^T = R^-1.
+    rx, ry, rz = rotation
+    Rx = np.array([[1, 0, 0],
+                   [0, math.cos(rx), -math.sin(rx)],
+                   [0, math.sin(rx), math.cos(rx)]])
+    Ry = np.array([[math.cos(ry), 0, math.sin(ry)],
+                   [0, 1, 0],
+                   [-math.sin(ry), 0, math.cos(ry)]])
+    Rz = np.array([[math.cos(rz), -math.sin(rz), 0],
+                   [math.sin(rz), math.cos(rz), 0],
+                   [0, 0, 1]])
+    R = Rz @ Ry @ Rx
+    v = np.array(vec) - np.array(center)
+    r = _renderer()
+    got_fwd = _run_rotate(r, "eulfwd", 'EULER_XYZ', False, vec, center, (0, 0, 0),
+                          0.0, rotation)
+    assert got_fwd == pytest.approx((R @ v + np.array(center)).tolist(), abs=5e-3), got_fwd
+    got_inv = _run_rotate(r, "eulinv", 'EULER_XYZ', True, vec, center, (0, 0, 0),
+                          0.0, rotation)
+    assert got_inv == pytest.approx((R.T @ v + np.array(center)).tolist(), abs=5e-3), got_inv
+
+
+# --------------------------------------------------------------------------- #
+# eval: dynamic linked operands via the compiler
+# --------------------------------------------------------------------------- #
+def test_eval_vec_math_linked_operands():
+    texA = Node('TEX_IMAGE')
+    texB = Node('TEX_IMAGE')
+    vm = Node('VECT_MATH', operation='ADD',
+              inputs=[Sock('Vector', 0.0, Link(texA, 'Color')),
+                      Sock('Vector', 0.0, Link(texB, 'Color')),
+                      Sock('Vector', 0.0),
+                      Sock('Scale', 1.0)])
+    base = Sock('Base Color', [0.5, 0.5, 0.5], Link(vm, 'Vector'))
+    compiled = C.compile_chain(base)
+    assert compiled is not None and compiled['num_tex'] == 2
+    r = _renderer()
+    _load_program(r, "vmlink", compiled,
+                  {id(texA): (0.1, 0.2, 0.3), id(texB): (0.4, 0.5, 0.6)})
+    got = r.sample_named_texture("vmlink", 0.5, 0.5)
+    assert got == pytest.approx([0.5, 0.7, 0.9], abs=3e-3), got
+
+
+# --------------------------------------------------------------------------- #
+# eval: Mix factor below zero / above one (default clamped vs unclamped)
+# --------------------------------------------------------------------------- #
+def _run_mix_factor(factor, unclamp):
+    r = _renderer()
+    make_solid_input(r, "mf_img", (0.5, 0.5, 0.5))
+    r.create_program_texture("mf_tex", "UV")
+    r.program_texture_add_input("mf_tex", "mf_img")
+    # slot0 = dummy tex; slot1 = factor; slot2 = black; slot3 = white
+    consts = [factor, factor, factor, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
+    imm = C.SVM_MIX_UNCLAMP_FACTOR if unclamp else 0
+    code = flat([
+        instr(OP_LOAD_TEX, out=0, imm=0),
+        instr(OP_LOAD_CONST, out=1, imm=0),
+        instr(OP_LOAD_CONST, out=2, imm=1),
+        instr(OP_LOAD_CONST, out=3, imm=2),
+        instr(OP_MIX, out=4, a=1, b=2, c=3, imm=imm),
+    ])
+    r.set_program_texture_program("mf_tex", 1, 4, code, consts, [])
+    return r.sample_named_texture("mf_tex", 0.5, 0.5)
+
+
+def test_eval_mix_factor_below_zero_and_above_one():
+    # default (clamped): factor -0.5 -> 0 -> black ; 1.5 -> 1 -> white
+    assert _run_mix_factor(-0.5, unclamp=False) == pytest.approx([0, 0, 0], abs=1e-6)
+    assert _run_mix_factor(1.5, unclamp=False) == pytest.approx([1, 1, 1], abs=1e-6)
+    # unclamped: factor passes through -> -0.5 and 1.5
+    assert _run_mix_factor(-0.5, unclamp=True) == pytest.approx([-0.5, -0.5, -0.5], abs=1e-6)
+    assert _run_mix_factor(1.5, unclamp=True) == pytest.approx([1.5, 1.5, 1.5], abs=1e-6)
+
+
+@pytest.mark.parametrize("source_type,expected", [
+    ("RGBA", 0.2 * 0.2126729 + 0.6 * 0.7151522 + 0.9 * 0.0721750),
+    ("VECTOR", (0.2 + 0.6 + 0.9) / 3),
+])
+def test_eval_compiled_scalar_conversion(source_type, expected):
+    tex = Node('TEX_IMAGE')
+    # An identity vector operation makes a real image -> vector -> scalar chain.
+    node = tex
+    if source_type == 'VECTOR':
+        node = Node('VECT_MATH', operation='ADD', inputs=[
+            Sock('Vector', link=Link(tex, type='RGBA')),
+            Sock('Vector', (0, 0, 0))])
+    mix = Node('MIX', data_type='FLOAT', blend_type='ADD', inputs=[
+        Sock('Factor', 1.0, type='VALUE'),
+        Sock('A', 0.0, type='VALUE'),
+        Sock('B', link=Link(node, type=source_type), type='VALUE')])
+    compiled = C.compile_chain(Sock('Base Color', link=Link(mix, 'Result', type='VALUE')))
+    r = _renderer()
+    _load_program(r, 'typed_scalar', compiled, {id(tex): (0.2, 0.6, 0.9)})
+    assert r.sample_named_texture('typed_scalar', 0.5, 0.5) == pytest.approx([expected] * 3, abs=1e-6)
+
+
+@pytest.mark.parametrize('rtype', list(C.VEC_ROTATE_TYPES))
+@pytest.mark.parametrize('invert', [False, True])
+def test_eval_compiled_rotate(rtype, invert):
+    tex = Node('TEX_IMAGE')
+    node = Node('VECTOR_ROTATE', rotation_type=rtype, invert=invert, inputs=[
+        Sock('Vector', link=Link(tex, type='RGBA')),
+        Sock('Center', (0, 0, 0)), Sock('Axis', (0, 0, 1)),
+        Sock('Angle', math.pi / 2, type='VALUE'),
+        Sock('Rotation', (0, 0, math.pi / 2))])
+    compiled = C.compile_chain(Sock('Color', link=Link(node, 'Vector', type='VECTOR')))
+    r = _renderer()
+    _load_program(r, 'compiled_rotate', compiled, {id(tex): (1, 1, 1)})
+    expected = {'X_AXIS': (1, -1, 1), 'Y_AXIS': (1, 1, -1)}.get(rtype, (-1, 1, 1))
+    if invert:
+        expected = {'X_AXIS': (1, 1, -1), 'Y_AXIS': (-1, 1, 1)}.get(rtype, (1, -1, 1))
+    assert r.sample_named_texture('compiled_rotate', 0.5, 0.5) == pytest.approx(expected, abs=1e-6)
+
+
+def test_eval_vector_power_zero_and_negative_bases():
+    r = _renderer()
+    assert _run_vec_math(r, 'powerzero', 'POWER', (0, 0, -2), (-1, 0, 3), (0, 0, 0), 1) == pytest.approx([0, 1, -8])
+    assert _run_vec_math(r, 'powerneg', 'POWER', (-2, -2, -2), (-2, -3, 0.5), (0, 0, 0), 1) == pytest.approx([0.25, -0.125, 0])
+
+
+def test_compile_indexable_euler_default():
+    class EulerDefault:
+        # Blender mathutils.Euler has sequence indexing without __iter__.
+        def __getitem__(self, index):
+            return (0.1, 0.2, 0.3)[index]
+
+    assert C._socket_default_rgb(Sock('Rotation', EulerDefault())) == [0.1, 0.2, 0.3]

--- a/tests/test_pkg230_vector_addon.py
+++ b/tests/test_pkg230_vector_addon.py
@@ -1,0 +1,105 @@
+"""pkg230 Phase 2 — coordinate-chain fallback warning (mocked addon, no bpy/engine).
+
+A Vector Math / Vector Rotate node on an image-texture coordinate chain is a
+per-texel coordinate op the affine resolver cannot express. It must surface a
+VISIBLE ``_warn_shader_fallback`` (recorded in the degradation report), never a
+silent plain-UV fallback. Uses the same stub-bpy loader pattern as the other
+addon tests; no built module is required.
+"""
+from test_blender_uv_plumbing import (
+    _FakeImage,
+    _load_blender_addon,
+    _Node,
+    _RecordingRenderer,
+    _Socket,
+)
+
+
+def _cls(monkeypatch):
+    return _load_blender_addon(monkeypatch).CustomRaytracerRenderEngine
+
+
+def test_vector_math_on_coord_chain_warns(monkeypatch):
+    cls = _cls(monkeypatch)
+    engine = cls()
+    vm = _Node('VECT_MATH')
+    socket = _Socket(linked_to=vm, output_name='Vector')
+    coord, scale, offset, _rotation, _layer = engine._resolve_vector_input(
+        socket, warn=engine._warn_shader_fallback)
+    # fallback behavior is preserved: default UV with identity transform
+    assert coord == "UV"
+    assert scale == (1.0, 1.0) and offset == (0.0, 0.0)
+    rep = engine._degradation_report()
+    assert any('VECT_MATH' in feature for feature, _ in rep.approximated)
+
+
+def test_vector_rotate_on_coord_chain_warns(monkeypatch):
+    cls = _cls(monkeypatch)
+    engine = cls()
+    vr = _Node('VECTOR_ROTATE')
+    socket = _Socket(linked_to=vr, output_name='Vector')
+    cls._resolve_vector_input(socket, warn=engine._warn_shader_fallback)
+    rep = engine._degradation_report()
+    assert any('VECTOR_ROTATE' in feature for feature, _ in rep.approximated)
+
+
+def test_supported_coord_source_does_not_warn(monkeypatch):
+    cls = _cls(monkeypatch)
+    engine = cls()
+    tc = _Node('TEX_COORD')
+    socket = _Socket(linked_to=tc, output_name='UV')
+    coord, *_ = engine._resolve_vector_input(socket, warn=engine._warn_shader_fallback)
+    assert coord == "UV"
+    assert engine._degradation_report().is_empty()
+
+
+def test_mapping_chain_with_inner_vector_math_warns(monkeypatch):
+    cls = _cls(monkeypatch)
+    engine = cls()
+    vm = _Node('VECT_MATH')
+    mapping = _Node('MAPPING', inputs={
+        'Vector': _Socket(linked_to=vm, output_name='Vector'),
+        'Location': _Socket(default=(0.0, 0.0, 0.0)),
+        'Rotation': _Socket(default=(0.0, 0.0, 0.0)),
+        'Scale': _Socket(default=(1.0, 1.0, 1.0)),
+    })
+    socket = _Socket(linked_to=mapping, output_name='Vector')
+    coord, *_ = engine._resolve_vector_input(socket, warn=engine._warn_shader_fallback)
+    assert coord == "UV"
+    rep = engine._degradation_report()
+    assert any('VECT_MATH' in feature for feature, _ in rep.approximated)
+
+
+def test_mapping_matrix_still_none_for_vector_math(monkeypatch):
+    # the affine resolver keeps returning None (behavior preserved) — the visible
+    # degradation entry comes from _resolve_vector_input's warn hook.
+    cls = _cls(monkeypatch)
+    engine = cls()
+    vm = _Node('VECT_MATH')
+    socket = _Socket(linked_to=vm, output_name='Vector')
+    assert engine._resolve_mapping_matrix(socket) is None
+
+
+def test_load_blender_image_vector_math_records_degradation(monkeypatch):
+    cls = _cls(monkeypatch)
+    engine = cls()
+    renderer = _RecordingRenderer()
+    image = _FakeImage(name="coords.png")
+    vm = _Node('VECT_MATH')
+    name = engine.load_blender_image(
+        image, renderer,
+        vector_input=_Socket(linked_to=vm, output_name='Vector'))
+    assert name is not None
+    rep = engine._degradation_report()
+    assert any('VECT_MATH' in feature for feature, _ in rep.approximated)
+
+
+def test_procedural_coordinate_warning_reports_generated_default(monkeypatch):
+    cls = _cls(monkeypatch)
+    warnings = []
+    coord, *_ = cls._resolve_vector_input(
+        _Socket(linked_to=_Node('VECTOR_ROTATE'), output_name='Vector'),
+        default_coord_mode='GENERATED', warn=lambda feature, reason: warnings.append(reason))
+    assert coord == 'GENERATED'
+    assert len(warnings) == 1 and 'GENERATED' in warnings[0]
+    assert 'plain UV' not in warnings[0]

--- a/tests/test_pkg230_vector_parity.py
+++ b/tests/test_pkg230_vector_parity.py
@@ -1,0 +1,155 @@
+"""pkg230 Phase 2 — CPU/GPU parity render for OP_VEC_MATH / OP_VEC_ROTATE / Mix.
+
+Renders a controlled 2x2 quad textured with an op-VM program (Vector Math ADD
+offset, Vector Rotate 90° about Z, and a Mix with a constant) on CPU and GPU and
+checks:
+  * the VM changes the image vs the plain (no-program) texture, on BOTH backends;
+  * GPU matches CPU within MC noise (per-channel mean-ratio).
+
+The GPU leg runs the same shared HD svm_eval inside the <HasProgram=true> shade
+specialization; parity is by construction. GPU-gated (CI has no CUDA device).
+Saves representative PNGs to test_results/pkg230-p2 for the parent's visual
+inspection. Left for the parent to execute after the fresh native rebuild.
+"""
+import os
+
+import astroray
+import numpy as np
+import pytest
+from base_helpers import create_renderer, render_image, save_image, setup_camera
+
+# opcode enums (mirror include/astroray/shader_vm.h)
+OP_LOAD_TEX, OP_LOAD_CONST = 1, 2
+OP_MIX, OP_VEC_MATH, OP_VEC_ROTATE = 4, 15, 16
+VECMATH_ADD = 0
+VECROT_Z_AXIS = 3
+MIX_BLEND = 0
+
+_OUT = os.path.join(os.path.dirname(__file__), "..", "test_results", "pkg230-p2")
+
+
+def _has_cuda_gpu(renderer):
+    return bool(astroray.__features__.get("cuda", False)) and \
+        bool(getattr(renderer, "gpu_available", False))
+
+
+def _quad_image():
+    img = np.array([
+        [[0.8, 0.2, 0.1], [0.1, 0.8, 0.2]],
+        [[0.2, 0.1, 0.8], [0.6, 0.6, 0.3]],
+    ], dtype=np.float32)
+    return img.reshape(-1).tolist(), 2, 2
+
+
+def _program(kind):
+    """Return (num_tex, out_slot, code_flat, consts_flat) for a program texture."""
+    if kind == 'vec_math':
+        # tex + (0.2, -0.1, 0.05)
+        return 1, 2, [
+            OP_LOAD_TEX, 0, 0, 0, 0, 0, 0, 0,
+            OP_LOAD_CONST, 1, 0, 0, 0, 0, 0, 0,
+            OP_VEC_MATH, 2, 0, 1, 0, 0, 0, VECMATH_ADD,
+        ], [0.2, -0.1, 0.05]
+    if kind == 'vec_rotate':
+        # rotate 90° about Z: (r,g,b) -> (-g, r, b)
+        return 1, 3, [
+            OP_LOAD_TEX, 0, 0, 0, 0, 0, 0, 0,
+            OP_LOAD_CONST, 1, 0, 0, 0, 0, 0, 0,      # center (0,0,0)
+            OP_LOAD_CONST, 2, 0, 0, 0, 0, 0, 1,      # angle (pi/2 broadcast)
+            OP_VEC_ROTATE, 3, 0, 1, 0, 2, 0, VECROT_Z_AXIS,
+        ], [0.0, 0.0, 0.0, np.pi / 2, np.pi / 2, np.pi / 2]
+    if kind == 'mix':
+        # blend tex 60% toward (0.9, 0.1, 0.2)
+        return 1, 3, [
+            OP_LOAD_TEX, 0, 0, 0, 0, 0, 0, 0,
+            OP_LOAD_CONST, 1, 0, 0, 0, 0, 0, 0,      # factor 0.6
+            OP_LOAD_CONST, 2, 0, 0, 0, 0, 0, 1,      # color
+            OP_MIX, 3, 1, 0, 2, 0, 0, MIX_BLEND,
+        ], [0.6, 0.6, 0.6, 0.9, 0.1, 0.2]
+    raise ValueError(kind)
+
+
+def _build_scene(renderer, *, kind):
+    renderer.set_background_color([0.5, 0.5, 0.5])
+    data, w, h = _quad_image()
+    renderer.load_texture("pkg230v_img", data, w, h, "UV")
+    ntex, out_slot, code, consts = _program(kind)
+    renderer.create_program_texture("pkg230v_prog", "UV")
+    renderer.program_texture_add_input("pkg230v_prog", "pkg230v_img")
+    renderer.set_program_texture_program("pkg230v_prog", ntex, out_slot, code, consts, [])
+    mat = renderer.create_material("lambertian", [1.0, 1.0, 1.0],
+                                   {"texture": "pkg230v_prog"})
+    A, B = [-1, -1, 0], [1, -1, 0]
+    C, D = [1, 1, 0], [-1, 1, 0]
+    n = [0, 0, 1]
+    renderer.add_triangle_layers(A, B, C, mat, {"UVMap": [[0, 0], [1, 0], [1, 1]]},
+                                 n, n, n)
+    renderer.add_triangle_layers(A, C, D, mat, {"UVMap": [[0, 0], [1, 1], [0, 1]]},
+                                 n, n, n)
+    setup_camera(renderer, look_from=[0, 0, 3], look_at=[0, 0, 0], vup=[0, 1, 0],
+                 vfov=45, width=64, height=64)
+
+
+def _render(kind, use_gpu, samples=64, seed=1):
+    r = create_renderer()
+    if use_gpu:
+        if not _has_cuda_gpu(r):
+            pytest.skip("No CUDA GPU — pkg230 vector leg runs on the RTX box.")
+        r.set_use_gpu(True)
+    r.set_seed(seed)
+    _build_scene(r, kind=kind)
+    return render_image(r, samples=samples, max_depth=2, apply_gamma=False)
+
+
+@pytest.mark.parametrize("kind", ["vec_math", "vec_rotate", "mix"])
+def test_cpu_program_changes_image(kind):
+    plain = _render_plain(use_gpu=False)
+    prog = _render(kind, use_gpu=False)
+    mad = float(np.abs(plain - prog).mean())
+    assert mad > 0.02, f"CPU {kind} had no effect (mean|diff|={mad:.4f})"
+    save_image(prog, os.path.join(_OUT, f"pkg230_{kind}_cpu.png"))
+    np.save(os.path.join(_OUT, f"pkg230_{kind}_cpu.npy"), prog)
+
+
+@pytest.mark.parametrize("kind", ["vec_math", "vec_rotate", "mix"])
+def test_gpu_program_changes_image(kind):
+    plain = _render_plain(use_gpu=True)
+    prog = _render(kind, use_gpu=True)
+    mad = float(np.abs(plain - prog).mean())
+    assert mad > 0.02, f"GPU {kind} had no effect (mean|diff|={mad:.4f})"
+    save_image(prog, os.path.join(_OUT, f"pkg230_{kind}_gpu.png"))
+    np.save(os.path.join(_OUT, f"pkg230_{kind}_gpu.npy"), prog)
+
+
+@pytest.mark.parametrize("kind", ["vec_math", "vec_rotate", "mix"])
+def test_gpu_matches_cpu(kind):
+    cpu = _render(kind, use_gpu=False)
+    gpu = _render(kind, use_gpu=True)
+    for ch in range(3):
+        c = float(cpu[..., ch].mean())
+        g = float(gpu[..., ch].mean())
+        if c < 1e-4:
+            continue
+        ratio = g / c
+        assert 0.95 < ratio < 1.05, f"{kind} channel {ch} CPU/GPU mean-ratio {ratio:.3f}"
+
+
+def _render_plain(use_gpu):
+    r = create_renderer()
+    if use_gpu:
+        if not _has_cuda_gpu(r):
+            pytest.skip("No CUDA GPU — pkg230 vector leg runs on the RTX box.")
+        r.set_use_gpu(True)
+    r.set_seed(1)
+    r.set_background_color([0.5, 0.5, 0.5])
+    data, w, h = _quad_image()
+    r.load_texture("pkg230v_img", data, w, h, "UV")
+    mat = r.create_material("lambertian", [1.0, 1.0, 1.0], {"texture": "pkg230v_img"})
+    A, B = [-1, -1, 0], [1, -1, 0]
+    C, D = [1, 1, 0], [-1, 1, 0]
+    n = [0, 0, 1]
+    r.add_triangle_layers(A, B, C, mat, {"UVMap": [[0, 0], [1, 0], [1, 1]]}, n, n, n)
+    r.add_triangle_layers(A, C, D, mat, {"UVMap": [[0, 0], [1, 1], [0, 1]]}, n, n, n)
+    setup_camera(r, look_from=[0, 0, 3], look_at=[0, 0, 0], vup=[0, 1, 0],
+                 vfov=45, width=64, height=64)
+    return render_image(r, samples=64, max_depth=2, apply_gamma=False)


### PR DESCRIPTION
Image-driven Vector Math and Vector Rotate now evaluate per texel in the shared CPU/GPU shader VM. Modern Mix honors `clamp_factor=OFF`, while legacy raw programs retain their default clamping. Unsupported coordinate-chain vector nodes produce visible degradation warnings.

The compiler handles all 30 vector operations, five rotation modes, duplicate/typed Blender sockets, used operands, and implicit color/vector-to-scalar conversion. Instruction/program layouts, material bindings, eight-slot limits, and GPU specialization axes stay unchanged. Cycles 5.1 reference methods and attribution are recorded in `.astroray_plan/docs/pkg230-phase2-vector-semantics-research.md`.

The canonical Blender comparison harness now selects the requested Astroray backend and applies effective native sample/denoising controls plus Astroray's adaptive control. Its backdrop test requests 256 samples on both engines: baseline and feature improve identically from SSIM 0.8395 at 64 to 0.9141 at 256; the 0.90 threshold is unchanged.

### Verification

- All 30 vector operations, five rotations, edge cases, enum/flag parity, legacy Mix, unsupported modes and coordinate warnings covered. Real Blender compilation covers 43 graph variants.
- CPU-only addon: 96 native tests passed; three image-program tests passed (six GPU-only skipped).
- Final RTX 5070 Ti / CUDA 12.8 / MSVC / sm_120 addon: 158 focused pkg219/pkg230 tests passed. OpenMP disabled, intended imported module/build ID, native architecture and ABI canaries verified.
- Fifteen real Blender CPU-only/GPU/Cycles charts at 128x128 and 256 samples passed. Interior RGB mean deviation from Cycles is at most 2.38% against the 5% gate; GPU/CPU deviation is below 0.06%. Astra qualitative inspection passed. This comparison is scoped to the reported diffuse Principled carrier, perspective camera and Closest filtering.
- All 64 non-program shade variants retain identical measured resource fields; 128 total variants. Fleet REG 254 / STACK 3400 / CONSTANT[0] 1748 / LOCAL 0.
- Full split run: 1642 CPU passes and 684 serial passes, with four initial failures. The Blender environment/sampling failures were investigated: the isolated dev-loop smoke passes and all 37 harness tests pass. Two existing failures remain: HDRI SSIM and PostInit ULP reproduce on fresh main; pkg237/pkg238 track diagnosis. Later snapshot stages were measured explicitly and match main exactly within their bounds; no thresholds were weakened.
- Caller/binding sweep and differential Ruff/cppcheck/markdownlint/codespell/diff-check are clean; no unavailable/error tools.

### Limits and retained evidence

Coordinate-vector support, standalone BSDF texture loss, image filtering, test isolation, and baseline numerical issues are separate OPEN follow-ups (#697–#700). The backdrop also retains a small local highlight difference from Cycles on both main and this branch; a separate diagnostic spec records it. No owner queue priority or Pillar 4 pause changes.

The non-hermetic smoke test's attempted live-profile install was repaired with the original native module preserved; subsequent smoke used a verified temporary Blender profile. The live user addon remains at its original build.

Full measurements, source/build identity and local artifact names are in `.astroray_plan/docs/pkg230-phase2-delivery-evidence.md`. Representative renders and raw linear arrays are retained under `test_results/pkg230-p2/` in the feature and root workspaces.

Independent Claude final SIGN-OFF granted on 4035a00 for math, ABI/callers, runtime evidence and visual inspection; merge remains conditional on green CI. The baseline failure exceptions and pkg239 filing were reviewed explicitly.
