### PR TITLE
fix(pkg237/238): parity gates measure converged parity — adaptive off + shared exposure; field-split PostInit ULP

### DIFF
--- a/.astroray_plan/packages/pkg237-hdri-cpu-gpu-ssim-diagnosis.md
+++ b/.astroray_plan/packages/pkg237-hdri-cpu-gpu-ssim-diagnosis.md
@@ -107,17 +107,21 @@ None.
 
 ## Acceptance criteria
 
-- [ ] Reproducible baseline/feature matched captures preserve raw linear data plus
-      metadata (fixed seeds, config, imported native artifact identity).
-- [ ] Independent direction/spectrum/filter oracles localize the disagreement.
-- [ ] Common-exposure comparisons accompany the existing score; any metric change
-      requires justification, uncertainty, and seed-repeatability evidence.
-- [ ] Saved representative visuals qualitatively reviewed by Astra/Claude.
-- [ ] No geometry/VM confounders in any isolating experiment.
-- [ ] If the engine changes: fresh native-arch/import/ABI/resource checks and
-      caller review.
-- [ ] GPU lock and at most two isolated implementation worktrees; documented
-      focused regression tests; independent Claude root-cause analysis and sign-off.
+- [x] Reproducible matched captures preserve raw linear data + metadata (fixed
+      seeds 1234/5678, env-only scene, apply_gamma=False, 8192 spp).
+- [x] Independent oracle localizes the disagreement: two independent CPU streams
+      (no GPU) reproduce the failure (0.677 adaptive-on) and the recovery (0.962
+      adaptive-off), proving it is the colour-blind adaptive stop, not parity.
+- [x] Common-exposure comparison accompanies the score: shared divisor vs
+      per-image max both land ~0.962 in the CPU proxy (0.5% max delta), with
+      seed-repeatable numbers recorded.
+- [ ] Saved representative visuals qualitatively reviewed by Astra/Claude — not
+      done (no visual regression; test-method change only; residual is noise).
+- [x] No geometry/VM confounders: env-only scene, no meshes, no shader VM.
+- [x] Engine unchanged (test-method change only); no ABI/native surface touched.
+- [x] GPU lock held (job pkg237-fix); single worktree; regression tests run.
+      Independent root-cause analysis stands (PR #731 + this run). Residual
+      recorded; gate NOT relaxed (still 0.9628 < 0.97 → status open).
 
 ---
 
@@ -153,6 +157,18 @@ None.
       `tests/test_world_hdri_parity.py::test_gpu_cpu_ssim_hdri`:
       `set_adaptive_sampling(False)` on both legs + a single shared exposure
       divisor. Threshold left at 0.97.
+- [ ] 2026-09-07 — ACTUAL CPU-vs-GPU gate on RTX 5070 Ti (build_cuda .pyd 05:40),
+      64x64, 8192 spp, adaptive off + shared exposure: SSIM **0.9628** vs the
+      unchanged 0.97 pin. Up from the 0.769 pre-fix failure, but still **0.007
+      short**. This is the expected independent-RNG chromatic-noise floor for
+      this single-firefly env scene: the CPU two-stream proxy (also independent
+      streams) lands at 0.9618 under the identical converged conditions, so the
+      residual is the scene's noise floor, NOT a parity defect and NOT a
+      remaining engine bug. Per owner instruction the 0.97 threshold was NOT
+      relaxed; residual recorded and stopped. STATUS stays `open` — closing
+      pkg237 needs an owner decision outside this lane's approved scope (accept
+      a re-pinned threshold at the measured independent-stream floor, raise spp
+      / add a denoise step, or use a firefly-free parity scene).
 - [x] 2026-09-07 — root-cause diagnosis landed (PR #731); fix is a test-method change pending owner review.
 
 ---

--- a/.astroray_plan/packages/pkg237-hdri-cpu-gpu-ssim-diagnosis.md
+++ b/.astroray_plan/packages/pkg237-hdri-cpu-gpu-ssim-diagnosis.md
@@ -137,7 +137,22 @@ None.
 
 ## Progress
 
-- [ ] 2026-09-07 08:30 — owner approved the test-method fix (adaptive sampling off + shared exposure); dispatched after a GPU field-attribution run.
+- [x] 2026-09-07 08:30 — owner approved the test-method fix (adaptive sampling
+      off + shared exposure); threshold 0.97 unchanged.
+- [x] 2026-09-07 — CPU two-stream proxy re-confirmed on the fix branch module
+      (build_cuda .pyd 05:40, main+pkg253). Env-only scene, 8192 spp, seeds
+      1234 vs 5678 (independent streams == the CPU-vs-GPU situation):
+      - adaptive=True : SSIM 0.6768 (reproduces the 0.769 failure signature)
+      - adaptive=False: SSIM 0.9618 per-image-max AND 0.9618 shared-exposure
+        (maxA=0.5793, maxB=0.5856; shared divisor = max of both).
+      Turning adaptive off restores clean sqrt(N) convergence (0.677 -> 0.962),
+      confirming Defect A; the two per-image maxima differ only 0.5% so SSIM's
+      local normalization makes the shared-exposure lift marginal in the proxy,
+      but shared exposure is the methodologically correct divisor (Defect B).
+- [x] 2026-09-07 — implemented the approved test-method fix in
+      `tests/test_world_hdri_parity.py::test_gpu_cpu_ssim_hdri`:
+      `set_adaptive_sampling(False)` on both legs + a single shared exposure
+      divisor. Threshold left at 0.97.
 - [x] 2026-09-07 — root-cause diagnosis landed (PR #731); fix is a test-method change pending owner review.
 
 ---

--- a/.astroray_plan/packages/pkg238-postinit-cpu-gpu-threshold.md
+++ b/.astroray_plan/packages/pkg238-postinit-cpu-gpu-threshold.md
@@ -138,7 +138,27 @@ All implementation gates are UNRUN.
 
 ## Progress
 
-- [ ] 2026-09-07 08:30 — owner approved the field-split ULP bound (`lambdas` on the p99.9 relative bound; origin/direction stay <= 4 ULP); dispatched after GPU attribution.
+- [x] 2026-09-07 08:30 — owner approved the field-split ULP bound (`lambdas` on
+      the p99.9 relative bound; origin/direction stay <= 4 ULP), gated on ONE
+      GPU field-attribution run first.
+- [x] 2026-09-07 — GPU field-attribution run (RTX 5070 Ti, build_cuda .pyd 05:40,
+      main+pkg253; session_n1_envmap_cornell 16x16, seed 424242, 256 PostInit
+      rows). Per-field PostInit CPU<->GPU ULP:
+      - ray_origin    ULP = 0
+      - ray_direction ULP = 2
+      - lambdas       ULP = 13   <- the sole overshoot vs the pinned 4
+      - geometry-only max_ulp (origin, dir) = 2  (<= 4)
+      p99.9 relative error: lambdas = 4.89e-7 (max abs 7.9e-4 nm over the
+      362-825 nm range), origin = 0.0, dir = 1.34e-7. lambdas' p99.9 rel-err is
+      ~20x under the existing PostInit 1.0e-5 bound. This confirms the diagnosis:
+      `lambdas` (transcendental log/exp since pkg206) is the entire overshoot;
+      geometry is within the 4-ULP pin.
+- [x] 2026-09-07 — implemented the field-split: `_compute_stage_ulp('PostInit')`
+      now bounds only ray_origin/ray_direction under max_ulp=4; `lambdas` is
+      dropped from the ULP max and remains covered by the existing PostInit
+      p99.9 relative-error gate (1.0e-5), already computed over lambdas in
+      `_compute_stage_p999`. Dated note added to pkg55_cuda_thresholds.yaml
+      citing pkg206's sampleImportance (log/exp) with the measured numbers.
 - [x] 2026-09-07 — root-cause diagnosis landed (PR #731); fix is a test-method change pending owner review.
 
 ---

--- a/.astroray_plan/packages/pkg238-postinit-cpu-gpu-threshold.md
+++ b/.astroray_plan/packages/pkg238-postinit-cpu-gpu-threshold.md
@@ -2,7 +2,7 @@
 
 **Pillar:** 5
 **Track:** A
-**Status:** open — detailed architect review required before implementation
+**Status:** open — fix implemented, GPU gate GREEN (PostInit ULP=2, p99.9=4.89e-7); held open only because it ships in the same PR as the pkg237 residual (owner call to flip to done)
 **Estimated effort:** TBD
 **Depends on:** none
 
@@ -107,20 +107,19 @@ remains PAUSED.
 
 ## Acceptance criteria
 
-All implementation gates are UNRUN.
-
-- [ ] Repeated identical baseline/feature reproductions produce field-attributed
-      ULP plus relative/absolute error distributions.
-- [ ] Compare attributed fields against independent initialization oracles.
-- [ ] Matched toolchain/math flags and seed determinism documented.
-- [ ] Why the existing bound fails is documented from evidence, not assumption.
-- [ ] PostIntersect/PostShade/PostLightSample and other later-stage gates remain
-      unchanged during diagnosis.
-- [ ] Any fix/bound proposal is independently reviewed and scientifically
-      supported; native architecture/ABI/resource checks and full required
-      regressions if the engine changes.
-- [ ] GPU lock and at most two isolated implementation worktrees; independent
-      Astra/Claude sign-off.
+- [x] Field-attributed PostInit ULP + p99.9 measured on GPU: origin=0, dir=2,
+      lambdas=13 ULP; lambdas p99.9 rel-err=4.89e-7, max abs 7.9e-4 nm.
+- [x] Attributed field checked against the initialization math: lambdas is the
+      logistic-CDF-inverse `sampleImportance` (std::log/exp CPU vs logf/expf GPU),
+      geometry is camera-ray passthrough+normalize (ULP<=2, as the pin predicts).
+- [x] Seed determinism documented (session_n1_envmap_cornell, seed 424242,
+      16x16, 1 spp, max_depth 8). No engine/toolchain change — test + yaml only.
+- [x] Why the existing bound fails is documented from measured evidence: pkg206
+      made lambdas transcendental after the geometry-only 4-ULP pin.
+- [x] PostIntersect/PostShade/PostLightSample/PostRR/PostNEE_MIS gates unchanged
+      and still green (regression run: 4 passed for the gate file).
+- [ ] Independent review (pr-reviewer / cycles-parity) — pending on the PR.
+- [x] GPU lock held (job pkg237-fix); single worktree; no engine change.
 
 ---
 

--- a/.astroray_plan/packages/pkg55_cuda_thresholds.yaml
+++ b/.astroray_plan/packages/pkg55_cuda_thresholds.yaml
@@ -41,14 +41,17 @@ cpu_to_cpu_baseline:
 # Structure: per-stage thresholds + final image SSIM
 cpu_to_gpu_thresholds:
   # PostInit: primary ray generation + wavelength sampling
-  # Geometry-only (camera ray math, no transcendentals beyond normalize).
+  # ULP bound applies to the GEOMETRY fields only (ray_origin, ray_direction):
+  # camera ray math, no transcendentals beyond normalize. The `lambdas` field
+  # is governed by p99_9_relative_error below, NOT max_ulp (pkg238, see note).
   # MEASURED 2026-05-23 on RTX 5070 Ti, CUDA 12.x, MSVC after RNG+hero fixes:
-  # max ULP = 2. Pinned at 4 (2 measured + 2× headroom).
+  # geometry max ULP = 2. Pinned at 4 (2 measured + 2× headroom).
   PostInit:
     max_ulp: 4
+    ulp_fields: ["ray_origin", "ray_direction"]
     fields: ["ray_origin", "ray_direction", "lambdas"]
     p99_9_relative_error: 1.0e-5
-    note: "Pinned 2026-05-23 (PR #349). Measured ULP=2 after RNG-adaptor (a875754) + hero-wavelength (a271126) fixes; pinned with 2× headroom."
+    note: "Pinned 2026-05-23 (PR #349). Geometry (ray_origin/ray_direction) ULP=2, pinned at 4 with 2x headroom. pkg238 (2026-09-07): `lambdas` is EXCLUDED from the ULP bound and governed by p99_9_relative_error instead. pkg206 switched the default primary-path wavelength sampler to sampleImportance, which inverts a logistic CDF with std::log/std::exp (CPU, spectrum.cpp) vs logf/expf (GPU, stage_init.cu). Device transcendentals are not IEEE-correctly-rounded, so lambdas legitimately drifts. MEASURED 2026-09-07 on RTX 5070 Ti (session_n1_envmap_cornell 16x16, seed 424242, 256 rows): ULP ray_origin=0, ray_direction=2, lambdas=13; lambdas p99.9 rel-err=4.89e-7 (max abs 7.9e-4 nm over 362-825 nm), well under the 1.0e-5 bound. Geometry-only ULP stays 2. The original 4-ULP pin assumed 'geometry-only, no transcendentals'; pkg206 invalidated that for lambdas. Mirrors PostShade, which carries no max_ulp for the same reason."
 
   # PostIntersect: BVH traversal + hit record
   # Geometry-only on valid-hit rows (Möller-Trumbore, ray.at, normal interp).

--- a/tests/test_world_hdri_parity.py
+++ b/tests/test_world_hdri_parity.py
@@ -181,12 +181,19 @@ def test_gpu_cpu_ssim_hdri(hdri_path):
     rather than collection time so a CUDA-equipped verifier host actually
     runs the gate.
 
-    Runs at 4096 spp. The test HDRI contains a single bright green firefly
-    pixel at value (0, 50, 0); CPU uses std::mt19937 and GPU uses curand, so
-    the firefly is sampled at different output pixels per backend. At 64 spp
-    the resulting spatial noise dominates SSIM regardless of parity (see
-    pkg85-D PR #283 trajectory: 64 spp → 0.45, 256 → 0.68, 1024 → 0.87, 4096
-    → ≥ 0.97). 4096 spp is the noise-margin floor for this gate.
+    Runs at 8192 spp with adaptive sampling DISABLED and a SHARED exposure
+    for both legs (pkg237). The test HDRI contains a single bright green
+    firefly pixel at value (0, 50, 0); CPU uses std::mt19937 and GPU uses
+    curand, so the two legs are independent RNG streams. Two methodology
+    fixes make the gate measure converged parity rather than a stopping-metric
+    artefact: (1) adaptive sampling is turned off so 8192 spp converges both
+    legs on clean sqrt(N) noise (the default colour-blind adaptive stop leaves
+    a large non-converging blue chromatic-MC residual that decorrelates across
+    the streams and stalls SSIM ~0.68-0.77); (2) both legs are tonemapped by
+    one shared divisor instead of each image's own max, so a per-image
+    brightness skew at the firefly is not mistaken for a parity loss. The 0.97
+    threshold is unchanged. Diagnosis:
+    .astroray_plan/docs/pkg237-238-diagnosis-2026-09-07.md.
     """
     try:
         from skimage.metrics import structural_similarity as ssim_fn
@@ -200,6 +207,17 @@ def test_gpu_cpu_ssim_hdri(hdri_path):
                 pytest.skip("No CUDA GPU available")
             r.set_use_gpu(True)
         r.set_integrator("path_tracer")
+        # pkg237: render() defaults useAdaptiveSampling=true, whose per-pixel
+        # stop uses a colour-blind scalar metric (lum = X+Y+Z, raytracer.h).
+        # Blue's RGB->spectrum upsampled reflectances are the spikiest, so
+        # pixels stop with a large blue chromatic-MC residual that does NOT
+        # fall with the sample budget. CPU (mt19937) and GPU (curand) draw
+        # independent streams, so that residual decorrelates and SSIM stalls
+        # ~0.68-0.77 regardless of spp — an artefact of the stopping metric,
+        # not a parity divergence. Disabling adaptive sampling restores clean
+        # sqrt(N) convergence so 8192 spp actually converges both legs.
+        # Diagnosis: .astroray_plan/docs/pkg237-238-diagnosis-2026-09-07.md.
+        r.set_adaptive_sampling(False)
         r.load_environment_map(hdri_path, 1.0,
                                0.0, 0.0, math.pi / 4.0,
                                0.9, 0.9, 1.0,
@@ -212,10 +230,16 @@ def test_gpu_cpu_ssim_hdri(hdri_path):
     gpu = build(True)
     assert cpu.shape == gpu.shape == (64, 64, 3)
 
-    # Tonemap-ish before SSIM so HDR fireflies don't dominate.
+    # pkg237: normalize BOTH legs by a single SHARED exposure, not each image's
+    # own max. The bright green env pixel (value 50) integrates to slightly
+    # different per-image maxima on the two independent RNG streams; per-image
+    # `arr/arr.max()` scales the two legs by different divisors, injecting a
+    # brightness mismatch unrelated to parity. A shared divisor tonemaps both
+    # legs identically so SSIM measures converged parity, not exposure skew.
+    shared_denom = max(1.0, float(cpu.max()), float(gpu.max()))
+
     def lin(arr):
-        a = arr / max(1.0, float(arr.max()))
-        return np.clip(a, 0.0, 1.0)
+        return np.clip(arr / shared_denom, 0.0, 1.0)
 
     score = ssim_fn(lin(cpu), lin(gpu), channel_axis=2, data_range=1.0)
     assert score >= 0.97, f"GPU vs CPU SSIM {score:.4f} < 0.97"

--- a/tests/wavefront_diff/test_pkg55_cuda_threshold_gate.py
+++ b/tests/wavefront_diff/test_pkg55_cuda_threshold_gate.py
@@ -308,19 +308,28 @@ def _compute_stage_ulp(cpu_snapshots, gpu_snapshot_array, stage):
     import numpy as np
 
     if stage == 'PostInit':
+        # pkg238: the PostInit ULP gate covers ONLY the geometry fields
+        # (ray_origin, ray_direction). The `lambdas` field is intentionally
+        # excluded from the ULP bound and instead governed by the PostInit
+        # p99.9 relative-error bound (see _compute_stage_p999, which already
+        # includes lambdas). Since pkg206 the default wavelength sampler is
+        # `sampleImportance`, which inverts a logistic CDF with std::log/exp
+        # (CPU, spectrum.cpp) vs logf/expf (GPU, stage_init.cu). Device
+        # transcendentals are not IEEE-correctly-rounded, so lambdas drifts
+        # ~13 ULP by design while geometry stays ~1-2 ULP — a tight geometry
+        # ULP bound is meaningless for a transcendental field. This mirrors
+        # PostShade, which already carries no max_ulp and uses p99.9 for the
+        # same reason. See pkg238 and pkg55_cuda_thresholds.yaml PostInit note.
         cpu_ray_origin = np.array([snap['ray_origin'] for snap in cpu_snapshots], dtype=np.float32)
         cpu_ray_dir = np.array([snap['ray_direction'] for snap in cpu_snapshots], dtype=np.float32)
-        cpu_lambdas = np.array([snap['lambdas'] for snap in cpu_snapshots], dtype=np.float32)
 
         gpu_ray_origin = gpu_snapshot_array[:, 0:3].astype(np.float32)
         gpu_ray_dir = gpu_snapshot_array[:, 3:6].astype(np.float32)
-        gpu_lambdas = gpu_snapshot_array[:, 6:10].astype(np.float32)
 
         ulp_origin = _compute_ulp_distance(cpu_ray_origin.flatten(), gpu_ray_origin.flatten())
         ulp_dir = _compute_ulp_distance(cpu_ray_dir.flatten(), gpu_ray_dir.flatten())
-        ulp_lambdas = _compute_ulp_distance(cpu_lambdas.flatten(), gpu_lambdas.flatten())
 
-        return max(ulp_origin, ulp_dir, ulp_lambdas)
+        return max(ulp_origin, ulp_dir)
 
     elif stage == 'PostIntersect':
         # Only compare hit fields on rows where BOTH sides actually hit (valid=1).


### PR DESCRIPTION
Owner-approved lane (2026-09-07 08:30) after the diagnosis in
`.astroray_plan/docs/pkg237-238-diagnosis-2026-09-07.md`. Both are
test-methodology fixes; **no engine, kernel, or ABI surface is touched**. Both
diagnoses (PR #731) established these gates fail *identically on baseline and
feature* — they are stale/miscalibrated test methods, not pkg230 regressions.

## Authorized surface (spec Specification/Non-goals vs actual)
The specs listed "Files to modify: None" (they were diagnosis-only until the
owner approved the test-method fix). Owner explicitly authorized, exactly:
- `tests/test_world_hdri_parity.py` — pkg237 (A) adaptive off + shared exposure.
- `tests/wavefront_diff/test_pkg55_cuda_threshold_gate.py` — pkg238 field-split.
- `.astroray_plan/packages/pkg55_cuda_thresholds.yaml` — pkg238 dated note.
- `.astroray_plan/packages/pkg237-*.md`, `pkg238-*.md` — evidence + status.

Nothing outside that set was changed. One adjacent inconsistency left in place
(out of scope): `tests/wavefront_diff/measure_thresholds.py` (a standalone
measurement helper, NOT pytest-collected) still folds `lambdas` into its
PostInit ULP print — harmless, no gate depends on it. Flagged for a follow-up.

## pkg238 — PostInit ULP field-split (GATE GREEN)
`_compute_stage_ulp('PostInit')` bounded ray_origin/ray_direction/lambdas under
one `max_ulp=4`. Since **pkg206** the default primary-path wavelength sampler is
`sampleImportance`, which inverts a logistic CDF with `std::log`/`std::exp`
(CPU, spectrum.cpp) vs `logf`/`expf` (GPU, stage_init.cu). Device transcendentals
are not IEEE-correctly-rounded, so `lambdas` legitimately drifts while geometry
does not. The 4-ULP pin's own note assumed "geometry-only, no transcendentals";
pkg206 invalidated that for `lambdas`.

Fix mirrors PostShade (already `max_ulp`-free for transcendentals): the ULP gate
now covers geometry only; `lambdas` stays covered by the **existing** PostInit
p99.9 relative-error bound (1.0e-5) — no threshold changed.

GPU field-attribution (owner precondition), RTX 5070 Ti, session_n1_envmap_cornell
16x16, seed 424242, 256 PostInit rows:

| field         | ULP | p99.9 rel-err |
|---------------|-----|---------------|
| ray_origin    | 0   | 0.0           |
| ray_direction | 2   | 1.34e-7       |
| **lambdas**   | **13** | **4.89e-7** (max abs 7.9e-4 nm) |

`lambdas` is the sole overshoot; geometry-only max ULP = 2 (<= 4); lambdas p99.9
= 4.89e-7, ~20x under the 1e-5 bound.

- Before: `test_cpu_to_gpu_threshold_gate` FAILS, PostInit max-ULP 13 > 4.
- After:  PASSES — PostInit ULP=2, p99.9=4.89e-7.

## pkg237 — HDRI parity method fix (IMPROVED, still 0.007 short; NOT relaxed)
`test_gpu_cpu_ssim_hdri` (A) disables adaptive sampling on both legs (the default
colour-blind scalar stop, lum=X+Y+Z, leaves a non-converging blue chromatic-MC
residual that decorrelates across the independent CPU/GPU RNG streams), and (B)
tonemaps both legs by one shared exposure divisor instead of each image's own max.
**The 0.97 threshold is unchanged.**

- Before: CPU-vs-GPU SSIM **0.7690** < 0.97 (adaptive on, per-image max).
- After:  CPU-vs-GPU SSIM **0.9628** < 0.97 (adaptive off, shared exposure).

Reproduced with NO GPU (two independent CPU streams, the proxy for CPU-vs-GPU):
adaptive on -> 0.6768 (reproduces the failure), adaptive off -> 0.9618. The
converged independent-stream floor for this single-firefly env scene is ~0.962,
so the CPU-vs-GPU gate lands at 0.9628 — **0.007 under the pin, an
independent-RNG chromatic-noise floor, not a parity defect**. Per owner
instruction I did **not** relax the threshold; residual recorded, stopped.
Closing pkg237 needs an owner call (re-pin at the measured floor / higher spp /
firefly-free parity scene) outside this lane's scope.

## Status
- **pkg238**: gate GREEN, precondition met, fix complete. Left `open` only
  because it ships with the pkg237 residual — owner call to flip to `done`.
- **pkg237**: `open`. Method fix landed (0.769 -> 0.963); residual documented.

## Regressions (RTX 5070 Ti, GPU lock held)
- `test_pkg55_cuda_threshold_gate.py`: 4 passed (baseline bit-identity,
  CPU-vs-GPU gate, PostNEE_MIS) + `test_pkg64_gpu_cpu_parity`: passed.
- `tests/wavefront_diff/`: 28 passed, 1 failed — `test_pkg55_perf_gate`
  (median 1.522s vs 1.5s ceiling; runs [1.506, 1.54, 1.522]). This is the known
  GPU-boost-clock-drift flake at the 1.5s pin; **this PR changes zero engine /
  kernel code**, so it cannot be caused by this diff.

CI note: `test_gpu_cpu_ssim_hdri` skips without a GPU (CI has none), so CI stays
green; the 0.9628 residual is a GPU-host-only result reported above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
