### PR TITLE
docs: record pkg230b delivery and current parallel work

### DIFF
--- a/.astroray_plan/docs/NEXT_STAGE_REPORT.md
+++ b/.astroray_plan/docs/NEXT_STAGE_REPORT.md
@@ -1,39 +1,32 @@
 # Astroray Next Stage Report
 
-## 2026-09-06 CURRENT — implemented round awaiting final independent review
+## 2026-09-06 CURRENT — pkg230b landed; smoke isolation in progress
 
-The owner delegated next-package selection to Astra after pkg230 Phase 2 and
-#703. This round implemented pkg230b and parallel pkg232, and audited the plans.
+- **pkg230b LANDED in PR #708**, merge `8217234b`, 2026-09-06 00:24:49 UTC.
+  The owner approved Terra/DeepSeek independent review while Claude is unavailable.
+  Terra final source/caller/binding/visual SIGN-OFF passed. PR CI: **2133 passed,
+  269 skipped, 15 xfailed, 4 xpassed**; host and CUDA checks passed.
+- Local pkg230b evidence remains **101 focused passes**, six real-RNA probe sets,
+  **21 CPU/GPU/Cycles render legs** and both isolated package smokes passing.
+  Full local suites remain **2370 passed, two reproduced baseline failures**
+  (pkg237 HDRI SSIM / pkg238 PostInit ULP); NOT GREEN, neither failure closed.
+- **pkg232 already landed #705.** Specs **pkg241–248 are filed**, #704/#706/#709;
+  filing approval is not implementation approval. Pillar 4 remains PAUSED.
+- **pkg236 is IN PROGRESS** in `.claude/worktrees/pkg236`, parallel lower backlog
+  authorized by the owner. Smoke profile isolation and transactional installation
+  have 62 focused passes plus real isolated CPU smoke evidence; independent final
+  review/delivery are pending. Do not duplicate-dispatch.
+- **Next main feature: pkg241 Phase 0**, completing the existing interactive
+  recorder and measuring actual Blender response/cancellation before behavior
+  changes. pkg242 then improves procedural mapping; pkg245 covers normal/bump
+  provenance. pkg240 CI cost audit is suitable parallel throughput work.
+- **Spark CLI access verified** with the installed Codex CLI and current account.
+  Bounded Spark workers can run via CLI even though this task's native subagent
+  roster lacks Spark. No account/configuration change was required.
 
-- **pkg230b: implemented locally, UNCOMMITTED / NOT MERGED.** Affine coordinate
-  chains and image-program cache isolation pass 101 focused tests, six real-RNA
-  probe sets, all 21 CPU/GPU/Cycles render legs, and isolated CPU/CUDA package
-  smokes. Full split suites: **2370 passed, two failures**. HDRI SSIM and PostInit
-  ULP failures reproduce against untouched source with the same fresh native
-  artifact (pkg237/pkg238); the full suite is **NOT green**.
-- **pkg230b release blocker:** independent Claude architecture approval passed,
-  but final source/ABI/parity/visual review has NOT run. Claude's subscription
-  weekly limit resets 2026-09-10 at 13:00 Australia/Sydney. Do not treat earlier
-  architecture approval or Astra visual inspection as final independent sign-off.
-  Preserve `codex/pkg230b` in `.claude/worktrees/pkg230b`; do not redispatch it.
-- **pkg232 LANDED in PR #705**, merge `d997c499` at 2026-09-05 18:50:24 UTC.
-  Windows Job containment passed 39 Windows tests, 14 actual-Linux tests, real
-  opencode smoke, caller review and independent Claude source SIGN-OFF. Both CI
-  runs passed host tests (2088 passed each) and CUDA syntax checks. Do not redispatch.
-- **Merged specifications:** pkg241–244 in #704 and pkg245 in #706. Their
-  implementation gates remain UNRUN. Three further local **DRAFT** specs,
-  pkg246 spectral RGB reconstruction, pkg247 launch-timeout boundary, and pkg248
-  content-change evidence, await independent filing review and are NOT dispatch
-  eligible. They remain in `.claude/worktrees/pkg230-followups`.
-- **Next after pkg230b closes: pkg241 Phase 0**, measuring render cancellation
-  and viewport response before implementation architecture. pkg242 follows for
-  procedural mapping fidelity; pkg243 preserves scientific output provenance.
-  pkg127 Phase 2 still requires topology/spec reconciliation before dispatch.
-- **Pillar 4 remains PAUSED.** GPU verification is finished and the GPU lock is
-  released. The user's live Blender profile was not used by this round's tests.
-
-Actual gates, retained failure evidence, reviewed filings and resumption state:
+See [pkg230b evidence](pkg230b-delivery-evidence.md) and
 [round delivery status](round-20260906-delivery-status.md).
+
 
 ---
 

--- a/.astroray_plan/docs/ROADMAP.md
+++ b/.astroray_plan/docs/ROADMAP.md
@@ -129,30 +129,27 @@ Full evidence:
 [pkg230-phase2-delivery-evidence.md](pkg230-phase2-delivery-evidence.md). pkg219d
 scalar parameter textures remain landed (#674); pkg210 is SUPERSEDED and pkg180
 CLOSED.
-**Owner update 2026-09-06:** next-package priority is delegated to Astra, with
-parallel lower-level backlog and a roadmap gap audit. The round implemented
-**pkg230b affine coordinate chains** locally and shipped **pkg232 delegate
-containment** in PR #705 (`d997c499`; independent approval, both host/CUDA CI runs
-passed). Common texture placement outranked the larger Principled arc and
-specialized caustic/sampling extensions.
-
-Pkg230b remains **uncommitted/unmerged**: 2370 local tests passed and two native
-failures reproduced against untouched source; all 21 CPU/GPU/Cycles chart legs
-and both isolated package smokes passed. The full suite is NOT green. Required
-Claude final source/ABI/parity/visual review is blocked by its weekly subscription
-limit (reported reset 2026-09-10 13:00 Australia/Sydney). Architecture approval
-alone is not release approval. Do not duplicate-dispatch pkg230b.
-
-After pkg230b closes, **pkg241 Phase 0 cancellation/viewport-response measurement**
-is next, followed by pkg242 procedural mapping/bake parity. pkg243 preserves raw
-relative-band output; pkg244 covers compiler-identity/cache-reset safeguards;
-pkg245 covers normal/bump coordinate provenance. Specs pkg241–245 are merged
-(#704/#706), OPEN with implementation gates UNRUN. Local pkg246–248 drafts await
-independent filing review and are NOT dispatch eligible. pkg127 Phase 2 needs
-reconciliation against existing pkg227 topology and gates before dispatch.
-See the [production gap audit](production-gap-audit-2026-09-06.md) and
-[round delivery status](round-20260906-delivery-status.md).
-**Pillar 4 remains PAUSED**; priority delegation does not unpause astrophysics.
+**Owner update 2026-09-06:** Astra chooses next-package priority and parallel
+lower backlog. While Claude is unavailable, the owner authorizes Terra or
+DeepSeek independent review and accepts documented reversible risks this round.
+**pkg230b LANDED #708 (`8217234b`)** after Terra source/caller/binding/visual
+SIGN-OFF and green PR host/CUDA CI (2133 host tests passed). Local 101 focused
+passes, 21 CPU/GPU/Cycles legs and isolated CPU/CUDA package smokes passed;
+the full local suite remains 2370 passed / two reproduced baseline failures
+(pkg237/pkg238), not green. Neither baseline failure is closed.
+**pkg232 LANDED #705**; specs241–248 filed #704/#706/#709 with independent filing
+review, implementation gates remain pending. **pkg236 smoke isolation is in
+progress** in its isolated worktree, with 62 focused passes and actual CPU smoke;
+independent final review/delivery remain pending. Do not duplicate-dispatch.
+**Next main feature: pkg241 Phase0**, finish the existing interactive recorder
+and measure actual UI/cancel response before behavior changes; then pkg242
+procedural mapping and pkg245 normal/bump provenance. pkg240 CI cost audit is a
+useful parallel throughput lane; pkg244 shares builder ownership with pkg236.
+pkg127 Phase2 still needs topology/spec reconciliation. Spark CLI access is
+verified for bounded work without changing account/configuration; native
+subagent availability is a separate interface limit.
+See [round delivery status](round-20260906-delivery-status.md).
+**Pillar4 remains PAUSED.**
 
 **Explicitly de-prioritized (owner-endorsed):** the sub-percent GPU/CPU
 parity tail — **pkg172 effect (B) / pkg173** (bounce-1 geometry-sampling

--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -1,39 +1,32 @@
 # Astroray Status
 
-## 2026-09-06 CURRENT — implemented round awaiting final independent review
+## 2026-09-06 CURRENT — pkg230b landed; smoke isolation in progress
 
-The owner delegated next-package selection to Astra after pkg230 Phase 2 and
-#703. This round implemented pkg230b and parallel pkg232, and audited the plans.
+- **pkg230b LANDED in PR #708**, merge `8217234b`, 2026-09-06 00:24:49 UTC.
+  The owner approved Terra/DeepSeek independent review while Claude is unavailable.
+  Terra final source/caller/binding/visual SIGN-OFF passed. PR CI: **2133 passed,
+  269 skipped, 15 xfailed, 4 xpassed**; host and CUDA checks passed.
+- Local pkg230b evidence remains **101 focused passes**, six real-RNA probe sets,
+  **21 CPU/GPU/Cycles render legs** and both isolated package smokes passing.
+  Full local suites remain **2370 passed, two reproduced baseline failures**
+  (pkg237 HDRI SSIM / pkg238 PostInit ULP); NOT GREEN, neither failure closed.
+- **pkg232 already landed #705.** Specs **pkg241–248 are filed**, #704/#706/#709;
+  filing approval is not implementation approval. Pillar 4 remains PAUSED.
+- **pkg236 is IN PROGRESS** in `.claude/worktrees/pkg236`, parallel lower backlog
+  authorized by the owner. Smoke profile isolation and transactional installation
+  have 62 focused passes plus real isolated CPU smoke evidence; independent final
+  review/delivery are pending. Do not duplicate-dispatch.
+- **Next main feature: pkg241 Phase 0**, completing the existing interactive
+  recorder and measuring actual Blender response/cancellation before behavior
+  changes. pkg242 then improves procedural mapping; pkg245 covers normal/bump
+  provenance. pkg240 CI cost audit is suitable parallel throughput work.
+- **Spark CLI access verified** with the installed Codex CLI and current account.
+  Bounded Spark workers can run via CLI even though this task's native subagent
+  roster lacks Spark. No account/configuration change was required.
 
-- **pkg230b: implemented locally, UNCOMMITTED / NOT MERGED.** Affine coordinate
-  chains and image-program cache isolation pass 101 focused tests, six real-RNA
-  probe sets, all 21 CPU/GPU/Cycles render legs, and isolated CPU/CUDA package
-  smokes. Full split suites: **2370 passed, two failures**. HDRI SSIM and PostInit
-  ULP failures reproduce against untouched source with the same fresh native
-  artifact (pkg237/pkg238); the full suite is **NOT green**.
-- **pkg230b release blocker:** independent Claude architecture approval passed,
-  but final source/ABI/parity/visual review has NOT run. Claude's subscription
-  weekly limit resets 2026-09-10 at 13:00 Australia/Sydney. Do not treat earlier
-  architecture approval or Astra visual inspection as final independent sign-off.
-  Preserve `codex/pkg230b` in `.claude/worktrees/pkg230b`; do not redispatch it.
-- **pkg232 LANDED in PR #705**, merge `d997c499` at 2026-09-05 18:50:24 UTC.
-  Windows Job containment passed 39 Windows tests, 14 actual-Linux tests, real
-  opencode smoke, caller review and independent Claude source SIGN-OFF. Both CI
-  runs passed host tests (2088 passed each) and CUDA syntax checks. Do not redispatch.
-- **Merged specifications:** pkg241–244 in #704 and pkg245 in #706. Their
-  implementation gates remain UNRUN. Three further local **DRAFT** specs,
-  pkg246 spectral RGB reconstruction, pkg247 launch-timeout boundary, and pkg248
-  content-change evidence, await independent filing review and are NOT dispatch
-  eligible. They remain in `.claude/worktrees/pkg230-followups`.
-- **Next after pkg230b closes: pkg241 Phase 0**, measuring render cancellation
-  and viewport response before implementation architecture. pkg242 follows for
-  procedural mapping fidelity; pkg243 preserves scientific output provenance.
-  pkg127 Phase 2 still requires topology/spec reconciliation before dispatch.
-- **Pillar 4 remains PAUSED.** GPU verification is finished and the GPU lock is
-  released. The user's live Blender profile was not used by this round's tests.
-
-Actual gates, retained failure evidence, reviewed filings and resumption state:
+See [pkg230b evidence](pkg230b-delivery-evidence.md) and
 [round delivery status](round-20260906-delivery-status.md).
+
 
 ---
 

--- a/.astroray_plan/docs/pkg230b-delivery-evidence.md
+++ b/.astroray_plan/docs/pkg230b-delivery-evidence.md
@@ -1,7 +1,7 @@
 # pkg230b — affine coordinate delivery evidence
 
 Status: implemented and locally verified with two reproduced baseline failures;
-**REVIEW APPROVED; delivery and CI pending**. Independent Claude architecture review passed.
+**LANDED in PR #708, merge8217234b**. Independent Claude architecture review passed.
 On 2026-09-06 the owner approved commit/merge and explicitly authorized Terra or
 DeepSeek independent review while Claude is unavailable. Terra final review
 returned SIGN-OFF after source/caller/binding and visual inspection.
@@ -154,3 +154,12 @@ sheets and confirmed correct placement, rotations, mirroring and distinct shared
 program mappings. Review: root `test_results/pkg230b/final-terra-review.txt`.
 All five source/test manifest hashes remain exact; documentation hashes were
 refreshed after recording approval. CI and final merge are recorded at closeout.
+
+## Delivery
+
+PR #708 merged2026-09-06 00:24:49 UTC. PR CI run34000095026 passed
+host (2133 passed,269 skipped,15 xfailed,4 xpassed) and CUDA syntax checks.
+Source0cf3a3d, reviewed integration0b98f9e; no renderer source changed after
+review. The duplicate push run was still finishing at merge. Local baseline
+failures remain unresolved. Full local logs and final Terra review remain in
+root test_results/pkg230b/.

--- a/.astroray_plan/docs/round-20260906-delivery-status.md
+++ b/.astroray_plan/docs/round-20260906-delivery-status.md
@@ -1,5 +1,29 @@
 # Delivery round status — 2026-09-06
 
+## Current update — pkg230b shipped, 2026-09-06
+
+Pkg230b landed in #708, merge `8217234be0ce981075635647259fc78abdb1b77c`, at
+00:24:49 UTC. Owner-authorized Terra final SIGN-OFF covered source, callers,
+bindings, numerical evidence and actual saved visuals. PR run34000095026 passed
+host (2133 passed,269 skipped,15 xfailed,4 xpassed;1202.30s test step) and CUDA
+syntax checks. The duplicate push run34000075314 was still finishing at merge;
+no claim that it passed then. Local full-suite failures remain baseline debt,
+not passing gates. Source commit0cf3a3d; reviewed integration head0b98f9e.
+
+The three local draft specs246–248 received Terra filing SIGN-OFF and landed
+#709 (`45331d3`). They require detailed architecture before implementation.
+Pkg236 is now parallel in-flight work:62 focused passes, actual isolated CPU
+Blender smoke, live-profile hashes unchanged; independent final review and
+release pending. Main feature priority remains pkg241 measurement then viewport
+response, followed by mapped procedural/normal fidelity. No astrophysics unpause.
+
+Spark access was tested successfully through Codex CLI0.153.4. One bounded real
+critique completed; Astra/Terra rejected its false positives. The session's native
+subagent roster still lacks Spark, but CLI execution requires no new setup.
+
+## Earlier closeout — historical state, superseded above
+
+
 This is a factual handoff, not final approval of pkg230b or a new scope decision.
 The owner requested another implementation after pkg230 Phase 2, parallel lower
 backlog, and specifications for production gaps. Pillar 4 remains PAUSED.

--- a/.astroray_plan/packages/pkg230b-vector-coordinate-chain.md
+++ b/.astroray_plan/packages/pkg230b-vector-coordinate-chain.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 5 (Blender integration / shader-node coverage)
 **Track:** A
-**Status:** IN PROGRESS — Terra final SIGN-OFF; delivery and CI pending
+**Status:** DONE — PR #708, merge8217234b; owner-authorized Terra SIGN-OFF and PR CI passed
 **Estimated effort:** M
 **Depends on:** pkg219a, pkg230 Phase 2
 
@@ -187,7 +187,7 @@ program children, false procedural support, rotation convention, and stale
 native module selection. Current results and retained failed reference cases are
 recorded in [delivery evidence](../docs/pkg230b-delivery-evidence.md).
 Full tests and isolated CPU/CUDA package smokes are complete; the two baseline
-failures remain unresolved. Final independent review passed; delivery and CI remain pending.
+failures remain unresolved. Final independent review passed; delivery completed in PR #708.
 The owner explicitly approved commit/merge and Terra or DeepSeek independent
 review on 2026-09-06 while Claude is unavailable. Terra approved the final
 source/ABI/parity/visual evidence; the earlier architecture approval remains


### PR DESCRIPTION
Record pkg230b landed in #708 with owner-authorized Terra final review, actual PR CI counts and retained baseline failures. Mark specs246-248 filed via #709, identify pkg236 as current isolated parallel work, and retain pkg241 as next main feature. Record verified Spark CLI access without claiming native subagent availability.

Factual documentation only; no function/class signatures changed. Differential lint: zero new findings across three tools. Renderer gates are referenced from the approved delivery evidence; no new tests or build claims.
