### PR TITLE
docs: file gate-(b) support-or-warn specs — Metallic BSDF, Sky texture, Displacement (pkg255–257)

### DIFF
--- a/.astroray_plan/packages/pkg255-metallic-bsdf-node.md
+++ b/.astroray_plan/packages/pkg255-metallic-bsdf-node.md
@@ -1,0 +1,179 @@
+# pkg255 — Metallic BSDF node (`ShaderNodeBsdfMetallic`)
+
+**Pillar:** 5
+**Track:** A
+**Status:** open
+**Estimated effort:** 2 sessions (~6 h)
+**Depends on:** pkg178, pkg229, pkg253
+
+---
+
+## Goal
+
+Before: `ShaderNodeBsdfMetallic` is read for exactly two of its fourteen
+sockets/props (Base Color via a dead defensive branch that the AST scanner
+misreads as a version-compat guard, and Roughness) and lowered to a crude
+`metallic=1.0` Principled fallback — bypassing the F82-tint conductor model
+(Gulbrandsen 2014 / Kutz-Hoffman) Astroray already ships for the Principled
+BSDF's own metallic lobe, CPU **and** GPU. After: the node's `F82` Fresnel
+mode (Base Color, Edge Tint, Roughness, Anisotropy, Rotation, Thin Film
+Thickness/IOR) routes through that existing conductor machinery with the
+coverage matrix showing it SUPPORTED-or-APPROXIMATED-with-warning per gate
+(b); `PHYSICAL_CONDUCTOR` mode (direct complex-IOR Fresnel from IOR/
+Extinction) and Normal/Tangent/Weight/`distribution` are APPROXIMATED with an
+explicit warning naming each, never silently dropped.
+
+---
+
+## Context
+
+Filed per the owner's 2026-09-07 08:30 gate-(b) decision: Metallic BSDF must
+be SUPPORTED or APPROXIMATED-with-warning for the Pillar-4 exit gate
+(`north-star-and-integration-gate-2026-09-07.md` §2(b)). Reading the addon
+before writing anything (CLAUDE.md §1) found the pkg253 blind-spot pattern
+recurring in miniature: `_standalone_bsdf_spec`'s `BSDF_METALLIC` branch
+(`blender_addon/__init__.py:4024-4031`) already reads Base Color and
+Roughness and calls `_warn_shader_fallback`, but the scanner's
+`_extract_if_else_guarded_reads` treats the node's defensive
+`if node.inputs.get('Base Color') is not None: ... else: color =
+get_color_input(node, 'Color', ...)` as a cross-version socket-rename guard
+and excludes both names from credited coverage — live-Blender-5.2 probe
+(2026-09-07, `ShaderNodeBsdfMetallic().inputs`) confirms `Color` has never
+existed on this node; the `else` branch is dead code, not a real
+compatibility fallback. More importantly, the current handler never reaches
+`principled.cpp`'s `conductorNK`/`thinFilmConductorRGB`/GPU
+`gpu_pr_conductorNK` — the exact F82-tint physics this node needs — because
+it routes through the generic `{'kind': 'principled', params: {metallic:
+1.0, roughness}}` fallback spec instead of the native-principled conductor
+path pkg178/pkg253 already wired end-to-end.
+
+---
+
+## Reference
+
+- Coverage matrix: `docs/blender_parity/coverage_matrix.json`, `feature ==
+  "BSDF_METALLIC"` (14 rows; live 2026-09-07: Roughness APPROXIMATED, the
+  other 13 — Base Color, Edge Tint, IOR, Extinction, Anisotropy, Rotation,
+  Normal, Tangent, Weight, Thin Film Thickness, Thin Film IOR,
+  `prop:distribution`, `prop:fresnel_type` — DROPPED-SILENT).
+- Reaudit backlog row 6: `.astroray_plan/docs/blender-coverage-reaudit-2026-09.md`.
+- Existing conductor/F82 implementation (reuse, do not reinvent —
+  CLAUDE.md §6): `plugins/materials/principled.cpp:373-419`
+  (`conductorNK`, `precomputeConductorNK`, `thinFilmConductorRGB`,
+  `thinFilmConductorSpectral` — Gulbrandsen, "Artist Friendly Metallic
+  Fresnel", JCGT 2014; Kutz & Hoffman F82-tint; Belcour-Barla 2017 thin
+  film) and its GPU mirror `include/astroray/gpu_materials.h:1525-1580`
+  (`gpu_pr_conductorNK`, `gpu_pr_thinFilmConductorRGB`,
+  `gpu_pr_thinFilmConductorSpectral`).
+- External (ceiling only, not vendored): `intern/cycles/kernel/closure/
+  bsdf_microfacet.h` `bsdf_microfacet_setup_fresnel_conductor` (complex-IOR
+  Fresnel from IOR+Extinction) — cite in code per CLAUDE.md §6 if Phase 2
+  is scheduled; not reproduced here.
+- pkg253 spec (sibling, same node-audit lineage): `.astroray_plan/packages/pkg253-principled-advanced-inputs.md`.
+
+---
+
+## Prerequisites
+
+- [x] pkg178 done — native conductor/F82 machinery exists CPU+GPU.
+- [x] pkg253 done — the native-principled param-plumbing pattern
+      (`_principled_native_params`, `put_float`/`put_vec`) to mirror.
+- [x] pkg229 done — coverage matrix regenerable headlessly.
+- [ ] Build passes on main.
+
+---
+
+## Specification
+
+### Files to create
+
+| File | Purpose |
+|---|---|
+| `tests/test_pkg255_metallic_f82.py` | TDD gate: F82-mode Metallic BSDF renders a tinted-edge conductor (not flat grey), Edge Tint changes grazing-angle color, monotone in Roughness, CPU/GPU parity within the existing conductor mean-ratio band; a `PHYSICAL_CONDUCTOR`-mode node renders (falls back to F82 params) and emits the degradation warning asserted verbatim. |
+
+### Files to modify
+
+| File | What changes |
+|---|---|
+| `blender_addon/__init__.py` | `_standalone_bsdf_spec`'s `BSDF_METALLIC` branch (`~L4024-4031`): drop the dead `Color`-socket else-branch (read `Base Color` directly — removes the scanner false-negative without touching the scanner, CLAUDE.md §3); read `Edge Tint`, `Anisotropy`, `Rotation`, `Thin Film Thickness`, `Thin Film IOR`; branch on `fresnel_type` — `F82` maps Base Color/Edge Tint/Roughness/Anisotropy/Rotation/Thin-Film onto the same native-principled param keys pkg253's `_principled_native_params` already emits for the Principled metallic lobe (`specular_tint`≈Edge Tint, `anisotropic`, `anisotropic_rotation`, `thin_film_thickness`, `thin_film_ior`), so it rides the existing conductor path with **zero new engine code**; `PHYSICAL_CONDUCTOR` calls `_warn_shader_fallback('BSDF_METALLIC', 'complex-IOR conductor Fresnel is approximated with the F82-tint model; IOR/Extinction spectra are not read')` and falls back to F82 defaults. One `_warn_shader_fallback` call each (message names the socket) for Normal, Tangent, Weight, `distribution` — dropped, not silently ignored. |
+| `docs/blender_parity/coverage_matrix.json` | Regenerated after the fix (headless Blender 5.2, pkg229 reproduce block). |
+| `docs/blender_parity/report.md` | Regenerated alongside the matrix. |
+
+### Key design decisions
+
+1. **Reuse the existing conductor closure; do not write a new one.**
+   `principled.cpp`'s F82/Gulbrandsen machinery already implements exactly
+   the physics `ShaderNodeBsdfMetallic`'s `F82` Fresnel mode specifies — the
+   gap is addon plumbing, not engine math. This mirrors pkg253 decision 1
+   (investigate before implementing) and keeps the change addon-only, no
+   C++/CUDA touched, no register-pressure risk on the shade kernel.
+2. **`PHYSICAL_CONDUCTOR` (complex IOR from spectra) is the genuine ceiling
+   item**, not a plumbing gap — Astroray has no direct complex-IOR Fresnel
+   evaluator anywhere in the engine (CPU or GPU); building one needs
+   `cite-algorithm` against `bsdf_microfacet.h`'s conductor setup before any
+   code is written (CLAUDE.md §6). Phase 1 approximates it with F82 defaults
+   plus a named warning; Phase 2 is the real closure.
+3. **Removing the dead `Color`-branch is a genuine simplification, not a
+   scanner workaround.** The live-Blender probe confirms no shipped version
+   of this node ever exposed a `Color` socket, so the defensive fallback was
+   speculative (CLAUDE.md §2). Deleting it is preferred over patching
+   `_extract_if_else_guarded_reads` (CLAUDE.md §3 — that scanner mechanism
+   is correct elsewhere, e.g. pkg253's `_float_with_fallback`).
+4. **`distribution` (Beckmann/GGX/Multi-GGX) is a model-selection prop, not
+   a value plug** — same class as pkg253's non-goal for Principled's own
+   `distribution`/`subsurface_method`. Astroray's conductor lobe implements
+   one model; selecting between three is a future package if ever
+   prioritized, not part of this floor.
+
+---
+
+## Acceptance criteria
+
+- [ ] `tests/test_pkg255_metallic_f82.py` passes: F82-mode renders a
+      non-grey, Edge-Tint-responsive conductor; Roughness monotone;
+      CPU/GPU parity in-band; `PHYSICAL_CONDUCTOR`-mode node renders without
+      exception and the degradation report contains the exact warning text
+      asserted by the test.
+- [ ] Coverage matrix regenerated: `BSDF_METALLIC` shows Base Color,
+      Edge Tint, Anisotropy, Rotation, Thin Film Thickness, Thin Film IOR,
+      `prop:fresnel_type` moved DROPPED-SILENT → SUPPORTED or APPROXIMATED
+      (all credited, none silent); Normal, Tangent, Weight,
+      `prop:distribution` remain DROPPED-SILENT but are provably
+      APPROXIMATED-with-warning at render time per criterion 1 — the same
+      classification-vs-runtime-warning residual pkg229 already documents
+      for `BSDF_HAIR_PRINCIPLED`.
+- [ ] Headless Cycles A/B: a tiny (64×64, low-SPP) scene with an F82-mode
+      Metallic sphere renders on Astroray and on Cycles; visually inspected
+      side by side (not a numeric parity gate — no reference conductor
+      parametrization match is claimed) and archived alongside the test.
+- [ ] Signature sweep: no new `Material` virtuals or engine-facing
+      signatures added (addon-only change) — confirmed by diff.
+
+---
+
+## Non-goals
+
+- `PHYSICAL_CONDUCTOR` complex-IOR Fresnel from IOR/Extinction spectra —
+  Phase 2 ceiling; needs `cite-algorithm` first, no engine code exists to
+  build on.
+- Normal / Tangent (per-lobe custom normal/tangent) — no per-lobe
+  normal/tangent input exists on the native material, per pkg253's
+  identical finding for Principled's own Coat Normal/Tangent.
+- `Weight` (generic per-closure mix weight) — same non-goal as pkg253;
+  needs a weighted-mix wrapper, separate package.
+- `prop:distribution` (Beckmann/GGX/Multi-GGX selection) — model-selection
+  prop, not a socket fix; Astroray implements one conductor model.
+- GPU wavefront closure-graph changes — none needed; Phase 1 reuses the
+  existing native-principled conductor path unchanged.
+
+---
+
+## Progress
+
+- [ ] 2026-09-07 — filed per owner gate-(b) decision.
+
+---
+
+## Lessons
+
+*(Fill in after the package is done.)*

--- a/.astroray_plan/packages/pkg256-sky-texture-node.md
+++ b/.astroray_plan/packages/pkg256-sky-texture-node.md
@@ -1,0 +1,180 @@
+# pkg256 — Sky texture node (`ShaderNodeTexSky`)
+
+**Pillar:** 5
+**Track:** A
+**Status:** open
+**Estimated effort:** 1 week
+**Depends on:** pkg63, pkg229
+
+---
+
+## Goal
+
+Before: `ShaderNodeTexSky` is never referenced anywhere in
+`blender_addon/__init__.py` — a World using it silently falls through
+`setup_world`'s `TEX_ENVIRONMENT`/`BACKGROUND` walk to the flat solid-color
+fallback, with no warning (all 14 sockets/props DROPPED-SILENT). After: at
+scene export, a `TEX_SKY` node feeding the World Background bakes a
+Nishita-or-Hosek-Wilkie sky (per `sky_type`) into a temporary equirectangular
+image loaded through the existing `renderer.load_environment_map` HDRI path,
+with an explicit warning listing the sockets/props the bake does not honor
+(sun disc, altitude, ozone/aerosol/air density, ground albedo); the coverage
+matrix shows `TEX_SKY` SUPPORTED-or-APPROXIMATED-with-warning, never silent.
+
+---
+
+## Context
+
+Filed per the owner's 2026-09-07 08:30 gate-(b) decision
+(`north-star-and-integration-gate-2026-09-07.md` §2(b), reaudit backlog row
+5). pkg63 (World/HDRI parity, done) explicitly deferred this: "Do not
+implement Sky Texture node conversion (Hosek-Wilkie / Nishita). Separate
+package — needs its own research note." `setup_world`
+(`blender_addon/__init__.py:5232-5339`) already owns the exact insertion
+point — it resolves an `hdri_path` string and hands it to
+`renderer.load_environment_map(hdri_path, strength, rx, ry, rz, tint, ...)`.
+A baked sky is just another `hdri_path` (a temp file), so no new engine
+plumbing is needed for the floor — only a Python-side sky evaluator and a
+bake-to-image step, which is genuinely new physics and therefore requires
+`cite-algorithm` (CLAUDE.md §6) before writing it.
+
+---
+
+## Evidence
+
+- 2026-09-07: live Blender 5.2.0 probe — `ShaderNodeTexSky().inputs =
+  ['Vector']`; `sky_type` enum = `{SINGLE_SCATTERING, MULTIPLE_SCATTERING,
+  PREETHAM, HOSEK_WILKIE}` — four models, not just "Nishita/Hosek";
+  `SINGLE_SCATTERING`/`MULTIPLE_SCATTERING` are Cycles' current
+  Nishita-family names, the other two are legacy analytic models.
+- Coverage matrix (`docs/blender_parity/coverage_matrix.json`,
+  `feature == "TEX_SKY"`, 2026-09-07): all 14 rows DROPPED-SILENT —
+  `input:Vector`, `prop:sky_type`, `prop:sun_direction`, `prop:sun_disc`,
+  `prop:sun_size`, `prop:sun_intensity`, `prop:sun_elevation`,
+  `prop:sun_rotation`, `prop:altitude`, `prop:air_density`,
+  `prop:aerosol_density`, `prop:ozone_density`, `prop:turbidity`,
+  `prop:ground_albedo`.
+
+---
+
+## Reference
+
+- `blender_addon/__init__.py:5232-5339` (`setup_world`) — the
+  `TEX_ENVIRONMENT`/`BACKGROUND`/`MAPPING` walk and the `hdri_path` →
+  `renderer.load_environment_map` call this package extends.
+- pkg63 spec (explicit non-goal / deferral):
+  `.astroray_plan/packages/pkg63-world-hdri-parity.md`.
+- External (not vendored in `external/cycles_light_tree`, cite in code per
+  CLAUDE.md §6): `intern/cycles/kernel/svm/sky.h` (Nishita
+  single/multiple-scattering LUT model, current Cycles default) and
+  `intern/cycles/kernel/svm/sky_model.h` (Hosek-Wilkie 2012 closed-form,
+  `HOSEK_WILKIE`/`PREETHAM` legacy modes). Hosek & Wilkie, ACM TOG 2012;
+  Nishita et al., SIGGRAPH 1993. `cite-algorithm` must run first — no
+  reference implementation is vendored today.
+- `docs/blender_parity/coverage_matrix.json` / `report.md` — regenerate via
+  the pkg229 reproduce block after landing.
+
+---
+
+## Prerequisites
+
+- [x] pkg63 done — HDRI load path (`load_environment_map`) exists and is
+      the target integration point.
+- [x] pkg229 done — coverage matrix regenerable headlessly.
+- [ ] `cite-algorithm` run for the chosen sky model (research note saved to
+      `.astroray_plan/docs/` per CLAUDE.md §6) before implementation starts.
+- [ ] Build passes on main.
+
+---
+
+## Specification
+
+### Files to create
+
+| File | Purpose |
+|---|---|
+| `blender_addon/sky_bake.py` | Standalone (no bpy-only calls beyond image I/O) sky evaluator: given `sky_type` + the sun/atmosphere props, produces an equirectangular `float32` RGB array, matching the cited Nishita or Hosek-Wilkie formulation. Two-lane structure (one function per model family) — no speculative third model. |
+| `tests/test_pkg256_sky_bake.py` | TDD gate: a `TEX_SKY` world bakes to a non-uniform equirect image (bright near the sun direction, darker toward the horizon opposite it), `sky_type` changes the output, the degradation warning names the dropped sockets verbatim, and the resulting temp file loads successfully through `renderer.load_environment_map`. |
+
+### Files to modify
+
+| File | What changes |
+|---|---|
+| `blender_addon/__init__.py` | `setup_world`'s node walk (`~L5259-5260`) gains a `node.type == 'TEX_SKY'` branch: calls `sky_bake.bake_to_equirect(node)`, writes the result to a session temp file (`tempfile.gettempdir()`, cleaned up after `load_environment_map` returns — no persistent artifact), and sets `hdri_path` to it; `strength`/tint/rotation continue to come from the sibling `BACKGROUND`/`MAPPING` nodes exactly as today. One `_warn_shader_fallback('TEX_SKY', ...)` call naming the dropped sockets (sun disc, altitude, ozone/aerosol/air density, ground albedo, `Vector` custom mapping). |
+
+### Key design decisions
+
+1. **Bake to a static HDRI at export time, not a live analytic world
+   lookup.** The task's floor target and `setup_world`'s existing
+   `hdri_path`-based contract both point here: one bake per render/preview
+   refresh reuses 100% of the existing environment-map loader (rotation,
+   tint, `blender_convention` coordinate swap) with zero engine changes.
+   The ceiling (analytic per-ray sky evaluation in the engine's world
+   lookup, avoiding a fixed-resolution bake) is Phase 2 and needs its own
+   `cite-algorithm` pass against the LUT/closed-form math, not attempted
+   here.
+2. **Model scope: `SINGLE_SCATTERING`/`MULTIPLE_SCATTERING` (current Cycles
+   Nishita) is the floor's primary target — highest real-world usage
+   (Blender's default `sky_type` since 2.83).** `PREETHAM`/`HOSEK_WILKIE`
+   are lower-frequency legacy choices; if `cite-algorithm` research shows
+   implementing all four in one pass is disproportionate effort, landing
+   Nishita first with `PREETHAM`/`HOSEK_WILKIE` routed to the Nishita bake
+   plus a warning ("legacy sky model X approximated with Nishita") is an
+   acceptable narrower floor — record the actual choice made in Progress.
+3. **Sun direction**: read the resolved `sun_direction` vector prop
+   directly rather than re-deriving it from `sun_elevation`/`sun_rotation`
+   — one source of truth.
+4. **No persistent cache file** — CLAUDE.md §2: re-bake every `setup_world`
+   call. Viewport re-bake cost, if it matters, is a follow-up performance
+   package with its own measurement.
+
+---
+
+## Acceptance criteria
+
+- [ ] `tests/test_pkg256_sky_bake.py` passes: non-uniform bake, `sky_type`
+      changes output, warning text asserted verbatim, temp file loads via
+      `load_environment_map`.
+- [ ] Coverage matrix regenerated: `TEX_SKY`'s implemented props (at minimum
+      `prop:sky_type`, `prop:sun_direction`, `prop:sun_intensity`, plus
+      whichever atmosphere props the chosen model consumes) move
+      DROPPED-SILENT → SUPPORTED/APPROXIMATED; every prop the bake does not
+      consume stays DROPPED-SILENT in the matrix **but** is named in the
+      runtime warning asserted by criterion 1 — no prop is both
+      unclassified and unwarned.
+- [ ] Headless Cycles A/B: a tiny (64×64, low-SPP) outdoor scene (ground
+      plane + Sky-textured world) renders on Astroray and Cycles; visually
+      inspected side by side for sun-position and horizon-gradient
+      plausibility (no numeric parity claimed — a bake is not the same
+      model Cycles evaluates per-ray) and archived alongside the test.
+- [ ] `cite-algorithm` research note exists under `.astroray_plan/docs/`
+      before the bake evaluator lands, cited in `sky_bake.py`'s header.
+- [ ] Signature sweep: `load_environment_map`'s call sites unchanged in
+      count/shape (new caller, same signature) — grepped.
+
+---
+
+## Non-goals
+
+- Analytic per-ray sky evaluation in the engine's world lookup (the
+  ceiling) — Phase 2, needs its own research/citation pass.
+- Sun disc rendering (a visible sun disc/glare in the sky image) —
+  explicitly named in the floor warning as dropped.
+- `altitude`, `ozone_density`, `air_density`, `aerosol_density`,
+  `ground_albedo` — named in the warning, not consumed by the floor bake.
+- Motion/animation-aware re-bake optimization — re-bake is unconditional
+  per Key design decision 4.
+- Implementing all four `sky_type` values with full accuracy in one pass —
+  decision 2 allows a narrower floor; record the actual scope landed.
+
+---
+
+## Progress
+
+- [ ] 2026-09-07 — filed per owner gate-(b) decision.
+
+---
+
+## Lessons
+
+*(Fill in after the package is done.)*

--- a/.astroray_plan/packages/pkg257-displacement-node.md
+++ b/.astroray_plan/packages/pkg257-displacement-node.md
@@ -1,0 +1,180 @@
+# pkg257 — Displacement (`ShaderNodeDisplacement` + material displacement method)
+
+**Pillar:** 5
+**Track:** A
+**Status:** open
+**Estimated effort:** 3 sessions (~9 h)
+**Depends on:** pkg223b, pkg229
+
+---
+
+## Goal
+
+Before: the Material Output node's `Displacement` socket is never read
+anywhere in the addon (`convert_node_material` reads only `Surface` and
+`Volume`) — a `ShaderNodeDisplacement` node wired into it, and
+`material.displacement_method`, are both silently ignored regardless of
+value (all 5 sockets/props DROPPED-SILENT). After: `Displacement.Height`
+(offset by `Midlevel`, magnitude from `Scale`) is approximated as a bump
+perturbation through the existing pkg223b bump machinery — the same
+`bump_map_texture`/`bump_strength`/`bump_distance` material params a
+`ShaderNodeBump` on a BSDF's `Normal` already produces, now also reachable
+from the Material Output's `Displacement` socket — with an explicit warning
+when `displacement_method` requests true geometric displacement (`BOTH` or
+`DISPLACEMENT`) or when `Normal`/`space` are wired, since neither is honored
+by a bump-only approximation.
+
+---
+
+## Context
+
+Filed per the owner's 2026-09-07 08:30 gate-(b) decision
+(`north-star-and-integration-gate-2026-09-07.md` §2(b), reaudit backlog row
+9, which explicitly scores this "S if bump-approximated"). pkg223b (done,
+2026-08-29) already built and hardware-verified the CPU+GPU bump-perturbation
+machinery this floor reuses — confirmed by reading
+`blender_addon/__init__.py:2911-2948` (`get_normal_inputs`, which walks a
+BSDF's `Normal` socket for a `ShaderNodeBump` and emits `bump_image`/
+`bump_strength`/`bump_distance`) and `plugins/materials/normal_mapped.cpp`
+(`NormalMappedPlugin`'s bump fields, CPU-verified) plus the GPU mirror
+pkg223b added. The gap this package closes is different: Blender's
+**Displacement** node lives on the *Material Output*'s `Displacement` input
+(a separate socket from any BSDF's `Normal`) and reads `Height`, not a
+`ShaderNodeBump`'s own inputs — that dispatch path does not exist at all
+today, confirmed by a zero-hit grep for `"displacement"` across
+`blender_addon/`.
+
+---
+
+## Evidence
+
+- 2026-09-07: zero references to `ShaderNodeDisplacement`, `"Displacement"`,
+  or `displacement_method` anywhere in `blender_addon/__init__.py`,
+  `exporter.py`, or `settings_map.py`.
+- 2026-09-07: live Blender 5.2.0 probe — `ShaderNodeDisplacement().inputs =
+  ['Height', 'Midlevel', 'Scale', 'Normal']`; `space` enum =
+  `{OBJECT, WORLD}`; `material.displacement_method` enum =
+  `{BUMP, DISPLACEMENT, BOTH}` (Blender's own default is `BUMP` — i.e. even
+  stock Cycles bump-approximates by default; `DISPLACEMENT`/`BOTH` opt into
+  true geometry offset).
+- Coverage matrix (`docs/blender_parity/coverage_matrix.json`,
+  `feature == "DISPLACEMENT"`, 2026-09-07): all 5 rows DROPPED-SILENT —
+  `input:Height`, `input:Midlevel`, `input:Scale`, `input:Normal`,
+  `prop:space`.
+
+---
+
+## Reference
+
+- pkg223b spec (bump machinery this reuses):
+  `.astroray_plan/packages/pkg223b-bump-node.md`.
+- `blender_addon/__init__.py:2911-2948` (`get_normal_inputs`) and
+  `:4358-4369`/`:4145-4149` (bump params reaching
+  `_create_material_from_shader_spec`) — the pattern this package extends
+  to a second entry point (Material Output `Displacement`, not BSDF
+  `Normal`).
+- `blender_addon/__init__.py:2267-2284` (`convert_node_material`'s
+  `Surface`/`Volume` read) — the function this package adds a
+  `Displacement` read to.
+- External (cited already in pkg223b, reused unchanged): Cycles
+  `intern/cycles/kernel/svm/displace.h` (`svm_node_set_bump`),
+  Mikkelsen 2010 surface-gradient bump.
+
+---
+
+## Prerequisites
+
+- [x] pkg223b done — CPU+GPU bump perturbation hardware-verified.
+- [x] pkg229 done — coverage matrix regenerable headlessly.
+- [ ] Build passes on main.
+
+---
+
+## Specification
+
+### Files to create
+
+| File | Purpose |
+|---|---|
+| `tests/test_pkg257_displacement_bump.py` | TDD gate: a Material Output with a `ShaderNodeDisplacement` wired into `Displacement` (Height fed by an image or procedural texture) renders visible bump relief identical in mechanism to an equivalent `ShaderNodeBump`-on-Normal scene (reuses pkg223b's own render assertions); `Midlevel`/`Scale` change relief direction/magnitude monotonically; `displacement_method in (DISPLACEMENT, BOTH)` and a linked `Normal` input each emit the degradation warning asserted verbatim; geometry vertex count is unchanged (proves no true displacement occurred, which the warning must be honest about). |
+
+### Files to modify
+
+| File | What changes |
+|---|---|
+| `blender_addon/__init__.py` | `convert_node_material` (`~L2261-2284`): also read `output.inputs.get('Displacement')`; if linked to a `DISPLACEMENT`-type node, extract `Height` (via `get_image_from_socket`, mirroring `get_normal_inputs`'s `BUMP` branch), `Midlevel`/`Scale` (via `get_float_input`), and pass them into `convert_shader_node` (new optional parameter) so the returned spec gains `bump_map_texture`/`bump_strength` (from `Scale`)/`bump_distance` before `_create_material_from_shader_spec` runs — reusing the plumbing keys its `~L4145-4149` loop already forwards, no change needed there. `Midlevel` shifts the sampled height (`height - midlevel`), matching `svm_node_set_bump` centering. `_warn_shader_fallback('DISPLACEMENT', ...)` names `Normal` (dropped) and, when `displacement_method != 'BUMP'`, that true geometric displacement was requested but bump-approximated. |
+| `docs/blender_parity/coverage_matrix.json` | Regenerated after the fix (headless Blender 5.2, pkg229 reproduce block). |
+| `docs/blender_parity/report.md` | Regenerated alongside the matrix. |
+
+### Key design decisions
+
+1. **Displacement's `Height` becomes a bump texture, not a new closure.**
+   pkg223b already proved the CPU+GPU surface-gradient bump math at
+   parity; this package's entire job is a second addon-side entry point
+   (Material Output `Displacement` in addition to BSDF `Normal`) feeding
+   the same material params. Zero engine (C++/CUDA) changes.
+2. **`convert_shader_node` gains one optional parameter** (the extracted
+   displacement bump params) rather than a second global/thread-local
+   channel — keeps the data flow explicit and traceable (CLAUDE.md §2:
+   minimum change, no hidden state).
+3. **Honesty about the ceiling.** Blender's own default `displacement_method`
+   is `BUMP`, so this floor matches Cycles' *default* behavior exactly for
+   the common case; the warning fires only when the scene explicitly opted
+   into `DISPLACEMENT`/`BOTH` or wired a custom `Normal` — default-method
+   scenes get zero spurious warnings.
+4. **`space` (`OBJECT`/`WORLD`)** only matters for true displacement
+   direction; folded into the same `displacement_method != BUMP` warning
+   (one consolidated message, not a warning storm per socket).
+
+---
+
+## Acceptance criteria
+
+- [ ] `tests/test_pkg257_displacement_bump.py` passes: relief visible,
+      Midlevel/Scale monotone, warnings asserted verbatim for
+      `Normal`-linked and non-`BUMP` `displacement_method` cases, vertex
+      count unchanged (proves floor scope honestly).
+- [ ] Coverage matrix regenerated: `input:Height`, `input:Midlevel`,
+      `input:Scale` move DROPPED-SILENT → APPROXIMATED; `input:Normal` and
+      `prop:space` remain DROPPED-SILENT in the matrix **but** are named in
+      the runtime warning asserted by criterion 1 — no prop is both
+      unclassified and unwarned.
+- [ ] Headless Cycles A/B: a tiny (64×64, low-SPP) scene with a tessellated
+      plane, an image-textured Height driving Displacement, renders on
+      Astroray (bump-approximated) and Cycles (`BUMP` method, so the
+      comparison is apples-to-apples) side by side; visually inspected for
+      relief-direction plausibility (no numeric parity gate — different
+      derivative sources per pkg223b's own documented CPU/GPU parity band)
+      and archived alongside the test.
+- [ ] Signature sweep: `convert_shader_node`'s new optional parameter —
+      grep every call site (production + `tests/`) and confirm each passes
+      the argument or relies on its default unchanged.
+
+---
+
+## Non-goals
+
+- True geometric displacement (mesh subdivision/offset at export, or
+  engine-side micro-displacement) — the ceiling; needs Blender's own
+  displacement-to-mesh bake or engine subdivision infrastructure that does
+  not exist today. Separate package.
+- `Normal` input (custom analytic normal feeding the displacement gradient)
+  — the bump path derives its own gradient from `Height`; named in the
+  warning, not consumed.
+- `space` (`OBJECT`/`WORLD`) — folded into the same warning as decision 4.
+- Volume displacement / `PRINCIPLED_VOLUME` Displacement chains — unrelated
+  code path.
+- Any change to `plugins/materials/normal_mapped.cpp` or GPU bump kernels —
+  pkg223b's machinery is reused unchanged.
+
+---
+
+## Progress
+
+- [ ] 2026-09-07 — filed per owner gate-(b) decision.
+
+---
+
+## Lessons
+
+*(Fill in after the package is done.)*


### PR DESCRIPTION
## Summary
- Files pkg255 (Metallic BSDF), pkg256 (Sky texture), pkg257 (Displacement) per the owner's 2026-09-07 08:30 gate-(b) decision: each must be SUPPORTED or explicitly APPROXIMATED-with-warning for the Pillar-4 exit gate (`north-star-and-integration-gate-2026-09-07.md` §2(b), reaudit backlog rows 6/5/9).
- Each spec cites the exact socket list from `docs/blender_parity/coverage_matrix.json` (confirmed against a live Blender 5.2 probe), a floor that reuses existing engine machinery instead of inventing new physics (pkg178/pkg253's F82-tint conductor path for Metallic, pkg63's HDRI loader for Sky, pkg223b's bump-perturbation machinery for Displacement), and a ceiling for the real remaining gap.
- pkg255 additionally surfaces a scanner/dead-code finding (Base Color on `ShaderNodeBsdfMetallic` reads as DROPPED-SILENT only because of a dead version-compat branch, not a real gap).

## Test plan
- [x] `python scripts/project_index.py lint --no-baseline <file>` prints `lint OK` for all three specs individually.
- [x] `python scripts/project_index.py lint --all` stays green (266 checked, 234 pre-existing baselined, no new baseline entries from these files).
- [ ] No code changes in this PR — nothing to build or render-verify; acceptance criteria in each spec gate the eventual implementation PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)