### PR TITLE
docs: record pkg232 delivery and pkg230b pending review

### DIFF
--- a/.astroray_plan/docs/NEXT_STAGE_REPORT.md
+++ b/.astroray_plan/docs/NEXT_STAGE_REPORT.md
@@ -1,31 +1,39 @@
 # Astroray Next Stage Report
 
-## 2026-09-06 CURRENT — owner delegates next-package selection to Astra
+## 2026-09-06 CURRENT — implemented round awaiting final independent review
 
-After pkg230 Phase 2 and #703 completed, the owner explicitly requested another
-implemented package, parallel lower-level backlog work, and a roadmap gap audit.
-This supersedes the previous requirement to stop for an owner choice.
+The owner delegated next-package selection to Astra after pkg230 Phase 2 and
+#703. This round implemented pkg230b and parallel pkg232, and audited the plans.
 
-- **Active delivery: pkg230b** affine Vector Math/Rotate coordinate chains.
-  Astra selected common texture-placement fidelity over the larger Principled
-  arc and specialized caustic/sampling extensions. Architecture independently
-  signed off; implementation, runtime, visual and CI gates remain pending.
-- **Parallel maintenance: pkg232** Windows delegate process containment.
-  Architecture independently signed off; implementation and real process gates
-  remain pending. At most two implementation worktrees; GPU work serialized.
-- New OPEN specifications: pkg241 cancellation/viewport response, pkg242
-  procedural mapping/bake parity, pkg243 raw relative-band output/provenance,
-  and pkg244 compiler-identity/configuration safeguards. All implementation
-  gates UNRUN. Details and coverage exclusions:
-  [production gap audit](production-gap-audit-2026-09-06.md).
-- **Recommended next after this round: pkg241 Phase 0**, measuring response and
-  cancellation latency before choosing its implementation architecture.
-  pkg242 follows pkg230b for procedural fidelity; pkg243 is a lower-priority
-  scientific-output foundation. pkg127 Phase 2 requires topology/spec
-  reconciliation before dispatch; code existence does not prove its gates.
-- Pillar 4 remains PAUSED. The owner delegated priority judgment, not an
-  astrophysics unpause. The completed pkg230 evidence and its two reproduced
-  baseline test failures remain recorded below.
+- **pkg230b: implemented locally, UNCOMMITTED / NOT MERGED.** Affine coordinate
+  chains and image-program cache isolation pass 101 focused tests, six real-RNA
+  probe sets, all 21 CPU/GPU/Cycles render legs, and isolated CPU/CUDA package
+  smokes. Full split suites: **2370 passed, two failures**. HDRI SSIM and PostInit
+  ULP failures reproduce against untouched source with the same fresh native
+  artifact (pkg237/pkg238); the full suite is **NOT green**.
+- **pkg230b release blocker:** independent Claude architecture approval passed,
+  but final source/ABI/parity/visual review has NOT run. Claude's subscription
+  weekly limit resets 2026-09-10 at 13:00 Australia/Sydney. Do not treat earlier
+  architecture approval or Astra visual inspection as final independent sign-off.
+  Preserve `codex/pkg230b` in `.claude/worktrees/pkg230b`; do not redispatch it.
+- **pkg232 LANDED in PR #705**, merge `d997c499` at 2026-09-05 18:50:24 UTC.
+  Windows Job containment passed 39 Windows tests, 14 actual-Linux tests, real
+  opencode smoke, caller review and independent Claude source SIGN-OFF. Both CI
+  runs passed host tests (2088 passed each) and CUDA syntax checks. Do not redispatch.
+- **Merged specifications:** pkg241–244 in #704 and pkg245 in #706. Their
+  implementation gates remain UNRUN. Three further local **DRAFT** specs,
+  pkg246 spectral RGB reconstruction, pkg247 launch-timeout boundary, and pkg248
+  content-change evidence, await independent filing review and are NOT dispatch
+  eligible. They remain in `.claude/worktrees/pkg230-followups`.
+- **Next after pkg230b closes: pkg241 Phase 0**, measuring render cancellation
+  and viewport response before implementation architecture. pkg242 follows for
+  procedural mapping fidelity; pkg243 preserves scientific output provenance.
+  pkg127 Phase 2 still requires topology/spec reconciliation before dispatch.
+- **Pillar 4 remains PAUSED.** GPU verification is finished and the GPU lock is
+  released. The user's live Blender profile was not used by this round's tests.
+
+Actual gates, retained failure evidence, reviewed filings and resumption state:
+[round delivery status](round-20260906-delivery-status.md).
 
 ---
 

--- a/.astroray_plan/docs/ROADMAP.md
+++ b/.astroray_plan/docs/ROADMAP.md
@@ -130,21 +130,28 @@ Full evidence:
 scalar parameter textures remain landed (#674); pkg210 is SUPERSEDED and pkg180
 CLOSED.
 **Owner update 2026-09-06:** next-package priority is delegated to Astra, with
-parallel lower-level backlog work and an evidence-backed roadmap gap audit.
-The current round selects **pkg230b affine coordinate chains**, alongside
-**pkg232 delegate containment**; both architectures are independently signed
-off and implementation/verification is in progress. Common texture-placement
-fidelity is the bounded next Blender gain; the larger Principled arc and
-specialized caustic/sampling extensions remain future work.
+parallel lower-level backlog and a roadmap gap audit. The round implemented
+**pkg230b affine coordinate chains** locally and shipped **pkg232 delegate
+containment** in PR #705 (`d997c499`; independent approval, both host/CUDA CI runs
+passed). Common texture placement outranked the larger Principled arc and
+specialized caustic/sampling extensions.
 
-After this round, **pkg241 Phase 0 cancellation/viewport-response measurement**
-is the recommended next pickup, followed by pkg242 procedural mapping/bake
-parity. pkg243 preserves raw relative-band output as a lower-priority scientific
-foundation. pkg244 records the reproduced compiler-identity/cache-reset build
-defect separately from pkg231 latency and pkg240 CI cost. These new specs are
-OPEN, with implementation gates UNRUN; see the
-[production gap audit](production-gap-audit-2026-09-06.md). pkg127 Phase 2 needs
+Pkg230b remains **uncommitted/unmerged**: 2370 local tests passed and two native
+failures reproduced against untouched source; all 21 CPU/GPU/Cycles chart legs
+and both isolated package smokes passed. The full suite is NOT green. Required
+Claude final source/ABI/parity/visual review is blocked by its weekly subscription
+limit (reported reset 2026-09-10 13:00 Australia/Sydney). Architecture approval
+alone is not release approval. Do not duplicate-dispatch pkg230b.
+
+After pkg230b closes, **pkg241 Phase 0 cancellation/viewport-response measurement**
+is next, followed by pkg242 procedural mapping/bake parity. pkg243 preserves raw
+relative-band output; pkg244 covers compiler-identity/cache-reset safeguards;
+pkg245 covers normal/bump coordinate provenance. Specs pkg241–245 are merged
+(#704/#706), OPEN with implementation gates UNRUN. Local pkg246–248 drafts await
+independent filing review and are NOT dispatch eligible. pkg127 Phase 2 needs
 reconciliation against existing pkg227 topology and gates before dispatch.
+See the [production gap audit](production-gap-audit-2026-09-06.md) and
+[round delivery status](round-20260906-delivery-status.md).
 **Pillar 4 remains PAUSED**; priority delegation does not unpause astrophysics.
 
 **Explicitly de-prioritized (owner-endorsed):** the sub-percent GPU/CPU

--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -1,31 +1,39 @@
 # Astroray Status
 
-## 2026-09-06 CURRENT — owner delegates next-package selection to Astra
+## 2026-09-06 CURRENT — implemented round awaiting final independent review
 
-After pkg230 Phase 2 and #703 completed, the owner explicitly requested another
-implemented package, parallel lower-level backlog work, and a roadmap gap audit.
-This supersedes the previous requirement to stop for an owner choice.
+The owner delegated next-package selection to Astra after pkg230 Phase 2 and
+#703. This round implemented pkg230b and parallel pkg232, and audited the plans.
 
-- **Active delivery: pkg230b** affine Vector Math/Rotate coordinate chains.
-  Astra selected common texture-placement fidelity over the larger Principled
-  arc and specialized caustic/sampling extensions. Architecture independently
-  signed off; implementation, runtime, visual and CI gates remain pending.
-- **Parallel maintenance: pkg232** Windows delegate process containment.
-  Architecture independently signed off; implementation and real process gates
-  remain pending. At most two implementation worktrees; GPU work serialized.
-- New OPEN specifications: pkg241 cancellation/viewport response, pkg242
-  procedural mapping/bake parity, pkg243 raw relative-band output/provenance,
-  and pkg244 compiler-identity/configuration safeguards. All implementation
-  gates UNRUN. Details and coverage exclusions:
-  [production gap audit](production-gap-audit-2026-09-06.md).
-- **Recommended next after this round: pkg241 Phase 0**, measuring response and
-  cancellation latency before choosing its implementation architecture.
-  pkg242 follows pkg230b for procedural fidelity; pkg243 is a lower-priority
-  scientific-output foundation. pkg127 Phase 2 requires topology/spec
-  reconciliation before dispatch; code existence does not prove its gates.
-- Pillar 4 remains PAUSED. The owner delegated priority judgment, not an
-  astrophysics unpause. The completed pkg230 evidence and its two reproduced
-  baseline test failures remain recorded below.
+- **pkg230b: implemented locally, UNCOMMITTED / NOT MERGED.** Affine coordinate
+  chains and image-program cache isolation pass 101 focused tests, six real-RNA
+  probe sets, all 21 CPU/GPU/Cycles render legs, and isolated CPU/CUDA package
+  smokes. Full split suites: **2370 passed, two failures**. HDRI SSIM and PostInit
+  ULP failures reproduce against untouched source with the same fresh native
+  artifact (pkg237/pkg238); the full suite is **NOT green**.
+- **pkg230b release blocker:** independent Claude architecture approval passed,
+  but final source/ABI/parity/visual review has NOT run. Claude's subscription
+  weekly limit resets 2026-09-10 at 13:00 Australia/Sydney. Do not treat earlier
+  architecture approval or Astra visual inspection as final independent sign-off.
+  Preserve `codex/pkg230b` in `.claude/worktrees/pkg230b`; do not redispatch it.
+- **pkg232 LANDED in PR #705**, merge `d997c499` at 2026-09-05 18:50:24 UTC.
+  Windows Job containment passed 39 Windows tests, 14 actual-Linux tests, real
+  opencode smoke, caller review and independent Claude source SIGN-OFF. Both CI
+  runs passed host tests (2088 passed each) and CUDA syntax checks. Do not redispatch.
+- **Merged specifications:** pkg241–244 in #704 and pkg245 in #706. Their
+  implementation gates remain UNRUN. Three further local **DRAFT** specs,
+  pkg246 spectral RGB reconstruction, pkg247 launch-timeout boundary, and pkg248
+  content-change evidence, await independent filing review and are NOT dispatch
+  eligible. They remain in `.claude/worktrees/pkg230-followups`.
+- **Next after pkg230b closes: pkg241 Phase 0**, measuring render cancellation
+  and viewport response before implementation architecture. pkg242 follows for
+  procedural mapping fidelity; pkg243 preserves scientific output provenance.
+  pkg127 Phase 2 still requires topology/spec reconciliation before dispatch.
+- **Pillar 4 remains PAUSED.** GPU verification is finished and the GPU lock is
+  released. The user's live Blender profile was not used by this round's tests.
+
+Actual gates, retained failure evidence, reviewed filings and resumption state:
+[round delivery status](round-20260906-delivery-status.md).
 
 ---
 

--- a/.astroray_plan/docs/round-20260906-delivery-status.md
+++ b/.astroray_plan/docs/round-20260906-delivery-status.md
@@ -1,0 +1,117 @@
+# Delivery round status — 2026-09-06
+
+This is a factual handoff, not final approval of pkg230b or a new scope decision.
+The owner requested another implementation after pkg230 Phase 2, parallel lower
+backlog, and specifications for production gaps. Pillar 4 remains PAUSED.
+
+## Delivered and pending work
+
+| Work | Actual state |
+| --- | --- |
+| pkg230 Phase 2, previous round | Landed #701, closeout #703; do not repeat |
+| pkg230b affine coordinate chains | Implemented locally; uncommitted/unpushed; final independent review pending |
+| pkg232 Windows delegate containment | LANDED #705, `d997c499`, 2026-09-05 18:50:24 UTC |
+| pkg241–244 production/build specs | Filed and merged #704; implementation gates UNRUN |
+| pkg245 normal/bump coordinate provenance | Filed and merged #706; implementation gates UNRUN |
+| pkg246–248 reconstruction/delegate follow-ups | Local DRAFT specs; independent filing review pending; not dispatch eligible |
+
+## pkg230b evidence and limitations
+
+The addon folds bounded affine Vector Math and constant Rotate chains into the
+existing mapping matrix. Coordinate provenance and transform resolve together;
+programs sharing an image retain independent parent mappings. No native source,
+ABI/layout, spectral transport or physical model changed. Unsupported procedural
+transforms and incompatible per-image program coordinates warn explicitly.
+
+- Focused tests: 101 passed, one native-binding skip; 45 new semantic tests.
+- Real Blender RNA: six chains, three points each, maximum absolute transform
+  error 1.074934e-7 against a 1e-6 gate.
+- Final visual set: seven cases across CPU-only, RTX5070Ti CUDA and Cycles,
+  128x128, 256 spp, seed 7, linear float32, Closest/Extend, denoise/adaptive off.
+  All 21 legs meet chart gates and Astra qualitative inspection. Maximum RGB
+  mean deviation from Cycles 3.486% (5% gate), GPU/CPU 0.120%; minimum
+  nonidentity effect MAD 0.05593 (>0.01 gate).
+- Fresh CPU and CUDA native builds from source-identical cache `4035a00`:
+  intended import paths confirmed, host ABI canaries pass, CUDA embeds sm_120
+  only. The initial failed CMake reconfigure is retained for pkg244.
+- Both staged CPU/CUDA packages passed actual isolated Blender smoke checks.
+  Pre-staging dependency probes emitted DLL import errors and are not counted
+  as passes. Full runtime/packaged Blender checks used the required dependencies.
+- CPU split: 1687 passed, 56 skipped, 9 xfailed (815.68 s). Serial split:
+  683 passed, two failed, 19 skipped, 9 xfailed, 5 xpassed (638.81 s).
+  Combined **2370 passed, two failures; full suite NOT green**. Skips and
+  xpasses remain explicit; separate manual renders do not cover every skip.
+- HDRI SSIM: feature 0.7642104, untouched baseline 0.7654136, gate >=0.97
+  (pkg237). PostInit: feature and baseline 13 ULP, gate <=4 (pkg238).
+  Both reproduced using the same fresh native artifact on untouched source.
+  They do not traverse the addon resolver; reproduction is not a waiver.
+- Caller/binding sweep and whole-diff lint: zero new findings, four applicable
+  tools. Final documentation lint: zero new findings, three tools.
+
+Initial Repeat-vs-clamp reference failures remain in `initial-repeat-extension/`.
+Matching Extend left two strongly clamped red-channel residuals (7.94%/13.04%).
+Untouched-addon equivalent Mapping reproduces mirror exactly and arithmetic at
+MAD 3.096e-8. The clamped cases remain saved in `clamped-extend-baseline/`;
+final in-domain charts improve visible pattern coverage without relaxing gates.
+Existing-LUT quadrature correlates with those residuals, but does not establish
+their full physical cause. Draft pkg246 defines a separate contract audit.
+
+Evidence is retained in root `test_results/pkg230b/`: `delivery-evidence.md`,
+`source-manifest.json`, `comparison-metrics.json`, `representative-comparison.png`,
+full 21-tile sheet, raw arrays/logs, real-RNA probes, full-suite logs/XML,
+`current-baseline-failures.*`, native identities and staged-package smokes.
+The primary worktree retains the implementation and its detailed specification.
+
+## pkg232 independent evidence
+
+Reviewed source commit `32458d64be8ed444df63f3fdbf49339b467702bc` uses a Windows
+Job with KILL_ON_JOB_CLOSE and a helper blocked until exact-handle assignment.
+Cleanup confirms zero owned processes before final snapshot evidence. Unknown
+cleanup yields explicitly unavailable evidence; no broad process-name kills.
+
+Windows: 39 passed, one platform skip, independently replayed by parent.
+Actual Ubuntu WSL: 14 passed, 26 Windows-only skips. Real opencode smoke completed
+in 58.9 s with confirmed cleanup/zero active processes. Independent Claude final
+source SIGN-OFF predates the subscription limit; its actual-Linux condition is
+satisfied by WSL and CI. The canonical timeout remains a worker-runtime budget
+starting after synchronous payload delivery; draft pkg247 owns the launch gap.
+Draft pkg248 owns content changes missed by porcelain-status-only snapshots.
+
+Push CI: 2088 passed, 269 skipped, 14 xfailed, 5 xpassed; host and CUDA syntax
+checks passed. PR CI: 2088 passed, 269 skipped, 15 xfailed, 4 xpassed; host and
+CUDA syntax checks passed, including actual non-Windows runtime. Run IDs:
+33983634230 (push), 33983636316 (PR). PR #705 merged at 2026-09-05 18:50:24 UTC,
+commit `d997c499203e6e4b7493d8377e887c435e86c6bf`. No renderer code changed.
+Root `test_results/pkg232/` retains reviewed source hashes, Windows/Linux logs,
+real-process evidence, final Claude review and GitHub CI logs.
+
+## Plans and exact resumption boundary
+
+The merged [production gap audit](production-gap-audit-2026-09-06.md) explains
+pkg241 cancellation/response, pkg242 procedural mapping, pkg243 relative-band
+provenance, and pkg244 build configuration. Pkg245 adds the independently reviewed
+normal/bump coordinate and tangent-basis contract. None is implemented here.
+
+Local drafts in `.claude/worktrees/pkg230-followups/.astroray_plan/packages/`:
+`pkg246-spectral-rgb-roundtrip-contract.md`,
+`pkg247-delegate-launch-timeout-boundary.md`, and
+`pkg248-delegate-content-change-evidence.md`. All three passed Astra scope/link
+review and differential lint; independent filing review remains pending. The
+pkg248 disposable-repository probe reproduced both same-status edits and
+dirty-to-clean reverts missing from `files_changed`, without live-index mutation.
+
+Claude reports its weekly subscription limit resets **2026-09-10 at 13:00
+Australia/Sydney**. Pkg230b's final source/ABI/parity/visual review has not run.
+Earlier architecture approval and Astra visual inspection do not satisfy it.
+Keep the uncommitted worktree `codex/pkg230b` intact; complete required independent
+review, adjudicate unresolved gates, then follow the authorized delivery workflow.
+No CI or merge result exists for pkg230b. Do not duplicate its implementation.
+
+After that closure, **pkg241 Phase 0** is the next eligible package: measure
+cancellation/viewport response before choosing the implementation. pkg242 follows
+for texture fidelity. Pkg127 Phase 2 needs topology/spec reconciliation first.
+No paused astrophysics package was resumed.
+
+GPU verification is complete; the lock was released. Both implementation agents
+and the documentation delegate have stopped. The user's live Blender profile and
+pre-existing untracked files were preserved by this round.

--- a/.astroray_plan/packages/pkg230b-vector-coordinate-chain.md
+++ b/.astroray_plan/packages/pkg230b-vector-coordinate-chain.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 5 (Blender integration / shader-node coverage)
 **Track:** A
-**Status:** OPEN — detailed architect review required before dispatch
+**Status:** IN PROGRESS — implemented locally; independent final review pending
 **Estimated effort:** M
 **Depends on:** pkg219a, pkg230 Phase 2
 
@@ -78,4 +78,18 @@ or independent per-image program coordinates. The latter require their own
 architecture if real usage warrants them.
 
 Independent Claude review (2026-09-05): SIGN-OFF to file this bounded future
-spec. Detailed implementation readiness and every acceptance gate remain pending.
+spec. At filing, detailed implementation readiness and every acceptance gate
+were pending; the current delivery state below supersedes that factual status.
+
+## Current delivery state — 2026-09-06
+
+Architecture SIGN-OFF received; implementation and local verification completed
+in `codex/pkg230b`, worktree `.claude/worktrees/pkg230b`. Source remains
+uncommitted/unpushed pending required independent final review. Full split tests:
+2370 passed, two reproduced native baseline failures (pkg237/pkg238); NOT green.
+All 21 CPU/GPU/Cycles comparison legs and isolated CPU/CUDA package smokes passed
+Astra inspection. Claude's weekly subscription limit blocks final source/ABI/
+parity/visual review; reported reset 2026-09-10 13:00 Australia/Sydney.
+Do not redispatch. The detailed implementation specification and full evidence
+are retained in that worktree; factual handoff:
+[round delivery status](../docs/round-20260906-delivery-status.md).

--- a/.astroray_plan/packages/pkg232-delegate-timeout-process-tree.md
+++ b/.astroray_plan/packages/pkg232-delegate-timeout-process-tree.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 5
 **Track:** A
-**Status:** verified locally — independent final source sign-off and parent integration passed; CI/delivery pending
+**Status:** DONE — PR #705 merged 2026-09-06 Sydney
 **Estimated effort:** one bounded maintenance slice
 **Depends on:** none
 **Dispatch authority:** owner instruction 2026-09-06 authorizes parallel lower-level backlog; parent selected pkg232 in isolated worktree codex/pkg232 at 305caf5.
@@ -187,7 +187,7 @@ process supervisor or imply that an escaped/brokered process is contained.
 ## Progress
 
 - [x] Detailed architecture reviewed by Astra and independent Claude (2026-09-06).
-- [x] Implementation and scoped Windows gates complete (2026-09-06); CI and final review remain explicit gates.
+- [x] Implementation, Windows/Linux gates, independent final review and CI complete; PR #705 merged.
 Independent Claude filing review: SIGN-OFF TO FILE ONLY, 2026-09-06.
 Evidence: `test_results/pkg232-235/claude-filing-review.txt`.
 
@@ -234,7 +234,8 @@ Evidence in the pkg232 worktree under `test_results/pkg232/`:
 `focused.xml`, `lint.log`, `real-opencode-smoke.json`, `caller-signatures.json`,
 `caller-sweep.txt`, `source-manifest.json`, `non-windows-tests.log`, and
 `non-windows.xml`. `final-claude.txt` records independent final SIGN-OFF
-conditional on parent integration/CI and actual Linux verification (now run). No commit, push, PR, CI success or merge is claimed here.
+conditional on parent integration/CI and actual Linux verification; all conditions
+are now fulfilled by the evidence above and release record below.
 
 Parent integration raised a separate launch-latency edge after final source
 review: the configured worker timeout starts after synchronous stdin payload
@@ -249,3 +250,21 @@ reviewed architecture and required this explicit limitation in the spec and
 SKILL. The process implementation remains byte-identical to final-reviewed
 source. Bounded startup/payload delivery remains future hardening, outside this
 package's containment fix; no full-launch deadline is claimed.
+
+## Release record — 2026-09-06 Sydney
+
+PR #705 merged at 2026-09-05 18:50:24 UTC, commit
+`d997c499203e6e4b7493d8377e887c435e86c6bf`. Reviewed source commit
+`32458d64be8ed444df63f3fdbf49339b467702bc` remained unchanged through delivery.
+Both CI runs passed host build/tests and CUDA syntax checks:
+
+- Push 33983634230: 2088 passed, 269 skipped, 14 xfailed, 5 xpassed.
+- PR 33983636316: 2088 passed, 269 skipped, 15 xfailed, 4 xpassed; actual
+  `test_non_windows_actual_runtime` passed.
+
+Root `test_results/pkg232/ci-push.log`, `ci-pr.log`, source manifest and independent
+review retain the evidence. No renderer/visual behavior changed; no GPU runtime
+result is claimed for this maintenance package. The worker-runtime timeout
+boundary remains explicit above; local DRAFT pkg247 covers startup/payload time.
+Local DRAFT pkg248 covers content-aware snapshots; neither draft is approved for
+implementation. Do not redispatch pkg232.


### PR DESCRIPTION
The live plans still described pkg230b/pkg232 as awaiting implementation. Record pkg232's completed delivery in #705 and pkg230b's actual local evidence: 2370 passed, two reproduced native baseline failures, 21 passing CPU/GPU/Cycles chart legs, and isolated CPU/CUDA package smokes. Pkg230b remains uncommitted/unmerged because required final independent Claude review is blocked by its subscription limit; architecture approval is not final source approval.

This is a factual planning closeout: six documentation files only. It records the five reviewed specs already merged in #704/#706 and the existence of three local unreviewed drafts; none of those drafts or pkg230b's source is included. Next remains pkg241 Phase 0 after pkg230b closure; Pillar 4 remains paused.

Validation: Astra checked the source/evidence manifests, Windows/Linux process gates, final independent pkg232 sign-off and both green CI runs (2088 host tests passed each plus CUDA syntax). Differential documentation lint: zero new findings, all three applicable tools available. No callable signatures or renderer behavior changed in this PR.