### PR TITLE
docs: close pkg230 Phase 2 and scope CI cost audit

### DIFF
--- a/.astroray_plan/docs/NEXT_STAGE_REPORT.md
+++ b/.astroray_plan/docs/NEXT_STAGE_REPORT.md
@@ -1,6 +1,52 @@
 # Astroray Next Stage Report
 
-## 2026-09-05 LIVE HANDOFF — reconciled with `origin/main`
+## 2026-09-06 CURRENT HANDOFF — pkg230 Phase 2 LANDED (#701)
+
+pkg230 Phase 2 (30 Vector Math ops, 5 Vector Rotate modes, faithful Mix factor
+clamping in the color/scalar op-VM chain) is **LANDED in PR #701**, merged
+2026-09-05 17:10 UTC (2026-09-06 Sydney), commit
+`b38a7d8471884c43c7aa5a2fd60ddb447c859309`. Independent Claude final SIGN-OFF
+covers reviewed source `4035a000f8b45dc549e072ebfd31799f608f1755`.
+Both push and PR CI runs passed host build/tests and CUDA syntax checks.
+The PR host run recorded 2074 passed, 243 skipped, 15 xfailed, 4 xpassed.
+Do not redispatch Phase 2.
+
+**Gates (concise; full gates/artifacts in
+[pkg230-phase2-delivery-evidence.md](pkg230-phase2-delivery-evidence.md)):**
+
+- 158 focused pkg219/pkg230 tests passed; 37 harness tests passed; isolated
+  Blender dev-loop smoke PASS after live-profile-incident recovery.
+- 15 real-Blender comparison legs = 5 cases across CPU-only Astroray, GPU
+  Astroray, and Cycles; max RGB mean-ratio deviation 2.38% vs the 5% gate.
+  Astra and independent Claude visual review PASS; charts saved.
+- All 64 non-program shade variants match their recorded baseline resource
+  fields. Fleet: REG 254 / STACK 3400 / CONST 1748 / LOCAL 0. The comparison
+  measured resources, not complete machine-code byte streams.
+- Original full split run: 2326 passed (1642 CPU + 684 serial), 4 original
+  failures. Two environment/sampling failures resolved on rerun (hermetic
+  profile smoke; backdrop correct artifact + 256 samples); two baseline
+  HDRI/ULP failures remain under pkg237/pkg238. The original full suite is NOT
+  green and was NOT wholly rerun.
+- A local bright patch on the backdrop persists on main+feature despite the
+  global SSIM pass at 256; pkg239 follow-up #702. No claim of perfect
+  baseline/Cycles visual parity.
+- Follow-ups filed separately, all OPEN for architect review before
+  implementation, no queue promotion: pkg230b #697, build-latency pkg231 #698,
+  pkg232–235 #699, pkg236–238 #700, pkg239 #702. This closeout also files
+  pkg240 CI workflow cost audit, separate from renderer work and pkg231.
+
+**Scope boundaries:** the verified real-Blender carrier is textured Principled
+with specular zero and Closest filtering — not universal BSDF/filter coverage.
+Coordinate chains warn/defer to pkg230b.
+
+**NEXT is OWNER CHOICE** among pkg127 Phase 2, Principled
+advanced-inputs (needs a scoped spec), pkg211 prototype-first-or-park, and the
+pkg136 GPU leg. No autonomous priority promotion; Pillar 4 remains PAUSED. Mere
+filed follow-ups do not preempt owner choice.
+
+---
+
+## 2026-09-05 HISTORICAL HANDOFF — superseded by 2026-09-06 above
 
 The earlier 2026-09-03 handoff below is historical. Since then, pkg225-S3/S4/S5/S6
 landed (#676, #681–#684), pkg127 Phase 1 landed (#685), pkg229's coverage re-audit
@@ -26,7 +72,8 @@ untouched by construction). Caught & fixed a Cycles-parity bug (`svm_clampf`
 diverges from Cycles `min(max())` when min>max). Spec:
 `.astroray_plan/packages/pkg230-opvm-utility-opcodes.md`.
 
-**IMMEDIATE NEXT PICKUP — pkg230 Phase 2** (spec written, not started): **Vector
+**Historical pickup on 2026-09-05 — pkg230 Phase 2** (then scoped and unstarted;
+superseded by the current handoff above): **Vector
 Math + Vector Rotate** op-VM opcodes + **faithful Mix `clamp_factor=OFF`**. Key
 context for whoever takes it:
 - The op-VM (`include/astroray/shader_vm.h`) is one shared `HD svm_eval` with a

--- a/.astroray_plan/docs/ROADMAP.md
+++ b/.astroray_plan/docs/ROADMAP.md
@@ -109,7 +109,7 @@ render progressive-refinement fps). **All features being built should be
 astrophysical pipeline will need from them (volumes for nebulae, curves for
 filaments, spectral for emission lines).
 
-**Current active queue (2026-09-05):** pkg225 hair rendering is complete through
+**Current active queue (2026-09-06):** pkg225 hair rendering is complete through
 S6 (PRs #670, #673, #676, #681–#684). pkg127 Phase 1 is landed (#685), pkg229's
 coverage re-audit is landed (spec #692 + re-audit #695), and pkg136 CPU Stage 1
 (1A+1B) is landed (#693/#694). **pkg136's ≥2× variance campaign is CONCLUDED, not
@@ -119,13 +119,20 @@ real architectural bug (discarded training samples: 3× ray waste + a high-α da
 bias) and delivered a genuine ~1.3× equal-cost win on the hard-transport slot
 scene (#694). **pkg230 Phase 1 (op-VM utility opcodes: Clamp + Math `use_clamp` +
 Mix `clamp_result`) is landed (#696)** — CI green + RTX HW-verified (REG:254 held).
-**NEXT = pkg230 Phase 2** (Vector Math + Vector Rotate op-VM opcodes + faithful Mix
-`clamp_factor=OFF`; spec written, coordinate-chain-vs-op-VM fork documented),
-followed by the owner's choice of pkg127 Phase 2, Principled advanced-inputs
-(highest-value single node, L), pkg211's prototype-first/park path, or pkg136's GPU
-leg. pkg219d scalar parameter textures remain landed (#674); pkg210 is SUPERSEDED
-and pkg180 CLOSED.
-The exact dispatch order is an architect decision per round.
+**pkg230 Phase 2 (Vector Math + Vector Rotate op-VM opcodes + faithful Mix
+`clamp_factor=OFF`) is LANDED in PR #701**, merged 2026-09-06 Sydney at
+`b38a7d8471884c43c7aa5a2fd60ddb447c859309`. Independent Claude final SIGN-OFF
+covered reviewed source `4035a00`; both host CI and CUDA syntax runs passed.
+Local hardware/visual gates passed with the two reproduced baseline test
+failures explicitly retained under pkg237/pkg238. Do not redispatch Phase 2.
+Full evidence:
+[pkg230-phase2-delivery-evidence.md](pkg230-phase2-delivery-evidence.md). pkg219d
+scalar parameter textures remain landed (#674); pkg210 is SUPERSEDED and pkg180
+CLOSED.
+NEXT is an OWNER CHOICE among pkg127 Phase 2, Principled
+advanced-inputs (needs a scoped spec), pkg211's prototype-first/park path, and
+pkg136's GPU leg — no autonomous priority promotion; Pillar 4 remains PAUSED, and
+mere filed follow-ups do not preempt owner choice.
 
 **Explicitly de-prioritized (owner-endorsed):** the sub-percent GPU/CPU
 parity tail — **pkg172 effect (B) / pkg173** (bounce-1 geometry-sampling

--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -1,10 +1,55 @@
 # Astroray Status
 
-**2026-09-05 (LIVE RECONCILIATION — verified against `origin/main` at
-`aecff0d` and merged PRs #676, #681–#685, #692–#696): pkg225 hair is complete
-through the Blender addon; pkg127 Phase 1 and pkg136 CPU Stage 1A/1B are
-landed; pkg229's coverage re-audit is landed; pkg230 Phase 1 (op-VM utility
-opcodes) is landed. NEXT = pkg230 Phase 2 (Vector Math/Rotate).**
+**2026-09-06 (CURRENT — pkg230 Phase 2 LANDED):** pkg230
+Phase 2 (30 Vector Math ops, 5 Vector Rotate modes, faithful Mix factor
+clamping in the color/scalar op-VM chain) is **LANDED in PR #701**, merged
+2026-09-05 17:10 UTC (2026-09-06 Sydney), commit
+`b38a7d8471884c43c7aa5a2fd60ddb447c859309`. Independent Claude final SIGN-OFF
+covers reviewed source `4035a000f8b45dc549e072ebfd31799f608f1755`.
+Both push and PR CI runs passed host build/tests and CUDA syntax checks.
+The PR host run recorded 2074 passed, 243 skipped, 15 xfailed, 4 xpassed.
+Do not redispatch Phase 2.
+
+- **Evidence-backed gates (concise; full gates/artifacts in
+  [pkg230-phase2-delivery-evidence.md](pkg230-phase2-delivery-evidence.md)):**
+  - 158 focused pkg219/pkg230 tests passed; 37 harness tests passed; isolated
+    Blender dev-loop smoke PASS after live-profile-incident recovery.
+  - 15 real-Blender comparison legs = 5 cases across CPU-only Astroray, GPU
+    Astroray, and Cycles; max RGB mean-ratio deviation 2.38% vs the 5% gate.
+    Astra and independent Claude visual review PASS; charts saved.
+  - All 64 non-program shade variants match their recorded baseline resource
+    fields. Fleet: REG 254 / STACK 3400 / CONST 1748 / LOCAL 0. The comparison
+    measured resources, not complete machine-code byte streams.
+  - Original full split run: 2326 passed (1642 CPU + 684 serial), 4 original
+    failures. Two environment/sampling failures resolved on rerun (hermetic
+    profile smoke; backdrop correct artifact + 256 samples); two baseline
+    HDRI/ULP failures remain under pkg237/pkg238. The original full suite is
+    NOT green and was NOT wholly rerun.
+  - A local bright patch on the backdrop persists on main+feature despite the
+    global SSIM pass at 256; pkg239 follow-up #702. No claim of perfect
+    baseline/Cycles visual parity.
+  - Follow-ups filed separately, all OPEN for architect review before
+    implementation, no queue promotion: pkg230b #697, build-latency pkg231
+    #698, pkg232–235 #699, pkg236–238 #700, pkg239 #702.
+    This closeout also files pkg240 CI workflow cost audit, separately scoped
+    from the renderer change and pkg231 local CUDA rebuild diagnosis.
+- **Scope delivered:** 30 Vector Math operations, 5 Vector
+  Rotate modes, faithful Mix factor clamping in the color/scalar op-VM chain;
+  coordinate chains warn/defer to pkg230b. The verified real-Blender carrier is
+  textured Principled with specular zero and Closest filtering — not universal
+  BSDF/filter coverage.
+- **NEXT is OWNER CHOICE** among pkg127 Phase 2, Principled
+  advanced-inputs (needs a scoped spec), pkg211 prototype-first-or-park, and
+  the pkg136 GPU leg. No autonomous priority promotion; Pillar 4 remains PAUSED.
+  Mere filed follow-ups do not preempt owner choice.
+
+---
+
+**2026-09-05 (HISTORICAL / SUPERSEDED — see 2026-09-06 above; verified against
+`origin/main` at `aecff0d` and merged PRs #676, #681–#685, #692–#696): pkg225
+hair is complete through the Blender addon; pkg127 Phase 1 and pkg136 CPU Stage
+1A/1B are landed; pkg229's coverage re-audit is landed; pkg230 Phase 1 (op-VM
+utility opcodes) is landed. NEXT = pkg230 Phase 2 (Vector Math/Rotate).**
 - **pkg225-S1 — CPU ray-curve (hair) intersection — LANDED** (PR #670). The
   prior handoff's "bug in curves.h" diagnosis was WRONG: a standalone native
   harness proved the pbrt-ported primitive hits correctly (t / position /
@@ -66,10 +111,11 @@ opcodes) is landed. NEXT = pkg230 Phase 2 (Vector Math/Rotate).**
   `cuobjdump` REG:254 across all 128 shade specializations, no spill). Fixed a
   Cycles-parity bug (`svm_clampf` vs Cycles `min(max())` when min>max). Spec:
   `.astroray_plan/packages/pkg230-opvm-utility-opcodes.md`.
-- **NEXT: pkg230 Phase 2** (spec written, not started) — Vector Math + Vector
-  Rotate op-VM opcodes + faithful Mix `clamp_factor=OFF`; the coordinate-chain-vs-
-  op-VM fork is documented in the spec + NEXT_STAGE_REPORT. Then the owner chooses
-  among pkg127 Phase 2, Principled advanced-inputs (highest-value single node, L),
+- **Historical pickup on 2026-09-05 (superseded above): pkg230 Phase 2** (spec written,
+  not started at that time) — Vector Math + Vector Rotate op-VM opcodes +
+  faithful Mix `clamp_factor=OFF`; the coordinate-chain-vs-op-VM fork is
+  documented in the spec + NEXT_STAGE_REPORT. Then the owner chooses among
+  pkg127 Phase 2, Principled advanced-inputs (highest-value single node, L),
   pkg211's prototype-first/park path, and the pkg136 GPU leg. **pkg229 coverage
   re-audit is landed in #695**
   (152 SUPPORTED / 35 APPROX / 340 DROPPED of 527; op-VM scanner blind spot fixed,

--- a/.astroray_plan/docs/pkg230-phase2-delivery-evidence.md
+++ b/.astroray_plan/docs/pkg230-phase2-delivery-evidence.md
@@ -1,6 +1,10 @@
 # pkg230 Phase 2 delivery evidence
 
-Verified implementation, 2026-09-06; final independent sign-off and CI/merge pending.
+LANDED in [PR #701](https://github.com/HendrikGC02/Astroray/pull/701),
+2026-09-05 17:10:30 UTC (2026-09-06 Sydney), merge
+`b38a7d8471884c43c7aa5a2fd60ddb447c859309`.
+Independent final sign-off and both CI runs passed on reviewed source
+`4035a000f8b45dc549e072ebfd31799f608f1755`.
 Base: `31f30298c79dad151b270bef448184b598995137`.
 
 ## Architecture and scope
@@ -123,7 +127,7 @@ The other two failures were investigated and corrected for reruns:
   **All 37 harness tests pass in 7.68 s.** Astra inspected the convergence sheet:
   noise decreases and baseline/feature structure agrees. A small bright patch on
   the green backdrop persists in both Astroray builds and is absent in Cycles;
-  this local baseline discrepancy is a separate diagnostic follow-up, not a
+  this local baseline discrepancy is filed as pkg239 (#702), not a
   claim of perfect backdrop parity.
 
 ## Callers, hygiene and independent review
@@ -139,19 +143,39 @@ material layouts change. Final caller sweep is saved.
 
 Differential Ruff/cppcheck/markdownlint/codespell/diff-check reports zero new
 findings, no unavailable/error tools. clang-format is skipped because the repo
-has no style configuration. Final harness/evidence edits will receive the same
+has no style configuration. Final harness/evidence edits passed the same
 scoped check before commit.
 
 Two early cheap source-critic attempts timed out: incomplete, never counted as
 PASS. Later bounded opencode call-path and settings traces completed; Astra
 corrected their mistaken inferences before use. Claude architecture, source and
-conditional failure reviews are retained. Final independent judgment and CI
-remain release gates.
+conditional failure reviews are retained. Final independent Claude SIGN-OFF
+accepted the exact source, math, ABI/callers, hardware evidence, visual inspection,
+and baseline-failure exceptions. Both CI runs passed before merge, and the
+reviewed implementation remained unchanged. The subsequent source rebase changed only
+already-merged follow-up docs; `tested-source-identity.json` records source identity.
+No GPU result is claimed after the implementation commit.
+
+## Final CI and merge
+
+- PR run [33978574168](https://github.com/HendrikGC02/Astroray/actions/runs/33978574168):
+  host build/test and CUDA syntax **SUCCESS**. Host tests: **2074 passed,
+  243 skipped, 15 xfailed, 4 xpassed, 5 warnings in 1421.70 s**.
+- Push run [33978571904](https://github.com/HendrikGC02/Astroray/actions/runs/33978571904):
+  host build/test and CUDA syntax **SUCCESS** on the same reviewed head.
+- PR #701 merged only after all six checks (two changes, two host, two CUDA)
+  completed successfully. Host CI does not replace the local RTX/Blender gates
+  or erase the two documented local baseline failures.
+- `ci-pr-701.log`, `ci-push-701.log`, corresponding job JSON, and
+  `pr-701-merged.json` are saved under the root evidence directory.
 
 ## Follow-ups and artifacts
 
 Separately filed after independent Claude review and docs CI: pkg230b (#697),
-pkg231 (#698), pkg232-235 (#699), pkg236-238 (#700). All new follow-ups remain OPEN
+pkg231 (#698), pkg232-235 (#699), pkg236-238 (#700), pkg239 (#702).
+The planning closeout separately files pkg240 CI workflow cost audit; it makes
+no speedup or new-regression claim and preserves full validation coverage.
+All new follow-ups remain OPEN
 with implementation gates UNRUN, no queue promotion. Pillar 4 remains PAUSED.
 
 `test_results/pkg230-p2/` retains builds, import proofs, raw resource dumps,

--- a/.astroray_plan/packages/pkg230-opvm-utility-opcodes.md
+++ b/.astroray_plan/packages/pkg230-opvm-utility-opcodes.md
@@ -2,8 +2,8 @@
 
 **Pillar:** 5 (Blender integration / shader-node coverage)
 **Track:** A
-**Status:** Phase 1 LANDED (#696); Phase 2 VERIFIED 2026-09-06; final sign-off/CI/merge pending
-(branch `codex/pkg230-p2`, architecture independently signed off)
+**Status:** DONE — Phase 1 LANDED (#696); Phase 2 LANDED (#701, 2026-09-06 Sydney)
+(branch `codex/pkg230-p2`, reviewed implementation `4035a00`)
 **Estimated effort:** Phase 1 S (~1 session); Phase 2 M
 **Depends on:** pkg219a/b/c (op-VM evaluator), pkg229 (re-audit that ranked these)
 
@@ -132,8 +132,10 @@ flag and inverse-convention conditions included above.
       non-program fleet kernel REG/STACK/CONST against same-toolchain baseline.
 - [x] Headless Blender real graphs render through exporter; compare saved
       vector/Mix charts with Cycles in common linear space.
-- [ ] Full local suite, focused regressions, differential lint and caller/binding
-      sweep recorded; independent Claude final sign-off and green CI.
+- [x] Full local suite, focused regressions, differential lint and caller/binding
+      sweep recorded; independent Claude final sign-off and green CI. Two local
+      baseline failures remain explicitly accepted/tracked under pkg237/pkg238;
+      the original full local run is not represented as green.
 
 ---
 
@@ -159,8 +161,8 @@ flag and inverse-convention conditions included above.
       specializations** — no spill; the fleet `<0,…>` is REG:254/STACK:3400/
       CONSTANT[0]:1748 (STACK/CONST are current-main baseline; the VM rides
       `<HasProgram=true>`, so the fleet `<false>` path is untouched by construction).
-- [ ] Phase 2 — Vector Math / Vector Rotate op-VM opcodes (color-chain) + faithful
-      Mix `clamp_factor=OFF`, fork resolved.
+- [x] Phase 2 — Vector Math / Vector Rotate op-VM opcodes (color-chain) + faithful
+      Mix `clamp_factor=OFF`, fork resolved. LANDED #701, merge `b38a7d8`.
 
 ## Lessons
 
@@ -168,4 +170,5 @@ Hardware/visual verification and investigated baseline failures are recorded in
 [Phase 2 delivery evidence](../docs/pkg230-phase2-delivery-evidence.md).
 The full suite recorded 2326 passes and four failures; corrected Blender/harness
 reruns pass, while HDRI SSIM and PostInit ULP remain baseline-reproduced failures.
-No rendering thresholds were weakened. Final independent sign-off and CI pending.
+No rendering thresholds were weakened. Independent Claude final sign-off granted
+on `4035a00`; both CI runs passed before #701 merged as `b38a7d8`.

--- a/.astroray_plan/packages/pkg240-ci-workflow-cost-audit.md
+++ b/.astroray_plan/packages/pkg240-ci-workflow-cost-audit.md
@@ -1,0 +1,78 @@
+# pkg240 — CI workflow cost audit
+
+**Pillar:** 5 (delivery tooling for Blender/DCC)
+**Track:** A
+**Status:** OPEN — detailed architect review required before implementation
+**Estimated effort:** TBD at architect review
+**Depends on:** none
+
+## Goal
+
+Audit CI workflow cost and trigger duplication in `.github/workflows/ci.yml`
+before any deduplication or runner change. Produce a measured per-build /
+per-test / per-queue / per-job walltime and supported-usage breakdown, and
+assess whether the canonical split runner can be safely reused under CI
+constraints. Detailed architect review selects the trigger policy and exact
+implementation scope after the audit.
+
+## Context / evidence
+
+- `.github/workflows/ci.yml` triggers on **both `push` and `pull_request`**;
+  the concurrency group `ci-${{ github.workflow }}-${{ github.ref }}`
+  distinguishes their refs, so both events can run simultaneously.
+- **PR #701** (head `4035a00`) produced simultaneous runs **33978571904 (push)**
+  and **33978574168 (PR)**, each scheduling host + CUDA jobs. Both succeeded.
+  Push host 16:40:13→17:08:46 = **28m33s**; PR host 16:40:13→17:06:02 =
+  **25m49s**. Push CUDA 16:40:14→16:56:08 = **15m54s**; PR CUDA
+  16:40:12→16:56:04 = **15m52s** (2026-09-05 UTC, check timestamps).
+  These observed durations are neither billed-cost proof nor a speedup or
+  new-regression claim; the prior successful PR is in the same broad range.
+- **Historical successful PR #696 baseline** (statusCheckRollup timestamps,
+  2026-09-05 UTC) — observed job durations, NOT a candidate speedup or billed
+  cost proof: host 11:59:45→12:27:32 = **27m47s**; other host 11:59:32→12:28:45 =
+  **29m13s**; CUDA 11:59:46→12:11:39 = **11m53s**; other CUDA 11:59:32→12:14:45 =
+  **15m13s**.
+- The Host Test step runs serial `python -m pytest tests/ -v`. Canonical
+  `scripts/test/run_split.py` already exists: CPU-marked tests run through
+  xdist; everything not positively CPU-classified stays serial. This round's
+  local split measured CPU **342.08s** and serial **239.70s** on local hardware —
+  these are **not** CI performance estimates.
+
+## Investigation scope
+
+1. Measure trigger duplication and per build/test/queue/job breakdown.
+2. Inspect the tested head vs PR merge revisions before any deduplication.
+3. Assess safe reuse of the canonical split runner under CI constraints.
+4. Preserve: branch-only and PR/merge validation; full collected test coverage
+   and skip/xfail/xpass semantics; serial/GPU/unclassified isolation;
+   required-check names/reporting and docs-only skip behavior;
+   trusted-context/fork permissions.
+
+## Candidate existing scripts (extend, do not fork)
+
+- `.github/workflows/ci.yml` and `scripts/test/run_split.py` (candidate
+  extension points only). **No new parallel one-off runner.**
+
+## Non-goals / risks
+
+- No arbitrary test removal, timeout changes, threshold changes, CI
+  secret/permission expansion, or unrelated engine optimization.
+- No candidate speedup claim without measurements.
+- Concurrent duplicate-job time must be accounted for separately from elapsed
+  latency; local split timings are not CI estimates.
+- No owner queue priority change; Pillar 4 remains PAUSED.
+- Distinct from **pkg231** (LOCAL CUDA rebuild latency); coordinate only shared
+  evidence, no priority promotion.
+
+## Acceptance — all implementation gates UNRUN
+
+- [ ] Capture baseline/candidate run IDs, source + event + toolchain/cache/
+      hardware config, and queue/build/test/job/total walltime plus billed
+      compute or supported usage data before any claim.
+- [ ] Account for concurrent duplicate-job time separately from elapsed latency.
+- [ ] Demonstrate collection/node-ID/marker and skip/xfail/xpass parity with the serial baseline.
+- [ ] Prove safe CPU-parallel vs serial/GPU execution.
+- [ ] Branch-only / internal-PR / fork-PR / docs-only matrix preserves
+      required-check completion and trust boundaries.
+- [ ] Measured benefit for the accepted change with no lost validation.
+- [ ] Independent Astra/Claude review.


### PR DESCRIPTION
pkg230 Phase 2 is merged in #701. Update STATUS, NEXT_STAGE_REPORT, ROADMAP, its specification and delivery evidence to record the actual merge, reviewed source and green CI, while retaining the two reproduced local baseline failures and the measured rendering scope.

Also file the separately scoped pkg240 CI workflow cost audit: measure duplicate push/PR jobs and assess reuse of the canonical split runner while preserving coverage, serial/GPU isolation, required checks and permissions. It remains OPEN for detailed architect review; no workflow or owner-priority change is included.

Validation: differential markdownlint, codespell and git-diff-check all ran with zero new findings. Independent Claude SIGN-OFF covers both the factual closeout and pkg240 filing, checking the saved CI/merge records and unchanged implementation source. pkg230 #701 passed both host/CUDA CI runs; each host recorded 2074 passed, 243 skipped, 15 xfailed and 4 xpassed. Local hardware, visual and baseline-exception evidence remains in the delivery record. No runtime code changed in this PR.
