### PR TITLE
fix(pkg250): restore standalone CUDA wavefront dispatch

### DIFF
--- a/.astroray_plan/packages/pkg250-standalone-cuda-wavefront-dispatch.md
+++ b/.astroray_plan/packages/pkg250-standalone-cuda-wavefront-dispatch.md
@@ -1,0 +1,84 @@
+# pkg250 — Standalone CUDA wavefront dispatch
+
+**Pillar:** 5 (renderer verification and delivery tooling)
+**Track:** A
+**Status:** IMPLEMENTING — CPU checks passed; clean CUDA build, GPU runtime and independent review pending
+**Depends on:** existing pkg55-C7 wavefront backend; no new renderer algorithm
+
+## Problem and scope
+
+The owner-requested full root rebuild at source `f30bc5f` exposed the stale
+`cudaRenderer.render(...)` call in `apps/main.cpp`. That entry point was removed
+in pkg55-C7; the CUDA standalone target no longer compiled even though the
+Python/addon targets used the current wavefront entry point. This is a bounded
+prerequisite build repair for the current rebuild and handoff, without changing
+the pkg241/240 milestone, promoting other backlog work, or unpausing Pillar 4.
+
+Own only `apps/main.cpp`, focused behavior additions in
+`tests/test_standalone_renderer.py`, and this spec. No engine, binding, ABI,
+reference, CI workflow, or rendering-physics changes.
+
+## Architecture decision
+
+- Route the existing standalone `auto`/`gpu` path-tracer selection through
+  `astroray::wavefront::cuda_wavefront_render`, matching the binding contract.
+  The wavefront implementation builds and uploads its own scene/environment;
+  remove the legacy `uploadScene` and `uploadEnvironmentMap` calls.
+- Guard the snapshot header and wavefront call with CUDA and
+  `ASTRORAY_WAVEFRONT_CUDA_N3`. In CUDA builds without N3, `auto` uses CPU;
+  explicit `gpu` reports the wavefront-build requirement and exits with error.
+  Preserve unavailable-device and unsupported-integrator errors.
+- Mirror the binding's path-tracer parameters: `getFloat` wavelength bounds
+  defaulting to 380–780 nm, output-mode inference at 379.5–780.5 nm, and NEE on.
+  Seed zero obtains a random-device seed; nonzero renderer seeds pass through.
+  Do not add a seed flag or other CLI options.
+- Copy interleaved linear RGB results into camera pixels. Keep the CPU render
+  invocation unchanged: its existing `true` argument enables adaptive sampling,
+  while gamma defaults off. Existing PNG/PPM writers apply display gamma once.
+
+## Acceptance and evidence
+
+1. Review the exact binding and wavefront contracts and sweep standalone callers;
+   no removed CUDA-render entry point remains in this caller.
+2. Build the CPU standalone target and complete the full clean root CUDA
+   `ALL_BUILD`. Exercise CUDA/N3-off compilation and CPU-auto/explicit-GPU error
+   behavior where feasible; report any unrun configuration explicitly.
+3. Run actual executable tests for explicit CPU/GPU Cornell and material scenes,
+   PNG/PPM validity, auto fallback and explicit errors when unavailable, decimal
+   wavelength/output-mode parameters, and an uploaded environment image.
+4. Save representative CPU/GPU images with source, artifact and settings identity.
+   Astra qualitative review and an independent source/ABI review are required;
+   numerical checks alone do not establish image correctness or gamma parity.
+5. Run focused tests and differential lint. The implement delegate's wrapper JSON
+   is process evidence; inspect its diff and verify locally before sign-off.
+
+Local checks on 2026-09-06 (isolated `pkg250` worktree, source repair above
+`083c84b`; the intervening main change only corrected builder documentation):
+
+| Check | Result |
+| --- | --- |
+| MSVC Release CPU standalone, `windows-cpu-vs`, Python/OIDN off | PASS; `build/bin/Release/raytracer.exe` |
+| Full standalone suite against that CPU binary | 11 passed, 5 explicitly skipped because CUDA was not compiled |
+| MSVC `/Zs` host syntax, CUDA defined with N3 off and on | PASS for both; no CUDA compilation or linking in these checks |
+| Delegated implement process | Completed in 304.5 s, Windows Job cleanup confirmed, zero active processes |
+
+The delegate diff required local repairs: retain the scene builder's required
+`buildAcceleration()` precondition and implement N3-off automatic CPU fallback.
+No function signatures changed. The caller sweep covers the standalone test
+suite, `CMakeLists.txt` target, and the binding/header implementation contract.
+The final standalone caller has no legacy upload or removed render call.
+
+Hardware/build evidence and final independent judgment are owned by the parent
+delivery agent. CPU tests produced images in `test_results/`; qualitative
+review, CUDA completion, GPU images, and CUDA/N3-off runtime behavior remain
+pending. Syntax-only checks do not establish linking or device behavior.
+
+## Limits
+
+The binding's visible defaults (380–780 nm) and CPU spectral defaults
+(360–830 nm) already differ. Arbitrary integrator-parameter parity is outside
+this repair. In particular, the existing CLI parser stores integer literals as
+integers, while binding-compatible `getFloat` wavelength extraction accepts
+float values; tests use explicit decimal literals. No parameter-typing or
+spectral-default redesign is included. Existing seed-zero runs are stochastic;
+the behavior tests do not claim cross-device bitwise equality or convergence.

--- a/apps/main.cpp
+++ b/apps/main.cpp
@@ -5,6 +5,9 @@
 #include "astroray/register.h"
 #ifdef ASTRORAY_CUDA_ENABLED
 #include "astroray/gpu_renderer.h"
+#  ifdef ASTRORAY_WAVEFRONT_CUDA_N3
+#include "../src/gpu/wavefront/gpu_wavefront_snapshot.h"
+#  endif
 #endif
 #include "stb_image_write.h"
 #include <iostream>
@@ -14,8 +17,10 @@
 #include <algorithm>
 #include <cmath>
 #include <cctype>
+#include <cstdint>
 #include <cstdlib>
 #include <memory>
+#include <random>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -236,10 +241,20 @@ int main(int argc, char* argv[]) {
     bool useGpu = false;
     CUDARenderer cudaRenderer;
     bool cudaAvailable = cudaRenderer.isAvailable();
-    if ((device == "auto" && cudaAvailable && pathTracerSelected) || device == "gpu") {
+#ifdef ASTRORAY_WAVEFRONT_CUDA_N3
+    const bool wavefrontAvailable = true;
+#else
+    const bool wavefrontAvailable = false;
+#endif
+    if ((device == "auto" && cudaAvailable && wavefrontAvailable && pathTracerSelected) || device == "gpu") {
         if (!pathTracerSelected) {
             std::cerr << "Error: CUDA standalone backend currently supports path_tracer only; requested integrator '"
                       << integratorName << "'. Use --device cpu for this integrator.\n";
+            return 2;
+        }
+        if (!wavefrontAvailable) {
+            std::cerr << "Error: GPU rendering requires the wavefront build "
+                         "(ASTRORAY_WAVEFRONT_CUDA_N3=ON).\n";
             return 2;
         }
         if (!cudaAvailable) {
@@ -268,17 +283,42 @@ int main(int argc, char* argv[]) {
     auto start = std::chrono::high_resolution_clock::now();
 #ifdef ASTRORAY_CUDA_ENABLED
     if (useGpu) {
+#  ifdef ASTRORAY_WAVEFRONT_CUDA_N3
         try {
             renderer.buildAcceleration();
-            cudaRenderer.uploadScene(renderer, camera);
-            if (!envmap.empty() && renderer.getEnvironmentMap() && renderer.getEnvironmentMap()->loaded()) {
-                cudaRenderer.uploadEnvironmentMap(*renderer.getEnvironmentMap());
+            // Match the binding's path_tracer dispatch; wavefront owns uploads.
+            float lmin = integratorParams.getFloat("lambda_min", 380.0f);
+            float lmax = integratorParams.getFloat("lambda_max", 780.0f);
+            std::string mode = integratorParams.getString("output_mode", "");
+            bool useLum;
+            if (mode.empty())
+                useLum = !(lmin >= 379.5f && lmax <= 780.5f);
+            else
+                useLum = (mode == "luminance");
+            const uint64_t effectiveSeed =
+                (renderer.getSeed() == 0)
+                    ? static_cast<uint64_t>(std::random_device{}())
+                    : static_cast<uint64_t>(renderer.getSeed());
+            auto rgb = astroray::wavefront::cuda_wavefront_render(
+                renderer, camera, camera.width, camera.height,
+                samples, depth, effectiveSeed,
+                lmin, lmax, useLum, /*enableNEE=*/true);
+            for (size_t i = 0; i < camera.pixels.size(); ++i) {
+                camera.pixels[i] = Vec3(rgb[i * 3 + 0],
+                                        rgb[i * 3 + 1],
+                                        rgb[i * 3 + 2]);
             }
-            cudaRenderer.render(camera.pixels, camera.width, camera.height, renderer.getSeed(), samples, depth);
         } catch (const std::exception& e) {
             std::cerr << "Error: CUDA standalone render failed: " << e.what() << "\n";
             return 2;
         }
+#  else
+        // pkg55-C7: the megakernels are deleted; a CUDA build without the
+        // wavefront has no GPU render path.
+        std::cerr << "Error: GPU rendering requires the wavefront build "
+                     "(ASTRORAY_WAVEFRONT_CUDA_N3=ON).\n";
+        return 2;
+#  endif
     } else
 #endif
     {

--- a/tests/test_standalone_renderer.py
+++ b/tests/test_standalone_renderer.py
@@ -202,6 +202,124 @@ def test_energy_conservation_diffuse_light(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Explicit device dispatch regression coverage (pkg250)
+# ---------------------------------------------------------------------------
+
+def _dispatch_args(device, output, scene="1"):
+    return ["--device", device, "--scene", scene,
+            "--width", "48", "--height", "36", "--samples", "8",
+            "--depth", "6", "--output", str(output)]
+
+
+def _assert_gpu_result(result, output):
+    """Accept only documented unavailable builds; never hide a render error."""
+    unavailable = (
+        "compiled without CUDA",
+        "no CUDA GPU is available",
+        "GPU rendering requires the wavefront build",
+    )
+    if any(message in result.stderr for message in unavailable):
+        assert result.returncode == 2, result.stderr
+        assert not output.exists()
+        pytest.skip(result.stderr.strip())
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Device: CUDA GPU" in result.stdout
+
+
+@pytest.mark.parametrize("scene,extension", [("1", "png"), ("2", "ppm")])
+def test_explicit_cpu_images(tmp_path, scene, extension):
+    """CPU remains usable independently of CUDA availability and output type."""
+    output = tmp_path / f"cpu-scene{scene}.{extension}"
+    result = _run(_dispatch_args("cpu", output, scene))
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Device: CPU" in result.stdout
+    pixels = _assert_png_valid(output)
+    assert pixels.shape == (36, 48, 3)
+    assert np.ptp(pixels) > 0.05
+
+
+@pytest.mark.parametrize("scene,extension", [("1", "png"), ("2", "ppm")])
+def test_explicit_gpu_images(tmp_path, scene, extension):
+    """The actual CUDA path writes nonempty Cornell and material images."""
+    output = tmp_path / f"gpu-scene{scene}.{extension}"
+    result = _run(_dispatch_args("gpu", output, scene))
+    _assert_gpu_result(result, output)
+    pixels = _assert_png_valid(output)
+    assert pixels.shape == (36, 48, 3)
+    assert np.ptp(pixels) > 0.05
+
+
+def test_auto_falls_back_when_gpu_unavailable(tmp_path):
+    """No CUDA/device/wavefront build must leave auto usable on the CPU."""
+    gpu_output = tmp_path / "probe.png"
+    result = _run(_dispatch_args("gpu", gpu_output))
+    if result.returncode == 0:
+        assert "Device: CUDA GPU" in result.stdout
+        pytest.skip("GPU backend available; fallback requires another build/device")
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert any(message in result.stderr for message in (
+        "compiled without CUDA", "no CUDA GPU is available",
+        "GPU rendering requires the wavefront build",
+    )), result.stderr
+    assert not gpu_output.exists()
+    auto_output = tmp_path / "auto.png"
+    auto = _run(_dispatch_args("auto", auto_output))
+    assert auto.returncode == 0, auto.stdout + auto.stderr
+    assert "Device: CPU" in auto.stdout
+    _assert_png_valid(auto_output)
+
+
+def test_gpu_visible_wavelength_band(tmp_path):
+    """The requested narrow visible band reaches the GPU spectral sampler."""
+    output = tmp_path / "band-visible.png"
+    result = _run(_dispatch_args("gpu", output) + [
+        "--integrator-param", "lambda_min=540.0",
+        "--integrator-param", "lambda_max=550.0",
+        "--integrator-param", "output_mode=rgb",
+    ])
+    _assert_gpu_result(result, output)
+    pixels = _assert_png_valid(output)
+    assert np.mean(pixels[:, :, 1]) > np.mean(pixels[:, :, 0])
+    assert np.mean(np.max(pixels, axis=2) - np.min(pixels, axis=2)) > 0.01
+
+
+@pytest.mark.parametrize("mode,has_signal", [("rgb", False), ("luminance", True)])
+def test_gpu_nonvisible_output_mode(tmp_path, mode, has_signal):
+    """Only explicit band-radiance output retains signal beyond the CMF domain.
+
+    Equal XYZ is not neutral sRGB; an exact-gray PNG is not the luma contract.
+    This pair tests mode reachability without pinning that presentation debt.
+    """
+    output = tmp_path / f"band-ir-{mode}.png"
+    result = _run(_dispatch_args("gpu", output, "2") + [
+        "--integrator-param", "lambda_min=900.0",
+        "--integrator-param", "lambda_max=910.0",
+        "--integrator-param", f"output_mode={mode}",
+    ])
+    _assert_gpu_result(result, output)
+    pixels = np.asarray(Image.open(output))
+    assert pixels.shape == (36, 48, 3)
+    if has_signal:
+        assert pixels.max() > 0
+    else:
+        assert pixels.max() == 0
+
+
+def test_gpu_environment_upload(tmp_path):
+    """Wavefront uploads the loaded environment without the legacy uploader."""
+    env = tmp_path / "environment.png"
+    Image.new("RGB", (16, 8), (32, 64, 255)).save(env)
+    output = tmp_path / "environment-render.png"
+    result = _run(_dispatch_args("gpu", output, "2") + ["--envmap", str(env)])
+    _assert_gpu_result(result, output)
+    assert "Using environment map:" in result.stdout
+    pixels = _assert_png_valid(output)
+    # The material scene has open sky above its finite ground plane.
+    sky = pixels[0, :, :]
+    assert np.mean(sky[:, 2]) > np.mean(sky[:, 0]) + 0.05
+
+
+# ---------------------------------------------------------------------------
 # Stand-alone entry-point
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
The full clean CUDA all-target build failed because the standalone CLI still called CUDARenderer::render, removed with the megakernels. The CLI now uses the production wavefront entry point, including scene/environment upload, spectral/output parameters and seed handling. CPU auto fallback also works when CUDA is compiled without the wavefront; explicit GPU requests fail clearly. Existing CPU rendering and PNG/PPM gamma handling remain unchanged.

Validation:
- Initial failure retained; repaired CUDA ALL_BUILD passed in 4.30s using the unchanged freshly compiled CUDA library.
- CPU-only standalone build and suite: 11 passed, 6 documented CUDA-unavailable skips. Both CUDA/N3 host syntax configurations passed.
- Fresh CUDA GPU suite: 21 passed, 1 expected fallback skip. Actual CUDA/N3-off target built and ran: 11 passed, 6 explicit wavefront-unavailable skips; explicit GPU exits 2/no image, auto CPU renders successfully.
- Astra inspected saved CPU/GPU Cornell and material scenes, plus real Blender affine mapped charts (GPU/Cycles max RGB mean deviation 1.3693%, existing 5% gate). The missing procedural checker also reproduces through the unchanged binding; this baseline parity case remains NOT GREEN under pkg242.
- The first new luminance test used an invalid exact-gray assumption. Terra traced the existing XYZ-to-sRGB presentation behavior; the replacement same-band 900–910nm oracle checks explicit RGB zero versus positive band radiance. The failed original log is retained; presentation debt stays under pkg251.
- N3-off linking retained LNK4098; actual runtime gates passed. No warning suppression or runtime-library change.
- No renderer, binding, ABI or CMake signature change. Terra independent architecture, final source and local runtime sign-off passed; Astra performed the visual review.
- Scoped lint: zero new findings, five tools, none unavailable or errored.

Pkg250 spec records the decision and gates. Pkg251 separately records existing band/default/parameter-typing debt; pkg252 records the CI caller coverage gap. Neither is hidden in this repair. Existing pkg237/pkg238 local baseline failures and pkg249 advisory reference-smoke debt remain open; no full-suite-green claim is made from focused tests.
