### PR TITLE
fix(delegate): contain and await Windows worker process trees

### DIFF
--- a/.astroray_plan/packages/pkg232-delegate-timeout-process-tree.md
+++ b/.astroray_plan/packages/pkg232-delegate-timeout-process-tree.md
@@ -2,9 +2,10 @@
 
 **Pillar:** 5
 **Track:** A
-**Status:** open — detailed architect review required before dispatch
-**Estimated effort:** TBD at detailed architect review
+**Status:** verified locally — independent final source sign-off and parent integration passed; CI/delivery pending
+**Estimated effort:** one bounded maintenance slice
 **Depends on:** none
+**Dispatch authority:** owner instruction 2026-09-06 authorizes parallel lower-level backlog; parent selected pkg232 in isolated worktree codex/pkg232 at 305caf5.
 
 ---
 
@@ -25,27 +26,154 @@ Mechanism (`.claude/skills/delegate/scripts/delegate.py`): `_opencode_cmd` (L35)
 
 ## Specification
 
-### Files to modify
+### Files and ownership
 
-| File | What changes |
+| File | Bounded responsibility |
 |---|---|
-| `.claude/skills/delegate/scripts/delegate.py` | Own process-tree tracking/containment; bounded shutdown and await on timeout/cancellation/error; no post-return edits; final truthful snapshot after owned writers stopped; retained `timeout` status despite eventual child success. |
-| `tests/` (scoped, when implemented) | Mock process-lifecycle tests + bounded real-Windows canary. |
+| .claude/skills/delegate/scripts/delegate.py | Windows containment, private gated-helper entry point, lifecycle cleanup and truthful JSON evidence. Extend this wrapper; no parallel launcher script. |
+| tests/test_delegate_process_tree.py | Focused lifecycle/summary tests and real Windows child/grandchild/sentinel canaries; temporary worker programs are test fixtures. |
+| .claude/skills/delegate/SKILL.md | Document additive cleanup evidence and the explicit platform boundary. Preserve dynamic tier policy and routing. |
+| .astroray_plan/packages/pkg232-delegate-timeout-process-tree.md | Architecture, reviewed gates and factual delivery evidence. |
 
-### Key design decisions
+The existing script index and project index were consulted. No other existing
+process-tree helper was found in the scoped wrapper, tests, scripts, tools or
+benchmarks. Renderer, CUDA, Blender installation, tier configuration and live
+planning records are outside this implementation lane.
 
-- Ownership by instance/ancestry identity, never executable name alone; handle PID reuse; never terminate unrelated opencode processes.
-- No watchdog daemon, no broad killall, no model-policy changes.
-- Exact Windows containment implementation still needs architect review.
+### Architectural decision
 
----
+Use an unnamed Windows Job Object with JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+set neither breakaway flag. The parent retains the non-inheritable Job handle.
+All ordinary CreateProcess descendants of the assigned helper inherit the
+Job membership, so shim exit does not release its descendants. This is a
+lifecycle boundary for ordinary worker subprocesses, not a security sandbox
+against WMI, services or intentional out-of-process brokers.
 
-## Acceptance criteria (future — all UNRUN)
+Avoid the startup race by launching a private helper mode in this same Python
+file. The helper may only read a command from its stdin pipe until the parent
+has assigned its process instance to the configured Job. The parent sends one
+UTF-8 JSON argv record only after assignment succeeds; helper EOF before that
+record exits without launching a command. The helper then runs the existing
+_opencode_cmd argv unchanged, sends its stdout/stderr to the existing transcript,
+and returns the command exit code. The parent opens the unique transcript and
+passes it as helper stdout with stderr redirected to that same handle; the
+helper and command inherit that output only. Parent summary JSON remains on the
+parent stdout. This preserves --dir, argument boundaries,
+multiline task-file routing and the current shim selection.
 
-- [ ] Mock process-lifecycle tests: owned child/grandchild attempted delayed file writes are stopped; no delayed writes after return.
-- [ ] Bounded real-Windows canary: owned child/grandchild + separate unrelated sentinel; owned descendants stopped, no delayed writes after return, sentinel alive, evidence/timed-out snapshot true.
-- [ ] Retained `timeout` status even when the orphaned child would have completed; final snapshot only after owned writers stopped.
-- [ ] Independent Astra/Claude review of containment and PID-reuse/race/output-handle handling.
+Use documented Win32 APIs via a small local ctypes binding with explicit
+argument/result types and pointer-width-correct structures. Keep the Job handle
+and the process handle already owned by subprocess.Popen; never reopen a
+process by a later PID lookup. CPython's Windows Popen._handle is a private
+implementation detail: isolate access in the assignment helper, fail closed if
+unavailable, and cover the supported interpreter with the real Windows gate.
+Do not use NtResumeProcess, executable-name termination, PID-tree scans,
+taskkill, or breakaway flags. Existing console windows must remain hidden;
+the helper must use CREATE_NO_WINDOW, covered by a startup-flag assertion.
+
+### Lifecycle and failure semantics
+
+1. Allocate a unique invocation suffix for transcript/task paths so concurrent
+   delegates cannot delete each other's task files or share an output stream.
+   Snapshot the pre-state after the task file has been written, as today.
+2. Create/configure the Job; launch the blocked helper; assign the exact process
+   handle; release the command record. Any setup/assignment failure closes the
+   pipe, terminates and awaits only this blocked helper, then closes the Job.
+   No uncontained command is permitted to start.
+3. Wait for helper completion using the configured worker timeout. Timeout
+   permanently selects status: timeout; a later clean transcript cannot
+   overwrite it. A wrapper/launch exception or handled cancellation selects
+   errored with a concrete error entry. Add a structured termination reason
+   (normal, timeout, cancelled or error) so cleanup failure cannot erase the
+   initiating event. Retain command exit code when known. This is a worker-runtime
+   budget starting after launch-gate payload delivery; OS process creation and
+   synchronous control-pipe delivery are outside that budget. A stalled helper
+   or very large single-line prompt can delay timeout/cancellation checkpoints.
+   Do not claim a strict whole-launch deadline.
+4. On every exit path, including ordinary completion, terminate any remaining
+   Job processes and await helper termination. Query Job basic accounting until
+   ActiveProcesses == 0, using a bounded cleanup deadline. Do not treat Job
+   handle signaling or TerminateJobObject return alone as proof of exit.
+5. Once no owned writer remains, close Job/control/log handles, remove the owned
+   task file, then take the final git snapshot and parse the stable transcript.
+   Preserve existing event-based completed, errored and no_clean_finish
+   meanings; completed still means process completion, never task correctness.
+6. Add a cleanup evidence object describing containment method, confirmed
+   completion and any cleanup errors. If cleanup cannot be confirmed, retain
+   timeout when already timed out (otherwise errored), report cleanup failure,
+   and skip the final git snapshot and transcript-derived claims. Use explicit
+   null/unavailable evidence rather than a misleading empty changed-file list.
+   Close the last Job handle as a final termination fallback; never call this
+   a successful cleanup merely because handle closure was attempted.
+7. Handled Ctrl-C/termination goes through the same cleanup path; restore any
+   temporary signal handlers. Forced process death cannot emit JSON, but closing
+   its non-inherited last Job handle invokes kernel termination of members.
+
+Non-Windows keeps its existing subprocess.run path and documented direct-child
+termination behavior, with regression coverage. This package makes the full-tree
+containment guarantee on Windows only. It does not introduce a Linux/macOS
+process supervisor or imply that an escaped/brokered process is contained.
+
+### Acceptance gates (local results recorded below; CI/integration pending)
+
+- [x] Unit lifecycle tests cover configured Job before assignment, blocked helper
+  before command release, assignment/launch failures, no command after EOF,
+  handle closure on all paths and cancellation cleanup. The real Windows gate
+  must confirm assignment through Popen._handle succeeds on the current 64-bit
+  CPython (the handle therefore has the required assignment rights).
+- [x] Summary tests cover timeout followed by a clean-stop event (still timeout),
+  normal completion, error events, incomplete stream, launch error and cleanup
+  failure. Final snapshot/log parsing must occur only after confirmed cleanup;
+  failed cleanup must yield unavailable evidence, not a false clean snapshot.
+- [x] Real Windows canary starts an owned child and grandchild that acknowledge
+  startup, retain output handles, and attempt delayed writes. Timeout stops both;
+  files and transcript remain byte-identical after the delayed-write horizon.
+  An independently launched sentinel stays alive and writes successfully. Keep
+  handles for each test-owned process and clean them in the test's finally.
+- [x] Real Windows ordinary-completion canary exits the immediate worker while
+  its descendant remains pending; cleanup stops the descendant before snapshot.
+- [x] Real Windows cancellation and pre-release/assignment-failure canaries
+  confirm bounded termination and no uncontained work. Repeated calls do not
+  leak owned handles or task files; concurrent calls have distinct artifacts.
+- [x] Existing JSON fields and dynamic-tier/--dir/multiline-prompt behavior
+  remain covered. Run one bounded real opencode read-only smoke through the
+  wrapper after tests, inspect its returned JSON and retained transcript.
+- [x] Non-Windows regression tests run on that platform where available; on a
+  Windows-only host, mocked branch coverage is explicitly distinguished from
+  actual non-Windows runtime result. Both platform legs ran locally; GitHub CI remains pending.
+- [x] Run focused pytest, differential lint and the changed-signature/caller
+  sweep. No renderer build, GPU render or live Blender smoke is required for
+  this Python-only process-lifecycle change.
+- [x] Astra architecture review and independent Claude architecture/final
+  containment/race/PID/output-evidence sign-off. Parent integration independently
+  inspected the source and ran 39 passing Windows tests (one platform skip).
+
+### Risks and boundaries
+
+- Windows hosts may already place the wrapper in a restrictive Job. Nested Job
+  assignment failure must report an error before releasing the worker; silently
+  falling back to uncontained execution would reproduce the defect.
+- Forcibly stopping a descendant can leave a partially written file. The final
+  diff is evidence of that state, not a rollback or proof of a successful task.
+- The cleanup deadline bounds the failure path; an OS/API failure is reported
+  as unverified containment. The wrapper must never fabricate a final snapshot.
+- The private CPython process-handle seam and ctypes structure layout require
+  the real Windows gate, including pointer-sized fields on the current 64-bit
+  interpreter. No optional process-management dependency is introduced.
+- Ordinary completion now ends leftover background subprocesses. Delegated tasks
+  are bounded; persistent servers/daemons are not supported by this wrapper.
+
+### Primary references checked 2026-09-06
+
+- [Microsoft Job Objects](https://learn.microsoft.com/en-us/windows/win32/procthread/job-objects)
+  — descendant membership, no-breakaway policy, kill-on-close and accounting.
+- [AssignProcessToJobObject](https://learn.microsoft.com/en-us/windows/win32/api/jobapi2/nf-jobapi2-assignprocesstojobobject)
+  — process-instance handles and nested Job assignment requirements.
+- [TerminateJobObject](https://learn.microsoft.com/en-us/windows/win32/api/jobapi2/nf-jobapi2-terminatejobobject)
+  — termination covers the assigned Job and nested child Jobs.
+- [Python subprocess](https://docs.python.org/3/library/subprocess.html)
+  — run(timeout=) kills and waits its immediate child; Popen permits the
+  explicit lifecycle needed here.
 
 ---
 
@@ -58,7 +186,66 @@ Mechanism (`.claude/skills/delegate/scripts/delegate.py`): `_opencode_cmd` (L35)
 
 ## Progress
 
-- [ ] Detailed architect review of scope and Windows containment design (all implementation gates UNRUN).
-- [ ] Implementation + scoped tests (future).
+- [x] Detailed architecture reviewed by Astra and independent Claude (2026-09-06).
+- [x] Implementation and scoped Windows gates complete (2026-09-06); CI and final review remain explicit gates.
 Independent Claude filing review: SIGN-OFF TO FILE ONLY, 2026-09-06.
 Evidence: `test_results/pkg232-235/claude-filing-review.txt`.
+
+Architecture review: independent Claude SIGN-OFF 2026-09-06; binding corrections
+above incorporated. Evidence: root `test_results/pkg232/architecture-claude.txt`.
+
+## Local verification — 2026-09-06
+
+- Isolated branch `codex/pkg232`, base `305caf569b43c62cb8a8a0d6af9f35fb5f4fc9a2`;
+  only the four owned files changed. No renderer, GPU, build or live Blender work.
+- Initial dynamic implement delegation returned `no_clean_finish`, exit 0,
+  110 tool calls, 1075.3 seconds. This is draft evidence, not success. An
+  independent monitor retained exact process-instance handles and confirmed
+  all 1130 observed instances exited. Subsequent Astra inspection repaired
+  duplicated handle closure, setup interruption, cancellation classification,
+  insufficient canary acknowledgements and unavailable-evidence handling.
+- Focused pytest: **39 passed, 1 skipped in 6.66 seconds** on Windows 11,
+  64-bit CPython 3.13.12. The skip is the actual non-Windows runtime test;
+  the same suite also ran on actual Ubuntu WSL/Linux with Python 3.10.12:
+  **14 passed, 26 Windows-only skipped in 2.74 seconds**, including the actual
+  direct-child runtime test. This is local platform verification, not GitHub CI.
+- Real Windows tests prove assignment using the existing Popen process handle,
+  non-inheritable Job handle, exactly KILL_ON_JOB_CLOSE/no breakaway flags,
+  CREATE_NO_WINDOW helper startup, blocked launch before assignment,
+  timeout/cancel/error/normal cleanup, zero active processes, and closed helper
+  handles. Child and grandchild acknowledge startup; they attempt both file
+  and inherited stdout writes only after return. Neither writes; the unrelated
+  sentinel remains alive and writes successfully. Native handle count does not
+  grow across repeated runs; concurrent contained runs remain isolated.
+- Failure tests exercise assignment rejection/interruption/exception, Job/log/
+  helper creation failure, worker launch failure, query/termination/deadline
+  failure, and cancellation during assignment and cleanup. Unconfirmed cleanup
+  withholds snapshot/transcript-derived fields and retains the task file.
+- Real dynamic grunt-tier smoke: **completed**, 58.9 seconds, one read tool call,
+  finish_reason stop, exit 0, no changed files, cleanup confirmed with
+  **active_processes 0**. Parent independently inspected the JSON and transcript.
+- Differential lint: **0 new findings**, Ruff/markdownlint/codespell/diff-check
+  ran, no unavailable or errored tools. No existing callable signature changed;
+  new lifecycle helpers are private and their callers are in this wrapper and
+  the focused tests. Existing CLI consumers and agent/workflow docs were checked.
+
+Evidence in the pkg232 worktree under `test_results/pkg232/`:
+`implement-wrapper.json`, `implement-monitor.json`, `focused-tests.log`,
+`focused.xml`, `lint.log`, `real-opencode-smoke.json`, `caller-signatures.json`,
+`caller-sweep.txt`, `source-manifest.json`, `non-windows-tests.log`, and
+`non-windows.xml`. `final-claude.txt` records independent final SIGN-OFF
+conditional on parent integration/CI and actual Linux verification (now run). No commit, push, PR, CI success or merge is claimed here.
+
+Parent integration raised a separate launch-latency edge after final source
+review: the configured worker timeout starts after synchronous stdin payload
+handoff, so process creation or a stalled/large payload write can delay timeout
+and handled cancellation. Full Job cleanup/exit evidence after the handoff is
+unaffected; no strict whole-launch deadline has been proved. A targeted Claude
+follow-up could not run because the subscription reached its weekly limit
+(`timeout-boundary-claude.txt`). The existing final source sign-off is retained;
+no independent approval of this additional edge is claimed. Parent Astra
+integration accepted the existing worker-runtime budget as consistent with the
+reviewed architecture and required this explicit limitation in the spec and
+SKILL. The process implementation remains byte-identical to final-reviewed
+source. Bounded startup/payload delivery remains future hardening, outside this
+package's containment fix; no full-launch deadline is claimed.

--- a/.claude/skills/delegate/SKILL.md
+++ b/.claude/skills/delegate/SKILL.md
@@ -59,7 +59,22 @@ else you notice".
 ## The evidence contract (non-negotiable)
 
 The wrapper prints a JSON summary: `status` (`completed|timeout|errored|
-no_clean_finish`), `files_changed`, `tokens`, `cost`, `transcript` path.
+no_clean_finish`), `files_changed`, `tokens`, `cost`, `transcript`
+path, plus two additive fields introduced by pkg232:
+
+- `termination_reason` — `normal|timeout|cancelled|error`, the structured
+  initiating event. A cleanup failure cannot erase it: `status: timeout` stays
+  `timeout` even if the orphaned worker would later have completed.
+- `cleanup` — a cleanup-evidence object `{method, confirmed, error}`.
+  `method` is `windows_job_object` on Windows, `direct_child` elsewhere, or
+  `not_started` when command resolution failed before launch. For a Windows
+  Job, `confirmed: true` means the wrapper verified zero active processes and
+  awaited its helper before taking the final snapshot. For `direct_child`, it
+  proves only the immediate child exited; descendants may remain. If `confirmed: false`, the wrapper
+  reports `error`, skips the final git snapshot and transcript-derived claims,
+  and emits `files_changed: null` / `git_head: null` / `tool_calls: null` rather
+  than misleading empty evidence. The task file is retained for diagnosis.
+  Cancellation uses `status: errored` with `termination_reason: cancelled`.
 
 - `status: completed` means the PROCESS finished — **not that the task
   succeeded**. opencode has documented exit-0-on-error bugs; open models
@@ -70,6 +85,32 @@ no_clean_finish`), `files_changed`, `tokens`, `cost`, `transcript` path.
   applies unchanged.
 - The full JSONL transcript is kept for diagnosis — read it when the result
   looks wrong before re-dispatching.
+
+## Process-tree containment (platform boundary)
+
+On **Windows**, the wrapper launches the worker inside an unnamed Job Object
+with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` and no breakaway flags, so every
+ordinary `CreateProcess` descendant of the worker inherits Job membership. On
+timeout/cancellation/error — and on ordinary completion — the wrapper
+terminates and awaits the full Job tree, confirms `ActiveProcesses == 0`, and
+only then takes the final git snapshot and parses the transcript. No owned
+process keeps writing files after a return with `cleanup.confirmed: true`.
+If confirmation fails, the evidence explicitly remains unavailable. Ordinary
+completion now ends leftover background subprocesses; delegated tasks are
+bounded, so persistent servers/daemons are not supported.
+
+The configured timeout is a **worker-runtime budget after launch-gate payload
+delivery**, not a strict whole-launch deadline. OS process creation and the
+synchronous control-pipe handoff precede that budget. A stalled helper startup
+or very large single-line prompt can therefore delay the timeout or handled
+cancellation checkpoint. The bounded cleanup/exit-evidence contract applies
+when teardown runs; it does not prove a bound on pre-delivery startup latency.
+
+On **non-Windows** (Linux/macOS), the wrapper keeps its existing
+`subprocess.run(timeout=)` direct-child path: it kills and waits only the
+immediate child, with no descendant-tree supervisor. The full-tree containment
+guarantee is Windows-only; it does not imply that an escaped/brokered process
+is contained on any platform.
 
 ## Failure handling
 

--- a/.claude/skills/delegate/scripts/delegate.py
+++ b/.claude/skills/delegate/scripts/delegate.py
@@ -12,6 +12,15 @@ Rationale: opencode has documented cases of exiting 0 after a mid-session
 error (anomalyco/opencode #14551, #2489), and open models over-claim under
 uncertainty. Artifacts only.
 
+Windows process-tree containment (pkg232): on Windows the worker is launched
+inside an unnamed Job Object with JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE and no
+breakaway flags, so every ordinary CreateProcess descendant of the worker
+inherits Job membership. On timeout/cancellation/error -- and on ordinary
+completion -- the wrapper terminates and awaits the full Job tree before
+taking the final git snapshot and parsing the transcript, so no owned process
+keeps writing files after the wrapper returns its evidence. See SKILL.md for
+the platform boundary (non-Windows keeps the direct-child subprocess.run path).
+
 Usage:
   python delegate.py --tier grunt|implement|verify [--model provider/model]
                      [--agent NAME] [--dir PATH] [--timeout SEC]
@@ -22,22 +31,155 @@ import argparse
 import json
 import os
 import shutil
+import signal
 import subprocess
 import sys
+import threading
 import time
+import uuid
+from contextlib import contextmanager
 from pathlib import Path
 
 SKILL_DIR = Path(__file__).resolve().parent.parent
 TIERS_FILE = SKILL_DIR / "config" / "tiers.json"
 LOG_ROOT = Path(os.environ.get("LOCALAPPDATA", os.path.expanduser("~"))) / "astroray" / "delegate-logs"
 
+# Platform flag. Computed once at import so tests can stub the non-Windows
+# branch without mutating the global os.name (which would break pathlib).
+IS_WINDOWS = os.name == "nt"
+
+# ---------------------------------------------------------------------------
+# Windows Job Object containment (pkg232). A small local ctypes binding with
+# explicit argument/result types and pointer-width-correct structures.
+# References: Microsoft "Job Objects" and "AssignProcessToJobObject" docs.
+# ---------------------------------------------------------------------------
+
+if os.name == "nt":
+    import ctypes
+    from ctypes import wintypes
+
+    _kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+    # Job Object Information Class for basic accounting.
+    _JobObjectBasicAccountingInformation = 1
+    # Job Object Information Class for extended limit information.
+    _JobObjectExtendedLimitInformation = 9
+    # Limit flag: kill all members when the last Job handle closes.
+    _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000
+    # Startup flag: no console window for the helper.
+    _CREATE_NO_WINDOW = 0x08000000
+
+    class _JOBOBJECT_BASIC_LIMIT_INFORMATION(ctypes.Structure):
+        _fields_ = [
+            ("PerProcessUserTimeLimit", ctypes.c_int64),
+            ("PerJobUserTimeLimit", ctypes.c_int64),
+            ("LimitFlags", wintypes.DWORD),
+            ("MinimumWorkingSetSize", ctypes.c_size_t),
+            ("MaximumWorkingSetSize", ctypes.c_size_t),
+            ("ActiveProcessLimit", wintypes.DWORD),
+            ("Affinity", ctypes.c_size_t),
+            ("PriorityClass", wintypes.DWORD),
+            ("SchedulingClass", wintypes.DWORD),
+        ]
+
+    class _IO_COUNTERS(ctypes.Structure):
+        _fields_ = [
+            ("ReadOperationCount", ctypes.c_uint64),
+            ("WriteOperationCount", ctypes.c_uint64),
+            ("OtherOperationCount", ctypes.c_uint64),
+            ("ReadTransferCount", ctypes.c_uint64),
+            ("WriteTransferCount", ctypes.c_uint64),
+            ("OtherTransferCount", ctypes.c_uint64),
+        ]
+
+    class _JOBOBJECT_BASIC_ACCOUNTING_INFORMATION(ctypes.Structure):
+        _fields_ = [
+            ("TotalUserTime", ctypes.c_int64),
+            ("TotalKernelTime", ctypes.c_int64),
+            ("ThisPeriodTotalUserTime", ctypes.c_int64),
+            ("ThisPeriodTotalKernelTime", ctypes.c_int64),
+            ("TotalPageFaultCount", wintypes.DWORD),
+            ("TotalProcesses", wintypes.DWORD),
+            ("ActiveProcesses", wintypes.DWORD),
+            ("TotalTerminatedProcesses", wintypes.DWORD),
+        ]
+
+    class _JOBOBJECT_EXTENDED_LIMIT_INFORMATION(ctypes.Structure):
+        _fields_ = [
+            ("BasicLimitInformation", _JOBOBJECT_BASIC_LIMIT_INFORMATION),
+            ("IoInfo", _IO_COUNTERS),
+            ("ProcessMemoryLimit", ctypes.c_size_t),
+            ("JobMemoryLimit", ctypes.c_size_t),
+            ("PeakProcessMemoryUsed", ctypes.c_size_t),
+            ("PeakJobMemoryUsed", ctypes.c_size_t),
+        ]
+
+    _kernel32.CreateJobObjectW.restype = wintypes.HANDLE
+    _kernel32.CreateJobObjectW.argtypes = [ctypes.c_void_p, wintypes.LPCWSTR]
+
+    _kernel32.SetInformationJobObject.restype = wintypes.BOOL
+    _kernel32.SetInformationJobObject.argtypes = [
+        wintypes.HANDLE, ctypes.c_int, ctypes.c_void_p, wintypes.DWORD]
+
+    _kernel32.QueryInformationJobObject.restype = wintypes.BOOL
+    _kernel32.QueryInformationJobObject.argtypes = [
+        wintypes.HANDLE, ctypes.c_int, ctypes.c_void_p, wintypes.DWORD,
+        ctypes.POINTER(wintypes.DWORD)]
+
+    _kernel32.AssignProcessToJobObject.restype = wintypes.BOOL
+    _kernel32.AssignProcessToJobObject.argtypes = [wintypes.HANDLE, wintypes.HANDLE]
+
+    _kernel32.TerminateJobObject.restype = wintypes.BOOL
+    _kernel32.TerminateJobObject.argtypes = [wintypes.HANDLE, wintypes.UINT]
+
+    _kernel32.CloseHandle.restype = wintypes.BOOL
+    _kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+
+    def _create_job():
+        """Create an unnamed Job with KILL_ON_JOB_CLOSE and no breakaway flags.
+
+        Returns the non-inheritable Job handle, or None on failure.
+        """
+        handle = _kernel32.CreateJobObjectW(None, None)
+        if not handle:
+            return None
+        info = _JOBOBJECT_EXTENDED_LIMIT_INFORMATION()
+        info.BasicLimitInformation.LimitFlags = _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+        if not _kernel32.SetInformationJobObject(
+                handle, _JobObjectExtendedLimitInformation,
+                ctypes.byref(info), ctypes.sizeof(info)):
+            _kernel32.CloseHandle(handle)
+            return None
+        return handle
+
+    def _job_active_processes(job_handle):
+        """Return the number of active processes in the Job, or None on failure."""
+        acct = _JOBOBJECT_BASIC_ACCOUNTING_INFORMATION()
+        ret_len = wintypes.DWORD()
+        if not _kernel32.QueryInformationJobObject(
+                job_handle, _JobObjectBasicAccountingInformation,
+                ctypes.byref(acct), ctypes.sizeof(acct), ctypes.byref(ret_len)):
+            return None
+        return int(acct.ActiveProcesses)
+
+    def _terminate_job(job_handle):
+        """Terminate all processes in the Job. Returns True on success."""
+        return bool(_kernel32.TerminateJobObject(job_handle, 1))
+
+    def _close_handle(handle):
+        if handle:
+            _kernel32.CloseHandle(handle)
+
+    def _get_last_error():
+        return ctypes.get_last_error()
+
 
 def _opencode_cmd(args):
     """Windows can't CreateProcess a .ps1/.cmd directly -- route via cmd /c."""
     exe = shutil.which("opencode")
     if exe is None:
-        sys.exit("delegate.py: opencode not found on PATH")
-    if os.name == "nt" and exe.lower().endswith((".cmd", ".bat", ".ps1")):
+        raise FileNotFoundError("delegate.py: opencode not found on PATH")
+    if IS_WINDOWS and exe.lower().endswith((".cmd", ".bat", ".ps1")):
         # npm ships opencode.cmd alongside the .ps1; prefer the .cmd shim
         cmd_shim = str(Path(exe).with_suffix(".cmd"))
         if Path(cmd_shim).exists():
@@ -61,6 +203,222 @@ def _git_snapshot(workdir):
     return {"head": head, "dirty_files": sorted(status.splitlines()) if status else []}
 
 
+def _parse_transcript(log_path):
+    """Parse the JSONL event stream for evidence (defensively -- schema may drift)."""
+    tokens, cost, session_id, tool_calls, errors, finish_reason = None, None, None, 0, [], None
+    try:
+        for line in log_path.read_text(encoding="utf-8", errors="replace").splitlines():
+            line = line.strip()
+            if not line.startswith("{"):
+                continue
+            try:
+                ev = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            et = ev.get("type")
+            session_id = ev.get("sessionID", session_id)
+            part = ev.get("part", {})
+            if et == "tool_use":
+                tool_calls += 1
+            elif et == "step_finish":
+                tokens = part.get("tokens", tokens)
+                cost = part.get("cost", cost)
+                finish_reason = part.get("reason", finish_reason)
+            elif et == "error":
+                err = ev.get("error", {})
+                errors.append(err.get("name") or str(err)[:200])
+    except OSError:
+        pass
+    return tokens, cost, session_id, tool_calls, errors, finish_reason
+
+
+def _helper_main():
+    """Private launch gate: command stdin is released only after Job assignment."""
+    raw = sys.stdin.buffer.read()
+    if not raw:
+        return 0
+    try:
+        record = json.loads(raw.decode("utf-8"))
+        cmd, workdir = record["cmd"], record["cwd"]
+        if not (isinstance(cmd, list) and cmd
+                and all(isinstance(arg, str) for arg in cmd)
+                and isinstance(workdir, str)):
+            return 2
+    except (ValueError, KeyError, TypeError):
+        return 2
+    try:
+        # The parent owns the transcript; this helper and its descendants only
+        # inherit that output. They never inherit the parent's Job handle.
+        proc = subprocess.Popen(cmd, cwd=workdir, stdin=subprocess.DEVNULL,
+                                stdout=sys.stdout, stderr=sys.stderr)
+        return proc.wait()
+    except OSError as exc:
+        print(json.dumps({"type": "error", "error": {
+            "name": f"worker launch failed: {exc}"}}), flush=True)
+        return 1
+
+
+@contextmanager
+def _cancellation_state():
+    """Record console cancellation without interrupting resource acquisition.
+
+    Checkpoints raise only once handles have been stored. During cleanup the
+    handler only records a request, so repeated Ctrl-C cannot bypass teardown.
+    """
+    state = {"signal": None}
+    saved = {}
+
+    def record(signum, _frame):
+        state["signal"] = signum
+
+    if threading.current_thread() is threading.main_thread():
+        for name in ("SIGINT", "SIGTERM", "SIGBREAK"):
+            signum = getattr(signal, name, None)
+            if signum is not None:
+                saved[signum] = signal.signal(signum, record)
+    try:
+        yield state
+    finally:
+        for signum, handler in saved.items():
+            signal.signal(signum, handler)
+
+
+def _check_cancellation(state):
+    if state["signal"] is not None:
+        raise KeyboardInterrupt(f"signal {state['signal']}")
+
+
+def _cleanup_job(job_handle, helper, timeout=10.0):
+    """Stop owned instances and prove exit within one bounded cleanup deadline."""
+    deadline = time.monotonic() + timeout
+    errors = []
+    helper_exited = helper is None
+    active = 0 if job_handle is None else None
+    if job_handle is not None and not _terminate_job(job_handle):
+        errors.append(f"TerminateJobObject failed (error {_get_last_error()})")
+    if helper is not None:
+        try:
+            # Also covers a blocked helper whose assignment failed. Popen uses
+            # its retained process handle; no PID lookup or ancestry kill.
+            if helper.poll() is None:
+                helper.kill()
+            helper.wait(timeout=max(0.0, deadline - time.monotonic()))
+            helper_exited = True
+        except (OSError, subprocess.SubprocessError) as exc:
+            errors.append(f"helper exit unconfirmed: {exc}")
+    if job_handle is not None:
+        while True:
+            active = _job_active_processes(job_handle)
+            if active in (0, None) or time.monotonic() >= deadline:
+                break
+            time.sleep(min(0.05, max(0.0, deadline - time.monotonic())))
+        if active is None:
+            errors.append(f"QueryInformationJobObject failed (error {_get_last_error()})")
+        elif active:
+            errors.append(f"{active} Job processes still active at cleanup deadline")
+    return {"method": "windows_job_object", "confirmed": helper_exited and active == 0,
+            "active_processes": active, "error": "; ".join(errors) or None}
+
+
+def _run_windows_contained(cmd, workdir, log_path, timeout):
+    """Gate launch on Job assignment; finish teardown before returning evidence."""
+    job_handle = helper = log_fh = None
+    result = {"status": "completed", "exit_code": None,
+              "termination_reason": "normal", "errors": []}
+    with _cancellation_state() as cancellation:
+        try:
+            job_handle = _create_job()
+            if not job_handle:
+                raise OSError(f"Job creation/configuration failed (error {_get_last_error()})")
+            _check_cancellation(cancellation)
+            # Parent-opened transcript is distinct from parent JSON stdout.
+            log_fh = open(log_path, "w", encoding="utf-8")  # noqa: SIM115
+            helper = subprocess.Popen(
+                [sys.executable, str(Path(__file__).resolve()), "--_helper"],
+                cwd=workdir, stdin=subprocess.PIPE, stdout=log_fh,
+                stderr=subprocess.STDOUT, creationflags=_CREATE_NO_WINDOW)
+            _check_cancellation(cancellation)
+            proc_handle = getattr(helper, "_handle", None)
+            if proc_handle is None:
+                raise OSError("Popen._handle unavailable (unsupported interpreter)")
+            if not _kernel32.AssignProcessToJobObject(job_handle, proc_handle):
+                raise OSError(f"AssignProcessToJobObject failed (error {_get_last_error()})")
+            _check_cancellation(cancellation)
+            helper.stdin.write(json.dumps({"cmd": cmd, "cwd": workdir}).encode("utf-8"))
+            helper.stdin.close()  # EOF releases the complete record.
+            deadline = time.monotonic() + timeout
+            while True:
+                _check_cancellation(cancellation)
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise subprocess.TimeoutExpired(cmd, timeout)
+                try:
+                    result["exit_code"] = helper.wait(timeout=min(0.1, remaining))
+                    break
+                except subprocess.TimeoutExpired:
+                    continue
+            if result["exit_code"] != 0:
+                result["status"] = "errored"
+                result["termination_reason"] = "error"
+                result["errors"].append(f"worker exited with code {result['exit_code']}")
+        except subprocess.TimeoutExpired:
+            result.update(status="timeout", termination_reason="timeout")
+        except KeyboardInterrupt as exc:
+            result.update(status="errored", termination_reason="cancelled")
+            result["errors"].append(f"cancelled: {exc}")
+        except (OSError, subprocess.SubprocessError) as exc:
+            result.update(status="errored", termination_reason="error")
+            result["errors"].append(str(exc))
+        finally:
+            try:
+                result["cleanup_evidence"] = _cleanup_job(job_handle, helper)
+            except (OSError, subprocess.SubprocessError) as exc:
+                result["cleanup_evidence"] = {
+                    "method": "windows_job_object", "confirmed": False,
+                    "active_processes": None, "error": f"cleanup failed: {exc}"}
+            finally:
+                # One owner closes each handle exactly once. Last Job closure
+                # is the kernel fallback, never substituted for exit evidence.
+                if job_handle is not None:
+                    _close_handle(job_handle)
+                for stream in (helper.stdin if helper is not None else None, log_fh):
+                    if stream is not None:
+                        try:
+                            stream.close()
+                        except OSError as exc:
+                            result["errors"].append(f"stream close failed: {exc}")
+        if cancellation["signal"] is not None and result["termination_reason"] == "normal":
+            result.update(status="errored", termination_reason="cancelled")
+            result["errors"].append(f"cancelled: signal {cancellation['signal']}")
+    return result
+
+
+def _run_direct_child(cmd, workdir, log_path, timeout):
+    """Keep the existing non-Windows subprocess.run/direct-child boundary."""
+    result = {"status": "completed", "exit_code": None,
+              "termination_reason": "normal", "errors": [],
+              "cleanup_evidence": {"method": "direct_child", "confirmed": True,
+                                   "error": None}}
+    try:
+        with open(log_path, "w", encoding="utf-8") as log:
+            completed = subprocess.run(cmd, cwd=workdir, stdout=log,
+                                       stderr=subprocess.STDOUT, timeout=timeout,
+                                       text=True, check=False)
+            result["exit_code"] = completed.returncode
+    except subprocess.TimeoutExpired:
+        result.update(status="timeout", termination_reason="timeout")
+    except KeyboardInterrupt as exc:
+        # subprocess.run does not promise a child has exited on Ctrl-C.
+        result.update(status="errored", termination_reason="cancelled")
+        result["cleanup_evidence"].update(confirmed=False,
+                                          error="direct-child exit unconfirmed after cancellation")
+        result["errors"].append(f"cancelled: {exc}")
+    except OSError as exc:
+        result.update(status="errored", termination_reason="error")
+        result["errors"].append(str(exc))
+    return result
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--tier", choices=["grunt", "implement", "verify"])
@@ -72,7 +430,11 @@ def main():
     ap.add_argument("--timeout", type=int, help="seconds; default from tier config")
     ap.add_argument("--prompt")
     ap.add_argument("--prompt-file")
+    ap.add_argument("--_helper", action="store_true", help=argparse.SUPPRESS)
     args = ap.parse_args()
+
+    if args._helper:
+        return _helper_main()
 
     if not args.prompt and not args.prompt_file:
         sys.exit("delegate.py: --prompt or --prompt-file required")
@@ -88,7 +450,9 @@ def main():
 
     workdir = str(Path(args.dir).resolve())
     LOG_ROOT.mkdir(parents=True, exist_ok=True)
-    stamp = time.strftime("%Y%m%d-%H%M%S")
+    # Unique invocation suffix so concurrent delegates cannot delete each
+    # other's task files or share an output stream.
+    stamp = time.strftime("%Y%m%d-%H%M%S") + f"-{uuid.uuid4().hex[:12]}"
     log_path = LOG_ROOT / f"{stamp}-{(args.tier or 'custom')}.jsonl"
 
     # Multi-line prompts do NOT survive the Windows cmd /c argv path (cmd
@@ -119,56 +483,64 @@ def main():
     oc_args.append(prompt)
 
     t0 = time.monotonic()
-    status = "completed"
-    exit_code = None
     try:
-        with open(log_path, "w", encoding="utf-8") as log:
-            r = subprocess.run(_opencode_cmd(oc_args), cwd=workdir,
-                               stdout=log, stderr=subprocess.STDOUT,
-                               timeout=timeout, text=True, check=False)
-            exit_code = r.returncode
-    except subprocess.TimeoutExpired:
-        status = "timeout"
-    finally:
-        if task_file is not None:
+        cmd = _opencode_cmd(oc_args)
+    except OSError as exc:
+        # Command resolution can fail before any worker was launched.
+        result = {"status": "errored", "exit_code": None,
+                  "termination_reason": "error", "errors": [str(exc)],
+                  "cleanup_evidence": {"method": "not_started", "confirmed": True,
+                                       "error": None}}
+    else:
+        runner = _run_windows_contained if IS_WINDOWS else _run_direct_child
+        result = runner(cmd, workdir, log_path, timeout)
+    status, exit_code = result["status"], result["exit_code"]
+    termination_reason = result["termination_reason"]
+    cleanup_evidence = result["cleanup_evidence"]
+    wrapper_errors = result.get("errors", [])
+    if task_file is not None and cleanup_evidence["confirmed"]:
+        try:
             task_file.unlink(missing_ok=True)
+        except OSError as exc:
+            wrapper_errors.append(f"task-file removal failed: {exc}")
+            if status == "completed":
+                status = "errored"
+
     wall_s = round(time.monotonic() - t0, 1)
 
-    post = _git_snapshot(workdir)
+    # Only take the final snapshot and parse the transcript once cleanup is
+    # confirmed. If cleanup could not be confirmed, report unavailable evidence
+    # rather than a misleading clean snapshot.
+    cleanup_confirmed = bool(cleanup_evidence and cleanup_evidence.get("confirmed"))
+    if cleanup_confirmed:
+        post = _git_snapshot(workdir)
+        tokens, cost, session_id, tool_calls, errors, finish_reason = \
+            _parse_transcript(log_path)
 
-    # Parse the event stream for evidence (defensively -- schema may drift).
-    tokens, cost, session_id, tool_calls, errors, finish_reason = None, None, None, 0, [], None
-    try:
-        for line in log_path.read_text(encoding="utf-8", errors="replace").splitlines():
-            line = line.strip()
-            if not line.startswith("{"):
-                continue
-            try:
-                ev = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            et = ev.get("type")
-            session_id = ev.get("sessionID", session_id)
-            part = ev.get("part", {})
-            if et == "tool_use":
-                tool_calls += 1
-            elif et == "step_finish":
-                tokens = part.get("tokens", tokens)
-                cost = part.get("cost", cost)
-                finish_reason = part.get("reason", finish_reason)
-            elif et == "error":
-                err = ev.get("error", {})
-                errors.append(err.get("name") or str(err)[:200])
-    except OSError:
-        pass
+        if errors and status == "completed":
+            status = "errored"
+        if status == "completed" and finish_reason != "stop":
+            # Stream ended without a clean stop -- documented unreliable-stream case.
+            status = "no_clean_finish"
 
+        changed = sorted(set(post["dirty_files"]) - set(pre["dirty_files"]))
+        git_head = post["head"]
+        head_moved = pre["head"] != post["head"]
+    else:
+        # Cleanup unconfirmed: retain timeout when already timed out, else
+        # errored; skip snapshot and transcript-derived claims.
+        if status != "timeout":
+            status = "errored"
+        tokens = cost = session_id = finish_reason = None
+        tool_calls = None
+        errors = []
+        changed = None
+        git_head = None
+        head_moved = None
+
+    errors = wrapper_errors + errors
     if errors and status == "completed":
         status = "errored"
-    if status == "completed" and finish_reason != "stop":
-        # Stream ended without a clean stop -- documented unreliable-stream case.
-        status = "no_clean_finish"
-
-    changed = sorted(set(post["dirty_files"]) - set(pre["dirty_files"]))
     summary = {
         "status": status,               # completed | timeout | errored | no_clean_finish
         "model": model,
@@ -176,14 +548,16 @@ def main():
         "workdir": workdir,
         "wall_s": wall_s,
         "exit_code": exit_code,
+        "termination_reason": termination_reason,  # normal | timeout | cancelled | error
+        "cleanup": cleanup_evidence,
         "finish_reason": finish_reason,
         "tool_calls": tool_calls,
         "tokens": tokens,
         "cost": cost,
         "session_id": session_id,
         "errors": errors,
-        "git_head": post["head"],
-        "head_moved": pre["head"] != post["head"],
+        "git_head": git_head,
+        "head_moved": head_moved,
         "files_changed": changed,
         "transcript": str(log_path),
         "verdict": "EVIDENCE ONLY -- caller must verify via build/tests/diff; never trust worker narrative",

--- a/tests/test_delegate_process_tree.py
+++ b/tests/test_delegate_process_tree.py
@@ -1,0 +1,645 @@
+#!/usr/bin/env python
+"""Focused lifecycle/summary tests and real Windows process-tree canaries for
+the delegate wrapper's Windows Job Object containment (pkg232).
+
+The wrapper (`.claude/skills/delegate/scripts/delegate.py`) must own, stop and
+await its full descendant process tree on timeout/cancellation/error and on
+ordinary completion, before taking the final git snapshot and parsing the
+transcript. These tests exercise that machinery directly (never invoking a real
+opencode worker) plus the summary/evidence logic.
+
+Temporary worker programs are test fixtures written into pytest temporary
+directories; test-owned process handles are cleaned in `finally` blocks so a
+failure cannot leak processes.
+"""
+
+import io
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+
+DELEGATE_PY = Path(__file__).resolve().parent.parent / ".claude" / "skills" / "delegate" / "scripts" / "delegate.py"
+
+# Import the wrapper module by path (it is not a package).
+import importlib.util
+
+_spec = importlib.util.spec_from_file_location("delegate", DELEGATE_PY)
+delegate = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(delegate)
+
+IS_WINDOWS = os.name == "nt"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_worker(tmp_path, name, body):
+    """Write a small Python worker program into tmp_path and return its path."""
+    p = tmp_path / name
+    p.write_text(body, encoding="utf-8")
+    return str(p)
+
+
+def _python_cmd(script_path, *args):
+    return [sys.executable, script_path, *args]
+
+
+def _setup_main(monkeypatch, tmp_path, argv):
+    """Stub the worker + config for tests that call delegate.main(), and set
+    sys.argv so argparse parses our args (not pytest's)."""
+    monkeypatch.setattr(delegate, "_opencode_cmd", lambda args: ["fake", *args])
+    monkeypatch.setattr(delegate, "LOG_ROOT", tmp_path / "logs")
+    monkeypatch.setattr(delegate, "TIERS_FILE", tmp_path / "tiers.json")
+    (tmp_path / "tiers.json").write_text(json.dumps({
+        "tiers": {"grunt": {"primary": "m/x", "default_timeout_s": 5}}}),
+        encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", ["delegate.py", *argv])
+    return io.StringIO()
+
+
+def _run_main(monkeypatch, tmp_path, argv, contained_result):
+    """Run delegate.main() with a stubbed containment result; return (rc, summary)."""
+    monkeypatch.setattr(delegate, "IS_WINDOWS", True)
+    buf = _setup_main(monkeypatch, tmp_path, argv)
+    if contained_result is not None:
+        monkeypatch.setattr(delegate, "_run_windows_contained",
+                            lambda cmd, workdir, log_path, timeout: contained_result)
+    with redirect_stdout(buf):
+        rc = delegate.main()
+    return rc, json.loads(buf.getvalue())
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: Job object creation / accounting (Windows only)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not IS_WINDOWS, reason="Windows-only Job Object API")
+class TestJobObject:
+    def test_create_job_returns_handle(self):
+        h = delegate._create_job()
+        assert h, "CreateJobObjectW should return a valid handle"
+        try:
+            assert delegate._job_active_processes(h) == 0
+        finally:
+            delegate._close_handle(h)
+
+    def test_job_handle_closed(self):
+        h = delegate._create_job()
+        assert h
+        delegate._close_handle(h)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: helper mode (no command after EOF, bad argv)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not IS_WINDOWS, reason="helper is Windows-only")
+class TestHelperMode:
+    def test_eof_before_record_exits_without_launch(self, tmp_path):
+        marker = tmp_path / "marker.txt"
+        r = subprocess.run(
+            [sys.executable, str(DELEGATE_PY), "--_helper"],
+            input=b"", capture_output=True, check=False,
+            creationflags=delegate._CREATE_NO_WINDOW, timeout=5,
+        )
+        assert r.returncode == 0
+        assert not marker.exists()
+
+    def test_bad_json_exits_nonzero(self):
+        r = subprocess.run(
+            [sys.executable, str(DELEGATE_PY), "--_helper"],
+            input=b"not-json", capture_output=True, check=False,
+            creationflags=delegate._CREATE_NO_WINDOW, timeout=5,
+        )
+        assert r.returncode == 2
+
+    def test_runs_command_and_returns_exit_code(self, tmp_path):
+        marker = tmp_path / "ran.txt"
+        worker = _write_worker(tmp_path, "w.py",
+                               "import sys\nopen(sys.argv[1],'w').write('x')\n")
+        record = json.dumps({"cmd": _python_cmd(worker, str(marker)),
+                             "cwd": str(tmp_path)}).encode("utf-8")
+        r = subprocess.run(
+            [sys.executable, str(DELEGATE_PY), "--_helper"],
+            input=record, capture_output=True, check=False,
+            creationflags=delegate._CREATE_NO_WINDOW, timeout=5,
+        )
+        assert r.returncode == 0
+        assert marker.exists()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: summary / order / failure / unavailable evidence
+# ---------------------------------------------------------------------------
+
+class TestSummaryLogic:
+    def _completed(self):
+        return {"status": "completed", "exit_code": 0,
+                "termination_reason": "normal",
+                "cleanup_evidence": {"method": "windows_job_object",
+                                     "confirmed": True, "error": None}}
+
+    def test_completed_summary_fields(self, monkeypatch, tmp_path):
+        def fake(cmd, workdir, log_path, timeout):
+            with open(log_path, "w", encoding="utf-8") as f:
+                f.write(json.dumps({"type": "step_finish",
+                                    "part": {"reason": "stop", "tokens": 10,
+                                             "cost": 0.01}}) + "\n")
+            return self._completed()
+        monkeypatch.setattr(delegate, "_run_windows_contained", fake)
+        rc, s = _run_main(monkeypatch, tmp_path,
+                          ["--tier", "grunt", "--prompt", "hello"], None)
+        assert rc == 0
+        assert s["status"] == "completed"
+        assert s["termination_reason"] == "normal"
+        assert s["cleanup"]["confirmed"] is True
+        assert s["finish_reason"] == "stop"
+        assert s["tool_calls"] == 0
+
+    def test_timeout_then_clean_stop_still_timeout(self, monkeypatch, tmp_path):
+        def fake(cmd, workdir, log_path, timeout):
+            with open(log_path, "w", encoding="utf-8") as f:
+                f.write(json.dumps({"type": "step_finish",
+                                    "part": {"reason": "stop"}}) + "\n")
+            return {"status": "timeout", "exit_code": None,
+                    "termination_reason": "timeout",
+                    "cleanup_evidence": {"method": "windows_job_object",
+                                         "confirmed": True, "error": None}}
+        monkeypatch.setattr(delegate, "_run_windows_contained", fake)
+        _, s = _run_main(monkeypatch, tmp_path,
+                         ["--tier", "grunt", "--prompt", "hello"], None)
+        # A later clean-stop event must NOT overwrite the sticky timeout.
+        assert s["status"] == "timeout"
+        assert s["termination_reason"] == "timeout"
+
+    def test_cleanup_failure_yields_unavailable_evidence(self, monkeypatch, tmp_path):
+        def fake(cmd, workdir, log_path, timeout):
+            with open(log_path, "w", encoding="utf-8") as f:
+                f.write(json.dumps({"type": "step_finish",
+                                    "part": {"reason": "stop"}}) + "\n")
+            return {"status": "completed", "exit_code": 0,
+                    "termination_reason": "normal",
+                    "cleanup_evidence": {"method": "windows_job_object",
+                                         "confirmed": False,
+                                         "error": "still active"}}
+        monkeypatch.setattr(delegate, "_run_windows_contained", fake)
+        _, s = _run_main(monkeypatch, tmp_path,
+                         ["--tier", "grunt", "--prompt", "hello"], None)
+        # Cleanup unconfirmed -> errored, no fabricated snapshot.
+        assert s["status"] == "errored"
+        assert s["files_changed"] is None
+        assert s["git_head"] is None
+        assert s["cleanup"]["confirmed"] is False
+
+    def test_cleanup_failure_retains_timeout(self, monkeypatch, tmp_path):
+        def fake(cmd, workdir, log_path, timeout):
+            return {"status": "timeout", "exit_code": None,
+                    "termination_reason": "timeout",
+                    "cleanup_evidence": {"method": "windows_job_object",
+                                         "confirmed": False, "error": "x"}}
+        monkeypatch.setattr(delegate, "_run_windows_contained", fake)
+        _, s = _run_main(monkeypatch, tmp_path,
+                         ["--tier", "grunt", "--prompt", "hello"], None)
+        assert s["status"] == "timeout"
+        assert s["files_changed"] is None
+
+    def test_multiline_prompt_routes_to_task_file(self, monkeypatch, tmp_path):
+        seen = {}
+
+        def fake(cmd, workdir, log_path, timeout):
+            seen["cmd"] = cmd
+            with open(log_path, "w", encoding="utf-8") as f:
+                f.write(json.dumps({"type": "step_finish",
+                                    "part": {"reason": "stop"}}) + "\n")
+            return self._completed()
+        monkeypatch.setattr(delegate, "_run_windows_contained", fake)
+        _run_main(monkeypatch, tmp_path,
+                  ["--tier", "grunt", "--dir", str(tmp_path),
+                   "--prompt", "line one\nline two"], None)
+        # The multiline prompt must be routed through a task file, so the final
+        # argv prompt is the single-line "Read the file ..." instruction.
+        assert "Read the file" in seen["cmd"][-1]
+        # Task file must have been cleaned up.
+        assert not list(tmp_path.glob(".delegate-task-*.md"))
+
+    def test_dir_flag_forwarded(self, monkeypatch, tmp_path):
+        seen = {}
+
+        def fake(cmd, workdir, log_path, timeout):
+            seen["cmd"] = cmd
+            seen["workdir"] = workdir
+            with open(log_path, "w", encoding="utf-8") as f:
+                f.write(json.dumps({"type": "step_finish",
+                                    "part": {"reason": "stop"}}) + "\n")
+            return self._completed()
+        monkeypatch.setattr(delegate, "_run_windows_contained", fake)
+        _run_main(monkeypatch, tmp_path,
+                  ["--tier", "grunt", "--dir", str(tmp_path),
+                   "--prompt", "hello"], None)
+        assert "--dir" in seen["cmd"]
+        assert seen["workdir"] == str(tmp_path.resolve())
+
+
+# ---------------------------------------------------------------------------
+# Real Windows canaries
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def owned_helpers(monkeypatch):
+    """Retain helper process-instance handles; verify teardown even on failures."""
+    owned = []
+    original = subprocess.Popen
+
+    def launch(*args, **kwargs):
+        process = original(*args, **kwargs)
+        if "--_helper" in args[0]:
+            owned.append(process)
+            assert kwargs["creationflags"] & delegate._CREATE_NO_WINDOW
+        return process
+
+    monkeypatch.setattr(subprocess, "Popen", launch)
+    yield owned
+    for process in owned:
+        if process.poll() is None:
+            process.kill()
+        process.wait(timeout=5)
+
+
+@pytest.mark.skipif(not IS_WINDOWS, reason="real Windows Job Object canary")
+class TestWindowsCanaries:
+    @pytest.mark.parametrize("ending", ["timeout", "normal", "error", "cancelled"])
+    def test_owned_writers_stop_and_sentinel_survives(
+            self, tmp_path, monkeypatch, owned_helpers, ending):
+        # Both descendants acknowledge startup, then attempt a file AND inherited
+        # stdout write only when the test signals that the wrapper has returned.
+        writer = _write_worker(tmp_path, "writer.py", """
+import pathlib, subprocess, sys, time
+root = pathlib.Path(sys.argv[1])
+role = sys.argv[2]
+if role == 'child':
+    subprocess.Popen([sys.executable, __file__, str(root), 'grandchild'])
+(root / (role + '.ready')).write_text('ready')
+deadline = time.monotonic() + 12
+while not (root / 'after-return').exists() and time.monotonic() < deadline:
+    time.sleep(0.02)
+if (root / 'after-return').exists():
+    (root / (role + '.late')).write_text('late')
+    print(role + ' late inherited output', flush=True)
+""")
+        worker = _write_worker(tmp_path, "worker.py", """
+import pathlib, subprocess, sys, time
+root = pathlib.Path(sys.argv[1])
+subprocess.Popen([sys.executable, sys.argv[2], str(root), 'child'])
+deadline = time.monotonic() + 8
+while not (root / 'grandchild.ready').exists() and time.monotonic() < deadline:
+    time.sleep(0.02)
+if sys.argv[3] == 'normal':
+    sys.exit(0)
+if sys.argv[3] == 'error':
+    sys.exit(7)
+while time.monotonic() < deadline:
+    time.sleep(0.02)
+""")
+        sentinel = subprocess.Popen(_python_cmd(writer, str(tmp_path), "sentinel"),
+                                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        # owned_helpers replaces the constructor only; use the actual process type.
+        original_wait = type(sentinel).wait
+        cancelled = False
+        previous_signal = signal.getsignal(signal.SIGINT)
+
+        def wait(process, timeout=None):
+            nonlocal cancelled
+            if (ending == "cancelled" and not cancelled
+                    and (tmp_path / "grandchild.ready").exists()
+                    and process in owned_helpers):
+                cancelled = True
+                signal.raise_signal(signal.SIGINT)
+            return original_wait(process, timeout=timeout)
+
+        monkeypatch.setattr(type(sentinel), "wait", wait)
+        log = tmp_path / "transcript.jsonl"
+        try:
+            result = delegate._run_windows_contained(
+                _python_cmd(worker, str(tmp_path), writer, ending),
+                str(tmp_path), log, timeout=1.5)
+            assert result["termination_reason"] == ending
+            assert result["status"] == ({"normal": "completed", "timeout": "timeout"}
+                                         .get(ending, "errored"))
+            assert result["cleanup_evidence"]["confirmed"] is True
+            assert result["cleanup_evidence"]["active_processes"] == 0
+            assert all(process.poll() is not None for process in owned_helpers)
+            for role in ("child", "grandchild", "sentinel"):
+                assert (tmp_path / (role + ".ready")).read_text() == "ready"
+            assert sentinel.poll() is None
+            before = log.read_bytes()
+            (tmp_path / "after-return").touch()
+            sentinel.wait(timeout=3)
+            time.sleep(0.2)
+            assert (tmp_path / "sentinel.late").read_text() == "late"
+            assert not (tmp_path / "child.late").exists()
+            assert not (tmp_path / "grandchild.late").exists()
+            assert log.read_bytes() == before
+            assert signal.getsignal(signal.SIGINT) is previous_signal
+        finally:
+            (tmp_path / "after-return").touch()
+            if sentinel.poll() is None:
+                sentinel.kill()
+            sentinel.wait(timeout=5)
+
+    @pytest.mark.parametrize("failure", ["assignment", "interruption", "exception"])
+    def test_assignment_never_releases_uncontained_command(
+            self, tmp_path, monkeypatch, owned_helpers, failure):
+        marker = tmp_path / "uncontained.txt"
+        command = [sys.executable, "-c", f"open({str(marker)!r},'w').write('bad')"]
+
+        def assign(_job, _process):
+            if failure == "interruption":
+                raise KeyboardInterrupt("during assignment")
+            if failure == "exception":
+                raise OSError("assignment exception")
+            return False
+
+        monkeypatch.setattr(delegate._kernel32, "AssignProcessToJobObject", assign)
+        result = delegate._run_windows_contained(command, str(tmp_path),
+                                                  tmp_path / "log.jsonl", timeout=2)
+        assert result["status"] == "errored"
+        assert result["termination_reason"] == ("cancelled" if failure == "interruption" else "error")
+        assert result["cleanup_evidence"]["confirmed"] is True
+        assert all(process.poll() is not None for process in owned_helpers)
+        assert not marker.exists()
+        assert result["errors"]
+
+    def test_job_handle_has_one_close_owner(self, tmp_path, monkeypatch):
+        closed = []
+        original = delegate._close_handle
+
+        def close(handle):
+            closed.append(handle)
+            original(handle)
+
+        monkeypatch.setattr(delegate, "_close_handle", close)
+        result = delegate._run_windows_contained([sys.executable, "-c", "pass"],
+                                                  str(tmp_path), tmp_path / "log", 2)
+        assert result["cleanup_evidence"]["confirmed"] is True
+        assert len(closed) == 1
+
+    def test_query_failure_withholds_snapshot(self, tmp_path, monkeypatch, owned_helpers):
+        snapshots = []
+        monkeypatch.setattr(delegate, "_git_snapshot", lambda _wd: (
+            snapshots.append("snapshot") or {"head": "base", "dirty_files": []}))
+        monkeypatch.setattr(delegate, "_job_active_processes", lambda _job: None)
+        monkeypatch.setattr(delegate, "_parse_transcript", lambda _path: pytest.fail("unstable transcript parsed"))
+        buf = _setup_main(monkeypatch, tmp_path, ["--tier", "grunt", "--dir", str(tmp_path),
+                                                  "--prompt", "two\nlines"])
+        monkeypatch.setattr(delegate, "_opencode_cmd", lambda _args: [sys.executable, "-c", "pass"])
+        with redirect_stdout(buf):
+            delegate.main()
+        result = json.loads(buf.getvalue())
+        assert snapshots == ["snapshot"]  # pre-state only
+        assert result["status"] == "errored"
+        assert result["cleanup"]["confirmed"] is False
+        assert result["files_changed"] is None
+        assert result["tool_calls"] is None
+        assert list(tmp_path.glob(".delegate-task-*.md"))  # retain pointer on unverified teardown
+
+    def test_worker_launch_failure_has_structured_error(self, tmp_path):
+        result = delegate._run_windows_contained([str(tmp_path / "missing.exe")],
+                                                  str(tmp_path), tmp_path / "log", 2)
+        assert result["status"] == "errored"
+        assert result["exit_code"] != 0
+        assert result["cleanup_evidence"]["confirmed"] is True
+        assert "worker launch failed" in (tmp_path / "log").read_text()
+
+
+# ---------------------------------------------------------------------------
+# Non-Windows branch (mocked on Windows host; real on non-Windows)
+# ---------------------------------------------------------------------------
+
+class TestNonWindowsBranch:
+    def test_non_windows_uses_subprocess_run(self, monkeypatch, tmp_path):
+        """The non-Windows path keeps subprocess.run direct-child semantics."""
+        calls = {}
+
+        def fake_run(cmd, cwd=None, stdout=None, stderr=None, timeout=None,
+                     text=None, check=None, **kwargs):
+            if kwargs.get("capture_output"):
+                # _git() call -- return a benign empty result.
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+            calls["cmd"] = cmd
+            calls["cwd"] = cwd
+            calls["timeout"] = timeout
+            stdout.write(json.dumps({"type": "step_finish",
+                                     "part": {"reason": "stop"}}) + "\n")
+            return subprocess.CompletedProcess(cmd, 0)
+
+        monkeypatch.setattr(delegate, "IS_WINDOWS", False)
+        monkeypatch.setattr(delegate.subprocess, "run", fake_run)
+        buf = _setup_main(monkeypatch, tmp_path,
+                          ["--tier", "grunt", "--prompt", "hello"])
+        with redirect_stdout(buf):
+            delegate.main()
+        s = json.loads(buf.getvalue())
+        assert s["status"] == "completed"
+        assert s["cleanup"]["method"] == "direct_child"
+        assert calls["timeout"] == 5
+
+
+@pytest.mark.parametrize("event, expected", [
+    ({"type": "error", "error": {"name": "worker failed"}}, "errored"),
+    ({"type": "step_finish", "part": {"reason": "tool-calls"}}, "no_clean_finish"),
+])
+def test_stream_evidence_status(monkeypatch, tmp_path, event, expected):
+    def run(_cmd, _wd, path, _timeout):
+        Path(path).write_text(json.dumps(event), encoding="utf-8")
+        return TestSummaryLogic()._completed()
+
+    monkeypatch.setattr(delegate, "_run_windows_contained", run)
+    _, result = _run_main(monkeypatch, tmp_path,
+                          ["--tier", "grunt", "--dir", str(tmp_path), "--prompt", "hello"], None)
+    assert result["status"] == expected
+
+
+def test_same_process_same_second_invocations_are_unique(monkeypatch, tmp_path):
+    logs, tasks = [], []
+    monkeypatch.setattr(delegate.time, "strftime", lambda _fmt: "fixed-second")
+
+    def run(_cmd, workdir, path, _timeout):
+        logs.append(str(path))
+        task, = Path(workdir).glob(".delegate-task-*.md")
+        tasks.append(task.name)
+        assert task.read_text(encoding="utf-8") == "first\nsecond"
+        Path(path).write_text('{"type":"step_finish","part":{"reason":"stop"}}', encoding="utf-8")
+        return TestSummaryLogic()._completed()
+
+    monkeypatch.setattr(delegate, "_run_windows_contained", run)
+    for _ in range(2):
+        _run_main(monkeypatch, tmp_path, ["--tier", "grunt", "--dir", str(tmp_path),
+                                         "--prompt", "first\nsecond"], None)
+    assert len(set(logs)) == len(set(tasks)) == 2
+    assert not list(tmp_path.glob(".delegate-task-*.md"))
+
+
+@pytest.mark.parametrize("failure", ["timeout", "cancelled", "launch"])
+def test_direct_child_failure_semantics(monkeypatch, tmp_path, failure):
+    def run(cmd, **_kwargs):
+        if failure == "timeout":
+            raise subprocess.TimeoutExpired(cmd, 1)
+        if failure == "cancelled":
+            raise KeyboardInterrupt
+        raise FileNotFoundError("missing command")
+
+    monkeypatch.setattr(delegate.subprocess, "run", run)
+    result = delegate._run_direct_child(["fixture"], str(tmp_path), tmp_path / "log", 1)
+    assert result["status"] == ("timeout" if failure == "timeout" else "errored")
+    assert result["termination_reason"] == ("error" if failure == "launch" else failure)
+    assert result["cleanup_evidence"]["confirmed"] is (failure != "cancelled")
+
+
+@pytest.mark.skipif(IS_WINDOWS, reason="actual non-Windows subprocess runtime gate")
+def test_non_windows_actual_runtime(tmp_path):
+    result = delegate._run_direct_child(
+        [sys.executable, "-c", "print('native direct child')"], str(tmp_path), tmp_path / "log", 5)
+    assert result["status"] == "completed"
+    assert result["exit_code"] == 0
+    assert (tmp_path / "log").read_text().strip() == "native direct child"
+
+
+@pytest.mark.skipif(not IS_WINDOWS, reason="Windows cleanup failure canaries")
+@pytest.mark.parametrize("failure", ["query", "terminate", "deadline"])
+def test_cleanup_failure_is_never_a_false_success(monkeypatch, failure):
+    monkeypatch.setattr(delegate, "_get_last_error", lambda: 123)
+    monkeypatch.setattr(delegate, "_terminate_job", lambda _job: failure != "terminate")
+    monkeypatch.setattr(delegate, "_job_active_processes", lambda _job: None if failure == "query" else 1)
+    result = delegate._cleanup_job(42, None, timeout=0.001)
+    assert result["confirmed"] is False
+    assert result["error"]
+
+
+@pytest.mark.skipif(not IS_WINDOWS, reason="Windows resource acquisition failures")
+@pytest.mark.parametrize("failure", ["job", "log", "helper"])
+def test_startup_failure_has_no_uncontained_worker(tmp_path, monkeypatch, owned_helpers, failure):
+    if failure == "job":
+        monkeypatch.setattr(delegate, "_create_job", lambda: None)
+    elif failure == "helper":
+        def fail(*_args, **_kwargs):
+            raise OSError("helper creation failed")
+        monkeypatch.setattr(delegate.subprocess, "Popen", fail)
+    log = tmp_path / "missing" / "log" if failure == "log" else tmp_path / "log"
+    result = delegate._run_windows_contained([sys.executable, "-c", "pass"], str(tmp_path), log, 1)
+    assert result["status"] == "errored"
+    assert result["cleanup_evidence"]["confirmed"] is True
+    assert not owned_helpers
+    assert result["errors"]
+
+
+@pytest.mark.skipif(not IS_WINDOWS, reason="Windows handle and gate contract")
+def test_job_flags_and_real_instance_assignment(tmp_path, monkeypatch, owned_helpers):
+    import ctypes
+    from ctypes import wintypes
+
+    original = delegate._kernel32.AssignProcessToJobObject
+    marker = tmp_path / "released"
+    assigned = []
+
+    def assign(job, process):
+        assert process == owned_helpers[-1]._handle
+        flags = wintypes.DWORD()
+        get_flags = delegate._kernel32.GetHandleInformation
+        get_flags.argtypes = [wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD)]
+        get_flags.restype = wintypes.BOOL
+        assert get_flags(job, ctypes.byref(flags))
+        assert flags.value & 1 == 0
+        info = delegate._JOBOBJECT_EXTENDED_LIMIT_INFORMATION()
+        assert delegate._kernel32.QueryInformationJobObject(
+            job, 9, ctypes.byref(info), ctypes.sizeof(info), None)
+        assert info.BasicLimitInformation.LimitFlags == 0x2000
+        time.sleep(0.1)  # helper remains blocked even though it is already running
+        assert not marker.exists()
+        success = original(job, process)
+        assigned.append(bool(success))
+        return success
+
+    monkeypatch.setattr(delegate._kernel32, "AssignProcessToJobObject", assign)
+    result = delegate._run_windows_contained(
+        [sys.executable, "-c", f"open({str(marker)!r},'w').write('released')"],
+        str(tmp_path), tmp_path / "log", 2)
+    assert assigned == [True]  # actual Popen handle has required Win32 rights
+    assert result["cleanup_evidence"]["confirmed"] is True
+    assert marker.read_text() == "released"
+
+
+@pytest.mark.skipif(not IS_WINDOWS, reason="Windows cancellation checkpoints")
+@pytest.mark.parametrize("stage", ["assignment", "cleanup"])
+def test_recorded_cancellation_is_preserved(tmp_path, monkeypatch, stage):
+    if stage == "assignment":
+        original = delegate._kernel32.AssignProcessToJobObject
+
+        def assign(job, process):
+            result = original(job, process)
+            signal.raise_signal(signal.SIGINT)
+            return result
+
+        monkeypatch.setattr(delegate._kernel32, "AssignProcessToJobObject", assign)
+    else:
+        original = delegate._cleanup_job
+
+        def cleanup(job, helper):
+            signal.raise_signal(signal.SIGINT)
+            return original(job, helper)
+
+        monkeypatch.setattr(delegate, "_cleanup_job", cleanup)
+    marker = tmp_path / "started"
+    result = delegate._run_windows_contained(
+        [sys.executable, "-c", f"open({str(marker)!r},'w').write('started')"],
+        str(tmp_path), tmp_path / "log", 2)
+    assert result["status"] == "errored"
+    assert result["termination_reason"] == "cancelled"
+    assert result["cleanup_evidence"]["confirmed"] is True
+    assert marker.exists() is (stage == "cleanup")
+
+
+@pytest.mark.skipif(not IS_WINDOWS, reason="Windows handle-count regression")
+def test_repeated_runs_do_not_leak_native_handles(tmp_path):
+    import ctypes
+    import gc
+    from ctypes import wintypes
+
+    get_count = delegate._kernel32.GetProcessHandleCount
+    get_count.argtypes = [wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD)]
+    get_count.restype = wintypes.BOOL
+
+    def count():
+        gc.collect()
+        value = wintypes.DWORD()
+        assert get_count(wintypes.HANDLE(-1), ctypes.byref(value))
+        return value.value
+
+    before = count()
+    for iteration in range(4):
+        result = delegate._run_windows_contained([sys.executable, "-c", "pass"],
+                                                  str(tmp_path), tmp_path / str(iteration), 2)
+        assert result["cleanup_evidence"]["confirmed"] is True
+    assert count() <= before
+
+
+@pytest.mark.skipif(not IS_WINDOWS, reason="concurrent Windows Job isolation")
+def test_concurrent_contained_runs(tmp_path):
+    from concurrent.futures import ThreadPoolExecutor
+
+    def run(value):
+        output = tmp_path / str(value)
+        result = delegate._run_windows_contained(
+            [sys.executable, "-c", f"print({value})"], str(tmp_path), output, 3)
+        assert result["cleanup_evidence"]["confirmed"] is True
+        return output.read_text().strip()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        assert list(pool.map(run, [101, 202])) == ["101", "202"]


### PR DESCRIPTION
Windows delegate timeouts previously stopped the command shim while its opencode descendants could keep editing files. Gate worker launch on assignment to a non-breakaway Windows Job Object, then stop and await every owned process before reporting the final repository/transcript evidence on normal exit, timeout, cancellation or error.

Cleanup must prove zero active Job members; otherwise final snapshot fields are unavailable and timeout remains sticky. Unique invocation artifacts prevent simultaneous delegates from sharing logs. The process implementation has independent Claude final SIGN-OFF and Astra integration approval.

Validation:
- Windows real-process suite: 39 passed, 1 Linux-only skip; independently replayed by Astra.
- Ubuntu WSL suite: 14 passed, 26 Windows-only skips.
- Real opencode smoke: completed, clean stop, zero active owned processes, no edits.
- Differential lint: zero new findings across four available tools. Caller/CLI sweep passed.

The full process-tree guarantee is Windows-only. The configured timeout measures worker runtime after gated payload delivery; process creation or a stalled payload write can delay it. No strict whole-launch deadline is claimed. No renderer or native module changes.
