### PR TITLE
docs(pkg237/238): CPU/GPU parity gate root-cause diagnosis

### DIFF
--- a/.astroray_plan/docs/pkg237-238-diagnosis-2026-09-07.md
+++ b/.astroray_plan/docs/pkg237-238-diagnosis-2026-09-07.md
@@ -1,0 +1,147 @@
+# pkg237 / pkg238 CPU/GPU parity diagnosis — 2026-09-07
+
+Branch: fix/pkg237-238-diagnosis. Worktree: .claude/worktrees/pkg237.
+Module used for CPU experiments: build_cuda/astroray.cp313-win_amd64.pyd (main checkout).
+
+## pkg237 — HDRI CPU/GPU SSIM 0.769 vs 0.97
+
+### Confirmed fact 1: CPU blue channel has a per-pixel VARIANCE FLOOR (not √N)
+Env-only scene (test_world_hdri_parity scene: tint 0.9,0.9,1.0, rz=pi/4, blender_conv),
+64x64, CPU path_tracer, apply_gamma=False. Cross-seed (1234 vs 5678) per-pixel diff std
+per channel:
+
+| spp  | R diff-std | G diff-std | B diff-std |
+|------|-----------|-----------|-----------|
+| 64   | 0.0371    | 0.0120    | 0.1198    |
+| 256  | 0.0233    | 0.0081    | 0.0760    |
+| 1024 | 0.0157    | 0.0055    | 0.0515    |
+| 4096 | 0.0153    | 0.0053    | 0.0497    |
+
+Both channels STALL around spp=1024 (64->4096 is 64x samples => expect 8x std drop;
+observed only ~2.4x, then flat). This is a per-pixel term that is constant across the
+spp samples within one render (so averaging does not reduce it) but changes with the
+global seed. Blue's floor (~0.05) is ~3.2x red's (~0.015).
+
+Interpretation: the amplification of blue + non-convergence is the signature of
+CORRELATED WAVELENGTH SAMPLING across samples within a pixel. Blue RGB->spectrum
+upsampled reflectances are the spikiest (worst-conditioned), so stochastic hero-wavelength
+integration has the highest variance in blue; if the wavelength stratum offset is drawn
+once per pixel (shared by all spp) the chromatic MC noise never averages away.
+NEXT: confirm in the render loop where SampledWavelengths are drawn per sample.
+
+### Confirmed fact 2: the floor is ADAPTIVE SAMPLING (colour-blind Dammertz metric)
+render() defaults useAdaptiveSampling=true (blender_module.cpp:438). Re-ran cross-seed
+diff with set_adaptive_sampling(False) vs default True:
+
+adaptive=False (clean sqrt(N), all channels):
+  spp=256:  R=0.0181 G=0.0065 B=0.0604
+  spp=1024: R=0.0092 G=0.0032 B=0.0295
+  spp=4096: R=0.0046 G=0.0016 B=0.0149
+adaptive=True (STALLS — variance floor):
+  spp=256:  R=0.0233 G=0.0081 B=0.0760
+  spp=1024: R=0.0157 G=0.0055 B=0.0515
+  spp=4096: R=0.0153 G=0.0053 B=0.0497
+
+Root cause: the per-pixel adaptive stopping uses a SCALAR luminance-ish metric
+(lum = X+Y+Z; raytracer.h:4072, Dammertz half-buffer). It stops each pixel once the
+scalar noise falls below a threshold auto-derived from the sample budget. That metric is
+colour-blind: blue's RGB->spectrum upsampled reflectances are the spikiest, so the blue
+channel carries ~3x the residual chromatic variance the scalar metric implies. Raising the
+sample budget tightens the threshold but pixels still stop with a large blue residual, so
+blue noise does NOT fall with the budget. CPU and GPU draw INDEPENDENT RNG streams, so
+their residual blue-noise patterns are decorrelated -> the CPU/GPU SSIM never climbs to
+0.97 no matter how high spp goes. This is why the test's own docstring trajectory
+(4096 spp -> 0.97, measured pre-adaptive-default) no longer holds and the gate fails
+identically on baseline and feature (pkg230 not the cause; adaptive-default-on is).
+
+### Confirmed fact 3: the failure reproduces with NO GPU (two independent CPU streams)
+Rendered the SAME scene twice with different seeds (independent RNG streams == exactly the
+CPU-vs-GPU situation), 8192 spp, then applied the test's own lin()=arr/max normalization +
+SSIM:
+  adaptive=True : SSIM@8192 = 0.6766   (maxA=0.695, maxB=0.765)
+  adaptive=False: SSIM@8192 = 0.9622   (maxA=0.579, maxB=0.582)
+
+=> The "CPU/GPU SSIM 0.769" is NOT a CPU-vs-GPU algorithmic divergence. Two independent CPU
+streams reproduce it. Root cause is the colour-blind adaptive floor (drops 0.96 -> 0.68).
+
+### pkg237 TWO compounding defects (pkg73 pattern)
+Defect A (dominant, the actual engine surface): adaptive stopping metric is colour-blind
+(scalar X+Y+Z). It leaves a large, non-converging blue chromatic-MC residual. Independent
+CPU/GPU streams decorrelate in that residual -> SSIM stuck ~0.68-0.77. Distinguishing test:
+set_adaptive_sampling(False) restores clean sqrt(N) convergence and SSIM 0.96 (above).
+Defect B (masks/keeps it red even when A fixed): the test metric normalizes each image by
+its OWN max (arr/max(1,arr.max())). The green firefly (value 50) integrates to slightly
+different per-image maxima on the two independent streams (0.579 vs 0.582 even converged),
+so the two legs are scaled differently before SSIM; combined with residual blue chromatic
+variance this caps converged SSIM at ~0.96, still under the 0.97 pin. Distinguishing test:
+common-exposure normalization (divide BOTH images by a shared constant) instead of per-image
+max should lift converged independent-stream SSIM. (cf. memory: SSIM wrong gate for
+independent RNG; use per-channel mean-ratio / common exposure.)
+
+CONCLUSION pkg237: NOT an engine parity bug. Two test-methodology defects: (A) the parity
+render must disable adaptive sampling so 8192 spp actually converges both legs; (B) the
+metric must use a common exposure, not per-image max. Neither is a threshold relaxation:
+both make the gate measure converged parity as its own docstring intends. Landing the metric
+change requires the owner's scientific-justification bar + independent review, so this
+diagnosis lands as docs; the fix is routed to package-implementer.
+
+## pkg238 — PostInit CPU/GPU max-ULP 13 vs pinned 4
+
+### Confirmed fact (static, GPU field-attribution pending): the overshoot is the
+### `lambdas` field, made transcendental by pkg206 AFTER the 4-ULP pin.
+PostInit compares fields ["ray_origin","ray_direction","lambdas"] under one max_ulp=4 bound.
+The pin note (pkg55_cuda_thresholds.yaml) states: "Geometry-only (camera ray math, no
+transcendentals beyond normalize)... MEASURED 2026-05-23 ... max ULP = 2. Pinned at 4."
+At pin time the wavelength sampler was the LINEAR sampleUniform (lambda = hero + i*step,
+pure add/mul -> bit-exact host/device, ~2 ULP with geometry).
+
+pkg206 later switched the DEFAULT primary-path sampler to sampleImportance (hero_importance
+default=1; spectral_path_tracer.cpp:120, path_kernel.cpp:105). sampleImportance inverts a
+logistic CDF:
+  CPU (spectrum.cpp:171): lam = kHeroX0 - std::log(1.0f/randL - 1.0f)/kHeroA
+  GPU (stage_init.cu:182): lam = kG_HeroX0 - logf (1.0f/randL - 1.0f)/kG_HeroA   (+ expf in CDF)
+std::log/std::exp (host libm) and logf/expf (CUDA device) are NOT bit-identical (the yaml
+header itself lists "CUDA sinf/expf/__fdividef are not IEEE-correctly-rounded"). At the
+result magnitude lambda~380-780 nm, 1 float32 ULP ~ 552*2^-23 ~ 6.6e-5 nm; a ~1e-6 relative
+transcendental divergence ~ 5e-4 nm ~ 8-13 ULP. This exactly accounts for the observed 13.
+Geometry (ray_origin passthrough; ray_direction = one rsqrt normalize) stays ~1-2 ULP.
+
+Fails IDENTICALLY on baseline+feature because it is a stable host/device transcendental
+property, not a regression from any recent PR (pkg230 not the cause). The REGRESSION that
+made a passing gate fail was pkg206 changing the character of the `lambdas` field under a pin
+whose stated rationale ("no transcendentals") no longer holds.
+
+### pkg238 TWO compounding defects (pkg73 pattern)
+Defect A (actual surface): the PostInit gate bounds `lambdas` (now transcendental log/exp,
+host!=device by design) under the SAME tight 4-ULP bound as geometry. Since pkg206 the
+lambda field legitimately drifts ~13 ULP.
+Defect B (why 4 looked right): the 4-ULP pin was measured under LINEAR sampleUniform and its
+note explicitly assumes "geometry-only, no transcendentals." pkg206 invalidated that
+assumption; the pin was never re-measured -> stale pin masking the field's changed character.
+
+Distinguishing tests (need GPU lock; not run — lock held by lead):
+  1. Split _compute_stage_ulp('PostInit') into ulp_origin/ulp_dir/ulp_lambdas and print each.
+     Hypothesis predicts ulp_lambdas ~13, ulp_origin/ulp_dir <=4.
+  2. Rebuild/run with hero_importance=0 (sampleUniform). Predict PostInit ULP drops to <=4,
+     proving the log/exp transcendental in the lambda field is the sole source.
+
+Proposed fix (field-attributed, NOT a blanket increase — mirrors how the yaml ALREADY
+handles transcendental stages): PostShade already carries NO max_ulp with the note
+"transcendentals make ULP comparisons meaningless" and uses a p99.9 relative-error bound
+instead. Apply the same to PostInit: keep ray_origin/ray_direction on a tight geometry ULP
+(<=4) and move `lambdas` to a p99.9 relative-error bound (PostInit already declares
+p99_9_relative_error: 1.0e-5, which the transcendental drift at ~2.3e-6 satisfies), OR give
+lambdas a separate transcendental-appropriate ULP (~16). Land only after the GPU field
+attribution above confirms lambdas (not geometry) is the overshoot, plus independent review.
+
+## PR #729 (CPU HDRI background-ROI mean 0.047 vs Cycles 0.121) — SEPARATE defect
+pkg237 is a NOISE/variance-parity issue: both CPU legs have the SAME, stable per-channel MEAN
+(R~0.458, G~0.014, B~0.475 across seeds; fact 1) and differ only in decorrelated residual
+noise. There is NO absolute-brightness error between the two Astroray legs. PR #729 is an
+ABSOLUTE-radiance deficit vs Cycles (~2.6x too dark) — a brightness/exposure surface, not a
+noise surface. It shares the HDRI code path but is a different symptom and different cause:
+most likely a world-strength / importance-weight normalization, or a colour-management /
+exposure / view-transform convention (raw-linear vs Filmic/AgX) in the addon output path
+(cf. memory: GPU emission RGB-approximated; addon colour-management). It is NOT the
+adaptive-sampling variance floor. Recommend PR #729 stays a separate package, not folded
+into pkg237/pkg238.

--- a/.astroray_plan/packages/pkg237-hdri-cpu-gpu-ssim-diagnosis.md
+++ b/.astroray_plan/packages/pkg237-hdri-cpu-gpu-ssim-diagnosis.md
@@ -56,3 +56,34 @@ rendering; metric validity is part of the diagnosis, not a pretext for relaxing 
 gate. No arbitrary SSIM threshold relaxation; no transport/VM rewrite; no
 HDRI-filter root-cause claim before evidence; no owner queue priority change; no
 Pillar 4 work.
+
+## Evidence — diagnosis 2026-09-07 (fix/pkg237-238-diagnosis)
+
+Full detail: `.astroray_plan/docs/pkg237-238-diagnosis-2026-09-07.md`.
+
+ROOT CAUSE (not an engine parity bug — reproduced with NO GPU). Two compounding
+test-methodology defects (pkg73 pattern):
+
+- Defect A (dominant): `render()` defaults `useAdaptiveSampling=true`. The per-pixel
+  adaptive stop uses a colour-blind scalar metric (lum = X+Y+Z, raytracer.h:4072). Blue's
+  RGB->spectrum upsampled reflectances are the spikiest, so blue carries ~3x the residual
+  chromatic MC variance the scalar metric implies. Pixels stop with a large blue residual
+  that does NOT fall with the sample budget. CPU and GPU draw independent RNG streams, so
+  their residual blue-noise patterns decorrelate and SSIM never reaches 0.97.
+  Distinguishing evidence: two INDEPENDENT CPU streams (proxy for CPU-vs-GPU) at 8192 spp,
+  lin()=arr/max normalization + SSIM: adaptive=True -> 0.677 (reproduces the 0.769 failure);
+  adaptive=False -> 0.962. Cross-seed per-pixel diff-std: adaptive OFF falls as clean
+  sqrt(N) in all channels; adaptive ON stalls (R~0.015, B~0.05).
+
+- Defect B (keeps it red even after A): the metric normalizes each image by its OWN max
+  (`arr / max(1, arr.max())`). The green firefly (value 50) integrates to slightly different
+  per-image maxima on independent streams (0.579 vs 0.582 even converged), scaling the two
+  legs differently; combined with residual blue chromatic variance this caps converged
+  independent-stream SSIM at ~0.96, still under the 0.97 pin. Distinguishing test: common-
+  exposure (shared divisor) instead of per-image max should lift converged SSIM.
+
+Proposed fix (routed to package-implementer, needs independent review + owner sign-off on the
+metric change): the parity test must (A) disable adaptive sampling so 8192 spp converges both
+legs, and (B) use a common exposure, not per-image max. Neither relaxes the threshold; both
+make the gate measure converged parity as its own docstring intends. NOT the same defect as
+PR #729 (absolute brightness vs Cycles) — see diagnosis doc.

--- a/.astroray_plan/packages/pkg238-postinit-cpu-gpu-threshold.md
+++ b/.astroray_plan/packages/pkg238-postinit-cpu-gpu-threshold.md
@@ -50,3 +50,35 @@ This follow-up does not change owner queue priority; Pillar 4 remains PAUSED.
 A blanket threshold increase could mask a genuine PostInit divergence or a later
 regression. No blanket threshold increase; no masking of later-stage failures; no
 shader VM/transport changes; no owner queue priority change; no Pillar 4 work.
+
+## Evidence — diagnosis 2026-09-07 (fix/pkg237-238-diagnosis)
+
+Full detail: `.astroray_plan/docs/pkg237-238-diagnosis-2026-09-07.md`.
+
+ROOT CAUSE: the overshoot is the `lambdas` field, made transcendental by pkg206 AFTER the
+4-ULP pin. Two compounding defects (pkg73 pattern):
+
+- Defect A (actual surface): PostInit bounds ["ray_origin","ray_direction","lambdas"] under
+  one max_ulp=4. Since pkg206 the default wavelength sampler is `sampleImportance`, which
+  inverts a logistic CDF with `std::log`/`std::exp` (CPU, spectrum.cpp:171) vs `logf`/`expf`
+  (GPU, stage_init.cu:182/163). Device transcendentals are not IEEE-correctly-rounded (the
+  yaml header says so). At lambda~552nm, 1 float32 ULP ~ 6.6e-5nm; a ~1e-6 relative log
+  divergence ~ 5e-4nm ~ 8-13 ULP => exactly the observed 13. Geometry stays ~1-2 ULP.
+
+- Defect B (why 4 looked right): the 4-ULP pin (pkg55_cuda_thresholds.yaml, "Measured ULP=2,
+  2026-05-23") was set under the LINEAR sampleUniform, and its note explicitly assumes
+  PostInit is "geometry-only, no transcendentals beyond normalize." pkg206 invalidated that;
+  the pin was never re-measured -> stale pin masking the field's changed character. Fails
+  identically on baseline+feature because it is a stable host/device transcendental property,
+  not a code regression (pkg230 not the cause).
+
+Distinguishing tests (need GPU lock — held by lead, not run): (1) split PostInit ULP into
+origin/dir/lambdas; predict lambdas~13, geometry<=4. (2) build with hero_importance=0
+(sampleUniform); predict PostInit ULP drops to <=4.
+
+Proposed fix (field-attributed, NOT a blanket increase; mirrors PostShade which already
+carries no max_ulp for transcendentals and uses p99.9 relative error): keep
+ray_origin/ray_direction on a tight geometry ULP (<=4) and move `lambdas` to the existing
+PostInit p99.9 relative-error bound (1.0e-5, satisfied by the ~2.3e-6 drift), or give lambdas
+a separate ~16-ULP transcendental bound. Land only after GPU field attribution + independent
+review.


### PR DESCRIPTION
Diagnosis-only (no engine/threshold change). Full detail: \`.astroray_plan/docs/pkg237-238-diagnosis-2026-09-07.md\`.

## pkg237 — HDRI CPU/GPU SSIM 0.769 vs 0.97
NOT a CPU/GPU algorithmic divergence. **Reproduced with zero GPU**: two independent CPU RNG streams at 8192 spp, using the test's own \`arr/max\` + SSIM, give **0.677 (adaptive ON)** vs **0.962 (adaptive OFF)**. Two compounding defects (pkg73 pattern):
- **A (dominant):** \`render()\` defaults \`useAdaptiveSampling=true\`; the per-pixel stop uses a colour-blind scalar metric (lum=X+Y+Z). Blue's RGB→spectrum upsampled reflectances are spikiest, so blue keeps ~3× the residual chromatic MC variance the metric implies. Pixels stop with a large blue residual that does **not** fall with the budget; CPU/GPU independent streams decorrelate → SSIM never reaches 0.97. Cross-seed diff-std falls as clean √N with adaptive OFF, stalls with adaptive ON.
- **B:** per-image \`max\` normalization + the green firefly gives the two independent legs different maxima (0.579 vs 0.582 even converged), capping converged SSIM at ~0.96.

Proposed fix (routed to package-implementer): parity test disables adaptive sampling AND uses a common exposure (not per-image max). Neither relaxes the threshold.

## pkg238 — PostInit max-ULP 13 vs pinned 4
The overshoot is the **\`lambdas\`** field. pkg206 switched the default wavelength sampler to \`sampleImportance\`, which inverts a logistic CDF with \`std::log\`/\`logf\` — host vs CUDA-device transcendentals (not IEEE-correctly-rounded). At λ≈552nm this maps to ~8–13 ULP, exactly the observed 13; geometry stays ~1–2 ULP. The 4-ULP "geometry-only" pin was measured under the **linear** \`sampleUniform\` **before** pkg206 and never re-measured → stale pin. Fails identically on baseline+feature (stable numeric property, not a code regression).

Proposed fix: field-attributed — keep ray_origin/ray_direction tight (≤4 ULP), move \`lambdas\` to the existing p99.9 relative-error bound (mirrors how PostShade already handles transcendentals). Distinguishing GPU tests documented; **not run (GPU lock held by lead)**.

## PR #729 (CPU HDRI ROI 0.047 vs Cycles 0.121)
**Separate defect** — absolute brightness/exposure/world-strength surface, not the adaptive variance floor. Both Astroray CPU legs share the same stable mean; only noise decorrelates.

Do not merge — awaiting independent different-model sign-off + owner call on the metric/pin changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)