### PR TITLE
fix(hooks): read tool_input.command; resolve the repo from -C/cd/cwd so worktree commits are checked against the worktree

### DIFF
--- a/.claude/hooks/_resolve_repo.ps1
+++ b/.claude/hooks/_resolve_repo.ps1
@@ -1,0 +1,46 @@
+#!/usr/bin/env pwsh
+# Shared helper for PreToolUse hooks: resolve which repo checkout to run
+# staged/unstaged checks against, given the Bash command about to run and
+# the hook's JSON payload.
+#
+# A commit issued via `git -C <path> commit ...` or `cd <path> && git commit
+# ...` (or `cd <path>; git commit ...`) targets <path>, which may be a linked
+# worktree, not the main checkout. Blindly checking $env:CLAUDE_PROJECT_DIR
+# in that case inspects the wrong repo's staged files.
+#
+# Resolution order:
+#   1. `git -C <path> ...` in the command -> that path
+#   2. command starts with `cd <path>` chained via && or ; -> that path
+#   3. the hook payload's .cwd field, if present
+#   4. $env:CLAUDE_PROJECT_DIR (main checkout) as the final fallback
+
+function Resolve-HookRepoPath {
+    param(
+        [string]$Command,
+        [string]$PayloadCwd
+    )
+
+    if ($Command) {
+        # git -C <path> ...
+        if ($Command -match "git\s+-C\s+(?:'([^']+)'|\`"([^\`"]+)\`"|(\S+))") {
+            $path = $Matches[1]
+            if (-not $path) { $path = $Matches[2] }
+            if (-not $path) { $path = $Matches[3] }
+            if ($path) { return $path }
+        }
+
+        # cd <path> && ... / cd <path>; ...  (must lead the command)
+        if ($Command -match "^\s*cd\s+(?:'([^']+)'|\`"([^\`"]+)\`"|(\S+))\s*(?:&&|;)") {
+            $path = $Matches[1]
+            if (-not $path) { $path = $Matches[2] }
+            if (-not $path) { $path = $Matches[3] }
+            if ($path) { return $path }
+        }
+    }
+
+    if ($PayloadCwd) {
+        return $PayloadCwd
+    }
+
+    return $env:CLAUDE_PROJECT_DIR
+}

--- a/.claude/hooks/pre_commit_diag_check.ps1
+++ b/.claude/hooks/pre_commit_diag_check.ps1
@@ -10,20 +10,29 @@ try {
     }
 } catch {}
 
-# Only act on Bash tool calls that invoke git commit
+# Only act on Bash tool calls that invoke git commit. The current
+# PreToolUse payload nests the command at .tool_input.command; the other
+# two shapes are kept as fallbacks for parity with the sibling spec-lint hook.
 $command = ""
-if ($inputJson -and $inputJson.command) {
+if ($inputJson -and $inputJson.tool_input -and $inputJson.tool_input.command) {
+    $command = $inputJson.tool_input.command
+} elseif ($inputJson -and $inputJson.command) {
     $command = $inputJson.command
 } elseif ($inputJson -and $inputJson.input -and $inputJson.input.command) {
     $command = $inputJson.input.command
 }
 
-if ($command -notmatch "git\s+commit") {
+if ($command -notmatch "git\s+(-C\s+(?:'[^']*'|`"[^`"]*`"|\S+)\s+)?commit\b") {
     exit 0
 }
 
+# Resolve which repo checkout to check: a `git -C <path>` or `cd <path> &&`
+# commit may target a linked worktree, not the main checkout.
+. "$PSScriptRoot\_resolve_repo.ps1"
+$repoPath = Resolve-HookRepoPath -Command $command -PayloadCwd $inputJson.cwd
+
 # Check staged changes for diagnostic markers
-Set-Location $env:CLAUDE_PROJECT_DIR
+Set-Location $repoPath
 
 $markerPatterns = @(
     '\[pkg\d+-diag\]',

--- a/.claude/hooks/pre_commit_spec_lint.ps1
+++ b/.claude/hooks/pre_commit_spec_lint.ps1
@@ -23,11 +23,16 @@ if ($inputJson -and $inputJson.tool_input -and $inputJson.tool_input.command) {
     $command = $inputJson.input.command
 }
 
-if ($command -notmatch "git\s+commit") {
+if ($command -notmatch "git\s+(-C\s+(?:'[^']*'|`"[^`"]*`"|\S+)\s+)?commit\b") {
     exit 0
 }
 
-Set-Location $env:CLAUDE_PROJECT_DIR
+# Resolve which repo checkout to check: a `git -C <path>` or `cd <path> &&`
+# commit may target a linked worktree, not the main checkout.
+. "$PSScriptRoot\_resolve_repo.ps1"
+$repoPath = Resolve-HookRepoPath -Command $command -PayloadCwd $inputJson.cwd
+
+Set-Location $repoPath
 
 # Collect staged AND unstaged package-spec paths: a combined "git add ... &&
 # git commit" stages files after this hook runs, so --cached alone misses

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Hermetic tests for the Claude Code PreToolUse hooks in .claude/hooks/.
+
+Covers the 2026-09-07 fixes:
+  * pre_commit_diag_check.ps1 was reading the tool command from JSON field
+    paths that don't match the real PreToolUse payload shape
+    (`.tool_input.command`), so it silently no-op'd on every real call.
+  * pre_commit_diag_check.ps1 and pre_commit_spec_lint.ps1 always checked
+    $env:CLAUDE_PROJECT_DIR (the main checkout) even when the commit
+    targeted a linked worktree via `git -C <path>` or `cd <path> && ...`.
+
+CPU-only and hermetic: builds disposable `git init` repos under tmp_path,
+each wired to a tiny stub `scripts/project_index.py` so the spec-lint hook's
+pass/fail outcome is deterministic and independent of the real linter.
+Invokes the real hook scripts in place (so `$PSScriptRoot` still finds the
+real `_resolve_repo.ps1`) via subprocess with a fake PreToolUse JSON payload
+on stdin. Skips if neither `pwsh` nor `powershell` is on PATH.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HOOKS_DIR = REPO_ROOT / ".claude" / "hooks"
+DIAG_HOOK = HOOKS_DIR / "pre_commit_diag_check.ps1"
+SPEC_LINT_HOOK = HOOKS_DIR / "pre_commit_spec_lint.ps1"
+
+# Minimal stand-in for `scripts/project_index.py lint <specs...>`: fails only
+# when one of the spec paths contains the literal marker "BADSPEC". Keeps the
+# hook test independent of the real lint rules.
+_STUB_PROJECT_INDEX = (
+    "import sys\n"
+    'bad = any("BADSPEC" in a for a in sys.argv[1:])\n'
+    "if bad:\n"
+    '    print("LINT FAIL")\n'
+    "    sys.exit(1)\n"
+    'print("LINT OK")\n'
+    "sys.exit(0)\n"
+)
+
+
+def _pwsh():
+    return shutil.which("pwsh") or shutil.which("powershell")
+
+
+def _init_repo(path: Path, diag_marker: bool, spec_bad: bool) -> Path:
+    """Create a disposable git repo with a staged diagnostic-marker file and
+    a staged package spec, wired to the stub project_index.py lint script."""
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "test"], cwd=path, check=True)
+
+    notes = path / "notes.txt"
+    if diag_marker:
+        # Built via concatenation, not a contiguous literal: this repo's own
+        # pre_commit_diag_check.ps1 (now fixed to actually run) would block a
+        # commit of this test file if the marker text appeared verbatim here.
+        marker = "// [" + "diag] " + "REMOVE" + " AFTER debug\n"
+        notes.write_text(marker, encoding="ascii")
+    else:
+        notes.write_text("clean content\n", encoding="ascii")
+
+    scripts = path / "scripts"
+    scripts.mkdir(exist_ok=True)
+    (scripts / "project_index.py").write_text(_STUB_PROJECT_INDEX, encoding="ascii")
+
+    packages = path / ".astroray_plan" / "packages"
+    packages.mkdir(parents=True, exist_ok=True)
+    spec_name = "BADSPEC-pkg.md" if spec_bad else "pkg-good.md"
+    (packages / spec_name).write_text("# spec\n", encoding="ascii")
+
+    subprocess.run(
+        ["git", "add", "notes.txt", "scripts/project_index.py",
+         f".astroray_plan/packages/{spec_name}"],
+        cwd=path, check=True,
+    )
+    return path
+
+
+def _run_hook(hook: Path, command: str, cwd_field: str, project_dir: Path, pwsh: str) -> subprocess.CompletedProcess:
+    payload = json.dumps({
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "cwd": cwd_field,
+        "session_id": "test-session",
+    })
+    env = dict(os.environ)
+    env["CLAUDE_PROJECT_DIR"] = str(project_dir)
+    return subprocess.run(
+        [pwsh, "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", str(hook)],
+        input=payload, capture_output=True, text=True, encoding="utf-8",
+        cwd=str(project_dir), env=env, timeout=60, check=False,
+    )
+
+
+@pytest.mark.cpu
+class TestPreCommitDiagCheckHook:
+    """A plain `git commit`, a `git -C <worktree> commit`, and a non-commit
+    command, against the fixed pre_commit_diag_check.ps1."""
+
+    def test_plain_commit_in_main_blocks_on_marker(self, tmp_path):
+        pwsh = _pwsh()
+        if pwsh is None:
+            pytest.skip("pwsh/powershell not found")
+        main = _init_repo(tmp_path / "main", diag_marker=True, spec_bad=False)
+        proc = _run_hook(DIAG_HOOK, "git commit -m x", str(main), main, pwsh)
+        assert proc.returncode == 2, proc.stdout + proc.stderr
+
+    def test_git_dash_c_worktree_checks_worktree_not_main(self, tmp_path):
+        pwsh = _pwsh()
+        if pwsh is None:
+            pytest.skip("pwsh/powershell not found")
+        # Main is dirty (staged diagnostic marker); the targeted worktree is
+        # clean. The hook must check the worktree, not $env:CLAUDE_PROJECT_DIR.
+        main = _init_repo(tmp_path / "main", diag_marker=True, spec_bad=False)
+        wt = _init_repo(tmp_path / "worktree", diag_marker=False, spec_bad=False)
+        command = 'git -C "{}" commit -m x'.format(wt)
+        proc = _run_hook(DIAG_HOOK, command, str(wt), main, pwsh)
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+
+    def test_non_commit_command_is_noop(self, tmp_path):
+        pwsh = _pwsh()
+        if pwsh is None:
+            pytest.skip("pwsh/powershell not found")
+        main = _init_repo(tmp_path / "main", diag_marker=True, spec_bad=False)
+        proc = _run_hook(DIAG_HOOK, "git status", str(main), main, pwsh)
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+@pytest.mark.cpu
+class TestPreCommitSpecLintHook:
+    """Same three payload shapes against pre_commit_spec_lint.ps1."""
+
+    def test_plain_commit_in_main_blocks_on_bad_spec(self, tmp_path):
+        pwsh = _pwsh()
+        if pwsh is None:
+            pytest.skip("pwsh/powershell not found")
+        main = _init_repo(tmp_path / "main", diag_marker=False, spec_bad=True)
+        proc = _run_hook(SPEC_LINT_HOOK, "git commit -m x", str(main), main, pwsh)
+        assert proc.returncode == 2, proc.stdout + proc.stderr
+
+    def test_git_dash_c_worktree_checks_worktree_not_main(self, tmp_path):
+        pwsh = _pwsh()
+        if pwsh is None:
+            pytest.skip("pwsh/powershell not found")
+        # Main has a bad spec staged; the targeted worktree's spec is clean.
+        # The hook must lint the worktree, not $env:CLAUDE_PROJECT_DIR.
+        main = _init_repo(tmp_path / "main", diag_marker=False, spec_bad=True)
+        wt = _init_repo(tmp_path / "worktree", diag_marker=False, spec_bad=False)
+        command = 'git -C "{}" commit -m x'.format(wt)
+        proc = _run_hook(SPEC_LINT_HOOK, command, str(wt), main, pwsh)
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+
+    def test_non_commit_command_is_noop(self, tmp_path):
+        pwsh = _pwsh()
+        if pwsh is None:
+            pytest.skip("pwsh/powershell not found")
+        main = _init_repo(tmp_path / "main", diag_marker=False, spec_bad=True)
+        proc = _run_hook(SPEC_LINT_HOOK, "git status", str(main), main, pwsh)
+        assert proc.returncode == 0, proc.stdout + proc.stderr


### PR DESCRIPTION
## Summary
- `pre_commit_diag_check.ps1` read the tool command from JSON field paths (`.command`, `.input.command`) that never match the real PreToolUse payload shape (`.tool_input.command`), so it silently no-op'd (exit 0) on every real `git commit` — confirmed 2026-09-07 by replaying the real payload shape against a staged diagnostic marker.
- Both `pre_commit_diag_check.ps1` and `pre_commit_spec_lint.ps1` always checked `$env:CLAUDE_PROJECT_DIR` (the main checkout) regardless of where the commit actually targeted, so a commit issued via `git -C <worktree>` or `cd <worktree> && git commit` was checked against the wrong repo — confirmed 2026-09-07 when a worktree commit was wrongly blocked by a staged spec-lint error that only existed in main.
- Adds a shared `.claude/hooks/_resolve_repo.ps1` (dot-sourced by both hooks) that resolves the repo to check in this order: `git -C <path>` in the command, else a leading `cd <path>` chained with `&&`/`;`, else the payload's `.cwd`, else `$env:CLAUDE_PROJECT_DIR`.
- Widens the `git\s+commit` matcher in both hooks to also recognize `git -C <path> commit` (the previous regex didn't match that form at all, which would have made the worktree fix untestable/unreachable for that command shape).

## Test plan
- [x] Reproduced Bug 1: piped the real PreToolUse payload shape at the pre-fix hook with a staged `REMOVE AFTER`/`[diag]` marker -> exit 0 (silent no-op). Re-ran post-fix -> exit 2, marker correctly reported.
- [x] Reproduced Bug 2 for both hooks: a `cd <worktree> && git commit` / `git -C <worktree> commit` targeting a clean worktree while `$env:CLAUDE_PROJECT_DIR` (main) has a staged diagnostic marker / failing spec lint -> pre-fix wrongly blocks (exit 2) checking main; post-fix correctly resolves to the worktree and allows the commit (exit 0). Also verified the reverse (bad worktree, clean main) still blocks post-fix, ruling out an "always passes" false fix.
- [x] Added `tests/test_claude_hooks.py` (`pytest.mark.cpu`, skips if `pwsh`/`powershell` missing): hermetic `git init` temp repos in `tmp_path`, three payload shapes (plain commit, `git -C <tmp worktree>` commit, non-commit command) against each hook.
- [x] `python -m pytest tests/test_claude_hooks.py -q -p no:cacheprovider` -> 6 passed.
- [x] Dry-ran both fixed hooks against this PR's own staged diff (via `git -C <worktree> commit`) before committing for real, to rule out the fixed diag-check hook false-positiving on its own pattern strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)