### PR TITLE
docs: close pkg236 delivery and plan the viewport milestone

### DIFF
--- a/.astroray_plan/docs/NEXT_STAGE_REPORT.md
+++ b/.astroray_plan/docs/NEXT_STAGE_REPORT.md
@@ -1,6 +1,6 @@
 # Astroray Next Stage Report
 
-## 2026-09-06 CURRENT — pkg230b landed; smoke isolation in progress
+## 2026-09-06 CURRENT — pkg230b and pkg236 landed
 
 - **pkg230b LANDED in PR #708**, merge `8217234b`, 2026-09-06 00:24:49 UTC.
   The owner approved Terra/DeepSeek independent review while Claude is unavailable.
@@ -12,10 +12,17 @@
   (pkg237 HDRI SSIM / pkg238 PostInit ULP); NOT GREEN, neither failure closed.
 - **pkg232 already landed #705.** Specs **pkg241–248 are filed**, #704/#706/#709;
   filing approval is not implementation approval. Pillar 4 remains PAUSED.
-- **pkg236 is IN PROGRESS** in `.claude/worktrees/pkg236`, parallel lower backlog
-  authorized by the owner. Smoke profile isolation and transactional installation
-  have 62 focused passes plus real isolated CPU smoke evidence; independent final
-  review/delivery are pending. Do not duplicate-dispatch.
+- **pkg236 LANDED #711**, merge `2699b43`; Terra final SIGN-OFF passed.
+  Smoke isolation and transactional installation passed 62 focused tests and the
+  exact real-Blender local-host test. PowerShell 7 and 5.1 CPU smokes passed;
+  all 471 live-profile files remained unchanged. Both CI runs: **2173 passed,
+  277 skipped, 15 xfailed, 4 xpassed**; host/CUDA checks passed.
+  [Evidence](pkg236-implementation-evidence.md) retains transaction limits and
+  the pre-existing non-blocking reference-smoke failure (two gates passed, one
+  failed). The advisory is NOT GREEN; pkg249 records the diagnostic follow-up.
+- **pkg240 baseline audit landed #712**: host tests occupy 90.1-91.7% of the
+  measured host job time. Package remains OPEN; no workflow change or speedup
+  claim. Detailed architecture precedes a controlled split-runner trial.
 - **Next main feature: pkg241 Phase 0**, completing the existing interactive
   recorder and measuring actual Blender response/cancellation before behavior
   changes. pkg242 then improves procedural mapping; pkg245 covers normal/bump

--- a/.astroray_plan/docs/ROADMAP.md
+++ b/.astroray_plan/docs/ROADMAP.md
@@ -138,9 +138,14 @@ passes, 21 CPU/GPU/Cycles legs and isolated CPU/CUDA package smokes passed;
 the full local suite remains 2370 passed / two reproduced baseline failures
 (pkg237/pkg238), not green. Neither baseline failure is closed.
 **pkg232 LANDED #705**; specs241–248 filed #704/#706/#709 with independent filing
-review, implementation gates remain pending. **pkg236 smoke isolation is in
-progress** in its isolated worktree, with 62 focused passes and actual CPU smoke;
-independent final review/delivery remain pending. Do not duplicate-dispatch.
+review, implementation gates remain pending. **pkg236 LANDED #711 (`2699b43`)**,
+with Terra final SIGN-OFF, 62 focused passes, the exact real-Blender local-host
+pass, PowerShell 7/5.1 CPU smokes and 471 unchanged live-profile files.
+Both CI runs passed host/CUDA checks: 2173 passed, 277 skipped, 15 xfailed,
+4 xpassed. Retain the existing reference-smoke advisory failure (two passed
+gates, one failed); pkg249 owns separate diagnosis. Do not duplicate-dispatch.
+**pkg240 baseline audit landed #712**; its controlled trial requires detailed
+architecture. No CI behavior change or candidate speedup is claimed.
 **Next main feature: pkg241 Phase0**, finish the existing interactive recorder
 and measure actual UI/cancel response before behavior changes; then pkg242
 procedural mapping and pkg245 normal/bump provenance. pkg240 CI cost audit is a

--- a/.astroray_plan/docs/STATUS.md
+++ b/.astroray_plan/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Astroray Status
 
-## 2026-09-06 CURRENT — pkg230b landed; smoke isolation in progress
+## 2026-09-06 CURRENT — pkg230b and pkg236 landed
 
 - **pkg230b LANDED in PR #708**, merge `8217234b`, 2026-09-06 00:24:49 UTC.
   The owner approved Terra/DeepSeek independent review while Claude is unavailable.
@@ -12,10 +12,17 @@
   (pkg237 HDRI SSIM / pkg238 PostInit ULP); NOT GREEN, neither failure closed.
 - **pkg232 already landed #705.** Specs **pkg241–248 are filed**, #704/#706/#709;
   filing approval is not implementation approval. Pillar 4 remains PAUSED.
-- **pkg236 is IN PROGRESS** in `.claude/worktrees/pkg236`, parallel lower backlog
-  authorized by the owner. Smoke profile isolation and transactional installation
-  have 62 focused passes plus real isolated CPU smoke evidence; independent final
-  review/delivery are pending. Do not duplicate-dispatch.
+- **pkg236 LANDED #711**, merge `2699b43`; Terra final SIGN-OFF passed.
+  Smoke isolation and transactional installation passed 62 focused tests and the
+  exact real-Blender local-host test. PowerShell 7 and 5.1 CPU smokes passed;
+  all 471 live-profile files remained unchanged. Both CI runs: **2173 passed,
+  277 skipped, 15 xfailed, 4 xpassed**; host/CUDA checks passed.
+  [Evidence](pkg236-implementation-evidence.md) retains transaction limits and
+  the pre-existing non-blocking reference-smoke failure (two gates passed, one
+  failed). The advisory is NOT GREEN; pkg249 records the diagnostic follow-up.
+- **pkg240 baseline audit landed #712**: host tests occupy 90.1-91.7% of the
+  measured host job time. Package remains OPEN; no workflow change or speedup
+  claim. Detailed architecture precedes a controlled split-runner trial.
 - **Next main feature: pkg241 Phase 0**, completing the existing interactive
   recorder and measuring actual Blender response/cancellation before behavior
   changes. pkg242 then improves procedural mapping; pkg245 covers normal/bump

--- a/.astroray_plan/docs/pkg230b-delivery-evidence.md
+++ b/.astroray_plan/docs/pkg230b-delivery-evidence.md
@@ -160,6 +160,7 @@ refreshed after recording approval. CI and final merge are recorded at closeout.
 PR #708 merged2026-09-06 00:24:49 UTC. PR CI run34000095026 passed
 host (2133 passed,269 skipped,15 xfailed,4 xpassed) and CUDA syntax checks.
 Source0cf3a3d, reviewed integration0b98f9e; no renderer source changed after
-review. The duplicate push run was still finishing at merge. Local baseline
-failures remain unresolved. Full local logs and final Terra review remain in
+review. The duplicate push run34000075314 was still finishing at merge and
+subsequently passed host (2133 passed, 269 skipped, 15 xfailed, 4 xpassed) and
+CUDA checks. Local baseline failures remain unresolved. Full local logs and final Terra review remain in
 root test_results/pkg230b/.

--- a/.astroray_plan/docs/pkg236-implementation-evidence.md
+++ b/.astroray_plan/docs/pkg236-implementation-evidence.md
@@ -3,7 +3,8 @@
 2026-09-06, isolated worktree `.claude/worktrees/pkg236`, branch `codex/pkg236`,
 base `45331d3f4e200f845885a612c709c130e4ee06a9`, integrated main `8217234`.
 Implementation, actual Blender smoke and owner-authorized Terra final SIGN-OFF
-complete; CI and delivery pending.
+complete. LANDED PR #711, merge `2699b43e05f648bed846f8b7b6abd406100677e7`,
+2026-09-06 01:04:32 UTC, reviewed source `2b81ad2`.
 
 ## Measured host gates
 
@@ -127,3 +128,26 @@ Final staging includes the landed pkg230b addon from main `8217234`.
   Root evidence: `test_results/pkg236/final-terra-review.txt`,
   `real-cpu-smoke.log`, `real-powershell51-cpu-smoke-final.log`,
   `real-smoke-guard-result.json`; feature `test_results/pkg236-local-host.xml`.
+
+## Delivery, CI and saved visual
+
+Push run34001549179 and PR run34001551993 both passed authoritative pytest:
+**2173 passed, 277 skipped, 15 xfailed, 4 xpassed, 5 warnings**, respectively
+1589.95s and1593.24s. Both CUDA syntax checks passed. Detailed logs are retained
+in root `test_results/pkg236/ci-push.log` and `ci-pr.log`.
+
+The existing informational reference-bank smoke is NOT GREEN: literal
+`FAIL (2/3 gates)` means two gates passed and one failed, followed by exit1.
+Both pkg236 runs and both earlier pkg230b runs have this same aggregate result.
+The unchanged workflow explicitly makes it non-blocking with continue-on-error;
+pytest remains authoritative. No renderer/native/reference-bank/workflow code
+changed. Independent Terra adjudicated the advisory non-blocking for pkg236,
+without claiming an exact image-level cause. Pkg249 records separate diagnosis.
+Evidence: root `test_results/pkg236/ci-terra-adjudication.txt`.
+
+Astra inspected saved `test_results/pkg236/cpu-smoke.png` (sRGB display) and its
+identity record: centered illuminated peach/orange geometry, expected noise,
+no visible corruption. Raw linear data is `cpu-smoke.npy`; qualitative decision
+is `astra-visual-review.json`. This is visible CPU smoke liveness only, not
+Cycles parity or a fresh native/GPU build. All471 live-profile files were also
+rechecked after the visual capture; no changed/new files, original PID36532 only.

--- a/.astroray_plan/docs/round-20260906-delivery-status.md
+++ b/.astroray_plan/docs/round-20260906-delivery-status.md
@@ -1,25 +1,69 @@
 # Delivery round status — 2026-09-06
 
-## Current update — pkg230b shipped, 2026-09-06
+## Current update — delivery and next milestone, 2026-09-06
 
 Pkg230b landed in #708, merge `8217234be0ce981075635647259fc78abdb1b77c`, at
 00:24:49 UTC. Owner-authorized Terra final SIGN-OFF covered source, callers,
 bindings, numerical evidence and actual saved visuals. PR run34000095026 passed
 host (2133 passed,269 skipped,15 xfailed,4 xpassed;1202.30s test step) and CUDA
 syntax checks. The duplicate push run34000075314 was still finishing at merge;
-no claim that it passed then. Local full-suite failures remain baseline debt,
+it subsequently passed host and CUDA checks (2133 passed, 269 skipped,
+15 xfailed, 4 xpassed; 1564.59s pytest). Local full-suite failures remain baseline debt,
 not passing gates. Source commit0cf3a3d; reviewed integration head0b98f9e.
 
 The three local draft specs246–248 received Terra filing SIGN-OFF and landed
 #709 (`45331d3`). They require detailed architecture before implementation.
-Pkg236 is now parallel in-flight work:62 focused passes, actual isolated CPU
-Blender smoke, live-profile hashes unchanged; independent final review and
-release pending. Main feature priority remains pkg241 measurement then viewport
-response, followed by mapped procedural/normal fidelity. No astrophysics unpause.
+Pkg236 landed in PR #711, merge `2699b43`, at 01:04:32 UTC, reviewed source
+`2b81ad2`, with owner-authorized
+Terra final SIGN-OFF. Host gates: 62 focused passes plus the exact real-Blender
+local-host test (1 passed, 8.15s); both PowerShell 7 and Windows PowerShell 5.1
+real isolated CPU smokes passed. All 471 live-profile files remained unchanged;
+only the original user Blender process remained. Both CI runs passed host/CUDA
+checks: 2173 passed, 277 skipped, 15 xfailed, 4 xpassed (5 warnings). The PR
+pytest run took 1593.24s; push 1589.95s. Runs: 34001551993 / 34001549179.
+The saved CPU smoke PNG and linear array received Astra qualitative inspection:
+visible illuminated geometry, expected noise, no visible corruption. This is a
+CPU liveness check, not a new native build, GPU test or Cycles parity claim.
+See [pkg236 evidence](pkg236-implementation-evidence.md) for transaction limits.
 
-Spark access was tested successfully through Codex CLI0.153.4. One bounded real
-critique completed; Astra/Terra rejected its false positives. The session's native
+The informational reference-bank smoke remains NOT GREEN: literal
+`FAIL (2/3 gates)` means two gates passed and one failed. It exited 1 in both
+pkg236 and both earlier pkg230b runs. The existing workflow makes it non-blocking;
+Terra independently adjudicated its lack of relevance to the installer change.
+No image-level cause is established. Pkg249 filed a separate diagnostic scope
+in #713 (`6bc382f`), with independent Terra filing SIGN-OFF and docs-only CI;
+no threshold, reference, required check or transport code changed.
+
+Pkg240's factual CI baseline audit landed in #712 (`6ae2421`). Four measured
+push/PR runs put host testing at 90.1–91.7% of host job time. The package remains
+OPEN: no workflow change, candidate speedup or collection-parity result is
+claimed. Independent Terra approved filing; docs-only CI passed change detection
+and skipped host/CUDA as designed. A controlled canonical split-runner trial is
+the next bounded throughput experiment.
+
+Spark access was tested successfully through Codex CLI0.153.4. Two bounded real
+critiques completed; Astra/Terra rejected false positives. The session's native
 subagent roster still lacks Spark, but CLI execution requires no new setup.
+
+### Recommended next milestone
+
+Pkg241 Phase 0 is the next main feature: finish the existing interactive recorder
+and measure actual Blender events before selecting behavior changes. The current
+interactive driver is a stub; native stage averages do not establish UI-event
+or cancellation percentiles. Reuse the canonical benchmark and isolated profile
+contract. Record CPU/GPU identity and raw event, update, presentation, cancel
+acknowledgement and completion timings; then pin workload-specific budgets.
+
+The visible milestone is orbit, settle/refine, edit, F12 cancel and restart on
+a representative expensive scene, without mixed accumulation or stale frames.
+Astra owns session/GIL/CUDA architecture, integration and actual visual judgment;
+owner-authorized Terra supplies independent review while Claude is unavailable.
+Use bounded Spark/DeepSeek workers for tracing, harness work and mechanical
+changes. Keep at most two implementation worktrees and serialize GPU work.
+After pkg240 detailed architecture, its controlled trial may run in parallel
+with this feature; follow with pkg242 procedural mapping and pkg245 normal/bump
+fidelity after checking file ownership. No paused
+astrophysics work resumes. The two known local baseline failures remain open.
 
 ## Earlier closeout — historical state, superseded above
 

--- a/.astroray_plan/packages/pkg236-hermetic-blender-smoke.md
+++ b/.astroray_plan/packages/pkg236-hermetic-blender-smoke.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 5 (Blender/DCC dev-loop tooling)
 **Track:** A
-**Status:** IMPLEMENTED — Terra SIGN-OFF and real Blender gates passed; CI/delivery pending
+**Status:** DONE — PR #711, merge2699b43, 2026-09-06; Terra SIGN-OFF and documented gates passed
 **Estimated effort:** TBD at architect review
 **Depends on:** none — reuses canonical `scripts/dev_addon.ps1` and existing build/install helpers; no owner queue promotion
 
@@ -49,7 +49,7 @@ Scope: `scripts/dev_addon.ps1`, `scripts/build/build_blender_addon.py`,
 `tests/test_dev_loop_smoke.py`, and `tests/test_pkg236_hermetic_install.py`.
 The owner authorized bounded parallel lower-backlog work for this round.
 
-## Acceptance — host/real-Blender/review complete; CI/delivery pending
+## Acceptance — implemented and delivered
 
 - [x] Disposable-profile real Blender register/smoke, with a sentinel proving the
       real user profile was never written.
@@ -74,6 +74,12 @@ Terra final review passed. Post-promotion
 backup cleanup failure is an explicitly reported incomplete cleanup, not a
 claim that the prior installation was restored. Full evidence and delegation
 JSON: [pkg236 implementation evidence](../docs/pkg236-implementation-evidence.md).
+
+Both push/PR CI runs passed authoritative pytest (2173 passed, 277 skipped,
+15 xfailed, 4 xpassed) and CUDA checks. The existing informational reference
+smoke remains a recorded failure: two gates passed, one failed; independent
+Terra adjudicated it non-blocking for this installer-only package. Pkg249 owns
+separate diagnosis; no exact image-level cause or full-reference-green claim.
 
 ## Non-goals
 

--- a/.astroray_plan/packages/pkg241-render-cancellation-viewport-response.md
+++ b/.astroray_plan/packages/pkg241-render-cancellation-viewport-response.md
@@ -5,8 +5,8 @@
 **Status:** OPEN — detailed architect review required before implementation
 **Estimated effort:** TBD at architect review
 **Depends on:** landed pkg52/81/191/192/196 viewport machinery and pkg147
-OpenMP/GIL safeguards; coordinate real Blender tests with OPEN pkg236's
-isolated-profile contract. OPEN pkg232 owns delegate subprocess cleanup only.
+OpenMP/GIL safeguards; coordinate real Blender tests with DONE pkg236's (#711)
+isolated-profile contract. DONE pkg232 (#705) owns delegate subprocess cleanup only.
 
 Coverage specs: [pkg52](pkg52-persistent-viewport-session.md),
 [pkg81](pkg81-viewport-interactivity-parity.md),


### PR DESCRIPTION
Record pkg236 delivered in PR711 after Terra source/caller and CI adjudication, 62 focused tests, the exact real-Blender local-host test, real PowerShell7/5.1 isolated CPU smokes, and preservation of all471 live-profile files. Both CI runs passed authoritative pytest:2173passed277skipped15xfailed4xpassed, plus CUDA checks.

Retain the non-blocking reference-bank advisory as a failure (two gates passed, one failed), with separate pkg249 diagnosis and no asserted image-level cause. Record saved CPU visual proof and transaction limitations. Update the live planning hierarchy, pkg236 status, pkg241 completed dependencies, pkg240 baseline audit and concrete viewport milestone. pkg230b's two reproduced local baseline failures remain open; Pillar4 remains paused.

Documentation only; no changed function/class signatures or callers. Canonical differential lint:zero new findings, three tools available. Astra factual integration and independent Terra filing review.
