### PR TITLE
docs: file backdrop local-highlight parity diagnosis

### DIFF
--- a/.astroray_plan/packages/pkg239-backdrop-highlight-parity.md
+++ b/.astroray_plan/packages/pkg239-backdrop-highlight-parity.md
@@ -1,0 +1,50 @@
+# pkg239 — Backdrop local-highlight parity diagnosis
+
+**Pillar:** 5 (Blender/Cycles visual parity)
+**Track:** A
+**Status:** OPEN — detailed architect review required before implementation
+**Estimated effort:** TBD at architect review
+**Depends on:** none (diagnosis of existing behavior)
+
+## Evidence
+
+Astra qualitative inspection of `test_results/pkg230-p2/backdrop_convergence.png`
+shows a small bright white highlight at the top of the green band in BOTH fresh
+main and pkg230 renders, absent in Cycles. It persists at 64 and 256 spp.
+Recorded normalized global SSIM gate threshold 0.90: at 256 spp main
+0.91410756, feature 0.91410750 (both pass); at 64 spp both 0.8395174 (fail),
+while the local highlight persists. Source metrics retained in
+`test_results/pkg230-p2/backdrop-convergence.json`. This is a
+baseline-reproduced local visual mismatch, not established pkg230 causation; a
+global metric pass does NOT establish full visual parity. No root-cause claim.
+
+## Goal
+
+Diagnose standalone Diffuse export/material routing, light visibility/transport,
+and spatial metric sensitivity. `_apply_solid_diffuse` in
+`benchmarks/blender_parity/scene_library.py` creates `ShaderNodeBsdfDiffuse`;
+`_add_backdrop` builds solid-color quads without VM. Preserve fixed-seed matched
+main/feature/Cycles captures, raw linear floats, a fixed highlight crop, and
+convergence outputs. Use independent closure/light oracles; retain competing
+hypotheses until evidence supports a cause. Coordinate with pkg233 only for a
+shared exporter: it owns texture omission; this owns the solid-color highlight.
+
+Detailed architect review sets the diagnostic scope before any implementation.
+Owner queue priority stays unchanged; Pillar 4 remains PAUSED.
+
+## Acceptance — all implementation gates UNRUN
+
+- [ ] Repeat baseline/feature/Cycles at 64 and 256 spp plus a justified
+      convergence extension with fixed seeds/configs.
+- [ ] Raw linear arrays, matched crop, and localized error statistics alongside global SSIM.
+- [ ] Independent Diffuse/light-visibility oracles localize the cause.
+- [ ] Saved full-frame/crop/convergence outputs receive Astra/Claude qualitative review.
+- [ ] Existing global gate retained unchanged.
+- [ ] Any implementation requires documented regressions, fresh intended
+      native-import/ABI/resource checks, GPU lock, and at most two isolated worktrees.
+- [ ] Independent Astra/Claude causal review and sign-off.
+
+## Non-goals
+
+No SSIM threshold relaxation, VM/math change, broad transport rewrite, queue
+promotion, or paused Pillar 4 work. No claim of whole-baseline visual parity.


### PR DESCRIPTION
Records the local bright patch visible on the solid Diffuse backdrop in both fresh main and pkg230 renders, absent in Cycles. The existing global SSIM gate passes at 256 samples while this local difference persists, so the follow-up requires crop evidence and independent material/light diagnosis.

OPEN pending detailed architecture review; all implementation gates UNRUN. No root cause, threshold change, queue promotion, or implementation is claimed. Scope is separate from pkg233's texture omission.

Validation: Astra image/source review; independent Claude filing SIGN-OFF; markdownlint, codespell and diff-check clean. Representative linear captures, metrics and contact sheet are retained in test_results/pkg230-p2.
