### PR TITLE
feat(pkg230b): preserve affine texture coordinates and program cache identity

### DIFF
--- a/.astroray_plan/docs/pkg230b-delivery-evidence.md
+++ b/.astroray_plan/docs/pkg230b-delivery-evidence.md
@@ -1,0 +1,156 @@
+# pkg230b — affine coordinate delivery evidence
+
+Status: implemented and locally verified with two reproduced baseline failures;
+**REVIEW APPROVED; delivery and CI pending**. Independent Claude architecture review passed.
+On 2026-09-06 the owner approved commit/merge and explicitly authorized Terra or
+DeepSeek independent review while Claude is unavailable. Terra final review
+returned SIGN-OFF after source/caller/binding and visual inspection.
+Full-suite results remain recorded below; the full suite is NOT green.
+
+## Implementation and architectural limits
+
+One bounded addon resolver carries coordinate provenance and the affine matrix
+together. It supports ADD/SUBTRACT/MULTIPLY/SCALE with at most one varying vector,
+all five constant-control Rotate modes, centered inverse rotations, Mapping order,
+zero/mirrored scales, linked constants, stable RNA node identity and finite native
+matrix values. Unlinked Mapping Vector sockets use Blender's constant semantics.
+
+Image cache identities preserve small edits and named UV layers. Image programs
+receive isolated identity child samplers for each parent mapping; unsupported
+per-input program coordinate differences warn. Procedural transformed-p behavior
+remains under pkg242, normal/bump provenance under pkg245, and image filtering /
+extension behavior under pkg234. No C++/CUDA, ABI/layout, transport, spectral or
+scientific-output code changed. Pillar4 remains PAUSED.
+
+## Focused and real Blender evidence
+
+- 45 new coordinate tests; 101 focused mock tests passed, one native-binding skip.
+- Six real Blender 5.1 RNA chains, three point probes each, matched independent
+  `mathutils`/arithmetic expectations within absolute/relative 1e-6. Maximum
+  absolute error 1.074934e-7; UV provenance retained; no fallback warnings.
+- Final 21 render legs: seven cases across CPU-only Astroray, RTX5070Ti CUDA
+  Astroray and Cycles, 128x128, 256 spp, seed7, linear float32, denoise/adaptive
+  off. Closest + Extend are explicit common supported settings. The arithmetic
+  and mirror charts stay within the image domain so the nonuniform pattern
+  demonstrates placement rather than mostly sampling one clamped texel.
+- ROI [16:112,16:112]; per-channel mean ratio gate [0.95,1.05], transformed/control
+  mean absolute difference gate >0.01. Every final case passes. Maximum deviation
+  from Cycles is 3.486%; maximum GPU/CPU deviation 0.120%; minimum nonidentity
+  effect MAD 0.05593. These are bounded chart gates, not universal Cycles parity.
+
+| Case | Max RGB deviation vs Cycles | Max GPU/CPU deviation | Min effect MAD |
+| --- | --- | --- | --- |
+| plain | 1.940% | 0.120% | 0.00000 |
+| arithmetic | 3.486% | 0.080% | 0.11370 |
+| euler | 1.873% | 0.099% | 0.05593 |
+| axis | 1.754% | 0.095% | 0.05760 |
+| mirror | 1.828% | 0.050% | 0.08651 |
+| program | 1.759% | 0.098% | 0.07430 |
+| shared_programs | 1.373% | 0.082% | 0.07078 |
+
+Astra qualitative review: PASS for transform placement, centered rotation, mirror
+orientation and independently mapped materials sharing one image. Minor spectral
+color differences remain. Claude final visual review is **PENDING**.
+
+![Representative CPU/GPU/Cycles comparison](../../test_results/pkg230b/representative-comparison.png)
+
+Full sheet: `test_results/pkg230b/cpu-gpu-cycles-comparison.png`.
+Metrics and raw float arrays are retained beside it.
+
+## Failed references were investigated, not discarded
+
+The first fixtures used Cycles Repeat while native image samplers clamp. The
+large spatial/mean differences remain saved in `initial-repeat-extension/`.
+Matching Extend fixed the extension mismatch; two strongly clamped fixtures still
+failed the 5% red-channel gate (arithmetic 7.94%, mirror 13.04%). Those cases and
+comparisons remain in `clamped-extend-baseline/`.
+
+The untouched prior addon (4035a00) with equivalent ordinary Mapping nodes
+reproduces them: mirror is pixel-identical; arithmetic image MAD is 3.096e-8
+(max pixel difference 0.001174). Thus this behavior predates pkg230b. A separate
+non-render numerical reconstruction using existing spectral LUT/CIE1964/D65 data
+predicted red ratios 1.07562 / 1.12618, close to the rendered 1.079 / 1.130.
+That is corroboration of shared spectral round-trip bias, not proof of its full
+underlying cause. Spectral/color-contract investigation is drafted as pkg246,
+pending independent filing review and not dispatch eligible;
+no ad-hoc compensation or tolerance relaxation was added here.
+
+The final in-domain charts improve visual sensitivity to mirroring and arithmetic.
+All affected CPU/GPU/Cycles legs were rerun; unchanged rotation/plain/program legs
+retain their matching Extend outputs. This does not turn the saved out-of-domain
+failures into passing cases or waive their remaining limitations.
+
+## Native build and packaging identity
+
+Native cache: `.claude/worktrees/pkg230-p2` at 4035a00. Native sources are identical
+to primary base305caf5 and this addon-only diff. Layout-header hash matches both
+worktrees and the existing cache stamp. Both stale modules were rebuilt before
+GPU verification, with explicit intended import paths:
+
+- CPU: build ID `4035a00+20260905T173933Z`, CUDA/OpenMP false, ABI canary PASS.
+- CUDA: build ID `4035a00+20260905T173857Z`, CUDA/wavefront true, OpenMP false,
+  Release; ABI canary PASS; cuobjdump proves embedded sm_120 only.
+- Native build files, module identities and timestamps are captured under
+  `test_results/pkg230b/fresh-*-*.{json,log}` in the root workspace. CUDA work is
+  serialized under the project GPU lock. No post-commit rebuild is claimed.
+
+An initial CUDA reconfigure failed after a case-only compiler-path change reset
+Release/native/OpenMP settings. The corrected rebuild restored the intended flags;
+the failed log remains evidence for pkg244, not a successful build claim.
+
+Canonical staging produced CPU/CUDA zip archives with the current addon hash
+`450a64f87743967c77fd970bd8608df6b2d34ba70a53a6dc97538ed250238d8e`.
+Its pre-staging probe emitted missing-DLL warnings; these probes did not pass.
+Successful native import/canary and real-Blender legs used the full dependency
+setup. Both actual staged packages passed isolated Blender smoke verification:
+
+- CPU archive extracted under this worktree: canonical pkg175 smoke PASS,
+  finite 96x96 RGB, mean luminance 0.117186, nonblack fraction 1.0.
+- CUDA staging installed only into the isolated test profile: canonical
+  `test_dev_loop_smoke_local_host` PASS (8.640 s); installed addon hash and native
+  build ID match the records above.
+
+Evidence: `cpu-package-smoke.log`, `isolated-install-identity.json`,
+`staged-artifacts.json`, and serial JUnit XML. Nothing was installed into the
+live profile. All five Blender user-path variables were redirected for tests.
+
+## Full tests, callers, lint and delivery
+
+Canonical split-suite results against the explicitly selected fresh CUDA native
+artifact (CPU tests use its CPU rendering path):
+
+- CPU lane: **1687 passed, 56 skipped, 9 xfailed**, 815.68 s.
+- Serial lane: **683 passed, 2 failed, 19 skipped, 9 xfailed, 5 xpassed**,
+  1749 deselected, 638.81 s. The deselected tests belong to the other lane.
+- Combined: **2370 passed, 2 failed**. The full suite is **NOT green**. Skips
+  include missing local standalone/harness artifact discovery and optional
+  dependencies; the 21 explicit Blender comparison legs and package smokes above
+  supply their own evidence, not blanket coverage of skipped tests.
+
+Both failures were replayed against untouched addon/native source `4035a00`
+with the SAME fresh native artifact and reproduced in 6.54 s:
+
+| Test | pkg230b result | Untouched baseline | Gate |
+| --- | --- | --- | --- |
+| `test_gpu_cpu_ssim_hdri` (pkg237) | 0.7642104 | 0.7654136 | SSIM >= 0.97 |
+| `test_cpu_to_gpu_threshold_gate` (pkg238) | 13 | 13 | PostInit ULP <= 4 |
+
+These native-only scene/init paths do not consume the addon coordinate resolver.
+This establishes baseline reproduction, not a waiver or independent final
+adjudication. Logs/XML: `full-cpu`, `full-serial`, and root-workspace
+`current-baseline-failures`; machine-readable summary: `full-suite-summary.json`.
+
+Existing callable signatures remain compatible. Parent integration inspected
+image/program/procedural callers and native matrix bindings; the normal/bump
+routing loss was filed separately as pkg245. Differential whole-diff lint passed
+with zero new findings across all four applicable tools; public signatures remain
+unchanged. Final documentation lint is retained with the same evidence.
+
+Owner-authorized independent Terra final review returned SIGN-OFF. It found the
+two native-only baseline failures do not block this addon package under the
+owner's accepted-risk directive. Neither failure is waived or closed, and the
+full suite remains NOT green. The reviewer inspected both saved comparison
+sheets and confirmed correct placement, rotations, mirroring and distinct shared
+program mappings. Review: root `test_results/pkg230b/final-terra-review.txt`.
+All five source/test manifest hashes remain exact; documentation hashes were
+refreshed after recording approval. CI and final merge are recorded at closeout.

--- a/.astroray_plan/packages/pkg230b-vector-coordinate-chain.md
+++ b/.astroray_plan/packages/pkg230b-vector-coordinate-chain.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 5 (Blender integration / shader-node coverage)
 **Track:** A
-**Status:** OPEN — detailed architect review required before dispatch
+**Status:** IN PROGRESS — Terra final SIGN-OFF; delivery and CI pending
 **Estimated effort:** M
 **Depends on:** pkg219a, pkg230 Phase 2
 
@@ -13,9 +13,11 @@ Its audit of base `31f3029` found that the same nodes *before* an image lookup
 silently returned the default coordinates. Phase 2 adds a visible warning;
 this follow-up adds support for a bounded affine subset.
 
-This package does not outrank the owner's post-pkg230 choice in STATUS,
-NEXT_STAGE_REPORT and ROADMAP. It neither unpauses Pillar 4 nor introduces a
-universal coordinate VM. Confirm current source-package status before dispatch.
+The owner delegated next-package selection to Astra on 2026-09-06 after #703.
+This round selects pkg230b for common Blender texture-placement fidelity, ahead
+of specialized caustics/sampling extensions and the larger Principled arc.
+pkg219a and pkg230 Phase 2 are landed; base `305caf5`, no open PRs at selection.
+Pillar 4 remains PAUSED; no universal coordinate VM is introduced.
 
 ## Proposed scope
 
@@ -36,9 +38,10 @@ Trace all consumers before implementation:
 
 - Image textures: `load_blender_image`, `_resolve_vector_input`,
   `_resolve_mapping_matrix`, `_apply_texture_transform`, `_texture_variant_key`.
-- Procedural textures: `load_procedural_texture` uses the same coordinate
-  resolver but currently applies only the older 2D transform. A full-affine
-  implementation must wire both its transform application and cache key.
+- Procedural textures: `load_procedural_texture` currently applies only the
+  older 2D transform, while native evaluation leaves procedural p unchanged.
+  This addon-only phase warns for new unrepresentable affine chains; full 3D
+  mapping and bake/cache integration belong to the separate native follow-up.
 - Program textures: `_maybe_build_program_texture` takes coordinates from the
   first image input. Preserve/document differing child-image mapping limits.
 
@@ -49,7 +52,7 @@ include small numeric edits that the current four-decimal matrix key can alias.
 Candidate implementation ownership is `blender_addon/__init__.py` plus focused
 resolver/cache tests. Inspect real call paths before fixing the file list.
 
-## Acceptance (all UNRUN)
+## Acceptance (results in delivery evidence)
 
 The detailed architect pass must pin numerical tolerances before implementation.
 
@@ -63,7 +66,8 @@ The detailed architect pass must pin numerical tolerances before implementation.
 - No GMaterial growth or new universal shader specialization. If engine code is
   needed, use fresh native builds, intended import path, GPU lock and linked
   kernel resource checks; addon-only changes still require visual review.
-- Full tests, caller/binding sweep and independent Claude sign-off.
+- Full tests, caller/binding sweep and independent sign-off (Terra authorized by
+  the owner on 2026-09-06 while Claude is unavailable).
 
 ## References and limits
 
@@ -79,3 +83,127 @@ architecture if real usage warrants them.
 
 Independent Claude review (2026-09-05): SIGN-OFF to file this bounded future
 spec. Detailed implementation readiness and every acceptance gate remain pending.
+
+
+## Implementation decision — 2026-09-06
+
+This is an addon-only coordinate translation package. Reuse the existing 3x4
+matrix binding and shared native image/program sampler. No C++/CUDA, GMaterial,
+ABI, specialization, spectral transport or scientific-output changes.
+
+### Resolver contract
+
+- Introduce one bounded affine-chain resolver shared by the coordinate-source
+  and matrix wrappers, keeping existing public helper signatures compatible.
+  Return provenance (coordinate mode and UV layer) together with the matrix so
+  they cannot follow different upstream operands. Preserve ordinary Mapping
+  behavior and the legacy five-field wrapper used by tests/older callers.
+- Support ADD, SUBTRACT, component-wise MULTIPLY and SCALE with at most one
+  varying vector. Read duplicate Vector sockets by position; read only active
+  operands. Preserve constant-minus-varying order. Fold unlinked constants and
+  simple linked VALUE/RGB/constant Combine XYZ where straightforward; reject
+  unsupported linked controls instead of reading their unused socket defaults.
+- Rotate supports AXIS_ANGLE, X/Y/Z and EULER_XYZ with constant controls, a
+  nonzero center and invert. Compose T(center) R T(-center) with the upstream
+  affine. Euler inverse is transpose; axis inverse negates the angle; zero
+  axis is identity. Normative reference remains pinned Cycles v5.1.0.
+- Mapping composition is outer @ inner. An unlinked Mapping Vector uses its
+  actual constant default, matching pinned Cycles `MappingNode::constant_fold`
+  in `shader_nodes.cpp` and Blender `node_shader_mapping.cc` socket declaration;
+  tests intending a varying source must link UV explicitly. This corrects the
+  old implicit-UV approximation while retaining the five-tuple wrapper shape.
+  Zero/mirror affine scales are valid.
+  Preserve identity cancellation and tiny edits (do not use approximate
+  identity detection that erases a meaningful transform). Handle a singular
+  inverse Mapping without an uncaught exception: use pinned Cycles safe-divide
+  semantics if representable, otherwise report a visible fallback. NORMAL
+  mapping involves normalization; preserve and report its bounded existing
+  approximation instead of claiming a general affine representation.
+- Bound traversal and detect cycles by node identity along the current path.
+  Unsupported operations, multiple varying sources, invalid controls, cycles,
+  and depth exhaustion warn with the rejected node and fallback behavior.
+  Valid outer Mapping operations may remain on the explicit fallback, matching
+  the existing degradation contract; do not silently take the first operand.
+
+### Consumers and cache identity
+
+- Bare images receive resolved provenance and full affine matrix. Keys retain
+  sufficient float precision to distinguish edits below 0.0001 and include
+  mode, named UV layer and mapping. Exact identity may share the plain image.
+- Image-program coordinates come from the first image input. Verify remaining
+  image coordinate signatures; differing mappings must visibly degrade rather
+  than silently sample the first mapping. Do not add a per-input coordinate VM.
+- GPU upload deduplicates by child ImageTexture pointer but carries the parent
+  ProgramTexture mapping in that descriptor (`scene_upload.cu:829-848`). Allocate
+  distinct plain child samplers/cache variants for distinct parent coordinate
+  signatures; child coordinates remain identity to avoid double transformation.
+  This fixes same-image/different-program mapping aliasing without native edits.
+- Procedural exception: native Texture::value/sampleSpectral currently transform
+  UV only, passing original p to 3D procedural evaluation
+  (`advanced_features.h:177-194,249-258`). Setting a matrix alone cannot implement
+  the requested 3D transform. Preserve the existing procedural path and emit an
+  explicit warning for new affine chains it cannot honor. Do not claim these
+  consumers support full affine mapping. A separate procedural mapping/bake
+  parity package will own the native change and cache/bake-domain integration.
+- Missing matrix bindings must emit a visible degradation, rather than silently
+  treating a full-affine transform as identity or its partial 2D projection.
+
+### Ownership and measured gates (pin before implementation)
+
+Implementation: `blender_addon/__init__.py`, focused
+`tests/test_pkg230b_coordinate_chains.py`, and minimal updates to affected
+pkg219a/pkg230 addon tests. Parent owns this spec, delivery evidence, and new
+presets in the existing `benchmarks/blender_parity/scene_library.py`; extend the
+existing harness instead of creating another renderer script.
+
+1. Mathematical point probes: absolute/relative tolerance 1e-6 for transforms
+   against explicit arithmetic/Blender mathutils oracles; include noncommuting
+   Mapping, every rotation, nonzero center, inverse, zero/mirror and constant
+   subtraction. Cache keys must distinguish a 1e-5 edit exactly.
+2. Provenance, linked-operand rejection, dead sockets, cycles/depth and same-image
+   variants tested. Image, program and procedural consumers either honor the
+   feature or report the explicit limitation. No hidden program mapping alias.
+3. Real Blender 5.1 saved comparisons: CPU-only, RTX GPU and Cycles, common
+   linear float32, Closest image filtering and Extend extension, denoise/adaptive off, fixed nonzero
+   seed, 256 spp. Use textured Principled/specular-zero carrier to isolate this
+   feature from already-filed closure/filter gaps. Compare nonuniform patterns
+   and transform placement qualitatively; per-channel interior mean ratios
+   must lie within [0.95,1.05] CPU/GPU/Cycles. Transformed-vs-control image MAD
+   must exceed 0.01 in representative non-identity cases. Preserve zero-scale
+   and unsupported-chain cases as separate semantic probes, not this effect gate.
+4. Fresh native artifacts before GPU tests, intended import path and exact
+   native-source identity recorded. Reuse the canonical build and established
+   build cache where source-identical; no post-commit GPU result without rebuild.
+   Serialize GPU work under the project lock. No native resource-growth claim
+   is needed beyond proving the native source remains unchanged.
+5. Focused addon/program regressions, full local suite with isolated Blender
+   user paths, differential lint and caller/binding sweep. Investigate failures
+   against baseline; pkg237/238 remain documented debt, not assumed new bugs.
+6. Independent Claude architecture and owner-authorized Terra final source/ABI/visual sign-off, green
+   CI, autonomous merge and factual live-planning closeout.
+
+Risks: coordinate provenance mismatch, cache aliasing, double transforms in
+program children, false procedural support, rotation convention, and stale
+native module selection. Current results and retained failed reference cases are
+recorded in [delivery evidence](../docs/pkg230b-delivery-evidence.md).
+Full tests and isolated CPU/CUDA package smokes are complete; the two baseline
+failures remain unresolved. Final independent review passed; delivery and CI remain pending.
+The owner explicitly approved commit/merge and Terra or DeepSeek independent
+review on 2026-09-06 while Claude is unavailable. Terra approved the final
+source/ABI/parity/visual evidence; the earlier architecture approval remains
+separate. This round accepts documented baseline failures after adjudication,
+without claiming a green full suite or relaxing rendering thresholds.
+
+Terra final SIGN-OFF: `test_results/pkg230b/final-terra-review.txt` in the root
+workspace. Independent adjudication found the two native-only failures do not
+block this addon package under the owner's directive; neither failure is closed.
+
+Independent Claude architecture SIGN-OFF (2026-09-06):
+`test_results/pkg230b/architecture-claude.txt` in the root workspace.
+Stale procedural-scope prose reconciled; production consumers must call the
+shared resolver once and program-child salting must not duplicate bare-image keys.
+
+The final visual fixtures keep arithmetic/mirror coordinates inside the image
+domain to preserve pattern sensitivity. Out-of-domain Repeat and clamped-edge
+failures remain retained, with untouched-addon equivalent-Mapping controls;
+they are not counted as passing cases. See the delivery evidence.

--- a/benchmarks/blender_parity/scene_library.py
+++ b/benchmarks/blender_parity/scene_library.py
@@ -36,6 +36,8 @@ COMPOSITE_SCENES = (
     "mix_shader_stack", "texture_driven_roughness", "bump_plus_normal",
     "opvm_plain", "opvm_vector_math", "opvm_vector_rotate",
     "opvm_mix_clamped", "opvm_mix_unclamped",
+    "coords_plain", "coords_arithmetic", "coords_euler", "coords_axis",
+    "coords_mirror", "coords_program", "coords_shared_programs",
 )
 
 
@@ -490,6 +492,81 @@ def build_vector_opvm_scene(bpy, variant):
     return scene
 
 
+def build_affine_coordinate_scene(bpy, variant):
+    """pkg230b: spatial operations before image lookup, including shared samplers."""
+    scene = build_vector_opvm_scene(bpy, 'plain')
+    plane = next(obj for obj in scene.objects if obj.type == 'MESH')
+
+    def wire(material, mode):
+        nt = material.node_tree
+        image = next(node for node in nt.nodes if node.type == 'TEX_IMAGE')
+        # Native image samplers clamp outside [0,1]. Match Extend here; Repeat
+        # and the wider image-extension contract remain under pkg234.
+        image.extension = 'EXTEND'
+        principled = next(node for node in nt.nodes if node.type == 'BSDF_PRINCIPLED')
+        source = nt.nodes.new('ShaderNodeTexCoord').outputs['UV']
+
+        def vector_math(operation, constant, varying_slot=0):
+            nonlocal source
+            node = nt.nodes.new('ShaderNodeVectorMath')
+            node.operation = operation
+            nt.links.new(source, node.inputs[varying_slot])
+            node.inputs[1 - varying_slot].default_value = constant
+            source = node.outputs['Vector']
+
+        # Keep the arithmetic/mirror chart inside the image domain so the
+        # visible pattern tests placement rather than a clamped edge texel.
+        if mode == 'arithmetic':
+            vector_math('ADD', (0.13, -0.08, 0.0))
+            vector_math('MULTIPLY', (0.8, 0.7, 1.0))
+            vector_math('SUBTRACT', (1.05, 0.85, 0.0), varying_slot=1)
+            mapping = nt.nodes.new('ShaderNodeMapping')
+            mapping.inputs['Rotation'].default_value = (0.0, 0.0, 0.17)
+            mapping.inputs['Location'].default_value = (0.04, 0.02, 0.0)
+            nt.links.new(source, mapping.inputs['Vector'])
+            source = mapping.outputs['Vector']
+        elif mode in ('euler', 'axis', 'program'):
+            rotate = nt.nodes.new('ShaderNodeVectorRotate')
+            rotate.rotation_type = 'AXIS_ANGLE' if mode == 'axis' else 'EULER_XYZ'
+            rotate.invert = True
+            rotate.inputs['Center'].default_value = (0.42, 0.57, 0.1)
+            if mode == 'axis':
+                rotate.inputs['Axis'].default_value = (0.2, 0.3, 1.0)
+                rotate.inputs['Angle'].default_value = 0.65
+            else:
+                rotate.inputs['Rotation'].default_value = (0.2, -0.3, 0.55)
+            nt.links.new(source, rotate.inputs['Vector'])
+            source = rotate.outputs['Vector']
+        elif mode == 'mirror':
+            vector_math('MULTIPLY', (-0.8, 0.8, 1.0))
+            vector_math('ADD', (0.9, 0.08, 0.0))
+        elif mode != 'plain':
+            raise ValueError(f'unknown affine coordinate variant: {mode}')
+        nt.links.new(source, image.inputs['Vector'])
+        if variant in ('program', 'shared_programs'):
+            post = nt.nodes.new('ShaderNodeVectorMath')
+            post.operation = 'SCALE'
+            post.inputs['Scale'].default_value = 0.8
+            nt.links.new(image.outputs['Color'], post.inputs[0])
+            nt.links.new(post.outputs['Vector'], principled.inputs['Base Color'])
+
+    if variant == 'shared_programs':
+        # Independent materials share the SAME bpy image. Each program must
+        # carry its own mapping into the GPU descriptor, regardless of order.
+        right = plane.copy()
+        right.data = plane.data.copy()
+        scene.collection.objects.link(right)
+        right.data.materials.clear()
+        right.data.materials.append(plane.data.materials[0].copy())
+        plane.scale.x = right.scale.x = 0.5
+        plane.location.x, right.location.x = -0.5, 0.5
+        wire(plane.data.materials[0], 'euler')
+        wire(right.data.materials[0], 'mirror')
+    else:
+        wire(plane.data.materials[0], variant)
+    return scene
+
+
 COMPOSITE_BUILDERS = {
     "mix_shader_stack": build_mix_shader_stack,
     "texture_driven_roughness": build_texture_driven_roughness,
@@ -499,6 +576,13 @@ COMPOSITE_BUILDERS = {
     "opvm_vector_rotate": lambda bpy: build_vector_opvm_scene(bpy, 'vector_rotate'),
     "opvm_mix_clamped": lambda bpy: build_vector_opvm_scene(bpy, 'mix_clamped'),
     "opvm_mix_unclamped": lambda bpy: build_vector_opvm_scene(bpy, 'mix_unclamped'),
+    "coords_plain": lambda bpy: build_affine_coordinate_scene(bpy, 'plain'),
+    "coords_arithmetic": lambda bpy: build_affine_coordinate_scene(bpy, 'arithmetic'),
+    "coords_euler": lambda bpy: build_affine_coordinate_scene(bpy, 'euler'),
+    "coords_axis": lambda bpy: build_affine_coordinate_scene(bpy, 'axis'),
+    "coords_mirror": lambda bpy: build_affine_coordinate_scene(bpy, 'mirror'),
+    "coords_program": lambda bpy: build_affine_coordinate_scene(bpy, 'program'),
+    "coords_shared_programs": lambda bpy: build_affine_coordinate_scene(bpy, 'shared_programs'),
 }
 
 

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -2952,112 +2952,269 @@ class CustomRaytracerRenderEngine(RenderEngine):
     # ------------------------------------------------------------------ #
 
     @staticmethod
+    def _resolve_affine_coordinates(vector_socket, depth=0, default_coord_mode="UV",
+                                    warn=None, allow_affine=True):
+        """Resolve coordinates and their affine together (pkg230b).
+
+        Cycles v5.1.0 adfe2921d5f3c0fe699149bcd9bc347543bbd82e,
+        svm/{mapping_util,vector_rotate,math_util}.h (Apache-2.0).
+        The legacy fields preserve the outer Mapping node's 2-D interface;
+        image/program consumers use the matrix, never that approximation.
+        """
+        import math
+        import numpy as np
+        cls = CustomRaytracerRenderEngine
+        limit = 32
+
+        def result(matrix=None, mode=None, layer="", varying=True, legacy=None):
+            if matrix is not None and (not np.all(np.isfinite(matrix)) or
+                                       np.any(np.abs(matrix) > np.finfo(np.float32).max)):
+                raise ValueError('affine coefficients are not representable by native float32')
+            return {
+                'matrix': np.identity(4) if matrix is None else matrix,
+                'coord_mode': default_coord_mode if mode is None else mode,
+                'uv_layer': layer,
+                'varying': varying and (matrix is None or bool(np.any(matrix[:3, :3] != 0))),
+                'legacy': ((1.0, 1.0), (0.0, 0.0), 0.0) if legacy is None else legacy,
+            }
+
+        def reject(node, reason):
+            if warn is not None:
+                ntype = getattr(node, 'type', 'COORDINATES') or 'COORDINATES'
+                label = getattr(node, 'name', '') or ntype
+                warn(ntype, "coordinate node '%s': %s; using default %s coordinates; "
+                     "outer Mapping nodes remain" % (label, reason, default_coord_mode))
+            return result()
+
+        def node_identity(node):
+            # RNA may create different Python wrappers for the same Blender node.
+            pointer = getattr(node, 'as_pointer', None)
+            if callable(pointer):
+                try:
+                    address = int(pointer())
+                    if address:
+                        return ('rna', address)
+                except (ReferenceError, TypeError, ValueError):
+                    pass
+            return ('python', id(node))
+
+        def inp(node, name):
+            inputs = getattr(node, 'inputs', None)
+            return inputs.get(name) if inputs is not None else None
+
+        def positional(node, index):
+            inputs = getattr(node, 'inputs', None)
+            try:
+                return inputs[index]
+            except (KeyError, IndexError, TypeError):
+                # Legacy dict mocks only; real Blender duplicate Vector sockets
+                # must be indexed, because get('Vector') always returns the first.
+                if isinstance(inputs, dict):
+                    return list(inputs.values())[index] if index < len(inputs) else None
+                return None
+
+        def link(socket):
+            try:
+                return socket.links[0]
+            except (AttributeError, IndexError, TypeError):
+                raise ValueError('invalid linked socket')
+
+        def numeric(value, size):
+            try:
+                if size == 1:
+                    out = float(value)
+                elif hasattr(value, '__iter__') or hasattr(value, '__getitem__'):
+                    out = np.array([float(value[i]) for i in range(3)])
+                else:
+                    out = np.full(3, float(value))
+            except (TypeError, ValueError, IndexError, KeyError, OverflowError):
+                raise ValueError('invalid constant control') from None
+            if not np.all(np.isfinite(out)):
+                raise ValueError('non-finite constant control')
+            return out
+
+        def constant(socket, size, level, path):
+            if socket is None:
+                raise ValueError('missing active input')
+            if not getattr(socket, 'is_linked', False):
+                return numeric(getattr(socket, 'default_value', None), size)
+            edge = link(socket)
+            node = edge.from_node
+            if level > limit or node_identity(node) in path:
+                raise ValueError('constant control cycle or depth limit')
+            kind = getattr(node, 'type', None)
+            next_path = path | {node_identity(node)}
+            if kind in ('VALUE', 'RGB'):
+                source = edge.from_socket
+                if not hasattr(source, 'default_value'):
+                    try:
+                        source = node.outputs[0]
+                    except (AttributeError, KeyError, IndexError, TypeError):
+                        raise ValueError('constant output has no value') from None
+                value = source.default_value
+                if kind == 'RGB' and size == 1:
+                    rgb = numeric(value, 3)
+                    value = float(np.dot(rgb, [0.2126, 0.7152, 0.0722]))
+                return numeric(value, size)
+            if kind == 'COMBXYZ':
+                value = np.array([constant(inp(node, axis), 1, level + 1, next_path)
+                                  for axis in ('X', 'Y', 'Z')])
+                return float(np.mean(value)) if size == 1 else value
+            raise ValueError("linked %s control is not a supported constant" % kind)
+
+        def affine_constant(value):
+            matrix = np.zeros((4, 4))
+            matrix[:3, 3] = value
+            matrix[3, 3] = 1.0
+            return result(matrix, varying=False)
+
+        def walk(socket, level, path, implicit=False):
+            if socket is None or not getattr(socket, 'is_linked', False):
+                if implicit:
+                    return result()
+                return affine_constant(constant(socket, 3, level, path))
+            try:
+                edge = link(socket)
+                node = edge.from_node
+            except (ValueError, AttributeError):
+                return reject(None, 'invalid linked socket')
+            kind = getattr(node, 'type', None)
+            if level > limit:
+                return reject(node, 'coordinate depth limit exceeded')
+            if node_identity(node) in path:
+                return reject(node, 'coordinate cycle detected')
+            next_path = path | {node_identity(node)}
+            try:
+                if kind in ('TEX_COORD', 'UVMAP'):
+                    name = getattr(edge.from_socket, 'name', '')
+                    modes = {'UV': 'UV', 'Generated': 'GENERATED', 'Object': 'OBJECT',
+                             'Camera': 'CAMERA', 'Window': 'WINDOW',
+                             'Reflection': 'REFLECTION', 'Normal': 'NORMAL'}
+                    mode = 'UV' if kind == 'UVMAP' else modes.get(name)
+                    if mode is None:
+                        raise ValueError("unsupported coordinate output '%s'" % name)
+                    layer = (getattr(node, 'uv_map', '') or '') if mode == 'UV' else ''
+                    return result(mode=mode, layer=layer)
+                if kind in ('VALUE', 'RGB', 'COMBXYZ'):
+                    return affine_constant(constant(socket, 3, level, path))
+                if kind == 'MAPPING':
+                    values = []
+                    for name, neutral in (('Location', (0, 0, 0)),
+                                          ('Rotation', (0, 0, 0)),
+                                          ('Scale', (1, 1, 1))):
+                        control = inp(node, name)
+                        try:
+                            value = numeric(neutral, 3) if control is None else constant(
+                                control, 3, level + 1, next_path)
+                        except ValueError as error:
+                            # Preserve the established neutral-component fallback;
+                            # never read the ignored default of a linked socket.
+                            reject(node, "%s: %s; using neutral %s" % (name, error, neutral))
+                            value = numeric(neutral, 3)
+                        values.append(value)
+                    location, rotation, scale = values
+                    vector_type = getattr(node, 'vector_type', 'POINT')
+                    if vector_type not in ('POINT', 'VECTOR', 'TEXTURE', 'NORMAL'):
+                        raise ValueError('unsupported Mapping vector type')
+                    if vector_type == 'NORMAL' and warn is not None:
+                        warn('MAPPING', 'NORMAL Mapping uses the existing rotation-only '
+                             'approximation; inverse scale and normalization are not represented')
+                    vector_input = inp(node, 'Vector')
+                    if (vector_input is None or
+                            (not getattr(vector_input, 'is_linked', False) and
+                             not hasattr(getattr(vector_input, 'default_value', None), '__getitem__'))):
+                        inner = reject(node, 'malformed Mapping Vector socket')
+                    else:
+                        # Mapping Vector is an ordinary constant input when
+                        # unlinked, unlike an Image Texture's implicit UV input.
+                        inner = walk(vector_input, level + 1, next_path)
+                    outer = cls._compose_mapping_matrix(location, rotation, scale, vector_type)
+                    return result(outer @ inner['matrix'], inner['coord_mode'], inner['uv_layer'],
+                                  inner['varying'], (tuple(scale[:2]), tuple(location[:2]),
+                                                     float(rotation[2])))
+                if kind in ('VECT_MATH', 'VECTOR_ROTATE') and not allow_affine:
+                    raise ValueError('new affine chains are unsupported by the procedural '
+                                     'transformed-p evaluator (pkg242)')
+                if kind == 'VECT_MATH':
+                    operation = getattr(node, 'operation', None)
+                    if operation not in ('ADD', 'SUBTRACT', 'MULTIPLY', 'SCALE'):
+                        raise ValueError("unsupported Vector Math operation '%s'" % operation)
+                    a = walk(positional(node, 0), level + 1, next_path)
+                    if operation == 'SCALE':
+                        factor = constant(inp(node, 'Scale'), 1, level + 1, next_path)
+                        matrix = a['matrix'].copy()
+                        matrix[:3, :] *= factor
+                        return result(matrix, a['coord_mode'], a['uv_layer'], a['varying'])
+                    b = walk(positional(node, 1), level + 1, next_path)
+                    if a['varying'] and b['varying']:
+                        raise ValueError('multiple varying vector operands are unsupported')
+                    source = a if a['varying'] else b
+                    matrix = np.identity(4)
+                    if operation in ('ADD', 'SUBTRACT'):
+                        matrix[:3, :] = a['matrix'][:3, :] + (
+                            1 if operation == 'ADD' else -1) * b['matrix'][:3, :]
+                    else:
+                        varying, fixed = (a, b) if a['varying'] else (b, a)
+                        matrix[:3, :] = varying['matrix'][:3, :] * fixed['matrix'][:3, 3, None]
+                    return result(matrix, source['coord_mode'], source['uv_layer'],
+                                  a['varying'] or b['varying'])
+                if kind == 'VECTOR_ROTATE':
+                    rotation_type = getattr(node, 'rotation_type', None)
+                    if rotation_type not in ('AXIS_ANGLE', 'X_AXIS', 'Y_AXIS', 'Z_AXIS', 'EULER_XYZ'):
+                        raise ValueError('unsupported Vector Rotate mode')
+                    inner = walk(inp(node, 'Vector'), level + 1, next_path)
+                    center = constant(inp(node, 'Center'), 3, level + 1, next_path)
+                    invert = bool(getattr(node, 'invert', False))
+                    if rotation_type == 'EULER_XYZ':
+                        # Blender removes Axis/Angle sockets in this mode.
+                        angles = constant(inp(node, 'Rotation'), 3, level + 1, next_path)
+                        rotation = cls._compose_mapping_matrix((0, 0, 0), angles, (1, 1, 1))[:3, :3]
+                        if invert:
+                            rotation = rotation.T
+                    else:
+                        # Rotation is absent in axis modes; read only active controls.
+                        angle = constant(inp(node, 'Angle'), 1, level + 1, next_path)
+                        angle = -angle if invert else angle
+                        axis = (constant(inp(node, 'Axis'), 3, level + 1, next_path)
+                                if rotation_type == 'AXIS_ANGLE' else
+                                np.eye(3)[('X_AXIS', 'Y_AXIS', 'Z_AXIS').index(rotation_type)])
+                        length = float(np.linalg.norm(axis))
+                        if length == 0:
+                            rotation = np.identity(3)
+                        else:
+                            x, y, z = axis / length
+                            cross = np.array([[0, -z, y], [z, 0, -x], [-y, x, 0]])
+                            c, s = math.cos(angle), math.sin(angle)
+                            rotation = c * np.eye(3) + (1 - c) * np.outer(axis / length, axis / length) + s * cross
+                    outer = np.identity(4)
+                    outer[:3, :3] = rotation
+                    outer[:3, 3] = center - rotation @ center
+                    return result(outer @ inner['matrix'], inner['coord_mode'], inner['uv_layer'],
+                                  inner['varying'])
+                raise ValueError("unsupported coordinate node '%s'" % kind)
+            except (ValueError, TypeError, IndexError, KeyError, OverflowError, FloatingPointError) as error:
+                return reject(node, str(error))
+
+        with np.errstate(over='raise', invalid='raise', divide='raise'):
+            return walk(vector_socket, depth, frozenset(), implicit=True)
+
+    @staticmethod
     def _resolve_vector_input(vector_socket, depth=0, default_coord_mode="UV",
                               warn=None):
-        """Walk the Vector input on a TEX_IMAGE / procedural texture node and
-        return ``(coord_mode, scale_xy, offset_xy, rotation_z, uv_layer_name)``:
+        """Compatibility five-tuple; image/program paths use the shared affine."""
+        resolved = CustomRaytracerRenderEngine._resolve_affine_coordinates(
+            vector_socket, depth, default_coord_mode, warn)
+        scale, offset, rotation = resolved['legacy']
+        return resolved['coord_mode'], scale, offset, rotation, resolved['uv_layer']
 
-        - ``coord_mode``: one of "UV", "GENERATED", "OBJECT" — passed straight
-          to ``renderer.set_texture_coord_mode``. Other Texture Coordinate
-          outputs (Camera, Window, Reflection, Normal) currently fall back to
-          "UV"; the C++ side supports them but the Blender semantics need a
-          real test scene to pin down.
-        - ``scale_xy`` / ``offset_xy``: (sx, sy) and (ox, oy) baked from a
-          ``Mapping`` node on the chain.
-        - ``rotation_z``: float in radians, baked from a ``Mapping`` node's
-          Rotation.z (Blender 2D-effective Z component). Default 0.
-        - ``default_coord_mode``: fallback when vector_socket is unlinked.
-          Per pkg115 Blender parity audit: procedural textures default to
-          "GENERATED", Image Texture defaults to "UV".
-        - ``warn``: optional callable ``(node_type, message)`` — pkg230 Phase 2
-          surfaces a visible ``_warn_shader_fallback`` when a VECT_MATH /
-          VECTOR_ROTATE node appears on the coordinate chain (a per-texel
-          coordinate op the affine resolver cannot express). Static method, so
-          it cannot warn on its own; instance callers pass their warn hook.
-
-        Limit chain depth to avoid pathological node graphs (Mapping → Mapping
-        → Mapping…).
-        """
-        coord_mode = default_coord_mode
-        scale = (1.0, 1.0)
-        offset = (0.0, 0.0)
-        rotation = 0.0
-        uv_layer_name = ""
-        if depth > 4 or vector_socket is None or not getattr(vector_socket, 'is_linked', False):
-            return coord_mode, scale, offset, rotation, uv_layer_name
-        try:
-            link = vector_socket.links[0]
-            src = link.from_node
-            src_socket_name = link.from_socket.name
-        except (IndexError, AttributeError):
-            return coord_mode, scale, offset, rotation, uv_layer_name
-
-        ntype = getattr(src, 'type', None)
-        if ntype == 'MAPPING':
-            # Read Location, Rotation, and Scale defaults. Linked inputs
-            # aren't followed — would require a real expression evaluator.
-            # Most user-facing mappings have constant defaults.
-            loc_inp = src.inputs.get('Location') if hasattr(src, 'inputs') else None
-            if loc_inp is not None and not getattr(loc_inp, 'is_linked', False):
-                v = loc_inp.default_value
-                try:
-                    offset = (float(v[0]), float(v[1]))
-                except (TypeError, IndexError):
-                    pass
-            rot_inp = src.inputs.get('Rotation') if hasattr(src, 'inputs') else None
-            if rot_inp is not None and not getattr(rot_inp, 'is_linked', False):
-                v = rot_inp.default_value
-                try:
-                    # 2D-effective: only the Z component rotates UVs.
-                    rotation = float(v[2])
-                except (TypeError, IndexError):
-                    pass
-            scl_inp = src.inputs.get('Scale') if hasattr(src, 'inputs') else None
-            if scl_inp is not None and not getattr(scl_inp, 'is_linked', False):
-                v = scl_inp.default_value
-                try:
-                    scale = (float(v[0]), float(v[1]))
-                except (TypeError, IndexError):
-                    pass
-            # Recurse to find the upstream coord source.
-            inner_socket = src.inputs.get('Vector') if hasattr(src, 'inputs') else None
-            inner_coord, _inner_scale, _inner_offset, _inner_rot, inner_layer = \
-                CustomRaytracerRenderEngine._resolve_vector_input(inner_socket, depth + 1, default_coord_mode, warn)
-            return inner_coord, scale, offset, rotation, inner_layer
-
-        if ntype == 'TEX_COORD':
-            if src_socket_name == 'Generated':
-                return "GENERATED", scale, offset, rotation, uv_layer_name
-            if src_socket_name == 'Object':
-                return "OBJECT", scale, offset, rotation, uv_layer_name
-            if src_socket_name == 'UV':
-                return "UV", scale, offset, rotation, getattr(src, 'uv_map', '') or ""
-            # pkg219a: Camera / Window / Reflection / Normal are all implemented
-            # C++-side (Texture::CoordMode / parseCoordMode). Route them through
-            # instead of the old blanket UV fallback.
-            if src_socket_name == 'Camera':
-                return "CAMERA", scale, offset, rotation, uv_layer_name
-            if src_socket_name == 'Window':
-                return "WINDOW", scale, offset, rotation, uv_layer_name
-            if src_socket_name == 'Reflection':
-                return "REFLECTION", scale, offset, rotation, uv_layer_name
-            if src_socket_name == 'Normal':
-                return "NORMAL", scale, offset, rotation, uv_layer_name
-            return "UV", scale, offset, rotation, uv_layer_name
-
-        if ntype == 'UVMAP':
-            return "UV", scale, offset, rotation, getattr(src, 'uv_map', '') or ""
-
-        # pkg230 Phase 2 — a Vector Math / Vector Rotate node on the coordinate
-        # chain is a per-texel coordinate op the affine resolver cannot express.
-        # Surface a VISIBLE degradation entry (never a silent plain-UV fallback);
-        # the actual coordinate behaviour stays the deferred follow-up.
-        if ntype in ('VECT_MATH', 'VECTOR_ROTATE') and warn is not None:
-            warn(ntype, "per-texel Vector Math/Rotate on texture coordinates is "
-                        "unsupported — using default %s coordinates; outer Mapping nodes remain"
-                        % default_coord_mode)
-
-        return coord_mode, scale, offset, rotation, uv_layer_name
+    @staticmethod
+    def _affine_matrix_values(resolved):
+        """Exact identity detection preserves tiny edits and zero/mirror scales."""
+        import numpy as np
+        matrix = resolved['matrix']
+        if np.array_equal(matrix, np.identity(4)):
+            return None
+        return [float(value) for value in matrix[:3, :].reshape(-1)]
 
     @staticmethod
     def _compose_mapping_matrix(location, rotation, scale, vector_type='POINT'):
@@ -3095,67 +3252,25 @@ class CustomRaytracerRenderEngine(RenderEngine):
             M[:3, :3] = R @ S
             M[:3, 3] = [lx, ly, lz]
         if vector_type == 'TEXTURE':
-            M = np.linalg.inv(M)
+            # Cycles safe_divide(inverse_rotate(vector - location), scale).
+            # A zero scale component maps to zero, including singular matrices.
+            reciprocal = np.array([1.0 / v if v != 0.0 else 0.0 for v in (sx, sy, sz)])
+            M[:3, :3] = np.diag(reciprocal) @ R.T
+            M[:3, 3] = -M[:3, :3] @ np.array([lx, ly, lz])
         return M
 
     def _resolve_mapping_matrix(self, vector_socket, depth=0):
-        """Walk the Vector chain and compose all Mapping nodes into a single
-        3x4 (top-rows, row-major) affine, or return None if there is no
-        non-identity Mapping. pkg219a: full 3-D transform incl. X/Y rotation and
-        Z location/scale — supersedes the old 2-D ``_resolve_vector_input``
-        scale/offset/rotation for texture sampling.
-
-        Linked Location/Rotation/Scale inputs cannot be constant-folded (that is
-        the op-VM's job, pkg219b) — those components fall back to their socket
-        defaults and record a visible degradation entry.
-        """
-        import numpy as np
-        if depth > 4 or vector_socket is None or not getattr(vector_socket, 'is_linked', False):
-            return None
-        try:
-            src = vector_socket.links[0].from_node
-        except (IndexError, AttributeError):
-            return None
-        if getattr(src, 'type', None) != 'MAPPING':
-            return None
-
-        def _default(name, fallback):
-            inp = src.inputs.get(name) if hasattr(src, 'inputs') else None
-            if inp is None:
-                return fallback
-            if getattr(inp, 'is_linked', False):
-                self._warn_shader_fallback(
-                    'MAPPING',
-                    f"linked '{name}' input constant-folded to its default "
-                    f"(per-texel Mapping inputs need the op-VM, pkg219b)")
-                return fallback
-            v = inp.default_value
-            try:
-                return (float(v[0]), float(v[1]), float(v[2]))
-            except (TypeError, IndexError):
-                return fallback
-
-        location = _default('Location', (0.0, 0.0, 0.0))
-        rotation = _default('Rotation', (0.0, 0.0, 0.0))
-        scale = _default('Scale', (1.0, 1.0, 1.0))
-        vtype = getattr(src, 'vector_type', 'POINT')
-        M = self._compose_mapping_matrix(location, rotation, scale, vtype)
-
-        inner_socket = src.inputs.get('Vector') if hasattr(src, 'inputs') else None
-        inner = self._resolve_mapping_matrix(inner_socket, depth + 1)
-        if inner is not None:
-            M = M @ np.array(inner + [0.0, 0.0, 0.0, 1.0], dtype=np.float64).reshape(4, 4)
-
-        if np.allclose(M, np.identity(4), atol=1e-7):
-            return None
-        return [float(x) for x in M[:3, :].reshape(-1)]
+        """Compatibility 12-float matrix wrapper around the shared resolver."""
+        resolved = self._resolve_affine_coordinates(
+            vector_socket, depth=depth, warn=self._warn_shader_fallback)
+        return self._affine_matrix_values(resolved)
 
     @staticmethod
     def _is_default_uv_transform(coord_mode, scale, offset, rotation, uv_layer_name=""):
         return (coord_mode == "UV"
-                and abs(scale[0] - 1.0) < 1e-6 and abs(scale[1] - 1.0) < 1e-6
-                and abs(offset[0]) < 1e-6 and abs(offset[1]) < 1e-6
-                and abs(rotation) < 1e-6
+                and scale[0] == 1.0 and scale[1] == 1.0
+                and offset[0] == 0.0 and offset[1] == 0.0
+                and rotation == 0.0
                 and not uv_layer_name)
 
     @staticmethod
@@ -3171,12 +3286,12 @@ class CustomRaytracerRenderEngine(RenderEngine):
         # in the key so the same image under different 3-D mappings gets distinct
         # C++ texture entries.
         if mapping_matrix is not None:
-            mstr = ",".join(f"{v:.4f}" for v in mapping_matrix)
+            mstr = ",".join(f"{0.0 if v == 0.0 else v:.17g}" for v in mapping_matrix)
             return f"{base_name}::{coord_mode}::M[{mstr}]::{uv_layer_name}"
         return (f"{base_name}::{coord_mode}::"
-                f"{scale[0]:.4f},{scale[1]:.4f},"
-                f"{offset[0]:.4f},{offset[1]:.4f},"
-                f"{rotation:.4f}::{uv_layer_name}")
+                f"{scale[0]:.17g},{scale[1]:.17g},"
+                f"{offset[0]:.17g},{offset[1]:.17g},"
+                f"{rotation:.17g}::{uv_layer_name}")
 
     def _apply_texture_transform(self, renderer, tex_name, coord_mode,
                                  scale, offset, rotation, uv_layer_name="",
@@ -3197,13 +3312,17 @@ class CustomRaytracerRenderEngine(RenderEngine):
             # pkg219a: a full 3-D Mapping matrix supersedes the legacy 2-D UV
             # transform. Prefer it when present (image textures sample at
             # (M*coord).xy on both CPU and GPU).
-            if mapping_matrix is not None and hasattr(renderer, "set_texture_mapping_matrix"):
-                renderer.set_texture_mapping_matrix(tex_name, list(mapping_matrix))
+            if mapping_matrix is not None:
+                if hasattr(renderer, "set_texture_mapping_matrix"):
+                    renderer.set_texture_mapping_matrix(tex_name, list(mapping_matrix))
+                else:
+                    self._warn_shader_fallback('MAPPING', 'native matrix binding unavailable; '
+                                               'using untransformed coordinates')
                 return
             non_identity = (
-                abs(scale[0] - 1.0) >= 1e-6 or abs(scale[1] - 1.0) >= 1e-6
-                or abs(offset[0]) >= 1e-6 or abs(offset[1]) >= 1e-6
-                or abs(rotation) >= 1e-6
+                scale[0] != 1.0 or scale[1] != 1.0
+                or offset[0] != 0.0 or offset[1] != 0.0
+                or rotation != 0.0
             )
             if non_identity:
                 renderer.set_texture_uv_transform(
@@ -3212,9 +3331,9 @@ class CustomRaytracerRenderEngine(RenderEngine):
                     float(offset[0]), float(offset[1]),
                     float(rotation),
                 )
-        except AttributeError:
-            # Older C++ module without these bindings — silently skip.
-            pass
+        except AttributeError as error:
+            self._warn_shader_fallback('MAPPING', 'native coordinate binding unavailable '
+                                       '(%s); using available coordinate defaults' % error)
 
     def load_blender_image(self, bpy_image, renderer, vector_input=None):
         """Load a Blender image datablock into the renderer's texture manager.
@@ -3232,10 +3351,19 @@ class CustomRaytracerRenderEngine(RenderEngine):
         """
         if bpy_image is None:
             return None
-        # Image Texture defaults to UV when Vector socket is unconnected.
-        coord_mode, uv_scale, offset, rotation, uv_layer_name = self._resolve_vector_input(vector_input, default_coord_mode="UV", warn=self._warn_shader_fallback)
-        mapping_matrix = self._resolve_mapping_matrix(vector_input)
-        cache_key = self._texture_variant_key(bpy_image.name, coord_mode, uv_scale, offset, rotation, uv_layer_name, mapping_matrix)
+        # One traversal supplies both provenance and the complete affine.
+        resolved = self._resolve_affine_coordinates(vector_input, warn=self._warn_shader_fallback)
+        return self._load_blender_image_resolved(bpy_image, renderer, resolved)
+
+    def _load_blender_image_resolved(self, bpy_image, renderer, resolved, child_signature=None):
+        """Upload one resolved image; only program children receive isolation salt."""
+        coord_mode, uv_layer_name = resolved['coord_mode'], resolved['uv_layer']
+        uv_scale, offset, rotation = (1.0, 1.0), (0.0, 0.0), 0.0
+        mapping_matrix = self._affine_matrix_values(resolved)
+        cache_key = self._texture_variant_key(bpy_image.name, coord_mode, uv_scale,
+                                              offset, rotation, uv_layer_name, mapping_matrix)
+        if child_signature is not None:
+            cache_key += "::program-child[%s]" % child_signature
 
         # Deduplicate: a single (image, transform) pair is uploaded at most
         # once per conversion pass.
@@ -3297,7 +3425,13 @@ class CustomRaytracerRenderEngine(RenderEngine):
         # combination is always identical — the variant key is defensive.
         # pkg115 parity fix: procedural textures default to GENERATED when
         # Vector socket is unconnected (Blender standard behavior).
-        coord_mode, uv_scale, offset, rotation, uv_layer_name = self._resolve_vector_input(vector_input, default_coord_mode="GENERATED", warn=self._warn_shader_fallback)
+        # Native procedural evaluation still receives the original p. Keep the
+        # legacy Mapping behavior and visibly reject new affine node chains.
+        resolved = self._resolve_affine_coordinates(
+            vector_input, default_coord_mode="GENERATED", warn=self._warn_shader_fallback,
+            allow_affine=False)
+        coord_mode, uv_layer_name = resolved['coord_mode'], resolved['uv_layer']
+        uv_scale, offset, rotation = resolved['legacy']
         # pkg115 residual fix (black gradient/magic spheres): id(node) is NOT a
         # stable key — convert_node_material works on a temporary
         # inline_shader_nodes() tree that is freed after each material, and
@@ -3518,27 +3652,45 @@ class CustomRaytracerRenderEngine(RenderEngine):
         # Require image-texture inputs; a program input that is not a loadable
         # image texture is out of scope (procedural inputs stay on the pkg190
         # bake path).
-        child_names = []
-        for in_node in compiled['inputs']:
+        inputs = compiled['inputs']
+        if not inputs:
+            self._warn_shader_fallback('op-VM', 'program has no image inputs; flattened')
+            return None
+        resolved_inputs = []
+        signatures = []
+        for in_node in inputs:
             img = getattr(in_node, 'image', None)
             if getattr(in_node, 'type', None) != 'TEX_IMAGE' or img is None:
                 self._warn_shader_fallback(
-                    "op-VM", "op-VM input is not an image texture — flattened")
+                    "op-VM", "op-VM input is not an image texture; flattened")
                 return None
-            cn = self.load_blender_image(img, renderer, vector_input=None)
+            vinp = in_node.inputs.get('Vector') if hasattr(in_node, 'inputs') else None
+            resolved = self._resolve_affine_coordinates(vinp, warn=self._warn_shader_fallback)
+            resolved_inputs.append(resolved)
+            signatures.append(self._texture_variant_key(
+                '', resolved['coord_mode'], (1.0, 1.0), (0.0, 0.0), 0.0,
+                resolved['uv_layer'], self._affine_matrix_values(resolved)))
+        if any(signature != signatures[0] for signature in signatures[1:]):
+            self._warn_shader_fallback('op-VM', 'image inputs have differing coordinate mappings; '
+                                       'independent program coordinates are unsupported; flattened')
+            return None
+        resolved = resolved_inputs[0]
+        coord_mode, uvlayer = resolved['coord_mode'], resolved['uv_layer']
+        scale, offset, rot = (1.0, 1.0), (0.0, 0.0), 0.0
+        mapping_matrix = self._affine_matrix_values(resolved)
+        # scene_upload.cu deduplicates child ImageTexture pointers and attaches
+        # the first parent's mapping. Isolate identity child samplers by parent
+        # coordinates; CPU children must never apply that mapping a second time.
+        identity = {'matrix': np.identity(4), 'coord_mode': 'UV', 'uv_layer': ''}
+        child_names = []
+        for in_node in inputs:
+            cn = self._load_blender_image_resolved(
+                in_node.image, renderer, identity, child_signature=signatures[0])
             if cn is None:
                 return None
             child_names.append(cn)
         mat_name = getattr(self, "_current_material_name", "") or ""
         prog_name = "_prog_%s.%s.%s" % (mat_name, getattr(node, "name", "n"), input_name)
-        # Coord + Mapping come from the FIRST image input's Vector wiring and are
-        # applied to the PROGRAM texture (children are plain samplers); differing
-        # per-input mappings on a multi-image Mix are a documented follow-up.
-        first = compiled['inputs'][0]
-        vinp = first.inputs.get('Vector') if hasattr(first, 'inputs') else None
-        coord_mode, scale, offset, rot, uvlayer = self._resolve_vector_input(
-            vinp, default_coord_mode="UV", warn=self._warn_shader_fallback)
-        mapping_matrix = self._resolve_mapping_matrix(vinp)
         try:
             renderer.create_program_texture(prog_name, coord_mode)
             self._apply_texture_transform(renderer, prog_name, coord_mode, scale,

--- a/tests/test_blender_uv_plumbing.py
+++ b/tests/test_blender_uv_plumbing.py
@@ -201,7 +201,7 @@ def test_resolve_vector_input_mapping_scale_only(monkeypatch):
     addon = _load_blender_addon(monkeypatch)
     cls = addon.CustomRaytracerRenderEngine
     mapping = _Node('MAPPING', inputs={
-        'Vector': _Socket(),  # unlinked → 'UV' fallback
+        'Vector': _Socket(linked_to=_Node('TEX_COORD'), output_name='UV'),  # explicit varying UV coordinates
         'Location': _Socket(default=(0.0, 0.0, 0.0)),
         'Scale': _Socket(default=(2.0, 3.0, 1.0)),
     })
@@ -216,7 +216,7 @@ def test_resolve_vector_input_mapping_offset(monkeypatch):
     addon = _load_blender_addon(monkeypatch)
     cls = addon.CustomRaytracerRenderEngine
     mapping = _Node('MAPPING', inputs={
-        'Vector': _Socket(),
+        'Vector': _Socket(linked_to=_Node('TEX_COORD'), output_name='UV'),
         'Location': _Socket(default=(0.5, -0.25, 0.0)),
         'Scale': _Socket(default=(1.0, 1.0, 1.0)),
     })
@@ -294,7 +294,7 @@ def test_load_blender_image_with_mapping_applies_transform(monkeypatch):
     renderer = _RecordingRenderer()
     image = _FakeImage(name="brick.png")
     mapping = _Node('MAPPING', inputs={
-        'Vector':   _Socket(),  # unlinked → 'UV'
+        'Vector':   _Socket(linked_to=_Node('TEX_COORD'), output_name='UV'),  # explicit varying UV coordinates
         'Location': _Socket(default=(0.0, 0.0, 0.0)),
         'Scale':    _Socket(default=(2.0, 2.0, 1.0)),
     })
@@ -342,7 +342,7 @@ def test_load_blender_image_caches_per_transform(monkeypatch):
     n1 = engine.load_blender_image(image, renderer)
     # Second: Mapping(Scale=2).
     mapping = _Node('MAPPING', inputs={
-        'Vector':   _Socket(),
+        'Vector':   _Socket(linked_to=_Node('TEX_COORD'), output_name='UV'),
         'Location': _Socket(default=(0.0, 0.0, 0.0)),
         'Scale':    _Socket(default=(2.0, 2.0, 1.0)),
     })
@@ -371,7 +371,7 @@ def test_resolve_vector_input_mapping_rotation_z(monkeypatch):
     addon = _load_blender_addon(monkeypatch)
     cls = addon.CustomRaytracerRenderEngine
     mapping = _Node('MAPPING', inputs={
-        'Vector':   _Socket(),
+        'Vector':   _Socket(linked_to=_Node('TEX_COORD'), output_name='UV'),
         'Location': _Socket(default=(0.0, 0.0, 0.0)),
         'Rotation': _Socket(default=(0.0, 0.0, math.pi / 4)),
         'Scale':    _Socket(default=(1.0, 1.0, 1.0)),
@@ -394,7 +394,7 @@ def test_load_blender_image_with_mapping_rotation_passes_through(monkeypatch):
     renderer = _RecordingRenderer()
     image = _FakeImage(name="rotated.png")
     mapping = _Node('MAPPING', inputs={
-        'Vector':   _Socket(),
+        'Vector':   _Socket(linked_to=_Node('TEX_COORD'), output_name='UV'),
         'Location': _Socket(default=(0.0, 0.0, 0.0)),
         'Rotation': _Socket(default=(0.0, 0.0, math.pi / 6)),
         'Scale':    _Socket(default=(1.0, 1.0, 1.0)),
@@ -421,7 +421,7 @@ def test_resolve_vector_input_mapping_full_combo(monkeypatch):
     addon = _load_blender_addon(monkeypatch)
     cls = addon.CustomRaytracerRenderEngine
     mapping = _Node('MAPPING', inputs={
-        'Vector':   _Socket(),
+        'Vector':   _Socket(linked_to=_Node('TEX_COORD'), output_name='UV'),
         'Location': _Socket(default=(0.5, -0.25, 0.0)),
         'Rotation': _Socket(default=(0.0, 0.0, math.pi / 2)),
         'Scale':    _Socket(default=(2.0, 3.0, 1.0)),

--- a/tests/test_pkg219a_mapping_unification.py
+++ b/tests/test_pkg219a_mapping_unification.py
@@ -99,7 +99,7 @@ def test_resolve_matrix_none_for_identity_mapping(monkeypatch):
     cls = _cls(monkeypatch)
     engine = cls()
     mapping = _Node('MAPPING', inputs={
-        'Vector': _Socket(),
+        'Vector': _Socket(linked_to=_Node('TEX_COORD'), output_name='UV'),
         'Location': _Socket(default=(0.0, 0.0, 0.0)),
         'Rotation': _Socket(default=(0.0, 0.0, 0.0)),
         'Scale': _Socket(default=(1.0, 1.0, 1.0)),
@@ -113,7 +113,7 @@ def test_resolve_matrix_full_3d_rotation(monkeypatch):
     cls = _cls(monkeypatch)
     engine = cls()
     mapping = _Node('MAPPING', inputs={
-        'Vector': _Socket(),
+        'Vector': _Socket(linked_to=_Node('TEX_COORD'), output_name='UV'),
         'Location': _Socket(default=(0.0, 5.6, 0.0)),
         'Rotation': _Socket(default=(1.30, 0.87, 0.95)),  # owner's repro mapping
         'Scale': _Socket(default=(0.4, 0.4, 0.4)),
@@ -130,7 +130,7 @@ def test_resolve_matrix_chained_composes(monkeypatch):
     cls = _cls(monkeypatch)
     engine = cls()
     inner = _Node('MAPPING', inputs={
-        'Vector': _Socket(),
+        'Vector': _Socket(linked_to=_Node('TEX_COORD'), output_name='UV'),
         'Location': _Socket(default=(0.0, 0.0, 0.0)),
         'Rotation': _Socket(default=(0.0, 0.0, 0.0)),
         'Scale': _Socket(default=(2.0, 2.0, 2.0)),
@@ -155,7 +155,7 @@ def test_resolve_matrix_linked_input_degrades(monkeypatch):
     engine = cls()
     driver = _Node('TEX_NOISE')
     mapping = _Node('MAPPING', inputs={
-        'Vector': _Socket(),
+        'Vector': _Socket(linked_to=_Node('TEX_COORD'), output_name='UV'),
         'Location': _Socket(default=(1.0, 0.0, 0.0)),  # unlinked, non-identity
         'Rotation': _Socket(default=(0.0, 0.0, 0.0)),
         'Scale': _Socket(default=(2.0, 2.0, 2.0), linked_to=driver, output_name='Fac'),
@@ -217,7 +217,7 @@ def test_load_image_3d_mapping_sends_matrix(monkeypatch):
     renderer = _RecordingRenderer()
     image = _FakeImage(name="wood.png")
     mapping = _Node('MAPPING', inputs={
-        'Vector': _Socket(),
+        'Vector': _Socket(linked_to=_Node('TEX_COORD'), output_name='UV'),
         'Location': _Socket(default=(0.0, 5.6, 0.0)),
         'Rotation': _Socket(default=(1.30, 0.87, 0.95)),
         'Scale': _Socket(default=(0.4, 0.4, 0.4)),

--- a/tests/test_pkg230b_coordinate_chains.py
+++ b/tests/test_pkg230b_coordinate_chains.py
@@ -1,0 +1,383 @@
+"""pkg230b affine coordinate oracles and mock addon consumer contracts.
+
+No native renderer is imported or invoked. Rotation oracles apply elementary
+coordinate equations to points independently of the addon matrix builder.
+"""
+
+import math
+import sys
+import types
+
+import numpy as np
+import pytest
+from test_blender_uv_plumbing import (
+    _FakeImage,
+    _load_blender_addon,
+    _Node,
+    _RecordingRenderer,
+    _Socket,
+)
+
+
+class _Inputs:
+    """Blender-style duplicate names: get returns the FIRST matching socket."""
+
+    def __init__(self, sockets):
+        self.sockets = sockets
+
+    def __getitem__(self, index):
+        return self.sockets[index]
+
+    def get(self, name):
+        return next((socket for socket in self.sockets if socket.name == name), None)
+
+
+def _named(name, value=(0, 0, 0)):
+    socket = value if isinstance(value, _Socket) else _Socket(default=value)
+    socket.name = name
+    return socket
+
+
+def _source(mode='UV', layer=''):
+    return _Socket(linked_to=_Node('TEX_COORD', uv_map=layer), output_name=mode)
+
+
+def _math(operation, a, b=(0, 0, 0), scale=1.0):
+    node = _Node('VECT_MATH', operation=operation, inputs=_Inputs([
+        _named('Vector', a), _named('Vector', b),
+        _named('Vector', _Socket(linked_to=_Node('UNSUPPORTED'))),
+        _named('Scale', scale),
+    ]))
+    return _Socket(linked_to=node, output_name='Vector')
+
+
+def _mapping(vector, location=(0, 0, 0), rotation=(0, 0, 0), scale=(1, 1, 1), kind='POINT'):
+    return _Socket(linked_to=_Node('MAPPING', vector_type=kind, inputs={
+        'Vector': vector,
+        'Location': _named('Location', location),
+        'Rotation': _named('Rotation', rotation),
+        'Scale': _named('Scale', scale),
+    }), output_name='Vector')
+
+
+def _rotate(vector, kind, center=(0, 0, 0), angle=0.0, axis=(0, 0, 1),
+            euler=(0, 0, 0), invert=False):
+    inputs = {'Vector': vector, 'Center': _named('Center', center)}
+    # Blender 5.1 removes the other mode's sockets, rather than just disabling.
+    if kind == 'EULER_XYZ':
+        inputs['Rotation'] = _named('Rotation', euler)
+    else:
+        inputs['Angle'] = _named('Angle', angle)
+        if kind == 'AXIS_ANGLE':
+            inputs['Axis'] = _named('Axis', axis)
+    return _Socket(linked_to=_Node('VECTOR_ROTATE', rotation_type=kind,
+                                 invert=invert, inputs=inputs), output_name='Vector')
+
+
+@pytest.fixture
+def engine(monkeypatch):
+    return _load_blender_addon(monkeypatch).CustomRaytracerRenderEngine()
+
+
+def _resolved(engine, socket):
+    return engine._resolve_affine_coordinates(socket, warn=engine._warn_shader_fallback)
+
+
+def _point(engine, socket, point=(0.2, -0.3, 0.5)):
+    return (_resolved(engine, socket)['matrix'] @ np.array([*point, 1.0]))[:3]
+
+
+def _assert_point(got, expected):
+    np.testing.assert_allclose(got, expected, atol=1e-6, rtol=1e-6)
+
+
+@pytest.mark.parametrize(('operation', 'expected'), [
+    ('ADD', (2.2, 2.7, 4.5)),
+    ('SUBTRACT', (-1.8, -3.3, -3.5)),
+    ('MULTIPLY', (0.4, -0.9, 2.0)),
+    ('SCALE', (-0.4, 0.6, -1.0)),
+])
+def test_vector_math_explicit_point_oracles(engine, operation, expected):
+    _assert_point(_point(engine, _math(operation, _source(), (2, 3, 4), -2)), expected)
+    assert engine._degradation_report().is_empty()  # the unused third vector is invalid
+
+
+@pytest.mark.parametrize('operation', ['ADD', 'SUBTRACT', 'MULTIPLY'])
+def test_second_operand_provenance_and_order(engine, operation):
+    socket = _math(operation, (2, 3, 4), _source('Object'))
+    resolved = _resolved(engine, socket)
+    assert resolved['coord_mode'] == 'OBJECT'
+    expected = {'ADD': (2.2, 2.7, 4.5), 'SUBTRACT': (1.8, 3.3, 3.5),
+                'MULTIPLY': (0.4, -0.9, 2.0)}[operation]
+    _assert_point(_point(engine, socket), expected)
+
+
+def test_scale_reads_no_other_vector_operand(engine):
+    dead = _Socket(linked_to=_Node('UNSUPPORTED'))
+    _assert_point(_point(engine, _math('SCALE', _source(), dead, -2)), (-0.4, 0.6, -1))
+    assert engine._degradation_report().is_empty()
+
+
+def test_linked_value_rgb_combine_constants(engine):
+    value = _Node('VALUE', outputs=[types.SimpleNamespace(default_value=-2.0)])
+    rgb = _Node('RGB', outputs=[types.SimpleNamespace(default_value=(2, 3, 4, 1))])
+    combine = _Node('COMBXYZ', inputs={axis: _Socket(default=v)
+                                     for axis, v in zip('XYZ', (2, 3, 4))})
+    _assert_point(_point(engine, _math('SCALE', _source(), scale=_Socket(linked_to=value))),
+                  (-0.4, 0.6, -1))
+    for node in (rgb, combine):
+        _assert_point(_point(engine, _math('ADD', _source(), _Socket(linked_to=node))),
+                      (2.2, 2.7, 4.5))
+    assert engine._degradation_report().is_empty()
+
+
+def test_constant_only_affine_chain(engine):
+    socket = _math('MULTIPLY', (2, -3, 4), (0, 5, -2))
+    assert not _resolved(engine, socket)['varying']
+    _assert_point(_point(engine, socket, (100, 200, 300)), (0, -15, -8))
+
+
+def test_zero_scale_is_constant_and_can_combine_with_one_varying_source(engine):
+    zero = _math('SCALE', _source('UV'), scale=0)
+    assert not _resolved(engine, zero)['varying']
+    socket = _math('ADD', zero, _source('Object'))
+    _assert_point(_point(engine, socket), (0.2, -0.3, 0.5))
+    assert _resolved(engine, socket)['coord_mode'] == 'OBJECT'
+    assert engine._degradation_report().is_empty()
+
+
+@pytest.mark.parametrize('mode', ['Generated', 'Object', 'UV'])
+def test_coordinate_provenance_survives_rotations(engine, mode):
+    socket = _rotate(_math('ADD', (1, 2, 3), _source(mode, 'DetailUV')),
+                     'Z_AXIS', angle=0.4)
+    resolved = _resolved(engine, socket)
+    assert resolved['coord_mode'] == mode.upper()
+    assert resolved['uv_layer'] == ('DetailUV' if mode == 'UV' else '')
+
+
+def _axis_point(point, axis, angle):
+    # Elementary component equations, independent of the matrix constructor.
+    x, y, z = point
+    c, s = math.cos(angle), math.sin(angle)
+    if axis == 'X_AXIS':
+        return np.array([x, c * y - s * z, s * y + c * z])
+    if axis == 'Y_AXIS':
+        return np.array([c * x + s * z, y, -s * x + c * z])
+    return np.array([c * x - s * y, s * x + c * y, z])
+
+
+@pytest.mark.parametrize('kind', ['X_AXIS', 'Y_AXIS', 'Z_AXIS', 'AXIS_ANGLE', 'EULER_XYZ'])
+@pytest.mark.parametrize('invert', [False, True])
+def test_rotations_center_inverse_and_removed_sockets(engine, kind, invert):
+    point, center = np.array([0.2, -0.3, 0.5]), np.array([1.2, 2.3, -0.4])
+    angles, angle = (0.3, -0.7, 0.9), 0.7
+    if kind == 'EULER_XYZ':
+        local = point - center
+        # Inverse applies the REVERSED elementary rotations, not negative XYZ.
+        order = list(zip(('X_AXIS', 'Y_AXIS', 'Z_AXIS'), angles))
+        for axis, value in (reversed(order) if invert else order):
+            local = _axis_point(local, axis, -value if invert else value)
+        expected = center + local
+    else:
+        expected = center + _axis_point(point - center,
+                                       'Z_AXIS' if kind == 'AXIS_ANGLE' else kind,
+                                       -angle if invert else angle)
+    socket = _rotate(_source(), kind, center, angle, (0, 0, 3), angles, invert)
+    _assert_point(_point(engine, socket), expected)
+    assert engine._degradation_report().is_empty()
+
+
+def test_oblique_axis_and_zero_axis(engine):
+    # Rotating (1,0,0) by 120 degrees around (1,1,1) cyclically permutes XYZ.
+    socket = _rotate(_source(), 'AXIS_ANGLE', axis=(1, 1, 1), angle=2 * math.pi / 3)
+    _assert_point(_point(engine, socket, (1, 0, 0)), (0, 1, 0))
+    socket = _rotate(_source(), 'AXIS_ANGLE', center=(1, 2, 3), axis=(0, 0, 0), angle=1)
+    _assert_point(_point(engine, socket), (0.2, -0.3, 0.5))
+
+
+def test_noncommuting_mapping_rotation_chain(engine):
+    inner = _mapping(_source(), location=(2, 0, 1), scale=(2, 3, 4))
+    rotated = _rotate(inner, 'Z_AXIS', center=(1, 1, 0), angle=math.pi / 2)
+    outer = _mapping(rotated, location=(0, 5, 0), scale=(-1, 2, 0))
+    # p -> (2.4,-.9,3) -> (2.9,2.4,3) -> (-2.9,9.8,0)
+    _assert_point(_point(engine, outer), (-2.9, 9.8, 0))
+
+
+def test_singular_texture_mapping_safe_divide(engine):
+    socket = _mapping(_source(), (1, 2, 3), (0, 0, math.pi / 2), (0, 2, -3), 'TEXTURE')
+    _assert_point(_point(engine, socket, (3, 6, 9)), (0, -1, -2))
+
+
+def test_unlinked_mapping_vector_is_constant(engine):
+    socket = _mapping(_Socket(default=(2, -3, 4)), (1, 2, 3), scale=(2, 3, -1))
+    for point in ((0, 0, 0), (100, -200, 300)):
+        _assert_point(_point(engine, socket, point), (5, -7, -1))
+    assert not _resolved(engine, socket)['varying']
+    assert engine._degradation_report().is_empty()
+
+
+def test_malformed_mapping_vector_warns_instead_of_silent_implicit_coordinates(engine):
+    socket = _mapping(_Socket(default=0.0), location=(1, 0, 0))
+    _assert_point(_point(engine, socket), (1.2, -0.3, 0.5))
+    assert any('malformed Mapping Vector' in reason
+               for _, reason in engine._degradation_report().approximated)
+
+
+def test_rna_pointer_detects_cycle_across_distinct_python_wrappers(engine):
+    socket = _mapping(_source())
+    node = socket.links[0].from_node
+    other_wrapper = _Node('MAPPING', inputs=node.inputs)
+    node.as_pointer = other_wrapper.as_pointer = lambda: 123456
+    node.inputs['Vector'] = _Socket(linked_to=other_wrapper, output_name='Vector')
+    assert node is not other_wrapper
+    _resolved(engine, socket)
+    warnings = [reason for _, reason in engine._degradation_report().approximated]
+    assert any('cycle detected' in reason for reason in warnings)
+    assert not any('depth limit' in reason for reason in warnings)
+
+
+@pytest.mark.parametrize('socket', [
+    _math('SCALE', _source(), scale=1e39),
+    _mapping(_source(), scale=(1e-320, 1, 1), kind='TEXTURE'),
+])
+def test_nonrepresentable_composed_matrix_warns_and_stays_finite(engine, socket):
+    _assert_point(_point(engine, socket), (0.2, -0.3, 0.5))
+    assert not engine._degradation_report().is_empty()
+
+
+def test_normal_mapping_warns_about_bounded_approximation(engine):
+    _resolved(engine, _mapping(_source(), scale=(2, 3, 4), kind='NORMAL'))
+    assert any('normalization' in reason for _, reason in engine._degradation_report().approximated)
+
+
+@pytest.mark.parametrize('operation', ['DIVIDE', 'NORMALIZE', 'CROSS_PRODUCT'])
+def test_unsupported_operations_warn_and_fallback(engine, operation):
+    _assert_point(_point(engine, _math(operation, _source(), (2, 3, 4))), (0.2, -0.3, 0.5))
+    assert any(operation in reason for _, reason in engine._degradation_report().approximated)
+
+
+def test_two_varying_inputs_rejected_visibly(engine):
+    _assert_point(_point(engine, _math('ADD', _source('Generated'), _source('Object'))),
+                  (0.2, -0.3, 0.5))
+    assert any('multiple varying' in reason for _, reason in engine._degradation_report().approximated)
+
+
+def test_linked_rotation_control_never_uses_socket_default(engine):
+    control = _Socket(default=math.pi / 2, linked_to=_Node('TEX_NOISE'))
+    _assert_point(_point(engine, _rotate(_source(), 'Z_AXIS', angle=control)), (0.2, -0.3, 0.5))
+    assert any('linked TEX_NOISE' in reason for _, reason in engine._degradation_report().approximated)
+
+
+def test_cycle_and_depth_fallback_are_visible(engine):
+    cycle = _mapping(_source(), location=(1, 0, 0))
+    cycle.links[0].from_node.inputs['Vector'] = cycle
+    assert np.all(np.isfinite(_resolved(engine, cycle)['matrix']))
+    deep = _source()
+    for _ in range(40):
+        deep = _mapping(deep)
+    _resolved(engine, deep)
+    warnings = [reason for _, reason in engine._degradation_report().approximated]
+    assert any('cycle' in reason for reason in warnings)
+    assert any('depth limit' in reason for reason in warnings)
+
+
+def test_exact_identity_cancellation_and_tiny_cache_edits(engine):
+    renderer, image = _RecordingRenderer(), _FakeImage('shared.png')
+    plain = engine.load_blender_image(image, renderer)
+    cancelled = _math('SUBTRACT', _math('ADD', _source(), (1, 2, 3)), (1, 2, 3))
+    assert engine.load_blender_image(image, renderer, cancelled) == plain == 'shared.png'
+    first = engine.load_blender_image(image, renderer, _math('ADD', _source(), (1e-5, 0, 0)))
+    second = engine.load_blender_image(image, renderer, _math('ADD', _source(), (2e-5, 0, 0)))
+    tiny = engine.load_blender_image(image, renderer, _math('ADD', _source(), (1e-9, 0, 0)))
+    assert len({plain, first, second, tiny}) == 4
+    assert all('program-child' not in key for key in (plain, first, second, tiny))
+    assert len(renderer.loaded_textures) == 4
+    assert len(renderer.mapping_matrix_calls) == 3
+
+
+def test_image_resolves_once_and_preserves_named_uv(engine, monkeypatch):
+    original = engine._resolve_affine_coordinates
+    calls = []
+    def counted(*args, **kwargs):
+        calls.append(args[0])
+        return original(*args, **kwargs)
+    monkeypatch.setattr(engine, '_resolve_affine_coordinates', counted)
+    renderer = _RecordingRenderer()
+    socket = _math('SUBTRACT', (1, 1, 0), _source('UV', 'DetailUV'))
+    name = engine.load_blender_image(_FakeImage(), renderer, socket)
+    assert calls == [socket]
+    assert renderer.uv_layer_calls == [(name, 'DetailUV')]
+    assert len(renderer.mapping_matrix_calls) == 1
+
+
+class _ProgramRenderer(_RecordingRenderer):
+    def __init__(self):
+        super().__init__()
+        self.textures, self.programs = {}, {}
+
+    def load_texture(self, name, rgb, w, h):
+        super().load_texture(name, rgb, w, h)
+        self.textures[name] = object()
+
+    def create_program_texture(self, name, mode):
+        self.programs[name] = []
+
+    def program_texture_add_input(self, name, child):
+        self.programs[name].append(self.textures[child])
+
+    def set_program_texture_program(self, *_args):
+        pass
+
+
+def _program(engine, monkeypatch, renderer, images, name):
+    module = types.ModuleType('shader_vm_compiler')
+    module.VMCompileError = ValueError
+    module.compile_chain = lambda _socket: {
+        'inputs': images, 'num_tex': len(images), 'out_slot': 0,
+        'code_flat': [], 'consts_flat': [], 'ramps_flat': [],
+    }
+    monkeypatch.setitem(sys.modules, 'shader_vm_compiler', module)
+    return engine._maybe_build_program_texture(_Socket(), _Node('BSDF_PRINCIPLED', name=name),
+                                              'Base Color', renderer)
+
+
+def test_program_children_identity_and_mapping_pointer_isolation(engine, monkeypatch):
+    image, renderer = _FakeImage('same.png'), _ProgramRenderer()
+    nodes = [_Node('TEX_IMAGE', image=image, inputs={'Vector': _math('ADD', _source(), (x, 0, 0))})
+             for x in (0.1, 0.2)]
+    a = _program(engine, monkeypatch, renderer, [nodes[0]], 'A')
+    b = _program(engine, monkeypatch, renderer, [nodes[1]], 'B')
+    c = _program(engine, monkeypatch, renderer, [nodes[0]], 'C')
+    assert renderer.programs[a][0] is not renderer.programs[b][0]
+    assert renderer.programs[a][0] is renderer.programs[c][0]
+    assert len(renderer.loaded_textures) == 2
+    assert {name for name, _ in renderer.mapping_matrix_calls} == {a, b, c}
+    assert renderer.uv_transform_calls == []  # child textures receive no transform
+    assert engine._degradation_report().is_empty()
+
+
+def test_program_differing_input_mappings_degrade_before_upload(engine, monkeypatch):
+    image, renderer = _FakeImage(), _ProgramRenderer()
+    nodes = [_Node('TEX_IMAGE', image=image, inputs={'Vector': _source(mode)})
+             for mode in ('UV', 'Generated')]
+    assert _program(engine, monkeypatch, renderer, nodes, 'A') is None
+    assert renderer.loaded_textures == [] and not renderer.programs
+    assert any('differing coordinate' in reason for _, reason in engine._degradation_report().approximated)
+
+
+def test_procedural_new_chain_warns_and_keeps_outer_legacy_mapping(engine):
+    socket = _mapping(_math('ADD', _source(), (1, 2, 3)), location=(0.25, 0.5, 0))
+    node = _Node('TEX_CHECKER', inputs={'Vector': socket}, name='checker')
+    renderer = _RecordingRenderer()
+    name = engine.load_procedural_texture(node, renderer, socket)
+    assert name is not None and renderer.mapping_matrix_calls == []
+    assert renderer.uv_transform_calls == [(name, 1, 1, 0.25, 0.5, 0)]
+    assert (name, 'GENERATED') in renderer.coord_mode_calls
+    assert any('pkg242' in reason for _, reason in engine._degradation_report().approximated)
+
+
+def test_missing_matrix_binding_is_visible_and_does_not_project_to_2d(engine):
+    renderer = types.SimpleNamespace(set_texture_coord_mode=lambda *_args: None)
+    engine._apply_texture_transform(renderer, 'image', 'UV', (2, 3), (1, 2), 0.4,
+                                    mapping_matrix=[1, 0, 0, 1, 0, 1, 0, 2, 0, 0, 1, 3])
+    assert any('binding unavailable' in reason for _, reason in engine._degradation_report().approximated)


### PR DESCRIPTION
Blender Vector Math and Vector Rotate chains before image lookups now preserve supported affine transforms and UV provenance. Previously these chains fell back to default coordinates. Shared-image programs with different parent transforms now retain distinct GPU sampler identities.

The bounded subset covers ADD/SUBTRACT/MULTIPLY/SCALE with one varying operand, constant-control Rotate modes, Mapping composition, zero/mirrored scales and small cache-key edits. Unsupported procedural or independent per-input program coordinates warn explicitly. No native/CUDA/ABI or spectral transport code changes.

Verification:
- 101 focused tests passed, one native-binding skip; 45 new tests. Six real-Blender RNA probe sets pass 1e-6 (max error 1.075e-7).
- 21 CPU-only/GPU/Cycles render legs passed bounded chart gates; max Cycles channel deviation 3.486%, GPU/CPU 0.120%, nonidentity MAD at least 0.05593. Astra and independent Terra inspected saved comparison sheets.
- Fresh CPU/CUDA builds/import canaries and both isolated Blender package smokes passed. These are pre-commit hardware results against identical native source, not post-commit rebuild claims.
- Full split suites: 2370 passed, TWO FAILED (NOT GREEN). HDRI SSIM 0.7642104 (untouched baseline 0.7654136, gate 0.97); PostInit ULP13 (baseline13, gate4). Same fresh native artifact reproduces both on untouched source; paths do not consume this addon resolver. pkg237/pkg238 remain unresolved.
- Retained out-of-domain Repeat/clamped reference failures are not counted as passes. Equivalent old Mapping reproduces the clamped residuals; final in-domain fixtures test transform placement. No tolerance relaxation or RGB compensation.
- Existing public signatures retained; caller/test/mock/binding sweep and differential lint completed. Parent-only program mapping prevents double transforms; salted identity children prevent GPU pointer aliasing.
- Independent Claude architecture approved. Owner explicitly authorized Terra/DeepSeek final review and commit/merge on 2026-09-06. Terra final SIGN-OFF covered source/ABI/callers/visuals and adjudicated the two failures as nonblocking baseline debt under that directive; neither is waived or closed.

Evidence and pinned Cycles source references: .astroray_plan/docs/pkg230b-delivery-evidence.md and package spec. Representative PNGs, raw arrays, logs and final review retained in root test_results/pkg230b/. Limits remain assigned to pkg234 (image filtering/extension), pkg242 (procedural mapping), pkg245 (normal/bump provenance), and draft pkg246 (spectral RGB contract). Pillar 4 remains paused. CI pending.
